### PR TITLE
When creating a Cert from a WOLFSSL_X509, account for custom extensions

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -10738,7 +10738,8 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
     cert->altSigValCrit = x509->altSigValCrit;
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
-#ifdef WOLFSSL_CUSTOM_OID
+#if defined(WOLFSSL_ASN_TEMPLATE) && defined(WOLFSSL_CUSTOM_OID) && \
+    defined(HAVE_OID_ENCODING)
 
     if ((x509->customExtCount < 0) ||
             (x509->customExtCount >= NUM_CUSTOM_EXT)) {
@@ -10754,7 +10755,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             return WOLFSSL_FAILURE;
         }
     }
-#endif /* WOLFSSL_CUSTOM_OID */
+#endif /* WOLFSSL_ASN_TEMPLATE && WOLFSSL_CUSTOM_OID && HAVE_OID_ENCODING */
 
 #endif /* WOLFSSL_CERT_EXT */
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -10737,6 +10737,25 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
     cert->altSigValLen = x509->altSigValLen;
     cert->altSigValCrit = x509->altSigValCrit;
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
+
+#ifdef WOLFSSL_CUSTOM_OID
+
+    if ((x509->customExtCount < 0) ||
+            (x509->customExtCount >= NUM_CUSTOM_EXT)) {
+        WOLFSSL_MSG("Bad value for customExtCount.");
+        return WOLFSSL_FAILURE;
+    }
+
+    for (i = 0; i < x509->customExtCount; i++) {
+        if (wc_SetCustomExtension(cert, x509->custom_exts[i].crit,
+                x509->custom_exts[i].oid, x509->custom_exts[i].val,
+                x509->custom_exts[i].valSz))
+        {
+            return WOLFSSL_FAILURE;
+        }
+    }
+#endif /* WOLFSSL_CUSTOM_OID */
+
 #endif /* WOLFSSL_CERT_EXT */
 
 #ifdef WOLFSSL_CERT_REQ


### PR DESCRIPTION
Function 'CertFromX509' is used to convert a WOLFSSL_X509 to a Cert structure for writing out. It didn't copy custom extensions.

# Description

As shown in #8941, `wolfSSL_PEM_write_X509` doesn't write custom extensions in the certificate, added with `wolfSSL_X509_add_ext`. This is because they are not copied to the `wolfcrypt` structure when serializing to der

Please describe the scope of the fix or feature addition.

Custom extensions present in X.509 certificates are now also written when exporting an 'WOLFSSL_X509' to disk format.

Fixes zd#

# Testing

How did you test?
The following program generates a certificate without extension before this commit and a good one afterwards. This is the same program as provided in #8941 

~~~c
#include <stdio.h>
#include <err.h>

#ifdef USE_WOLFSSL

#define WOLFSSL_USE_OPTIONS_H

#include <wolfssl/ssl.h>
#include <wolfssl/openssl/pem.h>
#include <wolfssl/openssl/ssl.h>
#include <wolfssl/openssl/buffer.h>

#endif /* USE_WOLFSSL */

#ifdef USE_OPENSSL

#include <openssl/x509.h>
#include <openssl/pem.h>
#include <openssl/err.h>
#include <openssl/evp.h>
#include <openssl/x509v3.h>

#endif /* USE_OPENSSL */

#define ARRAY_LEN(a)           (sizeof (a) / sizeof (a[0]))

static const uint8_t g_data[] =
{
	0x30, 0x16, 0x80, 0x14, 0x60, 0x7B, 0x66, 0x1A,
	0x45, 0x0D, 0x97, 0xCA, 0x89, 0x50, 0x2F, 0x7D,
	0x04, 0xCD, 0x34, 0xA8, 0xFF, 0xFC, 0xFD, 0x4B,
};

static EVP_PKEY *generate_rsa_key ();

int main ()
{
	X509               *x509;
	ASN1_OBJECT        *object;
	ASN1_OCTET_STRING  *octet_string;
	X509_EXTENSION     *ext;
	EVP_PKEY           *pkey;
	X509_NAME          *name;

	if ((pkey = generate_rsa_key ()) == NULL)
		err (-1, "generate_rsa_key");

	if ((x509 = X509_new ()) == NULL)
		err (-1, "X509_new");

	if (X509_set_version (x509, 2) == 0)
		err (-1, "X509_set_version");

	ASN1_INTEGER_set (X509_get_serialNumber (x509), 1);

	if (X509_gmtime_adj (X509_get_notBefore (x509), 0) == NULL)
		err (-1, "X509_get_notBefore");

	if (X509_gmtime_adj (X509_get_notAfter (x509), 60*60*24*365) == NULL)
		err (-1, "X509_get_notAfter");

	if (X509_set_pubkey (x509, pkey) == 0)
		err (-1, "X509_set_pubkey");

	if ((name = X509_get_subject_name (x509)) == NULL)
		err (-1, "X509_get_subject_name");

	X509_NAME_add_entry_by_txt (name, "CN", MBSTRING_ASC, (const unsigned char *)"Dummy Cert", -1, -1, 0);

	if (X509_set_issuer_name(x509, name) == 0)
		err (-1, "X509_set_issuer_name");

	if ((object = OBJ_txt2obj ("2.5.29.35", 1)) == NULL)
		err (-1, "OBJ_txt2obj");

	if ((octet_string = ASN1_OCTET_STRING_new ()) == NULL)
		err (-1, "ASN1_OCTET_STRING_new");

	if (ASN1_OCTET_STRING_set (octet_string, g_data, ARRAY_LEN (g_data)) == 0)
		err (-1, "ASN1_OCTET_STRING_set");

	if ((ext = X509_EXTENSION_create_by_OBJ (NULL, object, 0, octet_string)) == NULL)
		err (-1, "X509_EXTENSION_create_by_OBJ");

	if (X509_add_ext (x509, ext, -1) == 0)
		err (-1, "X509_add_ext");

	if (X509_sign (x509, pkey, EVP_sha256 ()) == 0)
		err (-1, "X509_sign");

	if (PEM_write_X509 (stdout, x509) == 0)
		err (-1, "PEM_write_X509");

	X509_free (x509);
	return 0;
}

static EVP_PKEY *generate_rsa_key ()
{
	RSA        *rsa;
	EVP_PKEY   *pkey;
	BIGNUM     *e;

	if ((pkey = EVP_PKEY_new ()) == NULL)
		err (-1, "EVP_PKEY_new");

	if ((rsa = RSA_new ()) == NULL)
		err (-1, "RSA_new");

	if ((e = BN_new ()) == NULL)
		err (-1, "BN_new");

	if (BN_set_word (e, RSA_F4) == 0)
		err (-1, "BN_set_word");

	if (RSA_generate_key_ex (rsa, 2048, e, NULL) == 0)
		err (-1, "RSA_generate_key_ex");

	if (EVP_PKEY_assign_RSA (pkey, rsa) == 0)
		err (-1, "EVP_PKEY_assign_RSA");

	BN_free (e);

	return pkey;
}
~~~

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
