### PR TITLE
libspdm 3.3.0 -> 3.7.0

### DIFF
--- a/.github/workflows/libspdm.yml
+++ b/.github/workflows/libspdm.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         # List of releases to test
-        ref: [ 3.3.0 ]
+        ref: [ 3.7.0 ]
     name: ${{ matrix.ref }}
     if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-22.04


### PR DESCRIPTION
3.3.0 pulls cmocka from https://git.cryptomilk.org/projects/cmocka.git. Update to 3.7.0 to pull from https://gitlab.com/cmocka/cmocka.git.

Depends on https://github.com/wolfSSL/osp/pull/257