### PR TITLE
Rename variable index to idx to avoid conflicting declaration.

### DIFF
--- a/doc/dox_comments/header_files-ja/ssl.h
+++ b/doc/dox_comments/header_files-ja/ssl.h
@@ -2189,7 +2189,7 @@ int wolfSSL_GetSessionIndex(WOLFSSL* ssl);
     \sa LockMutex
     \sa wolfSSL_GetSessionIndex
 */
-int wolfSSL_GetSessionAtIndex(int index, WOLFSSL_SESSION* session);
+int wolfSSL_GetSessionAtIndex(int idx, WOLFSSL_SESSION* session);
 
 /*!
     \ingroup IO

--- a/doc/dox_comments/header_files/kdf.h
+++ b/doc/dox_comments/header_files/kdf.h
@@ -16,7 +16,7 @@
     \param [in] salt Random non-secret value.
     \param [in] saltSz Size of random in bytes.
     \param [in] kdrIdx Key derivation rate. kdr = 0 when -1, otherwise kdr = 2^kdrIdx.
-    \param [in] index Index value to XOR in.
+    \param [in] idx Index value to XOR in.
     \param [out] key1 First key. Label value of 0x00.
     \param [in] key1Sz Size of first key in bytes.
     \param [out] key2 Second key. Label value of 0x01.
@@ -29,14 +29,14 @@
     \code
     unsigned char key[16] = { ... };
     unsigned char salt[14] = { ... };
-    unsigned char index[6] = { ... };
+    unsigned char idx[6] = { ... };
     unsigned char keyE[16];
     unsigned char keyA[20];
     unsigned char keyS[14];
     int kdrIdx = 0; // Use all of index
     int ret;
 
-    ret = wc_SRTP_KDF(key, sizeof(key), salt, sizeof(salt), kdrIdx, index,
+    ret = wc_SRTP_KDF(key, sizeof(key), salt, sizeof(salt), kdrIdx, idx,
         keyE, sizeof(keyE), keyA, sizeof(keyA), keyS, sizeof(keyS));
     if (ret != 0) {
         WOLFSSL_MSG("wc_SRTP_KDF failed");
@@ -49,7 +49,7 @@
     \sa wc_SRTP_KDF_kdr_to_idx
 */
 int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
-        int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
+        int kdrIdx, const byte* idx, byte* key1, word32 key1Sz, byte* key2,
         word32 key2Sz, byte* key3, word32 key3Sz);
 
 /*!
@@ -69,7 +69,7 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
     \param [in] salt Random non-secret value.
     \param [in] saltSz Size of random in bytes.
     \param [in] kdrIdx Key derivation rate. kdr = 0 when -1, otherwise kdr = 2^kdrIdx.
-    \param [in] index Index value to XOR in.
+    \param [in] idx Index value to XOR in.
     \param [out] key1 First key. Label value of 0x00.
     \param [in] key1Sz Size of first key in bytes.
     \param [out] key2 Second key. Label value of 0x01.
@@ -82,14 +82,14 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
     \code
     unsigned char key[16] = { ... };
     unsigned char salt[14] = { ... };
-    unsigned char index[4] = { ... };
+    unsigned char idx[4] = { ... };
     unsigned char keyE[16];
     unsigned char keyA[20];
     unsigned char keyS[14];
     int kdrIdx = 0; // Use all of index
     int ret;
 
-    ret = wc_SRTCP_KDF(key, sizeof(key), salt, sizeof(salt), kdrIdx, index,
+    ret = wc_SRTCP_KDF(key, sizeof(key), salt, sizeof(salt), kdrIdx, idx,
         keyE, sizeof(keyE), keyA, sizeof(keyA), keyS, sizeof(keyS));
     if (ret != 0) {
         WOLFSSL_MSG("wc_SRTP_KDF failed");
@@ -102,7 +102,7 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
     \sa wc_SRTP_KDF_kdr_to_idx
 */
 int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
-        int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
+        int kdrIdx, const byte* idx, byte* key1, word32 key1Sz, byte* key2,
         word32 key2Sz, byte* key3, word32 key3Sz);
 /*!
     \ingroup SrtpKdf
@@ -121,7 +121,7 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
     \param [in] salt Random non-secret value.
     \param [in] saltSz Size of random in bytes.
     \param [in] kdrIdx Key derivation rate. kdr = 0 when -1, otherwise kdr = 2^kdrIdx.
-    \param [in] index Index value to XOR in.
+    \param [in] idx Index value to XOR in.
     \param [in] label Label to use when deriving key.
     \param [out] outKey Derived key.
     \param [in] outKeySz Size of derived key in bytes.
@@ -131,12 +131,12 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
     \code
     unsigned char key[16] = { ... };
     unsigned char salt[14] = { ... };
-    unsigned char index[6] = { ... };
+    unsigned char idx[6] = { ... };
     unsigned char keyE[16];
     int kdrIdx = 0; // Use all of index
     int ret;
 
-    ret = wc_SRTP_KDF_label(key, sizeof(key), salt, sizeof(salt), kdrIdx, index,
+    ret = wc_SRTP_KDF_label(key, sizeof(key), salt, sizeof(salt), kdrIdx, idx,
         WC_SRTP_LABEL_ENCRYPTION, keyE, sizeof(keyE));
     if (ret != 0) {
         WOLFSSL_MSG("wc_SRTP_KDF failed");
@@ -149,7 +149,7 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
     \sa wc_SRTP_KDF_kdr_to_idx
 */
 int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
-        word32 saltSz, int kdrIdx, const byte* index, byte label, byte* outKey,
+        word32 saltSz, int kdrIdx, const byte* idx, byte label, byte* outKey,
         word32 outKeySz);
 /*!
     \ingroup SrtpKdf
@@ -168,7 +168,7 @@ int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
     \param [in] salt Random non-secret value.
     \param [in] saltSz Size of random in bytes.
     \param [in] kdrIdx Key derivation rate. kdr = 0 when -1, otherwise kdr = 2^kdrIdx.
-    \param [in] index Index value to XOR in.
+    \param [in] idx Index value to XOR in.
     \param [in] label Label to use when deriving key.
     \param [out] outKey Derived key.
     \param [in] outKeySz Size of derived key in bytes.
@@ -178,13 +178,13 @@ int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
     \code
     unsigned char key[16] = { ... };
     unsigned char salt[14] = { ... };
-    unsigned char index[4] = { ... };
+    unsigned char idx[4] = { ... };
     unsigned char keyE[16];
     int kdrIdx = 0; // Use all of index
     int ret;
 
     ret = wc_SRTCP_KDF_label(key, sizeof(key), salt, sizeof(salt), kdrIdx,
-        index, WC_SRTCP_LABEL_ENCRYPTION, keyE, sizeof(keyE));
+        idx, WC_SRTCP_LABEL_ENCRYPTION, keyE, sizeof(keyE));
     if (ret != 0) {
         WOLFSSL_MSG("wc_SRTP_KDF failed");
     }
@@ -196,7 +196,7 @@ int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
     \sa wc_SRTP_KDF_kdr_to_idx
 */
 int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
-        word32 saltSz, int kdrIdx, const byte* index, byte label, byte* outKey,
+        word32 saltSz, int kdrIdx, const byte* idx, byte label, byte* outKey,
         word32 outKeySz);
 /*!
     \ingroup SrtpKdf

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -2847,7 +2847,7 @@ int wolfSSL_GetSessionIndex(WOLFSSL* ssl);
     \sa LockMutex
     \sa wolfSSL_GetSessionIndex
 */
-int wolfSSL_GetSessionAtIndex(int index, WOLFSSL_SESSION* session);
+int wolfSSL_GetSessionAtIndex(int idx, WOLFSSL_SESSION* session);
 
 /*!
     \ingroup IO

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -3269,25 +3269,25 @@ static int ProcessClientKeyExchange(const byte* input, int* sslBytes,
 static int ProcessKeyShare(KeyShareInfo* info, const byte* input, int len,
     word16 filter_group)
 {
-    int index = 0;
-    while (index < len) {
+    int idx = 0;
+    while (idx < len) {
         /* clear info (reset dh_key_bits and curve_id) */
         XMEMSET(info, 0, sizeof(KeyShareInfo));
 
         /* Named group and public key */
-        info->named_group = (word16)((input[index] << 8) | input[index+1]);
-        index += OPAQUE16_LEN;
+        info->named_group = (word16)((input[idx] << 8) | input[idx+1]);
+        idx += OPAQUE16_LEN;
         info->key_len = 0;
         info->key = NULL;
         /* If key was provided... (a hello_retry_request will not send a key) */
-        if (index + 2 <= len) {
-            info->key_len = (word16)((input[index] << 8) | input[index+1]);
-            index += OPAQUE16_LEN;
-            if (info->key_len == 0 || info->key_len > len - index) {
+        if (idx + 2 <= len) {
+            info->key_len = (word16)((input[idx] << 8) | input[idx+1]);
+            idx += OPAQUE16_LEN;
+            if (info->key_len == 0 || info->key_len > len - idx) {
                 return WOLFSSL_FATAL_ERROR;
             }
-            info->key = &input[index];
-            index += info->key_len;
+            info->key = &input[idx];
+            idx += info->key_len;
         }
 
         switch (info->named_group) {
@@ -7289,7 +7289,7 @@ static int addSecretNode(unsigned char* clientRandom,
                          unsigned char* secret,
                          char* error)
 {
-    int index = 0;
+    int idx = 0;
     int ret = 0;
     SecretNode* node = NULL;
 
@@ -7299,8 +7299,8 @@ static int addSecretNode(unsigned char* clientRandom,
 
     LOCK_SECRET_LIST();
 
-    index = secretHashFunction(clientRandom);
-    node = secretHashTable[index];
+    idx = secretHashFunction(clientRandom);
+    node = secretHashTable[idx];
 
     while(node) {
         /* Node already exists, so just add the requested secret */
@@ -7343,12 +7343,12 @@ static unsigned char* findSecret(unsigned char* clientRandom, int type)
 {
     unsigned char* secret = NULL;
     SecretNode* node = NULL;
-    unsigned int index = 0;
+    unsigned int idx = 0;
 
     LOCK_SECRET_LIST();
 
-    index = secretHashFunction(clientRandom);
-    node  = secretHashTable[index];
+    idx = secretHashFunction(clientRandom);
+    node  = secretHashTable[idx];
 
     while (node != NULL) {
         if (XMEMCMP(node->clientRandom,

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -8630,7 +8630,7 @@ void bench_srtpkdf(void)
     const byte *key = bench_key_buf;
     const byte salt[14] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                            0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e };
-    const byte index[6] = { 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA };
+    const byte idx[6] = { 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA };
     int kdrIdx = 0;
     int i;
     DECLARE_MULTI_VALUE_STATS_VARS()
@@ -8640,7 +8640,7 @@ void bench_srtpkdf(void)
     do {
         for (i = 0; i < numBlocks * 1000; i++) {
             ret = wc_SRTP_KDF(key, AES_128_KEY_SIZE, salt, sizeof(salt),
-                kdrIdx, index, keyE, AES_128_KEY_SIZE, keyA, sizeof(keyA),
+                kdrIdx, idx, keyE, AES_128_KEY_SIZE, keyA, sizeof(keyA),
                 keyS, sizeof(keyS));
             RECORD_MULTI_VALUE_STATS();
         }
@@ -8663,7 +8663,7 @@ void bench_srtpkdf(void)
     do {
         for (i = 0; i < numBlocks * 1000; i++) {
             ret = wc_SRTP_KDF(key, AES_256_KEY_SIZE, salt, sizeof(salt),
-                kdrIdx, index, keyE, AES_256_KEY_SIZE, keyA, sizeof(keyA),
+                kdrIdx, idx, keyE, AES_256_KEY_SIZE, keyA, sizeof(keyA),
                 keyS, sizeof(keyS));
             RECORD_MULTI_VALUE_STATS();
         }
@@ -8686,7 +8686,7 @@ void bench_srtpkdf(void)
     do {
         for (i = 0; i < numBlocks * 1000; i++) {
             ret = wc_SRTCP_KDF(key, AES_128_KEY_SIZE, salt, sizeof(salt),
-                kdrIdx, index, keyE, AES_128_KEY_SIZE, keyA, sizeof(keyA),
+                kdrIdx, idx, keyE, AES_128_KEY_SIZE, keyA, sizeof(keyA),
                 keyS, sizeof(keyS));
             RECORD_MULTI_VALUE_STATS();
         }
@@ -8709,7 +8709,7 @@ void bench_srtpkdf(void)
     do {
         for (i = 0; i < numBlocks * 1000; i++) {
             ret = wc_SRTCP_KDF(key, AES_256_KEY_SIZE, salt, sizeof(salt),
-                kdrIdx, index, keyE, AES_256_KEY_SIZE, keyA, sizeof(keyA),
+                kdrIdx, idx, keyE, AES_256_KEY_SIZE, keyA, sizeof(keyA),
                 keyS, sizeof(keyS));
             RECORD_MULTI_VALUE_STATS();
         }

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -902,12 +902,12 @@ int wc_SSH_KDF(byte hashId, byte keyId, byte* key, word32 keySz,
  * @param [in]  saltSz   Size of random value in bytes.
  * @param [in]  kdrIdx   Key derivation rate. kdr = 0 when -1, otherwise
  *                       kdr = 2^kdrIdx.
- * @param [in]  index    Index value to XOR in.
- * @param [in]  indexSz  Size of index value in bytes.
+ * @param [in]  idx      Index value to XOR in.
+ * @param [in]  idxSz    Size of index value in bytes.
  * @param [out] block    First block to encrypt.
  */
 static void wc_srtp_kdf_first_block(const byte* salt, word32 saltSz, int kdrIdx,
-        const byte* index, int indexSz, unsigned char* block)
+        const byte* idx, int idxSz, unsigned char* block)
 {
     int i;
 
@@ -924,21 +924,21 @@ static void wc_srtp_kdf_first_block(const byte* salt, word32 saltSz, int kdrIdx,
         /* Get the number of bits to shift index by. */
         word32 bits = kdrIdx & 0x7;
         /* Reduce index size by number of bytes to remove. */
-        indexSz -= kdrIdx >> 3;
+        idxSz -= kdrIdx >> 3;
 
         if ((kdrIdx & 0x7) == 0) {
             /* Just XOR in as no bit shifting. */
-            for (i = 0; i < indexSz; i++) {
-                block[i + WC_SRTP_MAX_SALT - indexSz] ^= index[i];
+            for (i = 0; i < idxSz; i++) {
+                block[i + WC_SRTP_MAX_SALT - idxSz] ^= idx[i];
             }
         }
         else {
             /* XOR in as bit shifted index. */
-            block[WC_SRTP_MAX_SALT - indexSz] ^= (byte)(index[0] >> bits);
-            for (i = 1; i < indexSz; i++) {
-                block[i + WC_SRTP_MAX_SALT - indexSz] ^=
-                    (byte)((index[i-1] << (8 - bits)) |
-                           (index[i+0] >>      bits ));
+            block[WC_SRTP_MAX_SALT - idxSz] ^= (byte)(idx[0] >> bits);
+            for (i = 1; i < idxSz; i++) {
+                block[i + WC_SRTP_MAX_SALT - idxSz] ^=
+                    (byte)((idx[i-1] << (8 - bits)) |
+                           (idx[i+0] >>      bits ));
             }
         }
     }
@@ -955,7 +955,7 @@ static void wc_srtp_kdf_first_block(const byte* salt, word32 saltSz, int kdrIdx,
  * @param [in]      aes      AES object to encrypt with.
  * @return  0 on success.
  */
-static int wc_srtp_kdf_derive_key(byte* block, int indexSz, byte label,
+static int wc_srtp_kdf_derive_key(byte* block, int idxSz, byte label,
         byte* key, word32 keySz, Aes* aes)
 {
     int i;
@@ -964,7 +964,7 @@ static int wc_srtp_kdf_derive_key(byte* block, int indexSz, byte label,
     int blocks = (int)(keySz / WC_AES_BLOCK_SIZE);
 
     /* XOR in label. */
-    block[WC_SRTP_MAX_SALT - indexSz - 1] ^= label;
+    block[WC_SRTP_MAX_SALT - idxSz - 1] ^= label;
     for (i = 0; (ret == 0) && (i < blocks); i++) {
         /* Set counter. */
         block[15] = (byte)i;
@@ -988,7 +988,7 @@ static int wc_srtp_kdf_derive_key(byte* block, int indexSz, byte label,
         }
     }
     /* XOR out label. */
-    block[WC_SRTP_MAX_SALT - indexSz - 1] ^= label;
+    block[WC_SRTP_MAX_SALT - idxSz - 1] ^= label;
 
     return ret;
 }
@@ -1018,7 +1018,7 @@ static int wc_srtp_kdf_derive_key(byte* block, int indexSz, byte label,
  * @return  0 on success.
  */
 int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
-        int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
+        int kdrIdx, const byte* idx, byte* key1, word32 key1Sz, byte* key2,
         word32 key2Sz, byte* key3, word32 key3Sz)
 {
     int ret = 0;
@@ -1056,7 +1056,7 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
 
     /* Calculate first block that can be used in each derivation. */
     if (ret == 0) {
-        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, index, WC_SRTP_INDEX_LEN,
+        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, idx, WC_SRTP_INDEX_LEN,
             block);
     }
 
@@ -1109,7 +1109,7 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
  * @return  0 on success.
  */
 int wc_SRTCP_KDF_ex(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
-        int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
+        int kdrIdx, const byte* idx, byte* key1, word32 key1Sz, byte* key2,
         word32 key2Sz, byte* key3, word32 key3Sz, int idxLenIndicator)
 {
     int ret = 0;
@@ -1156,7 +1156,7 @@ int wc_SRTCP_KDF_ex(const byte* key, word32 keySz, const byte* salt, word32 salt
 
     /* Calculate first block that can be used in each derivation. */
     if (ret == 0) {
-        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, index, idxLen, block);
+        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, idx, idxLen, block);
     }
 
     /* Calculate first key if required. */
@@ -1184,11 +1184,11 @@ int wc_SRTCP_KDF_ex(const byte* key, word32 keySz, const byte* salt, word32 salt
 }
 
 int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
-        int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
+        int kdrIdx, const byte* idx, byte* key1, word32 key1Sz, byte* key2,
         word32 key2Sz, byte* key3, word32 key3Sz)
 {
     /* The default 32-bit IDX expected by many implementations */
-    return wc_SRTCP_KDF_ex(key, keySz, salt, saltSz, kdrIdx, index,
+    return wc_SRTCP_KDF_ex(key, keySz, salt, saltSz, kdrIdx, idx,
                            key1, key1Sz, key2, key2Sz, key3, key3Sz,
                            WC_SRTCP_32BIT_IDX);
 }
@@ -1214,7 +1214,7 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
  * @return  0 on success.
  */
 int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
-        word32 saltSz, int kdrIdx, const byte* index, byte label, byte* outKey,
+        word32 saltSz, int kdrIdx, const byte* idx, byte label, byte* outKey,
         word32 outKeySz)
 {
     int ret = 0;
@@ -1253,7 +1253,7 @@ int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
 
     /* Calculate first block that can be used in each derivation. */
     if (ret == 0) {
-        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, index, WC_SRTP_INDEX_LEN,
+        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, idx, WC_SRTP_INDEX_LEN,
             block);
     }
     if (ret == 0) {
@@ -1293,7 +1293,7 @@ int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
  * @return  0 on success.
  */
 int wc_SRTCP_KDF_label(const byte* key, word32 keySz, const byte* salt,
-        word32 saltSz, int kdrIdx, const byte* index, byte label, byte* outKey,
+        word32 saltSz, int kdrIdx, const byte* idx, byte label, byte* outKey,
         word32 outKeySz)
 {
     int ret = 0;
@@ -1332,7 +1332,7 @@ int wc_SRTCP_KDF_label(const byte* key, word32 keySz, const byte* salt,
 
     /* Calculate first block that can be used in each derivation. */
     if (ret == 0) {
-        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, index, WC_SRTCP_INDEX_LEN,
+        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, idx, WC_SRTCP_INDEX_LEN,
             block);
     }
     if (ret == 0) {

--- a/wolfcrypt/src/port/cuda/aes-cuda.cu
+++ b/wolfcrypt/src/port/cuda/aes-cuda.cu
@@ -664,7 +664,7 @@ __global__ void AesEncrypt_C_CUDA(word32* rkBase, const byte* inBlockBase, byte*
     word32 s0, s1, s2, s3;
     word32 t0, t1, t2, t3;
     word32 sBox;
-    int index = blockIdx.x * blockDim.x + threadIdx.x;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int stride = blockDim.x * gridDim.x;
     const byte* inBlock = inBlockBase;
     byte* outBlock = outBlockBase;

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -535,7 +535,7 @@ static int Pkcs11Slot_FindByTokenName(Pkcs11Dev* dev,
     CK_RV         rv;
     CK_ULONG      slotCnt = 0;
     CK_TOKEN_INFO tinfo;
-    int           index = -1;
+    int           idx = -1;
     CK_SLOT_ID*   slot = NULL;
 
     rv = dev->func->C_GetSlotList(CK_TRUE, NULL, &slotCnt);
@@ -547,12 +547,12 @@ static int Pkcs11Slot_FindByTokenName(Pkcs11Dev* dev,
         rv = dev->func->C_GetSlotList(CK_TRUE, slot, &slotCnt);
         if (rv != CKR_OK)
             goto out;
-        for (index = 0; index < (int)slotCnt; index++) {
-            rv = dev->func->C_GetTokenInfo(slot[index], &tinfo);
+        for (idx = 0; idx < (int)slotCnt; idx++) {
+            rv = dev->func->C_GetTokenInfo(slot[idx], &tinfo);
             PKCS11_RV("C_GetTokenInfo", rv);
             if (rv == CKR_OK &&
                 XMEMCMP(tinfo.label, tokenName, tokenNameSz) == 0) {
-                ret =  (int)slot[index];
+                ret =  (int)slot[idx];
                 break;
             }
         }

--- a/wolfssl/wolfcrypt/kdf.h
+++ b/wolfssl/wolfcrypt/kdf.h
@@ -147,19 +147,19 @@ enum {
 #define WC_SRTP_MAX_SALT    14
 
 WOLFSSL_API int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt,
-    word32 saltSz, int kdrIdx, const byte* index, byte* key1, word32 key1Sz,
+    word32 saltSz, int kdrIdx, const byte* idx, byte* key1, word32 key1Sz,
     byte* key2, word32 key2Sz, byte* key3, word32 key3Sz);
 WOLFSSL_API int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt,
-    word32 saltSz, int kdrIdx, const byte* index, byte* key1, word32 key1Sz,
+    word32 saltSz, int kdrIdx, const byte* idx, byte* key1, word32 key1Sz,
     byte* key2, word32 key2Sz, byte* key3, word32 key3Sz);
 WOLFSSL_API int wc_SRTCP_KDF_ex(const byte* key, word32 keySz, const byte* salt,
-    word32 saltSz, int kdrIdx, const byte* index, byte* key1, word32 key1Sz,
+    word32 saltSz, int kdrIdx, const byte* idx, byte* key1, word32 key1Sz,
     byte* key2, word32 key2Sz, byte* key3, word32 key3Sz, int idxLenIndicator);
 WOLFSSL_API int wc_SRTP_KDF_label(const byte* key, word32 keySz,
-    const byte* salt, word32 saltSz, int kdrIdx, const byte* index, byte label,
+    const byte* salt, word32 saltSz, int kdrIdx, const byte* idx, byte label,
     byte* outKey, word32 outKeySz);
 WOLFSSL_API int wc_SRTCP_KDF_label(const byte* key, word32 keySz,
-    const byte* salt, word32 saltSz, int kdrIdx, const byte* index, byte label,
+    const byte* salt, word32 saltSz, int kdrIdx, const byte* idx, byte label,
     byte* outKey, word32 outKeySz);
 
 WOLFSSL_API int wc_SRTP_KDF_kdr_to_idx(word32 kdr);


### PR DESCRIPTION
Fixes https://github.com/wolfSSL/wolfssl/issues/8731

Portability fix: Issue with shadow declaration of "index" from `/usr/include/string.h` which is: `extern char *index (__const char *__s, int __c) __THROW __attribute_pure__;`.