### PR TITLE
Clarify supported encryption algorithms on wc_PKCS12_create()

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -19069,6 +19069,14 @@ static int test_wc_PKCS12_create_once(int keyEncType, int certEncType)
 static int test_wc_PKCS12_create(void)
 {
     EXPECT_DECLS;
+
+    EXPECT_TEST(test_wc_PKCS12_create_once(-1, -1));
+#if !defined(NO_RC4) && !defined(NO_SHA)
+    EXPECT_TEST(test_wc_PKCS12_create_once(PBE_SHA1_RC4_128, PBE_SHA1_RC4_128));
+#endif
+#if !defined(NO_DES3) && !defined(NO_SHA)
+    EXPECT_TEST(test_wc_PKCS12_create_once(PBE_SHA1_DES, PBE_SHA1_DES));
+#endif
 #if !defined(NO_DES3) && !defined(NO_SHA)
     EXPECT_TEST(test_wc_PKCS12_create_once(PBE_SHA1_DES3, PBE_SHA1_DES3));
 #endif

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1760,6 +1760,51 @@ exit_pk12par:
 }
 
 
+/* Helper function to get parameters for key and cert encryptions */
+static int wc_PKCS12_get_enc_params(int inAlgo, int* vPKCS, int* outAlgo,
+        int* blkOid, int* hmacOid)
+{
+    int ret = 0;
+
+    if (inAlgo == PBE_SHA1_RC4_128) {
+        *vPKCS = 1;   /* PKCS#12 */
+        *outAlgo = PBE_SHA1_RC4_128;
+        *blkOid = 0;  /* Unused */
+        *hmacOid = 0; /* Use SHA1 as default */
+    }
+    else if (inAlgo == PBE_SHA1_DES) {
+        *vPKCS = PKCS5;
+        *outAlgo = PBES1_SHA1_DES;
+        *blkOid = 0;  /* Unused */
+        *hmacOid = 0; /* Use SHA1 as default */
+    }
+    else if (inAlgo == PBE_SHA1_DES3) {
+        *vPKCS = 1;   /* PKCS#12 */
+        *outAlgo = PBE_SHA1_DES3;
+        *blkOid = 0;  /* Unused */
+        *hmacOid = 0; /* Use SHA1 as default */
+    }
+    else if (inAlgo == PBE_AES256_CBC) {
+        *vPKCS = PKCS5;
+        *outAlgo = PBES2;
+        *blkOid = AES256CBCb;
+        *hmacOid = HMAC_SHA256_OID;
+    }
+    else if (inAlgo == PBE_AES128_CBC) {
+        *vPKCS = PKCS5;
+        *outAlgo = PBES2;
+        *blkOid = AES128CBCb;
+        *hmacOid = HMAC_SHA256_OID;
+    }
+    else {
+        WOLFSSL_MSG("Unsupported algorithm for PKCS12 encryption");
+        ret = ALGO_ID_E;
+    }
+
+    return ret;
+}
+
+
 /* Helper function to shroud keys.
  *
  * pkcs12 structure to use with shrouding key
@@ -1781,15 +1826,15 @@ static int wc_PKCS12_shroud_key(WC_PKCS12* pkcs12, WC_RNG* rng,
 {
     void* heap;
     word32 tmpIdx = 0;
-    int vPKCS     = 1; /* PKCS#12 default set to 1 */
     word32 sz;
     word32 totalSz = 0;
     int ret;
     byte* pkcs8Key = NULL;
 
-     /* The blkOid and hmacOid are only valid for PKCS#5v2 (PBES2) */
+    int vPKCS = -1;
+    int outAlgo = -1;
     int blkOid = 0;
-    int hmacOid = 0; /* If 0, use the default HMAC algorithm */
+    int hmacOid = 0;
 
     if (outSz == NULL || pkcs12 == NULL || rng == NULL || key == NULL ||
             pass == NULL) {
@@ -1826,25 +1871,13 @@ static int wc_PKCS12_shroud_key(WC_PKCS12* pkcs12, WC_RNG* rng,
     else {
         WOLFSSL_MSG("creating PKCS12 Shrouded Key Bag");
 
-        /* Need to handle PKCS#5v1/v2 (=non-PKCS#12v1) encryptions */
-        if (vAlgo == PBE_SHA1_DES) {
-            vPKCS = PKCS5;
-            vAlgo = 10;
+        if ((ret = wc_PKCS12_get_enc_params(vAlgo, &vPKCS, &outAlgo, &blkOid,
+                &hmacOid)) < 0) {
+            return ret;
         }
-        else if (vAlgo == PBE_AES256_CBC) {
-            vPKCS = PKCS5;
-            vAlgo = PBES2;
-            blkOid = AES256CBCb;
-            hmacOid = HMAC_SHA256_OID;
-        }
-        else if (vAlgo == PBE_AES128_CBC) {
-            vPKCS = PKCS5;
-            vAlgo = PBES2;
-            blkOid = AES128CBCb;
-            hmacOid = HMAC_SHA256_OID;
-        }
+
         ret = TraditionalEnc_ex(key, keySz, pkcs8Key, &sz, pass, passSz,
-                vPKCS, vAlgo, blkOid, NULL, 0, itt, hmacOid, rng, heap);
+                vPKCS, outAlgo, blkOid, NULL, 0, itt, hmacOid, rng, heap);
     }
     if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         *outSz =  sz + MAX_LENGTH_SZ + 1;
@@ -2084,7 +2117,6 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
         const char* pass, int passSz, int iter, int type)
 {
     void* heap;
-    int vPKCS     = 1; /* PKCS#12 is always set to 1 */
     int ret;
     byte*  tmp;
     word32 idx = 0;
@@ -2092,6 +2124,9 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
     word32 length = 0;
     word32 tmpSz;
     word32 encSz;
+
+    int vPKCS = -1;
+    int outAlgo = -1;
     int blkOid = 0;
     int hmacOid = 0;
 
@@ -2111,23 +2146,14 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
     if (type == WC_PKCS12_ENCRYPTED_DATA) {
         word32 outerSz = 0;
 
-        /* Need to handle PKCS#5v1/v2 (=non-PKCS#12v1) encryptions */
-        if (vAlgo == PBE_AES256_CBC) {
-            vPKCS = PKCS5;
-            vAlgo = PBES2;
-            blkOid = AES256CBCb;
-            hmacOid = HMAC_SHA256_OID;
-        }
-        else if (vAlgo == PBE_AES128_CBC) {
-            vPKCS = PKCS5;
-            vAlgo = PBES2;
-            blkOid = AES128CBCb;
-            hmacOid = HMAC_SHA256_OID;
+        if ((ret = wc_PKCS12_get_enc_params(vAlgo, &vPKCS, &outAlgo, &blkOid,
+                &hmacOid)) < 0) {
+            return ret;
         }
 
         encSz = contentSz;
         if ((ret = EncryptContent(NULL, contentSz, NULL, &encSz,
-                   pass, passSz, vPKCS, vAlgo, blkOid, NULL, 0, iter, hmacOid,
+                   pass, passSz, vPKCS, outAlgo, blkOid, NULL, 0, iter, hmacOid,
                    rng, heap)) < 0) {
             if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
                 return ret;
@@ -2180,7 +2206,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
         }
 
         if ((ret = EncryptContent(content, contentSz, tmp, &encSz,
-                   pass, passSz, vPKCS, vAlgo, blkOid, NULL, 0, iter, hmacOid,
+                   pass, passSz, vPKCS, outAlgo, blkOid, NULL, 0, iter, hmacOid,
                    rng, heap)) < 0) {
             XFREE(tmp, heap, DYNAMIC_TYPE_TMP_BUFFER);
             return ret;


### PR DESCRIPTION
# Description

This PR clarifies supported encryption algorithms on `wc_PKCS12_create()`.
In old codes, it was difficult to know which algorithms are supported.

Also this PR adds tests for the algorithms.

In addition, the `PBE_SHA1_DES` certificate encryption is enabled by this PR.

# Testing

./configure CFLAGS="-DUSE_CERT_BUFFERS_2048" --enable-debug --enable-asn --enable-arc4 --enable-des3 && make test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
