### PR TITLE
20250521-fix-WC_SIPHASH_NO_ASM

### DIFF
--- a/wolfcrypt/src/siphash.c
+++ b/wolfcrypt/src/siphash.c
@@ -21,7 +21,7 @@
 
 #include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
-#ifdef WC_SIPHASH_NO_ASM
+#if defined(WC_SIPHASH_NO_ASM) && !defined(WOLFSSL_NO_ASM)
     #define WOLFSSL_NO_ASM
 #endif
 


### PR DESCRIPTION
`wolfcrypt/src/siphash.c`: for `WC_SIPHASH_NO_ASM`, don't define `WOLFSSL_NO_ASM` if it's already defined.

tested with `wolfssl-multi-test.sh ... check-source-text quantum-safe-wolfssl-all-noasm-sanitizer sanitizer-all-intelasm-c-fallback-fuzzer`
