### PR TITLE
20250717-linuxkm-include-am

### DIFF
--- a/linuxkm/include.am
+++ b/linuxkm/include.am
@@ -21,6 +21,7 @@ EXTRA_DIST += m4/ax_linuxkm.m4 \
 	      linuxkm/lkcapi_ecdsa_glue.c \
 	      linuxkm/lkcapi_ecdh_glue.c \
 	      linuxkm/lkcapi_rsa_glue.c \
+	      linuxkm/wolfcrypt.lds \
 	      linuxkm/patches/5.10.17/WOLFSSL_LINUXKM_HAVE_GET_RANDOM_CALLBACKS-5v10v17.patch \
 	      linuxkm/patches/5.10.236/WOLFSSL_LINUXKM_HAVE_GET_RANDOM_CALLBACKS-5v10v236.patch \
 	      linuxkm/patches/5.15/WOLFSSL_LINUXKM_HAVE_GET_RANDOM_CALLBACKS-5v15.patch \


### PR DESCRIPTION
`linuxkm/include.am`: add `linuxkm/wolfcrypt.lds` to `EXTRA_DIST`.

tested with `wolfssl-multi-test.sh ... make-dist-clean-check` with `make-dist-clean-check` tweaked to do an `--enable-linuxkm-pie` build.
