### PR TITLE
Set out ptr properly for RSA pad crypto cb inline

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3601,6 +3601,9 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
         ret = wc_CryptoCb_RsaPad(in, inLen, out,
                             &outLen, rsa_type, key, rng, &padding);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
+            if (outPtr != NULL) {
+                *outPtr = out;
+            }
             if (ret == 0) {
                 ret = (int)outLen;
             }


### PR DESCRIPTION
# Description

Fix RSA pad crypto cb handling to properly set the out ptr for inline case, consistent with other RSA HW handling.

Fixes zd 20260
