### PR TITLE
Make properties related to Renesas FSP Security Module TLS hidden for FSP SM context

### DIFF
--- a/IDE/Renesas/e2studio/RA6M4/common/user_settings.h
+++ b/IDE/Renesas/e2studio/RA6M4/common/user_settings.h
@@ -108,10 +108,10 @@
     #define WC_USE_DEVID 7890
     #define NO_AES_192
     #define NO_SW_BENCH
-#endif
-
-#if defined(WOLFSSL_RENESAS_SCEPROTECT_CRYPTONLY)
+    /* Use SCE RSAES-PKCS1-V1_5 RSA Function */
+    #define WOLF_CRYPTO_CB_RSA_PAD
     #define WOLFSSL_KEY_GEN
+    #define RSA_MIN_SIZE 512
 #endif
 
 #define CUSTOM_RAND_GENERATE_BLOCK wc_fspsm_GenerateRandBlock

--- a/IDE/Renesas/e2studio/RA6M4/test/src/wolf_client.c
+++ b/IDE/Renesas/e2studio/RA6M4/test/src/wolf_client.c
@@ -28,6 +28,7 @@
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/ssl.h"
 #include "wolfssl/certs_test.h"
+#include "wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h"
 
 uint32_t g_encrypted_root_public_key[140];
 WOLFSSL_CTX *client_ctx = NULL;
@@ -198,7 +199,6 @@ int wolfSSL_TLS_client_do(void *pvParam)
         #if !defined(TLS_MULTITHREAD_TEST)
 
         XMEMSET(&guser_PKCbInfo, 0, sizeof(FSPSM_ST));
-        guser_PKCbInfo.devId = 0;
         wc_sce_set_callback_ctx(ssl, (void*)&guser_PKCbInfo);
 
         #else

--- a/IDE/Renesas/e2studio/RA6M4/test/src/wolfssl_sce_unit_test.c
+++ b/IDE/Renesas/e2studio/RA6M4/test/src/wolfssl_sce_unit_test.c
@@ -798,10 +798,8 @@ int sce_crypt_test()
         /* sets wrapped rsa 1024 bits key */
         gCbInfo.wrapped_key_rsapri1024 =
                 &g_wrapped_pair_1024key.priv_key;
-        gCbInfo.keyflgs_crypt.bits.rsapri1024_installedkey_set = 1;
         gCbInfo.wrapped_key_rsapub1024 =
                 &g_wrapped_pair_1024key.pub_key;
-        gCbInfo.keyflgs_crypt.bits.rsapub1024_installedkey_set = 1;
     }
 
     err = R_SCE_RSA2048_WrappedKeyPairGenerate(&g_wrapped_pair_2048key);
@@ -809,11 +807,8 @@ int sce_crypt_test()
         /* sets wrapped rsa 1024 bits key */
         gCbInfo.wrapped_key_rsapri2048 =
                 &g_wrapped_pair_2048key.priv_key;
-        gCbInfo.keyflgs_crypt.bits.rsapri2048_installedkey_set = 1;
-
         gCbInfo.wrapped_key_rsapub2048 =
-                &g_wrapped_pair_2048key.pub_key;
-        gCbInfo.keyflgs_crypt.bits.rsapub2048_installedkey_set = 1;
+                &g_wrapped_pair_2048key.pub_key;;
     }
 
     /* Key generation for multi testing */
@@ -834,6 +829,10 @@ int sce_crypt_test()
 
     if (ret == 0) {
         printf(" sce_rsa_test(1024)");
+        gCbInfo.keyflgs_crypt.bits.rsapri1024_installedkey_set = 1;
+        gCbInfo.keyflgs_crypt.bits.rsapub1024_installedkey_set = 1;
+        gCbInfo.keyflgs_crypt.bits.rsapri2048_installedkey_set = 0;
+        gCbInfo.keyflgs_crypt.bits.rsapub2048_installedkey_set = 0;
         ret = sce_rsa_test(1, 1024);
         RESULT_STR(ret)
     }
@@ -846,6 +845,10 @@ int sce_crypt_test()
 
     if (ret == 0) {
         printf(" sce_rsa_test(2048)");
+        gCbInfo.keyflgs_crypt.bits.rsapri1024_installedkey_set = 0;
+        gCbInfo.keyflgs_crypt.bits.rsapub1024_installedkey_set = 0;
+        gCbInfo.keyflgs_crypt.bits.rsapri2048_installedkey_set = 1;
+        gCbInfo.keyflgs_crypt.bits.rsapub2048_installedkey_set = 1;
         ret = sce_rsa_test(1, 2048);
         RESULT_STR(ret)
     }

--- a/IDE/Renesas/e2studio/RA6M4/test/src/wolfssl_sce_unit_test.c
+++ b/IDE/Renesas/e2studio/RA6M4/test/src/wolfssl_sce_unit_test.c
@@ -808,7 +808,7 @@ int sce_crypt_test()
         gCbInfo.wrapped_key_rsapri2048 =
                 &g_wrapped_pair_2048key.priv_key;
         gCbInfo.wrapped_key_rsapub2048 =
-                &g_wrapped_pair_2048key.pub_key;;
+                &g_wrapped_pair_2048key.pub_key;
     }
 
     /* Key generation for multi testing */

--- a/src/keys.c
+++ b/src/keys.c
@@ -3556,7 +3556,7 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
         void* ctx = wolfSSL_GetEncryptKeysCtx(ssl);
         #if defined(WOLFSSL_RENESAS_FSPSM_TLS)
             FSPSM_ST* cbInfo = (FSPSM_ST*)ctx;
-            cbInfo->side = side;
+            cbInfo->internal->side = side;
         #elif defined(WOLFSSL_RENESAS_TSIP_TLS)
             TsipUserCtx* cbInfo = (TsipUserCtx*)ctx;
             cbInfo->key_side = side;

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -88,7 +88,7 @@ WOLFSSL_LOCAL int Renesas_cmn_Cleanup(struct WOLFSSL* ssl)
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_TlsCleanup(ssl);
 #elif defined(WOLFSSL_RENESAS_FSPSM_TLS)
-    wc_fspsm_TlsCleanup(ssl);
+    ret = wc_fspsm_TlsCleanup(ssl);
 #endif
 
     WOLFSSL_LEAVE("Renesas_cmn_Cleanup", ret);
@@ -699,7 +699,8 @@ static int Renesas_cmn_EncryptKeys(WOLFSSL* ssl, void* ctx)
  #elif defined(WOLFSSL_RENESAS_FSPSM_TLS)
     FSPSM_ST* cbInfo = (FSPSM_ST*)ctx;
 
-    if (cbInfo->internal->keyflgs_tls.bits.session_key_set == 1) {
+    if (cbInfo != NULL && cbInfo->internal != NULL && 
+        cbInfo->internal->keyflgs_tls.bits.session_key_set == 1) {
         switch(cbInfo->internal->side) {
  #endif
             case 1:/* ENCRYPT_SIDE_ONLY */

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -33,7 +33,7 @@
 #if defined(WOLFSSL_RENESAS_FSPSM_TLS) || \
     defined(WOLFSSL_RENESAS_FSPSM_CRYPTONLY)
 
-    #include <wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h>
+    #include <wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h>
     #define cmn_hw_lock    wc_fspsm_hw_lock
     #define cmn_hw_unlock  wc_fspsm_hw_unlock
 
@@ -87,6 +87,8 @@ WOLFSSL_LOCAL int Renesas_cmn_Cleanup(struct WOLFSSL* ssl)
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_TlsCleanup(ssl);
+#elif defined(WOLFSSL_RENESAS_FSPSM_TLS)
+    wc_fspsm_TlsCleanup(ssl);
 #endif
 
     WOLFSSL_LEAVE("Renesas_cmn_Cleanup", ret);
@@ -166,6 +168,7 @@ static int Renesas_cmn_CryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
 #elif defined(WOLFSSL_RENESAS_FSPSM_TLS) || \
       defined(WOLFSSL_RENESAS_FSPSM_CRYPTONLY)
     FSPSM_ST* cbInfo = (FSPSM_ST*)ctx;
+    (void)cbInfo;
 #endif
 
     if (info == NULL || ctx == NULL)
@@ -276,88 +279,19 @@ static int Renesas_cmn_CryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
 
     if (info->algo_type == WC_ALGO_TYPE_CIPHER) {
     #if !defined(NO_AES)
-    #ifdef HAVE_AESGCM
-        if (info->cipher.type == WC_CIPHER_AES_GCM) {
-
-            if (info->cipher.enc &&
-                (cbInfo->keyflgs_tls.bits.session_key_set == 1 ||
-                 (cbInfo->keyflgs_crypt.bits.aes256_installedkey_set == 1 &&
-                  info->cipher.aesgcm_enc.aes->keylen == 32) ||
-                 (cbInfo->keyflgs_crypt.bits.aes128_installedkey_set == 1 &&
-                  info->cipher.aesgcm_enc.aes->keylen == 16))) {
-
-                ret = wc_fspsm_AesGcmEncrypt(
-                        info->cipher.aesgcm_enc.aes,
-                        (byte*)info->cipher.aesgcm_enc.out,
-                        (byte*)info->cipher.aesgcm_enc.in,
-                        info->cipher.aesgcm_enc.sz,
-                        (byte*)info->cipher.aesgcm_enc.iv,
-                        info->cipher.aesgcm_enc.ivSz,
-                        (byte*)info->cipher.aesgcm_enc.authTag,
-                        info->cipher.aesgcm_enc.authTagSz,
-                        (byte*)info->cipher.aesgcm_enc.authIn,
-                        info->cipher.aesgcm_enc.authInSz,
-                        (void*)ctx);
-
-            }
-            else if (cbInfo->keyflgs_tls.bits.session_key_set == 1 ||
-                    (cbInfo->keyflgs_crypt.bits.aes256_installedkey_set == 1 &&
-                       info->cipher.aesgcm_dec.aes->keylen == 32) ||
-                    (cbInfo->keyflgs_crypt.bits.aes128_installedkey_set == 1 &&
-                       info->cipher.aesgcm_dec.aes->keylen == 16)) {
-
-                ret = wc_fspsm_AesGcmDecrypt(
-                        info->cipher.aesgcm_dec.aes,
-                        (byte*)info->cipher.aesgcm_dec.out,
-                        (byte*)info->cipher.aesgcm_dec.in,
-                        info->cipher.aesgcm_dec.sz,
-                        (byte*)info->cipher.aesgcm_dec.iv,
-                        info->cipher.aesgcm_dec.ivSz,
-                        (byte*)info->cipher.aesgcm_dec.authTag,
-                        info->cipher.aesgcm_dec.authTagSz,
-                        (byte*)info->cipher.aesgcm_dec.authIn,
-                        info->cipher.aesgcm_dec.authInSz,
-                        (void*)ctx);
-            }
-        }
-    #endif /* HAVE_AESGCM */
-    #ifdef HAVE_AES_CBC
-        if ((info->cipher.type == WC_CIPHER_AES_CBC) &&
-            (cbInfo->keyflgs_tls.bits.session_key_set == 1 ||
-            (cbInfo->keyflgs_crypt.bits.aes256_installedkey_set == 1 &&
-                info->cipher.aescbc.aes->keylen == 32) ||
-            (cbInfo->keyflgs_crypt.bits.aes128_installedkey_set == 1 &&
-                info->cipher.aescbc.aes->keylen == 16))) {
-                if (info->cipher.enc) {
-                    ret = wc_fspsm_AesCbcEncrypt(
-                        info->cipher.aescbc.aes,
-                        (byte*)info->cipher.aescbc.out,
-                        (byte*)info->cipher.aescbc.in,
-                        info->cipher.aescbc.sz);
-                }
-                else {
-                    ret = wc_fspsm_AesCbcDecrypt(
-                        info->cipher.aescbc.aes,
-                        (byte*)info->cipher.aescbc.out,
-                        (byte*)info->cipher.aescbc.in,
-                        info->cipher.aescbc.sz);
-                }
-        }
-    #endif /* HAVE_AES_CBC */
+         ret = wc_fspsm_AesCipher(devIdArg, info, ctx);
     #endif /* !NO_AES */
     }
 
 #if !defined(NO_RSA) && defined(WOLFSSL_RENESAS_FSPSM_CRYPTONLY)
     else if (info->algo_type == WC_ALGO_TYPE_PK) {
     #if defined(WOLFSSL_KEY_GEN)
-        if (info->pk.type == WC_PK_TYPE_RSA_KEYGEN &&
-            (info->pk.rsakg.size == 1024 ||
-             info->pk.rsakg.size == 2048)) {
+        if (info->pk.type == WC_PK_TYPE_RSA_KEYGEN) {
             ret = wc_fspsm_MakeRsaKey(info->pk.rsakg.key,
                     info->pk.rsakg.size, (void*)ctx);
         }
     #endif
-        if (info->pk.type == WC_PK_TYPE_RSA) {
+        if (info->pk.type == WC_PK_TYPE_RSA_PKCS) {
             /* to perform RSA on SCE, wrapped keys should be installed
              * in advance. SCE supports 1024 or 2048 bits key size.
              * otherwise, falls-through happens.
@@ -366,10 +300,6 @@ static int Renesas_cmn_CryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
                 cbInfo->keyflgs_crypt.bits.rsapub2048_installedkey_set ||
                 cbInfo->keyflgs_crypt.bits.rsapri1024_installedkey_set ||
                 cbInfo->keyflgs_crypt.bits.rsapub1024_installedkey_set ) {
-
-                ret = wc_fspsm_MakeRsaKey(info->pk.rsa.key, 0, cbInfo);
-                if (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
-                    return ret;
 
                 if (info->pk.rsa.type == RSA_PRIVATE_DECRYPT ||
                     info->pk.rsa.type == RSA_PUBLIC_ENCRYPT  )
@@ -769,8 +699,8 @@ static int Renesas_cmn_EncryptKeys(WOLFSSL* ssl, void* ctx)
  #elif defined(WOLFSSL_RENESAS_FSPSM_TLS)
     FSPSM_ST* cbInfo = (FSPSM_ST*)ctx;
 
-    if (cbInfo->keyflgs_tls.bits.session_key_set == 1) {
-        switch(cbInfo->side) {
+    if (cbInfo->internal->keyflgs_tls.bits.session_key_set == 1) {
+        switch(cbInfo->internal->side) {
  #endif
             case 1:/* ENCRYPT_SIDE_ONLY */
                 ssl->encrypt.setup = 1;

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -699,7 +699,7 @@ static int Renesas_cmn_EncryptKeys(WOLFSSL* ssl, void* ctx)
  #elif defined(WOLFSSL_RENESAS_FSPSM_TLS)
     FSPSM_ST* cbInfo = (FSPSM_ST*)ctx;
 
-    if (cbInfo != NULL && cbInfo->internal != NULL && 
+    if (cbInfo != NULL && cbInfo->internal != NULL &&
         cbInfo->internal->keyflgs_tls.bits.session_key_set == 1) {
         switch(cbInfo->internal->side) {
  #endif

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_aes.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_aes.c
@@ -244,7 +244,8 @@ WOLFSSL_LOCAL int  wc_fspsm_AesGcmEncrypt(struct Aes* aes, byte* out,
     (void) key_server_aes;
 
     /* sanity check */
-    if (aes == NULL || authTagSz > WC_AES_BLOCK_SIZE || ivSz == 0 || info == NULL) {
+    if (aes == NULL || authTagSz > WC_AES_BLOCK_SIZE || ivSz == 0 ||
+        info == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -453,7 +454,8 @@ WOLFSSL_LOCAL int  wc_fspsm_AesGcmDecrypt(struct Aes* aes, byte* out,
     FSPSM_AES_PWKEY      key_server_aes = NULL;
     (void) key_client_aes;
     /* sanity check */
-    if (aes == NULL || authTagSz > WC_AES_BLOCK_SIZE || ivSz == 0 || info == NULL) {
+    if (aes == NULL || authTagSz > WC_AES_BLOCK_SIZE || ivSz == 0 ||
+        info == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -812,14 +814,15 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
 }
 #endif
 
-WOLFSSL_LOCAL int wc_fspsm_AesCipher(int devIdArg, wc_CryptoInfo* info, void* ctx)
+WOLFSSL_LOCAL int wc_fspsm_AesCipher(int devIdArg, wc_CryptoInfo* info,
+                                                                    void* ctx)
 {
     int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
     FSPSM_ST* cbInfo = (FSPSM_ST*)ctx;
     (void)devIdArg;
 
     WOLFSSL_ENTER("wc_fspsm_AesCipher");
-    
+
     if (info == NULL || ctx == NULL) {
         return BAD_FUNC_ARG;
     }

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_aes.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_aes.c
@@ -823,7 +823,7 @@ WOLFSSL_LOCAL int wc_fspsm_AesCipher(int devIdArg, wc_CryptoInfo* info,
 
     WOLFSSL_ENTER("wc_fspsm_AesCipher");
 
-    if (info == NULL || ctx == NULL) {
+    if (info == NULL || cbInfo == NULL || cbInfo->internal == NULL) {
         return BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_rsa.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_rsa.c
@@ -34,7 +34,7 @@
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/rsa.h>
-#include <wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h>
+#include <wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h>
 
 #if defined(WOLFSSL_RENESAS_RSIP)
 extern FSPSM_INSTANCE   gFSPSM_ctrl;

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_sha.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_sha.c
@@ -35,7 +35,7 @@
     !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
 
 #include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h>
+#include <wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h>
 
 #if defined(WOLFSSL_RENESAS_RSIP)
 extern FSPSM_INSTANCE   gFSPSM_ctrl;

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
@@ -192,7 +192,7 @@ int wc_fspsm_GenerateRandBlock(byte* output, word32 sz)
 {
     /* Generate PRNG based on NIST SP800-90A AES CTR-DRBG */
     int ret = 0;
-    word32 fspbuf[RANDGEN_WORDS];
+    uint32_t fspbuf[RANDGEN_WORDS];
 
     while (sz > 0) {
         word32 len = sizeof(buffer);
@@ -201,8 +201,8 @@ int wc_fspsm_GenerateRandBlock(byte* output, word32 sz)
             len = sz;
         }
         /* return 4 words random number*/
-        ret = R_RANDOM_GEN((uint32_t*)fspbuf);
-        if(ret == FSP_SUCCESS) {
+        ret = R_RANDOM_GEN(fspbuf);
+        if (ret == FSP_SUCCESS) {
             XMEMCPY(output, &fspbuf, len);
             output += len;
             sz -= len;
@@ -404,7 +404,7 @@ int fspsm_EccSharedSecret(WOLFSSL* ssl, ecc_key* otherKey,
 
     /* sanity check */
     if (ssl == NULL || pubKeyDer == NULL || pubKeySz == NULL ||
-        out == NULL || outlen == NULL || cbInfo == NULL||
+        out == NULL || outlen == NULL || cbInfo == NULL ||
         cbInfo->internal == NULL)
       return WOLFSSL_FAILURE;
 
@@ -1251,6 +1251,7 @@ int wc_fspsm_TlsCleanup(WOLFSSL* ssl)
     /* zero clear */
     ForceZero(tuc, sizeof(FSPSM_ST));
     ssl->RenesasUserCtx = NULL;
+
     return ret;
 }
 /* Set callback contexts needed for sce TLS api handling */

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
@@ -67,10 +67,6 @@ static fspsm_key_data g_user_key_info;
 
 static uint32_t     g_encrypted_publicCA_key[HW_SCE_SINST_WORD_SIZE];
 extern uint32_t     g_CAscm_Idx;          /* index of CM table    */
-//#define USE_GLOBAL_INTERNAL
-#if !defined(USE_GLOBAL_INTERNAL)
-FSPSM_ST_Internal   g_internal;
-#endif
 #endif
 
 #endif /* WOLFSSL_RENESAS_FSPSM*/
@@ -445,7 +441,7 @@ int fspsm_EccSharedSecret(WOLFSSL* ssl, ecc_key* otherKey,
             }
             else {
                 /* set master secret generation callback for use */
-                wolfSSL_CTX_SetGenMasterSecretCb(ssl->ctx, 
+                wolfSSL_CTX_SetGenMasterSecretCb(ssl->ctx,
                                                 Renesas_cmn_genMasterSecret);
                 wolfSSL_SetGenMasterSecretCtx(ssl, cbInfo);
             }
@@ -458,7 +454,7 @@ int fspsm_EccSharedSecret(WOLFSSL* ssl, ecc_key* otherKey,
         wc_fspsm_hw_unlock();
 
         *outlen = 64;
-        WOLFSSL_PKMSG("PK ECC PMS: ret %d, PubKeySz %d, OutLen %d\n", 
+        WOLFSSL_PKMSG("PK ECC PMS: ret %d, PubKeySz %d, OutLen %d\n",
                                                 ret, *pubKeySz, *outlen);
     }
 
@@ -852,9 +848,9 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
                 /* ready-for-use flag will be set when SetKeySide() is called */
             }
 
-            if (cbInfo->internal->cipher == 
+            if (cbInfo->internal->cipher ==
                     SCE_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ||
-                cbInfo->internal->cipher == 
+                cbInfo->internal->cipher ==
                     SCE_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256) {
                 enc->aes->nonceSz = AEAD_MAX_IMP_SZ;
                 dec->aes->nonceSz = AEAD_MAX_IMP_SZ;
@@ -1151,12 +1147,12 @@ int wc_fspsm_storeKeyCtx(WOLFSSL* ssl, FSPSM_ST* info)
         ret = BAD_FUNC_ARG;
 
     if (ret == 0) {
-        XMEMCPY(info->internal->masterSecret, 
+        XMEMCPY(info->internal->masterSecret,
                         ssl->arrays->fspsm_masterSecret,
                         FSPSM_TLS_MASTERSECRET_SIZE);
-        XMEMCPY(info->internal->clientRandom, 
+        XMEMCPY(info->internal->clientRandom,
                         ssl->arrays->clientRandom, 32);
-        XMEMCPY(info->internal->serverRandom, 
+        XMEMCPY(info->internal->serverRandom,
                         ssl->arrays->serverRandom, 32);
 
         info->internal->cipher = (uint8_t)GetSceCipherSuite(
@@ -1246,12 +1242,8 @@ void wc_fspsm_TlsCleanup(WOLFSSL* ssl)
         return;
     /* free internal structure */
     if (tuc->internal) {
-#if !defined(USE_GLOBAL_INTERNAL)
         XFREE(tuc->internal, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
         tuc->internal = NULL;
-#else
-        ForceZero(tuc->internal, sizeof(FSPSM_ST_Internal));
-#endif
     }
 
     /* zero clear */
@@ -1272,14 +1264,9 @@ WOLFSSL_API int wc_fspsm_set_callback_ctx(WOLFSSL* ssl, void* user_ctx)
     }
 
     ForceZero(uCtx, sizeof(FSPSM_ST));
-#if !defined(USE_GLOBAL_INTERNAL)
     uCtx->internal = (FSPSM_ST_Internal*)XMALLOC(sizeof(FSPSM_ST_Internal),
                                         ssl->heap,
                                         DYNAMIC_TYPE_TMP_BUFFER);
-#else
-    printf("sizeof (FSPSM_ST_Internal) = %d\n", sizeof(FSPSM_ST_Internal));
-    uCtx->internal = &g_internal;
-#endif
     if (!uCtx->internal) {
         WOLFSSL_MSG("Failed to allocate memory for user ctx internal");
         return MEMORY_E;

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
@@ -1251,7 +1251,6 @@ int wc_fspsm_TlsCleanup(WOLFSSL* ssl)
     /* zero clear */
     ForceZero(tuc, sizeof(FSPSM_ST));
     ssl->RenesasUserCtx = NULL;
-    
     return ret;
 }
 /* Set callback contexts needed for sce TLS api handling */

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -63,7 +63,7 @@
     #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
 #endif
 #if defined(WOLFSSL_RENESAS_FSPSM)
-    #include <wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h>
+    #include <wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h>
 #endif
 #if defined(WOLFSSL_RENESAS_RX64_HASH)
     #include <wolfssl/wolfcrypt/port/Renesas/renesas-rx64-hw-crypt.h>

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -148,7 +148,7 @@ WOLFSSL_LOCAL void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c,
 #endif
 
 #if defined(WOLFSSL_RENESAS_FSPSM)
-    #include <wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h>
+    #include <wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h>
 #endif
 
 #ifdef WOLFSSL_MAXQ10XX_CRYPTO

--- a/wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h
@@ -46,7 +46,7 @@ typedef struct FSPSM_ST_Internal FSPSM_ST_Internal;
 typedef struct FSPSM_tag_ST {
     /* unique number for each session */
     int devId;
-    
+
     /* installed key handling */
     /* aes */
     FSPSM_W_KEYVAR   wrapped_key_aes256;

--- a/wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h
@@ -21,9 +21,6 @@
 #ifndef __RENESAS_FSPSM_CRYPT_H__
 #define __RENESAS_FSPSM_CRYPT_H__
 
-
-#include <wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-types.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -32,12 +29,6 @@ extern "C" {
 #define MAX_FSPSM_CBINDEX 5
 
 typedef void* FSPSM_W_KEYVAR;
-
-/* flsgas related to TLS */
-struct FSPSM_tls_flg_ST {
-    uint8_t pk_key_set:1;
-    uint8_t session_key_set:1;
-};
 
 /* flags Crypt Only */
 struct FSPSM_key_flg_ST {
@@ -50,25 +41,12 @@ struct FSPSM_key_flg_ST {
     uint8_t message_type:1;/*message 0, hashed 1*/
 };
 
+typedef struct FSPSM_ST_Internal FSPSM_ST_Internal;
+
 typedef struct FSPSM_tag_ST {
     /* unique number for each session */
     int devId;
-   #if defined(WOLFSSL_RENESAS_FSPSM_TLS) && \
-        !defined(WOLFSSL_RENESAS_FSPSM_CRYPTONLY)
-    /* out from R_SCE_TLS_ServerKeyExchangeVerify */
-    uint32_t
-        encrypted_ephemeral_ecdh_public_key[FSPSM_TLS_ENCRYPTED_ECCPUBKEY_SZ];
-    /* out from R_SCE_TLS_ECC_secp256r1_EphemeralWrappedKeyPairGenerate */
-    sce_tls_p256_ecc_wrapped_key_t ecc_p256_wrapped_key;
-    uint8_t ecc_ecdh_public_key[HW_SCE_ECC_PUBLIC_KEY_BYTE_SIZE];
-
-    uint32_t    masterSecret[FSPSM_TLS_MASTERSECRET_SIZE/4];
-    uint8_t     clientRandom[FSPSM_TLS_CLIENTRANDOM_SZ];
-    uint8_t     serverRandom[FSPSM_TLS_SERVERRANDOM_SZ];
-    uint8_t     cipher;
-    uint8_t     side; /* for key set side */
-   #endif
-
+    
     /* installed key handling */
     /* aes */
     FSPSM_W_KEYVAR   wrapped_key_aes256;
@@ -85,228 +63,27 @@ typedef struct FSPSM_tag_ST {
    #if defined(WOLFSSL_RENESAS_RSIP)
     uint8_t hash_type;
    #endif
-    /* key status flags */
-    /* flag whether encrypted ec key is set */
-    union {
-        uint8_t chr;
-        struct FSPSM_tls_flg_ST bits;
-    } keyflgs_tls;
+
     /* key status flags */
     /* flags shows status if wrapped keys are installed */
     union {
         uint8_t chr;
         struct FSPSM_key_flg_ST bits;
     } keyflgs_crypt;
+
+    FSPSM_ST_Internal* internal;
+
 } FSPSM_ST;
-
-typedef struct tagPKCbInfo {
-    FSPSM_ST    *user_PKCbInfo[MAX_FSPSM_CBINDEX];
-    uint32_t    num_session;
-} FSPSM_ST_PKC;
-
-#ifdef WOLFSSL_RENESAS_FSPSM_TLS
-typedef struct
-{
-    uint8_t                          *encrypted_provisioning_key;
-    uint8_t                          *iv;
-    uint8_t                          *encrypted_user_tls_key;
-    uint32_t                         encrypted_user_tls_key_type;
-    FSPSM_CACERT_PUB_WKEY            user_rsa2048_tls_wrappedkey;
-} fspsm_key_data;
-#endif
 
 struct WOLFSSL;
 struct WOLFSSL_CTX;
 struct ecc_key;
-
-WOLFSSL_LOCAL int     wc_fspsm_Open();
-WOLFSSL_LOCAL void    wc_fspsm_Close();
-WOLFSSL_LOCAL int     wc_fspsm_hw_lock();
-WOLFSSL_LOCAL void    wc_fspsm_hw_unlock( void );
-WOLFSSL_LOCAL int     wc_fspsm_usable(const struct WOLFSSL *ssl,
-                                    uint8_t session_key_generated);
-
-typedef struct {
-    FSPSM_AES_PWKEY   wrapped_key;
-    word32           keySize;
-#ifdef WOLFSSL_RENESAS_FSPSM_TLS
-    byte             setup;
-#endif
-} FSPSM_AES_CTX;
-
+struct wc_CryptoInfo;
 struct Aes;
-WOLFSSL_LOCAL void wc_fspsm_Aesfree(struct Aes* aes);
-WOLFSSL_LOCAL int wc_fspsm_AesCbcEncrypt(struct Aes* aes, byte* out,
-                        const byte* in, word32 sz);
-WOLFSSL_LOCAL int wc_fspsm_AesCbcDecrypt(struct Aes* aes, byte* out,
-                        const byte* in, word32 sz);
 
-WOLFSSL_LOCAL int  wc_fspsm_AesGcmEncrypt(struct Aes* aes, byte* out,
-                          const byte* in, word32 sz,
-                          byte* iv, word32 ivSz,
-                          byte* authTag, word32 authTagSz,
-                          const byte* authIn, word32 authInSz,
-                          void* ctx);
-
-WOLFSSL_LOCAL int  wc_fspsm_AesGcmDecrypt(struct Aes* aes, byte* out,
-                          const byte* in, word32 sz,
-                          const byte* iv, word32 ivSz,
-                          const byte* authTag, word32 authTagSz,
-                          const byte* authIn, word32 authInSz,
-                          void* ctx);
-
-#if (!defined(NO_SHA) || !defined(NO_SHA256) || defined(WOLFSSL_SH224) || \
-    defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)) && \
-    !defined(NO_WOLFSSL_RENESAS_FSPSM_HASH)
-
-typedef enum {
-#if defined(WOLFSSL_RENESAS_SCEPROTECT)
-    FSPSM_SHA256 = 1,
-#elif defined(WOLFSSL_RENESAS_RSIP)
-    FSPSM_SHA1 = RSIP_HASH_TYPE_SHA1,
-    FSPSM_SHA224 = RSIP_HASH_TYPE_SHA224,
-    FSPSM_SHA256 = RSIP_HASH_TYPE_SHA256,
-    FSPSM_SHA384 = RSIP_HASH_TYPE_SHA384,
-    FSPSM_SHA512 = RSIP_HASH_TYPE_SHA512,
-    FSPSM_SHA512_224 = RSIP_HASH_TYPE_SHA512_224,
-    FSPSM_SHA512_256 = RSIP_HASH_TYPE_SHA512_256,
-#endif
-} FSPSM_SHA_TYPE;
-
-typedef struct {
-    void*  heap;
-    word32 sha_type;
-#if defined(WOLFSSL_RENESAS_SCEPROTECT)
-    word32 used;
-    word32 len;
-    byte*  msg;
-#endif
-#if defined(WOLFSSL_RENESAS_RSIP)
-    FSPSM_SHA_HANDLE handle;
-#endif
-#if defined(WOLF_CRYPTO_CB)
-    word32 flags;
-    int devId;
-#endif
-} wolfssl_FSPSM_Hash;
-
-/* RAW hash function APIs are not implemented with SCE */
-#undef  WOLFSSL_NO_HASH_RAW
-#define WOLFSSL_NO_HASH_RAW
-
-#if !defined(NO_SHA) && defined(WOLFSSL_RENESAS_RSIP)
-    typedef wolfssl_FSPSM_Hash wc_Sha;
-#endif
-
-#if defined(WOLFSSL_SHA224) && defined(WOLFSSL_RENESAS_RSIP)
-    typedef wolfssl_FSPSM_Hash wc_Sha224;
-    #define WC_SHA224_TYPE_DEFINED
-#endif
-
-#if !defined(NO_SHA256) && \
-    (defined(WOLFSSL_RENESAS_SCEPROTECT) || defined(WOLFSSL_RENESAS_RSIP))
-    typedef wolfssl_FSPSM_Hash wc_Sha256;
-#endif
-
-#if defined(WOLFSSL_SHA384) && defined(WOLFSSL_RENESAS_RSIP)
-    typedef wolfssl_FSPSM_Hash wc_Sha384;
-    #define WC_SHA384_TYPE_DEFINED
-#endif
-
-#if defined(WOLFSSL_SHA512) && defined(WOLFSSL_RENESAS_RSIP)
-    typedef wolfssl_FSPSM_Hash wc_Sha512;
-    typedef wolfssl_FSPSM_Hash wc_Sha512_224;
-    typedef wolfssl_FSPSM_Hash wc_Sha512_256;
-    #define WC_SHA512_TYPE_DEFINED
-#endif
-
-#endif /* NO_SHA */
 
 #if defined(WOLFSSL_RENESAS_FSPSM_TLS) && \
         !defined(WOLFSSL_RENESAS_FSPSM_CRYPT_ONLY)
-
-WOLFSSL_LOCAL int     wc_fspsm_tls_RootCertVerify(
-            const   uint8_t* cert,         uint32_t cert_len,
-            uint32_t  key_n_start,        uint32_t key_n_len,
-            uint32_t  key_e_start,        uint32_t key_e_len,
-            uint32_t  cm_row);
-
-WOLFSSL_LOCAL int     wc_sce_tls_CertVerify(
-            const   uint8_t* cert,         uint32_t certSz,
-            const   uint8_t* signature,    uint32_t sigSz,
-            uint32_t  key_n_start,        uint32_t key_n_len,
-            uint32_t  key_e_start,        uint32_t key_e_len,
-            uint8_t*   sce_encRsaKeyIdx);
-
-
-WOLFSSL_LOCAL int     wc_fspsm_generatePremasterSecret(
-            uint8_t*   premaster,
-            uint32_t  preSz);
-
-WOLFSSL_LOCAL int     wc_fspsm_generateEncryptPreMasterSecret(
-            struct WOLFSSL* ssl,
-            uint8_t*           out,
-            uint32_t*         outSz);
-
-WOLFSSL_LOCAL int     wc_fspsm_Sha256GenerateHmac(
-            const struct WOLFSSL *ssl,
-            const uint8_t* myInner,
-            uint32_t      innerSz,
-            const uint8_t* in,
-            uint32_t      sz,
-            uint8_t*       digest);
-
-WOLFSSL_LOCAL int wc_fspsm_Sha256VerifyHmac(
-        const struct WOLFSSL *ssl,
-        const uint8_t* message,
-        uint32_t      messageSz,
-        uint32_t      macSz,
-        uint32_t      content);
-
-WOLFSSL_LOCAL int wc_fspsm_storeKeyCtx(
-        struct WOLFSSL* ssl,
-        FSPSM_ST* info);
-
-WOLFSSL_LOCAL int wc_fspsm_generateVerifyData(
-        const uint8_t*  ms, /* master secret */
-        const uint8_t*  side,
-        const uint8_t*  handshake_hash,
-        uint8_t*        hashes /* out */);
-
-WOLFSSL_LOCAL int wc_fspsm_generateSessionKey(
-        struct WOLFSSL*   ssl,
-        FSPSM_ST* cbInfo,
-        int               devId);
-
-WOLFSSL_LOCAL int wc_fspsm_generateMasterSecret(
-        uint8_t        cipherSuiteFirst,
-        uint8_t        cipherSuite,
-        const uint8_t *pr, /* pre-master    */
-        const uint8_t *cr, /* client random */
-        const uint8_t *sr, /* server random */
-        uint8_t *ms);
-
-WOLFSSL_LOCAL int wc_fspsm_RsaVerifyTLS(struct WOLFSSL* ssl, byte* sig,
-                        uint32_t sigSz, uint8_t** out,
-                        const byte* key, uint32_t keySz, void* ctx);
-WOLFSSL_LOCAL int wc_fspsm_EccVerifyTLS(struct WOLFSSL* ssl,
-                        const uint8_t* sig, uint32_t sigSz,
-                        const uint8_t* hash, uint32_t hashSz,
-                        const uint8_t* key, uint32_t keySz,
-                        int* result, void* ctx);
-WOLFSSL_LOCAL int wc_fspsm_tls_CertVerify(
-        const uint8_t* cert,       uint32_t certSz,
-        const uint8_t* signature,  uint32_t sigSz,
-        uint32_t      key_n_start,uint32_t key_n_len,
-        uint32_t      key_e_start,uint32_t key_e_len,
-        uint8_t*      fspsm_encPublickey);
-
-/* Callback for EccShareSecret */
-WOLFSSL_LOCAL int fspsm_EccSharedSecret(struct WOLFSSL* ssl,
-            struct ecc_key* otherKey,
-            uint8_t* pubKeyDer, unsigned int* pubKeySz,
-            uint8_t* out, unsigned int* outlen, int side, void* ctx);
-
 /* user API */
 WOLFSSL_API void FSPSM_INFORM_FUNC(
     uint8_t*     encrypted_provisioning_key,
@@ -318,28 +95,7 @@ WOLFSSL_API void FSPSM_CALLBACK_FUNC(struct WOLFSSL_CTX* ctx);
 WOLFSSL_API int  FSPSM_CALLBACK_CTX_FUNC(struct WOLFSSL* ssl, void* user_ctx);
 WOLFSSL_API void FSPSM_INFORM_CERT_SIGN(const uint8_t *sign);
 
-
 #endif  /* WOLFSSL_RENESAS_FSPSM_TLS &&
          * !WOLFSSL_RENESAS_FSPSM_CRYPT_ONLY */
 
-typedef struct FSPSM_RSA_CTX {
-    FSPSM_RSA1024_WPI_KEY *wrapped_pri1024_key;
-    FSPSM_RSA1024_WPB_KEY *wrapped_pub1024_key;
-    FSPSM_RSA2048_WPI_KEY *wrapped_pri2048_key;
-    FSPSM_RSA2048_WPB_KEY *wrapped_pub2048_key;
-    word32 keySz;
-} FSPSM_RSA_CTX;
-
-/* rsa */
-struct RsaKey;
-struct WC_RNG;
-WOLFSSL_LOCAL void wc_fspsm_RsaKeyFree(struct RsaKey *key);
-WOLFSSL_LOCAL int  wc_fspsm_RsaFunction(const byte* in, word32 inLen, byte* out,
-  word32 *outLen, int type, struct RsaKey* key, struct WC_RNG* rng);
-WOLFSSL_LOCAL int  wc_fspsm_MakeRsaKey(struct RsaKey* key, int size, void* ctx);
-WOLFSSL_LOCAL int  wc_fspsm_RsaSign(const byte* in, word32 inLen, byte* out,
-                    word32* outLen, struct RsaKey* key, void* ctx);
-WOLFSSL_LOCAL int  wc_fspsm_RsaVerify(const byte* in, word32 inLen, byte* out,
-                    word32* outLen,struct RsaKey* key, void* ctx);
-WOLFSSL_LOCAL int  wc_fspsm_GenerateRandBlock(byte* output, word32 size);
 #endif  /* __RENESAS_FSPSM_CRYPT_H__ */

--- a/wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h
@@ -1,0 +1,281 @@
+/* renesas_fspsm_internal.h
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef _RENESAS_FSPSM_INTERNAL_H_
+#define _RENESAS_FSPSM_INTERNAL_H_
+
+#include <wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-types.h>
+#include <wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h>
+
+/* flsgas related to TLS */
+struct FSPSM_tls_flg_ST {
+    uint8_t pk_key_set:1;
+    uint8_t session_key_set:1;
+};
+
+struct FSPSM_ST_Internal {
+
+#if defined(WOLFSSL_RENESAS_FSPSM_TLS) && \
+        !defined(WOLFSSL_RENESAS_FSPSM_CRYPTONLY)
+    /* out from R_SCE_TLS_ServerKeyExchangeVerify */
+    uint32_t
+        encrypted_ephemeral_ecdh_public_key[FSPSM_TLS_ENCRYPTED_ECCPUBKEY_SZ];
+    /* out from R_SCE_TLS_ECC_secp256r1_EphemeralWrappedKeyPairGenerate */
+    sce_tls_p256_ecc_wrapped_key_t ecc_p256_wrapped_key;
+    uint8_t ecc_ecdh_public_key[HW_SCE_ECC_PUBLIC_KEY_BYTE_SIZE];
+
+    uint32_t    masterSecret[FSPSM_TLS_MASTERSECRET_SIZE/4];
+    uint8_t     clientRandom[FSPSM_TLS_CLIENTRANDOM_SZ];
+    uint8_t     serverRandom[FSPSM_TLS_SERVERRANDOM_SZ];
+    uint8_t     cipher;
+    uint8_t     side; /* for key set side */
+#endif
+    /* key status flags */
+    /* flag whether encrypted ec key is set */
+    union {
+        uint8_t chr;
+        struct FSPSM_tls_flg_ST bits;
+    } keyflgs_tls;
+
+};
+
+#ifdef WOLFSSL_RENESAS_FSPSM_TLS
+typedef struct
+{
+    uint8_t                          *encrypted_provisioning_key;
+    uint8_t                          *iv;
+    uint8_t                          *encrypted_user_tls_key;
+    uint32_t                         encrypted_user_tls_key_type;
+    FSPSM_CACERT_PUB_WKEY            user_rsa2048_tls_wrappedkey;
+} fspsm_key_data;
+#endif
+
+typedef struct {
+    FSPSM_AES_PWKEY   wrapped_key;
+    word32           keySize;
+#ifdef WOLFSSL_RENESAS_FSPSM_TLS
+    byte             setup;
+#endif
+} FSPSM_AES_CTX;
+
+typedef struct FSPSM_RSA_CTX {
+    FSPSM_RSA1024_WPI_KEY *wrapped_pri1024_key;
+    FSPSM_RSA1024_WPB_KEY *wrapped_pub1024_key;
+    FSPSM_RSA2048_WPI_KEY *wrapped_pri2048_key;
+    FSPSM_RSA2048_WPB_KEY *wrapped_pub2048_key;
+    word32 keySz;
+} FSPSM_RSA_CTX;
+
+
+#if (!defined(NO_SHA) || !defined(NO_SHA256) || defined(WOLFSSL_SH224) || \
+    defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)) && \
+    !defined(NO_WOLFSSL_RENESAS_FSPSM_HASH)
+
+typedef struct {
+    void*  heap;
+    word32 sha_type;
+#if defined(WOLFSSL_RENESAS_SCEPROTECT)
+    word32 used;
+    word32 len;
+    byte*  msg;
+#endif
+#if defined(WOLFSSL_RENESAS_RSIP)
+    FSPSM_SHA_HANDLE handle;
+#endif
+#if defined(WOLF_CRYPTO_CB)
+    word32 flags;
+    int devId;
+#endif
+}wolfssl_FSPSM_Hash;
+
+typedef enum {
+#if defined(WOLFSSL_RENESAS_SCEPROTECT)
+    FSPSM_SHA256 = 1,
+#elif defined(WOLFSSL_RENESAS_RSIP)
+    FSPSM_SHA1 = RSIP_HASH_TYPE_SHA1,
+    FSPSM_SHA224 = RSIP_HASH_TYPE_SHA224,
+    FSPSM_SHA256 = RSIP_HASH_TYPE_SHA256,
+    FSPSM_SHA384 = RSIP_HASH_TYPE_SHA384,
+    FSPSM_SHA512 = RSIP_HASH_TYPE_SHA512,
+    FSPSM_SHA512_224 = RSIP_HASH_TYPE_SHA512_224,
+    FSPSM_SHA512_256 = RSIP_HASH_TYPE_SHA512_256,
+#endif
+} FSPSM_SHA_TYPE;
+
+/* RAW hash function APIs are not implemented with SCE */
+#undef  WOLFSSL_NO_HASH_RAW
+#define WOLFSSL_NO_HASH_RAW
+
+#if !defined(NO_SHA) && defined(WOLFSSL_RENESAS_RSIP)
+    typedef wolfssl_FSPSM_Hash wc_Sha;
+#endif
+
+#if defined(WOLFSSL_SHA224) && defined(WOLFSSL_RENESAS_RSIP)
+    typedef wolfssl_FSPSM_Hash wc_Sha224;
+    #define WC_SHA224_TYPE_DEFINED
+#endif
+
+#if !defined(NO_SHA256) && \
+    (defined(WOLFSSL_RENESAS_SCEPROTECT) || defined(WOLFSSL_RENESAS_RSIP))
+    typedef wolfssl_FSPSM_Hash wc_Sha256;
+#endif
+
+#if defined(WOLFSSL_SHA384) && defined(WOLFSSL_RENESAS_RSIP)
+    typedef wolfssl_FSPSM_Hash wc_Sha384;
+    #define WC_SHA384_TYPE_DEFINED
+#endif
+
+#if defined(WOLFSSL_SHA512) && defined(WOLFSSL_RENESAS_RSIP)
+    typedef wolfssl_FSPSM_Hash wc_Sha512;
+    typedef wolfssl_FSPSM_Hash wc_Sha512_224;
+    typedef wolfssl_FSPSM_Hash wc_Sha512_256;
+    #define WC_SHA512_TYPE_DEFINED
+#endif
+
+#endif /* NO_SHA */
+
+struct WOLFSSL;
+struct Aes;
+WOLFSSL_LOCAL void wc_fspsm_TlsCleanup(struct WOLFSSL* ssl);
+WOLFSSL_LOCAL int     wc_fspsm_Open();
+WOLFSSL_LOCAL void    wc_fspsm_Close();
+WOLFSSL_LOCAL int     wc_fspsm_hw_lock();
+WOLFSSL_LOCAL void    wc_fspsm_hw_unlock( void );
+WOLFSSL_LOCAL int     wc_fspsm_usable(const struct WOLFSSL *ssl,
+                                    uint8_t session_key_generated);
+WOLFSSL_LOCAL void wc_fspsm_Aesfree(struct Aes* aes);
+WOLFSSL_LOCAL int wc_fspsm_AesCbcEncrypt(struct Aes* aes, byte* out,
+                        const byte* in, word32 sz);
+WOLFSSL_LOCAL int wc_fspsm_AesCbcDecrypt(struct Aes* aes, byte* out,
+                        const byte* in, word32 sz);
+
+WOLFSSL_LOCAL int  wc_fspsm_AesGcmEncrypt(struct Aes* aes, byte* out,
+                          const byte* in, word32 sz,
+                          byte* iv, word32 ivSz,
+                          byte* authTag, word32 authTagSz,
+                          const byte* authIn, word32 authInSz,
+                          void* ctx);
+
+WOLFSSL_LOCAL int  wc_fspsm_AesGcmDecrypt(struct Aes* aes, byte* out,
+                          const byte* in, word32 sz,
+                          const byte* iv, word32 ivSz,
+                          const byte* authTag, word32 authTagSz,
+                          const byte* authIn, word32 authInSz,
+                          void* ctx);
+                          
+WOLFSSL_LOCAL int wc_fspsm_AesCipher(int devIdArg, struct wc_CryptoInfo* info,
+                                                                    void* ctx);
+WOLFSSL_LOCAL int     wc_fspsm_tls_RootCertVerify(
+            const   uint8_t* cert,         uint32_t cert_len,
+            uint32_t  key_n_start,        uint32_t key_n_len,
+            uint32_t  key_e_start,        uint32_t key_e_len,
+            uint32_t  cm_row);
+
+WOLFSSL_LOCAL int     wc_sce_tls_CertVerify(
+            const   uint8_t* cert,         uint32_t certSz,
+            const   uint8_t* signature,    uint32_t sigSz,
+            uint32_t  key_n_start,        uint32_t key_n_len,
+            uint32_t  key_e_start,        uint32_t key_e_len,
+            uint8_t*   sce_encRsaKeyIdx);
+
+
+WOLFSSL_LOCAL int     wc_fspsm_generatePremasterSecret(
+            uint8_t*   premaster,
+            uint32_t  preSz);
+
+WOLFSSL_LOCAL int     wc_fspsm_generateEncryptPreMasterSecret(
+            struct WOLFSSL* ssl,
+            uint8_t*           out,
+            uint32_t*         outSz);
+
+WOLFSSL_LOCAL int     wc_fspsm_Sha256GenerateHmac(
+            const struct WOLFSSL *ssl,
+            const uint8_t* myInner,
+            uint32_t      innerSz,
+            const uint8_t* in,
+            uint32_t      sz,
+            uint8_t*       digest);
+
+WOLFSSL_LOCAL int wc_fspsm_Sha256VerifyHmac(
+        const struct WOLFSSL *ssl,
+        const uint8_t* message,
+        uint32_t      messageSz,
+        uint32_t      macSz,
+        uint32_t      content);
+
+WOLFSSL_LOCAL int wc_fspsm_storeKeyCtx(
+        struct WOLFSSL* ssl,
+        FSPSM_ST* info);
+
+WOLFSSL_LOCAL int wc_fspsm_generateVerifyData(
+        const uint8_t*  ms, /* master secret */
+        const uint8_t*  side,
+        const uint8_t*  handshake_hash,
+        uint8_t*        hashes /* out */);
+
+WOLFSSL_LOCAL int wc_fspsm_generateSessionKey(
+        struct WOLFSSL*   ssl,
+        FSPSM_ST* cbInfo,
+        int               devId);
+
+WOLFSSL_LOCAL int wc_fspsm_generateMasterSecret(
+        uint8_t        cipherSuiteFirst,
+        uint8_t        cipherSuite,
+        const uint8_t *pr, /* pre-master    */
+        const uint8_t *cr, /* client random */
+        const uint8_t *sr, /* server random */
+        uint8_t *ms);
+
+WOLFSSL_LOCAL int wc_fspsm_RsaVerifyTLS(struct WOLFSSL* ssl, byte* sig,
+                        uint32_t sigSz, uint8_t** out,
+                        const byte* key, uint32_t keySz, void* ctx);
+WOLFSSL_LOCAL int wc_fspsm_EccVerifyTLS(struct WOLFSSL* ssl,
+                        const uint8_t* sig, uint32_t sigSz,
+                        const uint8_t* hash, uint32_t hashSz,
+                        const uint8_t* key, uint32_t keySz,
+                        int* result, void* ctx);
+WOLFSSL_LOCAL int wc_fspsm_tls_CertVerify(
+        const uint8_t* cert,       uint32_t certSz,
+        const uint8_t* signature,  uint32_t sigSz,
+        uint32_t      key_n_start,uint32_t key_n_len,
+        uint32_t      key_e_start,uint32_t key_e_len,
+        uint8_t*      fspsm_encPublickey);
+
+/* Callback for EccShareSecret */
+WOLFSSL_LOCAL int fspsm_EccSharedSecret(struct WOLFSSL* ssl,
+            struct ecc_key* otherKey,
+            uint8_t* pubKeyDer, unsigned int* pubKeySz,
+            uint8_t* out, unsigned int* outlen, int side, void* ctx);
+/* rsa */
+struct RsaKey;
+struct WC_RNG;
+WOLFSSL_LOCAL void wc_fspsm_RsaKeyFree(struct RsaKey *key);
+WOLFSSL_LOCAL int  wc_fspsm_RsaFunction(const byte* in, word32 inLen, byte* out,
+  word32 *outLen, int type, struct RsaKey* key, struct WC_RNG* rng);
+WOLFSSL_LOCAL int  wc_fspsm_MakeRsaKey(struct RsaKey* key, int size, void* ctx);
+WOLFSSL_LOCAL int  wc_fspsm_RsaSign(const byte* in, word32 inLen, byte* out,
+                    word32* outLen, struct RsaKey* key, void* ctx);
+WOLFSSL_LOCAL int  wc_fspsm_RsaVerify(const byte* in, word32 inLen, byte* out,
+                    word32* outLen,struct RsaKey* key, void* ctx);
+WOLFSSL_LOCAL int  wc_fspsm_GenerateRandBlock(byte* output, word32 size);
+
+#endif /* RENESAS_FSPSM_INTERNAL_H */
+

--- a/wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h
@@ -180,7 +180,7 @@ WOLFSSL_LOCAL int  wc_fspsm_AesGcmDecrypt(struct Aes* aes, byte* out,
                           const byte* authTag, word32 authTagSz,
                           const byte* authIn, word32 authInSz,
                           void* ctx);
-                          
+
 WOLFSSL_LOCAL int wc_fspsm_AesCipher(int devIdArg, struct wc_CryptoInfo* info,
                                                                     void* ctx);
 WOLFSSL_LOCAL int     wc_fspsm_tls_RootCertVerify(

--- a/wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h
@@ -154,7 +154,7 @@ typedef enum {
 
 struct WOLFSSL;
 struct Aes;
-WOLFSSL_LOCAL void wc_fspsm_TlsCleanup(struct WOLFSSL* ssl);
+WOLFSSL_LOCAL int wc_fspsm_TlsCleanup(struct WOLFSSL* ssl);
 WOLFSSL_LOCAL int     wc_fspsm_Open();
 WOLFSSL_LOCAL void    wc_fspsm_Close();
 WOLFSSL_LOCAL int     wc_fspsm_hw_lock();

--- a/wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h
@@ -25,7 +25,7 @@
 #include <wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-types.h>
 #include <wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h>
 
-/* flsgas related to TLS */
+/* Wrapped TLS FSP Key Set Flags */
 struct FSPSM_tls_flg_ST {
     uint8_t pk_key_set:1;
     uint8_t session_key_set:1;

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -90,7 +90,7 @@ RSA keys can be used to encrypt, decrypt, sign and verify data.
 #endif
 
 #if defined(WOLFSSL_RENESAS_FSPSM)
-    #include <wolfssl/wolfcrypt/port/renesas/renesas-fspsm-crypt.h>
+    #include <wolfssl/wolfcrypt/port/renesas/renesas_fspsm_internal.h>
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -141,7 +141,7 @@ enum {
 #elif (defined(WOLFSSL_RENESAS_SCEPROTECT) || \
        defined(WOLFSSL_RENESAS_RSIP))    && \
      !defined(NO_WOLFSSL_RENESAS_FSPSM_HASH)
-    #include "wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h"
+    #include "wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h"
 #elif defined(WOLFSSL_RENESAS_RX64_HASH)
     #include "wolfssl/wolfcrypt/port/Renesas/renesas-rx64-hw-crypt.h"
 #else

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -129,7 +129,7 @@ enum {
     #include "wolfssl/wolfcrypt/port/caam/wolfcaam_sha.h"
 #elif defined(WOLFSSL_RENESAS_RSIP) && \
      !defined(NO_WOLFSSL_RENESAS_FSPSM_HASH)
-    #include "wolfssl/wolfcrypt/port/Renesas/renesas-fspsm-crypt.h"
+    #include "wolfssl/wolfcrypt/port/Renesas/renesas_fspsm_internal.h"
 
 #else
 #if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)


### PR DESCRIPTION
# Description
Make properties related to Renesas FSP Security Module TLS hidden

 - Fix RSA Crypt callback
 - Eliminate WOLFSSL_LOCAL

# Testing

Run Renesas RA6M4 example including Crypt, Benchmark and Client

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
