### PR TITLE
Fix for building LMS with verify only

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -55,7 +55,8 @@ jobs:
             CPPFLAGS=''-DWC_RNG_SEED_CB -DWOLFSSL_NO_GETPID'' ',
           '--enable-opensslextra CPPFLAGS=''-DWOLFSSL_NO_CA_NAMES'' ',
           '--enable-opensslextra=x509small',
-          'CPPFLAGS=''-DWOLFSSL_EXTRA'' '
+          'CPPFLAGS=''-DWOLFSSL_EXTRA'' ',
+          '--enable-lms=small,verify-only --enable-xmss=small,verify-only'
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/wolfcrypt/src/wc_lms.c
+++ b/wolfcrypt/src/wc_lms.c
@@ -1258,6 +1258,8 @@ int wc_LmsKey_Verify(LmsKey* key, const byte* sig, word32 sigSz,
     return ret;
 }
 
+#ifndef WOLFSSL_LMS_VERIFY_ONLY
+
 /* Get the Key ID from the LMS key.
  *
  * PRIV = Q | PARAMS | SEED | I
@@ -1309,5 +1311,7 @@ const byte * wc_LmsKey_GetKidFromPrivRaw(const byte * priv, word32 privSz)
     }
     return priv + privSz - LMS_I_LEN;
 }
+
+#endif
 
 #endif /* WOLFSSL_HAVE_LMS && WOLFSSL_WC_LMS */


### PR DESCRIPTION
# Description

Fix for building LMS with verify only. Added tests for LMS/XMSS verify only. New `wc_LmsKey_GetKid` references `key->priv_raw` that is not available.

Broken in PR #8786

# Testing

See wolfBoot test failures from https://github.com/wolfSSL/wolfBoot/pull/576

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
