### PR TITLE
Fix x509 memory leak

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4849,7 +4849,7 @@ void FreeX509(WOLFSSL_X509* x509)
     }
     #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
-    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         wolfSSL_RefFree(&x509->ref);
     #endif
 }


### PR DESCRIPTION
# Description

The definition of `WOLFSSL_X509` class in Internal.h file adds `wolfSSL_Ref` by one of these two flags:
- OPENSSL_EXTRA
- OPENSSL_EXTRA_X509_SMALL

But the statement in `FreeX509` doesn't match the definition. So it doesn't free `ref` and causes memory leak.

# Testing

Run with `OPENSSL_EXTRA_X509_SMALL` and check memory with valgrind.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
