### PR TITLE
Initialize Dilithium keyTypeTemp and keySizeTemp

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -952,8 +952,8 @@ static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
     word32 idx;
     dilithium_key* key;
     int keyFormatTemp = 0;
-    int keyTypeTemp;
-    int keySizeTemp;
+    int keyTypeTemp = 0;
+    int keySizeTemp = 0;
 
     /* Allocate a Dilithium key to parse into. */
     key = (dilithium_key*)XMALLOC(sizeof(dilithium_key), heap,


### PR DESCRIPTION
# Description

Initialize `ProcessBufferTryDecodeDilithium` local variables.

```
    int keyTypeTemp = 0;
    int keySizeTemp = 0;
```

Without this change, observed in ESP32 ESP-IDF v5.4 when enabling PQ:
```
FAILED: esp-idf/wolfssl/CMakeFiles/__idf_wolfssl.dir/C_/workspace/wolfssl-gojimmypi-pr/src/ssl.c.obj 
ccache C:\SysGCC\esp32-master\tools\xtensa-esp-elf\esp-14.2.0_20241119\xtensa-esp-elf\bin\xtensa-esp32s3-elf-gcc.exe -DDETECTED_PROJECT_NAME=\"esp-pqc\" -DESP_PLATFORM -DIDF_VER=\"v5.4-552-ge37d33cc1c-dirty\" -DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\" -DSOC_MMU_PAGE_SIZE=CONFIG_MMU_PAGE_SIZE -DSOC_XTAL_FREQ_MHZ=CONFIG_XTAL_FREQ -DWOLFSSL_USER_SETTINGS_DIR=\"C://workspace//wolfssl-gojimmypi-pr//IDE//Espressif//ESP-IDF//examples//esp32-wolfsslPQC//components//wolfssl/include/user_settings.h\" -D_GLIBCXX_HAVE_POSIX_SEMAPHORE -D_GLIBCXX_USE_POSIX_SEMAPHORE -D_GNU_SOURCE -D_POSIX_READER_WRITER_LOCKS -IC:/workspace/wolfssl-gojimmypi-pr/IDE/Espressif/ESP-IDF/examples/esp32-wolfsslPQC/build/VisualGDB/Debug/config -IC:/workspace/wolfssl-gojimmypi-pr/IDE/Espressif/ESP-IDF/examples/esp32-wolfsslPQC/components/wolfssl/include -IC:/workspace/wolfssl-gojimmypi-pr -IC:/workspace/wolfssl-gojimmypi-pr/wolfssl -IC:/workspace/wolfssl-gojimmypi-pr/wolfssl/wolfcrypt -IC:/workspace/wolfssl-gojimmypi-pr/wolfssl/wolfcrypt/port/Espressif -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/freertos/FreeRTOS-Kernel/include/freertos -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_event/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_netif/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_wifi/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/newlib/platform_include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/freertos/config/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/freertos/config/include/freertos -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/freertos/config/xtensa/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/freertos/FreeRTOS-Kernel/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/freertos/FreeRTOS-Kernel/portable/xtensa/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/freertos/FreeRTOS-Kernel/portable/xtensa/include/freertos -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/freertos/esp_additions/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_hw_support/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_hw_support/include/soc -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_hw_support/include/soc/esp32s3 -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_hw_support/dma/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_hw_support/ldo/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_hw_support/debug_probe/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_hw_support/port/esp32s3/. -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_hw_support/port/esp32s3/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/heap/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/heap/tlsf -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/log/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/soc/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/soc/esp32s3 -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/soc/esp32s3/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/soc/esp32s3/register -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/hal/platform_port/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/hal/esp32s3/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/hal/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_rom/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_rom/esp32s3/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_rom/esp32s3/include/esp32s3 -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_rom/esp32s3 -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_common/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_system/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_system/port/soc -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_system/port/include/private -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/xtensa/esp32s3/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/xtensa/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/xtensa/deprecated_include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/lwip/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/lwip/include/apps -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/lwip/include/apps/sntp -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/lwip/lwip/src/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/lwip/port/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/lwip/port/freertos/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/lwip/port/esp32xx/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/lwip/port/esp32xx/include/arch -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/lwip/port/esp32xx/include/sys -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp-tls -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp-tls/esp-tls-crypto -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/mbedtls/port/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/mbedtls/mbedtls/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/mbedtls/mbedtls/library -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/mbedtls/esp_crt_bundle/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/mbedtls/mbedtls/3rdparty/everest/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/mbedtls/mbedtls/3rdparty/p256-m -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/mbedtls/mbedtls/3rdparty/p256-m/p256-m -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_timer/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/driver/deprecated -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/driver/i2c/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/driver/touch_sensor/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/driver/twai/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/driver/touch_sensor/esp32s3/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_pm/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_ringbuf/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_gpio/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_pcnt/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_gptimer/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_spi/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_mcpwm/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_ana_cmpr/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_i2s/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_sdmmc/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/sdmmc/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_sdspi/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_sdio/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_dac/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_rmt/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_tsens/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_sdm/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_i2c/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_uart/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/vfs/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_ledc/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_parlio/include -IC:/SysGCC/esp32-master/esp-idf/v5.4/components/esp_driver_usb_serial_jtag/include -mlongcalls  -fno-builtin-memcpy -fno-builtin-memset -fno-builtin-bzero -fno-builtin-stpcpy -fno-builtin-strncpy -DWOLFSSL_ESP_NO_WATCHDOG=1 -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS -DFOUND_PROTOCOL_EXAMPLES_DIR -DWOLFSSL_USER_SETTINGS -DWOLFSSL_CMAKE_REQUIRED_ESP_TLS=1 -DWOLFSSL_ESPIDF -DWOLFSSL_USER_SETTINGS -g -fdiagnostics-color=always -ffunction-sections -fdata-sections -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=deprecated-declarations -Wextra -Wno-error=extra -Wno-unused-parameter -Wno-sign-compare -Wno-enum-conversion -gdwarf-4 -ggdb -mdisable-hardware-atomics -Og -fno-shrink-wrap -fmacro-prefix-map=C:/workspace/wolfssl-gojimmypi-pr/IDE/Espressif/ESP-IDF/examples/esp32-wolfsslPQC=. -fmacro-prefix-map=C:/SysGCC/esp32-master/esp-idf/v5.4=/IDF -fstrict-volatile-bitfields -fno-jump-tables -fno-tree-switch-conversion -std=gnu17 -Wno-old-style-declaration -MD -MT esp-idf/wolfssl/CMakeFiles/__idf_wolfssl.dir/C_/workspace/wolfssl-gojimmypi-pr/src/ssl.c.obj -MF esp-idf\wolfssl\CMakeFiles\__idf_wolfssl.dir\C_\workspace\wolfssl-gojimmypi-pr\src\ssl.c.obj.d -o esp-idf/wolfssl/CMakeFiles/__idf_wolfssl.dir/C_/workspace/wolfssl-gojimmypi-pr/src/ssl.c.obj -c C:/workspace/wolfssl-gojimmypi-pr/src/ssl.c
In file included from C:/workspace/wolfssl-gojimmypi-pr/src/ssl.c:6608:
C:/workspace/wolfssl-gojimmypi-pr/src/ssl_load.c: In function 'ProcessBufferTryDecodeDilithium':
C:/workspace/wolfssl-gojimmypi-pr/src/ssl_load.c:1022:26: error: 'keyTypeTemp' may be used uninitialized [-Werror=maybe-uninitialized]
 1022 |                 *keyType = keyTypeTemp;
      |                 ~~~~~~~~~^~~~~~~~~~~~~
C:/workspace/wolfssl-gojimmypi-pr/src/ssl_load.c:955:9: note: 'keyTypeTemp' was declared here
  955 |     int keyTypeTemp;
      |         ^~~~~~~~~~~
C:/workspace/wolfssl-gojimmypi-pr/src/ssl_load.c:1023:26: error: 'keySizeTemp' may be used uninitialized [-Werror=maybe-uninitialized]
 1023 |                 *keySize = keySizeTemp;
      |                 ~~~~~~~~~^~~~~~~~~~~~~
C:/workspace/wolfssl-gojimmypi-pr/src/ssl_load.c:956:9: note: 'keySizeTemp' was declared here
  956 |     int keySizeTemp;
      |         ^~~~~~~~~~~
cc1.exe: some warnings being treated as errors
ninja: build stopped: subcommand failed.
```
Fixes zd# related to #20133

# Testing

How did you test?

untested

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
