### PR TITLE
Clarify the len range on SetShortInt()

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3259,6 +3259,10 @@ int SetShortInt(byte* output, word32* inOutIdx, word32 number, word32 maxIdx)
     else
         len = BytePrecision(number);
 
+    /* clarify the len range to prepare for the next right bit shifting */
+    if (len < 1 || len > sizeof(number)) {
+        return ASN_PARSE_E;
+    }
     if (number >> (WOLFSSL_BIT_SIZE * len - 1)) {
         /* Need one byte of zero value not to be negative number */
         extraByte = 1;


### PR DESCRIPTION
# Description

This PR adds the check for the len to stay in specific range on `SetShortInt()`.
This will remove a static code analysis warning.

Fixes Coverity CID 528301

# Testing

./configure && make test
./configure --enable-asn=original && make test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
