### PR TITLE
Revert PR #8911

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -19621,8 +19621,8 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
 #endif
 
     (void)out;
-    (void)input;
     (void)sz;
+    (void)type;
 
     if (input == NULL) {
         return BAD_FUNC_ARG;
@@ -19699,8 +19699,8 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
             additionalSz = writeAeadAuthData(ssl,
                     /* Length of the plain text minus the explicit
                      * IV length minus the authentication tag size. */
-                    sz - (word16)(AESGCM_EXP_IV_SZ) - ssl->specs.aead_mac_size, type,
-                    ssl->encrypt.additional, 0, NULL, CUR_ORDER);
+                    sz - (word16)(AESGCM_EXP_IV_SZ) - ssl->specs.aead_mac_size,
+                    type, ssl->encrypt.additional, 0, NULL, CUR_ORDER);
             if (additionalSz < 0) {
                 ret = additionalSz;
                 break;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -48,11 +48,9 @@
 #if !defined(WOLFSSL_ALLOW_NO_SUITES) && !defined(WOLFCRYPT_ONLY)
     #if defined(NO_DH) && !defined(HAVE_ECC) && !defined(WOLFSSL_STATIC_RSA) \
                 && !defined(WOLFSSL_STATIC_DH) && !defined(WOLFSSL_STATIC_PSK) \
-                && !defined(HAVE_CURVE25519) && !defined(HAVE_CURVE448) \
-                && defined(NO_RSA)
+                && !defined(HAVE_CURVE25519) && !defined(HAVE_CURVE448)
         #error "No cipher suites defined because DH disabled, ECC disabled, " \
-               "RSA disabled and no static suites defined. " \
-               "Please see top of README"
+               "and no static suites defined. Please see top of README"
     #endif
     #ifdef WOLFSSL_CERT_GEN
         /* need access to Cert struct for creating certificate */


### PR DESCRIPTION
# Description

Revert PR #8911. I should not have merged it.

After running some more tests on TLS v1.2 and TLS v1.3 the original error was correct.

* For TLS v1.2 RSA only is only supported with `WOLFSSL_STATIC_RSA`. 
* For TLS v1.3 RSA only is not supported (must be PFS).

# Testing

With and without `WOLFSSL_STATIC_RSA`.
```
./configure --disable-ecc --disable-dh --disable-curve448 --disable-ed448 --disable-curve25519 --disable-ed25519 --enable-debug --disable-shared --disable-tls13 --enable-sni CFLAGS="-DWOLFSSL_STATIC_RSA" && make
./examples/client/client -v 3 -h www.google.com -p 443 -g -x -S www.google.com -d
```

Without static RSA the result is -313. Works with static RSA.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
