### PR TITLE
20250516-remove-implicit-WOLFSSL_DEBUG_CERTIFICATE_LOADS

### DIFF
--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -152,10 +152,6 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
     #define WOLFSSL_TIME(n)  WC_DO_NOTHING
 #endif
 
-#if defined(DEBUG_WOLFSSL) && !defined(WOLFSSL_DEBUG_CERTIFICATE_LOADS)
-    #define WOLFSSL_DEBUG_CERTIFICATE_LOADS
-#endif
-
 #if defined(DEBUG_WOLFSSL) && !defined(WOLFSSL_DEBUG_ERRORS_ONLY)
     #if defined(_WIN32)
         #if defined(INTIME_RTOS)


### PR DESCRIPTION
`wolfssl/wolfcrypt/logging.h`: don't define `WOLFSSL_DEBUG_CERTIFICATE_LOADS` just because `defined(DEBUG_WOLFSSL)`.

tested with `check-source-text`
