### PR TITLE
API test ASN: must not have NO_ASN defined

### DIFF
--- a/.github/workflows/psk.yml
+++ b/.github/workflows/psk.yml
@@ -1,0 +1,51 @@
+name: PSK Tests
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  make_check:
+    strategy:
+      matrix:
+        config: [
+          # Add new configs here
+          '--enable-psk C_EXTRA_FLAGS=-DWOLFSSL_STATIC_PSK --disable-rsa --disable-ecc --disable-dh',
+          '--disable-oldtls --disable-tls13 --enable-psk -disable-rsa --disable-dh -disable-ecc --disable-asn C_EXTRA_FLAGS=-DWOLFSSL_STATIC_PSK --enable-lowresource --enable-singlethreaded --disable-asm --disable-errorstrings --disable-pkcs12 --disable-sha3 --disable-sha224 --disable-sha384 --disable-sha512 --disable-sha --disable-md5 -disable-aescbc --disable-chacha --disable-poly1305 --disable-coding --disable-sp-math-all'
+          '--disable-oldtls --disable-tlsv12 --enable-tls13 --enable-psk -disable-rsa --disable-dh -disable-ecc --disable-asn C_EXTRA_FLAGS=-DWOLFSSL_STATIC_PSK --enable-lowresource --enable-singlethreaded --disable-asm --disable-errorstrings --disable-pkcs12 --disable-sha3 --disable-sha224 --disable-sha384 --disable-sha512 --disable-sha --disable-md5 -disable-aescbc --disable-chacha --disable-poly1305 --disable-coding --disable-sp-math-all'
+        ]
+    name: make check
+    if: github.repository_owner == 'wolfssl'
+    runs-on: ubuntu-22.04
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout wolfSSL
+
+      - name: Test wolfSSL
+        run: |
+          ./autogen.sh
+          ./configure ${{ matrix.config }}
+          make -j 4
+          make check
+
+      - name: Print errors
+        if: ${{ failure() }}
+        run: |
+          for file in scripts/*.log
+          do
+              if [ -f "$file" ]; then
+                  echo "${file}:"
+                  cat "$file"
+                  echo "========================================================================"
+              fi
+          done

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -23,6 +23,7 @@
 
 #include <tests/api/test_asn.h>
 
+#ifndef NO_ASN
 static int test_SetShortInt_once(word32 val, byte* valDer, word32 valDerSz)
 {
     EXPECT_DECLS;
@@ -52,11 +53,13 @@ static int test_SetShortInt_once(word32 val, byte* valDer, word32 valDerSz)
 
     return EXPECT_RESULT();
 }
+#endif
 
 int test_SetShortInt(void)
 {
     EXPECT_DECLS;
 
+#ifndef NO_ASN
     byte valDer[MAX_SHORT_SZ] = {0};
 
     /* Corner tests for input size */
@@ -170,6 +173,7 @@ int test_SetShortInt(void)
         valDer[0] = 0x01;
         EXPECT_TEST(test_SetShortInt_once(0x01, valDer, 1));
     }
+#endif
 
     return EXPECT_RESULT();
 }


### PR DESCRIPTION
# Description

Add testing of PSK only to workflows.

# Testing

See new workflows.
Original failure found with:
./configure --enable-psk C_EXTRA_FLAGS=-DWOLFSSL_STATIC_PSK --disable-rsa --disable-ecc --disable-dh

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
