### PR TITLE
Fix build issue with ML-DSA 44 only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1470,18 +1470,20 @@ ENABLED_MLKEM_DECAPSULATE=no
 for v in `echo $ENABLED_MLKEM | tr "," " "`
 do
   case $v in
-  yes|all)
+  yes)
     ENABLED_MLKEM512=yes
     ENABLED_MLKEM768=yes
     ENABLED_MLKEM1024=yes
     ENABLED_MLKEM_MAKE_KEY=yes
     ENABLED_MLKEM_ENCAPSULATE=yes
     ENABLED_MLKEM_DECAPSULATE=yes
-    if test "$v" = "all"
-    then
-        ENABLED_ML_KEM=yes
-        ENABLED_ORIGINAL=yes
-    fi
+    ;;
+  all)
+    ENABLED_MLKEM_MAKE_KEY=yes
+    ENABLED_MLKEM_ENCAPSULATE=yes
+    ENABLED_MLKEM_DECAPSULATE=yes
+    ENABLED_ML_KEM=yes
+    ENABLED_ORIGINAL=yes
     ;;
   no)
     ;;

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -6682,7 +6682,6 @@ static int dilithium_sign_with_seed_mu(dilithium_key* key,
                             ze += DILITHIUM_GAMMA1_17_ENC_BITS / 2 *
                                   DILITHIUM_N / 4;
                         }
-                        else
                     #endif
                     #if !defined(WOLFSSL_NO_ML_DSA_65) || \
                         !defined(WOLFSSL_NO_ML_DSA_87)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -110,6 +110,8 @@ const byte const_byte_array[] = "A+Gd\0\0\0";
     heap_baselineAllocs = wolfCrypt_heap_peakAllocs_checkpoint();            \
     heap_baselineBytes = wolfCrypt_heap_peakBytes_checkpoint();              \
     }
+#define PRINT_HEAP_ADDRESS(p)                                        \
+    printf("Allocated address: %p", (void *)(p));
 #else
     #define PRINT_HEAP_CHECKPOINT(b, i) WC_DO_NOTHING;
     #define PRINT_HEAP_ADDRESS(p) WC_DO_NOTHING;


### PR DESCRIPTION
# Description

Fix build issue with ML-DSA 44 only. Fix --enable-mlkem=all to enable features (keygen/enc/dec) to match --enable-dilithium behavior and allow uses like: `--enable-mlkem=all,512,small`. Fix issue building mem track with missing `PRINT_HEAP_ADDRESS` (reproduced with `--enable-trackmemory=verbose --enable-stacksize=verbose`).

```
wolfcrypt/src/dilithium.c:6696:21: error: expected expression before '}' token
 6696 |                     }
      |
```

```
Configuration                        | Algorithm   | Stack    | Heap     | Total    | Heap 
                                     |             | (bytes)  | (bytes)  | (bytes)  | Allocs
-------------------------------------|-------------|----------|----------|----------|--------
Small code                           | MLKEM-512   | 23,568   | 7,552    | 31,120   | 3
                                     | MLKEM-768   | 32,672   | 11,968   | 44,640   | 3
                                     | MLKEM-1024  | 42,400   | 17,568   | 59,968   | 3
                                     | MLDSA-44    | 15,904   | 50,304   | 66,208   | 2
                                     | MLDSA-65    | 17,440   | 77,952   | 95,392   | 2
                                     | MLDSA-87    | 19,376   | 120,960  | 140,336  | 2

Small code with small mem            | MLKEM-512   | 23,696   | 3,968    | 27,664   | 3
                                     | MLKEM-768   | 32,928   | 5,824    | 38,752   | 3
                                     | MLKEM-1024  | 42,656   | 7,840    | 50,496   | 3
                                     | MLDSA-44    | 15,856   | 15,656   | 31,512   | 2
                                     | MLDSA-65    | 17,392   | 20,776   | 38,168   | 2
                                     | MLDSA-87    | 19,328   | 26,920   | 46,248   | 2

Small code with small mem + stack    | MLKEM-512   | 2,112    | 19,306   | 21,418   | 17
                                     | MLKEM-768   | 2,112    | 27,306   | 29,418   | 17
                                     | MLKEM-1024  | 2,112    | 35,786   | 37,898   | 17
                                     | MLDSA-44    | 2,112    | 28,211   | 30,323   | 7
                                     | MLDSA-65    | 2,112    | 33,331   | 35,443   | 7
                                     | MLDSA-87    | 2,160    | 39,475   | 41,635   | 7
```

# Testing

```
./configure --enable-dilithium=all,44,small --enable-mlkem=all,512,small --enable-trackmemory=verbose --enable-stacksize=verbose && make && ./wolfcrypt/test/testwolfcrypt
./configure --enable-dilithium=all,44,small --enable-mlkem=all,512,small CFLAGS="-DWOLFSSL_DILITHIUM_VERIFY_SMALL_MEM -DWOLFSSL_DILITHIUM_SIGN_SMALL_MEM -DWOLFSSL_DILITHIUM_MAKE_KEY_SMALL_MEM -DWOLFSSL_MLKEM_ENCAPSULATE_SMALL_MEM -DWOLFSSL_MLKEM_MAKEKEY_SMALL_MEM" --enable-trackmemory=verbose --enable-stacksize=verbose && make && ./wolfcrypt/test/testwolfcrypt
./configure --enable-dilithium=all,44,small --enable-mlkem=all,512,small CFLAGS="-DWOLFSSL_DILITHIUM_VERIFY_SMALL_MEM -DWOLFSSL_DILITHIUM_SIGN_SMALL_MEM -DWOLFSSL_DILITHIUM_MAKE_KEY_SMALL_MEM -DWOLFSSL_MLKEM_ENCAPSULATE_SMALL_MEM -DWOLFSSL_MLKEM_MAKEKEY_SMALL_MEM" --enable-trackmemory=verbose --enable-stacksize=verbose --enable-smallstack && make && ./wolfcrypt/test/testwolfcrypt
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
