### PR TITLE
Fix for broken `test_wolfSSL_check_domain_basic`

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -26,7 +26,7 @@ jobs:
           update: true
           install: git gcc autotools base-devel autoconf netcat
       - name: configure wolfSSL
-        run: ./autogen.sh && ./configure CFLAGS="-DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DNO_WRITE_TEMP_FILES"
+        run: ./autogen.sh && ./configure --disable-sys-ca-certs CFLAGS="-DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DNO_WRITE_TEMP_FILES"
       - name: build wolfSSL
         run: make
       - name: run tests

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -56,7 +56,8 @@ jobs:
           '--enable-opensslextra CPPFLAGS=''-DWOLFSSL_NO_CA_NAMES'' ',
           '--enable-opensslextra=x509small',
           'CPPFLAGS=''-DWOLFSSL_EXTRA'' ',
-          '--enable-lms=small,verify-only --enable-xmss=small,verify-only'
+          '--enable-lms=small,verify-only --enable-xmss=small,verify-only',
+          '--disable-sys-ca-certs'
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/tests/api.c
+++ b/tests/api.c
@@ -32797,7 +32797,7 @@ static int test_wolfSSL_check_domain(void)
 
 #endif /* OPENSSL_EXTRA && HAVE_SSL_MEMIO_TESTS_DEPENDENCIES */
 #if defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
-    !defined(WOLFSSL_SYS_CA_CERTS)
+    defined(WOLFSSL_SYS_CA_CERTS)
 static const char* dn = NULL;
 static int test_wolfSSL_check_domain_basic_client_ctx(WOLFSSL_CTX* ctx)
 {


### PR DESCRIPTION
# Description

Fix for new api.c test `test_wolfSSL_check_domain_basic` added in PR #8863 that fails with `--disable-sys-ca-certs`.

# Testing

`./configure --disable-sys-ca-certs && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
