### PR TITLE
Add API to decode SymmetricKeyPackage and OneSymmetricKey CMS objects

### DIFF
--- a/doc/dox_comments/header_files/pkcs7.h
+++ b/doc/dox_comments/header_files/pkcs7.h
@@ -734,8 +734,8 @@ int wc_PKCS7_DecodeEncryptedKeyPackage(wc_PKCS7 * pkcs7,
     \param[out] attrSz Buffer in which to store the size of the requested
     attribute object.
 */
-int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(byte const * skp,
-        word32 skpSz, size_t index, byte const ** attr, word32 * attrSz);
+int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(const byte * skp,
+        word32 skpSz, size_t index, const byte ** attr, word32 * attrSz);
 
 /*!
     \ingroup PKCS7
@@ -758,8 +758,8 @@ int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(byte const * skp,
     \param[out] keySz Buffer in which to store the size of the requested
     key object.
 */
-int wc_PKCS7_DecodeSymmetricKeyPackageKey(byte const * skp,
-        word32 skpSz, size_t index, byte const ** key, word32 * keySz);
+int wc_PKCS7_DecodeSymmetricKeyPackageKey(const byte * skp,
+        word32 skpSz, size_t index, const byte ** key, word32 * keySz);
 
 /*!
     \ingroup PKCS7
@@ -782,8 +782,8 @@ int wc_PKCS7_DecodeSymmetricKeyPackageKey(byte const * skp,
     \param[out] attrSz Buffer in which to store the size of the requested
     attribute object.
 */
-int wc_PKCS7_DecodeOneSymmetricKeyAttribute(byte const * osk,
-        word32 oskSz, size_t index, byte const ** attr, word32 * attrSz);
+int wc_PKCS7_DecodeOneSymmetricKeyAttribute(const byte * osk,
+        word32 oskSz, size_t index, const byte ** attr, word32 * attrSz);
 
 /*!
     \ingroup PKCS7
@@ -804,5 +804,5 @@ int wc_PKCS7_DecodeOneSymmetricKeyAttribute(byte const * osk,
     \param[out] keySz Buffer in which to store the size of the requested
     key object.
 */
-int wc_PKCS7_DecodeOneSymmetricKeyKey(byte const * osk,
-        word32 oskSz, byte const ** key, word32 * keySz);
+int wc_PKCS7_DecodeOneSymmetricKeyKey(const byte * osk,
+        word32 oskSz, const byte ** key, word32 * keySz);

--- a/doc/dox_comments/header_files/pkcs7.h
+++ b/doc/dox_comments/header_files/pkcs7.h
@@ -718,6 +718,14 @@ int wc_PKCS7_DecodeEncryptedKeyPackage(wc_PKCS7 * pkcs7,
 
     \brief This function provides access to a SymmetricKeyPackage attribute.
 
+    \return 0 The requested attribute has been successfully located.
+    attr and attrSz output variables are populated with the address and size of
+    the attribute. The attribute will be in the same buffer passed in via the
+    skp input pointer.
+    \return BAD_FUNC_ARG One of the input parameters is invalid.
+    \return ASN_PARSE_E An error was encountered parsing the input object.
+    \return BAD_INDEX_E The requested attribute index was invalid.
+
     \param[in] skp Input buffer containing the SymmetricKeyPackage object.
     \param[in] skpSz Size of the SymmetricKeyPackage object.
     \param[in] index Index of the attribute to access.
@@ -725,14 +733,6 @@ int wc_PKCS7_DecodeEncryptedKeyPackage(wc_PKCS7 * pkcs7,
     attribute object.
     \param[out] attrSz Buffer in which to store the size of the requested
     attribute object.
-
-    \retval 0 The requested attribute has been successfully located.
-    attr and attrSz output variables are populated with the address and size of
-    the attribute. The attribute will be in the same buffer passed in via the
-    skp input pointer.
-    \retval BAD_FUNC_ARG One of the input parameters is invalid.
-    \retval ASN_PARSE_E An error was encountered parsing the input object.
-    \retval BAD_INDEX_E The requested attribute index was invalid.
 */
 int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(byte const * skp,
         word32 skpSz, size_t index, byte const ** attr, word32 * attrSz);
@@ -742,6 +742,14 @@ int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(byte const * skp,
 
     \brief This function provides access to a SymmetricKeyPackage key.
 
+    \return 0 The requested key has been successfully located.
+    key and keySz output variables are populated with the address and size of
+    the key. The key will be in the same buffer passed in via the
+    skp input pointer.
+    \return BAD_FUNC_ARG One of the input parameters is invalid.
+    \return ASN_PARSE_E An error was encountered parsing the input object.
+    \return BAD_INDEX_E The requested key index was invalid.
+
     \param[in] skp Input buffer containing the SymmetricKeyPackage object.
     \param[in] skpSz Size of the SymmetricKeyPackage object.
     \param[in] index Index of the key to access.
@@ -749,14 +757,6 @@ int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(byte const * skp,
     key object.
     \param[out] keySz Buffer in which to store the size of the requested
     key object.
-
-    \retval 0 The requested key has been successfully located.
-    key and keySz output variables are populated with the address and size of
-    the key. The key will be in the same buffer passed in via the
-    skp input pointer.
-    \retval BAD_FUNC_ARG One of the input parameters is invalid.
-    \retval ASN_PARSE_E An error was encountered parsing the input object.
-    \retval BAD_INDEX_E The requested key index was invalid.
 */
 int wc_PKCS7_DecodeSymmetricKeyPackageKey(byte const * skp,
         word32 skpSz, size_t index, byte const ** key, word32 * keySz);
@@ -766,6 +766,14 @@ int wc_PKCS7_DecodeSymmetricKeyPackageKey(byte const * skp,
 
     \brief This function provides access to a OneSymmetricKey attribute.
 
+    \return 0 The requested attribute has been successfully located.
+    attr and attrSz output variables are populated with the address and size of
+    the attribute. The attribute will be in the same buffer passed in via the
+    osk input pointer.
+    \return BAD_FUNC_ARG One of the input parameters is invalid.
+    \return ASN_PARSE_E An error was encountered parsing the input object.
+    \return BAD_INDEX_E The requested attribute index was invalid.
+
     \param[in] osk Input buffer containing the OneSymmetricKey object.
     \param[in] oskSz Size of the OneSymmetricKey object.
     \param[in] index Index of the attribute to access.
@@ -773,14 +781,6 @@ int wc_PKCS7_DecodeSymmetricKeyPackageKey(byte const * skp,
     attribute object.
     \param[out] attrSz Buffer in which to store the size of the requested
     attribute object.
-
-    \retval 0 The requested attribute has been successfully located.
-    attr and attrSz output variables are populated with the address and size of
-    the attribute. The attribute will be in the same buffer passed in via the
-    osk input pointer.
-    \retval BAD_FUNC_ARG One of the input parameters is invalid.
-    \retval ASN_PARSE_E An error was encountered parsing the input object.
-    \retval BAD_INDEX_E The requested attribute index was invalid.
 */
 int wc_PKCS7_DecodeOneSymmetricKeyAttribute(byte const * osk,
         word32 oskSz, size_t index, byte const ** attr, word32 * attrSz);
@@ -790,19 +790,19 @@ int wc_PKCS7_DecodeOneSymmetricKeyAttribute(byte const * osk,
 
     \brief This function provides access to a OneSymmetricKey key.
 
+    \return 0 The requested key has been successfully located.
+    key and keySz output variables are populated with the address and size of
+    the key. The key will be in the same buffer passed in via the
+    osk input pointer.
+    \return BAD_FUNC_ARG One of the input parameters is invalid.
+    \return ASN_PARSE_E An error was encountered parsing the input object.
+
     \param[in] osk Input buffer containing the OneSymmetricKey object.
     \param[in] oskSz Size of the OneSymmetricKey object.
     \param[out] key Buffer in which to store the pointer to the requested
     key object.
     \param[out] keySz Buffer in which to store the size of the requested
     key object.
-
-    \retval 0 The requested key has been successfully located.
-    key and keySz output variables are populated with the address and size of
-    the key. The key will be in the same buffer passed in via the
-    osk input pointer.
-    \retval BAD_FUNC_ARG One of the input parameters is invalid.
-    \retval ASN_PARSE_E An error was encountered parsing the input object.
 */
 int wc_PKCS7_DecodeOneSymmetricKeyKey(byte const * osk,
         word32 oskSz, byte const ** key, word32 * keySz);

--- a/doc/dox_comments/header_files/pkcs7.h
+++ b/doc/dox_comments/header_files/pkcs7.h
@@ -712,3 +712,97 @@ int wc_PKCS7_DecodeEncryptedData(PKCS7* pkcs7, byte* pkiMsg,
 */
 int wc_PKCS7_DecodeEncryptedKeyPackage(wc_PKCS7 * pkcs7,
         byte * pkiMsg, word32 pkiMsgSz, byte * output, word32 outputSz);
+
+/*!
+    \ingroup PKCS7
+
+    \brief This function provides access to a SymmetricKeyPackage attribute.
+
+    \param[in] skp Input buffer containing the SymmetricKeyPackage object.
+    \param[in] skpSz Size of the SymmetricKeyPackage object.
+    \param[in] index Index of the attribute to access.
+    \param[out] attr Buffer in which to store the pointer to the requested
+    attribute object.
+    \param[out] attrSz Buffer in which to store the size of the requested
+    attribute object.
+
+    \retval 0 The requested attribute has been successfully located.
+    attr and attrSz output variables are populated with the address and size of
+    the attribute. The attribute will be in the same buffer passed in via the
+    skp input pointer.
+    \retval BAD_FUNC_ARG One of the input parameters is invalid.
+    \retval ASN_PARSE_E An error was encountered parsing the input object.
+    \retval BAD_INDEX_E The requested attribute index was invalid.
+*/
+int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(byte const * skp,
+        word32 skpSz, size_t index, byte const ** attr, word32 * attrSz);
+
+/*!
+    \ingroup PKCS7
+
+    \brief This function provides access to a SymmetricKeyPackage key.
+
+    \param[in] skp Input buffer containing the SymmetricKeyPackage object.
+    \param[in] skpSz Size of the SymmetricKeyPackage object.
+    \param[in] index Index of the key to access.
+    \param[out] key Buffer in which to store the pointer to the requested
+    key object.
+    \param[out] keySz Buffer in which to store the size of the requested
+    key object.
+
+    \retval 0 The requested key has been successfully located.
+    key and keySz output variables are populated with the address and size of
+    the key. The key will be in the same buffer passed in via the
+    skp input pointer.
+    \retval BAD_FUNC_ARG One of the input parameters is invalid.
+    \retval ASN_PARSE_E An error was encountered parsing the input object.
+    \retval BAD_INDEX_E The requested key index was invalid.
+*/
+int wc_PKCS7_DecodeSymmetricKeyPackageKey(byte const * skp,
+        word32 skpSz, size_t index, byte const ** key, word32 * keySz);
+
+/*!
+    \ingroup PKCS7
+
+    \brief This function provides access to a OneSymmetricKey attribute.
+
+    \param[in] osk Input buffer containing the OneSymmetricKey object.
+    \param[in] oskSz Size of the OneSymmetricKey object.
+    \param[in] index Index of the attribute to access.
+    \param[out] attr Buffer in which to store the pointer to the requested
+    attribute object.
+    \param[out] attrSz Buffer in which to store the size of the requested
+    attribute object.
+
+    \retval 0 The requested attribute has been successfully located.
+    attr and attrSz output variables are populated with the address and size of
+    the attribute. The attribute will be in the same buffer passed in via the
+    osk input pointer.
+    \retval BAD_FUNC_ARG One of the input parameters is invalid.
+    \retval ASN_PARSE_E An error was encountered parsing the input object.
+    \retval BAD_INDEX_E The requested attribute index was invalid.
+*/
+int wc_PKCS7_DecodeOneSymmetricKeyAttribute(byte const * osk,
+        word32 oskSz, size_t index, byte const ** attr, word32 * attrSz);
+
+/*!
+    \ingroup PKCS7
+
+    \brief This function provides access to a OneSymmetricKey key.
+
+    \param[in] osk Input buffer containing the OneSymmetricKey object.
+    \param[in] oskSz Size of the OneSymmetricKey object.
+    \param[out] key Buffer in which to store the pointer to the requested
+    key object.
+    \param[out] keySz Buffer in which to store the size of the requested
+    key object.
+
+    \retval 0 The requested key has been successfully located.
+    key and keySz output variables are populated with the address and size of
+    the key. The key will be in the same buffer passed in via the
+    osk input pointer.
+    \retval BAD_FUNC_ARG One of the input parameters is invalid.
+    \retval ASN_PARSE_E An error was encountered parsing the input object.
+*/
+int wc_PKCS7_DecodeOneSymmetricKeyKey(byte const * osk,
+        word32 oskSz, byte const ** key, word32 * keySz);

--- a/tests/api.c
+++ b/tests/api.c
@@ -18474,10 +18474,10 @@ static int test_wc_PKCS7_DecodeSymmetricKeyPackage(void)
 
     {
         const byte one_key[] = {
-            0x30, 0x08,
-              0x02, 0x01, 0x01,
-              0x30, 0x03,
-                0x02, 0x01, 0x01,
+            0x30, 0x08,             /* SymmetricKeyPackage SEQUENCE header  */
+              0x02, 0x01, 0x01,     /* version v1 */
+              0x30, 0x03,           /* sKeys SEQUENCE OF */
+                0x02, 0x01, 0x01,   /* INTEGER standin for OneSymmetricKey */
         };
         /* NULL input data pointer */
         ret = wc_PKCS7_DecodeSymmetricKeyPackageKey(
@@ -18520,7 +18520,7 @@ static int test_wc_PKCS7_DecodeSymmetricKeyPackage(void)
     /* Invalid SKP SEQUENCE header. */
     {
         const byte bad_seq_header[] = {
-            0x02, 0x01, 0x42,
+            0x02, 0x01, 0x42, /* Invalid SymmetricKeyPackage SEQUENCE header */
         };
         ret = wc_PKCS7_DecodeSymmetricKeyPackageKey(
                 bad_seq_header, sizeof(bad_seq_header), 0, &item, &itemSz);
@@ -18530,9 +18530,9 @@ static int test_wc_PKCS7_DecodeSymmetricKeyPackage(void)
     /* Missing version object */
     {
         const byte missing_version[] = {
-            0x30, 0x05,
-              0x30, 0x03,
-                0x02, 0x01, 0x01,
+            0x30, 0x05, /* SymmetricKeyPackage SEQUENCE header */
+              0x30, 0x03, /* sKeys SEQUENCE OF */
+                0x02, 0x01, 0x01, /* INTEGER standin for OneSymmetricKey */
         };
         ret = wc_PKCS7_DecodeSymmetricKeyPackageKey(
                 missing_version, sizeof(missing_version), 0, &item, &itemSz);
@@ -18542,10 +18542,10 @@ static int test_wc_PKCS7_DecodeSymmetricKeyPackage(void)
     /* Invalid version number */
     {
         const byte bad_version[] = {
-            0x30, 0x08,
-              0x02, 0x01, 0x00,
-              0x30, 0x03,
-                0x02, 0x01, 0x01,
+            0x30, 0x08, /* SymmetricKeyPackage SEQUENCE header */
+              0x02, 0x01, 0x00, /* version 0 (invalid) */
+              0x30, 0x03, /* sKeys SEQUENCE OF */
+                0x02, 0x01, 0x01, /* INTEGER standin for OneSymmetricKey */
         };
         ret = wc_PKCS7_DecodeSymmetricKeyPackageKey(
                 bad_version, sizeof(bad_version), 0, &item, &itemSz);
@@ -18554,16 +18554,16 @@ static int test_wc_PKCS7_DecodeSymmetricKeyPackage(void)
 
     {
         const byte key3_attr2[] = {
-            0x30, 0x18,
-              0x02, 0x01, 0x01,
-              0xA0, 0x08,
-                0x30, 0x06,
-                  0x02, 0x01, 0x40,
-                  0x02, 0x01, 0x41,
-              0x30, 0x09,
-                0x02, 0x01, 0x0A,
-                0x02, 0x01, 0x0B,
-                0x02, 0x01, 0x0C,
+            0x30, 0x18, /* SymmetricKeyPackage SEQUENCE header */
+              0x02, 0x01, 0x01, /* version v1 */
+              0xA0, 0x08, /* sKeyPkgAttrs EXPLICIT [0] header */
+                0x30, 0x06, /* sKeyPkgAttrs SEQUENCE OF header */
+                  0x02, 0x01, 0x40, /* INTEGER standin for Attribute 0 */
+                  0x02, 0x01, 0x41, /* INTEGER standin for Attribute 1 */
+              0x30, 0x09, /* sKeys SEQUENCE OF header */
+                0x02, 0x01, 0x0A, /* INTEGER standin for OneSymmetricKey 0 */
+                0x02, 0x01, 0x0B, /* INTEGER standin for OneSymmetricKey 1 */
+                0x02, 0x01, 0x0C, /* INTEGER standin for OneSymmetricKey 2 */
         };
 
         /* Valid attribute index 0 extraction */
@@ -18629,11 +18629,11 @@ static int test_wc_PKCS7_DecodeOneSymmetricKey(void)
 
     {
         const byte key1_attr2[] = {
-            0x30, 0x0E,
-              0x30, 0x06,
-                0x02, 0x01, 0x0A,
-                0x02, 0x01, 0x0B,
-              0x04, 0x04, 0xAA, 0xBB, 0xCC, 0xDD
+            0x30, 0x0E, /* OneSymmetricKey SEQUENCE header */
+              0x30, 0x06, /* sKeyAttrs SEQUENCE OF header */
+                0x02, 0x01, 0x0A, /* INTEGER standin for Attribute 0 */
+                0x02, 0x01, 0x0B, /* INTEGER standin for Attribute 1 */
+              0x04, 0x04, 0xAA, 0xBB, 0xCC, 0xDD /* sKey OCTET STRING */
         };
 
         /* NULL input data pointer */
@@ -18680,8 +18680,8 @@ static int test_wc_PKCS7_DecodeOneSymmetricKey(void)
 
     {
         const byte no_attrs[] = {
-            0x30, 0x06,
-              0x04, 0x04, 0xAA, 0xBB, 0xCC, 0xDD
+            0x30, 0x06, /* OneSymmetricKey SEQUENCE header */
+              0x04, 0x04, 0xAA, 0xBB, 0xCC, 0xDD /* sKey OCTET STRING */
         };
 
         /* Attribute index 0 out of range */
@@ -18699,10 +18699,10 @@ static int test_wc_PKCS7_DecodeOneSymmetricKey(void)
 
     {
         const byte key0_attr2[] = {
-            0x30, 0x08,
-              0x30, 0x06,
-                0x02, 0x01, 0x0A,
-                0x02, 0x01, 0x0B,
+            0x30, 0x08, /* OneSymmetricKey SEQUENCE header */
+              0x30, 0x06, /* sKeyAttrs SEQUENCE OF header */
+                0x02, 0x01, 0x0A, /* INTEGER standin for Attribute 0 */
+                0x02, 0x01, 0x0B, /* INTEGER standin for Attribute 1 */
         };
 
         /* Valid attribute 0 access */

--- a/tests/api.c
+++ b/tests/api.c
@@ -18468,12 +18468,12 @@ static int test_wc_PKCS7_DecodeSymmetricKeyPackage(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_PKCS7)
-    byte const * item;
+    const byte * item;
     word32 itemSz;
     int ret;
 
     {
-        static const byte one_key[] = {
+        const byte one_key[] = {
             0x30, 0x08,
               0x02, 0x01, 0x01,
               0x30, 0x03,
@@ -18519,7 +18519,7 @@ static int test_wc_PKCS7_DecodeSymmetricKeyPackage(void)
 
     /* Invalid SKP SEQUENCE header. */
     {
-        static const byte bad_seq_header[] = {
+        const byte bad_seq_header[] = {
             0x02, 0x01, 0x42,
         };
         ret = wc_PKCS7_DecodeSymmetricKeyPackageKey(
@@ -18529,7 +18529,7 @@ static int test_wc_PKCS7_DecodeSymmetricKeyPackage(void)
 
     /* Missing version object */
     {
-        static const byte missing_version[] = {
+        const byte missing_version[] = {
             0x30, 0x05,
               0x30, 0x03,
                 0x02, 0x01, 0x01,
@@ -18541,7 +18541,7 @@ static int test_wc_PKCS7_DecodeSymmetricKeyPackage(void)
 
     /* Invalid version number */
     {
-        static const byte bad_version[] = {
+        const byte bad_version[] = {
             0x30, 0x08,
               0x02, 0x01, 0x00,
               0x30, 0x03,
@@ -18553,7 +18553,7 @@ static int test_wc_PKCS7_DecodeSymmetricKeyPackage(void)
     }
 
     {
-        static const byte key3_attr2[] = {
+        const byte key3_attr2[] = {
             0x30, 0x18,
               0x02, 0x01, 0x01,
               0xA0, 0x08,
@@ -18623,12 +18623,12 @@ static int test_wc_PKCS7_DecodeOneSymmetricKey(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_PKCS7)
-    byte const * item;
+    const byte * item;
     word32 itemSz;
     int ret;
 
     {
-        static const byte key1_attr2[] = {
+        const byte key1_attr2[] = {
             0x30, 0x0E,
               0x30, 0x06,
                 0x02, 0x01, 0x0A,
@@ -18679,7 +18679,7 @@ static int test_wc_PKCS7_DecodeOneSymmetricKey(void)
     }
 
     {
-        static const byte no_attrs[] = {
+        const byte no_attrs[] = {
             0x30, 0x06,
               0x04, 0x04, 0xAA, 0xBB, 0xCC, 0xDD
         };
@@ -18698,7 +18698,7 @@ static int test_wc_PKCS7_DecodeOneSymmetricKey(void)
     }
 
     {
-        static const byte key0_attr2[] = {
+        const byte key0_attr2[] = {
             0x30, 0x08,
               0x30, 0x06,
                 0x02, 0x01, 0x0A,

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -177,3 +177,47 @@ int test_SetShortInt(void)
 
     return EXPECT_RESULT();
 }
+
+
+int test_IndexSequenceOf(void)
+{
+    EXPECT_DECLS;
+
+#ifndef NO_ASN
+    static const byte int_seq[] = {
+        0x30, 0x0A,
+        0x02, 0x01, 0x0A,
+        0x02, 0x02, 0x00, 0xF0,
+        0x02, 0x01, 0x7F,
+    };
+    static const byte bad_seq[] = {
+        0xA0, 0x01, 0x01,
+    };
+    static const byte empty_seq[] = {
+        0x30, 0x00,
+    };
+
+    byte const * element;
+    word32 elementSz;
+
+    ExpectIntEQ(IndexSequenceOf(int_seq, sizeof(int_seq), 0U, &element, &elementSz), 0);
+    ExpectPtrEq(element, &int_seq[2]);
+    ExpectIntEQ(elementSz, 3);
+
+    ExpectIntEQ(IndexSequenceOf(int_seq, sizeof(int_seq), 1U, &element, &elementSz), 0);
+    ExpectPtrEq(element, &int_seq[5]);
+    ExpectIntEQ(elementSz, 4);
+
+    ExpectIntEQ(IndexSequenceOf(int_seq, sizeof(int_seq), 2U, &element, &elementSz), 0);
+    ExpectPtrEq(element, &int_seq[9]);
+    ExpectIntEQ(elementSz, 3);
+
+    ExpectIntEQ(IndexSequenceOf(int_seq, sizeof(int_seq), 3U, &element, &elementSz), WC_NO_ERR_TRACE(BAD_INDEX_E));
+
+    ExpectIntEQ(IndexSequenceOf(bad_seq, sizeof(bad_seq), 0U, &element, &elementSz), WC_NO_ERR_TRACE(ASN_PARSE_E));
+
+    ExpectIntEQ(IndexSequenceOf(empty_seq, sizeof(empty_seq), 0U, &element, &elementSz), WC_NO_ERR_TRACE(BAD_INDEX_E));
+#endif
+
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -179,7 +179,7 @@ int test_SetShortInt(void)
 }
 
 
-int test_IndexSequenceOf(void)
+int test_wc_IndexSequenceOf(void)
 {
     EXPECT_DECLS;
 
@@ -200,23 +200,23 @@ int test_IndexSequenceOf(void)
     const byte * element;
     word32 elementSz;
 
-    ExpectIntEQ(IndexSequenceOf(int_seq, sizeof(int_seq), 0U, &element, &elementSz), 0);
+    ExpectIntEQ(wc_IndexSequenceOf(int_seq, sizeof(int_seq), 0U, &element, &elementSz), 0);
     ExpectPtrEq(element, &int_seq[2]);
     ExpectIntEQ(elementSz, 3);
 
-    ExpectIntEQ(IndexSequenceOf(int_seq, sizeof(int_seq), 1U, &element, &elementSz), 0);
+    ExpectIntEQ(wc_IndexSequenceOf(int_seq, sizeof(int_seq), 1U, &element, &elementSz), 0);
     ExpectPtrEq(element, &int_seq[5]);
     ExpectIntEQ(elementSz, 4);
 
-    ExpectIntEQ(IndexSequenceOf(int_seq, sizeof(int_seq), 2U, &element, &elementSz), 0);
+    ExpectIntEQ(wc_IndexSequenceOf(int_seq, sizeof(int_seq), 2U, &element, &elementSz), 0);
     ExpectPtrEq(element, &int_seq[9]);
     ExpectIntEQ(elementSz, 3);
 
-    ExpectIntEQ(IndexSequenceOf(int_seq, sizeof(int_seq), 3U, &element, &elementSz), WC_NO_ERR_TRACE(BAD_INDEX_E));
+    ExpectIntEQ(wc_IndexSequenceOf(int_seq, sizeof(int_seq), 3U, &element, &elementSz), WC_NO_ERR_TRACE(BAD_INDEX_E));
 
-    ExpectIntEQ(IndexSequenceOf(bad_seq, sizeof(bad_seq), 0U, &element, &elementSz), WC_NO_ERR_TRACE(ASN_PARSE_E));
+    ExpectIntEQ(wc_IndexSequenceOf(bad_seq, sizeof(bad_seq), 0U, &element, &elementSz), WC_NO_ERR_TRACE(ASN_PARSE_E));
 
-    ExpectIntEQ(IndexSequenceOf(empty_seq, sizeof(empty_seq), 0U, &element, &elementSz), WC_NO_ERR_TRACE(BAD_INDEX_E));
+    ExpectIntEQ(wc_IndexSequenceOf(empty_seq, sizeof(empty_seq), 0U, &element, &elementSz), WC_NO_ERR_TRACE(BAD_INDEX_E));
 #endif
 
     return EXPECT_RESULT();

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -184,20 +184,20 @@ int test_IndexSequenceOf(void)
     EXPECT_DECLS;
 
 #ifndef NO_ASN
-    static const byte int_seq[] = {
+    const byte int_seq[] = {
         0x30, 0x0A,
         0x02, 0x01, 0x0A,
         0x02, 0x02, 0x00, 0xF0,
         0x02, 0x01, 0x7F,
     };
-    static const byte bad_seq[] = {
+    const byte bad_seq[] = {
         0xA0, 0x01, 0x01,
     };
-    static const byte empty_seq[] = {
+    const byte empty_seq[] = {
         0x30, 0x00,
     };
 
-    byte const * element;
+    const byte * element;
     word32 elementSz;
 
     ExpectIntEQ(IndexSequenceOf(int_seq, sizeof(int_seq), 0U, &element, &elementSz), 0);

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -25,8 +25,10 @@
 #include <tests/api/api_decl.h>
 
 int test_SetShortInt(void);
+int test_IndexSequenceOf(void);
 
 #define TEST_ASN_DECLS                                              \
-    TEST_DECL_GROUP("asn", test_SetShortInt)                        \
+    TEST_DECL_GROUP("asn", test_SetShortInt),                       \
+    TEST_DECL_GROUP("asn", test_IndexSequenceOf)
 
 #endif /* WOLFCRYPT_TEST_ASN_H */

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -25,10 +25,10 @@
 #include <tests/api/api_decl.h>
 
 int test_SetShortInt(void);
-int test_IndexSequenceOf(void);
+int test_wc_IndexSequenceOf(void);
 
 #define TEST_ASN_DECLS                                              \
     TEST_DECL_GROUP("asn", test_SetShortInt),                       \
-    TEST_DECL_GROUP("asn", test_IndexSequenceOf)
+    TEST_DECL_GROUP("asn", test_wc_IndexSequenceOf)
 
 #endif /* WOLFCRYPT_TEST_ASN_H */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -2586,7 +2586,7 @@ int GetSequence_ex(const byte* input, word32* inOutIdx, int* len,
  * @return BAD_INDEX_E when the given seqIndex is out of range.
  * @return ASN_PARSE_E when the seqOf is not in the expected format.
  */
-int IndexSequenceOf(byte const * seqOf, word32 seqOfSz, size_t seqIndex,
+int wc_IndexSequenceOf(byte const * seqOf, word32 seqOfSz, size_t seqIndex,
         byte const ** out, word32 * outSz)
 {
     int length;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -2581,10 +2581,10 @@ int GetSequence_ex(const byte* input, word32* inOutIdx, int* len,
  * @param[out] outSz Buffer in which to store the length of the <seqIndex>th
  * element of the SEQUENCE OF object.
  *
- * @retval 0 on success.
- * @retval BUFFER_E when there is not enough data to parse.
- * @retval BAD_INDEX_E when the given seqIndex is out of range.
- * @retval ASN_PARSE_E when the seqOf is not in the expected format.
+ * @return 0 on success.
+ * @return BUFFER_E when there is not enough data to parse.
+ * @return BAD_INDEX_E when the given seqIndex is out of range.
+ * @return ASN_PARSE_E when the seqOf is not in the expected format.
  */
 int IndexSequenceOf(byte const * seqOf, word32 seqOfSz, size_t seqIndex,
         byte const ** out, word32 * outSz)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -2586,8 +2586,8 @@ int GetSequence_ex(const byte* input, word32* inOutIdx, int* len,
  * @return BAD_INDEX_E when the given seqIndex is out of range.
  * @return ASN_PARSE_E when the seqOf is not in the expected format.
  */
-int wc_IndexSequenceOf(byte const * seqOf, word32 seqOfSz, size_t seqIndex,
-        byte const ** out, word32 * outSz)
+int wc_IndexSequenceOf(const byte * seqOf, word32 seqOfSz, size_t seqIndex,
+        const byte ** out, word32 * outSz)
 {
     int length;
     word32 seqOfIdx = 0U;

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -650,6 +650,9 @@ const char* wc_GetErrorString(int error)
     case WC_ACCEL_INHIBIT_E:
         return "Crypto acceleration is currently inhibited";
 
+    case BAD_INDEX_E:
+        return "Bad index";
+
     case MAX_CODE_E:
     case WC_SPAN1_MIN_CODE_E:
     case MIN_CODE_E:

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -15335,8 +15335,8 @@ static int wc_PKCS7_DecodeSymmetricKeyPackage(const byte * skp, word32 skpSz,
         }
         else {
             /* sKeyPkgAttrs is present at &skp[skpIndex], length in length */
-            return IndexSequenceOf(&skp[skpIndex], (word32)length, index, out,
-                    outSz);
+            return wc_IndexSequenceOf(&skp[skpIndex], (word32)length, index,
+                    out, outSz);
         }
     }
 
@@ -15346,7 +15346,8 @@ static int wc_PKCS7_DecodeSymmetricKeyPackage(const byte * skp, word32 skpSz,
     }
 
     /* sKeys is present at &skp[skpIndex]. */
-    return IndexSequenceOf(&skp[skpIndex], skpSz - skpIndex, index, out, outSz);
+    return wc_IndexSequenceOf(&skp[skpIndex], skpSz - skpIndex, index,
+            out, outSz);
 }
 
 int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(const byte * skp,
@@ -15384,7 +15385,7 @@ int wc_PKCS7_DecodeOneSymmetricKeyAttribute(const byte * osk,
     }
 
     /* Index the sKeyAttrs SEQUENCE OF object with the given index. */
-    return IndexSequenceOf(&osk[oskIndex], oskSz - oskIndex, index, attr,
+    return wc_IndexSequenceOf(&osk[oskIndex], oskSz - oskIndex, index, attr,
             attrSz);
 }
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -15305,8 +15305,8 @@ int wc_PKCS7_DecodeCompressedData(wc_PKCS7* pkcs7, byte* pkiMsg,
 
 #endif /* HAVE_LIBZ && !NO_PKCS7_COMPRESSED_DATA */
 
-static int wc_PKCS7_DecodeSymmetricKeyPackage(byte const * skp, word32 skpSz,
-        size_t index, byte const ** out, word32 * outSz, int getKey)
+static int wc_PKCS7_DecodeSymmetricKeyPackage(const byte * skp, word32 skpSz,
+        size_t index, const byte ** out, word32 * outSz, int getKey)
 {
     word32 skpIndex = 0;
     int length = 0;
@@ -15335,7 +15335,8 @@ static int wc_PKCS7_DecodeSymmetricKeyPackage(byte const * skp, word32 skpSz,
         }
         else {
             /* sKeyPkgAttrs is present at &skp[skpIndex], length in length */
-            return IndexSequenceOf(&skp[skpIndex], (word32)length, index, out, outSz);
+            return IndexSequenceOf(&skp[skpIndex], (word32)length, index, out,
+                    outSz);
         }
     }
 
@@ -15348,20 +15349,21 @@ static int wc_PKCS7_DecodeSymmetricKeyPackage(byte const * skp, word32 skpSz,
     return IndexSequenceOf(&skp[skpIndex], skpSz - skpIndex, index, out, outSz);
 }
 
-int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(byte const * skp,
-        word32 skpSz, size_t index, byte const ** attr, word32 * attrSz)
+int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(const byte * skp,
+        word32 skpSz, size_t index, const byte ** attr, word32 * attrSz)
 {
-    return wc_PKCS7_DecodeSymmetricKeyPackage(skp, skpSz, index, attr, attrSz, 0);
+    return wc_PKCS7_DecodeSymmetricKeyPackage(skp, skpSz, index, attr, attrSz,
+            0);
 }
 
-int wc_PKCS7_DecodeSymmetricKeyPackageKey(byte const * skp,
-        word32 skpSz, size_t index, byte const ** key, word32 * keySz)
+int wc_PKCS7_DecodeSymmetricKeyPackageKey(const byte * skp,
+        word32 skpSz, size_t index, const byte ** key, word32 * keySz)
 {
     return wc_PKCS7_DecodeSymmetricKeyPackage(skp, skpSz, index, key, keySz, 1);
 }
 
-int wc_PKCS7_DecodeOneSymmetricKeyAttribute(byte const * osk,
-        word32 oskSz, size_t index, byte const ** attr, word32 * attrSz)
+int wc_PKCS7_DecodeOneSymmetricKeyAttribute(const byte * osk,
+        word32 oskSz, size_t index, const byte ** attr, word32 * attrSz)
 {
     word32 oskIndex = 0;
     word32 tmpIndex;
@@ -15382,11 +15384,12 @@ int wc_PKCS7_DecodeOneSymmetricKeyAttribute(byte const * osk,
     }
 
     /* Index the sKeyAttrs SEQUENCE OF object with the given index. */
-    return IndexSequenceOf(&osk[oskIndex], oskSz - oskIndex, index, attr, attrSz);
+    return IndexSequenceOf(&osk[oskIndex], oskSz - oskIndex, index, attr,
+            attrSz);
 }
 
-int wc_PKCS7_DecodeOneSymmetricKeyKey(byte const * osk,
-        word32 oskSz, byte const ** key, word32 * keySz)
+int wc_PKCS7_DecodeOneSymmetricKeyKey(const byte * osk,
+        word32 oskSz, const byte ** key, word32 * keySz)
 {
     word32 oskIndex = 0;
     int length = 0;

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2219,6 +2219,8 @@ WOLFSSL_LOCAL int GetSequence(const byte* input, word32* inOutIdx, int* len,
                              word32 maxIdx);
 WOLFSSL_LOCAL int GetSequence_ex(const byte* input, word32* inOutIdx, int* len,
                            word32 maxIdx, int check);
+WOLFSSL_TEST_VIS int IndexSequenceOf(byte const * seqOf, word32 seqOfSz,
+        size_t seqIndex, byte const ** out, word32 * outSz);
 WOLFSSL_LOCAL int GetOctetString(const byte* input, word32* inOutIdx, int* len,
                          word32 maxIdx);
 WOLFSSL_LOCAL int CheckBitString(const byte* input, word32* inOutIdx, int* len,

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2219,7 +2219,7 @@ WOLFSSL_LOCAL int GetSequence(const byte* input, word32* inOutIdx, int* len,
                              word32 maxIdx);
 WOLFSSL_LOCAL int GetSequence_ex(const byte* input, word32* inOutIdx, int* len,
                            word32 maxIdx, int check);
-WOLFSSL_TEST_VIS int IndexSequenceOf(byte const * seqOf, word32 seqOfSz,
+WOLFSSL_TEST_VIS int wc_IndexSequenceOf(byte const * seqOf, word32 seqOfSz,
         size_t seqIndex, byte const ** out, word32 * outSz);
 WOLFSSL_LOCAL int GetOctetString(const byte* input, word32* inOutIdx, int* len,
                          word32 maxIdx);

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -305,14 +305,13 @@ enum wolfCrypt_ErrorCodes {
     DEADLOCK_AVERTED_E  = -1000, /* Deadlock averted -- retry the call */
     ASCON_AUTH_E        = -1001, /* ASCON Authentication check failure */
     WC_ACCEL_INHIBIT_E  = -1002, /* Crypto acceleration is currently inhibited */
+    BAD_INDEX_E         = -1003, /* Bad index */
 
-    WC_SPAN2_LAST_E     = -1002, /* Update to indicate last used error code */
+    WC_SPAN2_LAST_E     = -1003, /* Update to indicate last used error code */
+    WC_LAST_E           = -1003, /* the last code used either here or in
+                                  * error-ssl.h */
+
     WC_SPAN2_MIN_CODE_E = -1999, /* Last usable code in span 2 */
-
-    WC_LAST_E           = -1002, /* the last code used either here or in
-                                  * error-ssl.h
-                                  */
-
     MIN_CODE_E          = -1999  /* the last code allocated either here or in
                                   * error-ssl.h
                                   */

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -552,10 +552,18 @@ WOLFSSL_API int wc_PKCS7_DecodeCompressedData(wc_PKCS7* pkcs7, byte* pkiMsg,
                                               word32 outputSz);
 #endif /* HAVE_LIBZ && !NO_PKCS7_COMPRESSED_DATA */
 
+WOLFSSL_API int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(byte const * skp,
+        word32 skpSz, size_t index, byte const ** attr, word32 * attrSz);
+WOLFSSL_API int wc_PKCS7_DecodeSymmetricKeyPackageKey(byte const * skp,
+        word32 skpSz, size_t index, byte const ** key, word32 * keySz);
+WOLFSSL_API int wc_PKCS7_DecodeOneSymmetricKeyAttribute(byte const * osk,
+        word32 oskSz, size_t index, byte const ** attr, word32 * attrSz);
+WOLFSSL_API int wc_PKCS7_DecodeOneSymmetricKeyKey(byte const * osk,
+        word32 oskSz, byte const ** key, word32 * keySz);
+
 #ifdef __cplusplus
     } /* extern "C" */
 #endif
 
 #endif /* HAVE_PKCS7 */
 #endif /* WOLF_CRYPT_PKCS7_H */
-

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -552,14 +552,14 @@ WOLFSSL_API int wc_PKCS7_DecodeCompressedData(wc_PKCS7* pkcs7, byte* pkiMsg,
                                               word32 outputSz);
 #endif /* HAVE_LIBZ && !NO_PKCS7_COMPRESSED_DATA */
 
-WOLFSSL_API int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(byte const * skp,
-        word32 skpSz, size_t index, byte const ** attr, word32 * attrSz);
-WOLFSSL_API int wc_PKCS7_DecodeSymmetricKeyPackageKey(byte const * skp,
-        word32 skpSz, size_t index, byte const ** key, word32 * keySz);
-WOLFSSL_API int wc_PKCS7_DecodeOneSymmetricKeyAttribute(byte const * osk,
-        word32 oskSz, size_t index, byte const ** attr, word32 * attrSz);
-WOLFSSL_API int wc_PKCS7_DecodeOneSymmetricKeyKey(byte const * osk,
-        word32 oskSz, byte const ** key, word32 * keySz);
+WOLFSSL_API int wc_PKCS7_DecodeSymmetricKeyPackageAttribute(const byte * skp,
+        word32 skpSz, size_t index, const byte ** attr, word32 * attrSz);
+WOLFSSL_API int wc_PKCS7_DecodeSymmetricKeyPackageKey(const byte * skp,
+        word32 skpSz, size_t index, const byte ** key, word32 * keySz);
+WOLFSSL_API int wc_PKCS7_DecodeOneSymmetricKeyAttribute(const byte * osk,
+        word32 oskSz, size_t index, const byte ** attr, word32 * attrSz);
+WOLFSSL_API int wc_PKCS7_DecodeOneSymmetricKeyKey(const byte * osk,
+        word32 oskSz, const byte ** key, word32 * keySz);
 
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
# Description

Add API to decode SymmetricKeyPackage and OneSymmetricKey CMS objects

# Testing

Added unit tests.

# Checklist

 - [X] added tests
 - [X] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
