### PR TITLE
Aarch64 XFENCE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3225,6 +3225,26 @@ then
             ENABLED_ARMASM_CRYPTO_SM4=yes
             ENABLED_ARMASM_PLUS=yes
             ;;
+        barrier-sb)
+            case $host_cpu in
+            *aarch64*)
+                ;;
+            *)
+                AC_MSG_ERROR([SB instructions only available on Aarch64 CPU.])
+                break;;
+            esac
+            ENABLED_ARMASM_BARRIER_SB=yes
+            ;;
+        barrier-detect)
+            case $host_cpu in
+            *aarch64*)
+                ;;
+            *)
+                AC_MSG_ERROR([SB instructions only available on Aarch64 CPU.])
+                break;;
+            esac
+            ENABLED_ARMASM_BARRIER_DETECT=yes
+            ;;
         *)
             AC_MSG_ERROR([Invalid choice of ARM asm inclusions (yes, sha512-crypto, sha3-crypto): $ENABLED_ARMASM.])
             break;;
@@ -3366,6 +3386,12 @@ if test "$ENABLED_ARMASM_SM3" = "yes"; then
 fi
 if test "$ENABLED_ARMASM_SM4" = "yes"; then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ARMASM_CRYPTO_SM4"
+fi
+if test "$ENABLED_ARMASM_BARRIER_SB" = "yes"; then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ARMASM_BARRIER_SB"
+fi
+if test "$ENABLED_ARMASM_BARRIER_DETECT" = "yes"; then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ARMASM_BARRIER_DETECT"
 fi
 if test "$ENABLED_ARMASM_CRYPTO" = "unknown"; then
     ENABLED_ARMASM_CRYPTO=no

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -25,6 +25,7 @@
     #include <AvailabilityMacros.h>
 #endif
 
+#include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef HAVE_ECC
     #include <wolfssl/wolfcrypt/ecc.h>
 #endif
@@ -145,6 +146,10 @@
 /* prevent multiple mutex initializations */
 static volatile int initRefCount = 0;
 
+#if defined(__aarch64__) && defined(WOLFSSL_ARMASM_BARRIER_DETECT)
+int aarch64_use_sb = 0;
+#endif
+
 /* Used to initialize state for wolfcrypt
    return 0 on success
  */
@@ -154,6 +159,10 @@ int wolfCrypt_Init(void)
     int ret = 0;
     if (initRefCount == 0) {
         WOLFSSL_ENTER("wolfCrypt_Init");
+
+    #if defined(__aarch64__) && defined(WOLFSSL_ARMASM_BARRIER_DETECT)
+        aarch64_use_sb = IS_AARCH64_SB(cpuid_get_flags());
+    #endif
 
     #ifdef WOLFSSL_CHECK_MEM_ZERO
         /* Initialize the mutex for access to the list of memory locations that

--- a/wolfssl/wolfcrypt/cpuid.h
+++ b/wolfssl/wolfcrypt/cpuid.h
@@ -70,14 +70,15 @@
 
 #elif defined(HAVE_CPUID_AARCH64)
 
-    #define CPUID_AES         0x0001
-    #define CPUID_PMULL       0x0002
-    #define CPUID_SHA256      0x0004
-    #define CPUID_SHA512      0x0008
-    #define CPUID_RDM         0x0010
-    #define CPUID_SHA3        0x0020
-    #define CPUID_SM3         0x0040
-    #define CPUID_SM4         0x0080
+    #define CPUID_AES         0x0001    /* AES enc/dec */
+    #define CPUID_PMULL       0x0002    /* Carryless multiplication */
+    #define CPUID_SHA256      0x0004    /* SHA-256 digest */
+    #define CPUID_SHA512      0x0008    /* SHA-512 digest */
+    #define CPUID_RDM         0x0010    /* SQRDMLAH and SQRDMLSH */
+    #define CPUID_SHA3        0x0020    /* SHA-3 digest */
+    #define CPUID_SM3         0x0040    /* SM3 digest */
+    #define CPUID_SM4         0x0080    /* SM4 enc/dec */
+    #define CPUID_SB          0x0100    /* Speculation barrier */
 
     #define IS_AARCH64_AES(f)       ((f) & CPUID_AES)
     #define IS_AARCH64_PMULL(f)     ((f) & CPUID_PMULL)
@@ -87,6 +88,7 @@
     #define IS_AARCH64_SHA3(f)      ((f) & CPUID_SHA3)
     #define IS_AARCH64_SM3(f)       ((f) & CPUID_SM3)
     #define IS_AARCH64_SM4(f)       ((f) & CPUID_SM4)
+    #define IS_AARCH64_SB(f)        ((f) & CPUID_SB)
 
 #endif
 

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1536,8 +1536,24 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
         #define XFENCE() WC_DO_NOTHING
     #elif defined (__i386__) || defined(__x86_64__)
         #define XFENCE() XASM_VOLATILE("lfence")
-    #elif (defined (__arm__) && (__ARM_ARCH > 6)) || defined(__aarch64__)
+    #elif defined (__arm__) && (__ARM_ARCH > 6)
         #define XFENCE() XASM_VOLATILE("isb")
+    #elif defined(__aarch64__)
+        /* Change ".inst 0xd50330ff" to "sb" when compilers support it. */
+        #ifdef WOLFSSL_ARMASM_BARRIER_SB
+            #define XFENCE() XASM_VOLATILE(".inst 0xd50330ff")
+        #elif defined(WOLFSSL_ARMASM_BARRIER_DETECT)
+	    extern int aarch64_use_sb;
+            #define XFENCE()                                \
+                do {                                        \
+                    if (aarch64_use_sb)                     \
+                        XASM_VOLATILE(".inst 0xd50330ff");  \
+                    else                                    \
+                        XASM_VOLATILE("isb");               \
+                } while (0)
+        #else
+            #define XFENCE() XASM_VOLATILE("isb")
+        #endif
     #elif defined(__riscv)
         #define XFENCE() XASM_VOLATILE("fence")
     #elif defined(__PPC__) || defined(__POWERPC__)


### PR DESCRIPTION
# Description

Use sb instruction instead of isb if available.

Fixes #8804

# Testing

./configure --disable-shared LDFLAGS=--static --host=aarch64 CC=aarch64-linux-gnu-gcc --enable-armasm=barrier-sb

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
