### PR TITLE
reduce check size to BLAKE2B_BLOCKBYTES

### DIFF
--- a/wolfcrypt/src/blake2b.c
+++ b/wolfcrypt/src/blake2b.c
@@ -356,7 +356,7 @@ int blake2b_final( blake2b_state *S, byte *out, byte outlen )
     }
 
     S->buflen -= BLAKE2B_BLOCKBYTES;
-    if ( S->buflen >= (BLAKE2B_BLOCKBYTES * 2) )
+    if ( S->buflen >= (BLAKE2B_BLOCKBYTES) )
       return BAD_LENGTH_E;
     XMEMCPY( S->buf, S->buf + BLAKE2B_BLOCKBYTES, (wolfssl_word)S->buflen );
   }


### PR DESCRIPTION
# Description

Initial check was too large and could lead to attempt to access buffer at location outside of buffer. Note that `byte buf [2 * BLAKE2B_BLOCKBYTES]`, but max length of `S->buflen` could be 255 according to original change.

The original change caused new Coverity issue CID 531298 Out-of-bounds access. This change is expected to fix CID 218595 Overlapping buffer in memory copy as well. However, changing XMEMCPY to XMEMMOVE may be necessary to remove issue rather than ignoring it.