### PR TITLE
tls13: clear tls1_3 on downgrade

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5118,6 +5118,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             /* Force client hello version 1.2 to work for static RSA. */
             ssl->chVersion.minor = TLSv1_2_MINOR;
             ssl->version.minor = TLSv1_2_MINOR;
+            ssl->options.tls1_3 = 0;
 
 #ifdef WOLFSSL_DTLS13
             if (ssl->options.dtls) {
@@ -5218,6 +5219,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (ssl->options.dtls) {
             ssl->chVersion.minor = DTLSv1_2_MINOR;
             ssl->version.minor = DTLSv1_2_MINOR;
+            ssl->options.tls1_3 = 0;
             ret = Dtls13ClientDoDowngrade(ssl);
             if (ret != 0)
                 return ret;
@@ -5231,6 +5233,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             return VERSION_ERROR;
         }
 #ifndef WOLFSSL_NO_TLS12
+        ssl->options.tls1_3 = 0;
         return DoServerHello(ssl, input, inOutIdx, helloSz);
 #else
         SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);


### PR DESCRIPTION
# Description
Unset ssl->options.tls1_3 whenever we drop to TLS 1.2 so PSK handshakes don’t hit -326 VERSION_ERROR.

Fixes zd#20006

# Testing
Reproduced with these configs:

client config:
`'CFLAGS=-DWOLFSSL_USER_SETTINGS -DWOLFSSL_SHA384 -DWOLFSSL_SHA512 -DWOLFSSL_AES_128 -DWOLFSSL_AES_256 -DWOLFSSL_STATIC_RSA -DHAVE_SERVER_RENEGOTIATION_INFO -DHAVE_AESGCM -DHAVE_AESCCM -DHAVE_CHACHA -DHAVE_POLY1305 -DHAVE_ONE_TIME_AUTH -DHAVE_TLS_EXTENSIONS -DHAVE_FFDHE_2048 -DHAVE_HKDF -DHAVE_ECC -DHAVE_SNI -DHAVE_EX_DATA -DNO_MD4 -DNO_RABBIT -DNO_DSA -DUSE_CERT_BUFFERS_3072 -DHAVE_SUPPORTED_CURVES -DWOLFSSL_ENCRYPTED_KEYS -DWOLFSSL_STATIC_PSK -DWOLFSSL_EXTRA_ALERTS -DWOLFSSL_ASN_TEMPLATE -DWOLFSSL_ALT_CERT_CHAINS -DWOLFSSL_TLS13 -DWC_RSA_PSS' '--enable-curve25519' '--enable-debug' '--enable-psk'`

server config:
`'--enable-debug' '--enable-psk' 'CFLAGS=-DWOLFSSL_NO_OPENSSL_RAND_CB -DWOLFSSL_USER_SETTINGS -DWOLFSSL_SHA384 -DWOLFSSL_SHA512 -DWOLFSSL_AES_128 -DWOLFSSL_AES_256 -DWOLFSSL_STATIC_RSA -DHAVE_SERVER_RENEGOTIATION_INFO -DHAVE_AESGCM -DHAVE_AESCCM -DHAVE_CHACHA -DHAVE_POLY1305 -DHAVE_ONE_TIME_AUTH -DHAVE_TLS_EXTENSIONS -DHAVE_FFDHE_2048 -DHAVE_HKDF -DHAVE_ECC -DHAVE_SNI -DHAVE_EX_DATA -DNO_MD4 -DNO_WOLFSSL_STUB -DNO_RABBIT -DNO_DSA -DUSE_FAST_MATH -DUSE_CERT_BUFFERS_3072 -DHAVE_SUPPORTED_CURVES -DWOLFSSL_ENCRYPTED_KEYS -DWOLFSSL_SMALL_CERT_VERIFY -DWOLFSSL_STATIC_PSK -DWOLFSSL_EXTRA_ALERTS -DWOLFSSL_ASN_TEMPLATE -DWOLFSSL_ALT_CERT_CHAINS' '--enable-curve25519' '--disable-tls13' '--disable-extended-master'`

And run the client and server examples like so:
./examples/client/client -s -p 11111 -h localhost -v d -d
./examples/server/server -s -p 11111 -v 3 -d

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
