### PR TITLE
Add wolfSSL_GetAllocators PSRAM support for Espressif ESP32

### DIFF
--- a/wolfcrypt/src/port/Espressif/esp32_sha.c
+++ b/wolfcrypt/src/port/Espressif/esp32_sha.c
@@ -1311,7 +1311,8 @@ int esp_sha_try_hw_lock(WC_ESP32SHA* ctx)
         }
     }
 
-#ifdef ESP_MONITOR_HW_TASK_LOCK
+#if defined(ESP_MONITOR_HW_TASK_LOCK) || \
+   (defined(WOLFSSL_DEBUG_MUTEX) && WOLFSSL_DEBUG_MUTEX)
     /* Nothing happening here other than messages based on mutex states */
     if (mutex_ctx_task == 0 || mutex_ctx_owner == 0) {
         /* no known stray mutex task owner */
@@ -1347,13 +1348,15 @@ int esp_sha_try_hw_lock(WC_ESP32SHA* ctx)
             } /* mutex owner ESP32_SHA_FREED check */
         } /* mutex_ctx_task is current task */
         else {
+#ifdef WOLFSSL_ESP32_HW_LOCK_DEBUG
             ESP_LOGW(TAG, "Warning: sha mutex unlock from unexpected task.");
             ESP_LOGW(TAG, "Locking task: 0x%x", (word32)mutex_ctx_task);
             ESP_LOGW(TAG, "This xTaskGetCurrentTaskHandle: 0x%x",
                           (word32)xTaskGetCurrentTaskHandle());
+#endif
         }
     }
-#endif /* ESP_MONITOR_HW_TASK_LOCK */
+#endif /* ESP_MONITOR_HW_TASK_LOCK || WOLFSSL_DEBUG_MUTEX */
 
     /* check if this SHA has been operated as SW or HW, or not yet init */
     if (ctx->mode == ESP32_SHA_INIT) {

--- a/wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h
@@ -212,8 +212,23 @@ WOLFSSL_LOCAL esp_err_t esp_sdk_wifi_show_ip(void);
 * Debug helpers
 ******************************************************************************/
 WOLFSSL_LOCAL esp_err_t sdk_init_meminfo(void);
+
+#if defined(DEBUG_WOLFSSL_MALLOC) || defined(DEBUG_WOLFSSL)
 WOLFSSL_LOCAL void* wc_debug_pvPortMalloc(size_t size,
                                 const char* file, int line, const char* fname);
+WOLFSSL_LOCAL void wc_debug_pvPortFree(void *ptr,
+                                const char* file, int line, const char* fname);
+#ifndef WOLFSSL_NO_REALLOC
+WOLFSSL_LOCAL void* wc_debug_pvPortRealloc(void* ptr, size_t size,
+                                const char* file, int line, const char* fname);
+#endif
+#else
+WOLFSSL_LOCAL void* wc_pvPortMalloc(size_t size);
+WOLFSSL_LOCAL void wc_pvPortFree(void *ptr);
+#ifndef WOLFSSL_NO_REALLOC
+WOLFSSL_LOCAL void* wc_pvPortRealloc(void* ptr, size_t size);
+#endif
+#endif /*DEBUG_WOLFSSL_MALLOC || DEBUG_WOLFSSL */
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
# Description

Improves and expands `DEBUG_WOLFSSL_MALLOC` for Espressif ESP32 targts.

Adds support for `wolfSSL_SetAllocators` and ability to push wolfSSL heap into PSRAM.

Fixes zd#

May be of interest to: 20133 and 20177

# Testing

How did you test?

manually tested. more testing in progress.,

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
