### PR TITLE
Add sniffer cleanup API's

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -7626,6 +7626,106 @@ int ssl_LoadSecretsFromKeyLogFile(const char* keylogfile, char* error)
 #endif /* WOLFSSL_SNIFFER_KEYLOGFILE */
 
 
+/*
+ * Removes a session from the SessionTable based on client/server IP & ports
+ * Returns 0 if a session was found and freed, -1 otherwise
+ */
+int ssl_RemoveSession(const char* clientIp, int clientPort,
+                      const char* serverIp, int serverPort,
+                      char* error)
+{
+    IpAddrInfo clientAddr;
+    IpAddrInfo serverAddr;
+    IpInfo ipInfo;
+    TcpInfo tcpInfo;
+    SnifferSession* session;
+    int ret = -1;  /* Default to not found */
+    word32 row;
+
+    if (clientIp == NULL || serverIp == NULL) {
+        SetError(BAD_IPVER_STR, error, NULL, 0);
+        return ret;
+    }
+
+    /* Set up client IP address */
+    clientAddr.version = IPV4;
+    clientAddr.ip4 = XINET_ADDR(clientIp);
+    if (clientAddr.ip4 == XINADDR_NONE) {
+    #ifdef FUSION_RTOS
+        if (XINET_PTON(AF_INET6, clientIp, clientAddr.ip6,
+                       sizeof(clientAddr.ip4)) == 1)
+    #else
+        if (XINET_PTON(AF_INET6, clientIp, clientAddr.ip6) == 1)
+    #endif
+        {
+            clientAddr.version = IPV6;
+        }
+        else {
+            SetError(BAD_IPVER_STR, error, NULL, 0);
+            return ret;
+        }
+    }
+
+    /* Set up server IP address */
+    serverAddr.version = IPV4;
+    serverAddr.ip4 = XINET_ADDR(serverIp);
+    if (serverAddr.ip4 == XINADDR_NONE) {
+    #ifdef FUSION_RTOS
+        if (XINET_PTON(AF_INET6, serverIp, serverAddr.ip6,
+                       sizeof(serverAddr.ip4)) == 1)
+    #else
+        if (XINET_PTON(AF_INET6, serverIp, serverAddr.ip6) == 1)
+    #endif
+        {
+            serverAddr.version = IPV6;
+        }
+        else {
+            SetError(BAD_IPVER_STR, error, NULL, 0);
+            return ret;
+        }
+    }
+
+    XMEMSET(&ipInfo, 0, sizeof(ipInfo));
+    XMEMSET(&tcpInfo, 0, sizeof(tcpInfo));
+
+    /* Set up client->server direction */
+    ipInfo.src = clientAddr;
+    ipInfo.dst = serverAddr;
+    tcpInfo.srcPort = clientPort;
+    tcpInfo.dstPort = serverPort;
+
+    /* Calculate the hash row for this session */
+    row = SessionHash(&ipInfo, &tcpInfo);
+
+    LOCK_SESSION();
+
+    /* Search only the specific row in the session table */
+    session = SessionTable[row];
+
+    while (session) {
+        SnifferSession* next = session->next;
+
+        /* Check if this session matches the specified client/server IP/port */
+        if (MatchAddr(session->client, clientAddr) &&
+            MatchAddr(session->server, serverAddr) &&
+            session->cliPort == clientPort &&
+            session->srvPort == serverPort) {
+
+            /* Use RemoveSession to remove and free the session */
+            RemoveSession(session, NULL, NULL, row);
+            ret = 0;  /* Session found and freed */
+            break;
+        }
+
+        session = next;
+    }
+
+    UNLOCK_SESSION();
+
+    return ret;
+}
+
+
 #undef ERROR_OUT
 
 #endif /* WOLFSSL_SNIFFER */

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -5129,6 +5129,12 @@ static void RemoveStaleSessions(void)
     }
 }
 
+void ssl_RemoveStaleSessions(void)
+{
+    LOCK_SESSION();
+    RemoveStaleSessions();
+    UNLOCK_SESSION();
+}
 
 /* Create a new Sniffer Session */
 static SnifferSession* CreateSession(IpInfo* ipInfo, TcpInfo* tcpInfo,

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -345,6 +345,11 @@ typedef int (*SSLSnifferSecretCb)(unsigned char* client_random,
 
 #endif /* WOLFSSL_SNIFFER_KEYLOGFILE */
 
+WOLFSSL_API
+SSL_SNIFFER_API int ssl_RemoveSession(const char* clientIp, int clientPort,
+                                      const char* serverIp, int serverPort,
+                                      char* error);
+
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -150,6 +150,8 @@ SSL_SNIFFER_API void ssl_InitSniffer_ex2(int threadNum);
 WOLFSSL_API
 SSL_SNIFFER_API void ssl_FreeSniffer(void);
 
+WOLFSSL_API
+SSL_SNIFFER_API void ssl_RemoveStaleSessions(void);
 
 /* ssl_SetPrivateKey typeKs */
 enum {


### PR DESCRIPTION
# Description

- Expose RemoveStaleSessions sniffer API so that users can remove sessions that have timed-out. Currently, this function only gets called when the number of sessions reaches a certain number
- Add `ssl_RemoveSession()` function. Allows users to remove/free specific TLS sessions using client/server IP & ports

Fixes zd#19853

# Testing

./configure --enable-sniffer && make

Tested the new ssl_RemoveSession API with the snifftest and the patch below:
```
diff --git a/sslSniffer/sslSnifferTest/snifftest.c b/sslSniffer/sslSnifferTest/snifftest.c
index 8eb25affa..e1864e007 100644
--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -1360,6 +1360,9 @@ int main(int argc, char** argv)
              * bad packet was encountered */
             hadBadPacket = DecodePacket((byte*)packet, header->caplen,
                                         packetNumber,err);
+
+            if(packetNumber == 6)
+                ssl_RemoveSession("127.0.0.1",49275,"127.0.0.1",11111,err);
 #endif
         }
         /* check if we are done reading file */
```

And made sure the session was getting removed as expected:
```
./sslSniffer/sslSnifferTest/snifftest -pcap ./scripts/sniffer-tls13-ecc.pcap -key ./certs/statickeys/ecc-secp256r1.pem -server 127.0.0.1 -port 11111
snifftest 5.8.0
sniffer features: key_callback tls_v13 tls_v12 static_ephemeral sni extended_master rsa dh ecc rsa_static dh_static 

Using packet filter: (ip6 or ip) and tcp and port 11111
ssl_Decode ret = -1, Session Not Found on packet number 7
ssl_Decode ret = -1, Session Not Found on packet number 9
ssl_Decode ret = -1, Session Not Found on packet number 11
ssl_Decode ret = -1, Session Not Found on packet number 13
ssl_Decode ret = -1, Session Not Found on packet number 15
ssl_Decode ret = -1, Session Not Found on packet number 17
ssl_Decode ret = -1, Session Not Found on packet number 19
ssl_Decode ret = -1, Session Not Found on packet number 21
ssl_Decode ret = -1, Session Not Found on packet number 22
ssl_Decode ret = -1, Session Not Found on packet number 25
ssl_Decode ret = -1, Session Not Found on packet number 27
ssl_Decode ret = -1, Session Not Found on packet number 28
ssl_Decode ret = -1, Session Not Found on packet number 33
SSL App Data(60:14):hello wolfssl!
SSL App Data(62:22):I hear you fa shizzle!
SSL App Data(94:14):hello wolfssl!

```
# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
