### PR TITLE
Coverity: Check values

### DIFF
--- a/src/dtls.c
+++ b/src/dtls.c
@@ -678,6 +678,8 @@ static int SendStatelessReplyDtls13(const WOLFSSL* ssl, WolfSSL_CH* ch)
             ERROR_OUT(BUFFER_ERROR, dtls13_cleanup);
         if ((sigAlgs.size % 2) != 0)
             ERROR_OUT(BUFFER_ERROR, dtls13_cleanup);
+        if (sigAlgs.size > WOLFSSL_MAX_SIGALGO)
+            ERROR_OUT(BUFFER_ERROR, dtls13_cleanup);
         suites.hashSigAlgoSz = (word16)sigAlgs.size;
         XMEMCPY(suites.hashSigAlgo, sigAlgs.elements, sigAlgs.size);
         haveSA = 1;

--- a/wolfcrypt/src/blake2b.c
+++ b/wolfcrypt/src/blake2b.c
@@ -356,6 +356,8 @@ int blake2b_final( blake2b_state *S, byte *out, byte outlen )
     }
 
     S->buflen -= BLAKE2B_BLOCKBYTES;
+    if ( S->buflen >= (BLAKE2B_BLOCKBYTES * 2) )
+      return BAD_LENGTH_E;
     XMEMCPY( S->buf, S->buf + BLAKE2B_BLOCKBYTES, (wolfssl_word)S->buflen );
   }
 

--- a/wolfcrypt/src/des3.c
+++ b/wolfcrypt/src/des3.c
@@ -1727,6 +1727,10 @@
     {
         word32 blocks = sz / DES_BLOCK_SIZE;
 
+        if (des == NULL || out == NULL || in == NULL) {
+            return BAD_FUNC_ARG;
+        }
+
         while (blocks--) {
             xorbuf((byte*)des->reg, in, DES_BLOCK_SIZE);
             DesProcessBlock(des, (byte*)des->reg, (byte*)des->reg);


### PR DESCRIPTION
# Description

**487948 Untrusted loop bound** - compare `sigAlgs.size` to `WOLFSSL_MAX_SIGALGO` to prevent buffer overflow when using XMEMCPY on `suites.hashSigAlgo`
**351991 Dereference after null check** - return BAD_FUNC_ARG in `wc_Des_CbcEncrypt()` if `des`, `out`, or `in` are NULL
**218595 Overlapping buffer in memory copy** - add `buflen` check to fix undefined behavior caused by XMEMCPY

# Testing

`./configure --enable-all && make check`
