### PR TITLE
domain name policy for WOLFSSL_APPLE_NATIVE_CERT_VALIDATION

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -42789,7 +42789,8 @@ static int DoAppleNativeCertValidation(WOLFSSL* ssl,
             ssl->buffers.domainName.length > 0) {
         /* Create policy with specified value to require host name match */
         hostname = CFStringCreateWithCString(kCFAllocatorDefault,
-        (const char*)ssl->buffers.domainName.buffer, kCFStringEncodingUTF8);
+                                (const char*)ssl->buffers.domainName.buffer,
+                                 kCFStringEncodingUTF8);
     }
     if (hostname != NULL) {
         policy = SecPolicyCreateSSL(true, hostname);

--- a/src/internal.c
+++ b/src/internal.c
@@ -16809,7 +16809,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             /* If we can't validate the peer cert chain against the CAs loaded
              * into wolfSSL, try to validate against the system certificates
              * using Apple's native trust APIs */
-            if ((ret != 0) && (ssl->ctx->doAppleNativeCertValidationFlag)) {
+            if ((ret == ASN_NO_SIGNER_E) &&
+                (ssl->ctx->doAppleNativeCertValidationFlag)) {
                 if (DoAppleNativeCertValidation(ssl, args->certs,
                                                      args->totalCerts)) {
                     WOLFSSL_MSG("Apple native cert chain validation SUCCESS");

--- a/src/internal.c
+++ b/src/internal.c
@@ -16809,7 +16809,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             /* If we can't validate the peer cert chain against the CAs loaded
              * into wolfSSL, try to validate against the system certificates
              * using Apple's native trust APIs */
-            if ((ret == ASN_NO_SIGNER_E) &&
+            if ((ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E)) &&
                 (ssl->ctx->doAppleNativeCertValidationFlag)) {
                 if (DoAppleNativeCertValidation(ssl, args->certs,
                                                      args->totalCerts)) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -213,7 +213,7 @@ int writeAeadAuthData(WOLFSSL* ssl, word16 sz, byte type, byte* additional,
 #include <Security/SecCertificate.h>
 #include <Security/SecTrust.h>
 #include <Security/SecPolicy.h>
-static int DoAppleNativeCertValidation(const WOLFSSL_BUFFER_INFO* certs,
+static int DoAppleNativeCertValidation(WOLFSSL* ssl, const WOLFSSL_BUFFER_INFO* certs,
                                             int totalCerts);
 #endif /* #if defined(__APPLE__) && defined(WOLFSSL_SYS_CA_CERTS) */
 
@@ -16810,7 +16810,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
              * into wolfSSL, try to validate against the system certificates
              * using Apple's native trust APIs */
             if ((ret != 0) && (ssl->ctx->doAppleNativeCertValidationFlag)) {
-                if (DoAppleNativeCertValidation(args->certs,
+                if (DoAppleNativeCertValidation(ssl, args->certs,
                                                      args->totalCerts)) {
                     WOLFSSL_MSG("Apple native cert chain validation SUCCESS");
                     ret = 0;
@@ -42744,7 +42744,8 @@ cleanup:
  * wolfSSL's built-in certificate validation mechanisms anymore. We instead
  * must call into the Security Framework APIs to authenticate peer certificates
  */
-static int DoAppleNativeCertValidation(const WOLFSSL_BUFFER_INFO* certs,
+static int DoAppleNativeCertValidation(WOLFSSL* ssl,
+                                            const WOLFSSL_BUFFER_INFO* certs,
                                             int totalCerts)
 {
     int i;
@@ -42753,7 +42754,8 @@ static int DoAppleNativeCertValidation(const WOLFSSL_BUFFER_INFO* certs,
     CFMutableArrayRef certArray = NULL;
     SecCertificateRef secCert   = NULL;
     SecTrustRef       trust     = NULL;
-    SecPolicyRef      policy    = NULL ;
+    SecPolicyRef      policy    = NULL;
+    CFStringRef       hostname  = NULL;
 
     WOLFSSL_ENTER("DoAppleNativeCertValidation");
 
@@ -42782,7 +42784,17 @@ static int DoAppleNativeCertValidation(const WOLFSSL_BUFFER_INFO* certs,
     }
 
     /* Create trust object for SecCertifiate Ref */
-    policy = SecPolicyCreateSSL(true, NULL);
+    if (ssl->buffers.domainName.buffer &&
+            ssl->buffers.domainName.length > 0) {
+        /* Create policy with specified value to require host name match */
+        hostname = CFStringCreateWithCString(kCFAllocatorDefault,
+        (const char*)ssl->buffers.domainName.buffer, kCFStringEncodingUTF8);
+    }
+    if (hostname != NULL) {
+        policy = SecPolicyCreateSSL(true, hostname);
+    } else {
+        policy = SecPolicyCreateSSL(true, NULL);
+    }
     status = SecTrustCreateWithCertificates(certArray, policy, &trust);
     if (status != errSecSuccess) {
         WOLFSSL_MSG_EX("Error creating trust object, "
@@ -42812,6 +42824,9 @@ cleanup:
     }
     if (policy) {
         CFRelease(policy);
+    }
+    if (hostname) {
+        CFRelease(hostname);
     }
 
     WOLFSSL_LEAVE("DoAppleNativeCertValidation", ret);


### PR DESCRIPTION
# Description
Use WOLFSSL domain name to create policy for WOLFSSL_APPLE_NATIVE_CERT_VALIDATION. When no domain name is available, `SecPolicyCreateSSL()` uses NULL for the hostname parameter.

Fixes zd[#19957](https://wolfssl.zendesk.com/agent/tickets/19957)

# Testing

Tested using `make check` and test provided in zendesk ticket

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
