### PR TITLE
Support CFLAGS="-Wno-shadow"

### DIFF
--- a/m4/ax_harden_compiler_flags.m4
+++ b/m4/ax_harden_compiler_flags.m4
@@ -145,7 +145,9 @@
       AX_APPEND_COMPILE_FLAGS([-Wpointer-arith],,[$ax_append_compile_cflags_extra])
       AX_APPEND_COMPILE_FLAGS([-Wpointer-sign],,[$ax_append_compile_cflags_extra])
 dnl      AX_APPEND_COMPILE_FLAGS([-Wredundant-decls],,[$ax_append_compile_cflags_extra])
-      AX_APPEND_COMPILE_FLAGS([-Wshadow],,[$ax_append_compile_cflags_extra])
+      AS_CASE([$CFLAGS], [*-Wno-shadow*], [], [
+        AX_APPEND_COMPILE_FLAGS([-Wshadow],,[$ax_append_compile_cflags_extra])
+        ])
       AX_APPEND_COMPILE_FLAGS([-Wshorten-64-to-32],,[$ax_append_compile_cflags_extra])
       AX_APPEND_COMPILE_FLAGS([-Wsign-compare],,[$ax_append_compile_cflags_extra])
       AX_APPEND_COMPILE_FLAGS([-Wstrict-overflow=1],,[$ax_append_compile_cflags_extra])
@@ -207,7 +209,9 @@ dnl      AX_APPEND_COMPILE_FLAGS([-Wredundant-decls],,[$ax_append_compile_cflags
       AX_APPEND_COMPILE_FLAGS([-Woverloaded-virtual],,[$ax_append_compile_cxxflags_extra])
       AX_APPEND_COMPILE_FLAGS([-Wpointer-arith],,[$ax_append_compile_cxxflags_extra])
 dnl      AX_APPEND_COMPILE_FLAGS([-Wredundant-decls],,[$ax_append_compile_cxxflags_extra])
-      AX_APPEND_COMPILE_FLAGS([-Wshadow],,[$ax_append_compile_cxxflags_extra])
+      AS_CASE([$CFLAGS], [*-Wno-shadow*], [], [
+        AX_APPEND_COMPILE_FLAGS([-Wshadow],,[$ax_append_compile_cxxflags_extra])
+        ])
       AX_APPEND_COMPILE_FLAGS([-Wshorten-64-to-32],,[$ax_append_compile_cxxflags_extra])
       AX_APPEND_COMPILE_FLAGS([-Wsign-compare],,[$ax_append_compile_cxxflags_extra])
       AX_APPEND_COMPILE_FLAGS([-Wstrict-overflow=1],,[$ax_append_compile_cxxflags_extra])


### PR DESCRIPTION
Avoid appending "-Wshadow" in the end of compiler flags if the user provided CFLAGS="-Wno-shadow"

# Description

Old versions of `gcc` are stricter about local variables shadowing global declarations, and generate warnings like this:
~~~log
tests/api.c: In function 'test_wolfSSL_ASN1_INTEGER':
tests/api.c:19508: error: declaration of 'dup' shadows a global declaration
~~~
Fixing  these cases is easy, but since modern versions don't complain, they keep appearing from time to time.
Users of old compilers could not use `CFLAGS="-Wno-shadow"` because it was overwritten by the hardening flags.

Now, "-Wshadow" will **NOT** be appended if the user has provided `CFLAGS="-Wno-shadow"`

Please describe the scope of the fix or feature addition.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
