### PR TITLE
Fix possible memory leak with X509 reference counter when using x509small

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4849,7 +4849,7 @@ void FreeX509(WOLFSSL_X509* x509)
     }
     #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
-    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
+    #if defined(OPENSSL_EXTRA_X509_SMALL) || defined(OPENSSL_EXTRA)
         wolfSSL_RefFree(&x509->ref);
     #endif
 }


### PR DESCRIPTION
# Description

Fix issue with X509 reference counter with `--enable-opensslextra=x509small` or `OPENSSL_EXTRA_X509_SMALL`. Thank you Mohre. Reported in #8938.

# Testing

```
./configure --enable-opensslextra=x509small --enable-valgrind CFLAGS="-DWOLFSSL_NO_ATOMICS" && make
valgrind -v --tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=5 ./tests/unit.test
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
