### PR TITLE
linuxkm rsa: fix ret value usage for crypto_sig_sign.

### DIFF
--- a/linuxkm/lkcapi_rsa_glue.c
+++ b/linuxkm/lkcapi_rsa_glue.c
@@ -1364,7 +1364,13 @@ static int km_pkcs1_sign(struct crypto_sig *tfm,
         goto pkcs1_sign_out;
     }
 
+    /* in 6.15 crypto_sig_sign switched from returning 0 on success to
+     * returning sig_len. */
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
     err = sig_len;
+    #else
+    err = 0;
+    #endif /* linux >= 6.15.0 */
 pkcs1_sign_out:
     if (msg != NULL) { free(msg); msg = NULL; }
 
@@ -3107,12 +3113,16 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
+    /* in 6.15 crypto_sig_sign switched from returning 0 on success to
+     * returning sig_len. */
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
     if ((word32) ret != sig_len) {
         pr_err("error: crypto_sig_sign returned %d, expected %d\n", ret,
                sig_len);
         test_rc = BAD_FUNC_ARG;
         goto test_pkcs1_end;
     }
+    #endif /* linux >= 6.15.0 */
 
     n_diff = memcmp(km_sig, sig, sig_len);
     if (n_diff) {


### PR DESCRIPTION
# Description

Fix crypto_sig_sign callback and unit test to match correct behavior:

- linux version >= 6.13 and < 6.15: crypto_sig_sign returns 0 on success.
- linux version >= 6.15: crypto_sig_sign returns sig_len on success.

## Testing

Tested with:
- linux-6.15-rc6 
- linux-6.14-rc5
- linux-6.13.6-gentoo
- linux-6.12.10-gentoo

with these additional cflags:
- `-DWOLFKM_DEBUG_RSA -DWOLFKM_DEBUG_RSA_GENERIC`

## References:

- 6.14: https://github.com/torvalds/linux/blob/v6.14/include/crypto/sig.h#L189
- 6.15: https://github.com/torvalds/linux/blob/v6.15-rc1/include/crypto/sig.h#L190

Also can see difference in crypto/testmgr.c:
- https://github.com/torvalds/linux/blob/v6.14/crypto/testmgr.c#L4342
- https://github.com/torvalds/linux/blob/v6.15-rc1/crypto/testmgr.c#L4206
