### PR TITLE
Drop DTLS packets with bogus minor version number

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -11788,6 +11788,10 @@ static int GetDtlsRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
     *inOutIdx += ENUM_LEN + VERSION_SZ;
     ato16(ssl->buffers.inputBuffer.buffer + *inOutIdx, &ssl->keys.curEpoch);
 
+    if (rh->pvMajor == DTLS_MAJOR && rh->pvMinor == DTLS_BOGUS_MINOR) {
+        return SEQUENCE_ERROR;
+    }
+
 #ifdef WOLFSSL_DTLS_CID
     if (rh->type == dtls12_cid && (cidSz = DtlsGetCidRxSize(ssl)) == 0)
         return DTLS_CID_ERROR;

--- a/tests/api.c
+++ b/tests/api.c
@@ -68023,6 +68023,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_dtls_cid_parse),
     TEST_DECL(test_dtls13_epochs),
     TEST_DECL(test_dtls13_ack_order),
+    TEST_DECL(test_dtls_version_checking),
     TEST_DECL(test_ocsp_status_callback),
     TEST_DECL(test_ocsp_basic_verify),
     TEST_DECL(test_ocsp_response_parsing),

--- a/tests/api/test_dtls.h
+++ b/tests/api/test_dtls.h
@@ -27,5 +27,6 @@ int test_dtls13_basic_connection_id(void);
 int test_wolfSSL_dtls_cid_parse(void);
 int test_dtls13_epochs(void);
 int test_dtls13_ack_order(void);
+int test_dtls_version_checking(void);
 
 #endif /* TESTS_API_DTLS_H */


### PR DESCRIPTION
DTLS v1.1 is not a valid version, ignore record using this version.

Fix #5226 