### PR TITLE
WOLFSSL_ASN_ALLOW_0_SERIAL not handled in make check

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -45925,7 +45925,8 @@ static int test_MakeCertWith0Ser(void)
 
     wc_InitDecodedCert(&decodedCert, der, (word32)derSize, NULL);
 
-#if !defined(WOLFSSL_NO_ASN_STRICT) && !defined(WOLFSSL_PYTHON)
+#if !defined(WOLFSSL_NO_ASN_STRICT) && !defined(WOLFSSL_PYTHON) && \
+    !defined(WOLFSSL_ASN_ALLOW_0_SERIAL)
     ExpectIntEQ(wc_ParseCert(&decodedCert, CERT_TYPE, NO_VERIFY, NULL),
         WC_NO_ERR_TRACE(ASN_PARSE_E));
 #else


### PR DESCRIPTION
# Description

test_MakeCertWith0Ser in unit.test did not account for WOLFSSL_ASN_ALLOW_0_SERIAL.

This test fails when the library is configured as ./configure --enable-certreq --enable-certgen CFLAGS='-DWOLFSSL_ASN_ALLOW_0_SERIAL'.

test_MakeCertWith0Ser needed an extra #define check for WOLFSSL_ASN_ALLOW_0_SERIAL. Previously, it was validating that a 0 serial number should not work -> now it validates that a 0 serial number does work.

Fixes zd#

No ticket is fixed by this, but it is related to a suggested configuration proposed in #19960 that will soon be added to the PRB test configurations.

# Testing

I ran the specific test for test_MakeCertWith0Ser in isolation and it passed. I then ran make check and that passed as well.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
