### PR TITLE
Coverity fixes for Zendesk issue

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -28814,10 +28814,6 @@ int SetSuitesHashSigAlgo(Suites* suites, const char* list)
 
     do {
         if (*list == '+') {
-            if (mac_alg != 0) {
-                ret = 0;
-                break;
-            }
             sig_alg = GetSigAlgFromName(s, (int)(list - s));
             if (sig_alg == 0) {
                 ret = 0;

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -3549,7 +3549,7 @@ int wolfSSL_ASN1_STRING_print_ex(WOLFSSL_BIO *bio, WOLFSSL_ASN1_STRING *str,
         }
     }
 
-    if ((!err) && (str_len != -1)) {
+    if ((!err) && (str_len >= 0)) {
         /* Include any characters written for type. */
         str_len += type_len;
     }

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -1043,7 +1043,6 @@ static int wolfssl_asn1_integer_require_len(WOLFSSL_ASN1_INTEGER* a, int len,
     int ret = 1;
     byte* data;
     byte* oldData = a->intData;
-    int oldLen = a->length;
 
     if (a->isDynamic && (len > (int)a->dataMax)) {
         oldData = a->data;
@@ -1051,7 +1050,6 @@ static int wolfssl_asn1_integer_require_len(WOLFSSL_ASN1_INTEGER* a, int len,
         a->data = a->intData;
         a->dataMax = (unsigned int)sizeof(a->intData);
     }
-    a->length = 0;
     if ((!a->isDynamic) && (len > (int)a->dataMax)) {
         /* Create a new buffer to hold large integer value. */
         data = (byte*)XMALLOC((size_t)len, NULL, DYNAMIC_TYPE_OPENSSL);
@@ -1068,10 +1066,10 @@ static int wolfssl_asn1_integer_require_len(WOLFSSL_ASN1_INTEGER* a, int len,
     if (keepOldData) {
          if (oldData != a->data) {
              /* Copy old data into new buffer. */
-             XMEMCPY(a->data, oldData, (size_t)oldLen);
+             XMEMCPY(a->data, oldData, (size_t)a->length);
          }
-         /* Restore old length. */
-         a->length = oldLen;
+    } else {
+        a->length = 0;
     }
     if (oldData != a->intData) {
          /* Dispose of the old dynamic data. */

--- a/wolfcrypt/src/ed448.c
+++ b/wolfcrypt/src/ed448.c
@@ -1017,7 +1017,9 @@ int wc_ed448_import_public_ex(const byte* in, word32 inLen, ed448_key* key,
         ret = BAD_FUNC_ARG;
     }
 
-    if ((inLen != ED448_PUB_KEY_SIZE) && (inLen != ED448_PUB_KEY_SIZE + 1)) {
+    if ((inLen != ED448_PUB_KEY_SIZE) &&
+        (inLen != ED448_PUB_KEY_SIZE + 1) &&
+        (inLen != 2 * ED448_PUB_KEY_SIZE + 1)) {
         ret = BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -1376,7 +1376,9 @@ void* wolfSSL_Realloc(void *ptr, size_t size, void* heap, int type)
                 WOLFSSL_MSG("Error IO memory was not large enough");
                 res = NULL; /* return NULL in error case */
             }
-            res = pt->buffer;
+            else {
+                res = pt->buffer;
+            }
         }
         else
     #endif


### PR DESCRIPTION
# Description

- Unused values
    - Move `res = pt->buffer` inside else statement so NULL assignment is not overwritten.
- Overflowed array index
    - Set check to include any negative value. Function expects only WOLFSSL_FATAL_ERROR to be returned, but adding check in the event another error value can be returned.
- Logically dead code
    - Remove unused check, mac_alg is always 0 when iteration returns.
    - Add additional check for inLen > 2*ED448_PUB_KEY_SIZE, ensures importing uncompressed public key can be reached, ensures importing uncompressed public key can be reached. Also reported by wolfSSL Coverity build (CI **299583**)
- Failure to restore non-local value
    - Removes `oldLen` and sets `a->length` to 0 if `keepOldData` is not set. The value of `a->length` is not changed in other parts of the function, so it is able to be used instead of `oldLen` when copying `oldData` into new buffer. wolfSSL Coverity Project CID **315966**

Addresses Coverity issues from zd#20212
