### PR TITLE
Add HAVE_GETPID to options.h if getpid detected

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,9 @@ fi
 #ifdef HAVE_STDLIB_H
     #include <stdlib.h>
 #endif
+#ifdef HAVE_UNISTD_H
+    #include <unistd.h>
+#endif
 #ifdef HAVE_CTYPE_H
     #include <ctype.h>
 #endif
@@ -10467,6 +10470,12 @@ fi
 if test "$ac_cv_type___uint128_t" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE___UINT128_T=1"
+fi
+
+# Add HAVE_GETPID to AM_CFLAGS for inclusion in options.h
+if test "$ac_cv_func_getpid" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_GETPID=1"
 fi
 
 LIB_SOCKET_NSL

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -25514,7 +25514,7 @@ static int wolfSSL_RAND_InitMutex(void)
 #ifdef OPENSSL_EXTRA
 
 #if defined(HAVE_GETPID) && !defined(WOLFSSL_NO_GETPID) && \
-    defined(HAVE_FIPS) && FIPS_VERSION3_LT(6,0,0)
+    ((defined(HAVE_FIPS) && FIPS_VERSION3_LT(6,0,0)) || defined(HAVE_SELFTEST))
 /* In older FIPS bundles add check for reseed here since it does not exist in
  * the older random.c certified files. */
 static pid_t currentRandPid = 0;
@@ -25533,7 +25533,9 @@ int wolfSSL_RAND_Init(void)
             ret = wc_InitRng(&globalRNG);
             if (ret == 0) {
             #if defined(HAVE_GETPID) && !defined(WOLFSSL_NO_GETPID) && \
-                defined(HAVE_FIPS) && FIPS_VERSION3_LT(6,0,0)
+                ((defined(HAVE_FIPS) && FIPS_VERSION3_LT(6,0,0)) || \
+                 defined(HAVE_SELFTEST))
+
                 currentRandPid = getpid();
             #endif
                 initGlobalRNG = 1;
@@ -26014,7 +26016,8 @@ int wolfSSL_RAND_bytes(unsigned char* buf, int num)
          */
         if (initGlobalRNG) {
         #if defined(HAVE_GETPID) && !defined(WOLFSSL_NO_GETPID) && \
-                defined(HAVE_FIPS) && FIPS_VERSION3_LT(6,0,0)
+                ((defined(HAVE_FIPS) && FIPS_VERSION3_LT(6,0,0)) || \
+                 defined(HAVE_SELFTEST))
             pid_t p;
 
             p = getpid();

--- a/tests/api.c
+++ b/tests/api.c
@@ -33211,7 +33211,7 @@ static int test_wolfSSL_RAND_bytes(void)
 
     max_bufsize = size4;
 
-    ExpectNotNull(my_buf = (byte*)XMALLOC(max_bufsize * sizeof(byte), NULL,
+    ExpectNotNull(my_buf = (byte*)XMALLOC(max_bufsize * sizeof(byte), HEAP_HINT,
         DYNAMIC_TYPE_TMP_BUFFER));
 
     ExpectIntEQ(RAND_bytes(my_buf, 0), 1);
@@ -33222,6 +33222,7 @@ static int test_wolfSSL_RAND_bytes(void)
     ExpectIntEQ(RAND_bytes(my_buf, size2), 1);
     ExpectIntEQ(RAND_bytes(my_buf, size3), 1);
     ExpectIntEQ(RAND_bytes(my_buf, size4), 1);
+    XFREE(my_buf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 
 #if defined(OPENSSL_EXTRA) && defined(HAVE_GETPID)
     XMEMSET(seed, 0, sizeof(seed));
@@ -33262,8 +33263,6 @@ static int test_wolfSSL_RAND_bytes(void)
     }
     RAND_cleanup();
 #endif
-
-    XFREE(my_buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
     return EXPECT_RESULT();
 }


### PR DESCRIPTION
# Description

PR https://github.com/wolfSSL/wolfssl/pull/8867 added use of `getpid()`, and also adjusted the definition of `WC_RNG` in `wolfssl/wolfcrypt/random.h` based on `HAVE_PID`:

```
#if defined(HAVE_GETPID) && !defined(WOLFSSL_NO_GETPID)
    pid_t pid;
#endif
```

The `HAVE_GETPID` define was not being stored to `wolfssl/options.h`, so applications depending on the `sizeof(WC_RNG)` would have gotten a different structure size.

This PR modifies `configure.ac` to define `HAVE_GETPID` in `wolfssl/options.h` if `getpid()` is detected.

# Testing

Existing unit tests, and wolfcrypt-jni test cases.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
