### PR TITLE
20250510-testwolfcrypt-fix-exit-status

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2595,7 +2595,10 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #ifndef NO_MAIN_FUNCTION
     int main(int argc, char** argv)
     {
-        return (int)wolfcrypt_test_main(argc, argv);
+        if (wolfcrypt_test_main(argc, argv) >= 0)
+            return 0;
+        else
+            return 1;
     }
 #endif
 


### PR DESCRIPTION
`wolfcrypt/test/test.c`: in `main()`, `return` (exit with) `0` for success and `1` for failure.

Once in a blue moon, a `testwolfcrypt` failure code is zero mod 256, which results in a spurious zero exit status.  That blue moon rose over last night's nightlies, for `IN_CORE_FIPS_E`.  Lesson learned.
