### PR TITLE
Guard some benchmark tests by NO_SW_BENCH

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1821,10 +1821,12 @@ static const char* bench_result_words2[][5] = {
     #ifndef NO_HW_BENCH
         #define BENCH_DEVID
     #endif
-    #ifndef HAVE_RENESAS_SYNC
-        #define BENCH_DEVID_GET_NAME(useDeviceID) (useDeviceID) ? "HW" : "SW"
-    #else
-        #define BENCH_DEVID_GET_NAME(useDeviceID) ""
+    #if !defined(BENCH_DEVID_GET_NAME)
+        #ifndef HAVE_RENESAS_SYNC
+            #define BENCH_DEVID_GET_NAME(useDeviceID) (useDeviceID) ? "HW" : "SW"
+        #else
+            #define BENCH_DEVID_GET_NAME(useDeviceID) ""
+        #endif
     #endif
 #else
     #define BENCH_DEVID_GET_NAME(useDeviceID) ""
@@ -3260,7 +3262,8 @@ static void* benchmarks_do(void* args)
     #endif
     #if ((defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_3DES)) || \
          defined(HAVE_INTEL_QA_SYNC) || defined(HAVE_CAVIUM_OCTEON_SYNC) || \
-         defined(HAVE_RENESAS_SYNC)  || defined(WOLFSSL_CAAM)) || \
+         defined(HAVE_RENESAS_SYNC)  || defined(WOLFSSL_CAAM) || \
+         defined(BENCH_DEVID)) || \
          ((defined(WOLFSSL_MAX3266X) || defined(WOLFSSL_MAX3266X_OLD)) && \
          defined(WOLF_CRYPTO_CB)) && !defined(NO_HW_BENCH)
         bench_aes_aad_options_wrap(bench_aesgcm, 1);
@@ -3297,7 +3300,9 @@ static void* benchmarks_do(void* args)
 #endif
 #ifdef WOLFSSL_AES_COUNTER
     if (bench_all || (bench_cipher_algs & BENCH_AES_CTR)) {
+    #ifndef NO_SW_BENCH
         bench_aesctr(0);
+    #endif
     #ifdef BENCH_DEVID
         bench_aesctr(1);
     #endif
@@ -3833,7 +3838,9 @@ static void* benchmarks_do(void* args)
 
 #ifdef HAVE_CURVE25519
     if (bench_all || (bench_asym_algs & BENCH_CURVE25519_KEYGEN)) {
+    #ifndef NO_SW_BENCH
         bench_curve25519KeyGen(0);
+    #endif
     #ifdef BENCH_DEVID
         bench_curve25519KeyGen(1);
     #endif


### PR DESCRIPTION
# Description

Guard benchmark tests by NO_SW_BENCH so that not to run duplicate.
Allow to externally define BENCH_DEVID_GET_NAME

# Testing

Run benchmark on RH850

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
