### PR TITLE
Fix for Curve25519 and static ephemeral issue with blinding

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -45,6 +45,7 @@ jobs:
           '--enable-ascon --enable-experimental',
           '--enable-ascon CPPFLAGS=-DWOLFSSL_ASCON_UNROLL --enable-experimental',
           '--enable-all CPPFLAGS=''-DNO_AES_192 -DNO_AES_256'' ',
+          '--enable-sniffer --enable-curve25519 --enable-curve448 --enable-enckeys CFLAGS=-DWOLFSSL_DH_EXTRA',
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -24620,8 +24620,13 @@ int wolfSSL_StaticEphemeralKeyLoad(WOLFSSL* ssl, int keyAlgo, void* keyPtr)
             if (der != NULL) {
                 curve25519_key* key = (curve25519_key*)keyPtr;
                 WOLFSSL_MSG("Using static X25519 key");
-                ret = wc_Curve25519PrivateKeyDecode(der->buffer, &idx, key,
-                    der->length);
+
+            #ifdef WOLFSSL_CURVE25519_BLINDING
+                ret = wc_curve25519_set_rng(key, ssl->rng);
+                if (ret == 0)
+            #endif
+                    ret = wc_Curve25519PrivateKeyDecode(der->buffer, &idx, key,
+                        der->length);
             }
             break;
     #endif


### PR DESCRIPTION
# Description

Fix for Curve25519 and static ephemeral issue with curve25519 blinding. 
Added new test case (used by wolfKeyMgr).

Fixes wolfKeyMgr nightly test: https://github.com/wolfSSL/wolfKeyMgr/actions/runs/14950602954

Possibly broken since: https://github.com/wolfSSL/wolfssl/pull/8392

# Testing

```
./configure --enable-sniffer --enable-curve25519 --enable-curve448 --enable-enckeys CFLAGS=-DWOLFSSL_DH_EXTRA  && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
