### PR TITLE
20250514-WOLFSSL_DEBUG_PRINTF-C89

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3250,10 +3250,8 @@ static int ecc_mulmod(const mp_int* k, ecc_point* P, ecc_point* Q,
 #else
         /* Swap R[0] and R[1] if other index is needed. */
         swap ^= (int)b;
-        if (err == MP_OKAY) {
-            err = mp_cond_swap_ct_ex(R[0]->x, R[1]->x, (int)modulus->used, swap,
-                tmp);
-        }
+        err = mp_cond_swap_ct_ex(R[0]->x, R[1]->x, (int)modulus->used, swap,
+            tmp);
         if (err == MP_OKAY) {
             err = mp_cond_swap_ct_ex(R[0]->y, R[1]->y, (int)modulus->used, swap,
                 tmp);

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -245,20 +245,30 @@ static void wolfssl_log(const int logLevel, const char* const file_name,
     else {
 #if defined(WOLFSSL_USER_LOG)
         WOLFSSL_USER_LOG(logMessage);
-#elif defined(WOLFSSL_DEBUG_PRINTF)
+#elif defined(WOLFSSL_DEBUG_PRINTF_FN)
+    #ifdef WOLFSSL_MDK_ARM
+        fflush(stdout);
+    #endif
         if (log_prefix != NULL) {
             if (file_name != NULL)
-                WOLFSSL_DEBUG_PRINTF("[%s]: [%s L %d] %s\n",
+                WOLFSSL_DEBUG_PRINTF_FN(WOLFSSL_DEBUG_PRINTF_FIRST_ARGS
+                        "[%s]: [%s L %d] %s\n",
                         log_prefix, file_name, line_number, logMessage);
             else
-                WOLFSSL_DEBUG_PRINTF("[%s]: %s\n", log_prefix, logMessage);
+                WOLFSSL_DEBUG_PRINTF_FN(WOLFSSL_DEBUG_PRINTF_FIRST_ARGS
+                        "[%s]: %s\n", log_prefix, logMessage);
         } else {
             if (file_name != NULL)
-                WOLFSSL_DEBUG_PRINTF("[%s L %d] %s\n",
+                WOLFSSL_DEBUG_PRINTF_FN(WOLFSSL_DEBUG_PRINTF_FIRST_ARGS
+                        "[%s L %d] %s\n",
                         file_name, line_number, logMessage);
             else
-                WOLFSSL_DEBUG_PRINTF("%s\n", logMessage);
+                WOLFSSL_DEBUG_PRINTF_FN(WOLFSSL_DEBUG_PRINTF_FIRST_ARGS
+                        "%s\n", logMessage);
         }
+    #ifdef WOLFSSL_MDK_ARM
+        fflush(stdout);
+    #endif
 #elif defined(ARDUINO)
         wolfSSL_Arduino_Serial_Print(logMessage);
 #elif defined(WOLFSSL_UTASKER)

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -309,46 +309,55 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
     int dc_log_printf(char*, ...);
 #endif
 
-#ifdef WOLFSSL_DEBUG_PRINTF
+#ifdef WOLFSSL_DEBUG_PRINTF_FN
     /* user-supplied definition */
 #elif defined(ARDUINO)
     /* ARDUINO only has print and sprintf, no printf. */
 #elif defined(WOLFSSL_LOG_PRINTF) || defined(WOLFSSL_DEOS)
-    #define WOLFSSL_DEBUG_PRINTF(...) printf(__VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN printf
 #elif defined(THREADX) && !defined(THREADX_NO_DC_PRINTF)
-    #define WOLFSSL_DEBUG_PRINTF(...) dc_log_printf(__VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN dc_log_printf
 #elif defined(MICRIUM)
-    #define WOLFSSL_DEBUG_PRINTF(...) BSP_Ser_Printf(__VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN BSP_Ser_Printf
 #elif defined(WOLFSSL_MDK_ARM)
-    #define WOLFSSL_DEBUG_PRINTF(...) do { \
-            fflush(stdout);                \
-            printf(__VA_ARGS__);           \
-            fflush(stdout);                \
-        } while (0)
+    #define WOLFSSL_DEBUG_PRINTF_FN printf
 #elif defined(WOLFSSL_UTASKER)
     /* WOLFSSL_UTASKER only has fnDebugMsg and related primitives, no printf. */
 #elif defined(MQX_USE_IO_OLD)
-    #define WOLFSSL_DEBUG_PRINTF(...) fprintf(_mqxio_stderr, __VAR_ARGS)
+    #define WOLFSSL_DEBUG_PRINTF_FN fprintf
+    #define WOLFSSL_DEBUG_PRINTF_FIRST_ARGS _mqxio_stderr,
 #elif defined(WOLFSSL_APACHE_MYNEWT)
-    #define WOLFSSL_DEBUG_PRINTF(...) LOG_DEBUG(&mynewt_log, \
-        LOG_MODULE_DEFAULT, __VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN LOG_DEBUG
+    #define WOLFSSL_DEBUG_PRINTF_FIRST_ARGS &mynewt_log, LOG_MODULE_DEFAULT,
 #elif defined(WOLFSSL_ESPIDF)
-    #define WOLFSSL_DEBUG_PRINTF(...) ESP_LOGI("wolfssl", __VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN ESP_LOGI
+    #define WOLFSSL_DEBUG_PRINTF_FIRST_ARGS "wolfssl",
 #elif defined(WOLFSSL_ZEPHYR)
-    #define WOLFSSL_DEBUG_PRINTF(...) printk(__VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN printk
 #elif defined(WOLFSSL_TELIT_M2MB)
-    #define WOLFSSL_DEBUG_PRINTF(...) M2M_LOG_INFO(__VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN M2M_LOG_INFO
 #elif defined(WOLFSSL_ANDROID_DEBUG)
-    #define WOLFSSL_DEBUG_PRINTF(...) __android_log_print(ANDROID_LOG_VERBOSE, \
-                                                    "[wolfSSL]", __VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN __android_log_print
+    #define WOLFSSL_DEBUG_PRINTF_FIRST_ARGS ANDROID_LOG_VERBOSE, "[wolfSSL]"
 #elif defined(WOLFSSL_XILINX)
-    #define WOLFSSL_DEBUG_PRINTF(...) xil_printf(__VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN xil_printf
 #elif defined(WOLFSSL_LINUXKM)
-    #define WOLFSSL_DEBUG_PRINTF(...) printk(__VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN printk
 #elif defined(WOLFSSL_RENESAS_RA6M4)
-    #define WOLFSSL_DEBUG_PRINTF(...) myprintf(__VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN myprintf
 #else
-    #define WOLFSSL_DEBUG_PRINTF(...) fprintf(stderr, __VA_ARGS__)
+    #define WOLFSSL_DEBUG_PRINTF_FN fprintf
+    #define WOLFSSL_DEBUG_PRINTF_FIRST_ARGS stderr,
+#endif
+
+#ifndef WOLFSSL_DEBUG_PRINTF_FIRST_ARGS
+    #define WOLFSSL_DEBUG_PRINTF_FIRST_ARGS
+#endif
+
+#if defined(WOLFSSL_DEBUG_PRINTF_FN) && !defined(WOLFSSL_DEBUG_PRINTF) && \
+    !defined(WOLF_NO_VARIADIC_MACROS)
+    #define WOLFSSL_DEBUG_PRINTF(...) \
+        WOLFSSL_DEBUG_PRINTF_FN(WOLFSSL_DEBUG_PRINTF_FIRST_ARGS __VA_ARGS__)
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
`wolfssl/wolfcrypt/logging.h` and `wolfcrypt/src/logging.c`: add `WOLFSSL_DEBUG_PRINTF_FN` and `WOLFSSL_DEBUG_PRINTF_FIRST_ARGS`, and update refactored `wolfssl_log()`, for C89 compat.

`wolfcrypt/src/ecc.c`: fix `identicalInnerCondition` in ecc_mulmod().

tested with `wolfssl-multi-test.sh ... check-source-text allcryptonly-gcc-c89`
