### PR TITLE
coverity: prune dead code in ssl_sess.c.

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -5108,11 +5108,6 @@ int wolfSSL_add0_chain_cert(WOLFSSL* ssl, WOLFSSL_X509* x509)
             /* Push X509 object onto stack to be freed. */
             ret = wolfSSL_sk_X509_push(ssl->ourCertChain, x509) > 0
                     ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
-            if (ret != 1) {
-                /* Free it now on error. */
-                wolfSSL_X509_free(x509);
-                x509 = NULL;
-            }
         }
     }
     return WS_RC(ret);

--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -1179,9 +1179,6 @@ int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output)
 #endif /* WOLFSSL_TLS13 */
     byte         tmpBufSet = 0;
 #endif
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    WOLFSSL_X509* peer = NULL;
-#endif
     byte         bogusID[ID_LEN];
     byte         bogusIDSz = 0;
 
@@ -1447,13 +1444,6 @@ int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output)
     XFREE(preallocNonce, output->heap, DYNAMIC_TYPE_SESSION_TICK);
 #endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
 
-#endif
-
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    if (peer != NULL) {
-        wolfSSL_X509_free(peer);
-        peer = NULL;
-    }
 #endif
 
     return error;


### PR DESCRIPTION
## Description

Miscellaneous coverity fixes:
- Prune dead code in src/ssl_sess.c
- Do not free x509 on error in wolfSSL_add0_chain_cert. The API should only take ownership on success.

## Testing

```
./configure --enable-sessioncerts --enable-opensslextra
make
make test
```
