### PR TITLE
20250703-fixes-for-multi-test-reports

### DIFF
--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -1386,8 +1386,8 @@ static void dilithium_encode_gamma1_19_bits(const sword32* z, byte* s)
                    ((word64)z2 << 40) | ((word64)z3 << 60);
     #else
         word32* s32p = (word32*)s;
-        s32p[0] = (word16)( z0        | (z1 << 20)             );
-        s32p[1] = (word16)((z1 >> 12) | (z2 <<  8) | (z3 << 28));
+        s32p[0] = (word32)( z0        | (z1 << 20)             );
+        s32p[1] = (word32)((z1 >> 12) | (z2 <<  8) | (z3 << 28));
     #endif
         s16p[4] = (word16)((z3 >>  4)                          );
 #else

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -23714,7 +23714,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dh_test(void)
     }
 #endif
 
-#if (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)) && \
+#if !defined(WC_NO_RNG) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)) && \
             !defined(HAVE_SELFTEST)
     agreeSz = DH_TEST_BUF_SIZE;
     agreeSz2 = DH_TEST_BUF_SIZE;
@@ -23740,7 +23740,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dh_test(void)
     if (XMEMCMP(agree, agree2, agreeSz) != 0) {
         ERROR_OUT(WC_TEST_RET_ENC_NC, done);
     }
-#endif /* (!HAVE_FIPS || FIPS_VERSION_GE(7,0)) && !HAVE_SELFTEST */
+#endif /* !WC_NO_RNG && (!HAVE_FIPS || FIPS_VERSION_GE(7,0)) && !HAVE_SELFTEST */
 
     /* Test DH key import / export */
 #if defined(WOLFSSL_DH_EXTRA) && !defined(NO_FILESYSTEM) && \

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -725,7 +725,7 @@ int fp_leading_bit(fp_int *a);
 int fp_unsigned_bin_size(const fp_int *a);
 int fp_read_unsigned_bin(fp_int *a, const unsigned char *b, int c);
 int fp_to_unsigned_bin(fp_int *a, unsigned char *b);
-int fp_to_unsigned_bin_len_ct(fp_int *a, unsigned char *b, int c);
+int fp_to_unsigned_bin_len_ct(fp_int *a, unsigned char *out, int outSz);
 int fp_to_unsigned_bin_len(fp_int *a, unsigned char *b, int c);
 int fp_to_unsigned_bin_at_pos(int x, fp_int *t, unsigned char *b);
 


### PR DESCRIPTION
`wolfcrypt/src/dilithium.c`: fix cast flubs in `dilithium_encode_gamma1_19_bits()` (fixes `quantum-safe-wolfssl-all-gcc-latest-m32`).

`wolfcrypt/test/test.c`: fix gate in `dh_test()` (fixes `disable-sha256`).

`wolfssl/wolfcrypt/tfm.h`: fix arg names in `fp_to_unsigned_bin_len_ct()` prototype to match `tfm.c` (fixes `readability-inconsistent-declaration-parameter-name` in `clang-tidy-fips-140-3-defaults` etc.).

tested with `check-source-text` and the scenarios named in the commit msgs.
