### PR TITLE
quickfix: add missing include to asn.h 

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -91,6 +91,12 @@ that can be serialized and deserialized in a cross-platform way.
     #define WC_SHA256_DIGEST_SIZE 32
 #endif
 
+#ifdef WOLFSSL_NO_MALLOC
+/* need access to WC_MAX_DIGEST_SIZE for the fixed size digest buffer in the
+ * definition of the SignatureCtx struct when building with WOLFSSL_NO_MALLOC */
+#include <wolfssl/wolfcrypt/hash.h>
+#endif
+
 #ifdef __cplusplus
     extern "C" {
 #endif


### PR DESCRIPTION
# Description

Adds missing include to fix compiler errors in wolfBoot introduced when updating to the latest wolfSSL master. The wolfSSL upstream change that caused the error was introduced in #8725 - `WC_MAX_DIGEST_SIZE` is used to size a buffer in the no malloc case, but is defined in `hash.h` which was never included by `asn.h`.

Odd that our CI no malloc tests weren't able to catch this... I suspect it has something to do with using configure vs the wolfBoot user settings and makefile?

Let me know if you think there is a better way to do it.

