### PR TITLE
Allow `trusted_ca_keys` with TLSv1.3

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -16149,7 +16149,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                 /* RFC 8446 4.2.4 states trusted_ca_keys is not used
                    in TLS 1.3. */
                 if (IsAtLeastTLSv1_3(ssl->version)) {
-                    return EXT_NOT_ALLOWED;
+                    break;
                 }
                 else
 #endif

--- a/tests/test-tls13-down.conf
+++ b/tests/test-tls13-down.conf
@@ -51,7 +51,7 @@
 -v 3
 -H exitWithRet
 
-# server TLSv1.2 
+# server TLSv1.2
 -v 3
 -l ECDHE-RSA-AES256-GCM-SHA384
 -H exitWithRet
@@ -60,7 +60,7 @@
 -v 4
 -H exitWithRet
 
-# server TLSv1.2 
+# server TLSv1.2
 -v 3
 -l ECDHE-RSA-AES256-GCM-SHA384
 -H exitWithRet
@@ -119,3 +119,10 @@
 -7 3
 -s
 -l ECDHE-PSK-AES128-GCM-SHA256
+
+# server TLSv1.3
+-v 4
+
+# client downgrade with trusted ca
+-v d
+-5


### PR DESCRIPTION
# Description

It is possible that the client will provied `trusted_ca_keys` during a TLSv1.3 connection with 1.2 downgrade. wolfSSL would error with `EXT_NOT_ALLOWED`. The TLSv1.3 spec states that it can be provided and should be ignored.

Fixes zd#19936

# Testing

Using our example server and client:
```
./server -v4
```

```
./client -5 -vd
```

Before patch, server would return `EXT_NOT_ALLOWED`, after patch, connection successful.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
