### PR TITLE
Fix blake2b_final coverity reports

### DIFF
--- a/wolfcrypt/src/blake2b.c
+++ b/wolfcrypt/src/blake2b.c
@@ -358,7 +358,7 @@ int blake2b_final( blake2b_state *S, byte *out, byte outlen )
     S->buflen -= BLAKE2B_BLOCKBYTES;
     if ( S->buflen > BLAKE2B_BLOCKBYTES )
       return BAD_LENGTH_E;
-    XMEMCPY( S->buf, S->buf + BLAKE2B_BLOCKBYTES, (wolfssl_word)S->buflen );
+    XMEMMOVE( S->buf, S->buf + BLAKE2B_BLOCKBYTES, (wolfssl_word)S->buflen );
   }
 
   blake2b_increment_counter( S, S->buflen );

--- a/wolfcrypt/src/blake2b.c
+++ b/wolfcrypt/src/blake2b.c
@@ -356,7 +356,7 @@ int blake2b_final( blake2b_state *S, byte *out, byte outlen )
     }
 
     S->buflen -= BLAKE2B_BLOCKBYTES;
-    if ( S->buflen >= (BLAKE2B_BLOCKBYTES * 2) )
+    if ( S->buflen > BLAKE2B_BLOCKBYTES )
       return BAD_LENGTH_E;
     XMEMCPY( S->buf, S->buf + BLAKE2B_BLOCKBYTES, (wolfssl_word)S->buflen );
   }


### PR DESCRIPTION
# Description

- OOB access in blake2b_final
- Use memmove instead of memcpy

# Testing

Coverity confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
