### PR TITLE
20250620-clang-tidy-and-cppcheck-fixes-and-workarounds

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -35719,6 +35719,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
         (void)ssl;
 
+        if (args == NULL)
+            return;
+
     #if defined(HAVE_ECC) || defined(HAVE_CURVE25519) || defined(HAVE_CURVE448)
         XFREE(args->exportBuf, ssl->heap, DYNAMIC_TYPE_DER);
         args->exportBuf = NULL;
@@ -35728,16 +35731,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         args->verifySig = NULL;
     #endif
 
-        if (
-        #ifdef WOLFSSL_ASYNC_IO
-            args != NULL &&
-        #endif
-            args->input != NULL) {
+        if (args->input != NULL) {
             XFREE(args->input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
             args->input = NULL;
         }
-
-        (void)args;
     }
 
     /* handle generation of server_key_exchange (12) */

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -19271,18 +19271,15 @@ static int _sp_prime_trials(const sp_int* a, int trials, int* result)
 {
     int err = MP_OKAY;
     int i;
-    sp_int* n1;
-    sp_int* r;
-    DECL_SP_INT_ARRAY(t, a->used + 1, 2);
+    DECL_SP_INT(n1, a->used + 1);
+    DECL_SP_INT(r, a->used + 1);
     DECL_SP_INT(b, a->used * 2 + 1);
 
-    ALLOC_SP_INT_ARRAY(t, a->used + 1, 2, err, NULL);
+    ALLOC_SP_INT(n1, a->used + 1, err, NULL);
+    ALLOC_SP_INT(r, a->used + 1, err, NULL);
     /* Allocate number that will hold modular exponentiation result. */
     ALLOC_SP_INT(b, a->used * 2 + 1, err, NULL);
     if (err == MP_OKAY) {
-        n1 = t[0];
-        r  = t[1];
-
         _sp_init_size(n1, a->used + 1U);
         _sp_init_size(r, a->used + 1U);
         _sp_init_size(b, (sp_size_t)(a->used * 2U + 1U));
@@ -19305,7 +19302,8 @@ static int _sp_prime_trials(const sp_int* a, int trials, int* result)
 
     /* Free allocated temporary. */
     FREE_SP_INT(b, NULL);
-    FREE_SP_INT_ARRAY(t, NULL);
+    FREE_SP_INT(r, NULL);
+    FREE_SP_INT(n1, NULL);
     return err;
 }
 

--- a/wolfcrypt/src/wc_xmss_impl.c
+++ b/wolfcrypt/src/wc_xmss_impl.c
@@ -2590,7 +2590,7 @@ static void wc_xmss_bds_state_treehash_set_next_idx(BdsState* bds, int i,
 static void wc_xmss_bds_state_treehash_complete(BdsState* bds, int i)
 {
     byte* sk = bds->treeHash + i * 4;
-    sk[3] |= 1 << 7;
+    sk[3] |= 1 << 7; /* // NOLINT(clang-analyzer-core.NullDereference) */
 }
 
 /* Get the tree hash data at specified index for the BDS state.


### PR DESCRIPTION
`wolfcrypt/src/sp_int.c`: in `_sp_prime_trials()`, use `DECL_SP_INT()` not `DECL_SP_INT_ARRAY()` for `n1` and `r`, to mollify a very confused `clang-tidy` (fixes false positive `clang-analyzer-core.UndefinedBinaryOperatorResult` and `clang-analyzer-core.CallAndMessage`).

`src/internal.c`: in `FreeSskeArgs()`, move nullness check on args to the start, and make it unconditional, to resolve `nullPointerRedundantChecks`.

`wolfcrypt/src/wc_xmss_impl.c`: in `wc_xmss_bds_state_treehash_complete()`, add suppression for false positive `clang-analyzer-core.NullDereference` from LLVM-21 pre20250523+.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
clang-tidy-all-sp-all
quantum-safe-wolfssl-all-smallstack-clang-tidy
clang-tidy-defaults
clang-tidy-fips-140-3-v6-all
cppcheck-force-source
```

see https://github.com/llvm/llvm-project/issues/141514
