### PR TITLE
Coverity: api.c fix

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -20906,21 +20906,33 @@ static int test_wolfSSL_ASN1_TIME_adj(void)
     /* offset_sec = -45 * min;*/
     ExpectNotNull(asn_time =
             wolfSSL_ASN1_TIME_adj(s, t, offset_day, offset_sec));
-    ExpectTrue(asn_time->type == asn_utc_time);
-    ExpectNotNull(XSTRNCPY(date_str, (const char*)&asn_time->data,
-        CTC_DATE_SIZE));
-    date_str[CTC_DATE_SIZE] = '\0';
-    ExpectIntEQ(0, XMEMCMP(date_str, "000222211500Z", 13));
+    if (asn_time != NULL) {
+        ExpectTrue(asn_time->type == asn_utc_time);
+        ExpectNotNull(XSTRNCPY(date_str, (const char*)&asn_time->data,
+            CTC_DATE_SIZE));
+        date_str[CTC_DATE_SIZE] = '\0';
+        ExpectIntEQ(0, XMEMCMP(date_str, "000222211500Z", 13));
+        if (asn_time != s) {
+            XFREE(asn_time, NULL, DYNAMIC_TYPE_OPENSSL);
+        }
+        asn_time = NULL;
+    }
 
     /* negative offset */
     offset_sec = -45 * mini;
     asn_time = wolfSSL_ASN1_TIME_adj(s, t, offset_day, offset_sec);
     ExpectNotNull(asn_time);
-    ExpectTrue(asn_time->type == asn_utc_time);
-    ExpectNotNull(XSTRNCPY(date_str, (const char*)&asn_time->data,
-        CTC_DATE_SIZE));
-    date_str[CTC_DATE_SIZE] = '\0';
-    ExpectIntEQ(0, XMEMCMP(date_str, "000222194500Z", 13));
+    if (asn_time != NULL) {
+        ExpectTrue(asn_time->type == asn_utc_time);
+        ExpectNotNull(XSTRNCPY(date_str, (const char*)&asn_time->data,
+            CTC_DATE_SIZE));
+        date_str[CTC_DATE_SIZE] = '\0';
+        ExpectIntEQ(0, XMEMCMP(date_str, "000222194500Z", 13));
+        if (asn_time != s) {
+            XFREE(asn_time, NULL, DYNAMIC_TYPE_OPENSSL);
+        }
+        asn_time = NULL;
+    }
 
     XFREE(s, NULL, DYNAMIC_TYPE_OPENSSL);
     s = NULL;
@@ -20937,11 +20949,17 @@ static int test_wolfSSL_ASN1_TIME_adj(void)
         offset_sec = 10 * mini;
     ExpectNotNull(asn_time = wolfSSL_ASN1_TIME_adj(s, t, offset_day,
         offset_sec));
-    ExpectTrue(asn_time->type == asn_gen_time);
-    ExpectNotNull(XSTRNCPY(date_str, (const char*)&asn_time->data,
-        CTC_DATE_SIZE));
-    date_str[CTC_DATE_SIZE] = '\0';
-    ExpectIntEQ(0, XMEMCMP(date_str, "20550313091000Z", 15));
+    if (asn_time != NULL) {
+        ExpectTrue(asn_time->type == asn_gen_time);
+        ExpectNotNull(XSTRNCPY(date_str, (const char*)&asn_time->data,
+            CTC_DATE_SIZE));
+        date_str[CTC_DATE_SIZE] = '\0';
+        ExpectIntEQ(0, XMEMCMP(date_str, "20550313091000Z", 15));
+        if (asn_time != s) {
+            XFREE(asn_time, NULL, DYNAMIC_TYPE_OPENSSL);
+        }
+        asn_time = NULL;
+    }
 
     XFREE(s, NULL, DYNAMIC_TYPE_OPENSSL);
     s = NULL;
@@ -20956,22 +20974,26 @@ static int test_wolfSSL_ASN1_TIME_adj(void)
     offset_sec = 45 * mini;
     ExpectNotNull(asn_time = wolfSSL_ASN1_TIME_adj(s, t, offset_day,
         offset_sec));
-    ExpectTrue(asn_time->type == asn_utc_time);
-    ExpectNotNull(XSTRNCPY(date_str, (const char*)&asn_time->data,
-        CTC_DATE_SIZE));
-    date_str[CTC_DATE_SIZE] = '\0';
-    ExpectIntEQ(0, XMEMCMP(date_str, "000222211515Z", 13));
-    XFREE(asn_time, NULL, DYNAMIC_TYPE_OPENSSL);
-    asn_time = NULL;
-
+    if (asn_time != NULL) {
+        ExpectTrue(asn_time->type == asn_utc_time);
+        ExpectNotNull(XSTRNCPY(date_str, (const char*)&asn_time->data,
+            CTC_DATE_SIZE));
+        date_str[CTC_DATE_SIZE] = '\0';
+        ExpectIntEQ(0, XMEMCMP(date_str, "000222211515Z", 13));
+        XFREE(asn_time, NULL, DYNAMIC_TYPE_OPENSSL);
+        asn_time = NULL;
+    }
     ExpectNotNull(asn_time = wolfSSL_ASN1_TIME_adj(NULL, t, offset_day,
         offset_sec));
-    ExpectTrue(asn_time->type == asn_utc_time);
-    ExpectNotNull(XSTRNCPY(date_str, (const char*)&asn_time->data,
-        CTC_DATE_SIZE));
-    date_str[CTC_DATE_SIZE] = '\0';
-    ExpectIntEQ(0, XMEMCMP(date_str, "000222211515Z", 13));
-    XFREE(asn_time, NULL, DYNAMIC_TYPE_OPENSSL);
+    if (asn_time != NULL) {
+        ExpectTrue(asn_time->type == asn_utc_time);
+        ExpectNotNull(XSTRNCPY(date_str, (const char*)&asn_time->data,
+            CTC_DATE_SIZE));
+        date_str[CTC_DATE_SIZE] = '\0';
+        ExpectIntEQ(0, XMEMCMP(date_str, "000222211515Z", 13));
+        XFREE(asn_time, NULL, DYNAMIC_TYPE_OPENSSL);
+        asn_time = NULL;
+    }
 #endif
     return EXPECT_RESULT();
 }


### PR DESCRIPTION
# Description

Addresses Use after free issue in api.c. Assign value to `asn_time` before checking if NULL in test.