### PR TITLE
Allow setting the CA type when loading into cert manager and unloading specific CA types from the cert manager.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6142,6 +6142,49 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
     return ret == 0 ? WOLFSSL_SUCCESS : ret;
 }
 
+/* Sets the CA with the passed in subject hash
+   to the provided type. */
+int SetCAType(WOLFSSL_CERT_MANAGER* cm, byte* hash, int type)
+{
+    Signer* current;
+    int     ret = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
+    word32  row;
+
+    WOLFSSL_MSG_EX("Setting CA to type %d", type);
+
+    if (cm == NULL || hash == NULL ||
+        type < WOLFSSL_USER_CA || type > WOLFSSL_USER_INTER) {
+        return ret;
+    }
+
+    row = HashSigner(hash);
+
+    if (wc_LockMutex(&cm->caLock) != 0) {
+        return ret;
+    }
+    current = cm->caTable[row];
+    while (current) {
+        byte* subjectHash;
+
+    #ifndef NO_SKID
+        subjectHash = current->subjectKeyIdHash;
+    #else
+        subjectHash = current->subjectNameHash;
+    #endif
+
+        if (XMEMCMP(hash, subjectHash, SIGNER_DIGEST_SIZE) == 0) {
+            current->type = type;
+            ret = WOLFSSL_SUCCESS;
+            break;
+        }
+        current = current->next;
+    }
+    wc_UnLockMutex(&cm->caLock);
+
+    WOLFSSL_LEAVE("SetCAType", ret);
+
+    return ret;
+}
 #endif /* !NO_CERTS */
 
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6173,7 +6173,7 @@ int SetCAType(WOLFSSL_CERT_MANAGER* cm, byte* hash, int type)
     #endif
 
         if (XMEMCMP(hash, subjectHash, SIGNER_DIGEST_SIZE) == 0) {
-            current->type = type;
+            current->type = (byte)type;
             ret = WOLFSSL_SUCCESS;
             break;
         }

--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -608,11 +608,6 @@ int wolfSSL_CertManagerLoadCABufferType(WOLFSSL_CERT_MANAGER* cm,
                     ret = WOLFSSL_SUCCESS;
                 } else {
                     WOLFSSL_ERROR(ret);
-
-                    if (der != NULL) {
-                        FreeDer(&der);
-                    }
-
                     ret = WOLFSSL_FATAL_ERROR;
                 }
             }
@@ -632,6 +627,9 @@ int wolfSSL_CertManagerLoadCABufferType(WOLFSSL_CERT_MANAGER* cm,
             if (dCert) {
                 wc_FreeDecodedCert(dCert);
                 XFREE(dCert, cm->heap, DYNAMIC_TYPE_DCERT);
+            }
+            if (der) {
+                FreeDer(&der);
             }
         }
     }

--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -600,7 +600,7 @@ int wolfSSL_CertManagerLoadCABuffer_ex2(WOLFSSL_CERT_MANAGER* cm,
         } else {
             XMEMSET(dCert, 0, sizeof(DecodedCert));
             wc_InitDecodedCert(dCert, buff,
-                            sz, cm->heap);
+                            (word32)sz, cm->heap);
             ret = wc_ParseCert(dCert, CA_TYPE, NO_VERIFY, NULL);
             if (ret) {
                 ret = WOLFSSL_FATAL_ERROR;

--- a/tests/api.c
+++ b/tests/api.c
@@ -3147,7 +3147,7 @@ static int test_wolfSSL_CertManagerLoadCABufferType(void)
 {
     EXPECT_DECLS;
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_TLS) && \
-    !defined(NO_RSA)
+    !defined(NO_RSA) && !defined(WOLFSSL_TEST_APPLE_NATIVE_CERT_VALIDATION)
     const char* ca_cert = "./certs/ca-cert.pem";
     const char* int1_cert = "./certs/intermediate/ca-int-cert.pem";
     const char* int2_cert = "./certs/intermediate/ca-int2-cert.pem";

--- a/tests/api.c
+++ b/tests/api.c
@@ -3143,6 +3143,138 @@ static int test_wolfSSL_CertManagerLoadCABuffer_ex(void)
     return EXPECT_RESULT();
 }
 
+static int test_wolfSSL_CertManagerLoadCABufferType(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_TLS)
+    const char* ca_cert = "./certs/ca-cert.pem";
+    const char* int1_cert = "./certs/intermediate/ca-int-cert.pem";
+    const char* int2_cert = "./certs/intermediate/ca-int2-cert.pem";
+    const char* client_cert = "./certs/intermediate/client-int-cert.pem";
+    byte* ca_cert_buf = NULL;
+    byte* int1_cert_buf = NULL;
+    byte* int2_cert_buf = NULL;
+    byte* client_cert_buf = NULL;
+    size_t ca_cert_sz = 0;
+    size_t int1_cert_sz = 0;
+    size_t int2_cert_sz = 0;
+    size_t client_cert_sz = 0;
+    WOLFSSL_CERT_MANAGER* cm;
+
+    ExpectNotNull(cm = wolfSSL_CertManagerNew());
+    ExpectIntEQ(load_file(ca_cert, &ca_cert_buf, &ca_cert_sz), 0);
+    ExpectIntEQ(load_file(int1_cert, &int1_cert_buf, &int1_cert_sz), 0);
+    ExpectIntEQ(load_file(int2_cert, &int2_cert_buf, &int2_cert_sz), 0);
+    ExpectIntEQ(load_file(client_cert, &client_cert_buf, &client_cert_sz), 0);
+
+    ExpectIntNE(wolfSSL_CertManagerLoadCABufferType(cm, ca_cert_buf,
+        (sword32)ca_cert_sz, WOLFSSL_FILETYPE_PEM, 0,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, 0), WOLFSSL_SUCCESS);
+    ExpectIntNE(wolfSSL_CertManagerLoadCABufferType(cm, ca_cert_buf,
+        (sword32)ca_cert_sz, WOLFSSL_FILETYPE_PEM, 0,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, 5), WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, ca_cert_buf,
+        (sword32)ca_cert_sz, WOLFSSL_FILETYPE_PEM, 0,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_USER_CA),
+        WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
+        int1_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, int1_cert_buf,
+        (sword32)int1_cert_sz, WOLFSSL_FILETYPE_PEM, 0,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_USER_INTER),
+        WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
+        int2_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, int2_cert_buf,
+        (sword32)int2_cert_sz, WOLFSSL_FILETYPE_PEM, 0,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_USER_INTER),
+        WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
+        client_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, client_cert_buf,
+        (sword32)client_cert_sz, WOLFSSL_FILETYPE_PEM, 0,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_USER_INTER),
+        WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(wolfSSL_CertManagerUnloadTypeCerts(cm, WOLFSSL_USER_INTER),
+        WOLFSSL_SUCCESS);
+
+    /* Intermediate certs have been unloaded, but CA cert is still
+       loaded.  Expect first level intermediate to verify, rest to fail. */
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
+        int1_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
+        int2_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
+        client_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, int1_cert_buf,
+        (sword32)int1_cert_sz, WOLFSSL_FILETYPE_PEM, 0,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_TEMP_CA),
+        WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
+        int2_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, int2_cert_buf,
+        (sword32)int2_cert_sz, WOLFSSL_FILETYPE_PEM, 0,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_CHAIN_CA),
+        WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
+        client_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, client_cert_buf,
+        (sword32)client_cert_sz, WOLFSSL_FILETYPE_PEM, 0,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_USER_INTER),
+        WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(wolfSSL_CertManagerUnloadTypeCerts(cm, WOLFSSL_USER_INTER),
+        WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
+        int1_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
+        int2_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
+        client_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(wolfSSL_CertManagerUnloadTypeCerts(cm, WOLFSSL_CHAIN_CA),
+        WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
+        int1_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
+        int2_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
+        client_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(wolfSSL_CertManagerUnloadTypeCerts(cm, WOLFSSL_TEMP_CA),
+        WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
+        int1_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
+        int2_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
+        client_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(wolfSSL_CertManagerUnloadTypeCerts(cm, WOLFSSL_USER_CA),
+        WOLFSSL_SUCCESS);
+    ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
+        int1_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
+        int2_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
+        client_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+
+    wolfSSL_CertManagerFree(cm);
+    if (ca_cert_buf)
+        free(ca_cert_buf);
+    if (int1_cert_buf)
+        free(int1_cert_buf);
+    if (int2_cert_buf)
+        free(int2_cert_buf);
+    if (client_cert_buf)
+        free(client_cert_buf);
+#endif
+
+    return EXPECT_RESULT();
+}
 
 static int test_wolfSSL_CertManagerGetCerts(void)
 {
@@ -52866,6 +52998,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_CertManagerAPI),
     TEST_DECL(test_wolfSSL_CertManagerLoadCABuffer),
     TEST_DECL(test_wolfSSL_CertManagerLoadCABuffer_ex),
+    TEST_DECL(test_wolfSSL_CertManagerLoadCABufferType),
     TEST_DECL(test_wolfSSL_CertManagerGetCerts),
     TEST_DECL(test_wolfSSL_CertManagerSetVerify),
     TEST_DECL(test_wolfSSL_CertManagerNameConstraint),

--- a/tests/api.c
+++ b/tests/api.c
@@ -3146,7 +3146,8 @@ static int test_wolfSSL_CertManagerLoadCABuffer_ex(void)
 static int test_wolfSSL_CertManagerLoadCABufferType(void)
 {
     EXPECT_DECLS;
-#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_TLS)
+#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_TLS) && \
+    !defined(NO_RSA)
     const char* ca_cert = "./certs/ca-cert.pem";
     const char* int1_cert = "./certs/intermediate/ca-int-cert.pem";
     const char* int2_cert = "./certs/intermediate/ca-int2-cert.pem";
@@ -3159,7 +3160,7 @@ static int test_wolfSSL_CertManagerLoadCABufferType(void)
     size_t int1_cert_sz = 0;
     size_t int2_cert_sz = 0;
     size_t client_cert_sz = 0;
-    WOLFSSL_CERT_MANAGER* cm;
+    WOLFSSL_CERT_MANAGER* cm = NULL;
 
     ExpectNotNull(cm = wolfSSL_CertManagerNew());
     ExpectIntEQ(load_file(ca_cert, &ca_cert_buf, &ca_cert_sz), 0);
@@ -3262,7 +3263,8 @@ static int test_wolfSSL_CertManagerLoadCABufferType(void)
     ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
         client_cert_sz, WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
 
-    wolfSSL_CertManagerFree(cm);
+    if (cm)
+        wolfSSL_CertManagerFree(cm);
     if (ca_cert_buf)
         free(ca_cert_buf);
     if (int1_cert_buf)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4276,6 +4276,7 @@ int ProcessOldClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     WOLFSSL_LOCAL int AddSigner(WOLFSSL_CERT_MANAGER* cm, Signer *s);
     WOLFSSL_LOCAL
     int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify);
+    WOLFSSL_LOCAL int SetCAType(WOLFSSL_CERT_MANAGER* cm, byte* hash, int type);
     WOLFSSL_LOCAL
     int AlreadySigner(WOLFSSL_CERT_MANAGER* cm, byte* hash);
 #ifdef WOLFSSL_TRUST_PEER_CERT

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4203,7 +4203,7 @@ WOLFSSL_API void wolfSSL_CTX_SetPerformTlsRecordProcessingCb(WOLFSSL_CTX* ctx,
 
     WOLFSSL_API int wolfSSL_CertManagerLoadCA(WOLFSSL_CERT_MANAGER* cm,
         const char* f, const char* d);
-    WOLFSSL_API int wolfSSL_CertManagerLoadCABuffer_ex2(WOLFSSL_CERT_MANAGER* cm,
+    WOLFSSL_API int wolfSSL_CertManagerLoadCABufferType(WOLFSSL_CERT_MANAGER* cm,
         const unsigned char* buff, long sz, int format, int userChain,
         word32 flags, int type);
     WOLFSSL_API int wolfSSL_CertManagerLoadCABuffer_ex(WOLFSSL_CERT_MANAGER* cm,
@@ -4213,7 +4213,7 @@ WOLFSSL_API void wolfSSL_CTX_SetPerformTlsRecordProcessingCb(WOLFSSL_CTX* ctx,
         const unsigned char* buff, long sz, int format);
 
     WOLFSSL_API int wolfSSL_CertManagerUnloadCAs(WOLFSSL_CERT_MANAGER* cm);
-    WOLFSSL_API int wolfSSL_CertManagerUnloadIntermediateCertsEx(
+    WOLFSSL_API int wolfSSL_CertManagerUnloadTypeCerts(
                                 WOLFSSL_CERT_MANAGER* cm, byte type);
     WOLFSSL_API int wolfSSL_CertManagerUnloadIntermediateCerts(
         WOLFSSL_CERT_MANAGER* cm);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3719,8 +3719,9 @@ enum {
 
     WOLFSSL_USER_CA  = 1,          /* user added as trusted */
     WOLFSSL_CHAIN_CA = 2,          /* added to cache from trusted chain */
-    WOLFSSL_TEMP_CA = 3            /* Temp intermediate CA, only for use by
+    WOLFSSL_TEMP_CA  = 3,          /* Temp intermediate CA, only for use by
                                     * X509_STORE */
+    WOLFSSL_USER_INTER = 4         /* user added intermediate cert */
 };
 
 WOLFSSL_ABI WOLFSSL_API WC_RNG* wolfSSL_GetRNG(WOLFSSL* ssl);
@@ -4202,6 +4203,9 @@ WOLFSSL_API void wolfSSL_CTX_SetPerformTlsRecordProcessingCb(WOLFSSL_CTX* ctx,
 
     WOLFSSL_API int wolfSSL_CertManagerLoadCA(WOLFSSL_CERT_MANAGER* cm,
         const char* f, const char* d);
+    WOLFSSL_API int wolfSSL_CertManagerLoadCABuffer_ex2(WOLFSSL_CERT_MANAGER* cm,
+        const unsigned char* buff, long sz, int format, int userChain,
+        word32 flags, int type);
     WOLFSSL_API int wolfSSL_CertManagerLoadCABuffer_ex(WOLFSSL_CERT_MANAGER* cm,
         const unsigned char* buff, long sz, int format, int userChain,
         word32 flags);
@@ -4209,6 +4213,8 @@ WOLFSSL_API void wolfSSL_CTX_SetPerformTlsRecordProcessingCb(WOLFSSL_CTX* ctx,
         const unsigned char* buff, long sz, int format);
 
     WOLFSSL_API int wolfSSL_CertManagerUnloadCAs(WOLFSSL_CERT_MANAGER* cm);
+    WOLFSSL_API int wolfSSL_CertManagerUnloadIntermediateCertsEx(
+                                WOLFSSL_CERT_MANAGER* cm, byte type);
     WOLFSSL_API int wolfSSL_CertManagerUnloadIntermediateCerts(
         WOLFSSL_CERT_MANAGER* cm);
 #ifdef WOLFSSL_TRUST_PEER_CERT


### PR DESCRIPTION
# Description

Adds a new type WOLFSSL_USER_INTER, intended to be used to load intermediate certs.
This allows users to dynamically free certs marked with a certain type at runtime.

Fixes zd#20038

# Testing

Customer provided reproducer

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
