### PR TITLE
Fix PBE_SHA1_DES certificate encryption support on wc_PKCS12_create()

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -19070,6 +19070,9 @@ static int test_wc_PKCS12_create(void)
 {
     EXPECT_DECLS;
 #if !defined(NO_DES3) && !defined(NO_SHA)
+    EXPECT_TEST(test_wc_PKCS12_create_once(PBE_SHA1_DES, PBE_SHA1_DES));
+#endif
+#if !defined(NO_DES3) && !defined(NO_SHA)
     EXPECT_TEST(test_wc_PKCS12_create_once(PBE_SHA1_DES3, PBE_SHA1_DES3));
 #endif
 #if defined(HAVE_AES_CBC) && !defined(NO_AES) && !defined(NO_AES_256) && \

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1829,7 +1829,7 @@ static int wc_PKCS12_shroud_key(WC_PKCS12* pkcs12, WC_RNG* rng,
         /* Need to handle PKCS#5v1/v2 (=non-PKCS#12v1) encryptions */
         if (vAlgo == PBE_SHA1_DES) {
             vPKCS = PKCS5;
-            vAlgo = 10;
+            vAlgo = PBES1_SHA1_DES;
         }
         else if (vAlgo == PBE_AES256_CBC) {
             vPKCS = PKCS5;
@@ -2112,6 +2112,10 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
         word32 outerSz = 0;
 
         /* Need to handle PKCS#5v1/v2 (=non-PKCS#12v1) encryptions */
+        if (vAlgo == PBE_SHA1_DES) {
+           vPKCS = PKCS5;
+           vAlgo = PBES1_SHA1_DES;
+        }
         if (vAlgo == PBE_AES256_CBC) {
             vPKCS = PKCS5;
             vAlgo = PBES2;


### PR DESCRIPTION
# Description

Currently, `PBE_SHA1_DES` certificate support on wc_PKCS12_create() doesn't work.
This PR fixes it.

# Testing

./configure CFLAGS="-DUSE_CERT_BUFFERS_2048" --enable-debug --enable-des3 --enable-asn && make test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
