### PR TITLE
Avoid bogus warning on uninitialized variables on old versions of GCC

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3855,7 +3855,7 @@ WOLFSSL_ABI
 int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
                     word32 protocol_name_listSz, byte options)
 {
-    char    *list, *ptr, **token;
+    char    *list, *ptr = NULL, **token;
     word16  len;
     int     idx = 0;
     int     ret = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);

--- a/tests/api.c
+++ b/tests/api.c
@@ -47339,7 +47339,7 @@ static int test_sk_X509_CRL(void)
 #endif
     WOLFSSL_X509_REVOKED revoked;
     WOLFSSL_ASN1_INTEGER* asnInt = NULL;
-    const WOLFSSL_ASN1_INTEGER* sn;
+    const WOLFSSL_ASN1_INTEGER* sn = NULL;
 
 #if (!defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)) || \
     !defined(NO_BIO)
@@ -56468,7 +56468,7 @@ static int test_wolfSSL_EC_KEY_private_key(void)
     WOLFSSL_EC_KEY* key = NULL;
     WOLFSSL_BIGNUM* priv = NULL;
     WOLFSSL_BIGNUM* priv2 = NULL;
-    WOLFSSL_BIGNUM* bn;
+    WOLFSSL_BIGNUM* bn = NULL;
 
     ExpectNotNull(key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
     ExpectNotNull(priv = wolfSSL_BN_new());


### PR DESCRIPTION
gcc-4.3.3 erroneously complains that some variables may be used uninitialized. Silence it assigning NULL on declaration, as is already done with many other variables.

# Description

Compiling with `gcc-4.3.3` I get the following errors:

~~~log
src/ssl.c: In function 'wolfSSL_UseALPN':
src/ssl.c:3858: error: 'ptr' may be used uninitialized in this function

tests/api.c: In function 'test_wolfSSL_EC_KEY_private_key':
tests/api.c:56471: error: 'bn' may be used uninitialized in this function

tests/api.c: In function 'test_sk_X509_CRL':
tests/api.c:47342: error: 'sn' may be used uninitialized in this function
~~~

They are all false positives, but it can be easily avoided by assigning NULL on initialization

Please describe the scope of the fix or feature addition.

Assign NULL to variables when they are declared

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
