### PR TITLE
20250523-WC_NID_netscape_cert_type

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -901,7 +901,7 @@ extern const WOLFSSL_ObjectInfo wolfssl_object_info[];
 #define WC_SN_sm3        "SM3"
 
 /* NIDs */
-#define WC_NID_netscape_cert_type WC_NID_undef
+#define WC_NID_netscape_cert_type 71
 #define WC_NID_des 66
 #define WC_NID_des3 67
 #define WC_NID_sha256 672


### PR DESCRIPTION
`wolfssl/wolfcrypt/asn.h`: add a real value for `WC_NID_netscape_cert_type`.

See 2bae1d27a1 in #2503.

This change is intended to resolve this issue reported by @miyazakh: 

>By [PR8132](https://github.com/wolfSSL/wolfssl/pull/8132), it maps `WC_NID_netscape_cert_type` to `WC_NID_undef`. And by [PR8655](https://github.com/wolfSSL/wolfssl/pull/8655), it adds `WC_NID_netscape_cert_type` to `wolfssl_object_inf[]`.  As the result, `wolfSSL_OBJ_nid2sn()` returns Netscape Cert Type against id==0, then Qt test becomes failure. Qt unit-test tests a custom cert extension, and it expects to return `WC_NID_undef` [here](https://github.com/wolfSSL/wolfssl/blob/dfe0684bc755f358c3fd5b27f669ab8fd0a8d504/src/ssl.c#L20431) against unknown cert extension. I think super-easy fix for Qt  is removing `WC_NID_netscape_cert_type` addition from `wolfssl_object_inf[]`. However, I would like to know if it is possible to map `WC_NID_netscape_cert_type` another value rather than `WC_NID_undef`.

tested with `wolfssl-multi-test.sh ... super-quick-check`
