### PR TITLE
Add logic to match IPv6 domain addresses

### DIFF
--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -959,6 +959,9 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
     #define WOLFSSL_IP6 AF_INET6
 #endif
 
+#ifndef WOLFSSL_SOCKADDR_IN6
+    #define WOLFSSL_SOCKADDR_IN6 struct sockaddr_in6
+#endif
 
 #ifdef __cplusplus
     }  /* extern "C" */


### PR DESCRIPTION
# Description

This PR fixes a bug where we fail to match IPv6 domain names when we should. For example   `1002:097c:C2BB:0820:0010:0240:0115:0083` to `1002:97c:c2bb:820:10:240:115:84` or even `0000:0000:0000:0000:0000:0000:0000:0001` to `::1` . This was leading valid TLS connections to fail. The new logic uses inet_pton to handle all the parsing and makes matching the addresses easier. Guarded by `WOLFSSL_IP_ALT_NAME` 

Fixes zd#20210

# Testing

Tested with curl built against wolfssl. I've attached the script I used to test. The TLS connection would previously fail, and should now work.
[ipv6_test.zip](https://github.com/user-attachments/files/21188904/ipv6_test.zip)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
