### PR TITLE
Memory allocation failure testing fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -64461,13 +64461,15 @@ static int test_wolfSSL_SCR_after_resumption(void)
     ExpectIntEQ(func_cb_client.return_code, TEST_SUCCESS);
     ExpectIntEQ(func_cb_server.return_code, TEST_SUCCESS);
 
-    func_cb_client.ssl_ready = test_wolfSSL_SCR_after_resumption_ssl_ready;
-    func_cb_server.on_result = test_wolfSSL_SCR_after_resumption_on_result;
+    if (EXPECT_SUCCESS()) {
+        func_cb_client.ssl_ready = test_wolfSSL_SCR_after_resumption_ssl_ready;
+        func_cb_server.on_result = test_wolfSSL_SCR_after_resumption_on_result;
 
-    test_wolfSSL_client_server_nofail(&func_cb_client, &func_cb_server);
+        test_wolfSSL_client_server_nofail(&func_cb_client, &func_cb_server);
 
-    ExpectIntEQ(func_cb_client.return_code, TEST_SUCCESS);
-    ExpectIntEQ(func_cb_server.return_code, TEST_SUCCESS);
+        ExpectIntEQ(func_cb_client.return_code, TEST_SUCCESS);
+        ExpectIntEQ(func_cb_server.return_code, TEST_SUCCESS);
+    }
 
     wolfSSL_SESSION_free(test_wolfSSL_SCR_after_resumption_session);
 

--- a/tests/api/test_dtls.c
+++ b/tests/api/test_dtls.c
@@ -898,6 +898,7 @@ int test_dtls13_longer_length(void)
     struct test_memio_ctx test_ctx;
     unsigned char readBuf[50];
     int seq16bit = 0;
+    int ret;
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
 
@@ -930,7 +931,8 @@ int test_dtls13_longer_length(void)
     ExpectIntEQ(test_ctx.s_len, 0);
 
     ExpectIntEQ(test_dtls_communication(ssl_s, ssl_c), TEST_SUCCESS);
-    ExpectIntEQ(test_dtls_shutdown(ssl_s, ssl_c, ctx_c, ctx_s), TEST_SUCCESS);
+    ret = test_dtls_shutdown(ssl_s, ssl_c, ctx_c, ctx_s);
+    ExpectIntEQ(ret, TEST_SUCCESS);
 
     return EXPECT_RESULT();
 }
@@ -950,6 +952,7 @@ int test_dtls13_short_read(void)
     struct test_memio_ctx test_ctx;
     unsigned char readBuf[50];
     int i;
+    int ret;
 
     /* we setup two test, in the first one the server reads just two bytes of
      * the header, in the second one it reads just the header (5) */
@@ -980,8 +983,8 @@ int test_dtls13_short_read(void)
         ExpectIntEQ(test_ctx.s_len, 0);
 
         ExpectIntEQ(test_dtls_communication(ssl_s, ssl_c), TEST_SUCCESS);
-        ExpectIntEQ(test_dtls_shutdown(ssl_s, ssl_c, ctx_c, ctx_s),
-            TEST_SUCCESS);
+        ret = test_dtls_shutdown(ssl_s, ssl_c, ctx_c, ctx_s);
+        ExpectIntEQ(ret, TEST_SUCCESS);
         ssl_c = ssl_s = NULL;
         ctx_c = ctx_s = NULL;
     }
@@ -1004,6 +1007,7 @@ int test_dtls12_short_read(void)
     struct test_memio_ctx test_ctx;
     unsigned char readBuf[50];
     int i;
+    int ret;
 
     for (i = 0; i < 3; i++) {
         XMEMSET(&test_ctx, 0, sizeof(test_ctx));
@@ -1041,8 +1045,8 @@ int test_dtls12_short_read(void)
         ExpectIntEQ(test_ctx.s_len, 0);
 
         ExpectIntEQ(test_dtls_communication(ssl_s, ssl_c), TEST_SUCCESS);
-        ExpectIntEQ(test_dtls_shutdown(ssl_s, ssl_c, ctx_c, ctx_s),
-            TEST_SUCCESS);
+        ret = test_dtls_shutdown(ssl_s, ssl_c, ctx_c, ctx_s);
+        ExpectIntEQ(ret, TEST_SUCCESS);
         ssl_c = ssl_s = NULL;
         ctx_c = ctx_s = NULL;
     }
@@ -1064,6 +1068,7 @@ int test_dtls12_record_length_mismatch(void)
     WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
     struct test_memio_ctx test_ctx;
     unsigned char readBuf[50];
+    int ret;
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
 
@@ -1090,7 +1095,8 @@ int test_dtls12_record_length_mismatch(void)
     ExpectIntEQ(test_ctx.s_len, 0);
 
     ExpectIntEQ(test_dtls_communication(ssl_s, ssl_c), TEST_SUCCESS);
-    ExpectIntEQ(test_dtls_shutdown(ssl_s, ssl_c, ctx_c, ctx_s), TEST_SUCCESS);
+    ret = test_dtls_shutdown(ssl_s, ssl_c, ctx_c, ctx_s);
+    ExpectIntEQ(ret, TEST_SUCCESS);
 
     return EXPECT_RESULT();
 }
@@ -1175,6 +1181,7 @@ int test_dtls_short_ciphertext(void)
     WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
     struct test_memio_ctx test_ctx;
     unsigned char readBuf[50];
+    int ret;
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
 
@@ -1207,7 +1214,8 @@ int test_dtls_short_ciphertext(void)
 
     ExpectIntEQ(test_dtls_communication(ssl_s, ssl_c), TEST_SUCCESS);
 
-    ExpectIntEQ(test_dtls_shutdown(ssl_s, ssl_c, ctx_c, ctx_s), TEST_SUCCESS);
+    ret = test_dtls_shutdown(ssl_s, ssl_c, ctx_c, ctx_s);
+    ExpectIntEQ(ret, TEST_SUCCESS);
 
     return EXPECT_RESULT();
 }

--- a/tests/api/test_mldsa.c
+++ b/tests/api/test_mldsa.c
@@ -16680,6 +16680,7 @@ int test_mldsa_pkcs8(void)
     dilithium_key mldsa_key;
     WC_RNG rng;
     word32 size;
+    int ret;
 
     struct {
         int wcId;
@@ -16698,6 +16699,8 @@ int test_mldsa_pkcs8(void)
     };
 
     (void) pemSz;
+
+    XMEMSET(&rng, 0, sizeof(rng));
 
     ExpectNotNull(der = (byte*) XMALLOC(derMaxSz, NULL,
         DYNAMIC_TYPE_TMP_BUFFER));
@@ -16789,7 +16792,8 @@ int test_mldsa_pkcs8(void)
     }
 
     wc_dilithium_free(&mldsa_key);
-    ExpectIntEQ(wc_FreeRng(&rng), 0);
+    ret = wc_FreeRng(&rng);
+    ExpectIntEQ(ret, 0);
     wolfSSL_CTX_free(ctx);
     XFREE(temp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -16821,6 +16825,7 @@ int test_mldsa_pkcs12(void)
     WC_RNG rng;
     dilithium_key mldsa_key;
     char pkcs12Passwd[] = "mldsa";
+    int ret;
 
     struct {
         int enc;
@@ -16843,6 +16848,8 @@ int test_mldsa_pkcs12(void)
         {-1, WC_ML_DSA_87, ML_DSA_LEVEL5k,
             ML_DSA_LEVEL5_PRV_KEY_SIZE, CTC_ML_DSA_LEVEL5, ML_DSA_LEVEL5_TYPE},
     };
+
+    XMEMSET(&rng, 0, sizeof(rng));
 
     ExpectNotNull(inKey = (byte*) XMALLOC(inKeyMaxSz, NULL,
         DYNAMIC_TYPE_TMP_BUFFER));
@@ -16952,7 +16959,8 @@ int test_mldsa_pkcs12(void)
     }
 
     wc_dilithium_free(&mldsa_key);
-    ExpectIntEQ(wc_FreeRng(&rng), 0);
+    ret = wc_FreeRng(&rng);
+    ExpectIntEQ(ret, 0);
     wolfSSL_CTX_free(ctx);
     XFREE(inCert, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(inKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -12659,8 +12659,13 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(wc_PKCS7* pkcs7, byte* in,
         case WC_PKCS7_ENV_5:
 
         #ifndef NO_PKCS7_STREAM
+
             if ((ret = wc_PKCS7_AddDataToStream(pkcs7, in, inSz,
                             pkcs7->stream->expected, &pkiMsg, &idx)) != 0) {
+                if (ret != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E)) {
+                    wc_PKCS7_StreamGetVar(pkcs7, &encOID, NULL, NULL);
+                    wc_PKCS7_DecryptContentFree(pkcs7, encOID, pkcs7->heap);
+                }
                 return ret;
             }
 


### PR DESCRIPTION
# Description

Fixes for test code to cleanup on failure properly. pkcs7.c: when streaming, free the decrypting content when adding data to the stream fails.

# Testing

Memory allocation failure testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
