### PR TITLE
Fix GetShortInt/SetShortInt handling of negative values

### DIFF
--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -24,7 +24,7 @@
 #include <tests/api/test_asn.h>
 
 #ifndef NO_ASN
-static int test_SetShortInt_once(word32 val, byte* valDer, word32 valDerSz)
+static int test_GetSetShortInt_once(sword32 val, byte* valDer, word32 valDerSz)
 {
     EXPECT_DECLS;
 
@@ -36,6 +36,7 @@ static int test_SetShortInt_once(word32 val, byte* valDer, word32 valDerSz)
     word32 outDerSz = 0;
     word32 inOutIdx = 0;
     word32 maxIdx = MAX_SHORT_SZ;
+    sword32 decodedVal = 0;
 
     ExpectIntLE(2 + valDerSz, MAX_SHORT_SZ);
     ExpectIntEQ(outDerSz = SetShortInt(outDer, &inOutIdx, val, maxIdx),
@@ -43,6 +44,11 @@ static int test_SetShortInt_once(word32 val, byte* valDer, word32 valDerSz)
     ExpectIntEQ(outDer[0], ASN_INTEGER);
     ExpectIntEQ(outDer[1], valDerSz);
     ExpectIntEQ(XMEMCMP(outDer + 2, valDer, valDerSz), 0);
+
+    /* Verify we decode the same value that we just encoded. */
+    inOutIdx = 0;
+    ExpectIntEQ(GetShortInt(outDer, &inOutIdx, &decodedVal, maxIdx), 0);
+    ExpectIntEQ(decodedVal, val);
 
 #endif /* !WOLFSSL_ASN_TEMPLATE || HAVE_PKCS8 || HAVE_PKCS12 */
 #endif /* !NO_PWDBASED */
@@ -55,7 +61,7 @@ static int test_SetShortInt_once(word32 val, byte* valDer, word32 valDerSz)
 }
 #endif
 
-int test_SetShortInt(void)
+int test_GetSetShortInt(void)
 {
     EXPECT_DECLS;
 
@@ -66,51 +72,50 @@ int test_SetShortInt(void)
     {
         /* Input 1 byte min */
         valDer[0] = 0x00;
-        EXPECT_TEST(test_SetShortInt_once(0x00, valDer, 1));
+        EXPECT_TEST(test_GetSetShortInt_once(0x00, valDer, 1));
 
         /* Input 1 byte max */
         valDer[0] = 0x00;
         valDer[1] = 0xff;
-        EXPECT_TEST(test_SetShortInt_once(0xff, valDer, 2));
+        EXPECT_TEST(test_GetSetShortInt_once(0xff, valDer, 2));
 
         /* Input 2 bytes min */
         valDer[0] = 0x01;
         valDer[1] = 0x00;
-        EXPECT_TEST(test_SetShortInt_once(0x0100, valDer, 2));
+        EXPECT_TEST(test_GetSetShortInt_once(0x0100, valDer, 2));
 
         /* Input 2 bytes max */
         valDer[0] = 0x00;
         valDer[1] = 0xff;
         valDer[2] = 0xff;
-        EXPECT_TEST(test_SetShortInt_once(0xffff, valDer, 3));
+        EXPECT_TEST(test_GetSetShortInt_once(0xffff, valDer, 3));
 
         /* Input 3 bytes min */
         valDer[0] = 0x01;
         valDer[1] = 0x00;
         valDer[2] = 0x00;
-        EXPECT_TEST(test_SetShortInt_once(0x010000, valDer, 3));
+        EXPECT_TEST(test_GetSetShortInt_once(0x010000, valDer, 3));
 
         /* Input 3 bytes max */
         valDer[0] = 0x00;
         valDer[1] = 0xff;
         valDer[2] = 0xff;
         valDer[3] = 0xff;
-        EXPECT_TEST(test_SetShortInt_once(0xffffff, valDer, 4));
+        EXPECT_TEST(test_GetSetShortInt_once(0xffffff, valDer, 4));
 
         /* Input 4 bytes min */
         valDer[0] = 0x01;
         valDer[1] = 0x00;
         valDer[2] = 0x00;
         valDer[3] = 0x00;
-        EXPECT_TEST(test_SetShortInt_once(0x01000000, valDer, 4));
+        EXPECT_TEST(test_GetSetShortInt_once(0x01000000, valDer, 4));
 
         /* Input 4 bytes max */
-        valDer[0] = 0x00;
+        valDer[0] = 0x7f;
         valDer[1] = 0xff;
         valDer[2] = 0xff;
         valDer[3] = 0xff;
-        valDer[4] = 0xff;
-        EXPECT_TEST(test_SetShortInt_once(0xffffffff, valDer, 5));
+        EXPECT_TEST(test_GetSetShortInt_once(0x7fffffff, valDer, 4));
     }
 
     /* Corner tests for output size */
@@ -119,60 +124,96 @@ int test_SetShortInt(void)
 
         /* Output 1 byte max */
         valDer[0] = 0x7f;
-        EXPECT_TEST(test_SetShortInt_once(0x7f, valDer, 1));
+        EXPECT_TEST(test_GetSetShortInt_once(0x7f, valDer, 1));
 
         /* Output 2 bytes min */
         valDer[0] = 0x00;
         valDer[1] = 0x80;
-        EXPECT_TEST(test_SetShortInt_once(0x80, valDer, 2));
+        EXPECT_TEST(test_GetSetShortInt_once(0x80, valDer, 2));
 
         /* Output 2 bytes max */
         valDer[0] = 0x7f;
         valDer[1] = 0xff;
-        EXPECT_TEST(test_SetShortInt_once(0x7fff, valDer, 2));
+        EXPECT_TEST(test_GetSetShortInt_once(0x7fff, valDer, 2));
 
         /* Output 3 bytes min */
         valDer[0] = 0x00;
         valDer[1] = 0x80;
         valDer[2] = 0x00;
-        EXPECT_TEST(test_SetShortInt_once(0x8000, valDer, 3));
+        EXPECT_TEST(test_GetSetShortInt_once(0x8000, valDer, 3));
 
         /* Output 3 bytes max */
         valDer[0] = 0x7f;
         valDer[1] = 0xff;
         valDer[2] = 0xff;
-        EXPECT_TEST(test_SetShortInt_once(0x7fffff, valDer, 3));
+        EXPECT_TEST(test_GetSetShortInt_once(0x7fffff, valDer, 3));
 
         /* Output 4 bytes min */
         valDer[0] = 0x00;
         valDer[1] = 0x80;
         valDer[2] = 0x00;
         valDer[3] = 0x00;
-        EXPECT_TEST(test_SetShortInt_once(0x800000, valDer, 4));
+        EXPECT_TEST(test_GetSetShortInt_once(0x800000, valDer, 4));
 
-        /* Output 4 bytes max */
-        valDer[0] = 0x7f;
-        valDer[1] = 0xff;
-        valDer[2] = 0xff;
-        valDer[3] = 0xff;
-        EXPECT_TEST(test_SetShortInt_once(0x7fffffff, valDer, 4));
-
-        /* Output 5 bytes min */
-        valDer[0] = 0x00;
-        valDer[1] = 0x80;
+        /* Output 4 bytes min */
+        valDer[0] = 0x80;
+        valDer[1] = 0x00;
         valDer[2] = 0x00;
         valDer[3] = 0x00;
-        valDer[4] = 0x00;
-        EXPECT_TEST(test_SetShortInt_once(0x80000000, valDer, 5));
+        EXPECT_TEST(test_GetSetShortInt_once(0x80000000, valDer, 4));
 
-        /* Skip "Output 5 bytes max" because of same as "Input 4 bytes max" */
+        /* Test negative value encoding. */
+        valDer[0] = 0xff;
+        EXPECT_TEST(test_GetSetShortInt_once(0xffffffff, valDer, 1));
+
+        valDer[0] = 0xff;
+        valDer[1] = 0x55;
+        EXPECT_TEST(test_GetSetShortInt_once(0xffffff55, valDer, 2));
+
+        valDer[0] = 0xff;
+        valDer[1] = 0x55;
+        valDer[2] = 0x55;
+        EXPECT_TEST(test_GetSetShortInt_once(0xffff5555, valDer, 3));
+
+        valDer[0] = 0xff;
+        valDer[1] = 0x55;
+        valDer[2] = 0x55;
+        valDer[3] = 0x55;
+        EXPECT_TEST(test_GetSetShortInt_once(0xff555555, valDer, 4));
+
+        valDer[0] = 0x80;
+        EXPECT_TEST(test_GetSetShortInt_once(0xffffff80, valDer, 1));
+
+        valDer[0] = 0x80;
+        valDer[1] = 0x00;
+        EXPECT_TEST(test_GetSetShortInt_once(0xffff8000, valDer, 2));
+
+        valDer[0] = 0x80;
+        valDer[1] = 0x00;
+        valDer[2] = 0x00;
+        EXPECT_TEST(test_GetSetShortInt_once(0xff800000, valDer, 3));
     }
 
+#if !defined(NO_PWDBASED) || defined(WOLFSSL_ASN_EXTRA)
     /* Extra tests */
     {
+        word32 inOutIdx = 0U;
+        sword32 decodedVal = 0;
+
         valDer[0] = 0x01;
-        EXPECT_TEST(test_SetShortInt_once(0x01, valDer, 1));
+        EXPECT_TEST(test_GetSetShortInt_once(0x01, valDer, 1));
+
+        valDer[0] = ASN_INTEGER;
+        valDer[1] = 5U;
+        valDer[2] = 0x00U;
+        valDer[3] = 0x80U;
+        valDer[4] = 0x00U;
+        valDer[5] = 0x00U;
+        valDer[6] = 0x00U;
+        ExpectIntEQ(GetShortInt(valDer, &inOutIdx, &decodedVal, 7U), ASN_PARSE_E);
     }
+#endif
+
 #endif
 
     return EXPECT_RESULT();

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -24,9 +24,9 @@
 
 #include <tests/api/api_decl.h>
 
-int test_SetShortInt(void);
+int test_GetSetShortInt(void);
 
 #define TEST_ASN_DECLS                                              \
-    TEST_DECL_GROUP("asn", test_SetShortInt)                        \
+    TEST_DECL_GROUP("asn", test_GetSetShortInt)                     \
 
 #endif /* WOLFCRYPT_TEST_ASN_H */

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -488,7 +488,7 @@ static int GetSignData(WC_PKCS12* pkcs12, const byte* mem, word32* idx,
     /* check for MAC iterations, default to 1 */
     mac->itt = WC_PKCS12_MAC_DEFAULT;
     if (curIdx < totalSz) {
-        int number = 0;
+        sword32 number = 0;
         if (GetShortInt(mem, &curIdx, &number, totalSz) >= 0) {
             /* found a iteration value */
             mac->itt = number;
@@ -888,7 +888,7 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
             outerSz += mac->saltSz;
 
             /* MAC iterations */
-            ret = SetShortInt(ASNSHORT, &tmpIdx, (word32)mac->itt, MAX_SHORT_SZ);
+            ret = SetShortInt(ASNSHORT, &tmpIdx, mac->itt, MAX_SHORT_SZ);
             if (ret >= 0) {
                 outerSz += (word32)ret;
                 ret = 0;
@@ -943,7 +943,7 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
                 int tmpSz;
                 word32 tmpIdx = 0;
                 byte ar[MAX_SHORT_SZ];
-                tmpSz = SetShortInt(ar, &tmpIdx, (word32)mac->itt, MAX_SHORT_SZ);
+                tmpSz = SetShortInt(ar, &tmpIdx, mac->itt, MAX_SHORT_SZ);
                 if (tmpSz < 0) {
                     ret = tmpSz;
                 }
@@ -1165,7 +1165,8 @@ static int PKCS12_CheckConstructedZero(byte* data, word32 dataSz, word32* idx)
 {
     word32 oid;
     int    ret = 0;
-    int    number, size = 0;
+    sword32 number = 0;
+    int    size = 0;
     byte   tag = 0;
 
     if (GetSequence(data, idx, &size, dataSz) < 0) {
@@ -1360,7 +1361,7 @@ int wc_PKCS12_parse_ex(WC_PKCS12* pkcs12, const char* psw,
         data = ci->data;
 
         if (ci->type == WC_PKCS12_ENCRYPTED_DATA) {
-            int number;
+            sword32 number;
 
             WOLFSSL_MSG("Decrypting PKCS12 Content Info Container");
             if (GetASNTag(data, &idx, &tag, ci->dataSz) < 0) {

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2203,10 +2203,10 @@ WOLFSSL_ASN_API int SetName(byte* output, word32 outputSz, CertName* name);
 WOLFSSL_LOCAL const char* GetOneCertName(CertName* name, int idx);
 WOLFSSL_LOCAL byte GetCertNameId(int idx);
 #endif
-WOLFSSL_LOCAL int GetShortInt(const byte* input, word32* inOutIdx, int* number,
-                              word32 maxIdx);
-WOLFSSL_TEST_VIS int SetShortInt(byte* output, word32* inOutIdx, word32 number,
-                              word32 maxIdx);
+WOLFSSL_TEST_VIS int GetShortInt(const byte* input, word32* inOutIdx,
+        sword32 * number, word32 maxIdx);
+WOLFSSL_TEST_VIS int SetShortInt(byte* output, word32* inOutIdx,
+        sword32 number, word32 maxIdx);
 
 WOLFSSL_LOCAL const char* GetSigName(int oid);
 WOLFSSL_ASN_API int GetLength(const byte* input, word32* inOutIdx, int* len,


### PR DESCRIPTION
# Description

This PR fixes GetShortInt/SetShortInt handling of negative INTEGER values.

1. GetShortInt was not correctly decoding negative INTEGER values. This has been fixed.
2. SetShortInt was not correctly encoding negative INTEGER values. This has been fixed.
3. SetShortInt took an unsigned word32 input even though every call to it actually used a signed value and casted it to word32. SetShortInt now takes a sword32 input instead of word32.
4. GetShortInt returned the decoded INTEGER value both via an output pointer and as the function return value. Once it was fixed to properly decode negative INTEGER values, the return value could have conflicted with an actual error code. The return value is now 0 on success or an error code and the decoded INTEGER value is only returned via pointer.
5. GetShortInt returned the decoded INTEGER value via an int pointer. It now returns via sword32 pointer.

# Testing

How did you test?

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
