### PR TITLE
Add _new/_delete API for ML-KEM/ML-DSA

### DIFF
--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -8488,6 +8488,52 @@ int wc_dilithium_verify_ctx_hash(const byte* sig, word32 sigLen,
 }
 #endif /* WOLFSSL_DILITHIUM_NO_VERIFY */
 
+#ifndef WC_NO_CONSTRUCTORS
+/**
+ * Create a new dilithium key object.
+ *
+ * heap  [in]  Dynamic memory hint.
+ * devId [in]  Device Id.
+ * returns MEMORY_E when dynamic memory allocation fails
+ */
+
+dilithium_key* wc_dilithium_new(void* heap, int devId)
+{
+    int ret;
+    dilithium_key* key = (dilithium_key*)XMALLOC(sizeof(dilithium_key), heap,
+        DYNAMIC_TYPE_DILITHIUM);
+    if (key != NULL) {
+        ret = wc_dilithium_init_ex(key, heap, devId);
+        if (ret != 0) {
+            XFREE(key, heap, DYNAMIC_TYPE_DILITHIUM);
+            key = NULL;
+        }
+    }
+
+    return key;
+}
+
+/**
+ * Delete and free a dilithium key object.
+ *
+ * key   [in]       dilithium key object to delete.
+ * key_p [in, out]  Pointer to key pointer to set to NULL.
+ * returns BAD_FUNC_ARG when key is NULL
+ */
+
+int wc_dilithium_delete(dilithium_key* key, dilithium_key** key_p)
+{
+    if (key == NULL)
+        return BAD_FUNC_ARG;
+    wc_dilithium_free(key);
+    XFREE(key, key->heap, DYNAMIC_TYPE_DILITHIUM);
+    if (key_p != NULL)
+        *key_p = NULL;
+
+    return 0;
+}
+#endif /* !WC_NO_CONSTRUCTORS */
+
 /* Initialize the dilithium private/public key.
  *
  * key  [in]  Dilithium key.

--- a/wolfcrypt/src/wc_mlkem.c
+++ b/wolfcrypt/src/wc_mlkem.c
@@ -126,6 +126,60 @@ volatile sword16 mlkem_opt_blocker = 0;
 
 /******************************************************************************/
 
+#ifndef WC_NO_CONSTRUCTORS
+/**
+ * Create a new ML-KEM key object.
+ *
+ * Allocates and initializes a ML-KEM key object.
+ *
+ * @param  [in]   type         Type of key:
+ *                               WC_ML_KEM_512, WC_ML_KEM_768, WC_ML_KEM_1024,
+ *                               KYBER512, KYBER768, KYBER1024.
+ * @param  [in]   heap         Dynamic memory hint.
+ * @param  [in]   devId        Device Id.
+ * @return Pointer to new MlKemKey object, or NULL on failure.
+ */
+
+MlKemKey* wc_MlKemKey_New(int type, void* heap, int devId)
+{
+    int ret;
+    MlKemKey* key = (MlKemKey*)XMALLOC(sizeof(MlKemKey), heap,
+        DYNAMIC_TYPE_TMP_BUFFER);
+    if (key != NULL) {
+        ret = wc_MlKemKey_Init(key, type, heap, devId);
+        if (ret != 0) {
+            XFREE(key, heap, DYNAMIC_TYPE_TMP_BUFFER);
+            key = NULL;
+        }
+    }
+
+    return key;
+}
+
+/**
+ * Delete and free a ML-KEM key object.
+ *
+ * Frees resources associated with a ML-KEM key object and sets pointer to NULL.
+ *
+ * @param  [in]      key    ML-KEM key object to delete.
+ * @param  [in, out] key_p  Pointer to key pointer to set to NULL.
+ * @return  0 on success.
+ * @return  BAD_FUNC_ARG when key is NULL.
+ */
+
+int wc_MlKemKey_Delete(MlKemKey* key, MlKemKey** key_p)
+{
+    if (key == NULL)
+        return BAD_FUNC_ARG;
+    wc_MlKemKey_Free(key);
+    XFREE(key, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (key_p != NULL)
+        *key_p = NULL;
+
+    return 0;
+}
+#endif /* !WC_NO_CONSTRUCTORS */
+
 /**
  * Initialize the Kyber key.
  *

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -43481,6 +43481,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t mlkem_test(void)
 #endif
 #endif
 #endif
+#ifdef WOLFSSL_WC_MLKEM
+    MlKemKey *tmpKey = NULL;
+#endif
     int key_inited = 0;
     static const int testData[][4] = {
 #ifndef WOLFSSL_NO_ML_KEM
@@ -43628,6 +43631,15 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t mlkem_test(void)
 
         if (XMEMCMP(priv, priv2, testData[i][2]) != 0)
             ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
+
+#ifdef WOLFSSL_WC_MLKEM
+        tmpKey = wc_MlKemKey_New(testData[i][0], HEAP_HINT, INVALID_DEVID);
+        if (tmpKey == NULL)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        ret = wc_MlKemKey_Delete(tmpKey, &tmpKey);
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
+#endif
 #endif
     }
 
@@ -46865,6 +46877,7 @@ static wc_test_ret_t dilithium_param_test(int param, WC_RNG* rng)
 #ifndef WOLFSSL_DILITHIUM_NO_VERIFY
     int res = 0;
 #endif
+    dilithium_key* tmpKey = NULL;
 #endif
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
@@ -46909,6 +46922,14 @@ static wc_test_ret_t dilithium_param_test(int param, WC_RNG* rng)
         ERROR_OUT(WC_TEST_RET_ENC_EC(res), out);
 #endif
 #endif
+
+    tmpKey = wc_dilithium_new(HEAP_HINT, INVALID_DEVID);
+    if (tmpKey == NULL)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_dilithium_delete(tmpKey, &tmpKey);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
 out:
     wc_dilithium_free(key);

--- a/wolfssl/wolfcrypt/dilithium.h
+++ b/wolfssl/wolfcrypt/dilithium.h
@@ -789,6 +789,11 @@ int wc_dilithium_verify_ctx_hash(const byte* sig, word32 sigLen,
     word32 hashLen, int* res, dilithium_key* key);
 
 WOLFSSL_API
+dilithium_key* wc_dilithium_new(void* heap, int devId);
+WOLFSSL_API
+int wc_dilithium_delete(dilithium_key* key, dilithium_key** key_p);
+
+WOLFSSL_API
 int wc_dilithium_init(dilithium_key* key);
 
 WOLFSSL_API

--- a/wolfssl/wolfcrypt/mlkem.h
+++ b/wolfssl/wolfcrypt/mlkem.h
@@ -313,6 +313,9 @@ typedef struct MlKemKey MlKemKey;
     extern "C" {
 #endif
 
+WOLFSSL_API MlKemKey* wc_MlKemKey_New(int type, void* heap, int devId);
+WOLFSSL_API int  wc_MlKemKey_Delete(MlKemKey* key, MlKemKey** key_p);
+
 WOLFSSL_API int wc_MlKemKey_Init(MlKemKey* key, int type, void* heap,
     int devId);
 WOLFSSL_API int wc_MlKemKey_Free(MlKemKey* key);


### PR DESCRIPTION
# Description

Added below to solve trouble allocating memory for the MlKemKey structure in C#.
Since the size of the MlKemKey structure depends on the build options, these are needed.

- `wolfCrypt/wc_mlkem.c`: `wc_MlKemKey_New()`, `wc_MlKemKey_Delete()`
- `wolfCrypt/wc_dilithium.c`: `wc_dilithium_new()`, `wc_dilithium_delete()`

This PR is related to another PR I'll add in the comments.

I'm not familiar with adding code to wolfCrypt.
Please feel free to point out any inappropriate parts.

# Testing

Tested.

# Checklist

 - [x] added tests
 - [x] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
