### PR TITLE
20250710-linuxkm-crng-fixes

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -26199,9 +26199,9 @@ static wcchar END_PKCS7            = "-----END PKCS7-----";
     static wcchar END_DSA_PRIV     = "-----END DSA PRIVATE KEY-----";
 #endif
 #ifdef OPENSSL_EXTRA
-    wcchar BEGIN_PRIV_KEY_PREFIX = "-----BEGIN";
-    wcchar PRIV_KEY_SUFFIX = "PRIVATE KEY-----";
-    wcchar END_PRIV_KEY_PREFIX   = "-----END";
+    static wcchar BEGIN_PRIV_KEY_PREFIX = "-----BEGIN";
+    static wcchar PRIV_KEY_SUFFIX = "PRIVATE KEY-----";
+    static wcchar END_PRIV_KEY_PREFIX   = "-----END";
 #endif
 static wcchar BEGIN_PUB_KEY        = "-----BEGIN PUBLIC KEY-----";
 static wcchar END_PUB_KEY          = "-----END PUBLIC KEY-----";


### PR DESCRIPTION
`linuxkm/lkcapi_sha_glue.c`: add interruptibility and additional relaxation where possible, and fix a leaked lock scenario, in `get_drbg_n()`, `wc_linuxkm_drbg_seed()`, `wc_mix_pool_bytes()`, and `wc_crng_reseed()`;

`wolfcrypt/src/asn.c`: add a couple static attributes missed on the previous round of fixups.

tested with `check-source-text quantum-safe-wolfssl-all-crypto-only-intelasm-fips-dev-linuxkm-next-insmod`
