### PR TITLE
20250520-WC_SIPHASH_NO_ASM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -715,7 +715,7 @@ AC_ARG_WITH([linux-arch],
 
 if test "x$ENABLED_LINUXKM" = "xyes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LINUXKM"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LINUXKM -DWC_SIPHASH_NO_ASM"
     ENABLED_NO_LIBRARY=yes
     ENABLED_BENCHMARK=no
     output_objdir="$(realpath "$output_objdir")/linuxkm"

--- a/wolfcrypt/src/siphash.c
+++ b/wolfcrypt/src/siphash.c
@@ -21,6 +21,10 @@
 
 #include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
+#ifdef WC_SIPHASH_NO_ASM
+    #define WOLFSSL_NO_ASM
+#endif
+
 #include <wolfssl/wolfcrypt/siphash.h>
 
 #ifdef NO_INLINE


### PR DESCRIPTION
`wolfcrypt/src/siphash.c`: honor `WC_SIPHASH_NO_ASM`;

`configure.ac`: add `-DWC_SIPHASH_NO_ASM` when `ENABLED_LINUXKM`.

Background: `siphash_test()` is failing on amd64 under the gcc-16 sanitizer at the first opportunity (`error L=51030 i=0` on 05bc7e0d2f), but passes without asm.  I've seen similar wrong-result intelasm failures on SipHash over the years sporadically, on linuxkm and under sanitizers on earlier compilers.  So the asm seems to fragile, and presumptively unsafe in kernel.

The asm benefit is negligible, at least with latest-greatest optimizer.

With intelasm:
```
SipHash-8                 2715 MiB took 1.000 seconds, 2714.958 MiB/s Cycles per byte =   1.19
SipHash-16                2715 MiB took 1.000 seconds, 2714.961 MiB/s Cycles per byte =   1.19
```
Without:
```
SipHash-8                 2270 MiB took 1.000 seconds, 2268.937 MiB/s Cycles per byte =   1.43
SipHash-16                2275 MiB took 1.000 seconds, 2274.899 MiB/s Cycles per byte =   1.42
```

tested with
```
LIBWOLFSSL_CONFIGURE_ARGS_OVERRIDE=CFLAGS=-DWC_SIPHASH_NO_ASM wolfssl-multi-test.sh ...
check-source-text
sanitizer-all-intelasm-c-fallback-fuzzer
allcryptonly-no-malloc
allcryptonly-no-malloc-no-wolf-memory
all-gcc-c89-sanitize
quantum-safe-wolfssl-all-intelasm-sp-asm-sanitizer
quantum-safe-wolfssl-all-opensslextra-no-osp
liboqs-all-sanitizer
liboqs-hybrid-all-rpk-sanitizer
wolfsm-all-sanitizer
linuxkm-6.12-all-cryptonly-intelasm-fips-dev-dyn-hash-LKCAPI-insmod
sp-asn-template-asm-sanitizer
sp-asn-template-asm-smallstack-sanitizer
all-crypto-intelasm-no-sha-sanitizer
all-WOLFSSL_CALLBACKS-sanitizer
sp-all-asm-sanitizer
sanitizer-all-asm-smallstack-async
sanitizer-all-asm-smallstack-async-quic
sanitizer-all-secure-renegotiation
sanitizer-all-crypto-no-sha-1
all-sanitize-fips-140-3-dev
```
