### PR TITLE
Allow configuration with only RSA cipher suites

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -48,9 +48,11 @@
 #if !defined(WOLFSSL_ALLOW_NO_SUITES) && !defined(WOLFCRYPT_ONLY)
     #if defined(NO_DH) && !defined(HAVE_ECC) && !defined(WOLFSSL_STATIC_RSA) \
                 && !defined(WOLFSSL_STATIC_DH) && !defined(WOLFSSL_STATIC_PSK) \
-                && !defined(HAVE_CURVE25519) && !defined(HAVE_CURVE448)
+                && !defined(HAVE_CURVE25519) && !defined(HAVE_CURVE448) \
+                && defined(NO_RSA)
         #error "No cipher suites defined because DH disabled, ECC disabled, " \
-               "and no static suites defined. Please see top of README"
+               "RSA disabled and no static suites defined. " \
+               "Please see top of README"
     #endif
     #ifdef WOLFSSL_CERT_GEN
         /* need access to Cert struct for creating certificate */


### PR DESCRIPTION
# Description

Updates `settings.h` sanity check rule to allow all cipher suites except RSA to be disabled.

Currently the error is triggered when only RSA is enabled.

Fixes zd#

# Testing

How did you test? 

Mostly test in embedded using manual `user_settings.h`, for instance adding these settings at the end of [this ESP32 user_settings.h](https://github.com/wolfSSL/wolfssl/blob/master/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/include/user_settings.h) and toggling the `TEST_CASE` for only RSA or not:

```c
// #define TEST_CASE
#ifdef TEST_CASE
    #undef  NO_RSA
    #define NO_RSA
#else
    #undef  NO_RSA
    #define HAVE_RSA
    #define FP_MAX_BITS (2 * 4096)
#endif

#undef NO_OLD_TLS 
#undef NO_SHA
#undef NO_SHA1
#undef HAVE_ECC
#undef HAVE_CURVE25519
#undef HAVE_CURVE448
#undef HAVE_ED25519
#undef HAVE_ED448
#undef HAVE_SUPPORTED_CURVES
#undef HAVE_ECC
#undef HAVE_CURVE25519
#undef HAVE_CURVE448
#undef HAVE_ED25519
#undef HAVE_ED448
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
