### PR TITLE
20250522-FIPS-v5-no-implicit-DES

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1362,7 +1362,7 @@ then
         test "$enable_srtp_kdf" = "" && test "$enable_afalg" != "yes" && enable_srtp_kdf=yes
     fi
 
-    if test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 5; then
+    if test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -lt 5; then
         test "$enable_des3" = "" && enable_des3=yes
         test "$enable_des3" != "no" && AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"
     fi
@@ -2595,7 +2595,8 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DER_LOAD"
     AM_CFLAGS="$AM_CFLAGS -DATOMIC_USER"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_KEY_GEN"
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"
+    AS_IF([test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 2],
+          [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"])
     AM_CFLAGS="$AM_CFLAGS -DKEEP_OUR_CERT"
     AM_CFLAGS="$AM_CFLAGS -DKEEP_PEER_CERT"
     AM_CFLAGS="$AM_CFLAGS -DHAVE_KEYING_MATERIAL"
@@ -5309,13 +5310,13 @@ AC_ARG_ENABLE([des3],
     [ ENABLED_DES3=no ]
     )
 
-# Enable 3DES with OpenSSH and FIPS 140-2 but not 140-3
-if (test "$ENABLED_OPENSSH" = "yes" && \
-        (test "x$ENABLED_FIPS" = "xno" || test "$HAVE_FIPS_VERSION" -le 2)) || \
-   test "$ENABLED_QT" = "yes" || test "$ENABLED_OPENVPN" = "yes" || \
-   test "x$ENABLED_WPAS" != "xno"  || test "$ENABLED_NETSNMP" = "yes" || \
-   test "$ENABLED_LIBSSH2" = "yes" || test "$ENABLED_KRB" = "yes" || \
-   test "$ENABLED_WOLFENGINE" = "yes" || test "$ENABLED_STRONGSWAN" = "yes"
+# Enable 3DES for various metafeatures, unless FIPS 140-3
+if (test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 2) && \
+    (test "$ENABLED_OPENSSH" = "yes" || \
+     test "$ENABLED_QT" = "yes" || test "$ENABLED_OPENVPN" = "yes" || \
+     test "$ENABLED_WPAS" != "no"  || test "$ENABLED_NETSNMP" = "yes" || \
+     test "$ENABLED_LIBSSH2" = "yes" || test "$ENABLED_KRB" = "yes" || \
+     test "$ENABLED_WOLFENGINE" = "yes" || test "$ENABLED_STRONGSWAN" = "yes")
 then
     ENABLED_DES3="yes"
 fi
@@ -7543,7 +7544,9 @@ fi
 
 if test "$ENABLED_KRB" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_KRB -DWOLFSSL_AES_DIRECT -DWOLFSSL_DES_ECB"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_KRB -DWOLFSSL_AES_DIRECT"
+    AS_IF([test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 2],
+          [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"])
     AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA"
 
     # Requires PKCS7
@@ -7572,7 +7575,9 @@ fi
 if test "$ENABLED_BIND" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_BIND -DWOLFSSL_DSA_768_MODULUS"
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_DIRECT -DHAVE_AES_ECB -DWOLFSSL_DES_ECB"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_DIRECT -DHAVE_AES_ECB"
+    AS_IF([test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 2],
+          [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"])
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA224 -DWOLFSSL_SHA384 -DWOLFSSL_SHA512"
     AM_CFLAGS="$AM_CFLAGS -DOPENSSL_COMPATIBLE_DEFAULTS"
     ENABLED_SHA224="yes"
@@ -7590,7 +7595,9 @@ if test "$ENABLED_OPENVPN" = "yes"
 then
     ENABLED_SUPPORTED_CURVES="yes"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_OPENVPN -DHAVE_KEYING_MATERIAL"
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB -DHAVE_EX_DATA -DWOLFSSL_KEY_GEN"
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA -DWOLFSSL_KEY_GEN"
+    AS_IF([test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 2],
+          [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"])
 fi
 
 if test "$ENABLED_HITCH" = "yes"
@@ -7842,7 +7849,7 @@ then
         AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL"
     fi
 
-    if test "x$ENABLED_DES3" = "xno"
+    if test "$ENABLED_DES3" = "no" && (test "$ENABLED_FIPS" = "no" || test $HAVE_FIPS_VERSION -lt 5)
     then
         ENABLED_DES3="yes"
     fi
@@ -7890,7 +7897,9 @@ then
 
     AM_CFLAGS="$AM_CFLAGS -DHAVE_STUNNEL -DWOLFSSL_ALWAYS_VERIFY_CB"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALWAYS_KEEP_SNI -DHAVE_EX_DATA"
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB -DWOLFSSL_SIGNER_DER_CERT"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SIGNER_DER_CERT"
+    AS_IF([test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 2],
+          [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"])
     AM_CFLAGS="$AM_CFLAGS -DOPENSSL_COMPATIBLE_DEFAULTS -DWOLFSSL_TICKET_HAVE_ID"
 fi
 
@@ -7908,7 +7917,7 @@ then
         ENABLED_MD4="yes"
     fi
 
-    if test "x$ENABLED_DES3" = "xno"
+    if test "$ENABLED_DES3" = "no" && (test "$ENABLED_FIPS" = "no" || test $HAVE_FIPS_VERSION -lt 5)
     then
         ENABLED_DES3="yes"
     fi
@@ -7978,7 +7987,8 @@ then
     # FTPS server requires pointer to session cache
     AM_CFLAGS="$AM_CFLAGS -DNO_SESSION_CACHE_REF"
 
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"
+    AS_IF([test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 2],
+          [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"])
 
     # support longer session ticket nonce
     if test "$ENABLED_TICKET_NONCE_MALLOC" = "no_implicit"
@@ -8015,7 +8025,7 @@ then
         AM_CFLAGS="$AM_CFLAGS -DOPENSSL_EXTRA"
     fi
 
-    if test "x$ENABLED_DES3" = "xno"
+    if test "$ENABLED_DES3" = "no" && (test "$ENABLED_FIPS" = "no" || test $HAVE_FIPS_VERSION -lt 5)
     then
         ENABLED_DES3="yes"
     fi
@@ -9746,7 +9756,7 @@ then
     fi
 
     # Has support for DES3 encrypt/decrypt
-    if test "$ENABLED_DES3" = "no"
+    if test "$ENABLED_DES3" = "no" && (test "$ENABLED_FIPS" = "no" || test $HAVE_FIPS_VERSION -lt 5)
     then
         ENABLED_DES3="yes"
     fi
@@ -10001,7 +10011,9 @@ AS_IF([test "x$ENABLED_OCSP" = "xyes"],
       [AM_CFLAGS="$AM_CFLAGS -DHAVE_OCSP"])
 
 AS_IF([test "x$ENABLED_STRONGSWAN" = "xyes"],
-      [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB -DWOLFSSL_LOG_PRINTF -DWOLFSSL_PUBLIC_MP -DHAVE_EX_DATA"])
+      [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LOG_PRINTF -DWOLFSSL_PUBLIC_MP -DHAVE_EX_DATA"
+       AS_IF([test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 2],
+             [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"])])
 
 AS_IF([test "x$ENABLED_OPENLDAP" = "xyes"], [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SIGNER_DER_CERT"])
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -18940,15 +18940,17 @@ static int test_wc_PKCS12_create_once(int keyEncType, int certEncType)
 static int test_wc_PKCS12_create(void)
 {
     EXPECT_DECLS;
-#if !defined(NO_DES3)
+#if !defined(NO_DES3) && !defined(NO_SHA)
     ExpectIntEQ(test_wc_PKCS12_create_once(PBE_SHA1_DES3, PBE_SHA1_DES3),
         TEST_SUCCESS);
 #endif
-#if defined(HAVE_AES_CBC) && !defined(NO_AES_256) && !defined(NO_DES3)
+#if defined(HAVE_AES_CBC) && !defined(NO_AES_256) && !defined(NO_DES3) && \
+    !defined(NO_SHA)
     ExpectIntEQ(test_wc_PKCS12_create_once(PBE_AES256_CBC, PBE_SHA1_DES3),
         TEST_SUCCESS);
 #endif
-#if defined(HAVE_AES_CBC) && !defined(NO_AES_128) && !defined(NO_DES3)
+#if defined(HAVE_AES_CBC) && !defined(NO_AES_128) && !defined(NO_DES3) && \
+    !defined(NO_SHA)
     ExpectIntEQ(test_wc_PKCS12_create_once(PBE_AES128_CBC, PBE_SHA1_DES3),
         TEST_SUCCESS);
 #endif


### PR DESCRIPTION
`configure.ac`: remove implicit enablements of DES/DES3 on FIPS v5+.

(fixes unit test failures on `test_wc_PKCS12_create()` from 36668515891a.)

tested with `wolfssl-multi-test.sh ... check-source-text check-configure fips-140-3-v6-all`
