### PR TITLE
Fix size used by signature context struct with WOLFSSL_NO_MALLOC.

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1383,7 +1383,7 @@ struct SignatureCtx {
 #endif
 #if !defined(NO_RSA) || !defined(NO_DSA)
     #ifdef WOLFSSL_NO_MALLOC
-    byte  sigCpy[MAX_SIG_SZ];
+    byte  sigCpy[MAX_ENCODED_SIG_SZ];
     #else
     byte* sigCpy;
     #endif


### PR DESCRIPTION
This matches the size used by sigCpy/sigSz when building without WOLFSSL_NO_MALLOC.

# Description

Fixes zd#20239

# Testing

Built in tests.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
