### PR TITLE
Testing disabling various PK algs

### DIFF
--- a/.github/workflows/disable-pk-algs.yml
+++ b/.github/workflows/disable-pk-algs.yml
@@ -1,0 +1,63 @@
+name: disable-pk-algs Tests
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  make_check:
+    strategy:
+      matrix:
+        config: [
+          # Add new configs here
+          '--disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-rsa --enable-dh',
+          '--disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-ecc',
+          '--disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-rsa --enable-curve25519',
+          '--disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-ecc --enable-curve25519',
+          '--disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-rsa --enable-curve448',
+          '--disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-ecc --enable-curve448',
+          '--disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-curve25519 --enable-ed25519',
+          '--disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-curve448 --enable-ed448',
+          '-enable-cryptonly  --disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-rsa',
+          '--enable-cryptonly  --disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-dh',
+          '--enable-cryptonly  --disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-ecc',
+          '--enable-cryptonly  --disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-curve25519',
+          '--enable-cryptonly  --disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-ed25519',
+          '--enable-cryptonly  --disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-curve448',
+          '--enable-cryptonly  --disable-rsa --disable-dh --disable-ecc --disable-curve25519 --disable-ed25519 --disable-curve448 --disable-ed448 --enable-ed448',
+        ]
+    name: make check
+    if: github.repository_owner == 'wolfssl'
+    runs-on: ubuntu-22.04
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout wolfSSL
+
+      - name: Test wolfSSL
+        run: |
+          ./autogen.sh
+          ./configure ${{ matrix.config }}
+          make -j 4
+          make check
+
+      - name: Print errors
+        if: ${{ failure() }}
+        run: |
+          for file in scripts/*.log
+          do
+              if [ -f "$file" ]; then
+                  echo "${file}:"
+                  cat "$file"
+                  echo "========================================================================"
+              fi
+          done

--- a/tests/api.c
+++ b/tests/api.c
@@ -68246,12 +68246,13 @@ TEST_CASE testCases[] = {
 
 #if !defined(NO_CERTS) && (!defined(NO_WOLFSSL_CLIENT) || \
     !defined(WOLFSSL_NO_CLIENT_AUTH)) && !defined(NO_FILESYSTEM) && \
-    !defined(WOLFSSL_TEST_APPLE_NATIVE_CERT_VALIDATION)
+    !defined(WOLFSSL_TEST_APPLE_NATIVE_CERT_VALIDATION) && \
+    (!defined(NO_RSA) || defined(HAVE_ECC))
     /* Use the Cert Manager(CM) API to generate the error ASN_SIG_CONFIRM_E */
     /* Bad certificate signature tests */
     TEST_DECL(test_EccSigFailure_cm),
     TEST_DECL(test_RsaSigFailure_cm),
-#endif /* NO_CERTS */
+#endif
 
     /* PKCS8 testing */
     TEST_DECL(test_wolfSSL_no_password_cb),


### PR DESCRIPTION
# Description

Fix api.c: disable test_EccSigFailure_cm and test_RsaSigFailure_cm when the PK algorithm they use is disabled.

# Testing

Disable RSA and enable others, disable ECC and enable others.
New workflow covers it too.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
