### PR TITLE
Refactor to support CSR generation and signing with `WOLFSSL_NO_MALLOC`

### DIFF
--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -302,7 +302,9 @@ int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa)
     /* make a random string that will be multiplied against q */
     err = wc_RNG_GenerateBlock(rng, buf, (word32)(msize - qsize));
     if (err != MP_OKAY) {
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
         XFREE(buf, dsa->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    #endif
         return err;
     }
 

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -141,12 +141,13 @@ static int CheckDsaLN(int modLen, int divLen)
  * return 0 on success, negative on error */
 int wc_MakeDsaKey(WC_RNG *rng, DsaKey *dsa)
 {
-    byte* cBuf;
     int qSz, pSz, cSz, err;
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     mp_int *tmpQ = NULL;
+    byte* cBuf = NULL;
 #else
     mp_int tmpQ[1];
+    byte cBuf[(3072+64)/WOLFSSL_BIT_SIZE ];
 #endif
 
     if (rng == NULL || dsa == NULL)
@@ -161,15 +162,22 @@ int wc_MakeDsaKey(WC_RNG *rng, DsaKey *dsa)
 
     /* generate extra 64 bits so that bias from mod function is negligible */
     cSz = qSz + (64 / WOLFSSL_BIT_SIZE);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     cBuf = (byte*)XMALLOC((size_t)cSz, dsa->heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (cBuf == NULL) {
         return MEMORY_E;
     }
+#else
+    if (sizeof(cBuf) < (size_t)cSz) {
+        return BUFFER_E;
+    }
+#endif
 
     SAVE_VECTOR_REGISTERS(;);
 
-#ifdef WOLFSSL_SMALL_STACK
-    if ((tmpQ = (mp_int *)XMALLOC(sizeof(*tmpQ), NULL, DYNAMIC_TYPE_WOLF_BIGINT)) == NULL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+    if ((tmpQ = (mp_int *)XMALLOC(sizeof(*tmpQ), NULL,
+            DYNAMIC_TYPE_WOLF_BIGINT)) == NULL)
         err = MEMORY_E;
     else
         err = MP_OKAY;
@@ -223,9 +231,8 @@ int wc_MakeDsaKey(WC_RNG *rng, DsaKey *dsa)
         mp_clear(&dsa->y);
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     XFREE(cBuf, dsa->heap, DYNAMIC_TYPE_TMP_BUFFER);
-
-#ifdef WOLFSSL_SMALL_STACK
     if (tmpQ != NULL) {
         mp_clear(tmpQ);
         XFREE(tmpQ, dsa->heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -239,19 +246,20 @@ int wc_MakeDsaKey(WC_RNG *rng, DsaKey *dsa)
     return err;
 }
 
-
 /* modulus_size in bits */
 int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa)
 {
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     mp_int *tmp = NULL, *tmp2 = NULL;
+    unsigned char *buf = NULL;
 #else
     mp_int tmp[1], tmp2[1];
+    unsigned char buf[(3072/WOLFSSL_BIT_SIZE)-32];
 #endif
     int     err, msize, qsize,
             loop_check_prime = 0,
             check_prime = MP_NO;
-    unsigned char   *buf;
+
 
     if (rng == NULL || dsa == NULL)
         return BAD_FUNC_ARG;
@@ -278,12 +286,18 @@ int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa)
     /* modulus size in bytes */
     msize = modulus_size / WOLFSSL_BIT_SIZE;
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     /* allocate ram */
     buf = (unsigned char *)XMALLOC((size_t)(msize - qsize),
                                    dsa->heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (buf == NULL) {
         return MEMORY_E;
     }
+#else
+    if (sizeof(buf) < (size_t)(msize - qsize)) {
+        return BUFFER_E;
+    }
+#endif
 
     /* make a random string that will be multiplied against q */
     err = wc_RNG_GenerateBlock(rng, buf, (word32)(msize - qsize));
@@ -298,7 +312,7 @@ int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa)
     /* force even */
     buf[msize - qsize - 1] &= (unsigned char)~1;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     if (((tmp = (mp_int *)XMALLOC(sizeof(*tmp), NULL, DYNAMIC_TYPE_WOLF_BIGINT)) == NULL) ||
         ((tmp2 = (mp_int *)XMALLOC(sizeof(*tmp2), NULL, DYNAMIC_TYPE_WOLF_BIGINT)) == NULL))
         err = MEMORY_E;
@@ -380,9 +394,8 @@ int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa)
 #endif
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     XFREE(buf, dsa->heap, DYNAMIC_TYPE_TMP_BUFFER);
-
-#ifdef WOLFSSL_SMALL_STACK
     if (tmp != NULL) {
         mp_clear(tmp);
         XFREE(tmp, NULL, DYNAMIC_TYPE_WOLF_BIGINT);

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1107,8 +1107,6 @@ enum ECC_TYPES
 #endif
 
 enum Misc_ASN {
-    MAX_SALT_SIZE       =  64,     /* MAX PKCS Salt length */
-    MAX_IV_SIZE         =  64,     /* MAX PKCS Iv length */
     ASN_BOOL_SIZE       =   2,     /* including type */
     ASN_ECC_HEADER_SZ   =   2,     /* String type + 1 byte len */
     ASN_ECC_CONTEXT_SZ  =   2,     /* Content specific type + 1 byte len */
@@ -1129,60 +1127,10 @@ enum Misc_ASN {
                             ,
     DSA_PARAM_INTS      =   3,     /* DSA parameter ints */
     RSA_PUB_INTS        =   2,     /* RSA ints in public key */
-    DSA_PUB_INTS        =   4,     /* DSA ints in public key */
-    DSA_INTS            =   5,     /* DSA ints in private key */
     MIN_DATE_SIZE       =  12,
     MAX_DATE_SIZE       =  32,
     ASN_GEN_TIME_SZ     =  15,     /* 7 numbers * 2 + Zulu tag */
-#ifdef HAVE_SPHINCS
-    MAX_ENCODED_SIG_SZ  = 51200,
-#elif defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
-    MAX_ENCODED_SIG_SZ  = 5120,
-#elif !defined(NO_RSA)
-#ifdef WOLFSSL_HAPROXY
-    MAX_ENCODED_SIG_SZ  = 1024,    /* Supports 8192 bit keys */
-#else
-    MAX_ENCODED_SIG_SZ  = 512,     /* Supports 4096 bit keys */
-#endif
-#elif defined(HAVE_ECC)
-    MAX_ENCODED_SIG_SZ  = 140,
-#elif defined(HAVE_CURVE448)
-    MAX_ENCODED_SIG_SZ  = 114,
-#else
-    MAX_ENCODED_SIG_SZ  =  64,
-#endif
-    MAX_SIG_SZ          = 256,
-    MAX_ALGO_SZ         =  20,
-    MAX_LENGTH_SZ       = WOLFSSL_ASN_MAX_LENGTH_SZ, /* Max length size for DER encoding */
-    MAX_SHORT_SZ        = (1 + MAX_LENGTH_SZ),     /* asn int + byte len + 4 byte length */
-    MAX_SEQ_SZ          = (1 + MAX_LENGTH_SZ), /* enum(seq | con) + length(5) */
-    MAX_SET_SZ          = (1 + MAX_LENGTH_SZ), /* enum(set | con) + length(5) */
-    MAX_OCTET_STR_SZ    = (1 + MAX_LENGTH_SZ), /* enum(set | con) + length(5) */
-    MAX_EXP_SZ          = (1 + MAX_LENGTH_SZ), /* enum(contextspec|con|exp) + length(5) */
-    MAX_PRSTR_SZ        = (1 + MAX_LENGTH_SZ), /* enum(prstr) + length(5) */
-    MAX_VERSION_SZ      =   5,     /* enum + id + version(byte) + (header(2))*/
-    MAX_ENCODED_DIG_ASN_SZ = (5 + MAX_LENGTH_SZ),   /* enum(bit or octet) + length(5) */
-    MAX_ENCODED_DIG_SZ  =  64 + MAX_ENCODED_DIG_ASN_SZ, /* asn header + sha512 */
-    MAX_RSA_INT_SZ      = (512 + 1 + MAX_LENGTH_SZ), /* RSA raw sz 4096 for bits + tag + len(5) */
-    MAX_DSA_INT_SZ      = (384 + 1 + MAX_LENGTH_SZ), /* DSA raw sz 3072 for bits + tag + len(5) */
-    MAX_DSA_PUBKEY_SZ   = (DSA_PUB_INTS * MAX_DSA_INT_SZ) + (2 * MAX_SEQ_SZ) +
-                          2 + MAX_LENGTH_SZ, /* Maximum size of a DSA public
-                                      key taken from wc_SetDsaPublicKey. */
-    MAX_DSA_PRIVKEY_SZ  = (DSA_INTS * MAX_DSA_INT_SZ) + MAX_SEQ_SZ +
-                          MAX_VERSION_SZ, /* Maximum size of a DSA Private
-                                      key taken from DsaKeyIntsToDer. */
-#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
-    MAX_PQC_PUBLIC_KEY_SZ = 2592, /* Maximum size of a Dilithium public key. */
-#endif
-    MAX_RSA_E_SZ        =  16,     /* Max RSA public e size */
-    MAX_CA_SZ           =  32,     /* Max encoded CA basic constraint length */
-    MAX_SN_SZ           =  35,     /* Max encoded serial number (INT) length */
-    MAX_DER_DIGEST_SZ     = MAX_ENCODED_DIG_SZ + MAX_ALGO_SZ + MAX_SEQ_SZ,
-                            /* Maximum DER digest size */
-    MAX_DER_DIGEST_ASN_SZ = MAX_ENCODED_DIG_ASN_SZ + MAX_ALGO_SZ + MAX_SEQ_SZ,
-                            /* Maximum DER digest ASN header size */
-                            /* Max X509 header length indicates the max length + 2 ('\n', '\0') */
-    MAX_X509_HEADER_SZ  = (37 + 2), /* Maximum PEM Header/Footer Size */
+
 #ifdef WOLFSSL_CERT_GEN
     #ifdef WOLFSSL_CERT_REQ
                           /* Max encoded cert req attributes length */
@@ -1195,7 +1143,7 @@ enum Misc_ASN {
     #else
         MAX_EXTENSIONS_SZ   = 1 + MAX_LENGTH_SZ + MAX_CA_SZ,
     #endif
-                                   /* Max total extensions, id + len + others */
+                          /* Max total extensions, id + len + others */
 #endif
 #if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA) || \
         defined(HAVE_PKCS7) || defined(OPENSSL_EXTRA_X509_SMALL) || \
@@ -1220,16 +1168,6 @@ enum Misc_ASN {
     OCSP_NONCE_EXT_SZ   = 35,      /* OCSP Nonce Extension size */
     MAX_OCSP_EXT_SZ     = 58,      /* Max OCSP Extension length */
     MAX_OCSP_NONCE_SZ   = 16,      /* OCSP Nonce size           */
-#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
-    MAX_PUBLIC_KEY_SZ   = MAX_PQC_PUBLIC_KEY_SZ + MAX_ALGO_SZ + MAX_SEQ_SZ * 2,
-#else
-    MAX_PUBLIC_KEY_SZ   = MAX_DSA_PUBKEY_SZ + MAX_ALGO_SZ + MAX_SEQ_SZ * 2,
-#endif
-#ifdef WOLFSSL_ENCRYPTED_KEYS
-    HEADER_ENCRYPTED_KEY_SIZE = 88,/* Extra header size for encrypted key */
-#else
-    HEADER_ENCRYPTED_KEY_SIZE = 0,
-#endif
     TRAILING_ZERO       = 1,       /* Used for size of zero pad */
     ASN_TAG_SZ          = 1,       /* single byte ASN.1 tag */
     ASN_INDEF_END_SZ    = 2,       /* 0x00 0x00 at end of indef */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -2057,9 +2057,9 @@ enum Max_ASN {
     MAX_PUBLIC_KEY_SZ   = MAX_DSA_PUBKEY_SZ + MAX_ALGO_SZ + MAX_SEQ_SZ * 2,
 #endif
 #ifdef WOLFSSL_ENCRYPTED_KEYS
-    HEADER_ENCRYPTED_KEY_SIZE = 88,/* Extra header size for encrypted key */
+    HEADER_ENCRYPTED_KEY_SIZE = 88 /* Extra header size for encrypted key */
 #else
-    HEADER_ENCRYPTED_KEY_SIZE = 0,
+    HEADER_ENCRYPTED_KEY_SIZE = 0
 #endif
 };
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1991,8 +1991,82 @@ WOLFSSL_API word32 CheckRunTimeSettings(void);
 #endif
 
 
-#ifdef WOLFSSL_CERT_GEN
+/* Maximum ASN sizes */
+#ifndef WOLFSSL_ASN_MAX_LENGTH_SZ
+    #define WOLFSSL_ASN_MAX_LENGTH_SZ 5 /* 1 byte length + 4 bytes of number */
+#endif
 
+enum Max_ASN {
+    DSA_PUB_INTS        =   4,     /* DSA ints in public key */
+    DSA_INTS            =   5,     /* DSA ints in private key */
+    MAX_SALT_SIZE       =  64,     /* MAX PKCS Salt length */
+    MAX_IV_SIZE         =  64,     /* MAX PKCS Iv length */
+#ifdef HAVE_SPHINCS
+    MAX_ENCODED_SIG_SZ  = 51200,
+#elif defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
+    MAX_ENCODED_SIG_SZ  = 5120,
+#elif !defined(NO_RSA)
+#ifdef WOLFSSL_HAPROXY
+    MAX_ENCODED_SIG_SZ  = 1024,    /* Supports 8192 bit keys */
+#else
+    MAX_ENCODED_SIG_SZ  = 512,     /* Supports 4096 bit keys */
+#endif
+#elif defined(HAVE_ECC)
+    MAX_ENCODED_SIG_SZ  = 140,
+#elif defined(HAVE_CURVE448)
+    MAX_ENCODED_SIG_SZ  = 114,
+#else
+    MAX_ENCODED_SIG_SZ  =  64,
+#endif
+    MAX_SIG_SZ          = 256,
+    MAX_ALGO_SZ         =  20,
+    MAX_LENGTH_SZ       = WOLFSSL_ASN_MAX_LENGTH_SZ, /* Max length size for DER encoding */
+    MAX_SHORT_SZ        = (1 + MAX_LENGTH_SZ),     /* asn int + byte len + 4 byte length */
+    MAX_SEQ_SZ          = (1 + MAX_LENGTH_SZ), /* enum(seq | con) + length(5) */
+    MAX_SET_SZ          = (1 + MAX_LENGTH_SZ), /* enum(set | con) + length(5) */
+    MAX_OCTET_STR_SZ    = (1 + MAX_LENGTH_SZ), /* enum(set | con) + length(5) */
+    MAX_EXP_SZ          = (1 + MAX_LENGTH_SZ), /* enum(contextspec|con|exp) + length(5) */
+    MAX_PRSTR_SZ        = (1 + MAX_LENGTH_SZ), /* enum(prstr) + length(5) */
+    MAX_VERSION_SZ      =   5,     /* enum + id + version(byte) + (header(2))*/
+    MAX_ENCODED_DIG_ASN_SZ = (5 + MAX_LENGTH_SZ),   /* enum(bit or octet) + length(5) */
+    MAX_ENCODED_DIG_SZ  =  64 + MAX_ENCODED_DIG_ASN_SZ, /* asn header + sha512 */
+    MAX_RSA_INT_SZ      = (512 + 1 + MAX_LENGTH_SZ), /* RSA raw sz 4096 for bits + tag + len(5) */
+    MAX_DSA_INT_SZ      = (384 + 1 + MAX_LENGTH_SZ), /* DSA raw sz 3072 for bits + tag + len(5) */
+    MAX_DSA_PUBKEY_SZ   = (DSA_PUB_INTS * MAX_DSA_INT_SZ) + (2 * MAX_SEQ_SZ) +
+                          2 + MAX_LENGTH_SZ, /* Maximum size of a DSA public
+                                      key taken from wc_SetDsaPublicKey. */
+    MAX_DSA_PRIVKEY_SZ  = (DSA_INTS * MAX_DSA_INT_SZ) + MAX_SEQ_SZ +
+                          MAX_VERSION_SZ, /* Maximum size of a DSA Private
+                                      key taken from DsaKeyIntsToDer. */
+#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
+    MAX_PQC_PUBLIC_KEY_SZ = 2592, /* Maximum size of a Dilithium public key. */
+#endif
+    MAX_RSA_E_SZ        =  16,     /* Max RSA public e size */
+    MAX_CA_SZ           =  32,     /* Max encoded CA basic constraint length */
+    MAX_SN_SZ           =  35,     /* Max encoded serial number (INT) length */
+    MAX_DER_DIGEST_SZ     = MAX_ENCODED_DIG_SZ + MAX_ALGO_SZ + MAX_SEQ_SZ,
+                            /* Maximum DER digest size */
+    MAX_DER_DIGEST_ASN_SZ = MAX_ENCODED_DIG_ASN_SZ + MAX_ALGO_SZ + MAX_SEQ_SZ,
+                            /* Maximum DER digest ASN header size */
+                            /* Max X509 header length indicates the
+                             * max length + 2 ('\n', '\0') */
+    MAX_X509_HEADER_SZ  = (37 + 2), /* Maximum PEM Header/Footer Size */
+#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
+    MAX_PUBLIC_KEY_SZ   = MAX_PQC_PUBLIC_KEY_SZ + MAX_ALGO_SZ + MAX_SEQ_SZ * 2,
+#else
+    MAX_PUBLIC_KEY_SZ   = MAX_DSA_PUBKEY_SZ + MAX_ALGO_SZ + MAX_SEQ_SZ * 2,
+#endif
+#ifdef WOLFSSL_ENCRYPTED_KEYS
+    HEADER_ENCRYPTED_KEY_SIZE = 88,/* Extra header size for encrypted key */
+#else
+    HEADER_ENCRYPTED_KEY_SIZE = 0,
+#endif
+};
+
+#ifdef WOLFSSL_CERT_GEN
+    #ifdef WOLFSSL_NO_MALLOC
+    #include "wolfssl/wolfcrypt/hash.h" /* for max sizes */
+    #endif
     /* Used in asn.c MakeSignature for ECC and RSA non-blocking/async */
     enum CertSignState {
         CERTSIGN_STATE_BEGIN,
@@ -2002,11 +2076,22 @@ WOLFSSL_API word32 CheckRunTimeSettings(void);
     };
 
     typedef struct CertSignCtx {
+    #ifdef WOLFSSL_NO_MALLOC
+        byte sig[MAX_ENCODED_SIG_SZ];
+        byte digest[WC_MAX_DIGEST_SIZE];
+        #ifndef NO_RSA
+        byte encSig[MAX_DER_DIGEST_SZ];
+        #endif
+    #else
         byte* sig;
         byte* digest;
         #ifndef NO_RSA
-            byte* encSig;
-            int encSigSz;
+        byte* encSig;
+        #endif
+    #endif
+
+        #ifndef NO_RSA
+        int encSigSz;
         #endif
         int state; /* enum CertSignState */
     } CertSignCtx;


### PR DESCRIPTION
# Description

Refactor to support CSR generation and signing with `WOLFSSL_NO_MALLOC`.
ZD 19948

# Testing

` ./configure --enable-certgen --enable-certext --disable-examples --enable-cryptonly CFLAGS="-DWOLFSSL_NO_MALLOC" && make`

Tested using https://github.com/wolfSSL/wolfssl-examples/blob/master/certgen/csr_example.c

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
