### PR TITLE
ML-DSA: fix tests for different configs

### DIFF
--- a/tests/api/test_mldsa.c
+++ b/tests/api/test_mldsa.c
@@ -16665,6 +16665,7 @@ int test_mldsa_pkcs8(void)
     defined(HAVE_DILITHIUM) && !defined(NO_TLS) && \
     (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)) && \
     !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) && \
+    !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
     !defined(WOLFSSL_DILITHIUM_NO_ASN1)
 
     WOLFSSL_CTX* ctx = NULL;
@@ -16685,9 +16686,15 @@ int test_mldsa_pkcs8(void)
         int oidSum;
         int keySz;
     } test_variant[] = {
+#ifndef WOLFSSL_NO_ML_DSA_44
         {WC_ML_DSA_44, ML_DSA_LEVEL2k, ML_DSA_LEVEL2_PRV_KEY_SIZE},
+#endif
+#ifndef WOLFSSL_NO_ML_DSA_65
         {WC_ML_DSA_65, ML_DSA_LEVEL3k, ML_DSA_LEVEL3_PRV_KEY_SIZE},
+#endif
+#ifndef WOLFSSL_NO_ML_DSA_87
         {WC_ML_DSA_87, ML_DSA_LEVEL5k, ML_DSA_LEVEL5_PRV_KEY_SIZE}
+#endif
     };
 
     (void) pemSz;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -46814,7 +46814,9 @@ static wc_test_ret_t dilithium_param_test(int param, WC_RNG* rng)
     byte* sig = NULL;
 #else
     dilithium_key  key[1];
+#ifndef WOLFSSL_DILITHIUM_NO_SIGN
     byte sig[DILITHIUM_MAX_SIG_SIZE];
+#endif
 #endif
 #ifndef WOLFSSL_DILITHIUM_NO_SIGN
     word32 sigLen;


### PR DESCRIPTION
# Description

Setting the private key into SSL object requires signing to be available.
Only enable the parameters that are compiled in.

# Testing

./configure --disable-shared  --enable-dilithium=make,44,65,87
--disable-shared  --enable-dilithium=all,44

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
