### PR TITLE
Support verifying messages with multiple signers

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -6652,7 +6652,7 @@ static int PKCS7_VerifySignedData(wc_PKCS7* pkcs7, const byte* hashBuf,
 
                     if ((ret < 0 && ret != SIG_VERIFY_E) || ret == 0) {
                         /* Error that is not related to signature verification
-                        occured or the correct signer is found. */
+                        occurred or the correct signer is found. */
                         break;
                     } else if (idx == pkiMsg2Sz) {
                         hasNextSignerInfo = 0;


### PR DESCRIPTION
# Description

Support verifying messages with multiple signers. (ZD 20046)

# Testing

Verifying by `make unit_test`. The output can be found in [wolfssl-unit_test-out.txt](https://github.com/user-attachments/files/20612716/wolfssl-unit_test-out.txt), if required.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
