### PR TITLE
Support PBE_AES(256|128)_CBC key encryptions on wc_PKCS12_create()

### DIFF
--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -636,10 +636,14 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
                 break;
             }
     #endif
-    #if !defined(NO_AES) && defined(HAVE_AES_CBC)
+    #if !defined(NO_AES) && defined(HAVE_AES_CBC) && \
+        (defined(WOLFSSL_AES_256) || defined(WOLFSSL_AES_128))
         #ifdef WOLFSSL_AES_256
             case PBE_AES256_CBC:
+        #endif /* WOLFSSL_AES_256 */
+        #ifdef WOLFSSL_AES_128
             case PBE_AES128_CBC:
+        #endif /* WOLFSSL_AES_128 */
             {
                 int free_aes;
 
@@ -686,8 +690,7 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
             #endif
                 break;
             }
-        #endif /* WOLFSSL_AES_256 */
-    #endif /* !NO_AES && HAVE_AES_CBC */
+    #endif /* !NO_AES && HAVE_AES_CBC && (WOLFSSL_AES_256 || WOLFSSL_AES_128) */
     #ifdef WC_RC2
             case PBE_SHA1_40RC2_CBC:
             {

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2224,6 +2224,10 @@ WOLFSSL_LOCAL int ToTraditionalEnc(byte* input, word32 sz, const char* password,
 WOLFSSL_ASN_API int UnTraditionalEnc(byte* key, word32 keySz, byte* out,
         word32* outSz, const char* password, int passwordSz, int vPKCS,
         int vAlgo, byte* salt, word32 saltSz, int itt, WC_RNG* rng, void* heap);
+WOLFSSL_ASN_API int TraditionalEnc_ex(byte* key, word32 keySz, byte* out,
+        word32* outSz, const char* password, int passwordSz, int vPKCS,
+        int vAlgo, int encAlgId, byte* salt, word32 saltSz, int itt,
+        int hmacOid, WC_RNG* rng, void* heap);
 WOLFSSL_ASN_API int TraditionalEnc(byte* key, word32 keySz, byte* out,
         word32* outSz, const char* password, int passwordSz, int vPKCS,
         int vAlgo, int encAlgId, byte* salt, word32 saltSz, int itt,

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -798,6 +798,10 @@ WOLFSSL_API int wc_GetPkcs8TraditionalOffset(byte* input,
 WOLFSSL_API int wc_CreatePKCS8Key(byte* out, word32* outSz,
         byte* key, word32 keySz, int algoID, const byte* curveOID,
         word32 oidSz);
+WOLFSSL_API int wc_EncryptPKCS8Key_ex(byte* key, word32 keySz, byte* out,
+        word32* outSz, const char* password, int passwordSz, int vPKCS,
+        int pbeOid, int encAlgId, byte* salt, word32 saltSz, int itt,
+        int hmacOid, WC_RNG* rng, void* heap);
 WOLFSSL_API int wc_EncryptPKCS8Key(byte* key, word32 keySz, byte* out, word32* outSz,
         const char* password, int passwordSz, int vPKCS, int pbeOid,
         int encAlgId, byte* salt, word32 saltSz, int itt, WC_RNG* rng,


### PR DESCRIPTION
# Description

This PR adds `PBE_AES256_CBC` and `PBE_AES128_CBC` key encryption supports on `wc_PKCS12_create()`. HMAC algorithm is fixed to `HMAC_SHA256_OID`, that is expected to be mostly used, for the both key encryption.

This PR only updates key encryptions. Certificate encryptions will be updated on another PR later same as this PR.
 
Fixes zd#19747

# Testing

`./configure CFLAGS="-DUSE_CERT_BUFFERS_2048" --enable-debug --enable-des3 --enable-asn` && `make test`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation