### PR TITLE
linuxkm drbg: refactor drbg_ctx clear.

### DIFF
--- a/linuxkm/lkcapi_sha_glue.c
+++ b/linuxkm/lkcapi_sha_glue.c
@@ -908,6 +908,22 @@ struct wc_linuxkm_drbg_ctx {
     } *rngs; /* one per CPU ID */
 };
 
+static inline void wc_linuxkm_drbg_ctx_clear(struct wc_linuxkm_drbg_ctx * ctx)
+{
+    unsigned int i;
+
+    if (ctx->rngs) {
+        for (i = 0; i < nr_cpu_ids; ++i) {
+            (void)wc_FreeMutex(&ctx->rngs[i].lock);
+            wc_FreeRng(&ctx->rngs[i].rng);
+        }
+        free(ctx->rngs);
+        ctx->rngs = NULL;
+    }
+
+    return;
+}
+
 static int wc_linuxkm_drbg_init_tfm(struct crypto_tfm *tfm)
 {
     struct wc_linuxkm_drbg_ctx *ctx = (struct wc_linuxkm_drbg_ctx *)crypto_tfm_ctx(tfm);
@@ -937,12 +953,7 @@ static int wc_linuxkm_drbg_init_tfm(struct crypto_tfm *tfm)
     }
 
     if (ret != 0) {
-        for (i = 0; i < nr_cpu_ids; ++i) {
-            (void)wc_FreeMutex(&ctx->rngs[i].lock);
-            wc_FreeRng(&ctx->rngs[i].rng);
-        }
-        free(ctx->rngs);
-        ctx->rngs = NULL;
+        wc_linuxkm_drbg_ctx_clear(ctx);
     }
 
     return ret;
@@ -951,16 +962,8 @@ static int wc_linuxkm_drbg_init_tfm(struct crypto_tfm *tfm)
 static void wc_linuxkm_drbg_exit_tfm(struct crypto_tfm *tfm)
 {
     struct wc_linuxkm_drbg_ctx *ctx = (struct wc_linuxkm_drbg_ctx *)crypto_tfm_ctx(tfm);
-    unsigned int i;
 
-    if (ctx->rngs) {
-        for (i = 0; i < nr_cpu_ids; ++i) {
-            (void)wc_FreeMutex(&ctx->rngs[i].lock);
-            wc_FreeRng(&ctx->rngs[i].rng);
-        }
-        free(ctx->rngs);
-        ctx->rngs = NULL;
-    }
+    wc_linuxkm_drbg_ctx_clear(ctx);
 
     return;
 }


### PR DESCRIPTION
## Description

Refactor duplicate drbg_ctx cleanup code to function.
