### PR TITLE
coverity: misc changes to api.c

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -19448,6 +19448,7 @@ static int test_wolfSSL_d2i_ASN1_INTEGER(void)
     ExpectIntLT(wolfSSL_i2d_ASN1_INTEGER(a, &p2), 0);
     if (a != NULL) {
         /* Reset a->data. */
+        a->isDynamic = 0;
         a->data = a->intData;
     }
     /* Set a to valid value. */
@@ -39051,12 +39052,14 @@ static int test_wolfSSL_d2i_PrivateKeys_bio(void)
     {
         XFILE file = XBADFILE;
         const char* fname = "./certs/server-key.der";
+        long lsz = 0;
         size_t sz = 0;
         byte* buf = NULL;
 
         ExpectTrue((file = XFOPEN(fname, "rb")) != XBADFILE);
         ExpectTrue(XFSEEK(file, 0, XSEEK_END) == 0);
-        ExpectTrue((sz = XFTELL(file)) != 0);
+        ExpectTrue((lsz = XFTELL(file)) > 0);
+        sz = (size_t)lsz;
         ExpectTrue(XFSEEK(file, 0, XSEEK_SET) == 0);
         ExpectNotNull(buf = (byte*)XMALLOC(sz, HEAP_HINT, DYNAMIC_TYPE_FILE));
         ExpectIntEQ(XFREAD(buf, 1, sz, file), sz);

--- a/tests/api/test_digest.h
+++ b/tests/api/test_digest.h
@@ -510,6 +510,7 @@ do {                                                                           \
     byte data[WC_##upper##_BLOCK_SIZE];                                        \
                                                                                \
     XMEMSET(data, 0xa5, sizeof(data));                                         \
+    XMEMSET(&src, 0, sizeof(src));                                             \
                                                                                \
     ExpectIntEQ(wc_Init##name(&src, HEAP_HINT, INVALID_DEVID), 0);             \
     XMEMSET(&dst, 0, sizeof(dst));                                             \


### PR DESCRIPTION
prevent use after free

coverity: improper use of negative value, fix second in function

initialize src in DIGEST_ALT_COPY_TEST
