### PR TITLE
Updating configure/Cmake to track Apple options for resulting wolfssl.pc file that is generated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ set(WOLFSSL_DEFINITIONS)
 set(WOLFSSL_LINK_LIBS)
 set(WOLFSSL_INCLUDE_DIRS)
 
+# Initialize pkg-config private variables
+set(PC_LIBS_PRIVATE "")
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/functions.cmake)
 
@@ -2968,6 +2971,16 @@ if(WOLFSSL_INSTALL)
             set(LIBM)
         endif()
     endif()
+
+    # Add required frameworks for static linking on Apple platforms
+    if(APPLE AND NOT BUILD_SHARED_LIBS)
+        if(WOLFSSL_SYS_CA_CERTS)
+            list(APPEND PC_LIBS_PRIVATE "-framework CoreFoundation" "-framework Security")
+        endif()
+    endif()
+
+    # Convert lists to space-separated strings for pkg-config
+    string(JOIN " " PC_LIBS_PRIVATE ${PC_LIBS_PRIVATE})
 
     configure_file(support/wolfssl.pc.in ${CMAKE_CURRENT_BINARY_DIR}/support/wolfssl.pc @ONLY)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/support/wolfssl.pc

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,7 @@ OPTIMIZE_HUGE_CFLAGS="-funroll-loops -DTFM_SMALL_SET -DTFM_HUGE_SET"
 DEBUG_CFLAGS="-g -DDEBUG -DDEBUG_WOLFSSL"
 LIB_ADD=
 LIB_STATIC_ADD=
+PC_LIBS_PRIVATE=""
 
 OPTIMIZE_CFLAGS="$OPTIMIZE_CFLAGS $EXTRA_OPTS_CFLAGS"
 OPTIMIZE_FAST_CFLAGS="$OPTIMIZE_FAST_CFLAGS $EXTRA_OPTS_CFLAGS"
@@ -10642,6 +10643,13 @@ case $host_os in
                 MINGW_LIB_WARNING="yes"
             fi
         fi ;;
+    *darwin*)
+        # Add required frameworks for static linking on macOS
+        if test "$enable_shared" = "no"; then
+            if test "x$ENABLED_SYS_CA_CERTS" = "xyes"; then
+                PC_LIBS_PRIVATE="$PC_LIBS_PRIVATE -framework CoreFoundation -framework Security"
+            fi
+        fi ;;
 esac
 
 if test "$enable_shared" = "no"; then
@@ -10941,6 +10949,7 @@ AC_SUBST([AM_CCASFLAGS])
 AC_SUBST([LIB_ADD])
 AC_SUBST([LIB_STATIC_ADD])
 AC_SUBST([LIBM])
+AC_SUBST([PC_LIBS_PRIVATE])
 
 # FINAL
 AC_CONFIG_FILES([stamp-h], [echo timestamp > stamp-h])

--- a/support/wolfssl.pc.in
+++ b/support/wolfssl.pc.in
@@ -7,5 +7,5 @@ Name: wolfssl
 Description: wolfssl C library.
 Version: @VERSION@
 Libs: -L${libdir} -lwolfssl
-Libs.private: @LIBM@
+Libs.private: @LIBM@ @PC_LIBS_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
In response to Github Issue #9009 

Updating support/wolfssl.pc.in, CMakelist.txt, and configure.ac to track missing apple options in the resulting wolfssl.pc file by adding new PC_LIBS_PRIVATE to track options
