### PR TITLE
SP int: modular exponentiation constant time

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -14207,9 +14207,6 @@ static int _sp_exptmod_nct(const sp_int* b, const sp_int* e, const sp_int* m,
     if (bits > 450) {
         winBits = 6;
     }
-    else if (bits <= 21) {
-        winBits = 1;
-    }
     else if (bits <= 36) {
         winBits = 3;
     }


### PR DESCRIPTION
# Description

Using a 1-bit window size for small exponents isn't useful.

Fixes zd#20090

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
