### PR TITLE
tls13: handle malformed CCS and CCS before CH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2633,6 +2633,7 @@ if(WOLFSSL_EXAMPLES)
         tests/api/test_ocsp.c
         tests/api/test_evp.c
         tests/api/test_tls_ext.c
+        tests/api/test_tls.c
         tests/srp.c
         tests/suites.c
         tests/w64wrapper.c

--- a/src/internal.c
+++ b/src/internal.c
@@ -22117,7 +22117,11 @@ static int DoProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
             if ( ssl->options.side == WOLFSSL_SERVER_END &&
                  ssl->options.clientState == NULL_STATE &&
                  ssl->buffers.inputBuffer.buffer[ssl->buffers.inputBuffer.idx]
-                         != handshake) {
+                         != handshake &&
+                 /* change_cipher_spec here is an error but we want to handle
+                  * it correctly later */
+                 ssl->buffers.inputBuffer.buffer[ssl->buffers.inputBuffer.idx]
+                         != change_cipher_spec) {
                 byte b0, b1;
 
                 ssl->options.processReply = runProcessOldClientHello;
@@ -22733,16 +22737,28 @@ default:
                         }
                         if (ssl->curSize != 1 ||
                                       ssl->buffers.inputBuffer.buffer[i] != 1) {
-                            SendAlert(ssl, alert_fatal, illegal_parameter);
+                            SendAlert(ssl, alert_fatal, unexpected_message);
                             WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                             return UNKNOWN_RECORD_TYPE;
                         }
                         ssl->buffers.inputBuffer.idx++;
+                        if (ssl->options.side == WOLFSSL_SERVER_END &&
+                                !ssl->msgsReceived.got_client_hello) {
+                            /* Can't appear before CH */
+                            SendAlert(ssl, alert_fatal, unexpected_message);
+                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
+                            return UNKNOWN_RECORD_TYPE;
+                        }
                         if (!ssl->msgsReceived.got_change_cipher) {
                             ssl->msgsReceived.got_change_cipher = 1;
                         }
                         else {
                             SendAlert(ssl, alert_fatal, illegal_parameter);
+                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
+                            return UNKNOWN_RECORD_TYPE;
+                        }
+                        if (ssl->keys.decryptedCur == 1) {
+                            SendAlert(ssl, alert_fatal, unexpected_message);
                             WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                             return UNKNOWN_RECORD_TYPE;
                         }

--- a/tests/api.c
+++ b/tests/api.c
@@ -324,6 +324,7 @@
 #include <tests/api/test_ocsp.h>
 #include <tests/api/test_evp.h>
 #include <tests/api/test_tls_ext.h>
+#include <tests/api/test_tls.h>
 
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_TLS) && \
     !defined(NO_RSA)        && !defined(SINGLE_THREADED) && \
@@ -68179,6 +68180,8 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_ocsp_basic_verify),
     TEST_DECL(test_ocsp_response_parsing),
     TEST_DECL(test_ocsp_certid_enc_dec),
+    TEST_DECL(test_tls12_unexpected_ccs),
+    TEST_DECL(test_tls13_unexpected_ccs),
     /* This test needs to stay at the end to clean up any caches allocated. */
     TEST_DECL(test_wolfSSL_Cleanup)
 };

--- a/tests/api/include.am
+++ b/tests/api/include.am
@@ -53,6 +53,7 @@ tests_unit_test_SOURCES += tests/api/test_dtls.c
 tests_unit_test_SOURCES += tests/api/test_ocsp.c
 tests_unit_test_SOURCES += tests/api/test_evp.c
 tests_unit_test_SOURCES += tests/api/test_tls_ext.c
+tests_unit_test_SOURCES += tests/api/test_tls.c
 endif
 
 EXTRA_DIST += tests/api/api.h
@@ -103,4 +104,5 @@ EXTRA_DIST += tests/api/test_ocsp_test_blobs.h
 EXTRA_DIST += tests/api/create_ocsp_test_blobs.py
 EXTRA_DIST += tests/api/test_evp.h
 EXTRA_DIST += tests/api/test_tls_ext.h
+EXTRA_DIST += tests/api/test_tls.h
 

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -1,0 +1,143 @@
+/* test_tls.c
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <tests/unit.h>
+
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+
+#include <tests/utils.h>
+#include <tests/api/test_tls.h>
+
+
+int test_tls12_unexpected_ccs(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && !defined(WOLFSSL_NO_TLS12)
+    const byte ccs[] = {
+        0x14, /* ccs type */
+        0x03, 0x03, /* version */
+        0x00, 0x01, /* length */
+        0x01, /* ccs value */
+    };
+    const byte badccs[] = {
+        0x14, /* ccs type */
+        0x03, 0x03, /* version */
+        0x00, 0x01, /* length */
+        0x99, /* wrong ccs value */
+    };
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+
+    /* ccs in the wrong place */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    /* inject SH */
+    ExpectIntEQ(test_memio_inject_message(&test_ctx, 0,
+            (const char*)ccs, sizeof(ccs)), 0);
+    ExpectIntEQ(test_memio_setup(&test_ctx, NULL, &ctx_s, NULL, &ssl_s,
+                    NULL, wolfTLSv1_2_server_method), 0);
+    ExpectIntEQ(wolfSSL_accept(ssl_s), WOLFSSL_FATAL_ERROR);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WOLFSSL_FATAL_ERROR),
+            OUT_OF_ORDER_E);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_s);
+    ctx_s = NULL;
+    ssl_s = NULL;
+
+    /* malformed ccs */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_inject_message(&test_ctx, 0,
+            (const char*)badccs, sizeof(badccs)), 0);
+    ExpectIntEQ(test_memio_setup(&test_ctx, NULL, &ctx_s, NULL, &ssl_s,
+                    NULL, wolfTLSv1_2_server_method), 0);
+    ExpectIntEQ(wolfSSL_accept(ssl_s), WOLFSSL_FATAL_ERROR);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WOLFSSL_FATAL_ERROR),
+            LENGTH_ERROR);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
+
+int test_tls13_unexpected_ccs(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13)
+    const byte ccs[] = {
+        0x14, /* ccs type */
+        0x03, 0x03, /* version */
+        0x00, 0x01, /* length */
+        0x01, /* ccs value */
+    };
+    const byte badccs[] = {
+        0x14, /* ccs type */
+        0x03, 0x03, /* version */
+        0x00, 0x01, /* length */
+        0x99, /* wrong ccs value */
+    };
+    const byte unexpectedAlert[] = {
+        0x15, /* alert type */
+        0x03, 0x03, /* version */
+        0x00, 0x02, /* length */
+        0x02, /* level: fatal */
+        0x0a /* protocol version */
+    };
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+
+    /* ccs can't appear before a CH */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_inject_message(&test_ctx, 0,
+            (const char*)ccs, sizeof(ccs)), 0);
+    ExpectIntEQ(test_memio_setup(&test_ctx, NULL, &ctx_s, NULL, &ssl_s,
+                    NULL, wolfTLSv1_3_server_method), 0);
+    ExpectIntEQ(wolfSSL_accept(ssl_s), WOLFSSL_FATAL_ERROR);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WOLFSSL_FATAL_ERROR),
+            UNKNOWN_RECORD_TYPE);
+    ExpectIntEQ(test_ctx.c_len, sizeof(unexpectedAlert));
+    ExpectBufEQ(test_ctx.c_buff, unexpectedAlert, sizeof(unexpectedAlert));
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_s);
+    ctx_s = NULL;
+    ssl_s = NULL;
+
+    /* malformed ccs */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_inject_message(&test_ctx, 0,
+            (const char*)badccs, sizeof(badccs)), 0);
+    ExpectIntEQ(test_memio_setup(&test_ctx, NULL, &ctx_s, NULL, &ssl_s,
+                    NULL, wolfTLSv1_3_server_method), 0);
+    ExpectIntEQ(wolfSSL_accept(ssl_s), WOLFSSL_FATAL_ERROR);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WOLFSSL_FATAL_ERROR),
+            UNKNOWN_RECORD_TYPE);
+    ExpectIntEQ(test_ctx.c_len, sizeof(unexpectedAlert));
+    ExpectBufEQ(test_ctx.c_buff, unexpectedAlert, sizeof(unexpectedAlert));
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_tls.h
+++ b/tests/api/test_tls.h
@@ -1,0 +1,28 @@
+/* test_tls.h
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef TESTS_API_TEST_TLS_H
+#define TESTS_API_TEST_TLS_H
+
+int test_tls12_unexpected_ccs(void);
+int test_tls13_unexpected_ccs(void);
+
+#endif /* TESTS_API_TEST_TLS_EMS_H */


### PR DESCRIPTION
- fix incorrect alert type being sent
- error out when we receive a CCS before a CH
- error out when we receive an encrypted CCS
