### PR TITLE
20250529-linuxkm-fix-AesGcmCrypt_1-no-stream

### DIFF
--- a/linuxkm/lkcapi_aes_glue.c
+++ b/linuxkm/lkcapi_aes_glue.c
@@ -1432,9 +1432,6 @@ static int AesGcmCrypt_1(struct aead_request *req, int decrypt_p, int rfc4106_p)
 
 out:
 
-    if (sk_walk.nbytes)
-        (void)skcipher_walk_done(&sk_walk, -EINVAL); /* force summary cleanup */
-
     if (sg_buf) {
         free(sg_buf);
     }


### PR DESCRIPTION
`linuxkm/lkcapi_aes_glue.c`: in `AesGcmCrypt_1()`, in !`WOLFSSL_AESGCM_STREAM` version, don't call `skcipher_walk_done(&sk_walk, ...)` -- doesn't work, and not needed.

reverts two lines in  5c0a278c7f369ed286cba8c434150e4291147ea3 (#8810)

tested with
```
wolfssl-multi-test.sh ...
quantum-safe-wolfssl-all-crypto-only-noasm-linuxkm-insmod
quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-linuxkm-insmod
linuxkm-6.12-all-cryptonly-noasm-fips-v5-dyn-hash-LKCAPI-insmod
linuxkm-6.12-all-cryptonly-aesni-fips-v5-dyn-hash-LKCAPI-insmod
linuxkm-all-intelasm-insmod
linuxkm-aescbc-cryptonly-aesni-fips-v5-dyn-hash-LKCAPI-yes-twc-insmod
linuxkm-aescbc-cryptonly-noasm-fips-v5-dyn-hash-LKCAPI-yes-twc-insmod
linuxkm-aesni-sp-asm-pie-insmod-no-ecc521
linuxkm-cryptonly-aesni-fips-v5-dyn-hash-LKCAPI-yes-twc-insmod-kmemleak
```
