### PR TITLE
Fix for user_settings.h build with configure.ac and HAVE_CURVE25519

### DIFF
--- a/src/include.am
+++ b/src/include.am
@@ -1293,9 +1293,7 @@ endif
 endif !BUILD_FIPS_V6
 
 if BUILD_FEMATH
-if BUILD_CURVE25519_SMALL
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_low_mem.c
-else
 if BUILD_CURVE25519_INTELASM
 if !BUILD_X86_ASM
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_x25519_asm.S
@@ -1351,13 +1349,10 @@ else
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_operations.c
 endif !BUILD_ARMASM
 endif !BUILD_CURVE25519_INTELASM
-endif !BUILD_CURVE25519_SMALL
 endif BUILD_FEMATH
 
 if BUILD_GEMATH
-if BUILD_ED25519_SMALL
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ge_low_mem.c
-else
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ge_operations.c
 if !BUILD_FEMATH
 if BUILD_CURVE25519_INTELASM
@@ -1396,7 +1391,6 @@ endif !BUILD_ARMASM
 endif !BUILD_FIPS_V6
 endif !BUILD_CURVE25519_INTELASM
 endif !BUILD_FEMATH
-endif !BUILD_ED25519_SMALL
 endif BUILD_GEMATH
 
 if !BUILD_FIPS_V6


### PR DESCRIPTION
Fix for building with `./configure --enable-usersettings --disable-examples && make` when having the macro HAVE_CURVE25519 defined in user_settings.h.