### PR TITLE
20250530-ML-KEM-WC_SHA3_NO_ASM

### DIFF
--- a/.github/workflows/wolfCrypt-Wconversion.yml
+++ b/.github/workflows/wolfCrypt-Wconversion.yml
@@ -35,7 +35,10 @@ jobs:
         name: Checkout wolfSSL
 
       - name: install_multilib
-        run: sudo apt-get install -y gcc-multilib
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
 
       - name: Build wolfCrypt with extra type conversion warnings
         run: |

--- a/configure.ac
+++ b/configure.ac
@@ -1502,6 +1502,9 @@ do
   ml-kem)
     ENABLED_ML_KEM=yes
     ;;
+  noasm)
+    AM_CFLAGS="$AM_CFLAGS -DWC_MLKEM_NO_ASM"
+    ;;
   *)
     AC_MSG_ERROR([Invalid choice for MLKEM []: $ENABLED_MLKEM.])
     break;;

--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -143,6 +143,7 @@ $(obj)/wolfcrypt/src/chacha_asm.o: OBJECT_FILES_NON_STANDARD := y
 $(obj)/wolfcrypt/src/poly1305_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
 $(obj)/wolfcrypt/src/poly1305_asm.o: OBJECT_FILES_NON_STANDARD := y
 $(obj)/wolfcrypt/src/wc_mlkem_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
+$(obj)/wolfcrypt/src/wc_mlkem_asm.o: OBJECT_FILES_NON_STANDARD := y
 
 ifndef READELF
     READELF := readelf

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -248,9 +248,6 @@ while (0)
  *
  * s  The state.
  */
-#ifndef USE_INTEL_SPEEDUP
-static
-#endif
 void BlockSha3(word64* s)
 {
     byte i, x, y;
@@ -541,9 +538,6 @@ while (0)
  *
  * s  The state.
  */
-#ifndef USE_INTEL_SPEEDUP
-static
-#endif
 void BlockSha3(word64* s)
 {
     word64 n[25];

--- a/wolfcrypt/src/wc_mlkem.c
+++ b/wolfcrypt/src/wc_mlkem.c
@@ -65,6 +65,12 @@
 
 #include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
+#ifdef WC_MLKEM_NO_ASM
+    #undef USE_INTEL_SPEEDUP
+    #undef WOLFSSL_ARMASM
+    #undef WOLFSSL_RISCV_ASM
+#endif
+
 #include <wolfssl/wolfcrypt/mlkem.h>
 #include <wolfssl/wolfcrypt/wc_mlkem.h>
 #include <wolfssl/wolfcrypt/hash.h>

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -223,26 +223,22 @@ WOLFSSL_API int wc_Shake256_Copy(wc_Shake* src, wc_Sha3* dst);
 WOLFSSL_LOCAL void BlockSha3(word64 *s);
 
 #ifdef WC_SHA3_NO_ASM
-/* asm speedups disabled */
-#if defined(USE_INTEL_SPEEDUP) && !defined(WC_MLKEM_NO_ASM)
-    /* native ML-KEM uses this directly. */
-    WOLFSSL_LOCAL void sha3_blocksx4_avx2(word64* s);
-#endif
+    /* asm speedups disabled */
+    #if defined(USE_INTEL_SPEEDUP) && !defined(WC_MLKEM_NO_ASM)
+        /* native ML-KEM uses this directly. */
+        WOLFSSL_LOCAL void sha3_blocksx4_avx2(word64* s);
+    #endif
 #elif defined(USE_INTEL_SPEEDUP)
-WOLFSSL_LOCAL void sha3_block_n_bmi2(word64* s, const byte* data, word32 n,
-    word64 c);
-WOLFSSL_LOCAL void sha3_block_bmi2(word64* s);
-WOLFSSL_LOCAL void sha3_block_avx2(word64* s);
-WOLFSSL_LOCAL void sha3_blocksx4_avx2(word64* s);
-WOLFSSL_LOCAL void BlockSha3(word64 *s);
+    WOLFSSL_LOCAL void sha3_block_n_bmi2(word64* s, const byte* data, word32 n,
+        word64 c);
+    WOLFSSL_LOCAL void sha3_block_bmi2(word64* s);
+    WOLFSSL_LOCAL void sha3_block_avx2(word64* s);
+    WOLFSSL_LOCAL void sha3_blocksx4_avx2(word64* s);
 #elif defined(__aarch64__) && defined(WOLFSSL_ARMASM)
-#ifdef WOLFSSL_ARMASM_CRYPTO_SHA3
-WOLFSSL_LOCAL void BlockSha3_crypto(word64 *s);
-#endif
-WOLFSSL_LOCAL void BlockSha3_base(word64 *s);
-WOLFSSL_LOCAL void BlockSha3(word64 *s);
-#elif defined(WOLFSSL_ARMASM) || defined(WOLFSSL_RISCV_ASM)
-WOLFSSL_LOCAL void BlockSha3(word64 *s);
+    #ifdef WOLFSSL_ARMASM_CRYPTO_SHA3
+        WOLFSSL_LOCAL void BlockSha3_crypto(word64 *s);
+    #endif
+    WOLFSSL_LOCAL void BlockSha3_base(word64 *s);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -220,8 +220,14 @@ WOLFSSL_API int wc_Shake256_Copy(wc_Shake* src, wc_Sha3* dst);
     WOLFSSL_API int wc_Sha3_GetFlags(wc_Sha3* sha3, word32* flags);
 #endif
 
+WOLFSSL_LOCAL void BlockSha3(word64 *s);
+
 #ifdef WC_SHA3_NO_ASM
 /* asm speedups disabled */
+#if defined(USE_INTEL_SPEEDUP) && !defined(WC_MLKEM_NO_ASM)
+    /* native ML-KEM uses this directly. */
+    WOLFSSL_LOCAL void sha3_blocksx4_avx2(word64* s);
+#endif
 #elif defined(USE_INTEL_SPEEDUP)
 WOLFSSL_LOCAL void sha3_block_n_bmi2(word64* s, const byte* data, word32 n,
     word64 c);


### PR DESCRIPTION
`wolfcrypt/src/wc_mlkem_poly.c` and `configure.ac`: add support for `WC_MLKEM_NO_ASM`, and add gates to support `WC_SHA3_NO_ASM`;

`wolfcrypt/src/sha3.c` and `wolfssl/wolfcrypt/sha3.h`: `BlockSha3()` now always `WOLFSSL_LOCAL` (never static) to support calls from MLKEM implementation.

`linuxkm/Kbuild`: set `OBJECT_FILES_NON_STANDARD=y` for `wolfcrypt/src/wc_mlkem_asm.o` ("'naked' return found").

`.github/workflows/wolfCrypt-Wconversion.yml`: fix `apt-get` to `update` first.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
check-configure
quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-linuxkm-insmod
linuxkm-6.15-all-cryptonly-quantum-safe-intelasm-LKCAPI-insmod-crypto-fuzzer-kmemleak
linuxkm-6.15-all-cryptonly-quantum-safe-intelasm-LKCAPI-insmod-crypto-fuzzer-ksan
```
