### PR TITLE
Support PBE_AES(256|128)_CBC certificate encryptions on wc_PKCS12_create()

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -18924,8 +18924,9 @@ static int test_wc_i2d_PKCS12(void)
 static int test_wc_PKCS12_create_once(int keyEncType, int certEncType)
 {
     EXPECT_DECLS;
-#if !defined(NO_ASN) && defined(HAVE_PKCS12) && !defined(NO_PWDBASED) \
-    && !defined(NO_HMAC) && !defined(NO_CERTS) && defined(USE_CERT_BUFFERS_2048)
+#if !defined(NO_ASN) && defined(HAVE_PKCS12) && !defined(NO_PWDBASED) && \
+    !defined(NO_RSA) && !defined(NO_ASN_CRYPT) && \
+    !defined(NO_HMAC) && !defined(NO_CERTS) && defined(USE_CERT_BUFFERS_2048)
 
     byte* inKey = (byte*) server_key_der_2048;
     const word32 inKeySz= sizeof_server_key_der_2048;
@@ -18989,18 +18990,17 @@ static int test_wc_PKCS12_create(void)
 {
     EXPECT_DECLS;
 #if !defined(NO_DES3) && !defined(NO_SHA)
-    ExpectIntEQ(test_wc_PKCS12_create_once(PBE_SHA1_DES3, PBE_SHA1_DES3),
-        TEST_SUCCESS);
+    EXPECT_TEST(test_wc_PKCS12_create_once(PBE_SHA1_DES3, PBE_SHA1_DES3));
 #endif
-#if defined(HAVE_AES_CBC) && !defined(NO_AES_256) && !defined(NO_DES3) && \
-    !defined(NO_SHA)
-    ExpectIntEQ(test_wc_PKCS12_create_once(PBE_AES256_CBC, PBE_SHA1_DES3),
-        TEST_SUCCESS);
+#if defined(HAVE_AES_CBC) && !defined(NO_AES) && !defined(NO_AES_256) && \
+    !defined(NO_SHA) && defined(WOLFSSL_ASN_TEMPLATE)
+    /* Encoding certificate with PBE_AES256_CBC needs WOLFSSL_ASN_TEMPLATE */
+    EXPECT_TEST(test_wc_PKCS12_create_once(PBE_AES256_CBC, PBE_AES256_CBC));
 #endif
-#if defined(HAVE_AES_CBC) && !defined(NO_AES_128) && !defined(NO_DES3) && \
-    !defined(NO_SHA)
-    ExpectIntEQ(test_wc_PKCS12_create_once(PBE_AES128_CBC, PBE_SHA1_DES3),
-        TEST_SUCCESS);
+#if defined(HAVE_AES_CBC) && !defined(NO_AES) && !defined(NO_AES_128) && \
+    !defined(NO_SHA) && defined(WOLFSSL_ASN_TEMPLATE)
+    /* Encoding certificate with PBE_AES128_CBC needs WOLFSSL_ASN_TEMPLATE */
+    EXPECT_TEST(test_wc_PKCS12_create_once(PBE_AES128_CBC, PBE_AES128_CBC));
 #endif
     (void) test_wc_PKCS12_create_once;
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -19002,6 +19002,12 @@ static int test_wc_PKCS12_create(void)
     /* Encoding certificate with PBE_AES128_CBC needs WOLFSSL_ASN_TEMPLATE */
     EXPECT_TEST(test_wc_PKCS12_create_once(PBE_AES128_CBC, PBE_AES128_CBC));
 #endif
+/* Testing a mixture of 2 algorithms */
+#if defined(HAVE_AES_CBC) && !defined(NO_AES) && !defined(NO_AES_256) && \
+    !defined(NO_SHA) && defined(WOLFSSL_ASN_TEMPLATE) && !defined(NO_DES3)
+    EXPECT_TEST(test_wc_PKCS12_create_once(PBE_AES256_CBC, PBE_SHA1_DES3));
+#endif
+
     (void) test_wc_PKCS12_create_once;
 
     return EXPECT_RESULT();

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -512,8 +512,10 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
         switch (version) {
     #ifndef NO_HMAC
             case PKCS5v2:
+                PRIVATE_KEY_UNLOCK();
                 ret = wc_PBKDF2(key, (byte*)password, passwordSz,
                                 salt, saltSz, iterations, (int)derivedLen, typeH);
+                PRIVATE_KEY_LOCK();
                 break;
     #endif
     #ifndef NO_SHA

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1184,6 +1184,7 @@ enum Misc_ASN {
 #endif
 
     PKCS5_SALT_SZ       = 8,
+    PKCS5V2_SALT_SZ     = 16,
 
     PEM_LINE_SZ        = 64,               /* Length of Base64 encoded line, not including new line */
     PEM_LINE_LEN       = PEM_LINE_SZ + 12, /* PEM line max + fudge */
@@ -2172,8 +2173,9 @@ WOLFSSL_ASN_API int TraditionalEnc(byte* key, word32 keySz, byte* out,
         WC_RNG* rng, void* heap);
 WOLFSSL_LOCAL int DecryptContent(byte* input, word32 sz,const char* psw,int pswSz);
 WOLFSSL_LOCAL int EncryptContent(byte* input, word32 sz, byte* out, word32* outSz,
-        const char* password,int passwordSz, int vPKCS, int vAlgo,
-        byte* salt, word32 saltSz, int itt, WC_RNG* rng, void* heap);
+        const char* password,int passwordSz, int vPKCS, int vAlgo, int encAlgId,
+        byte* salt, word32 saltSz, int itt, int hmacOid, WC_RNG* rng,
+        void* heap);
 WOLFSSL_LOCAL int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID,
         word32* oidSz, int* algoID, void* heap);
 


### PR DESCRIPTION
# Description

This PR adds `PBE_AES256_CBC` and `PBE_AES128_CBC` certificate encryption supports on `wc_PKCS12_create()`.

Fixes zd#19747

# Testing
./configure CFLAGS="-DUSE_CERT_BUFFERS_2048" --enable-debug --enable-des3 --enable-asn && make test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
