### PR TITLE
wolfcrypt test: Fix build on 32 bit machines

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13171,7 +13171,7 @@ static wc_test_ret_t aes_xts_sector_test(void)
         0x24, 0xe7, 0x3d, 0x6f
     };
 
-    word64 s3 = 0x000000ffffffffff;
+    word64 s3 = W64LIT(0x000000ffffffffff);
 #endif
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)


### PR DESCRIPTION
Declare a 64 bit variable using W64LIT to avoid warnings on 32 bit machines

# Description

Build fails with the following error in an ARM32 machine:

~~~log
wolfcrypt/test/test.c: In function 'aes_xts_sector_test':
wolfcrypt/test/test.c:13174: error: integer constant is too large for 'long' type
~~~

Fix the literal integer constant declaration

Please describe the scope of the fix or feature addition.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
