### PR TITLE
Make properties related to TLS handshake hidden for TSIP TLS user-context structure

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -3559,7 +3559,7 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
             cbInfo->side = side;
         #elif defined(WOLFSSL_RENESAS_TSIP_TLS)
             TsipUserCtx* cbInfo = (TsipUserCtx*)ctx;
-            cbInfo->key_side = side;
+            _ACCESSOR(cbInfo)->key_side = side;
         #endif
         ret = ssl->ctx->EncryptKeysCb(ssl, ctx);
     }

--- a/src/tls.c
+++ b/src/tls.c
@@ -52,7 +52,7 @@
 #endif
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
-    #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
+    #include <wolfssl/wolfcrypt/port/Renesas/renesas_tsip_internal.h>
 #endif
 
 #include <wolfssl/wolfcrypt/hpke.h>

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -40,7 +40,7 @@
 #elif defined(WOLFSSL_RENESAS_TSIP_TLS) || \
       defined(WOLFSSL_RENESAS_TSIP_CRYPTONLY)
 
-    #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
+    #include <wolfssl/wolfcrypt/port/Renesas/renesas_tsip_internal.h>
     #define cmn_hw_lock    tsip_hw_lock
     #define cmn_hw_unlock  tsip_hw_unlock
 
@@ -494,7 +494,7 @@ int wc_CryptoCb_CryptInitRenesasCmn(struct WOLFSSL* ssl, void* ctx)
         if (gdevId < 0) {
             gdevId = INITIAL_DEVID;
         }
-        cbInfo->devId = gdevId++;
+        _ACCESSOR(cbInfo)->devId = gdevId++;
         cmn_hw_unlock();
     }
     else {
@@ -502,7 +502,7 @@ int wc_CryptoCb_CryptInitRenesasCmn(struct WOLFSSL* ssl, void* ctx)
         return INVALID_DEVID;
     }
 
-    if (wc_CryptoCb_RegisterDevice(cbInfo->devId,
+    if (wc_CryptoCb_RegisterDevice(_ACCESSOR(cbInfo)->devId,
                             Renesas_cmn_CryptoDevCb, cbInfo) < 0) {
         /* undo devId number */
         gdevId--;
@@ -513,12 +513,12 @@ int wc_CryptoCb_CryptInitRenesasCmn(struct WOLFSSL* ssl, void* ctx)
        !defined(WOLFSSL_RENESAS_TSIP_CRYPTONLY) && \
        !defined(HAVE_RENESAS_SYNC)
     if (ssl)
-        wolfSSL_SetDevId(ssl, cbInfo->devId);
+        wolfSSL_SetDevId(ssl, _ACCESSOR(cbInfo)->devId);
    #endif
 
-    gCbCtx[cbInfo->devId - INITIAL_DEVID] = (void*)cbInfo;
+    gCbCtx[_ACCESSOR(cbInfo)->devId - INITIAL_DEVID] = (void*)cbInfo;
 
-    return cbInfo->devId;
+    return _ACCESSOR(cbInfo)->devId;
 }
 
 /* Renesas Security Library Common Method
@@ -764,8 +764,8 @@ static int Renesas_cmn_EncryptKeys(WOLFSSL* ssl, void* ctx)
  #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     TsipUserCtx* cbInfo = (TsipUserCtx*)ctx;
 
-    if (cbInfo->session_key_set == 1) {
-        switch(cbInfo->key_side) {
+    if (_ACCESSOR(cbInfo)->session_key_set == 1) {
+        switch(_ACCESSOR(cbInfo)->key_side) {
  #elif defined(WOLFSSL_RENESAS_FSPSM_TLS)
     FSPSM_ST* cbInfo = (FSPSM_ST*)ctx;
 
@@ -820,7 +820,7 @@ WOLFSSL_LOCAL int Renesas_cmn_generateSessionKey(WOLFSSL* ssl, void* ctx)
     WOLFSSL_ENTER("Renesas_cmn_generateSessionKey");
     if (Renesas_cmn_usable(ssl, 0)) {
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
-        ret = wc_tsip_generateSessionKey(ssl, cbInfo, cbInfo->devId);
+        ret = wc_tsip_generateSessionKey(ssl, cbInfo, _ACCESSOR(cbInfo)->devId);
 #elif defined(WOLFSSL_RENESAS_FSPSM_TLS)
         ret = wc_fspsm_generateSessionKey(ssl, ctx, cbInfo->devId);
 #endif

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
@@ -40,7 +40,7 @@
 #include <wolfssl/internal.h>
 #endif
 #include <wolfssl/wolfcrypt/aes.h>
-#include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
+#include "wolfssl/wolfcrypt/port/Renesas/renesas_tsip_internal.h"
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
 #else
@@ -100,7 +100,7 @@ WOLFSSL_LOCAL int tsip_Tls13AesEncrypt(
 {
     int ret = 0;
     e_tsip_err_t    err = TSIP_SUCCESS;
-    TsipUserCtx*    tuc = NULL;
+    TsipUserCtx_Internal* tuc = NULL;
     e_tsip_tls13_cipher_suite_t cs;
     word32  cipher[(WC_AES_BLOCK_SIZE + TSIP_AES_GCM_AUTH_TAG_SIZE) /
                                                              sizeof(word32)];
@@ -122,7 +122,7 @@ WOLFSSL_LOCAL int tsip_Tls13AesEncrypt(
     }
 
     /* get user context for TSIP */
-    tuc = ssl->RenesasUserCtx;
+    tuc = (TsipUserCtx_Internal*)((TsipUserCtx*)ssl->RenesasUserCtx)->internal;
     if (tuc == NULL) {
         WOLFSSL_MSG("TsipUserCtx hasn't been set to ssl.");
         return CRYPTOCB_UNAVAILABLE;
@@ -247,7 +247,7 @@ WOLFSSL_LOCAL int tsip_Tls13AesDecrypt(
 {
     int ret = 0;
     e_tsip_err_t    err = TSIP_SUCCESS;
-    TsipUserCtx*    tuc = NULL;
+    TsipUserCtx_Internal* tuc = NULL;
     e_tsip_tls13_cipher_suite_t cs;
     word32          cipher[WC_AES_BLOCK_SIZE / sizeof(word32)];
     word32          plain[WC_AES_BLOCK_SIZE / sizeof(word32)];
@@ -269,7 +269,7 @@ WOLFSSL_LOCAL int tsip_Tls13AesDecrypt(
     }
 
     /* get user context for TSIP */
-    tuc = ssl->RenesasUserCtx;
+    tuc = (TsipUserCtx_Internal*)((TsipUserCtx*)(ssl->RenesasUserCtx))->internal;
     if (tuc == NULL) {
         WOLFSSL_MSG("TsipUserCtx hasn't been set to ssl.");
         return CRYPTOCB_UNAVAILABLE;
@@ -414,11 +414,11 @@ static int _tsip_cpAesKeyIndex2AesCtx(wc_CryptoInfo* info, TsipUserCtx* cb)
     }
 
     if (aes && cb->user_aes256_key_set == 1) {
-        XMEMCPY(&aes->ctx.tsip_keyIdx,&cb->user_aes256_key_index,
+        XMEMCPY(&aes->ctx.tsip_keyIdx, &cb->user_aes256_key_index,
                     sizeof(tsip_aes_key_index_t));
             aes->ctx.keySize = 32;
     }else if (aes && cb->user_aes128_key_set == 1) {
-        XMEMCPY(&aes->ctx.tsip_keyIdx,&cb->user_aes128_key_index,
+        XMEMCPY(&aes->ctx.tsip_keyIdx, &cb->user_aes128_key_index,
                     sizeof(tsip_aes_key_index_t));
         aes->ctx.keySize = 16;
     } else
@@ -439,16 +439,25 @@ int wc_tsip_AesCipher(int devIdArg, wc_CryptoInfo* info, void* ctx)
     }
 
     (void)devIdArg;
-
+    (void)_tsip_cpAesKeyIndex2AesCtx;
     if (info->algo_type == WC_ALGO_TYPE_CIPHER) {
 #if !defined(NO_AES)
 #ifdef HAVE_AESGCM
         if (info->cipher.type == WC_CIPHER_AES_GCM
         #ifdef WOLFSSL_RENESAS_TSIP_TLS
-            && cbInfo != NULL && cbInfo->session_key_set == 1
+            && cbInfo != NULL && _ACCESSOR(cbInfo)->session_key_set == 1
         #endif
             ) {
-            ret = _tsip_cpAesKeyIndex2AesCtx(info, cbInfo);
+            /* prioritize TLS Session Key than User TSIP Aes Key */
+            /* TODO : identify if Aes API is called through      */
+            /* while doing TLS handshake or Crypt API            */
+        #ifdef WOLFSSL_RENESAS_TSIP_TLS
+            if (_ACCESSOR(cbInfo)->session_key_set == 1)
+                ret = 0;
+            else
+        #else
+                ret = _tsip_cpAesKeyIndex2AesCtx(info, cbInfo);
+        #endif
             if (ret != 0) {
                 WOLFSSL_MSG("Failed to copy Aes Key Index from "
                             "UserCtx to AES Ctx");
@@ -489,12 +498,18 @@ int wc_tsip_AesCipher(int devIdArg, wc_CryptoInfo* info, void* ctx)
     #ifdef WOLFSSL_AES_COUNTER
         if (info->cipher.type == WC_CIPHER_AES_CTR
         #ifdef WOLFSSL_RENESAS_TSIP_TLS
-            && cbInfo != NULL && cbInfo->session_key_set == 1
+            && cbInfo != NULL && _ACCESSOR(cbInfo)->session_key_set == 1
         #endif
             ) {
             int remain = (int)(info->cipher.aesctr.sz % WC_AES_BLOCK_SIZE);
             if (remain == 0) {
-                ret = _tsip_cpAesKeyIndex2AesCtx(info, cbInfo);
+            #ifdef WOLFSSL_RENESAS_TSIP_TLS
+                if (_ACCESSOR(cbInfo)->session_key_set == 1)
+                    ret = 0;
+                else
+            #else
+                    ret = _tsip_cpAesKeyIndex2AesCtx(info, cbInfo);
+            #endif
                 if (ret != 0) {
                     WOLFSSL_MSG("Failed to copy Aes Key Index from "
                                 "UserCtx to AES Ctx");
@@ -513,10 +528,16 @@ int wc_tsip_AesCipher(int devIdArg, wc_CryptoInfo* info, void* ctx)
     #ifdef HAVE_AES_CBC
         if (info->cipher.type == WC_CIPHER_AES_CBC
         #ifdef WOLFSSL_RENESAS_TSIP_TLS
-            && cbInfo != NULL && cbInfo->session_key_set == 1
+            && cbInfo != NULL && _ACCESSOR(cbInfo)->session_key_set == 1
         #endif
             ) {
-            ret = _tsip_cpAesKeyIndex2AesCtx(info, cbInfo);
+        #ifdef WOLFSSL_RENESAS_TSIP_TLS
+            if (_ACCESSOR(cbInfo)->session_key_set == 1)
+                ret = 0;
+            else
+        #else
+                ret = _tsip_cpAesKeyIndex2AesCtx(info, cbInfo);
+        #endif
             if (ret != 0) {
                 WOLFSSL_MSG("Failed to copy Aes Key Index from "
                             "UserCtx to AES Ctx");
@@ -790,7 +811,7 @@ int wc_tsip_AesGcmEncrypt(
     uint32_t ivSz_l = 0;
 
     tsip_aes_key_index_t key_client_aes;
-    TsipUserCtx *userCtx;
+    TsipUserCtx* userCtx;
 
     WOLFSSL_ENTER("wc_tsip_AesGcmEncrypt");
 
@@ -819,7 +840,7 @@ int wc_tsip_AesGcmEncrypt(
         finalFn  = R_TSIP_Aes256GcmEncryptFinal;
     }
 
-    userCtx = (TsipUserCtx*)ctx;
+    userCtx = ((TsipUserCtx*)ctx);
 
     /* buffer for cipher data output must be multiple of WC_AES_BLOCK_SIZE */
     cipherBufSz = ((sz / WC_AES_BLOCK_SIZE) + 1) * WC_AES_BLOCK_SIZE;
@@ -850,15 +871,15 @@ int wc_tsip_AesGcmEncrypt(
 
     #if defined(WOLFSSL_RENESAS_TSIP_TLS)
         if (ret == 0 &&
-            userCtx->session_key_set == 1) {
+            _ACCESSOR(userCtx)->session_key_set == 1) {
             /* generate AES-GCM session key. The key stored in
              * Aes.ctx.tsip_keyIdx is not used here.
              */
             err = R_TSIP_TlsGenerateSessionKey(
-                    userCtx->tsip_cipher,
-                    (uint32_t*)userCtx->tsip_masterSecret,
-                    (uint8_t*) userCtx->tsip_clientRandom,
-                    (uint8_t*) userCtx->tsip_serverRandom,
+                    _ACCESSOR(userCtx)->tsip_cipher,
+                    (uint32_t*)_ACCESSOR(userCtx)->tsip_masterSecret,
+                    (uint8_t*) _ACCESSOR(userCtx)->tsip_clientRandom,
+                    (uint8_t*) _ACCESSOR(userCtx)->tsip_serverRandom,
                     &iv[AESGCM_IMP_IV_SZ], /* use exp_IV */
                     NULL,
                     NULL,
@@ -988,7 +1009,7 @@ int wc_tsip_AesGcmDecrypt(
     uint32_t ivSz_l = 0;
 
     tsip_aes_key_index_t key_server_aes;
-    TsipUserCtx *userCtx;
+    TsipUserCtx* userCtx;
 
     WOLFSSL_ENTER("wc_tsip_AesGcmDecrypt");
 
@@ -1018,7 +1039,7 @@ int wc_tsip_AesGcmDecrypt(
         finalFn  = R_TSIP_Aes256GcmDecryptFinal;
     }
 
-    userCtx = (TsipUserCtx *)ctx;
+    userCtx = ((TsipUserCtx *)ctx);
 
     /* buffer for plain data output must be multiple of WC_AES_BLOCK_SIZE */
     plainBufSz = ((sz / WC_AES_BLOCK_SIZE) + 1) * WC_AES_BLOCK_SIZE;
@@ -1049,15 +1070,15 @@ int wc_tsip_AesGcmDecrypt(
 
     #if defined(WOLFSSL_RENESAS_TSIP_TLS)
         if (ret == 0 &&
-            userCtx->session_key_set == 1) {
+            _ACCESSOR(userCtx)->session_key_set == 1) {
             /* generate AES-GCM session key. The key stored in
              * Aes.ctx.tsip_keyIdx is not used here.
              */
             err = R_TSIP_TlsGenerateSessionKey(
-                    userCtx->tsip_cipher,
-                    (uint32_t*)userCtx->tsip_masterSecret,
-                    (uint8_t*) userCtx->tsip_clientRandom,
-                    (uint8_t*) userCtx->tsip_serverRandom,
+                    _ACCESSOR(userCtx)->tsip_cipher,
+                    (uint32_t*)_ACCESSOR(userCtx)->tsip_masterSecret,
+                    (uint8_t*) _ACCESSOR(userCtx)->tsip_clientRandom,
+                    (uint8_t*) _ACCESSOR(userCtx)->tsip_serverRandom,
                     (uint8_t*)&iv[AESGCM_IMP_IV_SZ], /* use exp_IV */
                     NULL,
                     NULL,

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_sha.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_sha.c
@@ -43,7 +43,7 @@
 
 #include <wolfssl/wolfcrypt/memory.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
+#include <wolfssl/wolfcrypt/port/Renesas/renesas_tsip_internal.h>
 
 extern struct WOLFSSL_HEAP_HINT* tsip_heap_hint;
 
@@ -82,7 +82,7 @@ WOLFSSL_LOCAL int tsip_Tls13GetHmacMessages(struct WOLFSSL* ssl, byte* mac)
         if (tuc == NULL) {
             ret = CRYPTOCB_UNAVAILABLE;
         }
-        else if (!tuc->HandshakeClientTrafficKey_set) {
+        else if (!_ACCESSOR(tuc)->HandshakeClientTrafficKey_set) {
             WOLFSSL_MSG("Client handshake traffic keys aren't created by TSIP");
             ret = CRYPTOCB_UNAVAILABLE;
         }
@@ -97,8 +97,8 @@ WOLFSSL_LOCAL int tsip_Tls13GetHmacMessages(struct WOLFSSL* ssl, byte* mac)
     if (ret == 0) {
         if ((ret = tsip_hw_lock()) == 0) {
 
-            err = R_TSIP_Sha256HmacGenerateInit(&(tuc->hmacFinished13Handle),
-                                                &(tuc->clientFinished13Idx));
+            err = R_TSIP_Sha256HmacGenerateInit(&(_ACCESSOR(tuc)->hmacFinished13Handle),
+                                                &(_ACCESSOR(tuc)->clientFinished13Idx));
 
             if (err != TSIP_SUCCESS) {
                 WOLFSSL_MSG("R_TSIP_Sha256HmacGenerateInit failed");
@@ -108,7 +108,7 @@ WOLFSSL_LOCAL int tsip_Tls13GetHmacMessages(struct WOLFSSL* ssl, byte* mac)
             if (ret == 0) {
 
                 err = R_TSIP_Sha256HmacGenerateUpdate(
-                                                &(tuc->hmacFinished13Handle),
+                                                &(_ACCESSOR(tuc)->hmacFinished13Handle),
                                                 (uint8_t*)hash,
                                                 WC_SHA256_DIGEST_SIZE);
 
@@ -120,7 +120,7 @@ WOLFSSL_LOCAL int tsip_Tls13GetHmacMessages(struct WOLFSSL* ssl, byte* mac)
 
             if (ret == 0) {
                 err = R_TSIP_Sha256HmacGenerateFinal(
-                                            &(tuc->hmacFinished13Handle), mac);
+                                            &(_ACCESSOR(tuc)->hmacFinished13Handle), mac);
                 if (err != TSIP_SUCCESS) {
                     WOLFSSL_MSG("R_TSIP_Sha256HmacGenerateFinal failed");
                     ret = WC_HW_E;
@@ -185,7 +185,7 @@ WOLFSSL_LOCAL int tsip_StoreMessage(struct WOLFSSL* ssl, const byte* data,
 
     /* check if TSIP is used for this session */
     if (ret == 0) {
-        if (!tuc->Dhe_key_set) {
+        if (!_ACCESSOR(tuc)->Dhe_key_set) {
             WOLFSSL_MSG("DH key not set.");
             ret = CRYPTOCB_UNAVAILABLE;
         }
@@ -195,7 +195,7 @@ WOLFSSL_LOCAL int tsip_StoreMessage(struct WOLFSSL* ssl, const byte* data,
     if (ret == 0) {
         c24to32(&data[1], &messageSz);
 
-        bag = &(tuc->messageBag);
+        bag = &(_ACCESSOR(tuc)->messageBag);
 
         if (bag->msgIdx +1 > MAX_MSGBAG_MESSAGES ||
             bag->buffIdx + sz > MSGBAG_SIZE) {
@@ -246,7 +246,7 @@ WOLFSSL_LOCAL int tsip_GetMessageSha256(struct WOLFSSL* ssl, byte* hash,
         if (tuc == NULL) {
             ret = CRYPTOCB_UNAVAILABLE;
         }
-        bag = &(tuc->messageBag);
+        bag = &(_ACCESSOR(tuc)->messageBag);
     }
 
     if (ret == 0) {

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -142,7 +142,7 @@ This library contains implementation for the random number generator.
 #elif defined(WOLFSSL_TELIT_M2MB)
 #elif defined(WOLFSSL_RENESAS_TSIP)
     /* for wc_tsip_GenerateRandBlock */
-    #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
+    #include "wolfssl/wolfcrypt/port/Renesas/renesas_tsip_internal.h"
 #elif defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_TRNG)
 #elif defined(WOLFSSL_IMXRT1170_CAAM)
 #elif defined(CY_USING_HAL) && defined(COMPONENT_WOLFSSL)

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -60,7 +60,7 @@
     #include <wolfssl/wolfcrypt/port/atmel/atmel.h>
 #endif
 #if defined(WOLFSSL_RENESAS_TSIP)
-    #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
+    #include <wolfssl/wolfcrypt/port/Renesas/renesas_tsip_internal.h>
 #endif
 #if defined(WOLFSSL_RENESAS_FSPSM)
     #include <wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h>

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -291,7 +291,7 @@
 #endif
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
-    #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
+    #include <wolfssl/wolfcrypt/port/Renesas/renesas_tsip_internal.h>
 #endif
 
 #include <wolfssl/wolfcrypt/hpke.h>

--- a/wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
@@ -148,157 +148,13 @@ struct tsip_keyflgs_crypt {
 };
 #endif
 
+typedef struct TsipUserCtx_Internal TsipUserCtx_Internal;
 /*
  * TsipUserCtx holds mainly keys used for TLS handshake in TSIP specific format.
  */
 typedef struct TsipUserCtx {
-    /* unique number for each session */
-    int devId;
 
-    /* client key pair wrapped by provisioning key */
-    byte*                                              wrappedPrivateKey;
-    byte*                                              wrappedPublicKey;
-
-    int                                                wrappedKeyType;
-
-#ifdef WOLFSSL_RENESAS_TSIP_TLS
-    /* 0:working as a TLS client, 1: as a server */
-    byte                    side;
-    /* ENCRYPT_SIDE_ONLY:1 DECRYPT_SIDE_ONLY:2 ENCRYPT AND DECRYPT:3 */
-    byte                    key_side;
-    /* public key index for verification of RootCA cert */
-    uint32_t                user_key_id;
-
-    /* WOLFSSL object associated with */
-    struct WOLFSSL*         ssl;
-    struct WOLFSSL_CTX*     ctx;
-
-    /* HEAP_HINT */
-    void*                   heap;
-
-    /* TLSv1.3 handshake related members, mainly keys */
-
-    /* handle is used as work area for Tls13 handshake */
-    tsip_tls13_handle_t                                handle13;
-
-#if !defined(NO_RSA)
-    /* RSA-2048bit private and public key-index for client authentication */
-    tsip_rsa2048_private_key_index_t                   Rsa2048PrivateKeyIdx;
-    tsip_rsa2048_public_key_index_t                    Rsa2048PublicKeyIdx;
-#endif /* !NO_RSA */
-#if defined(HAVE_ECC)
-    /* ECC private and public key-index for client authentication */
-    tsip_ecc_private_key_index_t                       EcdsaPrivateKeyIdx;
-    tsip_ecc_public_key_index_t                        EcdsaPublicKeyIdx;
-#endif /* HAVE_ECC */
-
-    /* ECDHE private key index for Tls13 handshake */
-    tsip_tls_p256_ecc_key_index_t                      EcdhPrivKey13Idx;
-
-    /* ECDHE pre-master secret */
-    tsip_tls13_ephemeral_shared_secret_key_index_t     sharedSecret13Idx;
-
-    /* Handshake secret for Tls13 handshake */
-    tsip_tls13_ephemeral_handshake_secret_key_index_t  handshakeSecret13Idx;
-
-    /* the key to decrypt server-finished message */
-    tsip_tls13_ephemeral_server_finished_key_index_t   serverFinished13Idx;
-
-    /* key for Sha256-Hmac to gen "Client Finished" */
-    tsip_hmac_sha_key_index_t                          clientFinished13Idx;
-
-    /* AES decryption key for handshake */
-    tsip_aes_key_index_t                               serverWriteKey13Idx;
-
-    /* AES encryption key for handshake */
-    tsip_aes_key_index_t                               clientWriteKey13Idx;
-
-    /* Handshake verified data used for master secret */
-    word32                          verifyData13Idx[TSIP_TLS_VERIFY_DATA_WD_SZ];
-
-    /* master secret for TLS1.3 */
-    tsip_tls13_ephemeral_master_secret_key_index_t     masterSecret13Idx;
-
-    /* server app traffic secret */
-    tsip_tls13_ephemeral_app_secret_key_index_t        serverAppTraffic13Secret;
-
-    /* client app traffic secret */
-    tsip_tls13_ephemeral_app_secret_key_index_t        clientAppTraffic13Secret;
-
-    /* server write key */
-    tsip_aes_key_index_t                               serverAppWriteKey13Idx;
-
-    /* client write key */
-    tsip_aes_key_index_t                               clientAppWriteKey13Idx;
-
-    /* hash handle for transcript hash of handshake messages */
-    tsip_hmac_sha_handle_t                             hmacFinished13Handle;
-
-    /* storage for handshake messages */
-    MsgBag                                             messageBag;
-
-    /* signature data area for TLS1.3 CertificateVerify message  */
-    byte                             sigDataCertVerify[TSIP_TLS_MAX_SIGDATA_SZ];
-
-#if (WOLFSSL_RENESAS_TSIP_VER >=109)
-    /* out from R_SCE_TLS_ServerKeyExchangeVerify */
-    uint32_t encrypted_ephemeral_ecdh_public_key[ENCRYPTED_ECDHE_PUBKEY_SZ];
-
-    /* ephemeral ECDH pubkey index
-     * got from R_TSIP_GenerateTlsP256EccKeyIndex.
-     * Input to R_TSIP_TlsGeneratePreMasterSecretWithEccP256Key.
-     */
-    tsip_tls_p256_ecc_key_index_t ecc_p256_wrapped_key;
-
-    /* ephemeral ECDH pub-key Qx(256bit)||Qy(256bit)
-     * got from  R_TSIP_GenerateTlsP256EccKeyIndex.
-     * Should be sent to peer(server) in Client Key Exchange msg.
-     */
-    uint8_t ecc_ecdh_public_key[ECCP256_PUBKEY_SZ];
-#endif /* WOLFSSL_RENESAS_TSIP_VER >=109 */
-
-    /* info to generate session key */
-    uint32_t    tsip_masterSecret[TSIP_TLS_MASTERSECRET_SIZE/4];
-    uint8_t     tsip_clientRandom[TSIP_TLS_CLIENTRANDOM_SZ];
-    uint8_t     tsip_serverRandom[TSIP_TLS_SERVERRANDOM_SZ];
-
-    /* TSIP defined cipher suite number */
-    uint32_t    tsip_cipher;
-
-    /* flags */
-#if !defined(NO_RSA)
-    uint8_t ClientRsa2048PrivKey_set:1;
-    uint8_t ClientRsa2048PubKey_set:1;
-#endif
-#if defined(HAVE_ECC)
-    uint8_t ClientEccPrivKey_set:1;
-    uint8_t ClientEccPubKey_set:1;
-#endif
-
-    uint8_t HmacInitialized:1;
-    uint8_t RootCAverified:1;
-    uint8_t EcdsaPrivKey_set:1;
-    uint8_t Dhe_key_set:1;
-    uint8_t SharedSecret_set:1;
-    uint8_t EarlySecret_set:1;
-    uint8_t HandshakeSecret_set:1;
-    uint8_t HandshakeClientTrafficKey_set:1;
-    uint8_t HandshakeServerTrafficKey_set:1;
-    uint8_t HandshakeVerifiedData_set:1;
-    uint8_t MasterSecret_set:1;
-    uint8_t ServerTrafficSecret_set:1;
-    uint8_t ClientTrafficSecret_set:1;
-    uint8_t ServerWriteTrafficKey_set:1;
-    uint8_t ClientWriteTrafficKey_set:1;
-    uint8_t session_key_set:1;
-#endif /* WOLFSSL_RENESAS_TSIP_TLS */
-
-    /* installed key handling */
-    tsip_aes_key_index_t user_aes256_key_index;
-    uint8_t user_aes256_key_set:1;
-    tsip_aes_key_index_t user_aes128_key_index;
-    uint8_t user_aes128_key_set:1;
-
+    int wrappedKeyType;
 /* for tsip crypt only mode */
 #ifdef WOLFSSL_RENESAS_TSIP_CRYPTONLY
 #ifndef NO_RSA
@@ -330,16 +186,17 @@ typedef struct TsipUserCtx {
     } keyflgs_crypt;
 #endif /* WOLFSSL_RENESAS_TSIP_CRYPTONLY */
 
+    /* installed key handling */
+    tsip_aes_key_index_t user_aes256_key_index;
+    uint8_t user_aes256_key_set:1;
+    tsip_aes_key_index_t user_aes128_key_index;
+    uint8_t user_aes128_key_set:1;
+
+    TsipUserCtx_Internal* internal;
 } TsipUserCtx;
 
 typedef TsipUserCtx RenesasUserCtx;
 typedef TsipUserCtx user_PKCbInfo;
-
-typedef struct
-{
-    TsipUserCtx* userCtx;
-} TsipPKCbInfo;
-
 
 typedef struct
 {

--- a/wolfssl/wolfcrypt/port/Renesas/renesas_tsip_internal.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas_tsip_internal.h
@@ -1,0 +1,171 @@
+/* renesas_tsip_internal.h
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+#ifndef _RENESAS_TSIP_INTERNAL_H_
+#define _RENESAS_TSIP_INTERNAL_H_
+
+#include "renesas-tsip-crypt.h"
+
+#define _ACCESSOR(p) (p->internal)
+
+struct TsipUserCtx_Internal {
+
+    /* unique number for each session */
+    int devId;
+
+    /* client key pair wrapped by provisioning key */
+    byte*                                              wrappedPrivateKey;
+    byte*                                              wrappedPublicKey;
+
+
+#ifdef WOLFSSL_RENESAS_TSIP_TLS
+    /* 0:working as a TLS client, 1: as a server */
+    byte                    side;
+    /* ENCRYPT_SIDE_ONLY:1 DECRYPT_SIDE_ONLY:2 ENCRYPT AND DECRYPT:3 */
+    byte                    key_side;
+    /* public key index for verification of RootCA cert */
+    uint32_t                user_key_id;
+
+    /* WOLFSSL object associated with */
+    struct WOLFSSL*         ssl;
+    struct WOLFSSL_CTX*     ctx;
+
+    /* HEAP_HINT */
+    void*                   heap;
+
+    /* TLSv1.3 handshake related members, mainly keys */
+
+    /* handle is used as work area for Tls13 handshake */
+    tsip_tls13_handle_t                                handle13;
+
+#if !defined(NO_RSA)
+    /* RSA-2048bit private and public key-index for client authentication */
+    tsip_rsa2048_private_key_index_t                   Rsa2048PrivateKeyIdx;
+    tsip_rsa2048_public_key_index_t                    Rsa2048PublicKeyIdx;
+#endif /* !NO_RSA */
+#if defined(HAVE_ECC)
+    /* ECC private and public key-index for client authentication */
+    tsip_ecc_private_key_index_t                       EcdsaPrivateKeyIdx;
+    tsip_ecc_public_key_index_t                        EcdsaPublicKeyIdx;
+#endif /* HAVE_ECC */
+
+    /* ECDHE private key index for Tls13 handshake */
+    tsip_tls_p256_ecc_key_index_t                      EcdhPrivKey13Idx;
+
+    /* ECDHE pre-master secret */
+    tsip_tls13_ephemeral_shared_secret_key_index_t     sharedSecret13Idx;
+
+    /* Handshake secret for Tls13 handshake */
+    tsip_tls13_ephemeral_handshake_secret_key_index_t  handshakeSecret13Idx;
+
+    /* the key to decrypt server-finished message */
+    tsip_tls13_ephemeral_server_finished_key_index_t   serverFinished13Idx;
+
+    /* key for Sha256-Hmac to gen "Client Finished" */
+    tsip_hmac_sha_key_index_t                          clientFinished13Idx;
+
+    /* AES decryption key for handshake */
+    tsip_aes_key_index_t                               serverWriteKey13Idx;
+
+    /* AES encryption key for handshake */
+    tsip_aes_key_index_t                               clientWriteKey13Idx;
+
+    /* Handshake verified data used for master secret */
+    word32                          verifyData13Idx[TSIP_TLS_VERIFY_DATA_WD_SZ];
+
+    /* master secret for TLS1.3 */
+    tsip_tls13_ephemeral_master_secret_key_index_t     masterSecret13Idx;
+
+    /* server app traffic secret */
+    tsip_tls13_ephemeral_app_secret_key_index_t        serverAppTraffic13Secret;
+
+    /* client app traffic secret */
+    tsip_tls13_ephemeral_app_secret_key_index_t        clientAppTraffic13Secret;
+
+    /* server write key */
+    tsip_aes_key_index_t                               serverAppWriteKey13Idx;
+
+    /* client write key */
+    tsip_aes_key_index_t                               clientAppWriteKey13Idx;
+
+    /* hash handle for transcript hash of handshake messages */
+    tsip_hmac_sha_handle_t                             hmacFinished13Handle;
+
+    /* storage for handshake messages */
+    MsgBag                                             messageBag;
+
+    /* signature data area for TLS1.3 CertificateVerify message  */
+    byte                             sigDataCertVerify[TSIP_TLS_MAX_SIGDATA_SZ];
+
+#if (WOLFSSL_RENESAS_TSIP_VER >=109)
+    /* out from R_SCE_TLS_ServerKeyExchangeVerify */
+    uint32_t encrypted_ephemeral_ecdh_public_key[ENCRYPTED_ECDHE_PUBKEY_SZ];
+
+    /* ephemeral ECDH pubkey index
+     * got from R_TSIP_GenerateTlsP256EccKeyIndex.
+     * Input to R_TSIP_TlsGeneratePreMasterSecretWithEccP256Key.
+     */
+    tsip_tls_p256_ecc_key_index_t ecc_p256_wrapped_key;
+
+    /* ephemeral ECDH pub-key Qx(256bit)||Qy(256bit)
+     * got from  R_TSIP_GenerateTlsP256EccKeyIndex.
+     * Should be sent to peer(server) in Client Key Exchange msg.
+     */
+    uint8_t ecc_ecdh_public_key[ECCP256_PUBKEY_SZ];
+#endif /* WOLFSSL_RENESAS_TSIP_VER >=109 */
+
+    /* info to generate session key */
+    uint32_t    tsip_masterSecret[TSIP_TLS_MASTERSECRET_SIZE/4];
+    uint8_t     tsip_clientRandom[TSIP_TLS_CLIENTRANDOM_SZ];
+    uint8_t     tsip_serverRandom[TSIP_TLS_SERVERRANDOM_SZ];
+
+    /* TSIP defined cipher suite number */
+    uint32_t    tsip_cipher;
+        /* flags */
+#if !defined(NO_RSA)
+    uint8_t ClientRsa2048PrivKey_set:1;
+    uint8_t ClientRsa2048PubKey_set:1;
+#endif
+#if defined(HAVE_ECC)
+    uint8_t ClientEccPrivKey_set:1;
+    uint8_t ClientEccPubKey_set:1;
+#endif
+
+    uint8_t HmacInitialized:1;
+    uint8_t RootCAverified:1;
+    uint8_t EcdsaPrivKey_set:1;
+    uint8_t Dhe_key_set:1;
+    uint8_t SharedSecret_set:1;
+    uint8_t EarlySecret_set:1;
+    uint8_t HandshakeSecret_set:1;
+    uint8_t HandshakeClientTrafficKey_set:1;
+    uint8_t HandshakeServerTrafficKey_set:1;
+    uint8_t HandshakeVerifiedData_set:1;
+    uint8_t MasterSecret_set:1;
+    uint8_t ServerTrafficSecret_set:1;
+    uint8_t ClientTrafficSecret_set:1;
+    uint8_t ServerWriteTrafficKey_set:1;
+    uint8_t ClientWriteTrafficKey_set:1;
+    uint8_t session_key_set:1;
+#endif /* WOLFSSL_RENESAS_TSIP_TLS */
+
+};
+
+#endif


### PR DESCRIPTION
# Description
Make properties related to TLS handshake hidden for TSIP TLS user-context structure so that user just takes account of public properties when needed. E.g. Crypto API use.

# Testing

Example program including Crypt, Bench, Client/Server and Unit test cases in the repository

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
