### PR TITLE
Allow larger pathLen values in Basic Constraints.

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -20631,7 +20631,7 @@ static int DecodeBasicCaConstraint(const byte* input, int sz, DecodedCert* cert)
     if (ret == 0) {
         /* Get the CA boolean and path length when present. */
         GetASN_Boolean(&dataASN[BASICCONSASN_IDX_CA], &isCA);
-        GetASN_Int8Bit(&dataASN[BASICCONSASN_IDX_PLEN], &cert->pathLength);
+        GetASN_Int16Bit(&dataASN[BASICCONSASN_IDX_PLEN], &cert->pathLength);
 
         ret = GetASN_Items(basicConsASN, dataASN, basicConsASN_Length, 1, input,
                            &idx, (word32)sz);
@@ -20648,11 +20648,6 @@ static int DecodeBasicCaConstraint(const byte* input, int sz, DecodedCert* cert)
             ret = ASN_PARSE_E;
         }
 #endif
-        /* Path length must be a 7-bit value. */
-        if ((ret == 0) && (cert->pathLength >= (1 << 7))) {
-            WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-            ret = ASN_PARSE_E;
-        }
         if ((ret == 0) && cert->pathLength > WOLFSSL_MAX_PATH_LEN) {
             WOLFSSL_ERROR_VERBOSE(ASN_PATHLEN_SIZE_E);
             ret = ASN_PATHLEN_SIZE_E;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -20614,7 +20614,12 @@ static int DecodeBasicCaConstraint(const byte* input, int sz, DecodedCert* cert)
     ret = GetInteger16Bit(input, &idx, (word32)sz);
     if (ret < 0)
         return ret;
-    cert->pathLength = (byte)ret;
+    else if (ret > WOLFSSL_MAX_PATH_LEN) {
+        WOLFSSL_ERROR_VERBOSE(ASN_PATHLEN_SIZE_E);
+        return ASN_PATHLEN_SIZE_E;
+    }
+
+    cert->pathLength = (word16)ret;
     cert->pathLengthSet = 1;
 
     return 0;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -2744,7 +2744,7 @@ int GetASNInt(const byte* input, word32* inOutIdx, int* len,
 }
 
 #ifndef WOLFSSL_ASN_TEMPLATE
-#ifndef NO_CERTS
+#if !defined(NO_CERTS) && defined(WOLFSSL_CUSTOM_CURVES)
 /* Get the DER/BER encoding of an ASN.1 INTEGER that has a value of no more than
  * 7 bits.
  *
@@ -2776,7 +2776,7 @@ static int GetInteger7Bit(const byte* input, word32* inOutIdx, word32 maxIdx)
 }
 #endif /* !NO_CERTS */
 
-#if defined(WC_RSA_PSS) && !defined(NO_RSA)
+#if ((defined(WC_RSA_PSS) && !defined(NO_RSA)) || !defined(NO_CERTS))
 /* Get the DER/BER encoding of an ASN.1 INTEGER that has a value of no more than
  * 16 bits.
  *
@@ -20611,7 +20611,7 @@ static int DecodeBasicCaConstraint(const byte* input, int sz, DecodedCert* cert)
         return 0;
     }
 
-    ret = GetInteger7Bit(input, &idx, (word32)sz);
+    ret = GetInteger16Bit(input, &idx, (word32)sz);
     if (ret < 0)
         return ret;
     cert->pathLength = (byte)ret;

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1943,7 +1943,7 @@ struct Signer {
     word32  pubKeySize;
     word32  keyOID;                  /* key type */
     word16  keyUsage;
-    word16    maxPathLen;
+    word16  maxPathLen;
     WC_BITFIELD selfSigned:1;
     const byte* publicKey;
     int     nameLen;

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1642,8 +1642,8 @@ struct DecodedCert {
     const byte* extAuthKeyIdIssuerSN; /* Authority Key ID authorityCertSerialNumber */
     word32  extAuthKeyIdIssuerSNSz;   /* Authority Key ID authorityCertSerialNumber length */
 #endif
-    byte    pathLength;              /* CA basic constraint path length  */
-    byte    maxPathLen;              /* max_path_len see RFC 5280 section
+    word16    pathLength;              /* CA basic constraint path length  */
+    word16    maxPathLen;              /* max_path_len see RFC 5280 section
                                       * 6.1.2 "Initialization" - (k) for
                                       * description of max_path_len */
     byte    policyConstSkip;         /* Policy Constraints skip certs value */
@@ -1943,7 +1943,7 @@ struct Signer {
     word32  pubKeySize;
     word32  keyOID;                  /* key type */
     word16  keyUsage;
-    byte    maxPathLen;
+    word16    maxPathLen;
     WC_BITFIELD selfSigned:1;
     const byte* publicKey;
     int     nameLen;


### PR DESCRIPTION
# Description

Allow higher max_path_len values.  We are arbitrarily limiting this to 8 bits, the RFC has no such restriction (it is only limited to an integer there).

Maintains the default WOLFSSL_MAX_PATH_LEN value of 127, users will have to override this value at build time for higher values.

Fixes zd#20022

# Testing

Customer provided certs with pathLen=1000.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
