### PR TITLE
improper access of sp_int_minimal using sp_int

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -5102,7 +5102,7 @@ static void _sp_init_size(sp_int* a, unsigned int size)
 #endif
     _sp_zero((sp_int*)am);
 
-    a->size = (sp_size_t)size;
+    am->size = (sp_size_t)size;
 }
 
 /* Initialize the multi-precision number to be zero with a given max size.

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -932,7 +932,7 @@ typedef struct sp_int_minimal {
     sp_size_t    size;
 #ifdef WOLFSSL_SP_INT_NEGATIVE
     /** Indicates whether number is 0/positive or negative.  */
-    sp_uint8     sign;
+    sp_sign_t    sign;
 #endif
 #ifdef HAVE_WOLF_BIGINT
     /** Unsigned binary (big endian) representation of number. */


### PR DESCRIPTION
# Description

User was getting a compiler warning about an out of bounds access for an array. This turned out to be mostly unrelated to arrays as the issue appears due to a pointer dereference.

It would seem that an sp_int_minimal must be used instead of an sp_int and this fixes the issue.

related thread: https://bugzilla.redhat.com/show_bug.cgi?id=2047439

Also found an sp_uint8 in the sp_int_minimal struct that was not updated to sp_sign_t. This is unrelated to the compiler warning.

Fixes GH issue #8951

# Testing

GH issue #8951 describes the procedure for reproducing the issue.

I ended up using their fanpico project to build and test. Run cmake and use make to get the warning.

Some dependencies that were necessary to get cmake working for this project:
* arm-none-eabi-binutils-cs
* arm-none-eabi-gcc-cs
* arm-none-eabi-gcc-cs-c++
* arm-none-eabi-newlib

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
