### PR TITLE
Introduce CMakePresets.json and CMakeSettings.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,20 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 22,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "vs2022-x64",
+            "displayName": "Visual Studio 2022 x64",
+            "generator": "Visual Studio 17 2022",
+            "architecture": "x64",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
+        }
+    ]
+}

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,9 @@
+﻿{
+    "configurations": [
+        {
+            "name": "No-CMake",
+            "generator": "Ninja",
+            "buildCommandArgs": "echo 'No build command'"
+        }
+    ]
+}

--- a/Makefile.am
+++ b/Makefile.am
@@ -156,6 +156,8 @@ EXTRA_DIST+= LPCExpresso.cproject
 EXTRA_DIST+= LPCExpresso.project
 EXTRA_DIST+= resource.h wolfssl.rc
 EXTRA_DIST+= CMakeLists.txt
+EXTRA_DIST+= CMakePresets.json
+EXTRA_DIST+= CMakeSettings.json
 EXTRA_DIST+= m4/ax_atomic.m4
 
 include cmake/include.am

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -5,3 +5,55 @@ This directory contains some supplementary functions for the [CMakeLists.txt](..
 See also cmake notes in the [INSTALL](../INSTALL) documentation file.
 
 If new CMake build options are added `cmake/options.h.in` must also be updated.
+
+For more information on building wolfSSL, see the [wolfSSL Manual](https://www.wolfssl.com/documentation/manuals/wolfssl/).
+
+In summary for cmake:
+
+```
+# From the root of the wolfSSL repo:
+
+mkdir -p out
+pushd out
+cmake ..
+cmake --build .
+
+# View the available ciphers with:
+./examples/client/client -e
+popd
+```
+
+## CMake Presets
+
+The `CMakePresets.json`; see [cmake-presets(https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
+
+- Cross-platform and cross-IDE.
+
+- Standardized CMake feature (since CMake 3.19+, recommended after 3.21).
+
+- Works in Visual Studio, VS Code, CLI, CI systems, etc..
+
+## Visual Studio Settings
+
+There's also a Visual Studio specific file: `CMakeSettings.json`. This the file that supports the GUI CMake settings.
+
+See the Microsoft [CMakeSettings.json schema reference](https://learn.microsoft.com/en-us/cpp/build/cmakesettings-reference?view=msvc-170)
+
+## Visual Studio (2022 v17.1 and later):
+
+- Prefers `CMakePresets.json` if it exists.
+
+- Falls back to `CMakeSettings.json` if no presets are found.
+
+- Lets you override or extend presets via `CMakeSettings.json`.
+
+### Recommendations:
+
+- Use `CMakePresets.json` to define shared, cross-platform presets.
+
+- Use `CMakeSettings.json` to define Visual Studio-specific overrides, like:
+  * Custom output directories
+  * Specific environment variables
+  * *UI-related tweaks
+
+


### PR DESCRIPTION
# Description

Adds new `CMakePresets.json`  and `CMakeSettings.json` files for CMake. 

This PR improves the intitial Visual Studio experience when opening the wolfSSL root directory. Without the `CMakePresets.json` file, Visual Studio typically complains at startup time:

```
CMake Error at C:\workspace\wolfssl\CMakeLists.txt:37 (project):
  No CMAKE_ASM_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "ASM" or the CMake cache entry CMAKE_ASM_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
CMake Error at C:\workspace\CMakeLists.txt:37 (project):
  No CMAKE_C_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CC" or the CMake cache entry CMAKE_C_COMPILER to the full path to
  the compiler, or to the compiler name if it is in the PATH.
```

The `CMakeSettings.json` is Microsoft-specific and is typically generated automatically.

The `CMakePresets.json` is preferred for shared, cross-platform environments.

See enclosed new `CMakeSettings_README.md` for additional details.


Fixes zd# n/a

# Testing

How did you test?

Manually tested locally only.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
