### PR TITLE
Disable MD5 by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5487,7 +5487,8 @@ if test "$ENABLED_WPAS" = "yes" || test "$ENABLED_HAPROXY" = "yes" || \
     test "$ENABLED_OPENSSLEXTRA" = "yes" || test "$ENABLED_OPENVPN" = "yes" || \
     test "$ENABLED_TLSV10" = "yes" || test "$ENABLED_OLD_TLS" = "yes" || \
     test "$ENABLED_FORTRESS" = "yes" || test "$ENABLED_LIGHTY" = "yes" || \
-    test "$ENABLED_DES3" = "yes" || test "$ENABLED_BUMP" = "yes"
+    test "$ENABLED_DES3" = "yes" || test "$ENABLED_BUMP" = "yes" || \
+    test "$ENABLED_OPENSSLALL" = "yes"
 then
     ENABLED_MD5=yes
 fi


### PR DESCRIPTION
# Description

Disable the use of MD5 by default.
Add the conditional use of MD5 when `--enable-all-crypto` or `--enable-all` is present. 
Add the use of MD5 when `--enable-opensslextra` is present. 
Add the use of MD5 when `--enable-tlsv10` is present.

# Testing

Here are the following configure commands I tested:

## Test 1:
```
./configure
```
This produces a configure output indicating MD5 is disabled as expected.

## Test 2:
```
./configure --enable-all
```
and
```
./configure --enable-all-crypto
```
Both produce a configure output indicating MD5 is enabled as expected.

## Test 3:
```
./configure --enable-all --disable-md5
```
and
```
./configure --enable-all-crypto --disable-md5
```
Both produce a configure output indicating MD5 is disabled as expected.

## Test 4:
```
./configure --enable-tlsv10
```
This produced a configure output indicating MD5 is enabled as expected.