### PR TITLE
20250617-prime_test-uninited-wc_FreeRng

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -58640,6 +58640,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t prime_test(void)
     wc_test_ret_t ret;
     int isPrime = 0;
     WC_RNG rng;
+    int rng_inited = 0;
     WOLFSSL_ENTER("prime_test");
 
     ret = mp_init_multi(n, p1, p2, p3, NULL, NULL);
@@ -58655,7 +58656,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t prime_test(void)
 #endif
 
     ret = wc_InitRng(&rng);
-    if (ret != 0)
+    if (ret == 0)
+        rng_inited = 1;
+    else
         ret = WC_TEST_RET_ENC_EC(ret);
     if (ret == 0)
         ret = GenerateP(p1, p2, p3,
@@ -58759,7 +58762,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t prime_test(void)
     mp_clear(n);
 #endif
 
-    wc_FreeRng(&rng);
+    if (rng_inited)
+        wc_FreeRng(&rng);
 
     return ret;
 }


### PR DESCRIPTION
`wolfcrypt/test/test.c`: fix `prime_test()` uninitialized data access by `wc_FreeRng()`.

Discovered by kernel log `segfault` messages for `testwolfcrypt` in various multi-test FIPS scenarios, due to the combination of wrong FIPS hash (`IN_CORE_FIPS_E`) with `-DTEST_ALWAYS_RUN_TO_END`.

Tested with similar settings on patched code.
