### PR TITLE
ARM32/Thumb2/RISC-V 64 ASM: omit frame pointer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3367,7 +3367,7 @@ then
         armv7m*)
             # QEMU doesn't work with armv7-m
             AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ARMASM_THUMB2"
-            AM_CPPFLAGS="$AM_CPPFLAGS -march=armv7-r -DWOLFSSL_ARMASM_THUMB2 -fomit-frame-pointer -DWOLFSSL_ARMASM_NO_HW_CRYPTO -DWOLFSSL_ARM_ARCH=7"
+            AM_CPPFLAGS="$AM_CPPFLAGS -march=armv7-r -DWOLFSSL_ARMASM_THUMB2 -DWOLFSSL_ARMASM_NO_HW_CRYPTO -DWOLFSSL_ARM_ARCH=7"
             # Include options.h
             AM_CCASFLAGS="$AM_CCASFLAGS -DEXTERNAL_OPTS_OPENVPN"
             ENABLED_ARMASM_CRYPTO=no
@@ -3385,7 +3385,7 @@ then
             fi
             ;;
         armv6*)
-            AM_CPPFLAGS="$AM_CPPFLAGS -march=armv6 -fomit-frame-pointer -DWOLFSSL_ARMASM_NO_HW_CRYPTO -DWOLFSSL_ARM_ARCH=6"
+            AM_CPPFLAGS="$AM_CPPFLAGS -march=armv6 -DWOLFSSL_ARMASM_NO_HW_CRYPTO -DWOLFSSL_ARM_ARCH=6"
             AM_CCASFLAGS="$AM_CCASFLAGS -DEXTERNAL_OPTS_OPENVPN"
             ENABLED_ARMASM_CRYPTO=no
             ENABLED_ARMASM_NEON=no
@@ -3393,7 +3393,7 @@ then
             AC_MSG_NOTICE([32bit ARMv6 found])
             ;;
         armv4*)
-            AM_CPPFLAGS="$AM_CPPFLAGS -march=armv4 -fomit-frame-pointer -DWOLFSSL_ARMASM_NO_HW_CRYPTO -DWOLFSSL_ARM_ARCH=4"
+            AM_CPPFLAGS="$AM_CPPFLAGS -march=armv4 -DWOLFSSL_ARMASM_NO_HW_CRYPTO -DWOLFSSL_ARM_ARCH=4"
             AM_CCASFLAGS="$AM_CCASFLAGS -DEXTERNAL_OPTS_OPENVPN"
             ENABLED_ARMASM_CRYPTO=no
             ENABLED_ARMASM_NEON=no

--- a/wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
@@ -48,6 +48,7 @@
 #define __volatile__
 #define WOLFSSL_NO_VAR_ASSIGN_REG
 #endif /* __ghs__ */
+
 #ifndef NO_AES
 #include <wolfssl/wolfcrypt/aes.h>
 
@@ -204,9 +205,9 @@ static const word32* L_AES_ARM32_te = L_AES_ARM32_te_data;
 #ifdef HAVE_AES_DECRYPT
 void AES_invert_key(unsigned char* ks_p, word32 rounds_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_invert_key(unsigned char* ks_p, word32 rounds_p)
+WC_OMIT_FRAME_POINTER void AES_invert_key(unsigned char* ks_p, word32 rounds_p)
 #else
-void AES_invert_key(unsigned char* ks, word32 rounds)
+WC_OMIT_FRAME_POINTER void AES_invert_key(unsigned char* ks, word32 rounds)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -441,11 +442,11 @@ static const word32 L_AES_ARM32_rcon[] = {
 void AES_set_encrypt_key(const unsigned char* key_p, word32 len_p,
     unsigned char* ks_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_set_encrypt_key(const unsigned char* key_p, word32 len_p,
-    unsigned char* ks_p)
+WC_OMIT_FRAME_POINTER void AES_set_encrypt_key(const unsigned char* key_p,
+    word32 len_p, unsigned char* ks_p)
 #else
-void AES_set_encrypt_key(const unsigned char* key, word32 len,
-    unsigned char* ks)
+WC_OMIT_FRAME_POINTER void AES_set_encrypt_key(const unsigned char* key,
+    word32 len, unsigned char* ks)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -976,10 +977,11 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len,
 void AES_encrypt_block(const word32* te_p, int nr_p, int len_p,
     const word32* ks_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_encrypt_block(const word32* te_p, int nr_p, int len_p,
-    const word32* ks_p)
+WC_OMIT_FRAME_POINTER void AES_encrypt_block(const word32* te_p, int nr_p,
+    int len_p, const word32* ks_p)
 #else
-void AES_encrypt_block(const word32* te, int nr, int len, const word32* ks)
+WC_OMIT_FRAME_POINTER void AES_encrypt_block(const word32* te, int nr, int len,
+    const word32* ks)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1643,11 +1645,12 @@ static const word32* L_AES_ARM32_te_ecb = L_AES_ARM32_te_data;
 void AES_ECB_encrypt(const unsigned char* in_p, unsigned char* out_p,
     unsigned long len_p, const unsigned char* ks_p, int nr_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_ECB_encrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p)
+WC_OMIT_FRAME_POINTER void AES_ECB_encrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p)
 #else
-void AES_ECB_encrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr)
+WC_OMIT_FRAME_POINTER void AES_ECB_encrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1919,12 +1922,13 @@ void AES_CBC_encrypt(const unsigned char* in_p, unsigned char* out_p,
     unsigned long len_p, const unsigned char* ks_p, int nr_p,
     unsigned char* iv_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_CBC_encrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p,
-    unsigned char* iv_p)
+WC_OMIT_FRAME_POINTER void AES_CBC_encrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p, unsigned char* iv_p)
 #else
-void AES_CBC_encrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr, unsigned char* iv)
+WC_OMIT_FRAME_POINTER void AES_CBC_encrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr,
+    unsigned char* iv)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2217,12 +2221,13 @@ void AES_CTR_encrypt(const unsigned char* in_p, unsigned char* out_p,
     unsigned long len_p, const unsigned char* ks_p, int nr_p,
     unsigned char* ctr_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_CTR_encrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p,
-    unsigned char* ctr_p)
+WC_OMIT_FRAME_POINTER void AES_CTR_encrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p, unsigned char* ctr_p)
 #else
-void AES_CTR_encrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr, unsigned char* ctr)
+WC_OMIT_FRAME_POINTER void AES_CTR_encrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr,
+    unsigned char* ctr)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2516,9 +2521,11 @@ void AES_CTR_encrypt(const unsigned char* in, unsigned char* out,
         defined(HAVE_AES_CBC)
 void AES_decrypt_block(const word32* td_p, int nr_p, const byte* td4_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_decrypt_block(const word32* td_p, int nr_p, const byte* td4_p)
+WC_OMIT_FRAME_POINTER void AES_decrypt_block(const word32* td_p, int nr_p,
+    const byte* td4_p)
 #else
-void AES_decrypt_block(const word32* td, int nr, const byte* td4)
+WC_OMIT_FRAME_POINTER void AES_decrypt_block(const word32* td, int nr,
+    const byte* td4)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3215,11 +3222,12 @@ static const byte L_AES_ARM32_td4[] = {
 void AES_ECB_decrypt(const unsigned char* in_p, unsigned char* out_p,
     unsigned long len_p, const unsigned char* ks_p, int nr_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_ECB_decrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p)
+WC_OMIT_FRAME_POINTER void AES_ECB_decrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p)
 #else
-void AES_ECB_decrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr)
+WC_OMIT_FRAME_POINTER void AES_ECB_decrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3491,12 +3499,13 @@ void AES_CBC_decrypt(const unsigned char* in_p, unsigned char* out_p,
     unsigned long len_p, const unsigned char* ks_p, int nr_p,
     unsigned char* iv_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_CBC_decrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p,
-    unsigned char* iv_p)
+WC_OMIT_FRAME_POINTER void AES_CBC_decrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p, unsigned char* iv_p)
 #else
-void AES_CBC_decrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr, unsigned char* iv)
+WC_OMIT_FRAME_POINTER void AES_CBC_decrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr,
+    unsigned char* iv)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4163,11 +4172,11 @@ static const word32 L_GCM_gmult_len_r[] = {
 void GCM_gmult_len(unsigned char* x_p, const unsigned char** m_p,
     const unsigned char* data_p, unsigned long len_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void GCM_gmult_len(unsigned char* x_p, const unsigned char** m_p,
-    const unsigned char* data_p, unsigned long len_p)
+WC_OMIT_FRAME_POINTER void GCM_gmult_len(unsigned char* x_p,
+    const unsigned char** m_p, const unsigned char* data_p, unsigned long len_p)
 #else
-void GCM_gmult_len(unsigned char* x, const unsigned char** m,
-    const unsigned char* data, unsigned long len)
+WC_OMIT_FRAME_POINTER void GCM_gmult_len(unsigned char* x,
+    const unsigned char** m, const unsigned char* data, unsigned long len)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4774,12 +4783,13 @@ void AES_GCM_encrypt(const unsigned char* in_p, unsigned char* out_p,
     unsigned long len_p, const unsigned char* ks_p, int nr_p,
     unsigned char* ctr_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_GCM_encrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p,
-    unsigned char* ctr_p)
+WC_OMIT_FRAME_POINTER void AES_GCM_encrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p, unsigned char* ctr_p)
 #else
-void AES_GCM_encrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr, unsigned char* ctr)
+WC_OMIT_FRAME_POINTER void AES_GCM_encrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr,
+    unsigned char* ctr)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c
@@ -48,13 +48,16 @@
 #define __volatile__
 #define WOLFSSL_NO_VAR_ASSIGN_REG
 #endif /* __ghs__ */
+
 #ifdef HAVE_CHACHA
 #include <wolfssl/wolfcrypt/chacha.h>
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void wc_chacha_setiv(word32* x_p, const byte* iv_p, word32 counter_p)
+WC_OMIT_FRAME_POINTER void wc_chacha_setiv(word32* x_p, const byte* iv_p,
+    word32 counter_p)
 #else
-void wc_chacha_setiv(word32* x, const byte* iv, word32 counter)
+WC_OMIT_FRAME_POINTER void wc_chacha_setiv(word32* x, const byte* iv,
+    word32 counter)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -92,9 +95,11 @@ static const word32 L_chacha_arm32_constants[] = {
 };
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void wc_chacha_setkey(word32* x_p, const byte* key_p, word32 keySz_p)
+WC_OMIT_FRAME_POINTER void wc_chacha_setkey(word32* x_p, const byte* key_p,
+    word32 keySz_p)
 #else
-void wc_chacha_setkey(word32* x, const byte* key, word32 keySz)
+WC_OMIT_FRAME_POINTER void wc_chacha_setkey(word32* x, const byte* key,
+    word32 keySz)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -154,10 +159,11 @@ void wc_chacha_setkey(word32* x, const byte* key, word32 keySz)
 
 #ifdef WOLFSSL_ARMASM_NO_NEON
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void wc_chacha_crypt_bytes(ChaCha* ctx_p, byte* c_p, const byte* m_p,
-    word32 len_p)
+WC_OMIT_FRAME_POINTER void wc_chacha_crypt_bytes(ChaCha* ctx_p, byte* c_p,
+    const byte* m_p, word32 len_p)
 #else
-void wc_chacha_crypt_bytes(ChaCha* ctx, byte* c, const byte* m, word32 len)
+WC_OMIT_FRAME_POINTER void wc_chacha_crypt_bytes(ChaCha* ctx, byte* c,
+    const byte* m, word32 len)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -529,10 +535,11 @@ void wc_chacha_crypt_bytes(ChaCha* ctx, byte* c, const byte* m, word32 len)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void wc_chacha_use_over(byte* over_p, byte* output_p, const byte* input_p,
-    word32 len_p)
+WC_OMIT_FRAME_POINTER void wc_chacha_use_over(byte* over_p, byte* output_p,
+    const byte* input_p, word32 len_p)
 #else
-void wc_chacha_use_over(byte* over, byte* output, const byte* input, word32 len)
+WC_OMIT_FRAME_POINTER void wc_chacha_use_over(byte* over, byte* output,
+    const byte* input, word32 len)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
@@ -48,6 +48,7 @@
 #define __volatile__
 #define WOLFSSL_NO_VAR_ASSIGN_REG
 #endif /* __ghs__ */
+
 /* Based on work by: Emil Lenngren
  * https://github.com/pornin/X25519-Cortex-M4
  */
@@ -60,9 +61,9 @@
 #if !defined(CURVE25519_SMALL) || !defined(ED25519_SMALL)
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_init()
+WC_OMIT_FRAME_POINTER void fe_init()
 #else
-void fe_init()
+WC_OMIT_FRAME_POINTER void fe_init()
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -82,9 +83,9 @@ void fe_init()
 
 void fe_add_sub_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_add_sub_op()
+WC_OMIT_FRAME_POINTER void fe_add_sub_op()
 #else
-void fe_add_sub_op()
+WC_OMIT_FRAME_POINTER void fe_add_sub_op()
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -301,9 +302,9 @@ void fe_add_sub_op()
 
 void fe_sub_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sub_op()
+WC_OMIT_FRAME_POINTER void fe_sub_op()
 #else
-void fe_sub_op()
+WC_OMIT_FRAME_POINTER void fe_sub_op()
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -353,9 +354,9 @@ void fe_sub_op()
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sub(fe r_p, const fe a_p, const fe b_p)
+WC_OMIT_FRAME_POINTER void fe_sub(fe r_p, const fe a_p, const fe b_p)
 #else
-void fe_sub(fe r, const fe a, const fe b)
+WC_OMIT_FRAME_POINTER void fe_sub(fe r, const fe a, const fe b)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -380,9 +381,9 @@ void fe_sub(fe r, const fe a, const fe b)
 
 void fe_add_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_add_op()
+WC_OMIT_FRAME_POINTER void fe_add_op()
 #else
-void fe_add_op()
+WC_OMIT_FRAME_POINTER void fe_add_op()
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -433,9 +434,9 @@ void fe_add_op()
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_add(fe r_p, const fe a_p, const fe b_p)
+WC_OMIT_FRAME_POINTER void fe_add(fe r_p, const fe a_p, const fe b_p)
 #else
-void fe_add(fe r, const fe a, const fe b)
+WC_OMIT_FRAME_POINTER void fe_add(fe r, const fe a, const fe b)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -460,9 +461,9 @@ void fe_add(fe r, const fe a, const fe b)
 
 #ifdef HAVE_ED25519
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_frombytes(fe out_p, const unsigned char* in_p)
+WC_OMIT_FRAME_POINTER void fe_frombytes(fe out_p, const unsigned char* in_p)
 #else
-void fe_frombytes(fe out, const unsigned char* in)
+WC_OMIT_FRAME_POINTER void fe_frombytes(fe out, const unsigned char* in)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -504,9 +505,9 @@ void fe_frombytes(fe out, const unsigned char* in)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_tobytes(unsigned char* out_p, const fe n_p)
+WC_OMIT_FRAME_POINTER void fe_tobytes(unsigned char* out_p, const fe n_p)
 #else
-void fe_tobytes(unsigned char* out, const fe n)
+WC_OMIT_FRAME_POINTER void fe_tobytes(unsigned char* out, const fe n)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -559,9 +560,9 @@ void fe_tobytes(unsigned char* out, const fe n)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_1(fe n_p)
+WC_OMIT_FRAME_POINTER void fe_1(fe n_p)
 #else
-void fe_1(fe n)
+WC_OMIT_FRAME_POINTER void fe_1(fe n)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -591,9 +592,9 @@ void fe_1(fe n)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_0(fe n_p)
+WC_OMIT_FRAME_POINTER void fe_0(fe n_p)
 #else
-void fe_0(fe n)
+WC_OMIT_FRAME_POINTER void fe_0(fe n)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -623,9 +624,9 @@ void fe_0(fe n)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_copy(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_copy(fe r_p, const fe a_p)
 #else
-void fe_copy(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_copy(fe r, const fe a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -693,9 +694,9 @@ void fe_copy(fe r, const fe a)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_neg(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_neg(fe r_p, const fe a_p)
 #else
-void fe_neg(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_neg(fe r, const fe a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -731,9 +732,9 @@ void fe_neg(fe r, const fe a)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-int fe_isnonzero(const fe a_p)
+WC_OMIT_FRAME_POINTER int fe_isnonzero(const fe a_p)
 #else
-int fe_isnonzero(const fe a)
+WC_OMIT_FRAME_POINTER int fe_isnonzero(const fe a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -786,9 +787,9 @@ int fe_isnonzero(const fe a)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-int fe_isnegative(const fe a_p)
+WC_OMIT_FRAME_POINTER int fe_isnegative(const fe a_p)
 #else
-int fe_isnegative(const fe a)
+WC_OMIT_FRAME_POINTER int fe_isnegative(const fe a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -825,9 +826,9 @@ int fe_isnegative(const fe a)
 #if defined(HAVE_ED25519_MAKE_KEY) || defined(HAVE_ED25519_SIGN)
 #ifndef WC_NO_CACHE_RESISTANT
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
 #else
-void fe_cmov_table(fe* r, fe* base, signed char b)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, fe* base, signed char b)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2370,9 +2371,9 @@ void fe_cmov_table(fe* r, fe* base, signed char b)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
 #else
-void fe_cmov_table(fe* r, fe* base, signed char b)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, fe* base, signed char b)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2506,9 +2507,9 @@ void fe_cmov_table(fe* r, fe* base, signed char b)
 #if defined(WOLFSSL_ARM_ARCH) && (WOLFSSL_ARM_ARCH < 6)
 void fe_mul_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_mul_op()
+WC_OMIT_FRAME_POINTER void fe_mul_op()
 #else
-void fe_mul_op()
+WC_OMIT_FRAME_POINTER void fe_mul_op()
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2901,9 +2902,9 @@ void fe_mul_op()
 #else
 void fe_mul_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_mul_op()
+WC_OMIT_FRAME_POINTER void fe_mul_op()
 #else
-void fe_mul_op()
+WC_OMIT_FRAME_POINTER void fe_mul_op()
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3054,9 +3055,9 @@ void fe_mul_op()
 
 #endif /* WOLFSSL_ARM_ARCH && WOLFSSL_ARM_ARCH < 6 */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_mul(fe r_p, const fe a_p, const fe b_p)
+WC_OMIT_FRAME_POINTER void fe_mul(fe r_p, const fe a_p, const fe b_p)
 #else
-void fe_mul(fe r, const fe a, const fe b)
+WC_OMIT_FRAME_POINTER void fe_mul(fe r, const fe a, const fe b)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3082,9 +3083,9 @@ void fe_mul(fe r, const fe a, const fe b)
 #if defined(WOLFSSL_ARM_ARCH) && (WOLFSSL_ARM_ARCH < 6)
 void fe_sq_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sq_op()
+WC_OMIT_FRAME_POINTER void fe_sq_op()
 #else
-void fe_sq_op()
+WC_OMIT_FRAME_POINTER void fe_sq_op()
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3370,9 +3371,9 @@ void fe_sq_op()
 #else
 void fe_sq_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sq_op()
+WC_OMIT_FRAME_POINTER void fe_sq_op()
 #else
-void fe_sq_op()
+WC_OMIT_FRAME_POINTER void fe_sq_op()
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3509,9 +3510,9 @@ void fe_sq_op()
 
 #endif /* WOLFSSL_ARM_ARCH && WOLFSSL_ARM_ARCH < 6 */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sq(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_sq(fe r_p, const fe a_p)
 #else
-void fe_sq(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_sq(fe r, const fe a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3536,9 +3537,9 @@ void fe_sq(fe r, const fe a)
 #ifdef HAVE_CURVE25519
 #if defined(WOLFSSL_ARM_ARCH) && (WOLFSSL_ARM_ARCH < 6)
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_mul121666(fe r_p, fe a_p)
+WC_OMIT_FRAME_POINTER void fe_mul121666(fe r_p, fe a_p)
 #else
-void fe_mul121666(fe r, fe a)
+WC_OMIT_FRAME_POINTER void fe_mul121666(fe r, fe a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3620,9 +3621,9 @@ void fe_mul121666(fe r, fe a)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_mul121666(fe r_p, fe a_p)
+WC_OMIT_FRAME_POINTER void fe_mul121666(fe r_p, fe a_p)
 #else
-void fe_mul121666(fe r, fe a)
+WC_OMIT_FRAME_POINTER void fe_mul121666(fe r, fe a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3692,9 +3693,10 @@ void fe_mul121666(fe r, fe a)
 #endif /* WOLFSSL_ARM_ARCH && WOLFSSL_ARM_ARCH < 6 */
 #ifndef WC_NO_CACHE_RESISTANT
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-int curve25519(byte* r_p, const byte* n_p, const byte* a_p)
+WC_OMIT_FRAME_POINTER int curve25519(byte* r_p, const byte* n_p,
+    const byte* a_p)
 #else
-int curve25519(byte* r, const byte* n, const byte* a)
+WC_OMIT_FRAME_POINTER int curve25519(byte* r, const byte* n, const byte* a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4094,9 +4096,10 @@ int curve25519(byte* r, const byte* n, const byte* a)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-int curve25519(byte* r_p, const byte* n_p, const byte* a_p)
+WC_OMIT_FRAME_POINTER int curve25519(byte* r_p, const byte* n_p,
+    const byte* a_p)
 #else
-int curve25519(byte* r, const byte* n, const byte* a)
+WC_OMIT_FRAME_POINTER int curve25519(byte* r, const byte* n, const byte* a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4421,9 +4424,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
 #endif /* HAVE_CURVE25519 */
 #ifdef HAVE_ED25519
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_invert(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_invert(fe r_p, const fe a_p)
 #else
-void fe_invert(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_invert(fe r, const fe a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4604,9 +4607,9 @@ void fe_invert(fe r, const fe a)
 
 #if defined(WOLFSSL_ARM_ARCH) && (WOLFSSL_ARM_ARCH < 6)
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sq2(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_sq2(fe r_p, const fe a_p)
 #else
-void fe_sq2(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_sq2(fe r, const fe a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4935,9 +4938,9 @@ void fe_sq2(fe r, const fe a)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sq2(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_sq2(fe r_p, const fe a_p)
 #else
-void fe_sq2(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_sq2(fe r, const fe a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5125,9 +5128,9 @@ void fe_sq2(fe r, const fe a)
 
 #endif /* WOLFSSL_ARM_ARCH && WOLFSSL_ARM_ARCH < 6 */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_pow22523(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_pow22523(fe r_p, const fe a_p)
 #else
-void fe_pow22523(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_pow22523(fe r, const fe a)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5307,9 +5310,9 @@ void fe_pow22523(fe r, const fe a)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_p1p1_to_p2(ge_p2 * r_p, const ge_p1p1 * p_p)
+WC_OMIT_FRAME_POINTER void ge_p1p1_to_p2(ge_p2 * r_p, const ge_p1p1 * p_p)
 #else
-void ge_p1p1_to_p2(ge_p2 * r, const ge_p1p1 * p)
+WC_OMIT_FRAME_POINTER void ge_p1p1_to_p2(ge_p2 * r, const ge_p1p1 * p)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5349,9 +5352,9 @@ void ge_p1p1_to_p2(ge_p2 * r, const ge_p1p1 * p)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_p1p1_to_p3(ge_p3 * r_p, const ge_p1p1 * p_p)
+WC_OMIT_FRAME_POINTER void ge_p1p1_to_p3(ge_p3 * r_p, const ge_p1p1 * p_p)
 #else
-void ge_p1p1_to_p3(ge_p3 * r, const ge_p1p1 * p)
+WC_OMIT_FRAME_POINTER void ge_p1p1_to_p3(ge_p3 * r, const ge_p1p1 * p)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5396,9 +5399,9 @@ void ge_p1p1_to_p3(ge_p3 * r, const ge_p1p1 * p)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_p2_dbl(ge_p1p1 * r_p, const ge_p2 * p_p)
+WC_OMIT_FRAME_POINTER void ge_p2_dbl(ge_p1p1 * r_p, const ge_p2 * p_p)
 #else
-void ge_p2_dbl(ge_p1p1 * r, const ge_p2 * p)
+WC_OMIT_FRAME_POINTER void ge_p2_dbl(ge_p1p1 * r, const ge_p2 * p)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5455,9 +5458,11 @@ void ge_p2_dbl(ge_p1p1 * r, const ge_p2 * p)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_madd(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_precomp * q_p)
+WC_OMIT_FRAME_POINTER void ge_madd(ge_p1p1 * r_p, const ge_p3 * p_p,
+    const ge_precomp * q_p)
 #else
-void ge_madd(ge_p1p1 * r, const ge_p3 * p, const ge_precomp * q)
+WC_OMIT_FRAME_POINTER void ge_madd(ge_p1p1 * r, const ge_p3 * p,
+    const ge_precomp * q)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5553,9 +5558,11 @@ void ge_madd(ge_p1p1 * r, const ge_p3 * p, const ge_precomp * q)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_msub(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_precomp * q_p)
+WC_OMIT_FRAME_POINTER void ge_msub(ge_p1p1 * r_p, const ge_p3 * p_p,
+    const ge_precomp * q_p)
 #else
-void ge_msub(ge_p1p1 * r, const ge_p3 * p, const ge_precomp * q)
+WC_OMIT_FRAME_POINTER void ge_msub(ge_p1p1 * r, const ge_p3 * p,
+    const ge_precomp * q)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5652,9 +5659,11 @@ void ge_msub(ge_p1p1 * r, const ge_p3 * p, const ge_precomp * q)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_add(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_cached* q_p)
+WC_OMIT_FRAME_POINTER void ge_add(ge_p1p1 * r_p, const ge_p3 * p_p,
+    const ge_cached* q_p)
 #else
-void ge_add(ge_p1p1 * r, const ge_p3 * p, const ge_cached* q)
+WC_OMIT_FRAME_POINTER void ge_add(ge_p1p1 * r, const ge_p3 * p,
+    const ge_cached* q)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5751,9 +5760,11 @@ void ge_add(ge_p1p1 * r, const ge_p3 * p, const ge_cached* q)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_sub(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_cached* q_p)
+WC_OMIT_FRAME_POINTER void ge_sub(ge_p1p1 * r_p, const ge_p3 * p_p,
+    const ge_cached* q_p)
 #else
-void ge_sub(ge_p1p1 * r, const ge_p3 * p, const ge_cached* q)
+WC_OMIT_FRAME_POINTER void ge_sub(ge_p1p1 * r, const ge_p3 * p,
+    const ge_cached* q)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5851,9 +5862,9 @@ void ge_sub(ge_p1p1 * r, const ge_p3 * p, const ge_cached* q)
 
 #if defined(WOLFSSL_ARM_ARCH) && (WOLFSSL_ARM_ARCH < 6)
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void sc_reduce(byte* s_p)
+WC_OMIT_FRAME_POINTER void sc_reduce(byte* s_p)
 #else
-void sc_reduce(byte* s)
+WC_OMIT_FRAME_POINTER void sc_reduce(byte* s)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -6651,9 +6662,9 @@ void sc_reduce(byte* s)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void sc_reduce(byte* s_p)
+WC_OMIT_FRAME_POINTER void sc_reduce(byte* s_p)
 #else
-void sc_reduce(byte* s)
+WC_OMIT_FRAME_POINTER void sc_reduce(byte* s)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -7324,9 +7335,11 @@ void sc_reduce(byte* s)
 #ifdef HAVE_ED25519_SIGN
 #if defined(WOLFSSL_ARM_ARCH) && (WOLFSSL_ARM_ARCH < 6)
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void sc_muladd(byte* s_p, const byte* a_p, const byte* b_p, const byte* c_p)
+WC_OMIT_FRAME_POINTER void sc_muladd(byte* s_p, const byte* a_p,
+    const byte* b_p, const byte* c_p)
 #else
-void sc_muladd(byte* s, const byte* a, const byte* b, const byte* c)
+WC_OMIT_FRAME_POINTER void sc_muladd(byte* s, const byte* a, const byte* b,
+    const byte* c)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -8484,9 +8497,11 @@ void sc_muladd(byte* s, const byte* a, const byte* b, const byte* c)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void sc_muladd(byte* s_p, const byte* a_p, const byte* b_p, const byte* c_p)
+WC_OMIT_FRAME_POINTER void sc_muladd(byte* s_p, const byte* a_p,
+    const byte* b_p, const byte* c_p)
 #else
-void sc_muladd(byte* s, const byte* a, const byte* b, const byte* c)
+WC_OMIT_FRAME_POINTER void sc_muladd(byte* s, const byte* a, const byte* b,
+    const byte* c)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/armv8-32-mlkem-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-mlkem-asm_c.c
@@ -48,6 +48,7 @@
 #define __volatile__
 #define WOLFSSL_NO_VAR_ASSIGN_REG
 #endif /* __ghs__ */
+
 #include <wolfssl/wolfcrypt/wc_mlkem.h>
 
 #ifdef WOLFSSL_WC_MLKEM
@@ -87,9 +88,9 @@ static const word16 L_mlkem_arm32_ntt_zetas[] = {
 };
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void mlkem_arm32_ntt(sword16* r_p)
+WC_OMIT_FRAME_POINTER void mlkem_arm32_ntt(sword16* r_p)
 #else
-void mlkem_arm32_ntt(sword16* r)
+WC_OMIT_FRAME_POINTER void mlkem_arm32_ntt(sword16* r)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3140,9 +3141,9 @@ static const word16 L_mlkem_invntt_zetas_inv[] = {
 };
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void mlkem_arm32_invntt(sword16* r_p)
+WC_OMIT_FRAME_POINTER void mlkem_arm32_invntt(sword16* r_p)
 #else
-void mlkem_arm32_invntt(sword16* r)
+WC_OMIT_FRAME_POINTER void mlkem_arm32_invntt(sword16* r)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -7587,10 +7588,11 @@ static const word16 L_mlkem_basemul_mont_zetas[] = {
 };
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void mlkem_arm32_basemul_mont(sword16* r_p, const sword16* a_p,
-    const sword16* b_p)
+WC_OMIT_FRAME_POINTER void mlkem_arm32_basemul_mont(sword16* r_p,
+    const sword16* a_p, const sword16* b_p)
 #else
-void mlkem_arm32_basemul_mont(sword16* r, const sword16* a, const sword16* b)
+WC_OMIT_FRAME_POINTER void mlkem_arm32_basemul_mont(sword16* r,
+    const sword16* a, const sword16* b)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -7892,11 +7894,11 @@ void mlkem_arm32_basemul_mont(sword16* r, const sword16* a, const sword16* b)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void mlkem_arm32_basemul_mont_add(sword16* r_p, const sword16* a_p,
-    const sword16* b_p)
+WC_OMIT_FRAME_POINTER void mlkem_arm32_basemul_mont_add(sword16* r_p,
+    const sword16* a_p, const sword16* b_p)
 #else
-void mlkem_arm32_basemul_mont_add(sword16* r, const sword16* a,
-    const sword16* b)
+WC_OMIT_FRAME_POINTER void mlkem_arm32_basemul_mont_add(sword16* r,
+    const sword16* a, const sword16* b)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -8232,9 +8234,9 @@ void mlkem_arm32_basemul_mont_add(sword16* r, const sword16* a,
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void mlkem_arm32_csubq(sword16* p_p)
+WC_OMIT_FRAME_POINTER void mlkem_arm32_csubq(sword16* p_p)
 #else
-void mlkem_arm32_csubq(sword16* p)
+WC_OMIT_FRAME_POINTER void mlkem_arm32_csubq(sword16* p)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -8427,11 +8429,11 @@ void mlkem_arm32_csubq(sword16* p)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-unsigned int mlkem_arm32_rej_uniform(sword16* p_p, unsigned int len_p,
-    const byte* r_p, unsigned int rLen_p)
+WC_OMIT_FRAME_POINTER unsigned int mlkem_arm32_rej_uniform(sword16* p_p,
+    unsigned int len_p, const byte* r_p, unsigned int rLen_p)
 #else
-unsigned int mlkem_arm32_rej_uniform(sword16* p, unsigned int len,
-    const byte* r, unsigned int rLen)
+WC_OMIT_FRAME_POINTER unsigned int mlkem_arm32_rej_uniform(sword16* p,
+    unsigned int len, const byte* r, unsigned int rLen)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c
@@ -48,16 +48,17 @@
 #define __volatile__
 #define WOLFSSL_NO_VAR_ASSIGN_REG
 #endif /* __ghs__ */
+
 #ifdef HAVE_POLY1305
 #include <wolfssl/wolfcrypt/poly1305.h>
 
 #ifdef WOLFSSL_ARMASM_NO_NEON
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void poly1305_arm32_blocks_16(Poly1305* ctx_p, const byte* m_p, word32 len_p,
-    int notLast_p)
+WC_OMIT_FRAME_POINTER void poly1305_arm32_blocks_16(Poly1305* ctx_p,
+    const byte* m_p, word32 len_p, int notLast_p)
 #else
-void poly1305_arm32_blocks_16(Poly1305* ctx, const byte* m, word32 len,
-    int notLast)
+WC_OMIT_FRAME_POINTER void poly1305_arm32_blocks_16(Poly1305* ctx,
+    const byte* m, word32 len, int notLast)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -295,9 +296,9 @@ static const word32 L_poly1305_arm32_clamp[] = {
 };
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void poly1305_set_key(Poly1305* ctx_p, const byte* key_p)
+WC_OMIT_FRAME_POINTER void poly1305_set_key(Poly1305* ctx_p, const byte* key_p)
 #else
-void poly1305_set_key(Poly1305* ctx, const byte* key)
+WC_OMIT_FRAME_POINTER void poly1305_set_key(Poly1305* ctx, const byte* key)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -357,9 +358,9 @@ void poly1305_set_key(Poly1305* ctx, const byte* key)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void poly1305_final(Poly1305* ctx_p, byte* mac_p)
+WC_OMIT_FRAME_POINTER void poly1305_final(Poly1305* ctx_p, byte* mac_p)
 #else
-void poly1305_final(Poly1305* ctx, byte* mac)
+WC_OMIT_FRAME_POINTER void poly1305_final(Poly1305* ctx, byte* mac)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -425,11 +426,11 @@ void poly1305_final(Poly1305* ctx, byte* mac)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void poly1305_arm32_blocks_16(Poly1305* ctx_p, const byte* m_p, word32 len_p,
-    int notLast_p)
+WC_OMIT_FRAME_POINTER void poly1305_arm32_blocks_16(Poly1305* ctx_p,
+    const byte* m_p, word32 len_p, int notLast_p)
 #else
-void poly1305_arm32_blocks_16(Poly1305* ctx, const byte* m, word32 len,
-    int notLast)
+WC_OMIT_FRAME_POINTER void poly1305_arm32_blocks_16(Poly1305* ctx,
+    const byte* m, word32 len, int notLast)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -663,10 +664,11 @@ void poly1305_arm32_blocks_16(Poly1305* ctx, const byte* m, word32 len,
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void poly1305_arm32_blocks(Poly1305* ctx_p, const unsigned char* m_p,
-    size_t bytes_p)
+WC_OMIT_FRAME_POINTER void poly1305_arm32_blocks(Poly1305* ctx_p,
+    const unsigned char* m_p, size_t bytes_p)
 #else
-void poly1305_arm32_blocks(Poly1305* ctx, const unsigned char* m, size_t bytes)
+WC_OMIT_FRAME_POINTER void poly1305_arm32_blocks(Poly1305* ctx,
+    const unsigned char* m, size_t bytes)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1138,9 +1140,9 @@ static const word32 L_poly1305_arm32_clamp[] = {
 };
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void poly1305_set_key(Poly1305* ctx_p, const byte* key_p)
+WC_OMIT_FRAME_POINTER void poly1305_set_key(Poly1305* ctx_p, const byte* key_p)
 #else
-void poly1305_set_key(Poly1305* ctx, const byte* key)
+WC_OMIT_FRAME_POINTER void poly1305_set_key(Poly1305* ctx, const byte* key)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1380,9 +1382,9 @@ void poly1305_set_key(Poly1305* ctx, const byte* key)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void poly1305_final(Poly1305* ctx_p, byte* mac_p)
+WC_OMIT_FRAME_POINTER void poly1305_final(Poly1305* ctx_p, byte* mac_p)
 #else
-void poly1305_final(Poly1305* ctx, byte* mac)
+WC_OMIT_FRAME_POINTER void poly1305_final(Poly1305* ctx, byte* mac)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
@@ -48,6 +48,7 @@
 #define __volatile__
 #define WOLFSSL_NO_VAR_ASSIGN_REG
 #endif /* __ghs__ */
+
 #ifndef NO_SHA256
 #include <wolfssl/wolfcrypt/sha256.h>
 
@@ -74,9 +75,11 @@ static const word32 L_SHA256_transform_len_k[] = {
 void Transform_Sha256_Len(wc_Sha256* sha256_p, const byte* data_p,
     word32 len_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void Transform_Sha256_Len(wc_Sha256* sha256_p, const byte* data_p, word32 len_p)
+WC_OMIT_FRAME_POINTER void Transform_Sha256_Len(wc_Sha256* sha256_p,
+    const byte* data_p, word32 len_p)
 #else
-void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
+WC_OMIT_FRAME_POINTER void Transform_Sha256_Len(wc_Sha256* sha256,
+    const byte* data, word32 len)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1777,9 +1780,11 @@ static const word32 L_SHA256_transform_neon_len_k[] = {
 void Transform_Sha256_Len(wc_Sha256* sha256_p, const byte* data_p,
     word32 len_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void Transform_Sha256_Len(wc_Sha256* sha256_p, const byte* data_p, word32 len_p)
+WC_OMIT_FRAME_POINTER void Transform_Sha256_Len(wc_Sha256* sha256_p,
+    const byte* data_p, word32 len_p)
 #else
-void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
+WC_OMIT_FRAME_POINTER void Transform_Sha256_Len(wc_Sha256* sha256,
+    const byte* data, word32 len)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c
@@ -48,6 +48,7 @@
 #define __volatile__
 #define WOLFSSL_NO_VAR_ASSIGN_REG
 #endif /* __ghs__ */
+
 #ifdef WOLFSSL_SHA3
 #ifndef WOLFSSL_ARMASM_NO_NEON
 static const word64 L_sha3_arm2_neon_rt[] = {
@@ -68,9 +69,9 @@ static const word64 L_sha3_arm2_neon_rt[] = {
 #include <wolfssl/wolfcrypt/sha3.h>
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void BlockSha3(word64* state_p)
+WC_OMIT_FRAME_POINTER void BlockSha3(word64* state_p)
 #else
-void BlockSha3(word64* state)
+WC_OMIT_FRAME_POINTER void BlockSha3(word64* state)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -377,9 +378,9 @@ static const word64 L_sha3_arm2_rt[] = {
 #include <wolfssl/wolfcrypt/sha3.h>
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void BlockSha3(word64* state_p)
+WC_OMIT_FRAME_POINTER void BlockSha3(word64* state_p)
 #else
-void BlockSha3(word64* state)
+WC_OMIT_FRAME_POINTER void BlockSha3(word64* state)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
@@ -48,6 +48,7 @@
 #define __volatile__
 #define WOLFSSL_NO_VAR_ASSIGN_REG
 #endif /* __ghs__ */
+
 #if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 #include <wolfssl/wolfcrypt/sha512.h>
 
@@ -98,9 +99,11 @@ static const word64 L_SHA512_transform_len_k[] = {
 void Transform_Sha512_Len(wc_Sha512* sha512_p, const byte* data_p,
     word32 len_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void Transform_Sha512_Len(wc_Sha512* sha512_p, const byte* data_p, word32 len_p)
+WC_OMIT_FRAME_POINTER void Transform_Sha512_Len(wc_Sha512* sha512_p,
+    const byte* data_p, word32 len_p)
 #else
-void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
+WC_OMIT_FRAME_POINTER void Transform_Sha512_Len(wc_Sha512* sha512,
+    const byte* data, word32 len)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -7593,9 +7596,11 @@ static const word64 L_SHA512_transform_neon_len_k[] = {
 void Transform_Sha512_Len(wc_Sha512* sha512_p, const byte* data_p,
     word32 len_p);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void Transform_Sha512_Len(wc_Sha512* sha512_p, const byte* data_p, word32 len_p)
+WC_OMIT_FRAME_POINTER void Transform_Sha512_Len(wc_Sha512* sha512_p,
+    const byte* data_p, word32 len_p)
 #else
-void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
+WC_OMIT_FRAME_POINTER void Transform_Sha512_Len(wc_Sha512* sha512,
+    const byte* data, word32 len)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
@@ -41,6 +41,7 @@
 #define __asm__        __asm
 #define __volatile__   volatile
 #endif /* __KEIL__ */
+
 #ifndef NO_AES
 #include <wolfssl/wolfcrypt/aes.h>
 
@@ -197,9 +198,9 @@ static const word32* L_AES_Thumb2_te = L_AES_Thumb2_te_data;
 #ifdef HAVE_AES_DECRYPT
 void AES_invert_key(unsigned char* ks, word32 rounds);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_invert_key(unsigned char* ks_p, word32 rounds_p)
+WC_OMIT_FRAME_POINTER void AES_invert_key(unsigned char* ks_p, word32 rounds_p)
 #else
-void AES_invert_key(unsigned char* ks, word32 rounds)
+WC_OMIT_FRAME_POINTER void AES_invert_key(unsigned char* ks, word32 rounds)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -343,11 +344,11 @@ XALIGNED(16) static const word32 L_AES_Thumb2_rcon[] = {
 void AES_set_encrypt_key(const unsigned char* key, word32 len,
         unsigned char* ks);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_set_encrypt_key(const unsigned char* key_p, word32 len_p,
-    unsigned char* ks_p)
+WC_OMIT_FRAME_POINTER void AES_set_encrypt_key(const unsigned char* key_p,
+    word32 len_p, unsigned char* ks_p)
 #else
-void AES_set_encrypt_key(const unsigned char* key, word32 len,
-    unsigned char* ks)
+WC_OMIT_FRAME_POINTER void AES_set_encrypt_key(const unsigned char* key,
+    word32 len, unsigned char* ks)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -638,10 +639,11 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len,
 
 void AES_encrypt_block(const word32* te, int nr, int len, const word32* ks);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_encrypt_block(const word32* te_p, int nr_p, int len_p,
-    const word32* ks_p)
+WC_OMIT_FRAME_POINTER void AES_encrypt_block(const word32* te_p, int nr_p,
+    int len_p, const word32* ks_p)
 #else
-void AES_encrypt_block(const word32* te, int nr, int len, const word32* ks)
+WC_OMIT_FRAME_POINTER void AES_encrypt_block(const word32* te, int nr, int len,
+    const word32* ks)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -882,11 +884,12 @@ static const word32* L_AES_Thumb2_te_ecb = L_AES_Thumb2_te_data;
 void AES_ECB_encrypt(const unsigned char* in, unsigned char* out,
         unsigned long len, const unsigned char* ks, int nr);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_ECB_encrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p)
+WC_OMIT_FRAME_POINTER void AES_ECB_encrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p)
 #else
-void AES_ECB_encrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr)
+WC_OMIT_FRAME_POINTER void AES_ECB_encrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1105,12 +1108,13 @@ void AES_ECB_encrypt(const unsigned char* in, unsigned char* out,
 void AES_CBC_encrypt(const unsigned char* in, unsigned char* out,
         unsigned long len, const unsigned char* ks, int nr, unsigned char* iv);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_CBC_encrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p,
-    unsigned char* iv_p)
+WC_OMIT_FRAME_POINTER void AES_CBC_encrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p, unsigned char* iv_p)
 #else
-void AES_CBC_encrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr, unsigned char* iv)
+WC_OMIT_FRAME_POINTER void AES_CBC_encrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr,
+    unsigned char* iv)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1349,12 +1353,13 @@ void AES_CBC_encrypt(const unsigned char* in, unsigned char* out,
 void AES_CTR_encrypt(const unsigned char* in, unsigned char* out,
         unsigned long len, const unsigned char* ks, int nr, unsigned char* ctr);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_CTR_encrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p,
-    unsigned char* ctr_p)
+WC_OMIT_FRAME_POINTER void AES_CTR_encrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p, unsigned char* ctr_p)
 #else
-void AES_CTR_encrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr, unsigned char* ctr)
+WC_OMIT_FRAME_POINTER void AES_CTR_encrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr,
+    unsigned char* ctr)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1615,9 +1620,11 @@ void AES_CTR_encrypt(const unsigned char* in, unsigned char* out,
         defined(HAVE_AES_CBC)
 void AES_decrypt_block(const word32* td, int nr, const byte* td4);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_decrypt_block(const word32* td_p, int nr_p, const byte* td4_p)
+WC_OMIT_FRAME_POINTER void AES_decrypt_block(const word32* td_p, int nr_p,
+    const byte* td4_p)
 #else
-void AES_decrypt_block(const word32* td, int nr, const byte* td4)
+WC_OMIT_FRAME_POINTER void AES_decrypt_block(const word32* td, int nr,
+    const byte* td4)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1887,11 +1894,12 @@ static const byte L_AES_Thumb2_td4[] = {
 void AES_ECB_decrypt(const unsigned char* in, unsigned char* out,
         unsigned long len, const unsigned char* ks, int nr);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_ECB_decrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p)
+WC_OMIT_FRAME_POINTER void AES_ECB_decrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p)
 #else
-void AES_ECB_decrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr)
+WC_OMIT_FRAME_POINTER void AES_ECB_decrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2112,12 +2120,13 @@ void AES_ECB_decrypt(const unsigned char* in, unsigned char* out,
 void AES_CBC_decrypt(const unsigned char* in, unsigned char* out,
         unsigned long len, const unsigned char* ks, int nr, unsigned char* iv);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_CBC_decrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p,
-    unsigned char* iv_p)
+WC_OMIT_FRAME_POINTER void AES_CBC_decrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p, unsigned char* iv_p)
 #else
-void AES_CBC_decrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr, unsigned char* iv)
+WC_OMIT_FRAME_POINTER void AES_CBC_decrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr,
+    unsigned char* iv)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2533,11 +2542,11 @@ XALIGNED(16) static const word32 L_GCM_gmult_len_r[] = {
 void GCM_gmult_len(unsigned char* x, const unsigned char** m,
         const unsigned char* data, unsigned long len);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void GCM_gmult_len(unsigned char* x_p, const unsigned char** m_p,
-    const unsigned char* data_p, unsigned long len_p)
+WC_OMIT_FRAME_POINTER void GCM_gmult_len(unsigned char* x_p,
+    const unsigned char** m_p, const unsigned char* data_p, unsigned long len_p)
 #else
-void GCM_gmult_len(unsigned char* x, const unsigned char** m,
-    const unsigned char* data, unsigned long len)
+WC_OMIT_FRAME_POINTER void GCM_gmult_len(unsigned char* x,
+    const unsigned char** m, const unsigned char* data, unsigned long len)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3126,12 +3135,13 @@ static const word32* L_AES_Thumb2_te_gcm = L_AES_Thumb2_te_data;
 void AES_GCM_encrypt(const unsigned char* in, unsigned char* out,
         unsigned long len, const unsigned char* ks, int nr, unsigned char* ctr);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void AES_GCM_encrypt(const unsigned char* in_p, unsigned char* out_p,
-    unsigned long len_p, const unsigned char* ks_p, int nr_p,
-    unsigned char* ctr_p)
+WC_OMIT_FRAME_POINTER void AES_GCM_encrypt(const unsigned char* in_p,
+    unsigned char* out_p, unsigned long len_p, const unsigned char* ks_p,
+    int nr_p, unsigned char* ctr_p)
 #else
-void AES_GCM_encrypt(const unsigned char* in, unsigned char* out,
-    unsigned long len, const unsigned char* ks, int nr, unsigned char* ctr)
+WC_OMIT_FRAME_POINTER void AES_GCM_encrypt(const unsigned char* in,
+    unsigned char* out, unsigned long len, const unsigned char* ks, int nr,
+    unsigned char* ctr)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3381,4 +3391,5 @@ void AES_GCM_encrypt(const unsigned char* in, unsigned char* out,
 #endif /* !NO_AES */
 #endif /* WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
+
 #endif /* WOLFSSL_ARMASM_INLINE */

--- a/wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c
@@ -41,13 +41,16 @@
 #define __asm__        __asm
 #define __volatile__   volatile
 #endif /* __KEIL__ */
+
 #ifdef HAVE_CHACHA
 #include <wolfssl/wolfcrypt/chacha.h>
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void wc_chacha_setiv(word32* x_p, const byte* iv_p, word32 counter_p)
+WC_OMIT_FRAME_POINTER void wc_chacha_setiv(word32* x_p, const byte* iv_p,
+    word32 counter_p)
 #else
-void wc_chacha_setiv(word32* x, const byte* iv, word32 counter)
+WC_OMIT_FRAME_POINTER void wc_chacha_setiv(word32* x, const byte* iv,
+    word32 counter)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -80,9 +83,11 @@ XALIGNED(16) static const word32 L_chacha_thumb2_constants[] = {
 };
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void wc_chacha_setkey(word32* x_p, const byte* key_p, word32 keySz_p)
+WC_OMIT_FRAME_POINTER void wc_chacha_setkey(word32* x_p, const byte* key_p,
+    word32 keySz_p)
 #else
-void wc_chacha_setkey(word32* x, const byte* key, word32 keySz)
+WC_OMIT_FRAME_POINTER void wc_chacha_setkey(word32* x, const byte* key,
+    word32 keySz)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -146,10 +151,11 @@ void wc_chacha_setkey(word32* x, const byte* key, word32 keySz)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void wc_chacha_crypt_bytes(ChaCha* ctx_p, byte* c_p, const byte* m_p,
-    word32 len_p)
+WC_OMIT_FRAME_POINTER void wc_chacha_crypt_bytes(ChaCha* ctx_p, byte* c_p,
+    const byte* m_p, word32 len_p)
 #else
-void wc_chacha_crypt_bytes(ChaCha* ctx, byte* c, const byte* m, word32 len)
+WC_OMIT_FRAME_POINTER void wc_chacha_crypt_bytes(ChaCha* ctx, byte* c,
+    const byte* m, word32 len)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -585,10 +591,11 @@ void wc_chacha_crypt_bytes(ChaCha* ctx, byte* c, const byte* m, word32 len)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void wc_chacha_use_over(byte* over_p, byte* output_p, const byte* input_p,
-    word32 len_p)
+WC_OMIT_FRAME_POINTER void wc_chacha_use_over(byte* over_p, byte* output_p,
+    const byte* input_p, word32 len_p)
 #else
-void wc_chacha_use_over(byte* over, byte* output, const byte* input, word32 len)
+WC_OMIT_FRAME_POINTER void wc_chacha_use_over(byte* over, byte* output,
+    const byte* input, word32 len)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -730,4 +737,5 @@ void wc_chacha_use_over(byte* over, byte* output, const byte* input, word32 len)
 #endif /* HAVE_CHACHA */
 #endif /* WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
+
 #endif /* WOLFSSL_ARMASM_INLINE */

--- a/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
@@ -41,6 +41,7 @@
 #define __asm__        __asm
 #define __volatile__   volatile
 #endif /* __KEIL__ */
+
 /* Based on work by: Emil Lenngren
  * https://github.com/pornin/X25519-Cortex-M4
  */
@@ -53,9 +54,9 @@
 #if !defined(CURVE25519_SMALL) || !defined(ED25519_SMALL)
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_init()
+WC_OMIT_FRAME_POINTER void fe_init()
 #else
-void fe_init()
+WC_OMIT_FRAME_POINTER void fe_init()
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -70,9 +71,9 @@ void fe_init()
 
 void fe_add_sub_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_add_sub_op()
+WC_OMIT_FRAME_POINTER void fe_add_sub_op()
 #else
-void fe_add_sub_op()
+WC_OMIT_FRAME_POINTER void fe_add_sub_op()
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -173,9 +174,9 @@ void fe_add_sub_op()
 
 void fe_sub_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sub_op()
+WC_OMIT_FRAME_POINTER void fe_sub_op()
 #else
-void fe_sub_op()
+WC_OMIT_FRAME_POINTER void fe_sub_op()
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -213,9 +214,9 @@ void fe_sub_op()
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sub(fe r_p, const fe a_p, const fe b_p)
+WC_OMIT_FRAME_POINTER void fe_sub(fe r_p, const fe a_p, const fe b_p)
 #else
-void fe_sub(fe r, const fe a, const fe b)
+WC_OMIT_FRAME_POINTER void fe_sub(fe r, const fe a, const fe b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -235,9 +236,9 @@ void fe_sub(fe r, const fe a, const fe b)
 
 void fe_add_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_add_op()
+WC_OMIT_FRAME_POINTER void fe_add_op()
 #else
-void fe_add_op()
+WC_OMIT_FRAME_POINTER void fe_add_op()
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -275,9 +276,9 @@ void fe_add_op()
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_add(fe r_p, const fe a_p, const fe b_p)
+WC_OMIT_FRAME_POINTER void fe_add(fe r_p, const fe a_p, const fe b_p)
 #else
-void fe_add(fe r, const fe a, const fe b)
+WC_OMIT_FRAME_POINTER void fe_add(fe r, const fe a, const fe b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -297,9 +298,9 @@ void fe_add(fe r, const fe a, const fe b)
 
 #ifdef HAVE_ED25519
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_frombytes(fe out_p, const unsigned char* in_p)
+WC_OMIT_FRAME_POINTER void fe_frombytes(fe out_p, const unsigned char* in_p)
 #else
-void fe_frombytes(fe out, const unsigned char* in)
+WC_OMIT_FRAME_POINTER void fe_frombytes(fe out, const unsigned char* in)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -333,9 +334,9 @@ void fe_frombytes(fe out, const unsigned char* in)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_tobytes(unsigned char* out_p, const fe n_p)
+WC_OMIT_FRAME_POINTER void fe_tobytes(unsigned char* out_p, const fe n_p)
 #else
-void fe_tobytes(unsigned char* out, const fe n)
+WC_OMIT_FRAME_POINTER void fe_tobytes(unsigned char* out, const fe n)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -379,9 +380,9 @@ void fe_tobytes(unsigned char* out, const fe n)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_1(fe n_p)
+WC_OMIT_FRAME_POINTER void fe_1(fe n_p)
 #else
-void fe_1(fe n)
+WC_OMIT_FRAME_POINTER void fe_1(fe n)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -406,9 +407,9 @@ void fe_1(fe n)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_0(fe n_p)
+WC_OMIT_FRAME_POINTER void fe_0(fe n_p)
 #else
-void fe_0(fe n)
+WC_OMIT_FRAME_POINTER void fe_0(fe n)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -433,9 +434,9 @@ void fe_0(fe n)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_copy(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_copy(fe r_p, const fe a_p)
 #else
-void fe_copy(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_copy(fe r, const fe a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -460,9 +461,9 @@ void fe_copy(fe r, const fe a)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_neg(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_neg(fe r_p, const fe a_p)
 #else
-void fe_neg(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_neg(fe r, const fe a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -493,9 +494,9 @@ void fe_neg(fe r, const fe a)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-int fe_isnonzero(const fe a_p)
+WC_OMIT_FRAME_POINTER int fe_isnonzero(const fe a_p)
 #else
-int fe_isnonzero(const fe a)
+WC_OMIT_FRAME_POINTER int fe_isnonzero(const fe a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -539,9 +540,9 @@ int fe_isnonzero(const fe a)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-int fe_isnegative(const fe a_p)
+WC_OMIT_FRAME_POINTER int fe_isnegative(const fe a_p)
 #else
-int fe_isnegative(const fe a)
+WC_OMIT_FRAME_POINTER int fe_isnegative(const fe a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -573,9 +574,9 @@ int fe_isnegative(const fe a)
 #if defined(HAVE_ED25519_MAKE_KEY) || defined(HAVE_ED25519_SIGN)
 #ifndef WC_NO_CACHE_RESISTANT
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
 #else
-void fe_cmov_table(fe* r, fe* base, signed char b)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, fe* base, signed char b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1557,9 +1558,9 @@ void fe_cmov_table(fe* r, fe* base, signed char b)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
 #else
-void fe_cmov_table(fe* r, fe* base, signed char b)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, fe* base, signed char b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1674,9 +1675,9 @@ void fe_cmov_table(fe* r, fe* base, signed char b)
 #ifdef WOLFSSL_ARM_ARCH_7M
 void fe_mul_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_mul_op()
+WC_OMIT_FRAME_POINTER void fe_mul_op()
 #else
-void fe_mul_op()
+WC_OMIT_FRAME_POINTER void fe_mul_op()
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2060,9 +2061,9 @@ void fe_mul_op()
 #else
 void fe_mul_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_mul_op()
+WC_OMIT_FRAME_POINTER void fe_mul_op()
 #else
-void fe_mul_op()
+WC_OMIT_FRAME_POINTER void fe_mul_op()
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2199,9 +2200,9 @@ void fe_mul_op()
 
 #endif /* WOLFSSL_ARM_ARCH_7M */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_mul(fe r_p, const fe a_p, const fe b_p)
+WC_OMIT_FRAME_POINTER void fe_mul(fe r_p, const fe a_p, const fe b_p)
 #else
-void fe_mul(fe r, const fe a, const fe b)
+WC_OMIT_FRAME_POINTER void fe_mul(fe r, const fe a, const fe b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2222,9 +2223,9 @@ void fe_mul(fe r, const fe a, const fe b)
 #ifdef WOLFSSL_ARM_ARCH_7M
 void fe_sq_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sq_op()
+WC_OMIT_FRAME_POINTER void fe_sq_op()
 #else
-void fe_sq_op()
+WC_OMIT_FRAME_POINTER void fe_sq_op()
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2501,9 +2502,9 @@ void fe_sq_op()
 #else
 void fe_sq_op(void);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sq_op()
+WC_OMIT_FRAME_POINTER void fe_sq_op()
 #else
-void fe_sq_op()
+WC_OMIT_FRAME_POINTER void fe_sq_op()
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2626,9 +2627,9 @@ void fe_sq_op()
 
 #endif /* WOLFSSL_ARM_ARCH_7M */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sq(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_sq(fe r_p, const fe a_p)
 #else
-void fe_sq(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_sq(fe r, const fe a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2648,9 +2649,9 @@ void fe_sq(fe r, const fe a)
 #ifdef HAVE_CURVE25519
 #ifdef WOLFSSL_ARM_ARCH_7M
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_mul121666(fe r_p, fe a_p)
+WC_OMIT_FRAME_POINTER void fe_mul121666(fe r_p, fe a_p)
 #else
-void fe_mul121666(fe r, fe a)
+WC_OMIT_FRAME_POINTER void fe_mul121666(fe r, fe a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2708,9 +2709,9 @@ void fe_mul121666(fe r, fe a)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_mul121666(fe r_p, fe a_p)
+WC_OMIT_FRAME_POINTER void fe_mul121666(fe r_p, fe a_p)
 #else
-void fe_mul121666(fe r, fe a)
+WC_OMIT_FRAME_POINTER void fe_mul121666(fe r, fe a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2756,9 +2757,10 @@ void fe_mul121666(fe r, fe a)
 #endif /* WOLFSSL_ARM_ARCH_7M */
 #ifndef WC_NO_CACHE_RESISTANT
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-int curve25519(byte* r_p, const byte* n_p, const byte* a_p)
+WC_OMIT_FRAME_POINTER int curve25519(byte* r_p, const byte* n_p,
+    const byte* a_p)
 #else
-int curve25519(byte* r, const byte* n, const byte* a)
+WC_OMIT_FRAME_POINTER int curve25519(byte* r, const byte* n, const byte* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3253,9 +3255,10 @@ int curve25519(byte* r, const byte* n, const byte* a)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-int curve25519(byte* r_p, const byte* n_p, const byte* a_p)
+WC_OMIT_FRAME_POINTER int curve25519(byte* r_p, const byte* n_p,
+    const byte* a_p)
 #else
-int curve25519(byte* r, const byte* n, const byte* a)
+WC_OMIT_FRAME_POINTER int curve25519(byte* r, const byte* n, const byte* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3662,9 +3665,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
 #endif /* HAVE_CURVE25519 */
 #ifdef HAVE_ED25519
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_invert(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_invert(fe r_p, const fe a_p)
 #else
-void fe_invert(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_invert(fe r, const fe a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3920,9 +3923,9 @@ void fe_invert(fe r, const fe a)
 
 #ifdef WOLFSSL_ARM_ARCH_7M
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sq2(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_sq2(fe r_p, const fe a_p)
 #else
-void fe_sq2(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_sq2(fe r, const fe a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4234,9 +4237,9 @@ void fe_sq2(fe r, const fe a)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_sq2(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_sq2(fe r_p, const fe a_p)
 #else
-void fe_sq2(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_sq2(fe r, const fe a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4397,9 +4400,9 @@ void fe_sq2(fe r, const fe a)
 
 #endif /* WOLFSSL_ARM_ARCH_7M */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void fe_pow22523(fe r_p, const fe a_p)
+WC_OMIT_FRAME_POINTER void fe_pow22523(fe r_p, const fe a_p)
 #else
-void fe_pow22523(fe r, const fe a)
+WC_OMIT_FRAME_POINTER void fe_pow22523(fe r, const fe a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4654,9 +4657,9 @@ void fe_pow22523(fe r, const fe a)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_p1p1_to_p2(ge_p2 * r_p, const ge_p1p1 * p_p)
+WC_OMIT_FRAME_POINTER void ge_p1p1_to_p2(ge_p2 * r_p, const ge_p1p1 * p_p)
 #else
-void ge_p1p1_to_p2(ge_p2 * r, const ge_p1p1 * p)
+WC_OMIT_FRAME_POINTER void ge_p1p1_to_p2(ge_p2 * r, const ge_p1p1 * p)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4691,9 +4694,9 @@ void ge_p1p1_to_p2(ge_p2 * r, const ge_p1p1 * p)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_p1p1_to_p3(ge_p3 * r_p, const ge_p1p1 * p_p)
+WC_OMIT_FRAME_POINTER void ge_p1p1_to_p3(ge_p3 * r_p, const ge_p1p1 * p_p)
 #else
-void ge_p1p1_to_p3(ge_p3 * r, const ge_p1p1 * p)
+WC_OMIT_FRAME_POINTER void ge_p1p1_to_p3(ge_p3 * r, const ge_p1p1 * p)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4733,9 +4736,9 @@ void ge_p1p1_to_p3(ge_p3 * r, const ge_p1p1 * p)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_p2_dbl(ge_p1p1 * r_p, const ge_p2 * p_p)
+WC_OMIT_FRAME_POINTER void ge_p2_dbl(ge_p1p1 * r_p, const ge_p2 * p_p)
 #else
-void ge_p2_dbl(ge_p1p1 * r, const ge_p2 * p)
+WC_OMIT_FRAME_POINTER void ge_p2_dbl(ge_p1p1 * r, const ge_p2 * p)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4787,9 +4790,11 @@ void ge_p2_dbl(ge_p1p1 * r, const ge_p2 * p)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_madd(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_precomp * q_p)
+WC_OMIT_FRAME_POINTER void ge_madd(ge_p1p1 * r_p, const ge_p3 * p_p,
+    const ge_precomp * q_p)
 #else
-void ge_madd(ge_p1p1 * r, const ge_p3 * p, const ge_precomp * q)
+WC_OMIT_FRAME_POINTER void ge_madd(ge_p1p1 * r, const ge_p3 * p,
+    const ge_precomp * q)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4876,9 +4881,11 @@ void ge_madd(ge_p1p1 * r, const ge_p3 * p, const ge_precomp * q)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_msub(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_precomp * q_p)
+WC_OMIT_FRAME_POINTER void ge_msub(ge_p1p1 * r_p, const ge_p3 * p_p,
+    const ge_precomp * q_p)
 #else
-void ge_msub(ge_p1p1 * r, const ge_p3 * p, const ge_precomp * q)
+WC_OMIT_FRAME_POINTER void ge_msub(ge_p1p1 * r, const ge_p3 * p,
+    const ge_precomp * q)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4966,9 +4973,11 @@ void ge_msub(ge_p1p1 * r, const ge_p3 * p, const ge_precomp * q)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_add(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_cached* q_p)
+WC_OMIT_FRAME_POINTER void ge_add(ge_p1p1 * r_p, const ge_p3 * p_p,
+    const ge_cached* q_p)
 #else
-void ge_add(ge_p1p1 * r, const ge_p3 * p, const ge_cached* q)
+WC_OMIT_FRAME_POINTER void ge_add(ge_p1p1 * r, const ge_p3 * p,
+    const ge_cached* q)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5056,9 +5065,11 @@ void ge_add(ge_p1p1 * r, const ge_p3 * p, const ge_cached* q)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void ge_sub(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_cached* q_p)
+WC_OMIT_FRAME_POINTER void ge_sub(ge_p1p1 * r_p, const ge_p3 * p_p,
+    const ge_cached* q_p)
 #else
-void ge_sub(ge_p1p1 * r, const ge_p3 * p, const ge_cached* q)
+WC_OMIT_FRAME_POINTER void ge_sub(ge_p1p1 * r, const ge_p3 * p,
+    const ge_cached* q)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5147,9 +5158,9 @@ void ge_sub(ge_p1p1 * r, const ge_p3 * p, const ge_cached* q)
 
 #ifdef WOLFSSL_ARM_ARCH_7M
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void sc_reduce(byte* s_p)
+WC_OMIT_FRAME_POINTER void sc_reduce(byte* s_p)
 #else
-void sc_reduce(byte* s)
+WC_OMIT_FRAME_POINTER void sc_reduce(byte* s)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5582,9 +5593,9 @@ void sc_reduce(byte* s)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void sc_reduce(byte* s_p)
+WC_OMIT_FRAME_POINTER void sc_reduce(byte* s_p)
 #else
-void sc_reduce(byte* s)
+WC_OMIT_FRAME_POINTER void sc_reduce(byte* s)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5890,9 +5901,11 @@ void sc_reduce(byte* s)
 #ifdef HAVE_ED25519_SIGN
 #ifdef WOLFSSL_ARM_ARCH_7M
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void sc_muladd(byte* s_p, const byte* a_p, const byte* b_p, const byte* c_p)
+WC_OMIT_FRAME_POINTER void sc_muladd(byte* s_p, const byte* a_p,
+    const byte* b_p, const byte* c_p)
 #else
-void sc_muladd(byte* s, const byte* a, const byte* b, const byte* c)
+WC_OMIT_FRAME_POINTER void sc_muladd(byte* s, const byte* a, const byte* b,
+    const byte* c)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -6685,9 +6698,11 @@ void sc_muladd(byte* s, const byte* a, const byte* b, const byte* c)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void sc_muladd(byte* s_p, const byte* a_p, const byte* b_p, const byte* c_p)
+WC_OMIT_FRAME_POINTER void sc_muladd(byte* s_p, const byte* a_p,
+    const byte* b_p, const byte* c_p)
 #else
-void sc_muladd(byte* s, const byte* a, const byte* b, const byte* c)
+WC_OMIT_FRAME_POINTER void sc_muladd(byte* s, const byte* a, const byte* b,
+    const byte* c)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -7130,4 +7145,5 @@ void sc_muladd(byte* s, const byte* a, const byte* b, const byte* c)
 #endif /* HAVE_CURVE25519 || HAVE_ED25519 */
 #endif /* WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
+
 #endif /* WOLFSSL_ARMASM_INLINE */

--- a/wolfcrypt/src/port/arm/thumb2-mlkem-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-mlkem-asm_c.c
@@ -41,6 +41,7 @@
 #define __asm__        __asm
 #define __volatile__   volatile
 #endif /* __KEIL__ */
+
 #include <wolfssl/wolfcrypt/wc_mlkem.h>
 
 #ifdef WOLFSSL_WC_MLKEM
@@ -64,9 +65,9 @@ XALIGNED(16) static const word16 L_mlkem_thumb2_ntt_zetas[] = {
 };
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void mlkem_thumb2_ntt(sword16* r_p)
+WC_OMIT_FRAME_POINTER void mlkem_thumb2_ntt(sword16* r_p)
 #else
-void mlkem_thumb2_ntt(sword16* r)
+WC_OMIT_FRAME_POINTER void mlkem_thumb2_ntt(sword16* r)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1387,9 +1388,9 @@ XALIGNED(16) static const word16 L_mlkem_invntt_zetas_inv[] = {
 };
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void mlkem_thumb2_invntt(sword16* r_p)
+WC_OMIT_FRAME_POINTER void mlkem_thumb2_invntt(sword16* r_p)
 #else
-void mlkem_thumb2_invntt(sword16* r)
+WC_OMIT_FRAME_POINTER void mlkem_thumb2_invntt(sword16* r)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3077,10 +3078,11 @@ XALIGNED(16) static const word16 L_mlkem_basemul_mont_zetas[] = {
 };
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void mlkem_thumb2_basemul_mont(sword16* r_p, const sword16* a_p,
-    const sword16* b_p)
+WC_OMIT_FRAME_POINTER void mlkem_thumb2_basemul_mont(sword16* r_p,
+    const sword16* a_p, const sword16* b_p)
 #else
-void mlkem_thumb2_basemul_mont(sword16* r, const sword16* a, const sword16* b)
+WC_OMIT_FRAME_POINTER void mlkem_thumb2_basemul_mont(sword16* r,
+    const sword16* a, const sword16* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3227,11 +3229,11 @@ void mlkem_thumb2_basemul_mont(sword16* r, const sword16* a, const sword16* b)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void mlkem_thumb2_basemul_mont_add(sword16* r_p, const sword16* a_p,
-    const sword16* b_p)
+WC_OMIT_FRAME_POINTER void mlkem_thumb2_basemul_mont_add(sword16* r_p,
+    const sword16* a_p, const sword16* b_p)
 #else
-void mlkem_thumb2_basemul_mont_add(sword16* r, const sword16* a,
-    const sword16* b)
+WC_OMIT_FRAME_POINTER void mlkem_thumb2_basemul_mont_add(sword16* r,
+    const sword16* a, const sword16* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3390,9 +3392,9 @@ void mlkem_thumb2_basemul_mont_add(sword16* r, const sword16* a,
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void mlkem_thumb2_csubq(sword16* p_p)
+WC_OMIT_FRAME_POINTER void mlkem_thumb2_csubq(sword16* p_p)
 #else
-void mlkem_thumb2_csubq(sword16* p)
+WC_OMIT_FRAME_POINTER void mlkem_thumb2_csubq(sword16* p)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3503,11 +3505,11 @@ void mlkem_thumb2_csubq(sword16* p)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-unsigned int mlkem_thumb2_rej_uniform(sword16* p_p, unsigned int len_p,
-    const byte* r_p, unsigned int rLen_p)
+WC_OMIT_FRAME_POINTER unsigned int mlkem_thumb2_rej_uniform(sword16* p_p,
+    unsigned int len_p, const byte* r_p, unsigned int rLen_p)
 #else
-unsigned int mlkem_thumb2_rej_uniform(sword16* p, unsigned int len,
-    const byte* r, unsigned int rLen)
+WC_OMIT_FRAME_POINTER unsigned int mlkem_thumb2_rej_uniform(sword16* p,
+    unsigned int len, const byte* r, unsigned int rLen)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3856,4 +3858,5 @@ unsigned int mlkem_thumb2_rej_uniform(sword16* p, unsigned int len,
 #endif /* WOLFSSL_WC_MLKEM */
 #endif /* WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
+
 #endif /* WOLFSSL_ARMASM_INLINE */

--- a/wolfcrypt/src/port/arm/thumb2-poly1305-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-poly1305-asm_c.c
@@ -41,15 +41,16 @@
 #define __asm__        __asm
 #define __volatile__   volatile
 #endif /* __KEIL__ */
+
 #ifdef HAVE_POLY1305
 #include <wolfssl/wolfcrypt/poly1305.h>
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void poly1305_blocks_thumb2_16(Poly1305* ctx_p, const byte* m_p, word32 len_p,
-    int notLast_p)
+WC_OMIT_FRAME_POINTER void poly1305_blocks_thumb2_16(Poly1305* ctx_p,
+    const byte* m_p, word32 len_p, int notLast_p)
 #else
-void poly1305_blocks_thumb2_16(Poly1305* ctx, const byte* m, word32 len,
-    int notLast)
+WC_OMIT_FRAME_POINTER void poly1305_blocks_thumb2_16(Poly1305* ctx,
+    const byte* m, word32 len, int notLast)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -301,9 +302,9 @@ XALIGNED(16) static const word32 L_poly1305_thumb2_clamp[] = {
 };
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void poly1305_set_key(Poly1305* ctx_p, const byte* key_p)
+WC_OMIT_FRAME_POINTER void poly1305_set_key(Poly1305* ctx_p, const byte* key_p)
 #else
-void poly1305_set_key(Poly1305* ctx, const byte* key)
+WC_OMIT_FRAME_POINTER void poly1305_set_key(Poly1305* ctx, const byte* key)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -358,9 +359,9 @@ void poly1305_set_key(Poly1305* ctx, const byte* key)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void poly1305_final(Poly1305* ctx_p, byte* mac_p)
+WC_OMIT_FRAME_POINTER void poly1305_final(Poly1305* ctx_p, byte* mac_p)
 #else
-void poly1305_final(Poly1305* ctx, byte* mac)
+WC_OMIT_FRAME_POINTER void poly1305_final(Poly1305* ctx, byte* mac)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -422,4 +423,5 @@ void poly1305_final(Poly1305* ctx, byte* mac)
 #endif /* HAVE_POLY1305 */
 #endif /* WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
+
 #endif /* WOLFSSL_ARMASM_INLINE */

--- a/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
@@ -41,6 +41,7 @@
 #define __asm__        __asm
 #define __volatile__   volatile
 #endif /* __KEIL__ */
+
 #ifndef NO_SHA256
 #include <wolfssl/wolfcrypt/sha256.h>
 
@@ -66,9 +67,11 @@ XALIGNED(16) static const word32 L_SHA256_transform_len_k[] = {
 
 void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void Transform_Sha256_Len(wc_Sha256* sha256_p, const byte* data_p, word32 len_p)
+WC_OMIT_FRAME_POINTER void Transform_Sha256_Len(wc_Sha256* sha256_p,
+    const byte* data_p, word32 len_p)
 #else
-void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
+WC_OMIT_FRAME_POINTER void Transform_Sha256_Len(wc_Sha256* sha256,
+    const byte* data, word32 len)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1476,4 +1479,5 @@ void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
 #endif /* !NO_SHA256 */
 #endif /* WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
+
 #endif /* WOLFSSL_ARMASM_INLINE */

--- a/wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c
@@ -41,6 +41,7 @@
 #define __asm__        __asm
 #define __volatile__   volatile
 #endif /* __KEIL__ */
+
 #ifdef WOLFSSL_SHA3
 static const word64 L_sha3_thumb2_rt[] = {
     0x0000000000000001UL, 0x0000000000008082UL,
@@ -60,9 +61,9 @@ static const word64 L_sha3_thumb2_rt[] = {
 #include <wolfssl/wolfcrypt/sha3.h>
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void BlockSha3(word64* state_p)
+WC_OMIT_FRAME_POINTER void BlockSha3(word64* state_p)
 #else
-void BlockSha3(word64* state)
+WC_OMIT_FRAME_POINTER void BlockSha3(word64* state)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1162,4 +1163,5 @@ void BlockSha3(word64* state)
 #endif /* WOLFSSL_SHA3 */
 #endif /* WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
+
 #endif /* WOLFSSL_ARMASM_INLINE */

--- a/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
@@ -41,6 +41,7 @@
 #define __asm__        __asm
 #define __volatile__   volatile
 #endif /* __KEIL__ */
+
 #if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 #include <wolfssl/wolfcrypt/sha512.h>
 
@@ -90,9 +91,11 @@ static const word64 L_SHA512_transform_len_k[] = {
 
 void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len);
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-void Transform_Sha512_Len(wc_Sha512* sha512_p, const byte* data_p, word32 len_p)
+WC_OMIT_FRAME_POINTER void Transform_Sha512_Len(wc_Sha512* sha512_p,
+    const byte* data_p, word32 len_p)
 #else
-void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
+WC_OMIT_FRAME_POINTER void Transform_Sha512_Len(wc_Sha512* sha512,
+    const byte* data, word32 len)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3591,4 +3594,5 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
 #endif /* WOLFSSL_SHA512 || WOLFSSL_SHA384 */
 #endif /* WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
+
 #endif /* WOLFSSL_ARMASM_INLINE */

--- a/wolfcrypt/src/port/riscv/riscv-64-sha256.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-sha256.c
@@ -452,8 +452,8 @@ static WC_INLINE void AddLength(wc_Sha256* sha256, word32 len)
  * @param [in]      data    Buffer of data to hash.
  * @param [in]      blocks  Number of blocks of data to hash.
  */
-static WC_INLINE void Sha256Transform(wc_Sha256* sha256, const byte* data,
-    word32 blocks)
+static WC_OMIT_FRAME_POINTER WC_INLINE void Sha256Transform(wc_Sha256* sha256,
+    const byte* data, word32 blocks)
 {
     word32* k = (word32*)K;
 
@@ -567,6 +567,7 @@ static WC_INLINE void Sha256Transform(wc_Sha256* sha256, const byte* data,
           "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10",
           "s11"
     );
+
 }
 
 #else

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -252,11 +252,11 @@ static void sp_2048_to_bin_64(sp_digit* r, byte* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_mul_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mul_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-SP_NOINLINE static void sp_2048_mul_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mul_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -614,11 +614,11 @@ SP_NOINLINE static void sp_2048_mul_8(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_mul_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mul_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-SP_NOINLINE static void sp_2048_mul_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mul_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -754,10 +754,11 @@ SP_NOINLINE static void sp_2048_mul_8(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_add_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_2048_add_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -796,9 +797,11 @@ static sp_digit sp_2048_add_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_sub_in_place_16(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_in_place_16(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_2048_sub_in_place_16(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_in_place_16(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -850,11 +853,11 @@ static sp_digit sp_2048_sub_in_place_16(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_add_16(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_16(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_2048_add_16(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_16(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -972,9 +975,11 @@ SP_NOINLINE static void sp_2048_mul_16(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_sub_in_place_32(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_in_place_32(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_2048_sub_in_place_32(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_in_place_32(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1054,11 +1059,11 @@ static sp_digit sp_2048_sub_in_place_32(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_add_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_2048_add_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1208,9 +1213,11 @@ SP_NOINLINE static void sp_2048_mul_32(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_sub_in_place_64(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_in_place_64(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_2048_sub_in_place_64(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_in_place_64(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1346,11 +1353,11 @@ static sp_digit sp_2048_sub_in_place_64(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_add_64(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_64(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_2048_add_64(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_64(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1557,9 +1564,11 @@ SP_NOINLINE static void sp_2048_mul_64(sp_digit* r, const sp_digit* a,
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_sqr_8(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_sqr_8(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-SP_NOINLINE static void sp_2048_sqr_8(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_sqr_8(sp_digit* r,
+    const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1807,9 +1816,11 @@ SP_NOINLINE static void sp_2048_sqr_8(sp_digit* r, const sp_digit* a)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_sqr_8(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_sqr_8(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-SP_NOINLINE static void sp_2048_sqr_8(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_sqr_8(sp_digit* r,
+    const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1926,10 +1937,11 @@ SP_NOINLINE static void sp_2048_sqr_8(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_sub_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_2048_sub_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2004,11 +2016,11 @@ SP_NOINLINE static void sp_2048_sqr_16(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_sub_16(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_16(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_2048_sub_16(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_16(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2097,11 +2109,11 @@ SP_NOINLINE static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_sub_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_2048_sub_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2220,11 +2232,11 @@ SP_NOINLINE static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_add_64(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_64(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_2048_add_64(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_64(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2277,9 +2289,11 @@ static sp_digit sp_2048_add_64(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_sub_in_place_64(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_in_place_64(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_2048_sub_in_place_64(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_in_place_64(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2331,10 +2345,11 @@ static sp_digit sp_2048_sub_in_place_64(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_2048_mul_64(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_64(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_2048_mul_64(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_64(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2457,9 +2472,10 @@ static void sp_2048_mul_64(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_2048_sqr_64(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_2048_sqr_64(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2596,11 +2612,11 @@ static void sp_2048_mask_32(sp_digit* r, const sp_digit* a, sp_digit m)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_add_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_2048_add_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_add_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2653,9 +2669,11 @@ static sp_digit sp_2048_add_32(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_sub_in_place_32(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_in_place_32(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_2048_sub_in_place_32(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_in_place_32(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2707,10 +2725,11 @@ static sp_digit sp_2048_sub_in_place_32(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_2048_mul_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_2048_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_32(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2833,9 +2852,10 @@ static void sp_2048_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_2048_sqr_32(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_2048_sqr_32(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2976,9 +2996,11 @@ static void sp_2048_mont_setup(const sp_digit* a, sp_digit* rho)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_2048_mul_d_64(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_d_64(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_2048_mul_d_64(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_d_64(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3035,9 +3057,11 @@ static void sp_2048_mul_d_64(sp_digit* r, const sp_digit* a, sp_digit b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_2048_mul_d_64(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_d_64(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_2048_mul_d_64(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_d_64(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3399,11 +3423,11 @@ static void sp_2048_mont_norm_32(sp_digit* r, const sp_digit* m)
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_cond_sub_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_sub_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_2048_cond_sub_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_sub_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3457,11 +3481,11 @@ static sp_digit sp_2048_cond_sub_32(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_cond_sub_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_sub_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_2048_cond_sub_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_sub_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3603,11 +3627,11 @@ static sp_digit sp_2048_cond_sub_32(sp_digit* r, const sp_digit* a,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_32(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_32(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3917,11 +3941,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_32(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_32(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4040,11 +4064,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_32(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_32(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4264,11 +4288,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_32(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_32(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4405,9 +4429,11 @@ SP_NOINLINE static void sp_2048_mont_sqr_32(sp_digit* r, const sp_digit* a,
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_2048_mul_d_32(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_d_32(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_2048_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_d_32(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4464,9 +4490,11 @@ static void sp_2048_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_2048_mul_d_32(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_d_32(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_2048_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_2048_mul_d_32(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4654,11 +4682,11 @@ static void sp_2048_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_2048_word_32(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4721,11 +4749,11 @@ SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1, sp_digit d0,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_2048_word_32(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4803,9 +4831,11 @@ SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1, sp_digit d0,
  * respectively.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_int32 sp_2048_cmp_32(const sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_2048_cmp_32(const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_int32 sp_2048_cmp_32(const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_2048_cmp_32(const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5611,11 +5641,11 @@ static void sp_2048_mont_norm_64(sp_digit* r, const sp_digit* m)
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_cond_sub_64(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_sub_64(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_2048_cond_sub_64(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_sub_64(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5669,11 +5699,11 @@ static sp_digit sp_2048_cond_sub_64(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_cond_sub_64(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_sub_64(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_2048_cond_sub_64(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_sub_64(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -5927,11 +5957,11 @@ static sp_digit sp_2048_cond_sub_64(sp_digit* r, const sp_digit* a,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_64(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_64(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -6497,11 +6527,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_64(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_64(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -6620,11 +6650,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_64(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_64(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -7004,11 +7034,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_64(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_2048_mont_reduce_64(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -7145,11 +7175,11 @@ SP_NOINLINE static void sp_2048_mont_sqr_64(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_sub_64(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_64(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_2048_sub_64(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_64(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -7201,11 +7231,11 @@ static sp_digit sp_2048_sub_64(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_sub_64(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_64(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_2048_sub_64(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_sub_64(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -7347,11 +7377,11 @@ static sp_digit sp_2048_sub_64(sp_digit* r, const sp_digit* a,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_2048_word_64(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_2048_word_64(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_2048_word_64(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_2048_word_64(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -7414,11 +7444,11 @@ SP_NOINLINE static sp_digit div_2048_word_64(sp_digit d1, sp_digit d0,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_2048_word_64(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_2048_word_64(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_2048_word_64(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_2048_word_64(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -7599,9 +7629,11 @@ static void sp_2048_mask_64(sp_digit* r, const sp_digit* a, sp_digit m)
  * respectively.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_int32 sp_2048_cmp_64(const sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_2048_cmp_64(const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_int32 sp_2048_cmp_64(const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_2048_cmp_64(const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -8881,11 +8913,11 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_cond_add_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_add_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_2048_cond_add_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_add_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -8939,11 +8971,11 @@ static sp_digit sp_2048_cond_add_32(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_2048_cond_add_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_add_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_2048_cond_add_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_2048_cond_add_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -9391,9 +9423,11 @@ int sp_ModExp_2048(const mp_int* base, const mp_int* exp, const mp_int* mod,
 
 #ifdef HAVE_FFDHE_2048
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_2048_lshift_64(sp_digit* r_p, const sp_digit* a_p, byte n_p)
+WC_OMIT_FRAME_POINTER static void sp_2048_lshift_64(sp_digit* r_p,
+    const sp_digit* a_p, byte n_p)
 #else
-static void sp_2048_lshift_64(sp_digit* r, const sp_digit* a, byte n)
+WC_OMIT_FRAME_POINTER static void sp_2048_lshift_64(sp_digit* r,
+    const sp_digit* a, byte n)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -10219,10 +10253,11 @@ static void sp_3072_to_bin_96(sp_digit* r, byte* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_3072_mul_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_3072_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_12(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -11248,11 +11283,11 @@ static void sp_3072_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_add_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_3072_add_12(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -11298,9 +11333,11 @@ static sp_digit sp_3072_add_12(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_sub_in_place_24(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_in_place_24(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_3072_sub_in_place_24(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_in_place_24(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -11366,11 +11403,11 @@ static sp_digit sp_3072_sub_in_place_24(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_add_24(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_24(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_3072_add_24(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_24(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -11506,9 +11543,11 @@ SP_NOINLINE static void sp_3072_mul_24(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_sub_in_place_48(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_in_place_48(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_3072_sub_in_place_48(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_in_place_48(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -11616,11 +11655,11 @@ static sp_digit sp_3072_sub_in_place_48(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_add_48(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_48(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_3072_add_48(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_48(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -11798,9 +11837,11 @@ SP_NOINLINE static void sp_3072_mul_48(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_sub_in_place_96(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_in_place_96(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_3072_sub_in_place_96(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_in_place_96(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -11992,11 +12033,11 @@ static sp_digit sp_3072_sub_in_place_96(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_add_96(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_96(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_3072_add_96(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_96(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -12258,9 +12299,10 @@ SP_NOINLINE static void sp_3072_mul_96(sp_digit* r, const sp_digit* a,
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_3072_sqr_12(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_3072_sqr_12(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_3072_sqr_12(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_3072_sqr_12(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -12960,11 +13002,11 @@ static void sp_3072_sqr_12(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_sub_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_3072_sub_12(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -13046,11 +13088,11 @@ SP_NOINLINE static void sp_3072_sqr_24(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_sub_24(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_24(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_3072_sub_24(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_24(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -13153,11 +13195,11 @@ SP_NOINLINE static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_sub_48(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_48(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_3072_sub_48(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_48(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -13304,11 +13346,11 @@ SP_NOINLINE static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_add_96(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_96(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_3072_add_96(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_96(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -13361,9 +13403,11 @@ static sp_digit sp_3072_add_96(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_sub_in_place_96(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_in_place_96(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_3072_sub_in_place_96(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_in_place_96(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -13415,10 +13459,11 @@ static sp_digit sp_3072_sub_in_place_96(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_3072_mul_96(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_96(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_3072_mul_96(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_96(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -13541,9 +13586,10 @@ static void sp_3072_mul_96(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_3072_sqr_96(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_3072_sqr_96(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -13680,11 +13726,11 @@ static void sp_3072_mask_48(sp_digit* r, const sp_digit* a, sp_digit m)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_add_48(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_48(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_3072_add_48(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_add_48(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -13737,9 +13783,11 @@ static sp_digit sp_3072_add_48(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_sub_in_place_48(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_in_place_48(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_3072_sub_in_place_48(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_in_place_48(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -13791,10 +13839,11 @@ static sp_digit sp_3072_sub_in_place_48(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_3072_mul_48(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_48(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_3072_mul_48(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_48(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -13917,9 +13966,10 @@ static void sp_3072_mul_48(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_3072_sqr_48(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_3072_sqr_48(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -14060,9 +14110,11 @@ static void sp_3072_mont_setup(const sp_digit* a, sp_digit* rho)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_3072_mul_d_96(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_d_96(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_3072_mul_d_96(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_d_96(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -14119,9 +14171,11 @@ static void sp_3072_mul_d_96(sp_digit* r, const sp_digit* a, sp_digit b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_3072_mul_d_96(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_d_96(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_3072_mul_d_96(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_d_96(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -14643,11 +14697,11 @@ static void sp_3072_mont_norm_48(sp_digit* r, const sp_digit* m)
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_cond_sub_48(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_sub_48(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_3072_cond_sub_48(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_sub_48(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -14701,11 +14755,11 @@ static sp_digit sp_3072_cond_sub_48(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_cond_sub_48(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_sub_48(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_3072_cond_sub_48(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_sub_48(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -14903,11 +14957,11 @@ static sp_digit sp_3072_cond_sub_48(sp_digit* r, const sp_digit* a,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_48(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_48(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -15345,11 +15399,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_48(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_48(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -15468,11 +15522,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_48(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_48(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -15772,11 +15826,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_48(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_48(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -15913,9 +15967,11 @@ SP_NOINLINE static void sp_3072_mont_sqr_48(sp_digit* r, const sp_digit* a,
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_3072_mul_d_48(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_d_48(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_3072_mul_d_48(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_d_48(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -15972,9 +16028,11 @@ static void sp_3072_mul_d_48(sp_digit* r, const sp_digit* a, sp_digit b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_3072_mul_d_48(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_d_48(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_3072_mul_d_48(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_3072_mul_d_48(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -16242,11 +16300,11 @@ static void sp_3072_mul_d_48(sp_digit* r, const sp_digit* a, sp_digit b)
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_3072_word_48(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -16309,11 +16367,11 @@ SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1, sp_digit d0,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_3072_word_48(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -16391,9 +16449,11 @@ SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1, sp_digit d0,
  * respectively.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_int32 sp_3072_cmp_48(const sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_3072_cmp_48(const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_int32 sp_3072_cmp_48(const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_3072_cmp_48(const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -17375,11 +17435,11 @@ static void sp_3072_mont_norm_96(sp_digit* r, const sp_digit* m)
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_cond_sub_96(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_sub_96(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_3072_cond_sub_96(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_sub_96(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -17433,11 +17493,11 @@ static sp_digit sp_3072_cond_sub_96(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_cond_sub_96(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_sub_96(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_3072_cond_sub_96(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_sub_96(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -17803,11 +17863,11 @@ static sp_digit sp_3072_cond_sub_96(sp_digit* r, const sp_digit* a,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_96(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_96(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -18629,11 +18689,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_96(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_96(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -18752,11 +18812,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_96(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_96(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -19296,11 +19356,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_96(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_3072_mont_reduce_96(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -19437,11 +19497,11 @@ SP_NOINLINE static void sp_3072_mont_sqr_96(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_sub_96(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_96(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_3072_sub_96(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_96(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -19493,11 +19553,11 @@ static sp_digit sp_3072_sub_96(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_sub_96(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_96(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_3072_sub_96(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_sub_96(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -19695,11 +19755,11 @@ static sp_digit sp_3072_sub_96(sp_digit* r, const sp_digit* a,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_3072_word_96(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_3072_word_96(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_3072_word_96(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_3072_word_96(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -19762,11 +19822,11 @@ SP_NOINLINE static sp_digit div_3072_word_96(sp_digit d1, sp_digit d0,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_3072_word_96(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_3072_word_96(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_3072_word_96(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_3072_word_96(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -19947,9 +20007,11 @@ static void sp_3072_mask_96(sp_digit* r, const sp_digit* a, sp_digit m)
  * respectively.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_int32 sp_3072_cmp_96(const sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_3072_cmp_96(const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_int32 sp_3072_cmp_96(const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_3072_cmp_96(const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -21581,11 +21643,11 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_cond_add_48(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_add_48(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_3072_cond_add_48(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_add_48(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -21639,11 +21701,11 @@ static sp_digit sp_3072_cond_add_48(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_3072_cond_add_48(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_add_48(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_3072_cond_add_48(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_3072_cond_add_48(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -22147,9 +22209,11 @@ int sp_ModExp_3072(const mp_int* base, const mp_int* exp, const mp_int* mod,
 
 #ifdef HAVE_FFDHE_3072
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_3072_lshift_96(sp_digit* r_p, const sp_digit* a_p, byte n_p)
+WC_OMIT_FRAME_POINTER static void sp_3072_lshift_96(sp_digit* r_p,
+    const sp_digit* a_p, byte n_p)
 #else
-static void sp_3072_lshift_96(sp_digit* r, const sp_digit* a, byte n)
+WC_OMIT_FRAME_POINTER static void sp_3072_lshift_96(sp_digit* r,
+    const sp_digit* a, byte n)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -23166,9 +23230,11 @@ static void sp_4096_to_bin_128(sp_digit* r, byte* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_4096_sub_in_place_128(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_sub_in_place_128(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_4096_sub_in_place_128(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_sub_in_place_128(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -23416,11 +23482,11 @@ static sp_digit sp_4096_sub_in_place_128(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_4096_add_128(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_add_128(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_4096_add_128(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_add_128(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -23747,11 +23813,11 @@ SP_NOINLINE static void sp_4096_sqr_128(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_4096_add_128(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_add_128(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_4096_add_128(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_add_128(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -23804,9 +23870,11 @@ static sp_digit sp_4096_add_128(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_4096_sub_in_place_128(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_sub_in_place_128(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_4096_sub_in_place_128(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_sub_in_place_128(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -23858,10 +23926,11 @@ static sp_digit sp_4096_sub_in_place_128(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_4096_mul_128(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_4096_mul_128(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_4096_mul_128(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_4096_mul_128(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -23984,9 +24053,11 @@ static void sp_4096_mul_128(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_4096_sqr_128(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_4096_sqr_128(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_4096_sqr_128(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_4096_sqr_128(sp_digit* r,
+    const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -24125,9 +24196,11 @@ static void sp_4096_mont_setup(const sp_digit* a, sp_digit* rho)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_4096_mul_d_128(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_4096_mul_d_128(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_4096_mul_d_128(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_4096_mul_d_128(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -24184,9 +24257,11 @@ static void sp_4096_mul_d_128(sp_digit* r, const sp_digit* a, sp_digit b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_4096_mul_d_128(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_4096_mul_d_128(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_4096_mul_d_128(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_4096_mul_d_128(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -24869,11 +24944,11 @@ static void sp_4096_mont_norm_128(sp_digit* r, const sp_digit* m)
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_4096_cond_sub_128(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_cond_sub_128(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_4096_cond_sub_128(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_cond_sub_128(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -24927,11 +25002,11 @@ static sp_digit sp_4096_cond_sub_128(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_4096_cond_sub_128(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_cond_sub_128(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_4096_cond_sub_128(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_cond_sub_128(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -25409,11 +25484,11 @@ static sp_digit sp_4096_cond_sub_128(sp_digit* r, const sp_digit* a,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_4096_mont_reduce_128(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_4096_mont_reduce_128(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -26491,11 +26566,11 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_4096_mont_reduce_128(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_4096_mont_reduce_128(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -26614,11 +26689,11 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_4096_mont_reduce_128(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_4096_mont_reduce_128(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -27318,11 +27393,11 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_4096_mont_reduce_128(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_4096_mont_reduce_128(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -27459,11 +27534,11 @@ SP_NOINLINE static void sp_4096_mont_sqr_128(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_4096_sub_128(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_sub_128(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_4096_sub_128(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_sub_128(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -27515,11 +27590,11 @@ static sp_digit sp_4096_sub_128(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_4096_sub_128(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_sub_128(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_4096_sub_128(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_sub_128(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -27773,11 +27848,11 @@ static sp_digit sp_4096_sub_128(sp_digit* r, const sp_digit* a,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_4096_word_128(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_4096_word_128(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_4096_word_128(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_4096_word_128(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -27840,11 +27915,11 @@ SP_NOINLINE static sp_digit div_4096_word_128(sp_digit d1, sp_digit d0,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_4096_word_128(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_4096_word_128(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_4096_word_128(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_4096_word_128(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -28025,9 +28100,11 @@ static void sp_4096_mask_128(sp_digit* r, const sp_digit* a, sp_digit m)
  * respectively.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_int32 sp_4096_cmp_128(const sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_4096_cmp_128(const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_int32 sp_4096_cmp_128(const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_4096_cmp_128(const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -30011,11 +30088,11 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_4096_cond_add_64(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_cond_add_64(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_4096_cond_add_64(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_cond_add_64(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -30069,11 +30146,11 @@ static sp_digit sp_4096_cond_add_64(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_4096_cond_add_64(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_cond_add_64(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_4096_cond_add_64(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_4096_cond_add_64(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -30633,9 +30710,11 @@ int sp_ModExp_4096(const mp_int* base, const mp_int* exp, const mp_int* mod,
 
 #ifdef HAVE_FFDHE_4096
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_4096_lshift_128(sp_digit* r_p, const sp_digit* a_p, byte n_p)
+WC_OMIT_FRAME_POINTER static void sp_4096_lshift_128(sp_digit* r_p,
+    const sp_digit* a_p, byte n_p)
 #else
-static void sp_4096_lshift_128(sp_digit* r, const sp_digit* a, byte n)
+WC_OMIT_FRAME_POINTER static void sp_4096_lshift_128(sp_digit* r,
+    const sp_digit* a, byte n)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -31709,10 +31788,11 @@ static const sp_digit p256_b[8] = {
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_mul_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_256_mul_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_256_mul_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_256_mul_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -31838,11 +31918,11 @@ static void sp_256_mul_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mul_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mul_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-SP_NOINLINE static void sp_256_mul_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mul_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -32200,11 +32280,11 @@ SP_NOINLINE static void sp_256_mul_8(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mul_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mul_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-SP_NOINLINE static void sp_256_mul_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mul_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -32341,9 +32421,10 @@ SP_NOINLINE static void sp_256_mul_8(sp_digit* r, const sp_digit* a,
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_sqr_8(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_256_sqr_8(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -32461,9 +32542,11 @@ static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_sqr_8(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_sqr_8(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-SP_NOINLINE static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_sqr_8(sp_digit* r,
+    const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -32711,9 +32794,11 @@ SP_NOINLINE static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_sqr_8(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_sqr_8(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-SP_NOINLINE static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_sqr_8(sp_digit* r,
+    const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -32832,10 +32917,11 @@ SP_NOINLINE static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_add_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_add_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_256_add_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_add_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -32888,10 +32974,11 @@ static sp_digit sp_256_add_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_add_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_add_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_256_add_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_add_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -32932,11 +33019,11 @@ static sp_digit sp_256_add_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * m  The modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static int sp_256_mod_mul_norm_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER static int sp_256_mod_mul_norm_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-static int sp_256_mod_mul_norm_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER static int sp_256_mod_mul_norm_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -33380,11 +33467,12 @@ static int sp_256_point_to_ecc_point_8(const sp_point_256* p, ecc_point* pm)
  * mp  Montgomery multiplier.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_mul_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_mul_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p,
+    sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_mul_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, const sp_digit* m, sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_mul_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -33874,11 +33962,12 @@ SP_NOINLINE static void sp_256_mont_mul_8(sp_digit* r, const sp_digit* a,
  * mp  Montgomery multiplier.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_mul_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_mul_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p,
+    sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_mul_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, const sp_digit* m, sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_mul_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -34145,11 +34234,11 @@ SP_NOINLINE static void sp_256_mont_mul_8(sp_digit* r, const sp_digit* a,
  * mp  Montgomery multiplier.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_sqr_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_sqr_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_sqr_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* m, sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_sqr_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -34528,11 +34617,11 @@ SP_NOINLINE static void sp_256_mont_sqr_8(sp_digit* r, const sp_digit* a,
  * mp  Montgomery multiplier.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_sqr_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_sqr_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_sqr_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* m, sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_sqr_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -34876,9 +34965,11 @@ static void sp_256_mont_inv_8(sp_digit* r, const sp_digit* a, sp_digit* td)
  * respectively.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_int32 sp_256_cmp_8(const sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_256_cmp_8(const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_int32 sp_256_cmp_8(const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_256_cmp_8(const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -35032,11 +35123,11 @@ static sp_int32 sp_256_cmp_8(const sp_digit* a, const sp_digit* b)
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_cond_sub_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_cond_sub_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_256_cond_sub_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_cond_sub_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -35090,11 +35181,11 @@ static sp_digit sp_256_cond_sub_8(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_cond_sub_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_cond_sub_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_256_cond_sub_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_cond_sub_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -35154,11 +35245,11 @@ static sp_digit sp_256_cond_sub_8(sp_digit* r, const sp_digit* a,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a_p, const sp_digit* m_p,
-    sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_reduce_8(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a,
+    const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -35276,11 +35367,11 @@ SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a_p, const sp_digit* m_p,
-    sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_reduce_8(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a,
+    const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -35381,11 +35472,11 @@ SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a_p, const sp_digit* m_p,
-    sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_reduce_8(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a,
+    const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -35549,11 +35640,11 @@ SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_reduce_order_8(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a,
-    const sp_digit* m, sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_reduce_order_8(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -35671,11 +35762,11 @@ SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_reduce_order_8(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a,
-    const sp_digit* m, sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_reduce_order_8(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -35817,11 +35908,11 @@ static void sp_256_map_8(sp_point_256* r, const sp_point_256* p,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_add_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_add_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_256_mont_add_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_add_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -35885,11 +35976,11 @@ SP_NOINLINE static void sp_256_mont_add_8(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_dbl_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_dbl_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_256_mont_dbl_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_dbl_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -35948,11 +36039,11 @@ SP_NOINLINE static void sp_256_mont_dbl_8(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_tpl_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_tpl_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_256_mont_tpl_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_tpl_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -36044,11 +36135,11 @@ SP_NOINLINE static void sp_256_mont_tpl_8(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_sub_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_sub_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_256_mont_sub_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_sub_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -36110,11 +36201,11 @@ SP_NOINLINE static void sp_256_mont_sub_8(sp_digit* r, const sp_digit* a,
  * m  Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_div2_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_div2_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_256_mont_div2_8(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_256_mont_div2_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -39671,9 +39762,9 @@ int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_add_one_8(sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_256_add_one_8(sp_digit* a_p)
 #else
-static void sp_256_add_one_8(sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_256_add_one_8(sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -40085,9 +40176,11 @@ int sp_ecc_secret_gen_256_nb(sp_ecc_ctx_t* sp_ctx, const mp_int* priv,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_sub_in_place_8(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_sub_in_place_8(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_256_sub_in_place_8(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_sub_in_place_8(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -40137,9 +40230,11 @@ static sp_digit sp_256_sub_in_place_8(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_sub_in_place_8(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_sub_in_place_8(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_256_sub_in_place_8(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_sub_in_place_8(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -40179,9 +40274,11 @@ static sp_digit sp_256_sub_in_place_8(sp_digit* a, const sp_digit* b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_mul_d_8(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_256_mul_d_8(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_256_mul_d_8(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_256_mul_d_8(sp_digit* r, const sp_digit* a,
+    sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -40238,9 +40335,11 @@ static void sp_256_mul_d_8(sp_digit* r, const sp_digit* a, sp_digit b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_mul_d_8(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_256_mul_d_8(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_256_mul_d_8(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_256_mul_d_8(sp_digit* r, const sp_digit* a,
+    sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -40308,11 +40407,11 @@ static void sp_256_mul_d_8(sp_digit* r, const sp_digit* a, sp_digit b)
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1_p,
+    sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -40375,11 +40474,11 @@ SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1_p,
+    sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -41102,10 +41201,11 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_sub_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_sub_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_256_sub_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_sub_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -41157,10 +41257,11 @@ static sp_digit sp_256_sub_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_sub_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_sub_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_256_sub_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_256_sub_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -41194,9 +41295,11 @@ static sp_digit sp_256_sub_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
 
 #endif /* WOLFSSL_SP_SMALL */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_rshift1_8(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_256_rshift1_8(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_256_rshift1_8(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_256_rshift1_8(sp_digit* r,
+    const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -41245,10 +41348,11 @@ static void sp_256_rshift1_8(sp_digit* r, const sp_digit* a)
  * m  Modulus.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_div2_mod_8(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER static void sp_256_div2_mod_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-static void sp_256_div2_mod_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
+WC_OMIT_FRAME_POINTER static void sp_256_div2_mod_8(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -41333,9 +41437,9 @@ static void sp_256_div2_mod_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static int sp_256_num_bits_8(const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static int sp_256_num_bits_8(const sp_digit* a_p)
 #else
-static int sp_256_num_bits_8(const sp_digit* a)
+WC_OMIT_FRAME_POINTER static int sp_256_num_bits_8(const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -42615,10 +42719,11 @@ static const sp_digit p384_b[12] = {
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_384_mul_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_384_mul_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_384_mul_12(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -42743,10 +42848,11 @@ static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_384_mul_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_384_mul_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_384_mul_12(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -43773,9 +43879,10 @@ static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_384_sqr_12(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_384_sqr_12(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -43892,9 +43999,10 @@ static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_384_sqr_12(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_384_sqr_12(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -44596,10 +44704,11 @@ static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_384_add_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_add_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_384_add_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_add_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -44652,10 +44761,11 @@ static sp_digit sp_384_add_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_384_add_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_add_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_384_add_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_add_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -45002,11 +45112,11 @@ static int sp_384_point_to_ecc_point_12(const sp_point_384* p, ecc_point* pm)
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_384_cond_sub_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_cond_sub_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_384_cond_sub_12(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_cond_sub_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -45060,11 +45170,11 @@ static sp_digit sp_384_cond_sub_12(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_384_cond_sub_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_cond_sub_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_384_cond_sub_12(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_cond_sub_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -45137,11 +45247,11 @@ static sp_digit sp_384_cond_sub_12(sp_digit* r, const sp_digit* a,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_reduce_12(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a,
+    const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -45291,11 +45401,11 @@ SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_reduce_12(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a,
+    const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -45558,9 +45668,11 @@ static void sp_384_mont_inv_12(sp_digit* r, const sp_digit* a, sp_digit* td)
  * respectively.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_int32 sp_384_cmp_12(const sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_384_cmp_12(const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_int32 sp_384_cmp_12(const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_384_cmp_12(const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -45796,11 +45908,11 @@ static void sp_384_map_12(sp_point_384* r, const sp_point_384* p,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_384_mont_add_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_add_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_384_mont_add_12(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_add_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -45823,11 +45935,11 @@ SP_NOINLINE static void sp_384_mont_add_12(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_384_mont_dbl_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_dbl_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_384_mont_dbl_12(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_dbl_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -45849,11 +45961,11 @@ SP_NOINLINE static void sp_384_mont_dbl_12(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_384_mont_tpl_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_tpl_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_384_mont_tpl_12(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_tpl_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -45878,10 +45990,11 @@ SP_NOINLINE static void sp_384_mont_tpl_12(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_384_sub_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_sub_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_384_sub_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_sub_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -45933,10 +46046,11 @@ static sp_digit sp_384_sub_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_384_sub_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_sub_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_384_sub_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_sub_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -45986,11 +46100,11 @@ static sp_digit sp_384_sub_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_384_cond_add_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_cond_add_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_384_cond_add_12(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_cond_add_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -46044,11 +46158,11 @@ static sp_digit sp_384_cond_add_12(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_384_cond_add_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_cond_add_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_384_cond_add_12(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_cond_add_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -46119,11 +46233,11 @@ static sp_digit sp_384_cond_add_12(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_384_mont_sub_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_sub_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_384_mont_sub_12(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_384_mont_sub_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -46143,9 +46257,11 @@ SP_NOINLINE static void sp_384_mont_sub_12(sp_digit* r, const sp_digit* a,
 #else
 #endif /* WOLFSSL_SP_SMALL */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_384_rshift1_12(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_384_rshift1_12(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_384_rshift1_12(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_384_rshift1_12(sp_digit* r,
+    const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -49782,9 +49898,9 @@ int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_384_add_one_12(sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_384_add_one_12(sp_digit* a_p)
 #else
-static void sp_384_add_one_12(sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_384_add_one_12(sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -50202,9 +50318,11 @@ int sp_ecc_secret_gen_384_nb(sp_ecc_ctx_t* sp_ctx, const mp_int* priv,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_384_sub_in_place_12(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_sub_in_place_12(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_384_sub_in_place_12(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_sub_in_place_12(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -50254,9 +50372,11 @@ static sp_digit sp_384_sub_in_place_12(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_384_sub_in_place_12(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_sub_in_place_12(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_384_sub_in_place_12(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_384_sub_in_place_12(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -50303,9 +50423,11 @@ static sp_digit sp_384_sub_in_place_12(sp_digit* a, const sp_digit* b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_384_mul_d_12(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_384_mul_d_12(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_384_mul_d_12(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_384_mul_d_12(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -50362,9 +50484,11 @@ static void sp_384_mul_d_12(sp_digit* r, const sp_digit* a, sp_digit b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_384_mul_d_12(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_384_mul_d_12(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_384_mul_d_12(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_384_mul_d_12(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -50452,11 +50576,11 @@ static void sp_384_mul_d_12(sp_digit* r, const sp_digit* a, sp_digit b)
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1_p,
+    sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -50519,11 +50643,11 @@ SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1, sp_digit d0,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1_p,
+    sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -51216,11 +51340,11 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
  * m  Modulus.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_384_div2_mod_12(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER static void sp_384_div2_mod_12(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-static void sp_384_div2_mod_12(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER static void sp_384_div2_mod_12(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -51343,9 +51467,9 @@ static void sp_384_div2_mod_12(sp_digit* r, const sp_digit* a,
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static int sp_384_num_bits_12(const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static int sp_384_num_bits_12(const sp_digit* a_p)
 #else
-static int sp_384_num_bits_12(const sp_digit* a)
+WC_OMIT_FRAME_POINTER static int sp_384_num_bits_12(const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -52771,10 +52895,11 @@ static const sp_digit p521_b[17] = {
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_mul_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_521_mul_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_521_mul_17(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -52902,10 +53027,11 @@ static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_mul_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_521_mul_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_521_mul_17(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -54946,9 +55072,10 @@ static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_sqr_17(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_521_sqr_17(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -55068,9 +55195,10 @@ static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_sqr_17(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_521_sqr_17(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -56356,10 +56484,11 @@ static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_521_add_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_add_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_521_add_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_add_17(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -56418,10 +56547,11 @@ static sp_digit sp_521_add_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_521_add_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_add_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_521_add_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_add_17(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -56696,11 +56826,11 @@ static int sp_521_point_to_ecc_point_17(const sp_point_521* p, ecc_point* pm)
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_521_cond_sub_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_cond_sub_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_521_cond_sub_17(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_cond_sub_17(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -56754,11 +56884,11 @@ static sp_digit sp_521_cond_sub_17(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_521_cond_sub_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_cond_sub_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_521_cond_sub_17(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_cond_sub_17(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -56847,11 +56977,11 @@ static sp_digit sp_521_cond_sub_17(sp_digit* r, const sp_digit* a,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_521_mont_reduce_17(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_reduce_17(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_521_mont_reduce_17(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_reduce_17(sp_digit* a,
+    const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -56987,11 +57117,11 @@ SP_NOINLINE static void sp_521_mont_reduce_17(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_reduce_order_17(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a,
-    const sp_digit* m, sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_reduce_order_17(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -57268,11 +57398,11 @@ SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_reduce_order_17(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a,
-    const sp_digit* m, sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_reduce_order_17(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -57644,9 +57774,11 @@ static void sp_521_mont_inv_17(sp_digit* r, const sp_digit* a, sp_digit* td)
  * respectively.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_int32 sp_521_cmp_17(const sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_521_cmp_17(const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_int32 sp_521_cmp_17(const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_521_cmp_17(const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -57937,11 +58069,11 @@ static void sp_521_map_17(sp_point_521* r, const sp_point_521* p,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_521_mont_add_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_add_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_521_mont_add_17(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_add_17(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -58030,11 +58162,11 @@ SP_NOINLINE static void sp_521_mont_add_17(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_521_mont_dbl_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_dbl_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_521_mont_dbl_17(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_dbl_17(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -58113,11 +58245,11 @@ SP_NOINLINE static void sp_521_mont_dbl_17(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_521_mont_tpl_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_tpl_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_521_mont_tpl_17(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_tpl_17(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -58217,11 +58349,11 @@ SP_NOINLINE static void sp_521_mont_tpl_17(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_521_mont_sub_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_sub_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_521_mont_sub_17(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_521_mont_sub_17(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -58305,9 +58437,11 @@ SP_NOINLINE static void sp_521_mont_sub_17(sp_digit* r, const sp_digit* a,
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_rshift1_17(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_521_rshift1_17(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_521_rshift1_17(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_521_rshift1_17(sp_digit* r,
+    const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -62586,9 +62720,9 @@ int sp_ecc_mulmod_base_add_521(const mp_int* km, const ecc_point* am,
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_add_one_17(sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_521_add_one_17(sp_digit* a_p)
 #else
-static void sp_521_add_one_17(sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_521_add_one_17(sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -63008,9 +63142,11 @@ int sp_ecc_secret_gen_521_nb(sp_ecc_ctx_t* sp_ctx, const mp_int* priv,
 
 #if defined(HAVE_ECC_SIGN) || defined(HAVE_ECC_VERIFY)
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_rshift_17(sp_digit* r_p, const sp_digit* a_p, byte n_p)
+WC_OMIT_FRAME_POINTER static void sp_521_rshift_17(sp_digit* r_p,
+    const sp_digit* a_p, byte n_p)
 #else
-static void sp_521_rshift_17(sp_digit* r, const sp_digit* a, byte n)
+WC_OMIT_FRAME_POINTER static void sp_521_rshift_17(sp_digit* r,
+    const sp_digit* a, byte n)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -63113,9 +63249,11 @@ static void sp_521_rshift_17(sp_digit* r, const sp_digit* a, byte n)
 #endif
 #if defined(HAVE_ECC_SIGN) || defined(HAVE_ECC_VERIFY)
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_lshift_17(sp_digit* r_p, const sp_digit* a_p, byte n_p)
+WC_OMIT_FRAME_POINTER static void sp_521_lshift_17(sp_digit* r_p,
+    const sp_digit* a_p, byte n_p)
 #else
-static void sp_521_lshift_17(sp_digit* r, const sp_digit* a, byte n)
+WC_OMIT_FRAME_POINTER static void sp_521_lshift_17(sp_digit* r,
+    const sp_digit* a, byte n)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -63235,9 +63373,11 @@ static void sp_521_lshift_17(sp_digit* r, const sp_digit* a, byte n)
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_lshift_34(sp_digit* r_p, const sp_digit* a_p, byte n_p)
+WC_OMIT_FRAME_POINTER static void sp_521_lshift_34(sp_digit* r_p,
+    const sp_digit* a_p, byte n_p)
 #else
-static void sp_521_lshift_34(sp_digit* r, const sp_digit* a, byte n)
+WC_OMIT_FRAME_POINTER static void sp_521_lshift_34(sp_digit* r,
+    const sp_digit* a, byte n)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -63465,9 +63605,11 @@ static void sp_521_lshift_34(sp_digit* r, const sp_digit* a, byte n)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_521_sub_in_place_17(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_sub_in_place_17(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_521_sub_in_place_17(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_sub_in_place_17(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -63522,9 +63664,11 @@ static sp_digit sp_521_sub_in_place_17(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_521_sub_in_place_17(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_sub_in_place_17(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_521_sub_in_place_17(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_sub_in_place_17(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -63582,9 +63726,11 @@ static sp_digit sp_521_sub_in_place_17(sp_digit* a, const sp_digit* b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_mul_d_17(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_521_mul_d_17(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_521_mul_d_17(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_521_mul_d_17(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -63641,9 +63787,11 @@ static void sp_521_mul_d_17(sp_digit* r, const sp_digit* a, sp_digit b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_mul_d_17(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_521_mul_d_17(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_521_mul_d_17(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_521_mul_d_17(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -63756,11 +63904,11 @@ static void sp_521_mul_d_17(sp_digit* r, const sp_digit* a, sp_digit b)
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1_p,
+    sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -63823,11 +63971,11 @@ SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1, sp_digit d0,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1_p,
+    sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -64551,10 +64699,11 @@ int sp_ecc_sign_521_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_521_sub_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_sub_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_521_sub_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_sub_17(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -64611,10 +64760,11 @@ static sp_digit sp_521_sub_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_521_sub_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_sub_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_521_sub_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_521_sub_17(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -64672,11 +64822,11 @@ static sp_digit sp_521_sub_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * m  Modulus.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_521_div2_mod_17(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER static void sp_521_div2_mod_17(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-static void sp_521_div2_mod_17(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER static void sp_521_div2_mod_17(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -64834,9 +64984,9 @@ static void sp_521_div2_mod_17(sp_digit* r, const sp_digit* a,
 }
 
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static int sp_521_num_bits_17(const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static int sp_521_num_bits_17(const sp_digit* a_p)
 #else
-static int sp_521_num_bits_17(const sp_digit* a)
+WC_OMIT_FRAME_POINTER static int sp_521_num_bits_17(const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -66270,10 +66420,11 @@ typedef struct sp_point_1024 {
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_1024_mul_16(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_1024_mul_16(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_1024_mul_16(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_1024_mul_16(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -68080,9 +68231,10 @@ static void sp_1024_mul_16(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_1024_sqr_16(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_1024_sqr_16(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_1024_sqr_16(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_1024_sqr_16(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -69234,11 +69386,11 @@ static void sp_1024_sqr_16(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_1024_add_16(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_add_16(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_1024_add_16(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_add_16(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -69291,9 +69443,11 @@ static sp_digit sp_1024_add_16(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_1024_sub_in_place_32(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_sub_in_place_32(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_1024_sub_in_place_32(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_sub_in_place_32(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -69373,11 +69527,11 @@ static sp_digit sp_1024_sub_in_place_32(sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_1024_add_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_add_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_1024_add_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_add_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -69528,11 +69682,11 @@ SP_NOINLINE static void sp_1024_mul_32(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_1024_sub_16(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_sub_16(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_1024_sub_16(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_sub_16(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -69622,10 +69776,11 @@ SP_NOINLINE static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_1024_mul_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static void sp_1024_mul_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static void sp_1024_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static void sp_1024_mul_32(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -69748,9 +69903,10 @@ static void sp_1024_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * a  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_1024_sqr_32(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_1024_sqr_32(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -69953,9 +70109,11 @@ static const sp_point_1024 p1024_base = {
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_1024_sub_in_place_32(sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_sub_in_place_32(sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_1024_sub_in_place_32(sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_sub_in_place_32(sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -70009,11 +70167,11 @@ static sp_digit sp_1024_sub_in_place_32(sp_digit* a, const sp_digit* b)
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_1024_cond_sub_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_cond_sub_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_1024_cond_sub_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_cond_sub_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -70067,11 +70225,11 @@ static sp_digit sp_1024_cond_sub_32(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_1024_cond_sub_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_cond_sub_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_1024_cond_sub_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_cond_sub_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -70212,11 +70370,11 @@ static sp_digit sp_1024_cond_sub_32(sp_digit* r, const sp_digit* a,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_1024_add_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_add_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p)
 #else
-static sp_digit sp_1024_add_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_add_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -70270,9 +70428,11 @@ static sp_digit sp_1024_add_32(sp_digit* r, const sp_digit* a,
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_1024_mul_d_32(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_1024_mul_d_32(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_1024_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_1024_mul_d_32(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -70329,9 +70489,11 @@ static void sp_1024_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
  * b  A single precision digit.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_1024_mul_d_32(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+WC_OMIT_FRAME_POINTER static void sp_1024_mul_d_32(sp_digit* r_p,
+    const sp_digit* a_p, sp_digit b_p)
 #else
-static void sp_1024_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
+WC_OMIT_FRAME_POINTER static void sp_1024_mul_d_32(sp_digit* r,
+    const sp_digit* a, sp_digit b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -70519,11 +70681,11 @@ static void sp_1024_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_1024_word_32(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_1024_word_32(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_1024_word_32(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_1024_word_32(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -70586,11 +70748,11 @@ SP_NOINLINE static sp_digit div_1024_word_32(sp_digit d1, sp_digit d0,
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_1024_word_32(sp_digit d1_p, sp_digit d0_p,
-    sp_digit div_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_1024_word_32(
+    sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_1024_word_32(sp_digit d1, sp_digit d0,
-    sp_digit div)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static sp_digit div_1024_word_32(sp_digit d1,
+    sp_digit d0, sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -70698,9 +70860,11 @@ static void sp_1024_mask_32(sp_digit* r, const sp_digit* a, sp_digit m)
  * respectively.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_int32 sp_1024_cmp_32(const sp_digit* a_p, const sp_digit* b_p)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_1024_cmp_32(const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_int32 sp_1024_cmp_32(const sp_digit* a, const sp_digit* b)
+WC_OMIT_FRAME_POINTER static sp_int32 sp_1024_cmp_32(const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -71438,11 +71602,11 @@ static int sp_1024_point_to_ecc_point_32(const sp_point_1024* p, ecc_point* pm)
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_reduce_32(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_reduce_32(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -71757,11 +71921,11 @@ SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a_p,
-    const sp_digit* m_p, sp_digit mp_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_reduce_32(
+    sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a, const sp_digit* m,
-    sp_digit mp)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_reduce_32(
+    sp_digit* a, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -72124,11 +72288,11 @@ static void sp_1024_map_32(sp_point_1024* r, const sp_point_1024* p,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_1024_mont_add_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_add_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_1024_mont_add_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_add_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -72305,11 +72469,11 @@ SP_NOINLINE static void sp_1024_mont_add_32(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_1024_mont_dbl_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_dbl_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_1024_mont_dbl_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_dbl_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -72469,11 +72633,11 @@ SP_NOINLINE static void sp_1024_mont_dbl_32(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_1024_mont_tpl_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_tpl_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_1024_mont_tpl_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_tpl_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -72789,11 +72953,11 @@ SP_NOINLINE static void sp_1024_mont_tpl_32(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_1024_mont_sub_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, const sp_digit* m_p)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_sub_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_1024_mont_sub_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, const sp_digit* m)
+WC_OMIT_FRAME_POINTER SP_NOINLINE static void sp_1024_mont_sub_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -72967,11 +73131,11 @@ SP_NOINLINE static void sp_1024_mont_sub_32(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_1024_cond_add_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_cond_add_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_1024_cond_add_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_cond_add_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -73025,11 +73189,11 @@ static sp_digit sp_1024_cond_add_32(sp_digit* r, const sp_digit* a,
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_1024_cond_add_32(sp_digit* r_p, const sp_digit* a_p,
-    const sp_digit* b_p, sp_digit m_p)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_cond_add_32(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_1024_cond_add_32(sp_digit* r, const sp_digit* a,
-    const sp_digit* b, sp_digit m)
+WC_OMIT_FRAME_POINTER static sp_digit sp_1024_cond_add_32(sp_digit* r,
+    const sp_digit* a, const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -73163,9 +73327,11 @@ static sp_digit sp_1024_cond_add_32(sp_digit* r, const sp_digit* a,
 
 #endif /* WOLFSSL_SP_SMALL */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_1024_rshift1_32(sp_digit* r_p, const sp_digit* a_p)
+WC_OMIT_FRAME_POINTER static void sp_1024_rshift1_32(sp_digit* r_p,
+    const sp_digit* a_p)
 #else
-static void sp_1024_rshift1_32(sp_digit* r, const sp_digit* a)
+WC_OMIT_FRAME_POINTER static void sp_1024_rshift1_32(sp_digit* r,
+    const sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -138,6 +138,15 @@
 #endif
 #endif
 
+#ifndef WC_OMIT_FRAME_POINTER
+    #if defined(__GNUC__)
+        #define WC_OMIT_FRAME_POINTER  \
+            __attribute__((optimize("-fomit-frame-pointer")))
+    #else
+        #define WC_OMIT_FRAME_POINTER
+    #endif
+#endif
+
 /* THREADING/MUTEX SECTION */
 #if defined(SINGLE_THREADED) && defined(NO_FILESYSTEM)
     /* No system headers required for build. */


### PR DESCRIPTION
# Description

ARM32/Thumb2: Generated code now omits the frame pointer attribute on each function. Remove global use in configure.ac.
RISC-V 64: Omit the frame pointer on the one function that uses the register 's0'.

Fixes zd#20080

# Testing

Tested all inline ARM32/Thumb2/RISC-V 64 assembly.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
