### PR TITLE
Check for STDC_NO_ATOMICS

### DIFF
--- a/.wolfssl_known_macro_extras
+++ b/.wolfssl_known_macro_extras
@@ -1042,3 +1042,4 @@ ssize_t
 sun
 versal
 wc_Tls13_HKDF_Expand_Label
+__STDC_NO_ATOMICS__

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1524,7 +1524,8 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 #ifndef WOLFSSL_NO_FENCE
     #ifdef XFENCE
         /* use user-supplied XFENCE definition. */
-    #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+    #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && \
+          !defined(__STDC_NO_ATOMICS__)
         #include <stdatomic.h>
         #define XFENCE() atomic_thread_fence(memory_order_seq_cst)
     #elif defined(__GNUC__) && (__GNUC__ == 4) && \


### PR DESCRIPTION
# Description

The code checks for C11, then tries to include stdatomic.h, but MSVC does have this header (its an optional C11 feature). MSVC does `#define __STDC_NO_ATOMICS__`, which could be used

Fixes zd# 20088

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
