### PR TITLE
Fix parsing RPK with no parameters.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -61019,7 +61019,7 @@ static int test_wolfSSL_DTLS_fragment_buckets(void)
 
 #if !defined(NO_FILESYSTEM) && \
      defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) && \
-     defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES)
+     defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && !defined(NO_RSA)
 
 static int test_wolfSSL_dtls_stateless2(void)
 {

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -27,7 +27,8 @@
 #ifndef TESTS_UTILS_H
 #define TESTS_UTILS_H
 
-#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_RSA) && \
+#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && \
+    (!defined(NO_RSA) || defined(HAVE_RPK)) && \
     !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT) && \
     (!defined(WOLFSSL_NO_TLS12) || defined(WOLFSSL_TLS13))
 #define HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -22869,10 +22869,10 @@ static const ASNItem RPKCertASN[] = {
         /* Algorithm  OBJECT IDENTIFIER */
         /* TBS_SPUBKEYINFO_ALGO_OID     */       { 2, ASN_OBJECT_ID, 0, 0, 0 },
         /* parameters   ANY defined by algorithm OPTIONAL */
-        /* TBS_SPUBKEYINFO_ALGO_NULL     */      { 2, ASN_TAG_NULL, 0, 0, 2 },
-        /* TBS_SPUBKEYINFO_ALGO_CURVEID  */      { 2, ASN_OBJECT_ID, 0, 0, 2 },
+        /* TBS_SPUBKEYINFO_ALGO_NULL     */      { 2, ASN_TAG_NULL, 0, 0, 1 },
+        /* TBS_SPUBKEYINFO_ALGO_CURVEID  */      { 2, ASN_OBJECT_ID, 0, 0, 1 },
 #ifdef WC_RSA_PSS
-        /* TBS_SPUBKEYINFO_ALGO_P_SEQ    */      { 2, ASN_SEQUENCE, 1, 0, 2 },
+        /* TBS_SPUBKEYINFO_ALGO_P_SEQ    */      { 2, ASN_SEQUENCE, 1, 0, 1 },
 #endif
         /* subjectPublicKey   BIT STRING */
         /* TBS_SPUBKEYINFO_PUBKEY        */   { 1, ASN_BIT_STRING, 0, 0, 0 },


### PR DESCRIPTION
# Description

Fixes zd#19911

Fix parsing RPK with no parameters.  As per RFC7250 section 3, the algorithm parameters are optional.

Fix building unit tests with --enable-rpk --disable-rsa.

# Testing

Customer provided test key.

The following configure line was used for building unit tests:
```
./configure --enable-kyber --enable-mlkem --enable-dilithium --enable-dtls --enable-dtls13 --enable-dtls-frag-ch --enable-debug --enable-debug-trace-errcodes \
CFLAGS="-DHAVE_RPK -DWOLFSSL_DER_LOAD -DWOLFSSL_LOGGINGENABLED_DEFAULT=1" --disable-rsa
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
