### PR TITLE
Fix for ML-DSA with `WOLFSSL_DILITHIUM_NO_SIGN`

### DIFF
--- a/tests/api/test_mldsa.c
+++ b/tests/api/test_mldsa.c
@@ -16663,7 +16663,8 @@ int test_mldsa_pkcs8(void)
     EXPECT_DECLS;
 #if !defined(NO_ASN) && defined(HAVE_PKCS8) && \
     defined(HAVE_DILITHIUM) && !defined(NO_TLS) && \
-    (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER))
+    (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)) && \
+    !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY)
 
     WOLFSSL_CTX* ctx = NULL;
     size_t i;

--- a/tests/api/test_mldsa.c
+++ b/tests/api/test_mldsa.c
@@ -16664,7 +16664,8 @@ int test_mldsa_pkcs8(void)
 #if !defined(NO_ASN) && defined(HAVE_PKCS8) && \
     defined(HAVE_DILITHIUM) && !defined(NO_TLS) && \
     (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)) && \
-    !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY)
+    !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) && \
+    !defined(WOLFSSL_DILITHIUM_NO_ASN1)
 
     WOLFSSL_CTX* ctx = NULL;
     size_t i;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -31513,7 +31513,7 @@ static int MakeSignature(CertSignCtx* certSignCtx, const byte* buf, word32 sz,
                 ret = outSz;
         }
     #endif /* HAVE_FALCON */
-    #if defined(HAVE_DILITHIUM)
+    #if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN)
         if (!rsaKey && !eccKey && !ed25519Key && !ed448Key && !falconKey &&
             dilithiumKey) {
             word32 outSz = sigSz;
@@ -31535,7 +31535,7 @@ static int MakeSignature(CertSignCtx* certSignCtx, const byte* buf, word32 sz,
                     ret = outSz;
             }
         }
-    #endif /* HAVE_DILITHIUM */
+    #endif /* HAVE_DILITHIUM && !WOLFSSL_DILITHIUM_NO_SIGN */
     #if defined(HAVE_SPHINCS)
         if (!rsaKey && !eccKey && !ed25519Key && !ed448Key && !falconKey &&
             !dilithiumKey && sphincsKey) {

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -10108,6 +10108,8 @@ int wc_Dilithium_PublicKeyDecode(const byte* input, word32* inOutIdx,
                 /* This is the raw point data compressed or uncompressed. */
                 pubKeyLen = (word32)length;
                 pubKey = input + idx;
+
+                *inOutIdx += idx;
             }
     #endif
             if (ret == 0) {

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -4251,6 +4251,12 @@ extern void uITRON4_free(void *p) ;
 #error Please do not define HAVE_PQC yourself.
 #endif
 
+/* If no malloc then make sure the valid Dilithium settings are used */
+#if defined(HAVE_DILITHIUM) && defined(WOLFSSL_NO_MALLOC)
+    #undef  WOLFSSL_DILITHIUM_VERIFY_NO_MALLOC
+    #define WOLFSSL_DILITHIUM_VERIFY_NO_MALLOC
+#endif
+
 #if defined(HAVE_PQC) && defined(WOLFSSL_DTLS13) && \
     !defined(WOLFSSL_DTLS_CH_FRAG)
 #warning "Using DTLS 1.3 + pqc without WOLFSSL_DTLS_CH_FRAG will probably" \


### PR DESCRIPTION
# Description

* Fixed ML-DSA with `WOLFSSL_DILITHIUM_NO_SIGN`
* Fixed issues with `WOLFSSL_DILITHIUM_NO_ASN1`
* Added no malloc support for Dilithium tests. 

ZD 19948

# Testing

Reproduced with: `./configure --enable-dilithium=87,verify-only --enable-certgen && make`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
