### PR TITLE
Fix for STM32 AES GCM and older STM32Cube HAL that does not support `HeaderWidthUnit`

### DIFF
--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -479,7 +479,7 @@ int wc_Stm32_Aes_Init(Aes* aes, CRYP_HandleTypeDef* hcryp)
     hcryp->Init.pKey = (STM_CRYPT_TYPE*)aes->key;
 #ifdef STM32_HAL_V2
     hcryp->Init.DataWidthUnit = CRYP_DATAWIDTHUNIT_BYTE;
-    #ifdef STM_CRYPT_HEADER_WIDTH
+    #if defined(CRYP_HEADERWIDTHUNIT_BYTE) && defined(STM_CRYPT_HEADER_WIDTH)
     hcryp->Init.HeaderWidthUnit =
             (STM_CRYPT_HEADER_WIDTH == 4) ?
                 CRYP_HEADERWIDTHUNIT_WORD :


### PR DESCRIPTION
# Description

Fix for STM32 AES GCM with older STM32Cube HAL where the HeaderWidthUnit (`hcryp->Init.HeaderWidthUnit`) is not supported.

Fixes ZD 19926

# Testing

Customer is going to validate.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
