### PR TITLE
Coverity: address uninitialized scalar variable issues

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -34335,6 +34335,7 @@ static int test_HMAC_CTX_helper(const EVP_MD* type, unsigned char* digest,
     unsigned int digestSz2 = 64;
 
     HMAC_CTX_init(&ctx1);
+    HMAC_CTX_init(&ctx2);
 
     ExpectIntEQ(HMAC_Init(&ctx1, (const void*)key, keySz, type), SSL_SUCCESS);
     ExpectIntEQ(HMAC_Update(&ctx1, msg, msgSz), SSL_SUCCESS);
@@ -34813,13 +34814,13 @@ static int test_wolfSSL_DES(void)
         { 0xFE, 0xE0, 0xFE, 0xE0, 0xFE, 0xF1, 0xFE, 0xF1 }
     };
 
-    DES_check_key(1);
-    DES_set_key(&myDes, &key);
-
     /* check, check of odd parity */
     XMEMSET(myDes, 4, sizeof(const_DES_cblock));
-    myDes[0] = 6; /* set even parity */
     XMEMSET(key, 5, sizeof(DES_key_schedule));
+
+    DES_set_key(&myDes, &key);
+
+    myDes[0] = 6; /* set even parity */
     ExpectIntEQ(DES_set_key_checked(&myDes, &key), -1);
     ExpectIntNE(key[0], myDes[0]); /* should not have copied over key */
     ExpectIntEQ(DES_set_key_checked(NULL, NULL), -2);

--- a/tests/api/test_digest.h
+++ b/tests/api/test_digest.h
@@ -557,6 +557,8 @@ do {                                                                           \
     byte data[WC_##upper##_BLOCK_SIZE];                                        \
                                                                                \
     XMEMSET(data, 0xa5, sizeof(data));                                         \
+    XMEMSET(&src, 0, sizeof(src));                                              \
+    XMEMSET(&dst, 0, sizeof(dst));                                              \
                                                                                \
     ExpectIntEQ(wc_Init##name(&src, HEAP_HINT, INVALID_DEVID), 0);             \
     XMEMSET(&dst, 0, sizeof(dst));                                             \

--- a/tests/api/test_sha3.c
+++ b/tests/api/test_sha3.c
@@ -71,6 +71,8 @@ do {                                                                           \
     const char* emptyHash = emptyHashStr;                                      \
     const char* abcHash = abcHashStr;                                          \
                                                                                \
+    XMEMSET(&dgst, 0, sizeof(dgst));                                           \
+                                                                               \
     ExpectIntEQ(wc_Init##name(&dgst, HEAP_HINT, INVALID_DEVID), 0);            \
                                                                                \
     ExpectIntEQ(wc_##name##_GetHash(NULL, NULL),                               \

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -26328,7 +26328,7 @@ int wc_EncryptedInfoParse(EncryptedInfo* info, const char** pBuffer,
             newline = XSTRNSTR(finish, "\r", min(finishSz, PEM_LINE_LEN));
 
             /* get cipher name */
-            if (NAME_SZ < (finish - start)) /* buffer size of info->name */
+            if (NAME_SZ <= (finish - start)) /* buffer size of info->name */
                 return BUFFER_E;
             if (XMEMCPY(info->name, start, (size_t)(finish - start)) == NULL)
                 return BUFFER_E;


### PR DESCRIPTION
# Description

Initializes variables in tests/api.c, tests/api/test_digest.h and tests/api/test_sha3.c to pacify uninitialized scalar variable Coverity issues: CI#299549, 337256, 511407, and 511409.

Also addresses PR #8724 fix.