### PR TITLE
wc/asn: fix several inconsistent function prototype parameter names

### DIFF
--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -1192,7 +1192,7 @@ int wc_PemCertToDer(const char* fileName, unsigned char* derBuf, int derSz);
     \sa wc_PemCertToDer
 */
 int wc_DerToPem(const byte* der, word32 derSz, byte* output,
-                                word32 outputSz, int type);
+                                word32 outSz, int type);
 
 /*!
     \ingroup ASN
@@ -1219,7 +1219,7 @@ int wc_DerToPem(const byte* der, word32 derSz, byte* output,
     formatted certificate
     \param outSz size of the buffer in which to store the pem formatted
     certificate
-    \param cipher_inf Additional cipher information.
+    \param cipher_info Additional cipher information.
     \param type the type of certificate to generate. Valid types are:
     CERT_TYPE, PRIVATEKEY_TYPE, ECC_PRIVATEKEY_TYPE, and CERTREQ_TYPE.
 
@@ -1237,7 +1237,7 @@ int wc_DerToPem(const byte* der, word32 derSz, byte* output,
     \sa wc_PemCertToDer
 */
 int wc_DerToPemEx(const byte* der, word32 derSz, byte* output,
-                                word32 outputSz, byte *cipherIno, int type);
+                                word32 outSz, byte *cipher_info, int type);
 
 /*!
     \ingroup CertsKeys

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -352,7 +352,7 @@ WOLFSSL_LOCAL int SizeASN_Items(const ASNItem* asn, ASNSetData *data,
 WOLFSSL_LOCAL int SetASN_Items(const ASNItem* asn, ASNSetData *data, int count,
     byte* output);
 WOLFSSL_LOCAL int GetASN_Items(const ASNItem* asn, ASNGetData *data, int count,
-    int complete, const byte* input, word32* inOutIdx, word32 maxIdx);
+    int complete, const byte* input, word32* inOutIdx, word32 length);
 
 #ifdef WOLFSSL_ASN_TEMPLATE_TYPE_CHECK
 WOLFSSL_LOCAL void GetASN_Int8Bit(ASNGetData *dataASN, byte* num);
@@ -2150,15 +2150,14 @@ WOLFSSL_LOCAL void    FreeTrustedPeerTable(TrustedPeerCert** table, int rows,
                                            void* heap);
 #endif /* WOLFSSL_TRUST_PEER_CERT */
 
-WOLFSSL_ASN_API int ToTraditional(byte* buffer, word32 length);
-WOLFSSL_ASN_API int ToTraditional_ex(byte* buffer, word32 length,
-                                     word32* algId);
+WOLFSSL_ASN_API int ToTraditional(byte* input, word32 sz);
+WOLFSSL_ASN_API int ToTraditional_ex(byte* input, word32 sz, word32* algId);
 WOLFSSL_LOCAL int ToTraditionalInline(const byte* input, word32* inOutIdx,
-                                      word32 length);
+                                      word32 sz);
 WOLFSSL_LOCAL int ToTraditionalInline_ex(const byte* input, word32* inOutIdx,
-                                         word32 length, word32* algId);
+                                         word32 sz, word32* algId);
 WOLFSSL_LOCAL int ToTraditionalInline_ex2(const byte* input, word32* inOutIdx,
-                                          word32 length, word32* algId,
+                                          word32 sz, word32* algId,
                                           word32* eccOid);
 WOLFSSL_LOCAL int ToTraditionalEnc(byte* input, word32 sz, const char* password,
                      int passwordSz, word32* algId);
@@ -2173,7 +2172,7 @@ WOLFSSL_ASN_API int TraditionalEnc(byte* key, word32 keySz, byte* out,
         word32* outSz, const char* password, int passwordSz, int vPKCS,
         int vAlgo, int encAlgId, byte* salt, word32 saltSz, int itt,
         WC_RNG* rng, void* heap);
-WOLFSSL_LOCAL int DecryptContent(byte* input, word32 sz,const char* psw,int pswSz);
+WOLFSSL_LOCAL int DecryptContent(byte* input, word32 sz, const char* password, int passwordSz);
 WOLFSSL_LOCAL int EncryptContent(byte* input, word32 sz, byte* out, word32* outSz,
         const char* password,int passwordSz, int vPKCS, int vAlgo, int encAlgId,
         byte* salt, word32 saltSz, int itt, int hmacOid, WC_RNG* rng,
@@ -2204,7 +2203,7 @@ WOLFSSL_LOCAL byte GetCertNameId(int idx);
 #endif
 WOLFSSL_LOCAL int GetShortInt(const byte* input, word32* inOutIdx, int* number,
                               word32 maxIdx);
-WOLFSSL_TEST_VIS int SetShortInt(byte* input, word32* inOutIdx, word32 number,
+WOLFSSL_TEST_VIS int SetShortInt(byte* output, word32* inOutIdx, word32 number,
                               word32 maxIdx);
 
 WOLFSSL_LOCAL const char* GetSigName(int oid);
@@ -2255,8 +2254,8 @@ WOLFSSL_LOCAL int GetAlgoId(const byte* input, word32* inOutIdx, word32* oid,
                            word32 oidType, word32 maxIdx);
 WOLFSSL_LOCAL int GetAlgoIdEx(const byte* input, word32* inOutIdx, word32* oid,
                      word32 oidType, word32 maxIdx, byte *absentParams);
-WOLFSSL_ASN_API int GetASNTag(const byte* input, word32* idx, byte* tag,
-                              word32 inputSz);
+WOLFSSL_ASN_API int GetASNTag(const byte* input, word32* inOutIdx, byte* tag,
+                              word32 maxIdx);
 WOLFSSL_LOCAL int GetASN_BitString(const byte* input, word32 idx, int length);
 
 WOLFSSL_LOCAL word32 SetASNLength(word32 length, byte* output);
@@ -2354,9 +2353,9 @@ WOLFSSL_LOCAL int DecodeAsymKeyPublic(const byte* input, word32* inOutIdx,
 WOLFSSL_LOCAL int wc_EncryptedInfoParse(EncryptedInfo* info,
                                         const char** pBuffer, size_t bufSz);
 
-WOLFSSL_LOCAL int PemToDer(const unsigned char* buff, long sz, int type,
+WOLFSSL_LOCAL int PemToDer(const unsigned char* buff, long longSz, int type,
                           DerBuffer** pDer, void* heap, EncryptedInfo* info,
-                          int* eccKey);
+                          int* keyFormat);
 WOLFSSL_LOCAL int AllocDer(DerBuffer** der, word32 length, int type,
     void* heap);
 WOLFSSL_LOCAL int AllocCopyDer(DerBuffer** der, const unsigned char* buff,

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -642,9 +642,9 @@ WOLFSSL_API void wc_FreeDer(DerBuffer** pDer);
 #ifdef WOLFSSL_DER_TO_PEM
     WOLFSSL_ABI
     WOLFSSL_API int wc_DerToPem(const byte* der, word32 derSz, byte* output,
-                                word32 outputSz, int type);
+                                word32 outSz, int type);
     WOLFSSL_API int wc_DerToPemEx(const byte* der, word32 derSz, byte* output,
-                                word32 outputSz, byte *cipherIno, int type);
+                                word32 outSz, byte *cipher_info, int type);
 #endif
 
 WOLFSSL_API word32 wc_PkcsPad(byte* buf, word32 sz, word32 blockSz);


### PR DESCRIPTION
# Description

wc/asn: fix several inconsistent function prototype parameter names

# Testing

CI build only; only function parameter names in prototypes changed to be consistent with definitions

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
