### PR TITLE
Allow CA:FALSE on wolftpm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2085,6 +2085,7 @@ if(WOLFSSL_TPM)
     override_cache(WOLFSSL_CERTEXT  "yes")
     override_cache(WOLFSSL_PKCS7    "yes")
     override_cache(WOLFSSL_AESCFB   "yes")
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_ALLOW_ENCODING_CA_FALSE")
 endif()
 
 if(WOLFSSL_CLU)

--- a/configure.ac
+++ b/configure.ac
@@ -7243,6 +7243,9 @@ then
 
     # Requires public mp_
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_PUBLIC_MP"
+
+    # Requires allowing CA:FALSE in BasicConstraints
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALLOW_ENCODING_CA_FALSE"
 fi
 
 if test "x$ENABLED_SMIME" = "xyes"


### PR DESCRIPTION
# Description

The Intel CSME fTFM sets this basic constraint on their EK certificates and by default wolfSSL fails to parse because of this.

Example certificate:

```
-----BEGIN CERTIFICATE-----
MIICzzCCAlWgAwIBAgIQaWx/XGzvGhhODsyFg1K6lDAKBggqhkjOPQQDAzAeMRww
GgYDVQQDDBNDU01FIEFETCBQVFQgIDAxU1ZOMB4XDTIxMDYyMzAwMDAwMFoXDTQ5
MTIzMTIzNTk1OVowADB2MBAGByqGSM49AgEGBSuBBAAiA2IABOH2F8jF92pojt3o
DGsaKMl+NiX2JW3kypYCoCysJCK0//EmfLda5S+eslMu6Cc1TynKukCn4wjEVvbP
710w6uw3UwYJJwLtJA6crOeKUZn6L4u8uM8N+gxauudwZbbEmqOCAXQwggFwMB8G
A1UdIwQYMBaAFAmKek4rsrXPkzLDMg5M734D6KSCMA8GA1UdEwEB/wQFMAMBAQAw
DgYDVR0PAQH/BAQDAgMIMIGgBgNVHR8EgZgwgZUwgZKgSqBIhkZodHRwczovL3Rz
Y2kuaW50ZWwuY29tL2NvbnRlbnQvT25EaWVDQS9jcmxzL09EQ0FfQ0EyX0NTTUVf
SW5kaXJlY3QuY3JsokSkQjBAMSYwJAYDVQQLDB1PRENBIENBMiBDU01FIEludGVy
bWVkaWF0ZSBDQTEWMBQGA1UEAwwNd3d3LmludGVsLmNvbTAQBgNVHSUECTAHBgVn
gQUIATAlBgNVHQkBAQAEGzAZMBcGBWeBBQIQMQ4wDAwDMi4wAgEAAgIAijBQBgNV
HREBAf8ERjBEpEIwQDEWMBQGBWeBBQIBDAtpZDo0OTRFNTQ0MzEOMAwGBWeBBQIC
DANBREwxFjAUBgVngQUCAwwLaWQ6MDI1ODAwMTIwCgYIKoZIzj0EAwMDaAAwZQIx
AM/CaenfaKeOld6IRoGAlmUXoC9fORlpZQBTE8CHMYFbJIXz6eCjyXdhXV1uSDai
twIwcQsxIoQeSOetjuJaOqWUDTHdLTKMxrPWDX+i9nNJ9lQ2V5i191zljrJE/+WE
swBH
-----END CERTIFICATE-----
```

# Testing

On a machine with the Intel fTFM:

```
# wolfSSL
./configure --enable-wolftpm && make && sudo make install

# wolfTPM
./configure --enable-devtpm && make
sudo ./examples/endorsement/get_ek_certs
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
