### PR TITLE
Fix issue with benchmark help options and descriptions not lining up

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -15141,9 +15141,10 @@ static void Usage(void)
     e += 3;
 #endif
     printf("%s", bench_Usage_msg1[lng_index][e++]);    /* option -dgst_full */
-    printf("%s", bench_Usage_msg1[lng_index][e++]);    /* option -mca_final */
+    printf("%s", bench_Usage_msg1[lng_index][e++]);    /* option -mac_final */
+    printf("%s", bench_Usage_msg1[lng_index][e++]);    /* option -aead_set_key */
 #ifndef NO_RSA
-    printf("%s", bench_Usage_msg1[lng_index][e++]);    /* option -ras_sign */
+    printf("%s", bench_Usage_msg1[lng_index][e++]);    /* option -rsa_sign */
     #ifdef WOLFSSL_KEY_GEN
     printf("%s", bench_Usage_msg1[lng_index][e]);    /* option -rsa-sz */
     #endif


### PR DESCRIPTION
# Description

Fix issue with benchmark help options and descriptions not lining up due to new `-aead_set_key` added. Broken in #8160 on April 14, 2025.

# Testing

`./wolfcrypt/benchmark/benchmark -?`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
