### PR TITLE
20250515-fips-armasm-fixes

### DIFF
--- a/.github/workflows/smallStackSize.yml
+++ b/.github/workflows/smallStackSize.yml
@@ -44,9 +44,6 @@ jobs:
       - uses: actions/checkout@v4
         name: Checkout wolfSSL
 
-      - name: install_multilib
-        run: sudo apt-get install -y gcc-multilib
-
       - name: Build wolfCrypt with smallstack and stack depth warnings, and run testwolfcrypt
         run: |
           ./autogen.sh || $(exit 2)

--- a/configure.ac
+++ b/configure.ac
@@ -1174,6 +1174,15 @@ else
     DEFAULT_ENABLED_ALL_ASM=no
 fi
 
+if test "$ENABLED_FIPS" = "yes" && test "$HAVE_FIPS_VERSION" -lt 6
+then
+    case "$host_cpu" in
+        *x86_64*|*amd64*) ;;
+        *) DEFAULT_ENABLED_ALL_ASM=no
+           ;;
+    esac
+fi
+
 AC_ARG_ENABLE([all-asm],
     [AS_HELP_STRING([--enable-all-asm],[Enable all applicable assembly accelerations (default: disabled)])],
     [ ENABLED_ALL_ASM=$enableval ],

--- a/tests/api/test_sha256.c
+++ b/tests/api/test_sha256.c
@@ -217,7 +217,8 @@ int test_wc_Sha256Transform(void)
 int test_wc_Sha256_Flags(void)
 {
     EXPECT_DECLS;
-#if !defined(NO_SHA256) && defined(WOLFSSL_HASH_FLAGS)
+#if !defined(NO_SHA256) && defined(WOLFSSL_HASH_FLAGS) && \
+    (!defined(WOLFSSL_ARMASM) || !defined(HAVE_FIPS) || FIPS_VERSION3_GE(7,0,0))
     DIGEST_FLAGS_TEST(wc_Sha256, Sha256);
 #endif
     return EXPECT_RESULT();
@@ -363,7 +364,8 @@ int test_wc_Sha224GetHash(void)
 int test_wc_Sha224_Flags(void)
 {
     EXPECT_DECLS;
-#if defined(WOLFSSL_SHA224) && defined(WOLFSSL_HASH_FLAGS)
+#if defined(WOLFSSL_SHA224) && defined(WOLFSSL_HASH_FLAGS) && \
+    (!defined(WOLFSSL_ARMASM) || !defined(HAVE_FIPS) || FIPS_VERSION3_GE(7,0,0))
     DIGEST_FLAGS_TEST(wc_Sha224, Sha224);
 #endif
     return EXPECT_RESULT();

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2795,14 +2795,15 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 #if defined(__mips) || defined(__mips64) || \
-    defined(WOLFSSL_SP_MIPS64) || defined(WOLFSSL_SP_MIPS)
+    defined(WOLFSSL_SP_MIPS64) || defined(WOLFSSL_SP_MIPS) || \
+    defined(__sparc) || defined(__arm__) || defined(__aarch64__)
+    /* This setting currently only affects big endian targets, currently
+     * only in sp_read_unsigned_bin().
+     */
     #undef WOLFSSL_SP_INT_DIGIT_ALIGN
     #define WOLFSSL_SP_INT_DIGIT_ALIGN
 #endif
-#if defined(__sparc)
-    #undef WOLFSSL_SP_INT_DIGIT_ALIGN
-    #define WOLFSSL_SP_INT_DIGIT_ALIGN
-#endif
+
 #if defined(__APPLE__) || defined(WOLF_C89)
     #define WOLFSSL_SP_NO_DYN_STACK
 #endif


### PR DESCRIPTION
fixes for armasm:

`configure.ac`: set `DEFAULT_ENABLED_ALL_ASM=no` if FIPS <v6 and not on amd64 (i.e. if ARM);

`tests/api/test_sha256.c`: skip `test_wc_Sha256_Flags()` and `test_wc_Sha224_Flags()` if armasm and FIPS <v7;

`wolfssl/wolfcrypt/settings.h`: define `WOLFSSL_SP_INT_DIGIT_ALIGN` for ARM (needed on BE, and no effect on LE).

`.github/workflows/smallStackSize.yml`: don't install `multilib` (not needed).

tested with
```
wolfssl-multi-test.sh ... 
    cross-aarch64-armasm-fips-140-3-v5-unittest-sanitizer
    cross-aarch64-armasm-fips-140-3-v5-all-crypto-unittest-sanitizer
    cross-aarch64-armasm-fips-140-3-v6-unittest-sanitizer
    cross-aarch64-armasm-fips-140-3-v6-all-unittest-sanitizer
    cross-aarch64-armasm-fips-140-3-dev-all-unittest-sanitizer
```
