### PR TITLE
ML-DSA Static Memory Fix

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1073,6 +1073,15 @@ static WC_MAYBE_UNUSED int wc_DeleteRsaKey(RsaKey* key, RsaKey** key_p)
 #ifdef WOLFSSL_STATIC_MEMORY
     #if defined(WOLFSSL_STATIC_MEMORY_TEST_SZ)
         static byte gTestMemory[WOLFSSL_STATIC_MEMORY_TEST_SZ];
+    #elif defined(HAVE_DILITHIUM)
+        #if defined(WOLFSSL_DILITHIUM_VERIFY_SMALL_MEM) && \
+            defined(WOLFSSL_DILITHIUM_SIGN_SMALL_MEM) && \
+            defined(WOLFSSL_DILITHIUM_MAKE_KEY_SMALL_MEM) && \
+            defined(WOLFSSL_DILITHIUM_VERIFY_ONLY)
+            static byte gTestMemory[192*1024];  /* Dilithium low mem */
+        #else
+            static byte gTestMemory[576*1024];  /* Dilithium full mem */
+        #endif
     #elif defined(BENCH_EMBEDDED)
         static byte gTestMemory[14000];
     #elif defined(WOLFSSL_CERT_EXT)

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -133,7 +133,18 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
 
     #ifndef LARGEST_MEM_BUCKET
         #ifndef SESSION_CERTS
-            #define LARGEST_MEM_BUCKET 16128
+            #ifdef HAVE_DILITHIUM
+                #if defined(WOLFSSL_DILITHIUM_VERIFY_SMALL_MEM) && \
+                    defined(WOLFSSL_DILITHIUM_SIGN_SMALL_MEM) && \
+                    defined(WOLFSSL_DILITHIUM_MAKE_KEY_SMALL_MEM) && \
+                    defined(WOLFSSL_DILITHIUM_VERIFY_ONLY)
+                    #define LARGEST_MEM_BUCKET 14000 /* Dilithium low mem */
+                #else
+                    #define LARGEST_MEM_BUCKET 131072 /* Dilithium full mem */
+                #endif
+            #else
+                #define LARGEST_MEM_BUCKET 16128
+            #endif
         #elif defined(OPENSSL_EXTRA)
             #ifdef WOLFSSL_TLS13
                 #define LARGEST_MEM_BUCKET 30400
@@ -151,9 +162,24 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
 
     #ifndef WOLFMEM_BUCKETS
         #ifndef SESSION_CERTS
-            /* default size of chunks of memory to separate into */
-            #define WOLFMEM_BUCKETS 64,128,256,512,1024,2432,3456,4544,\
-                                    LARGEST_MEM_BUCKET
+            #ifdef HAVE_DILITHIUM
+                #if defined(WOLFSSL_DILITHIUM_VERIFY_SMALL_MEM) && \
+                    defined(WOLFSSL_DILITHIUM_SIGN_SMALL_MEM) && \
+                    defined(WOLFSSL_DILITHIUM_MAKE_KEY_SMALL_MEM) && \
+                    defined(WOLFSSL_DILITHIUM_VERIFY_ONLY)
+                    /* default size of chunks of memory to separate into */
+                    #define WOLFMEM_BUCKETS 64,128,256,512,1024,2048,4096,\
+                                           8192,LARGEST_MEM_BUCKET
+                #else
+                    /* default size of chunks of memory to separate into */
+                    #define WOLFMEM_BUCKETS 64,128,256,512,1024,8192,32768,\
+                                            65536,LARGEST_MEM_BUCKET
+                #endif
+            #else
+                /* default size of chunks of memory to separate into */
+                #define WOLFMEM_BUCKETS 64,128,256,512,1024,2432,3456,4544,\
+                                        LARGEST_MEM_BUCKET
+            #endif
         #elif defined(OPENSSL_EXTRA)
             /* extra storage in structs for multiple attributes and order */
             #define WOLFMEM_BUCKETS 64,128,256,512,1024,2432,3360,4480,\
@@ -168,7 +194,16 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
     #endif
 
     #ifndef WOLFMEM_DIST
-        #ifndef WOLFSSL_STATIC_MEMORY_SMALL
+        #ifdef HAVE_DILITHIUM
+            #if defined(WOLFSSL_DILITHIUM_VERIFY_SMALL_MEM) && \
+                defined(WOLFSSL_DILITHIUM_SIGN_SMALL_MEM) && \
+                defined(WOLFSSL_DILITHIUM_MAKE_KEY_SMALL_MEM) && \
+                defined(WOLFSSL_DILITHIUM_VERIFY_ONLY)
+                #define WOLFMEM_DIST    20,8,6,10,8,6,4,2,1
+            #else
+                #define WOLFMEM_DIST    30,10,8,15,8,10,8,5,1
+            #endif
+        #elif !defined(WOLFSSL_STATIC_MEMORY_SMALL)
             #define WOLFMEM_DIST    49,10,6,14,5,6,9,1,1
         #else
             /* Low resource and not RSA */


### PR DESCRIPTION
# Description

GDMS ML-DSA Static Memory Profiling / Optimization. Added conditional memory configuration for Dilithium that automatically uses roughly 14KB buckets and 192KB pool when small memory flags are enabled, or 128KB buckets and 576KB pool when they're disabled. 
Small Configure flags: "CFLAGS=-DWOLFSSL_DILITHIUM_VERIFY_SMALL_MEM -DWOLFSSL_DILITHIUM_SIGN_SMALL_MEM -DWOLFSSL_DILITHIUM_MAKE_KEY_SMALL_MEM -DWOLFSSL_DILITHIUM_VERIFY_ONLY"

Fixes zd#20132

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
