### PR TITLE
20250731-enable-all-crypto-PQC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1359,11 +1359,7 @@ then
         test "$enable_kyber" = "" && test "$enable_mlkem" = "" && enable_mlkem=yes
         test "$enable_lms" = "" && enable_lms='yes,sha256-192'
         test "$enable_xmss" = "" && enable_xmss=yes
-
-        if test "$ENABLED_EXPERIMENTAL" = "yes"
-        then
-            test "$enable_dilithium" = "" && enable_dilithium=yes
-        fi
+        test "$enable_dilithium" = "" && enable_dilithium=yes
 
         if test "$ENABLED_LINUXKM_DEFAULTS" != "yes"
         then
@@ -11193,7 +11189,7 @@ echo "   * AES-XTS:                    $ENABLED_AESXTS"
 echo "   * AES-XTS streaming:          $ENABLED_AESXTS_STREAM"
 echo "   * AES-SIV:                    $ENABLED_AESSIV"
 echo "   * AES-EAX:                    $ENABLED_AESEAX"
-echo "   * AES Bitspliced:             $ENABLED_AESBS"
+echo "   * AES Bitsliced:              $ENABLED_AESBS"
 echo "   * AES Key Wrap:               $ENABLED_AESKEYWRAP"
 echo "   * ARIA:                       $ENABLED_ARIA"
 echo "   * ASCON:                      $ENABLED_ASCON"

--- a/configure.ac
+++ b/configure.ac
@@ -1356,6 +1356,15 @@ then
         test "$enable_aessiv" = "" && enable_aessiv=yes
         test "$enable_aeseax" = "" && enable_aeseax=yes
 
+        test "$enable_kyber" = "" && test "$enable_mlkem" = "" && enable_mlkem=yes
+        test "$enable_lms" = "" && enable_lms='yes,sha256-192'
+        test "$enable_xmss" = "" && enable_xmss=yes
+
+        if test "$ENABLED_EXPERIMENTAL" = "yes"
+        then
+            test "$enable_dilithium" = "" && enable_dilithium=yes
+        fi
+
         if test "$ENABLED_LINUXKM_DEFAULTS" != "yes"
         then
             test "$enable_eccsi" = "" && test "$enable_ecc" != "no" && enable_eccsi=yes

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -18684,7 +18684,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                         goto exit_cs;
                     }
                     if ((ret = wc_dilithium_set_level(sigCtx->key.dilithium,
-                            level)) < 0) {
+                            (byte)level)) < 0) {
                         goto exit_cs;
                     }
                     if ((ret = wc_Dilithium_PublicKeyDecode(key, &idx,
@@ -31914,7 +31914,7 @@ static int MakeSignature(CertSignCtx* certSignCtx, const byte* buf, word32 sz,
                 ret = wc_dilithium_sign_ctx_msg(NULL, 0, buf, sz, sig,
                     &outSz, dilithiumKey, rng);
                 if (ret == 0)
-                    ret = outSz;
+                    ret = (int)outSz;
             }
         }
     #endif /* HAVE_DILITHIUM && !WOLFSSL_DILITHIUM_NO_SIGN */

--- a/wolfcrypt/src/wc_mlkem.c
+++ b/wolfcrypt/src/wc_mlkem.c
@@ -426,16 +426,16 @@ int wc_MlKemKey_MakeKeyWithRandom(MlKemKey* key, const unsigned char* rand,
 #ifndef WOLFSSL_MLKEM_MAKEKEY_SMALL_MEM
 #ifndef WOLFSSL_MLKEM_CACHE_A
         /* e (v) | a (m) */
-        e = (sword16*)XMALLOC((k + 1) * k * MLKEM_N * sizeof(sword16),
+        e = (sword16*)XMALLOC(((size_t)k + 1) * (size_t)k * MLKEM_N * sizeof(sword16),
             key->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #else
         /* e (v) */
-        e = (sword16*)XMALLOC(k * MLKEM_N * sizeof(sword16),
+        e = (sword16*)XMALLOC((size_t)k * MLKEM_N * sizeof(sword16),
             key->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 #else
         /* e (v) */
-        e = (sword16*)XMALLOC(k * MLKEM_N * sizeof(sword16),
+        e = (sword16*)XMALLOC((size_t)k * MLKEM_N * sizeof(sword16),
             key->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         if (e == NULL) {
@@ -467,7 +467,7 @@ int wc_MlKemKey_MakeKeyWithRandom(MlKemKey* key, const unsigned char* rand,
 #endif
 #ifndef WOLFSSL_NO_ML_KEM
         {
-            buf[0] = k;
+            buf[0] = (byte)k;
             /* Expand 33 bytes of random to 32.
              * Alg 13: Step 1: (rho,sigma) <- G(d||k)
              */
@@ -663,7 +663,7 @@ static int mlkemkey_encapsulate(MlKemKey* key, const byte* m, byte* r, byte* c)
     sword16* e1 = NULL;
     sword16* e2 = NULL;
 #endif
-    unsigned int k = 0;
+    int k = 0;
     unsigned int compVecSz = 0;
 #ifndef WOLFSSL_NO_MALLOC
     sword16* y = NULL;
@@ -729,10 +729,10 @@ static int mlkemkey_encapsulate(MlKemKey* key, const byte* m, byte* r, byte* c)
     if (ret == 0) {
         /* Allocate dynamic memory for all matrices, vectors and polynomials. */
 #ifndef WOLFSSL_MLKEM_ENCAPSULATE_SMALL_MEM
-        y = (sword16*)XMALLOC(((k + 3) * k + 3) * MLKEM_N * sizeof(sword16),
+        y = (sword16*)XMALLOC((((size_t)k + 3) * (size_t)k + 3) * MLKEM_N * sizeof(sword16),
             key->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #else
-        y = (sword16*)XMALLOC(3 * k * MLKEM_N * sizeof(sword16), key->heap,
+        y = (sword16*)XMALLOC(3 * (size_t)k * MLKEM_N * sizeof(sword16), key->heap,
             DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         if (y == NULL) {
@@ -825,7 +825,7 @@ static int mlkemkey_encapsulate(MlKemKey* key, const byte* m, byte* r, byte* c)
     #if defined(WOLFSSL_KYBER512) || defined(WOLFSSL_WC_ML_KEM_512)
         if (k == WC_ML_KEM_512_K) {
             /* Step 22: c_1 <- ByteEncode_d_u(Compress_d_u(u)) */
-            mlkem_vec_compress_10(c1, u, k);
+            mlkem_vec_compress_10(c1, u, (unsigned)k);
             /* Step 23: c_2 <- ByteEncode_d_v(Compress_d_v(v)) */
             mlkem_compress_4(c2, v);
             /* Step 24: return c <- (c_1||c_2) */
@@ -834,7 +834,7 @@ static int mlkemkey_encapsulate(MlKemKey* key, const byte* m, byte* r, byte* c)
     #if defined(WOLFSSL_KYBER768) || defined(WOLFSSL_WC_ML_KEM_768)
         if (k == WC_ML_KEM_768_K) {
             /* Step 22: c_1 <- ByteEncode_d_u(Compress_d_u(u)) */
-            mlkem_vec_compress_10(c1, u, k);
+            mlkem_vec_compress_10(c1, u, (unsigned)k);
             /* Step 23: c_2 <- ByteEncode_d_v(Compress_d_v(v)) */
             mlkem_compress_4(c2, v);
             /* Step 24: return c <- (c_1||c_2) */
@@ -1148,7 +1148,7 @@ static MLKEM_NOINLINE int mlkemkey_decapsulate(MlKemKey* key, byte* m,
     int ret = 0;
     sword16* v;
     sword16* w;
-    unsigned int k = 0;
+    int k = 0;
     unsigned int compVecSz;
 #if defined(WOLFSSL_SMALL_STACK) || \
     (!defined(USE_INTEL_SPEEDUP) && !defined(WOLFSSL_NO_MALLOC))
@@ -1230,7 +1230,7 @@ static MLKEM_NOINLINE int mlkemkey_decapsulate(MlKemKey* key, byte* m,
     #if defined(WOLFSSL_KYBER512) || defined(WOLFSSL_WC_ML_KEM_512)
         if (k == WC_ML_KEM_512_K) {
             /* Step 3: u' <= Decompress_d_u(ByteDecode_d_u(c1)) */
-            mlkem_vec_decompress_10(u, c1, k);
+            mlkem_vec_decompress_10(u, c1, (unsigned)k);
             /* Step 4: v' <= Decompress_d_v(ByteDecode_d_v(c2)) */
             mlkem_decompress_4(v, c2);
         }
@@ -1238,7 +1238,7 @@ static MLKEM_NOINLINE int mlkemkey_decapsulate(MlKemKey* key, byte* m,
     #if defined(WOLFSSL_KYBER768) || defined(WOLFSSL_WC_ML_KEM_768)
         if (k == WC_ML_KEM_768_K) {
             /* Step 3: u' <= Decompress_d_u(ByteDecode_d_u(c1)) */
-            mlkem_vec_decompress_10(u, c1, k);
+            mlkem_vec_decompress_10(u, c1, (unsigned)k);
             /* Step 4: v' <= Decompress_d_v(ByteDecode_d_v(c2)) */
             mlkem_decompress_4(v, c2);
         }
@@ -1408,7 +1408,7 @@ int wc_MlKemKey_Decapsulate(MlKemKey* key, unsigned char* ss,
     }
     if (ret == 0) {
         /* Compare generated cipher text with that passed in. */
-        fail = mlkem_cmp(ct, cmp, ctSz);
+        fail = mlkem_cmp(ct, cmp, (int)ctSz);
 
 #if defined(WOLFSSL_MLKEM_KYBER) && !defined(WOLFSSL_NO_ML_KEM)
         if (key->type & MLKEM_KYBER)
@@ -1437,7 +1437,7 @@ int wc_MlKemKey_Decapsulate(MlKemKey* key, unsigned char* ss,
             if (ret == 0) {
                /* Set secret to kr or fake secret on comparison failure. */
                for (i = 0; i < WC_ML_KEM_SYM_SZ; i++) {
-                   ss[i] = kr[i] ^ ((kr[i] ^ msg[i]) & fail);
+                   ss[i] = (byte)(kr[i] ^ ((kr[i] ^ msg[i]) & fail));
                }
             }
         }
@@ -1478,7 +1478,7 @@ static void mlkemkey_decode_public(sword16* pub, byte* pubSeed, const byte* p,
 
     /* Decode public key that is vector of polynomials.
      * Step 2: t <- ByteDecode_12(ek_PKE[0 : 384k]) */
-    mlkem_from_bytes(pub, p, k);
+    mlkem_from_bytes(pub, p, (int)k);
     p += k * WC_ML_KEM_POLY_SIZE;
 
     /* Read public key seed.
@@ -1594,7 +1594,7 @@ int wc_MlKemKey_DecodePrivateKey(MlKemKey* key, const unsigned char* in,
         /* Decode private key that is vector of polynomials.
          * Alg 18 Step 1: dk_PKE <- dk[0 : 384k]
          * Alg 15 Step 5: s_hat <- ByteDecode_12(dk_PKE) */
-        mlkem_from_bytes(key->priv, p, k);
+        mlkem_from_bytes(key->priv, p, (int)k);
         p += k * WC_ML_KEM_POLY_SIZE;
 
         /* Decode the public key that is after the private key. */
@@ -1938,7 +1938,7 @@ int wc_MlKemKey_EncodePrivateKey(MlKemKey* key, unsigned char* out, word32 len)
 
     if (ret == 0) {
         /* Encode private key that is vector of polynomials. */
-        mlkem_to_bytes(p, key->priv, k);
+        mlkem_to_bytes(p, key->priv, (int)k);
         p += WC_ML_KEM_POLY_SIZE * k;
 
         /* Encode public key. */
@@ -2055,7 +2055,7 @@ int wc_MlKemKey_EncodePublicKey(MlKemKey* key, unsigned char* out, word32 len)
         int i;
 
         /* Encode public key polynomial by polynomial. */
-        mlkem_to_bytes(p, key->pub, k);
+        mlkem_to_bytes(p, key->pub, (int)k);
         p += k * WC_ML_KEM_POLY_SIZE;
 
         /* Append public seed. */

--- a/wolfcrypt/src/wc_mlkem_poly.c
+++ b/wolfcrypt/src/wc_mlkem_poly.c
@@ -364,7 +364,7 @@ static void mlkem_ntt(sword16* r)
     }
 #else
     /* Unroll len (2, 3, 2) and start loops. */
-    unsigned int j;
+    int j;
     sword16 t0;
     sword16 t1;
     sword16 t2;
@@ -388,27 +388,27 @@ static void mlkem_ntt(sword16* r)
         t1 = MLKEM_MONT_RED((sword32)zeta128 * r5);
         t2 = MLKEM_MONT_RED((sword32)zeta128 * r6);
         t3 = MLKEM_MONT_RED((sword32)zeta128 * r7);
-        r4 = r0 - t0;
-        r5 = r1 - t1;
-        r6 = r2 - t2;
-        r7 = r3 - t3;
-        r0 += t0;
-        r1 += t1;
-        r2 += t2;
-        r3 += t3;
+        r4 = (sword16)(r0 - t0);
+        r5 = (sword16)(r1 - t1);
+        r6 = (sword16)(r2 - t2);
+        r7 = (sword16)(r3 - t3);
+        r0 = (sword16)(r0 + t0);
+        r1 = (sword16)(r1 + t1);
+        r2 = (sword16)(r2 + t2);
+        r3 = (sword16)(r3 + t3);
 
         t0 = MLKEM_MONT_RED((sword32)zeta64_0 * r2);
         t1 = MLKEM_MONT_RED((sword32)zeta64_0 * r3);
         t2 = MLKEM_MONT_RED((sword32)zeta64_1 * r6);
         t3 = MLKEM_MONT_RED((sword32)zeta64_1 * r7);
-        r2 = r0 - t0;
-        r3 = r1 - t1;
-        r6 = r4 - t2;
-        r7 = r5 - t3;
-        r0 += t0;
-        r1 += t1;
-        r4 += t2;
-        r5 += t3;
+        r2 = (sword16)(r0 - t0);
+        r3 = (sword16)(r1 - t1);
+        r6 = (sword16)(r4 - t2);
+        r7 = (sword16)(r5 - t3);
+        r0 = (sword16)(r0 + t0);
+        r1 = (sword16)(r1 + t1);
+        r4 = (sword16)(r4 + t2);
+        r5 = (sword16)(r5 + t3);
 
         r[j +   0] = r0;
         r[j +  32] = r1;
@@ -444,40 +444,40 @@ static void mlkem_ntt(sword16* r)
             t1 = MLKEM_MONT_RED((sword32)zeta32 * r5);
             t2 = MLKEM_MONT_RED((sword32)zeta32 * r6);
             t3 = MLKEM_MONT_RED((sword32)zeta32 * r7);
-            r4 = r0 - t0;
-            r5 = r1 - t1;
-            r6 = r2 - t2;
-            r7 = r3 - t3;
-            r0 += t0;
-            r1 += t1;
-            r2 += t2;
-            r3 += t3;
+            r4 = (sword16)(r0 - t0);
+            r5 = (sword16)(r1 - t1);
+            r6 = (sword16)(r2 - t2);
+            r7 = (sword16)(r3 - t3);
+            r0 = (sword16)(r0 + t0);
+            r1 = (sword16)(r1 + t1);
+            r2 = (sword16)(r2 + t2);
+            r3 = (sword16)(r3 + t3);
 
             t0 = MLKEM_MONT_RED((sword32)zeta16_0 * r2);
             t1 = MLKEM_MONT_RED((sword32)zeta16_0 * r3);
             t2 = MLKEM_MONT_RED((sword32)zeta16_1 * r6);
             t3 = MLKEM_MONT_RED((sword32)zeta16_1 * r7);
-            r2 = r0 - t0;
-            r3 = r1 - t1;
-            r6 = r4 - t2;
-            r7 = r5 - t3;
-            r0 += t0;
-            r1 += t1;
-            r4 += t2;
-            r5 += t3;
+            r2 = (sword16)(r0 - t0);
+            r3 = (sword16)(r1 - t1);
+            r6 = (sword16)(r4 - t2);
+            r7 = (sword16)(r5 - t3);
+            r0 = (sword16)(r0 + t0);
+            r1 = (sword16)(r1 + t1);
+            r4 = (sword16)(r4 + t2);
+            r5 = (sword16)(r5 + t3);
 
             t0 = MLKEM_MONT_RED((sword32)zeta8_0 * r1);
             t1 = MLKEM_MONT_RED((sword32)zeta8_1 * r3);
             t2 = MLKEM_MONT_RED((sword32)zeta8_2 * r5);
             t3 = MLKEM_MONT_RED((sword32)zeta8_3 * r7);
-            r1 = r0 - t0;
-            r3 = r2 - t1;
-            r5 = r4 - t2;
-            r7 = r6 - t3;
-            r0 += t0;
-            r2 += t1;
-            r4 += t2;
-            r6 += t3;
+            r1 = (sword16)(r0 - t0);
+            r3 = (sword16)(r2 - t1);
+            r5 = (sword16)(r4 - t2);
+            r7 = (sword16)(r6 - t3);
+            r0 = (sword16)(r0 + t0);
+            r2 = (sword16)(r2 + t1);
+            r4 = (sword16)(r4 + t2);
+            r6 = (sword16)(r6 + t3);
 
             r[j + i +  0] = r0;
             r[j + i +  8] = r1;
@@ -508,27 +508,27 @@ static void mlkem_ntt(sword16* r)
         t1 = MLKEM_MONT_RED((sword32)zeta4 * r5);
         t2 = MLKEM_MONT_RED((sword32)zeta4 * r6);
         t3 = MLKEM_MONT_RED((sword32)zeta4 * r7);
-        r4 = r0 - t0;
-        r5 = r1 - t1;
-        r6 = r2 - t2;
-        r7 = r3 - t3;
-        r0 += t0;
-        r1 += t1;
-        r2 += t2;
-        r3 += t3;
+        r4 = (sword16)(r0 - t0);
+        r5 = (sword16)(r1 - t1);
+        r6 = (sword16)(r2 - t2);
+        r7 = (sword16)(r3 - t3);
+        r0 = (sword16)(r0 + t0);
+        r1 = (sword16)(r1 + t1);
+        r2 = (sword16)(r2 + t2);
+        r3 = (sword16)(r3 + t3);
 
         t0 = MLKEM_MONT_RED((sword32)zeta2_0 * r2);
         t1 = MLKEM_MONT_RED((sword32)zeta2_0 * r3);
         t2 = MLKEM_MONT_RED((sword32)zeta2_1 * r6);
         t3 = MLKEM_MONT_RED((sword32)zeta2_1 * r7);
-        r2 = r0 - t0;
-        r3 = r1 - t1;
-        r6 = r4 - t2;
-        r7 = r5 - t3;
-        r0 += t0;
-        r1 += t1;
-        r4 += t2;
-        r5 += t3;
+        r2 = (sword16)(r0 - t0);
+        r3 = (sword16)(r1 - t1);
+        r6 = (sword16)(r4 - t2);
+        r7 = (sword16)(r5 - t3);
+        r0 = (sword16)(r0 + t0);
+        r1 = (sword16)(r1 + t1);
+        r4 = (sword16)(r4 + t2);
+        r5 = (sword16)(r5 + t3);
 
         r[j + 0] = MLKEM_BARRETT_RED(r0);
         r[j + 1] = MLKEM_BARRETT_RED(r1);
@@ -785,7 +785,7 @@ static void mlkem_invntt(sword16* r)
     }
 #else
     /* Unroll len (2, 3, 3) and start loops. */
-    unsigned int j;
+    int j;
     sword16 t0;
     sword16 t1;
     sword16 t2;
@@ -817,10 +817,10 @@ static void mlkem_invntt(sword16* r)
         t2 = MLKEM_MONT_RED(p);
         p = (sword32)zeta2_1 * (sword16)(r5 - r7);
         t3 = MLKEM_MONT_RED(p);
-        r0 += r2;
-        r1 += r3;
-        r4 += r6;
-        r5 += r7;
+        r0 = (sword16)(r0 + r2);
+        r1 = (sword16)(r1 + r3);
+        r4 = (sword16)(r4 + r6);
+        r5 = (sword16)(r5 + r7);
         r2 = t0;
         r3 = t1;
         r6 = t2;
@@ -834,10 +834,10 @@ static void mlkem_invntt(sword16* r)
         t2 = MLKEM_MONT_RED(p);
         p = (sword32)zeta4 * (sword16)(r3 - r7);
         t3 = MLKEM_MONT_RED(p);
-        r0 += r4;
-        r1 += r5;
-        r2 += r6;
-        r3 += r7;
+        r0 = (sword16)(r0 + r4);
+        r1 = (sword16)(r1 + r5);
+        r2 = (sword16)(r2 + r6);
+        r3 = (sword16)(r3 + r7);
         r4 = t0;
         r5 = t1;
         r6 = t2;
@@ -863,14 +863,14 @@ static void mlkem_invntt(sword16* r)
         sword16 zeta16_1 = zetas_inv[112 + j / 32 + 1];
         sword16 zeta32   = zetas_inv[120 + j / 64 + 0];
         for (i = 0; i < 8; i++) {
-            sword16 r0 = r[j + i +  0];
-            sword16 r1 = r[j + i +  8];
-            sword16 r2 = r[j + i + 16];
-            sword16 r3 = r[j + i + 24];
-            sword16 r4 = r[j + i + 32];
-            sword16 r5 = r[j + i + 40];
-            sword16 r6 = r[j + i + 48];
-            sword16 r7 = r[j + i + 56];
+            sword16 r0 = (sword16)r[j + i +  0];
+            sword16 r1 = (sword16)r[j + i +  8];
+            sword16 r2 = (sword16)r[j + i + 16];
+            sword16 r3 = (sword16)r[j + i + 24];
+            sword16 r4 = (sword16)r[j + i + 32];
+            sword16 r5 = (sword16)r[j + i + 40];
+            sword16 r6 = (sword16)r[j + i + 48];
+            sword16 r7 = (sword16)r[j + i + 56];
 
             p = (sword32)zeta8_0 * (sword16)(r0 - r1);
             t0 = MLKEM_MONT_RED(p);
@@ -897,10 +897,10 @@ static void mlkem_invntt(sword16* r)
             t2 = MLKEM_MONT_RED(p);
             p = (sword32)zeta16_1 * (sword16)(r5 - r7);
             t3 = MLKEM_MONT_RED(p);
-            r0 += r2;
-            r1 += r3;
-            r4 += r6;
-            r5 += r7;
+            r0 = (sword16)(r0 + r2);
+            r1 = (sword16)(r1 + r3);
+            r4 = (sword16)(r4 + r6);
+            r5 = (sword16)(r5 + r7);
             r2 = t0;
             r3 = t1;
             r6 = t2;
@@ -914,10 +914,10 @@ static void mlkem_invntt(sword16* r)
             t2 = MLKEM_MONT_RED(p);
             p = (sword32)zeta32 * (sword16)(r3 - r7);
             t3 = MLKEM_MONT_RED(p);
-            r0 += r4;
-            r1 += r5;
-            r2 += r6;
-            r3 += r7;
+            r0 = (sword16)(r0 + r4);
+            r1 = (sword16)(r1 + r5);
+            r2 = (sword16)(r2 + r6);
+            r3 = (sword16)(r3 + r7);
             r4 = t0;
             r5 = t1;
             r6 = t2;
@@ -973,10 +973,10 @@ static void mlkem_invntt(sword16* r)
         t2 = MLKEM_MONT_RED(p);
         p = (sword32)zeta128 * (sword16)(r3 - r7);
         t3 = MLKEM_MONT_RED(p);
-        r0 += r4;
-        r1 += r5;
-        r2 += r6;
-        r3 += r7;
+        r0 = (sword16)(r0 + r4);
+        r1 = (sword16)(r1 + r5);
+        r2 = (sword16)(r2 + r6);
+        r3 = (sword16)(r3 + r7);
         r4 = t0;
         r5 = t1;
         r6 = t2;
@@ -1096,13 +1096,13 @@ static void mlkem_basemul_mont(sword16* r, const sword16* a, const sword16* b)
     unsigned int i;
     for (i = 0; i < MLKEM_N; i += 16, zeta += 4) {
         mlkem_basemul(r + i +  0, a + i +  0, b + i +  0,  zeta[0]);
-        mlkem_basemul(r + i +  2, a + i +  2, b + i +  2, -zeta[0]);
+        mlkem_basemul(r + i +  2, a + i +  2, b + i +  2, (sword16)-zeta[0]);
         mlkem_basemul(r + i +  4, a + i +  4, b + i +  4,  zeta[1]);
-        mlkem_basemul(r + i +  6, a + i +  6, b + i +  6, -zeta[1]);
+        mlkem_basemul(r + i +  6, a + i +  6, b + i +  6, (sword16)-zeta[1]);
         mlkem_basemul(r + i +  8, a + i +  8, b + i +  8,  zeta[2]);
-        mlkem_basemul(r + i + 10, a + i + 10, b + i + 10, -zeta[2]);
+        mlkem_basemul(r + i + 10, a + i + 10, b + i + 10, (sword16)-zeta[2]);
         mlkem_basemul(r + i + 12, a + i + 12, b + i + 12,  zeta[3]);
-        mlkem_basemul(r + i + 14, a + i + 14, b + i + 14, -zeta[3]);
+        mlkem_basemul(r + i + 14, a + i + 14, b + i + 14, (sword16)-zeta[3]);
     }
 #endif
 }
@@ -1180,30 +1180,30 @@ static void mlkem_basemul_mont_add(sword16* r, const sword16* a,
         sword16 t14[2];
 
         mlkem_basemul(t0, a + i + 0, b + i + 0,  zeta[0]);
-        mlkem_basemul(t2, a + i + 2, b + i + 2, -zeta[0]);
+        mlkem_basemul(t2, a + i + 2, b + i + 2, (sword16)-zeta[0]);
         mlkem_basemul(t4, a + i + 4, b + i + 4,  zeta[1]);
-        mlkem_basemul(t6, a + i + 6, b + i + 6, -zeta[1]);
+        mlkem_basemul(t6, a + i + 6, b + i + 6, (sword16)-zeta[1]);
         mlkem_basemul(t8, a + i + 8, b + i + 8,  zeta[2]);
-        mlkem_basemul(t10, a + i + 10, b + i + 10, -zeta[2]);
+        mlkem_basemul(t10, a + i + 10, b + i + 10, (sword16)-zeta[2]);
         mlkem_basemul(t12, a + i + 12, b + i + 12,  zeta[3]);
-        mlkem_basemul(t14, a + i + 14, b + i + 14, -zeta[3]);
+        mlkem_basemul(t14, a + i + 14, b + i + 14, (sword16)-zeta[3]);
 
-        r[i + 0] += t0[0];
-        r[i + 1] += t0[1];
-        r[i + 2] += t2[0];
-        r[i + 3] += t2[1];
-        r[i + 4] += t4[0];
-        r[i + 5] += t4[1];
-        r[i + 6] += t6[0];
-        r[i + 7] += t6[1];
-        r[i + 8] += t8[0];
-        r[i + 9] += t8[1];
-        r[i + 10] += t10[0];
-        r[i + 11] += t10[1];
-        r[i + 12] += t12[0];
-        r[i + 13] += t12[1];
-        r[i + 14] += t14[0];
-        r[i + 15] += t14[1];
+        r[i + 0] = (sword16)(r[i + 0] + t0[0]);
+        r[i + 1] = (sword16)(r[i + 1] + t0[1]);
+        r[i + 2] = (sword16)(r[i + 2] + t2[0]);
+        r[i + 3] = (sword16)(r[i + 3] + t2[1]);
+        r[i + 4] = (sword16)(r[i + 4] + t4[0]);
+        r[i + 5] = (sword16)(r[i + 5] + t4[1]);
+        r[i + 6] = (sword16)(r[i + 6] + t6[0]);
+        r[i + 7] = (sword16)(r[i + 7] + t6[1]);
+        r[i + 8] = (sword16)(r[i + 8] + t8[0]);
+        r[i + 9] = (sword16)(r[i + 9] + t8[1]);
+        r[i + 10] = (sword16)(r[i + 10] + t10[0]);
+        r[i + 11] = (sword16)(r[i + 11] + t10[1]);
+        r[i + 12] = (sword16)(r[i + 12] + t12[0]);
+        r[i + 13] = (sword16)(r[i + 13] + t12[1]);
+        r[i + 14] = (sword16)(r[i + 14] + t14[0]);
+        r[i + 15] = (sword16)(r[i + 15] + t14[1]);
     }
 #endif
 }
@@ -1597,7 +1597,7 @@ static void mlkem_ntt_add_to(sword16* r, sword16* a)
     }
 #else /* !WOLFSSL_MLKEM_NTT_UNROLL */
     /* Unroll len (2, 3, 2) and start loops. */
-    unsigned int j;
+    int j;
     sword16 t0;
     sword16 t1;
     sword16 t2;
@@ -1621,27 +1621,27 @@ static void mlkem_ntt_add_to(sword16* r, sword16* a)
         t1 = MLKEM_MONT_RED((sword32)zeta128 * r5);
         t2 = MLKEM_MONT_RED((sword32)zeta128 * r6);
         t3 = MLKEM_MONT_RED((sword32)zeta128 * r7);
-        r4 = r0 - t0;
-        r5 = r1 - t1;
-        r6 = r2 - t2;
-        r7 = r3 - t3;
-        r0 += t0;
-        r1 += t1;
-        r2 += t2;
-        r3 += t3;
+        r4 = (sword16)(r0 - t0);
+        r5 = (sword16)(r1 - t1);
+        r6 = (sword16)(r2 - t2);
+        r7 = (sword16)(r3 - t3);
+        r0 = (sword16)(r0 + t0);
+        r1 = (sword16)(r1 + t1);
+        r2 = (sword16)(r2 + t2);
+        r3 = (sword16)(r3 + t3);
 
         t0 = MLKEM_MONT_RED((sword32)zeta64_0 * r2);
         t1 = MLKEM_MONT_RED((sword32)zeta64_0 * r3);
         t2 = MLKEM_MONT_RED((sword32)zeta64_1 * r6);
         t3 = MLKEM_MONT_RED((sword32)zeta64_1 * r7);
-        r2 = r0 - t0;
-        r3 = r1 - t1;
-        r6 = r4 - t2;
-        r7 = r5 - t3;
-        r0 += t0;
-        r1 += t1;
-        r4 += t2;
-        r5 += t3;
+        r2 = (sword16)(r0 - t0);
+        r3 = (sword16)(r1 - t1);
+        r6 = (sword16)(r4 - t2);
+        r7 = (sword16)(r5 - t3);
+        r0 = (sword16)(r0 + t0);
+        r1 = (sword16)(r1 + t1);
+        r4 = (sword16)(r4 + t2);
+        r5 = (sword16)(r5 + t3);
 
         r[j +   0] = r0;
         r[j +  32] = r1;
@@ -1677,40 +1677,40 @@ static void mlkem_ntt_add_to(sword16* r, sword16* a)
             t1 = MLKEM_MONT_RED((sword32)zeta32 * r5);
             t2 = MLKEM_MONT_RED((sword32)zeta32 * r6);
             t3 = MLKEM_MONT_RED((sword32)zeta32 * r7);
-            r4 = r0 - t0;
-            r5 = r1 - t1;
-            r6 = r2 - t2;
-            r7 = r3 - t3;
-            r0 += t0;
-            r1 += t1;
-            r2 += t2;
-            r3 += t3;
+            r4 = (sword16)(r0 - t0);
+            r5 = (sword16)(r1 - t1);
+            r6 = (sword16)(r2 - t2);
+            r7 = (sword16)(r3 - t3);
+            r0 = (sword16)(r0 + t0);
+            r1 = (sword16)(r1 + t1);
+            r2 = (sword16)(r2 + t2);
+            r3 = (sword16)(r3 + t3);
 
             t0 = MLKEM_MONT_RED((sword32)zeta16_0 * r2);
             t1 = MLKEM_MONT_RED((sword32)zeta16_0 * r3);
             t2 = MLKEM_MONT_RED((sword32)zeta16_1 * r6);
             t3 = MLKEM_MONT_RED((sword32)zeta16_1 * r7);
-            r2 = r0 - t0;
-            r3 = r1 - t1;
-            r6 = r4 - t2;
-            r7 = r5 - t3;
-            r0 += t0;
-            r1 += t1;
-            r4 += t2;
-            r5 += t3;
+            r2 = (sword16)(r0 - t0);
+            r3 = (sword16)(r1 - t1);
+            r6 = (sword16)(r4 - t2);
+            r7 = (sword16)(r5 - t3);
+            r0 = (sword16)(r0 + t0);
+            r1 = (sword16)(r1 + t1);
+            r4 = (sword16)(r4 + t2);
+            r5 = (sword16)(r5 + t3);
 
             t0 = MLKEM_MONT_RED((sword32)zeta8_0 * r1);
             t1 = MLKEM_MONT_RED((sword32)zeta8_1 * r3);
             t2 = MLKEM_MONT_RED((sword32)zeta8_2 * r5);
             t3 = MLKEM_MONT_RED((sword32)zeta8_3 * r7);
-            r1 = r0 - t0;
-            r3 = r2 - t1;
-            r5 = r4 - t2;
-            r7 = r6 - t3;
-            r0 += t0;
-            r2 += t1;
-            r4 += t2;
-            r6 += t3;
+            r1 = (sword16)(r0 - t0);
+            r3 = (sword16)(r2 - t1);
+            r5 = (sword16)(r4 - t2);
+            r7 = (sword16)(r6 - t3);
+            r0 = (sword16)(r0 + t0);
+            r2 = (sword16)(r2 + t1);
+            r4 = (sword16)(r4 + t2);
+            r6 = (sword16)(r6 + t3);
 
             r[j + i +  0] = r0;
             r[j + i +  8] = r1;
@@ -1741,36 +1741,36 @@ static void mlkem_ntt_add_to(sword16* r, sword16* a)
         t1 = MLKEM_MONT_RED((sword32)zeta4 * r5);
         t2 = MLKEM_MONT_RED((sword32)zeta4 * r6);
         t3 = MLKEM_MONT_RED((sword32)zeta4 * r7);
-        r4 = r0 - t0;
-        r5 = r1 - t1;
-        r6 = r2 - t2;
-        r7 = r3 - t3;
-        r0 += t0;
-        r1 += t1;
-        r2 += t2;
-        r3 += t3;
+        r4 = (sword16)(r0 - t0);
+        r5 = (sword16)(r1 - t1);
+        r6 = (sword16)(r2 - t2);
+        r7 = (sword16)(r3 - t3);
+        r0 = (sword16)(r0 + t0);
+        r1 = (sword16)(r1 + t1);
+        r2 = (sword16)(r2 + t2);
+        r3 = (sword16)(r3 + t3);
 
         t0 = MLKEM_MONT_RED((sword32)zeta2_0 * r2);
         t1 = MLKEM_MONT_RED((sword32)zeta2_0 * r3);
         t2 = MLKEM_MONT_RED((sword32)zeta2_1 * r6);
         t3 = MLKEM_MONT_RED((sword32)zeta2_1 * r7);
-        r2 = r0 - t0;
-        r3 = r1 - t1;
-        r6 = r4 - t2;
-        r7 = r5 - t3;
-        r0 += t0;
-        r1 += t1;
-        r4 += t2;
-        r5 += t3;
+        r2 = (sword16)(r0 - t0);
+        r3 = (sword16)(r1 - t1);
+        r6 = (sword16)(r4 - t2);
+        r7 = (sword16)(r5 - t3);
+        r0 = (sword16)(r0 + t0);
+        r1 = (sword16)(r1 + t1);
+        r4 = (sword16)(r4 + t2);
+        r5 = (sword16)(r5 + t3);
 
-        r0 += a[j + 0];
-        r1 += a[j + 1];
-        r2 += a[j + 2];
-        r3 += a[j + 3];
-        r4 += a[j + 4];
-        r5 += a[j + 5];
-        r6 += a[j + 6];
-        r7 += a[j + 7];
+        r0 = (sword16)(r0 + a[j + 0]);
+        r1 = (sword16)(r1 + a[j + 1]);
+        r2 = (sword16)(r2 + a[j + 2]);
+        r3 = (sword16)(r3 + a[j + 3]);
+        r4 = (sword16)(r4 + a[j + 4]);
+        r5 = (sword16)(r5 + a[j + 5]);
+        r6 = (sword16)(r6 + a[j + 6]);
+        r7 = (sword16)(r7 + a[j + 7]);
 
         a[j + 0] = MLKEM_BARRETT_RED(r0);
         a[j + 1] = MLKEM_BARRETT_RED(r1);
@@ -1815,11 +1815,11 @@ static void mlkem_keygen_c(sword16* s, sword16* t, sword16* e, const sword16* a,
     /* For each polynomial in the vectors.
      * Step 17, Step 18: Calculate public from A_hat, s_hat and e_hat. */
     for (i = 0; i < k; ++i) {
-        unsigned int j;
+        int j;
 
         /* Multiply a by private into public polynomial.
          * Step 18: ... A_hat o s_hat ... */
-        mlkem_pointwise_acc_mont(t + i * MLKEM_N, a + i * k * MLKEM_N, s, k);
+        mlkem_pointwise_acc_mont(t + i * MLKEM_N, a + i * k * MLKEM_N, s, (unsigned)k);
         /* Convert public polynomial to Montgomery form.
          * Step 18: ... MontRed(A_hat o s_hat) ... */
         for (j = 0; j < MLKEM_N; ++j) {
@@ -1993,10 +1993,10 @@ static void mlkem_encapsulate_c(const sword16* pub, sword16* u, sword16* v,
 
     /* For each polynomial in the vectors. */
     for (i = 0; i < k; ++i) {
-        unsigned int j;
+        int j;
 
         /* Multiply at by y into u polynomial. */
-        mlkem_pointwise_acc_mont(u + i * MLKEM_N, a + i * k * MLKEM_N, y, k);
+        mlkem_pointwise_acc_mont(u + i * MLKEM_N, a + i * k * MLKEM_N, y, (unsigned)k);
         /* Inverse transform u polynomial. */
         mlkem_invntt(u + i * MLKEM_N);
         /* Add errors to u and reduce. */
@@ -2007,14 +2007,14 @@ static void mlkem_encapsulate_c(const sword16* pub, sword16* u, sword16* v,
         }
 #else
         for (j = 0; j < MLKEM_N; j += 8) {
-            sword16 t0 = u[i * MLKEM_N + j + 0] + e1[i * MLKEM_N + j + 0];
-            sword16 t1 = u[i * MLKEM_N + j + 1] + e1[i * MLKEM_N + j + 1];
-            sword16 t2 = u[i * MLKEM_N + j + 2] + e1[i * MLKEM_N + j + 2];
-            sword16 t3 = u[i * MLKEM_N + j + 3] + e1[i * MLKEM_N + j + 3];
-            sword16 t4 = u[i * MLKEM_N + j + 4] + e1[i * MLKEM_N + j + 4];
-            sword16 t5 = u[i * MLKEM_N + j + 5] + e1[i * MLKEM_N + j + 5];
-            sword16 t6 = u[i * MLKEM_N + j + 6] + e1[i * MLKEM_N + j + 6];
-            sword16 t7 = u[i * MLKEM_N + j + 7] + e1[i * MLKEM_N + j + 7];
+            sword16 t0 = (sword16)(u[i * MLKEM_N + j + 0] + e1[i * MLKEM_N + j + 0]);
+            sword16 t1 = (sword16)(u[i * MLKEM_N + j + 1] + e1[i * MLKEM_N + j + 1]);
+            sword16 t2 = (sword16)(u[i * MLKEM_N + j + 2] + e1[i * MLKEM_N + j + 2]);
+            sword16 t3 = (sword16)(u[i * MLKEM_N + j + 3] + e1[i * MLKEM_N + j + 3]);
+            sword16 t4 = (sword16)(u[i * MLKEM_N + j + 4] + e1[i * MLKEM_N + j + 4]);
+            sword16 t5 = (sword16)(u[i * MLKEM_N + j + 5] + e1[i * MLKEM_N + j + 5]);
+            sword16 t6 = (sword16)(u[i * MLKEM_N + j + 6] + e1[i * MLKEM_N + j + 6]);
+            sword16 t7 = (sword16)(u[i * MLKEM_N + j + 7] + e1[i * MLKEM_N + j + 7]);
             u[i * MLKEM_N + j + 0] = MLKEM_BARRETT_RED(t0);
             u[i * MLKEM_N + j + 1] = MLKEM_BARRETT_RED(t1);
             u[i * MLKEM_N + j + 2] = MLKEM_BARRETT_RED(t2);
@@ -2028,12 +2028,12 @@ static void mlkem_encapsulate_c(const sword16* pub, sword16* u, sword16* v,
     }
 
     /* Multiply public key by y into v polynomial. */
-    mlkem_pointwise_acc_mont(v, pub, y, k);
+    mlkem_pointwise_acc_mont(v, pub, y, (unsigned)k);
     /* Inverse transform v. */
     mlkem_invntt(v);
     /* Add errors and message to v and reduce. */
     for (i = 0; i < MLKEM_N; ++i) {
-        sword16 t = v[i] + e2[i] + m[i];
+        sword16 t = (sword16)(v[i] + e2[i] + m[i]);
         v[i] = MLKEM_BARRETT_RED(t);
     }
 }
@@ -2218,14 +2218,14 @@ static void mlkem_decapsulate_c(const sword16* s, sword16* w, sword16* u,
 
     /* Multiply private key by u into w polynomial.
      * Step 6: ... s_hat_trans o NTT(u') */
-    mlkem_pointwise_acc_mont(w, s, u, k);
+    mlkem_pointwise_acc_mont(w, s, u, (unsigned)k);
     /* Inverse transform w.
      * Step 6: ... InvNTT(s_hat_trans o NTT(u')) */
     mlkem_invntt(w);
     /* Subtract errors (in w) out of v and reduce into w.
      * Step 6: w <- v' - InvNTT(s_hat_trans o NTT(u')) */
     for (i = 0; i < MLKEM_N; ++i) {
-        sword16 t = v[i] - w[i];
+        sword16 t = (sword16)(v[i] - w[i]);
         w[i] = MLKEM_BARRETT_RED(t);
     }
 }
@@ -2391,8 +2391,8 @@ static int mlkem_gen_matrix_k2_avx2(sword16* a, byte* seed, int transposed)
  */
 static int mlkem_gen_matrix_k3_avx2(sword16* a, byte* seed, int transposed)
 {
-    int i;
-    int k;
+    unsigned int i;
+    unsigned int k;
 #ifdef WOLFSSL_SMALL_STACK
     byte *rand = NULL;
     word64 *state = NULL;
@@ -2425,10 +2425,10 @@ static int mlkem_gen_matrix_k3_avx2(sword16* a, byte* seed, int transposed)
     for (k = 0; k < 2; k++) {
         for (i = 0; i < 4; i++) {
             if (!transposed) {
-                state[4*4 + i] = 0x1f0000 + (((k*4+i)/3) << 8) + ((k*4+i)%3);
+                state[4*4 + i] = 0x1f0000U + (((k*4+i)/3) << 8) + ((k*4+i)%3);
             }
             else {
-                state[4*4 + i] = 0x1f0000 + (((k*4+i)%3) << 8) + ((k*4+i)/3);
+                state[4*4 + i] = 0x1f0000U + (((k*4+i)%3) << 8) + ((k*4+i)/3);
             }
         }
 
@@ -2546,8 +2546,8 @@ static int mlkem_gen_matrix_k3_avx2(sword16* a, byte* seed, int transposed)
  */
 static int mlkem_gen_matrix_k4_avx2(sword16* a, byte* seed, int transposed)
 {
-    int i;
-    int k;
+    unsigned int i;
+    unsigned int k;
 #ifdef WOLFSSL_SMALL_STACK
     byte *rand = NULL;
     word64 *state = NULL;
@@ -2580,10 +2580,10 @@ static int mlkem_gen_matrix_k4_avx2(sword16* a, byte* seed, int transposed)
     for (k = 0; k < 4; k++) {
         for (i = 0; i < 4; i++) {
             if (!transposed) {
-                state[4*4 + i] = 0x1f0000 + (k << 8) + i;
+                state[4*4 + i] = 0x1f0000U + (k << 8) + i;
             }
             else {
-                state[4*4 + i] = 0x1f0000 + (i << 8) + k;
+                state[4*4 + i] = 0x1f0000U + (i << 8) + k;
             }
         }
 
@@ -2880,7 +2880,7 @@ static int mlkem_gen_matrix_k4_aarch64(sword16* a, byte* seed, int transposed)
  * @param  [in]       len       Length of data to absorb in bytes.
  * @return  0 on success always.
  */
-static int mlkem_xof_absorb(wc_Shake* shake128, byte* seed, int len)
+static int mlkem_xof_absorb(wc_Shake* shake128, byte* seed, word32 len)
 {
     int ret;
 
@@ -2902,7 +2902,7 @@ static int mlkem_xof_absorb(wc_Shake* shake128, byte* seed, int len)
  * @param  [in]       blocks    Number of blocks to write.
  * @return  0 on success always.
  */
-static int mlkem_xof_squeezeblocks(wc_Shake* shake128, byte* out, int blocks)
+static int mlkem_xof_squeezeblocks(wc_Shake* shake128, byte* out, word32 blocks)
 {
     return wc_Shake128_SqueezeBlocks(shake128, out, blocks);
 }
@@ -3454,17 +3454,17 @@ static int mlkem_gen_matrix_c(MLKEM_PRF_T* prf, sword16* a, int k, byte* seed,
         for (j = 0; (ret == 0) && (j < k); j++) {
             if (transposed) {
                 /* Alg 14, Step 6: .. rho||i||j ... */
-                extSeed[WC_ML_KEM_SYM_SZ + 0] = i;
-                extSeed[WC_ML_KEM_SYM_SZ + 1] = j;
+                extSeed[WC_ML_KEM_SYM_SZ + 0] = (byte)i;
+                extSeed[WC_ML_KEM_SYM_SZ + 1] = (byte)j;
             }
             else {
                 /* Alg 13, Step 5: .. rho||j||i ... */
-                extSeed[WC_ML_KEM_SYM_SZ + 0] = j;
-                extSeed[WC_ML_KEM_SYM_SZ + 1] = i;
+                extSeed[WC_ML_KEM_SYM_SZ + 0] = (byte)j;
+                extSeed[WC_ML_KEM_SYM_SZ + 1] = (byte)i;
             }
             /* Absorb the index specific seed.
              * Alg 7, Step 1-2 */
-            ret = mlkem_xof_absorb(prf, extSeed, sizeof(extSeed));
+            ret = mlkem_xof_absorb(prf, extSeed, (word32)sizeof(extSeed));
             if (ret == 0) {
                 /* Create data based on the seed.
                  * Alg 7, Step 5. Generating enough to, on average, be able to
@@ -3666,7 +3666,7 @@ static int mlkem_gen_matrix_i(MLKEM_PRF_T* prf, sword16* a, int k, byte* seed,
         }
         /* Absorb the index specific seed.
          * Alg 7, Step 1-2 */
-        ret = mlkem_xof_absorb(prf, extSeed, sizeof(extSeed));
+        ret = mlkem_xof_absorb(prf, extSeed, (word32)sizeof(extSeed));
         if (ret == 0) {
             /* Create out based on the seed.
              * Alg 7, Step 5. Generating enough to, on average, be able to get
@@ -3717,8 +3717,8 @@ static int mlkem_gen_matrix_i(MLKEM_PRF_T* prf, sword16* a, int k, byte* seed,
  * @return  Difference of the two values with range 0..2.
  */
 #define ETA2_SUB(d, i) \
-    (((sword16)(((d) >> ((i) * 4 + 0)) & 0x3)) - \
-     ((sword16)(((d) >> ((i) * 4 + 2)) & 0x3)))
+    ((sword16)(((sword16)(((d) >> ((i) * 4 + 0)) & 0x3)) -      \
+               ((sword16)(((d) >> ((i) * 4 + 2)) & 0x3))))
 
 /* Compute polynomial with coefficients distributed according to a centered
  * binomial distribution with parameter eta2 from uniform random bytes.
@@ -3833,8 +3833,8 @@ static void mlkem_cbd_eta2(sword16* p, const byte* r)
  * @return  Difference of the two values with range 0..3.
  */
 #define ETA3_SUB(d, i) \
-    (((sword16)(((d) >> ((i) * 6 + 0)) & 0x7)) - \
-     ((sword16)(((d) >> ((i) * 6 + 3)) & 0x7)))
+    ((sword16)(((sword16)(((d) >> ((i) * 6 + 0)) & 0x7)) -      \
+               ((sword16)(((d) >> ((i) * 6 + 3)) & 0x7))))
 
 /* Compute polynomial with coefficients distributed according to a centered
  * binomial distribution with parameter eta3 from uniform random bytes.
@@ -4090,7 +4090,7 @@ static int mlkem_get_noise_eta2_c(MLKEM_PRF_T* prf, sword16* p,
  */
 static void mlkem_get_noise_x4_eta2_avx2(byte* rand, byte* seed, byte o)
 {
-    int i;
+    word64 i;
     word64 state[25 * 4];
 
     for (i = 0; i < 4; i++) {
@@ -4564,7 +4564,7 @@ static int mlkem_get_noise_c(MLKEM_PRF_T* prf, int k, sword16* vec1, int eta1,
     /* Generate noise as private key. */
     for (i = 0; (ret == 0) && (i < k); i++) {
         /* Generate noise for each dimension of vector. */
-        ret = mlkem_get_noise_eta1_c(prf, vec1 + i * MLKEM_N, seed, eta1);
+        ret = mlkem_get_noise_eta1_c(prf, vec1 + i * MLKEM_N, seed, (byte)eta1);
         /* Increment value of appended byte. */
         seed[WC_ML_KEM_SYM_SZ]++;
     }
@@ -4572,13 +4572,13 @@ static int mlkem_get_noise_c(MLKEM_PRF_T* prf, int k, sword16* vec1, int eta1,
         /* Generate noise for error. */
         for (i = 0; (ret == 0) && (i < k); i++) {
             /* Generate noise for each dimension of vector. */
-            ret = mlkem_get_noise_eta1_c(prf, vec2 + i * MLKEM_N, seed, eta2);
+            ret = mlkem_get_noise_eta1_c(prf, vec2 + i * MLKEM_N, seed, (byte)eta2);
             /* Increment value of appended byte. */
             seed[WC_ML_KEM_SYM_SZ]++;
         }
     }
     else {
-        seed[WC_ML_KEM_SYM_SZ] = 2 * k;
+        seed[WC_ML_KEM_SYM_SZ] = (byte)(2 * k);
     }
     if ((ret == 0) && (poly != NULL)) {
         /* Generating random error polynomial. */
@@ -4738,7 +4738,7 @@ static int mlkem_cmp_c(const byte* a, const byte* b, int sz)
     for (i = 0; i < sz; i++) {
         r |= a[i] ^ b[i];
     }
-    return 0 - ((-(word32)r) >> 31);
+    return (int)(0 - ((-(word32)r) >> 31));
 }
 #endif
 
@@ -4787,9 +4787,9 @@ static MLKEM_NOINLINE void mlkem_csubq_c(sword16* p)
     unsigned int i;
 
     for (i = 0; i < MLKEM_N; ++i) {
-        sword16 t = p[i] - MLKEM_Q;
+        sword16 t = (sword16)(p[i] - MLKEM_Q);
         /* When top bit set, -ve number - need to add q back. */
-        p[i] = ((t >> 15) & MLKEM_Q) + t;
+        p[i] = (sword16)(((t >> 15) & MLKEM_Q) + t);
     }
 }
 
@@ -4909,8 +4909,8 @@ static MLKEM_NOINLINE void mlkem_csubq_c(sword16* p)
  * @return  Compressed value.
  */
 #define TO_COMP_WORD_10(v, i, j, k) \
-    ((((MLKEM_V54 << 10) * (v)[(i) * MLKEM_N + (j) + (k)]) + \
-      MLKEM_V54_HALF) >> 54)
+    ((sword16)((((MLKEM_V54 << 10) * (word64)(v)[(i) * MLKEM_N + (word64)(j) + (word64)(k)]) + \
+                MLKEM_V54_HALF) >> 54))
 
 /* Compress value to 11 bits.
  *
@@ -4926,8 +4926,8 @@ static MLKEM_NOINLINE void mlkem_csubq_c(sword16* p)
  * @return  Compressed value.
  */
 #define TO_COMP_WORD_11(v, i, j, k) \
-    ((((MLKEM_V53 << 11) * (v)[(i) * MLKEM_N + (j) + (k)]) + \
-      MLKEM_V53_HALF) >> 53)
+    ((sword16)((((MLKEM_V53 << 11) * (word64)(v)[(i) * MLKEM_N + (j) + (k)]) + \
+                MLKEM_V53_HALF) >> 53))
 
 #endif /* CONV_WITH_DIV */
 
@@ -5015,15 +5015,15 @@ static void mlkem_vec_compress_10_c(byte* r, sword16* v, unsigned int k)
 
             word32* r32 = (word32*)r;
             /* Pack sixteen 10-bit values into byte array. */
-            r32[0] =  t0        | ((word32)t1  << 10) | ((word32)t2  << 20) |
+            r32[0] =  (word32)t0        | ((word32)t1  << 10) | ((word32)t2  << 20) |
                                   ((word32)t3  << 30);
-            r32[1] = (t3  >> 2) | ((word32)t4  <<  8) | ((word32)t5  << 18) |
+            r32[1] = ((word32)t3  >> 2) | ((word32)t4  <<  8) | ((word32)t5  << 18) |
                                   ((word32)t6  << 28);
-            r32[2] = (t6  >> 4) | ((word32)t7  <<  6) | ((word32)t8  << 16) |
+            r32[2] = ((word32)t6  >> 4) | ((word32)t7  <<  6) | ((word32)t8  << 16) |
                                   ((word32)t9  << 26);
-            r32[3] = (t9  >> 6) | ((word32)t10 <<  4) | ((word32)t11 << 14) |
+            r32[3] = ((word32)t9  >> 6) | ((word32)t10 <<  4) | ((word32)t11 << 14) |
                                   ((word32)t12 << 24);
-            r32[4] = (t12 >> 8) | ((word32)t13 <<  2) | ((word32)t14 << 12) |
+            r32[4] = ((word32)t12 >> 8) | ((word32)t13 <<  2) | ((word32)t14 << 12) |
                                   ((word32)t15 << 22);
 
             /* Move over set bytes. */
@@ -5045,7 +5045,7 @@ void mlkem_vec_compress_10(byte* r, sword16* v, unsigned int k)
 {
 #ifdef USE_INTEL_SPEEDUP
     if (IS_INTEL_AVX2(cpuid_flags) && (SAVE_VECTOR_REGISTERS2() == 0)) {
-        mlkem_compress_10_avx2(r, v, k);
+        mlkem_compress_10_avx2(r, v, (int)k);
         RESTORE_VECTOR_REGISTERS();
     }
     else
@@ -5113,17 +5113,17 @@ static void mlkem_vec_compress_11_c(byte* r, sword16* v)
             sword16 t7 = TO_COMP_WORD_11(v, i, j, 7);
 
             /* Pack eight 11-bit values into byte array. */
-            r[ 0] = (t0 >>  0);
-            r[ 1] = (t0 >>  8) | (t1 << 3);
-            r[ 2] = (t1 >>  5) | (t2 << 6);
-            r[ 3] = (t2 >>  2);
-            r[ 4] = (t2 >> 10) | (t3 << 1);
-            r[ 5] = (t3 >>  7) | (t4 << 4);
-            r[ 6] = (t4 >>  4) | (t5 << 7);
-            r[ 7] = (t5 >>  1);
-            r[ 8] = (t5 >>  9) | (t6 << 2);
-            r[ 9] = (t6 >>  6) | (t7 << 5);
-            r[10] = (t7 >>  3);
+            r[ 0] = (byte)(t0 >>  0);
+            r[ 1] = (byte)((t0 >>  8) | (t1 << 3));
+            r[ 2] = (byte)((t1 >>  5) | (t2 << 6));
+            r[ 3] = (byte)(t2 >>  2);
+            r[ 4] = (byte)((t2 >> 10) | (t3 << 1));
+            r[ 5] = (byte)((t3 >>  7) | (t4 << 4));
+            r[ 6] = (byte)((t4 >>  4) | (t5 << 7));
+            r[ 7] = (byte)(t5 >>  1);
+            r[ 8] = (byte)((t5 >>  9) | (t6 << 2));
+            r[ 9] = (byte)((t6 >>  6) | (t7 << 5));
+            r[10] = (byte)(t7 >>  3);
         #endif
 
             /* Move over set bytes. */
@@ -5169,7 +5169,7 @@ void mlkem_vec_compress_11(byte* r, sword16* v)
  */
 #define DECOMP_10(v, i, j, k, t) \
     v[(i) * MLKEM_N + 4 * (j) + (k)] = \
-        (word16)((((word32)((t) & 0x3ff) * MLKEM_Q) + 512) >> 10)
+        (sword16)((((word32)((t) & 0x3ff) * MLKEM_Q) + 512) >> 10)
 
 /* Decompress an 11 bit value.
  *
@@ -5184,7 +5184,7 @@ void mlkem_vec_compress_11(byte* r, sword16* v)
  */
 #define DECOMP_11(v, i, j, k, t) \
     v[(i) * MLKEM_N + 8 * (j) + (k)] = \
-        (word16)((((word32)((t) & 0x7ff) * MLKEM_Q) + 1024) >> 11)
+        (sword16)((((word32)((t) & 0x7ff) * MLKEM_Q) + 1024) >> 11)
 
 #if defined(WOLFSSL_KYBER512) || defined(WOLFSSL_WC_ML_KEM_512) || \
     defined(WOLFSSL_KYBER768) || defined(WOLFSSL_WC_ML_KEM_768)
@@ -5223,10 +5223,10 @@ static void mlkem_vec_decompress_10_c(sword16* v, const byte* b, unsigned int k)
             }
         #else
             /* Extract out 4 values of 10 bits each. */
-            sword16 t0 = (b[0] >> 0) | ((word16)b[ 1] << 8);
-            sword16 t1 = (b[1] >> 2) | ((word16)b[ 2] << 6);
-            sword16 t2 = (b[2] >> 4) | ((word16)b[ 3] << 4);
-            sword16 t3 = (b[3] >> 6) | ((word16)b[ 4] << 2);
+            sword16 t0 = (sword16)((b[0] >> 0) | ((word16)b[ 1] << 8));
+            sword16 t1 = (sword16)((b[1] >> 2) | ((word16)b[ 2] << 6));
+            sword16 t2 = (sword16)((b[2] >> 4) | ((word16)b[ 3] << 4));
+            sword16 t3 = (sword16)((b[3] >> 6) | ((word16)b[ 4] << 2));
             b += 5;
 
             /* Decompress 4 values. */
@@ -5251,7 +5251,7 @@ void mlkem_vec_decompress_10(sword16* v, const byte* b, unsigned int k)
 {
 #ifdef USE_INTEL_SPEEDUP
     if (IS_INTEL_AVX2(cpuid_flags) && (SAVE_VECTOR_REGISTERS2() == 0)) {
-        mlkem_decompress_10_avx2(v, b, k);
+        mlkem_decompress_10_avx2(v, b, (int)k);
         RESTORE_VECTOR_REGISTERS();
     }
     else
@@ -5302,16 +5302,16 @@ static void mlkem_vec_decompress_11_c(sword16* v, const byte* b)
             }
         #else
             /* Extract out 8 values of 11 bits each. */
-            sword16 t0 = (b[0] >> 0) | ((word16)b[ 1] << 8);
-            sword16 t1 = (b[1] >> 3) | ((word16)b[ 2] << 5);
-            sword16 t2 = (b[2] >> 6) | ((word16)b[ 3] << 2) |
-                   ((word16)b[4] << 10);
-            sword16 t3 = (b[4] >> 1) | ((word16)b[ 5] << 7);
-            sword16 t4 = (b[5] >> 4) | ((word16)b[ 6] << 4);
-            sword16 t5 = (b[6] >> 7) | ((word16)b[ 7] << 1) |
-                   ((word16)b[8] <<  9);
-            sword16 t6 = (b[8] >> 2) | ((word16)b[ 9] << 6);
-            sword16 t7 = (b[9] >> 5) | ((word16)b[10] << 3);
+            sword16 t0 = (sword16)((b[0] >> 0) | ((word16)b[ 1] << 8));
+            sword16 t1 = (sword16)((b[1] >> 3) | ((word16)b[ 2] << 5));
+            sword16 t2 = (sword16)((b[2] >> 6) | ((word16)b[ 3] << 2) |
+                                   ((word16)b[4] << 10));
+            sword16 t3 = (sword16)((b[4] >> 1) | ((word16)b[ 5] << 7));
+            sword16 t4 = (sword16)((b[5] >> 4) | ((word16)b[ 6] << 4));
+            sword16 t5 = (sword16)((b[6] >> 7) | ((word16)b[ 7] << 1) |
+                                   ((word16)b[8] <<  9));
+            sword16 t6 = (sword16)((b[8] >> 2) | ((word16)b[ 9] << 6));
+            sword16 t7 = (sword16)((b[9] >> 5) | ((word16)b[10] << 3));
             b += 11;
 
             /* Decompress 8 values. */
@@ -5421,7 +5421,7 @@ void mlkem_vec_decompress_11(sword16* v, const byte* b)
  * @return  Compressed value.
  */
 #define TO_COMP_WORD_4(p, i, j) \
-    ((((MLKEM_V28 << 4) * (p)[(i) + (j)]) + MLKEM_V28_HALF) >> 28)
+    ((byte)((((MLKEM_V28 << 4) * (word32)(p)[(i) + (j)]) + MLKEM_V28_HALF) >> 28))
 
 /* Compress value to 5 bits.
  *
@@ -5435,7 +5435,7 @@ void mlkem_vec_decompress_11(sword16* v, const byte* b)
  * @return  Compressed value.
  */
 #define TO_COMP_WORD_5(p, i, j) \
-    ((((MLKEM_V27 << 5) * (p)[(i) + (j)]) + MLKEM_V27_HALF) >> 27)
+    ((byte)((((MLKEM_V27 << 5) * (word32)(p)[(i) + (j)]) + MLKEM_V27_HALF) >> 27))
 
 #endif /* CONV_WITH_DIV */
 
@@ -5486,10 +5486,10 @@ static void mlkem_compress_4_c(byte* b, sword16* p)
         byte t7 = TO_COMP_WORD_4(p, i, 7);
 
         /* Pack eight 4-bit values into byte array. */
-        b[0] = t0 | (t1 << 4);
-        b[1] = t2 | (t3 << 4);
-        b[2] = t4 | (t5 << 4);
-        b[3] = t6 | (t7 << 4);
+        b[0] = (byte)(t0 | (t1 << 4));
+        b[1] = (byte)(t2 | (t3 << 4));
+        b[2] = (byte)(t4 | (t5 << 4));
+        b[3] = (byte)(t6 | (t7 << 4));
     #endif
 
         /* Move over set bytes. */
@@ -5563,11 +5563,11 @@ static void mlkem_compress_5_c(byte* b, sword16* p)
         byte t7 = TO_COMP_WORD_5(p, i, 7);
 
         /* Pack eight 5-bit values into byte array. */
-        b[0] = (t0 >> 0) | (t1 << 5);
-        b[1] = (t1 >> 3) | (t2 << 2) | (t3 << 7);
-        b[2] = (t3 >> 1) | (t4 << 4);
-        b[3] = (t4 >> 4) | (t5 << 1) | (t6 << 6);
-        b[4] = (t6 >> 2) | (t7 << 3);
+        b[0] = (byte)((t0 >> 0) | (t1 << 5));
+        b[1] = (byte)((t1 >> 3) | (t2 << 2) | (t3 << 7));
+        b[2] = (byte)((t3 >> 1) | (t4 << 4));
+        b[3] = (byte)((t4 >> 4) | (t5 << 1) | (t6 << 6));
+        b[4] = (byte)((t6 >> 2) | (t7 << 3));
     #endif
 
         /* Move over set bytes. */
@@ -5610,7 +5610,7 @@ void mlkem_compress_5(byte* b, sword16* p)
  * @return  Decompressed value.
  */
 #define DECOMP_4(p, i, j, t) \
-    p[(i) + (j)] = ((word16)((t) * MLKEM_Q) + 8) >> 4
+    p[(i) + (j)] = (sword16)(((word16)((t) * MLKEM_Q) + 8) >> 4)
 
 /* Decompress a 5 bit value.
  *
@@ -5623,7 +5623,7 @@ void mlkem_compress_5(byte* b, sword16* p)
  * @return  Decompressed value.
  */
 #define DECOMP_5(p, i, j, t) \
-    p[(i) + (j)] = (((word32)((t) & 0x1f) * MLKEM_Q) + 16) >> 5
+    p[(i) + (j)] = (sword16)((((word32)((t) & 0x1f) * MLKEM_Q) + 16) >> 5)
 
 #if defined(WOLFSSL_KYBER512) || defined(WOLFSSL_WC_ML_KEM_512) || \
     defined(WOLFSSL_KYBER768) || defined(WOLFSSL_WC_ML_KEM_768)
@@ -5704,12 +5704,12 @@ static void mlkem_decompress_5_c(sword16* p, const byte* b)
     #else
         /* Extract out 8 values of 5 bits each. */
         byte t0 = (b[0] >> 0);
-        byte t1 = (b[0] >> 5) | (b[1] << 3);
+        byte t1 = (byte)((b[0] >> 5) | (b[1] << 3));
         byte t2 = (b[1] >> 2);
-        byte t3 = (b[1] >> 7) | (b[2] << 1);
-        byte t4 = (b[2] >> 4) | (b[3] << 4);
+        byte t3 = (byte)((b[1] >> 7) | (b[2] << 1));
+        byte t4 = (byte)((b[2] >> 4) | (b[3] << 4));
         byte t5 = (b[3] >> 1);
-        byte t6 = (b[3] >> 6) | (b[4] << 2);
+        byte t6 = (byte)((b[3] >> 6) | (b[4] << 2));
         byte t7 = (b[4] >> 3);
         b += 5;
 
@@ -5840,7 +5840,7 @@ void mlkem_from_msg(sword16* p, const byte* msg)
  * @param  [in]   j   Index of bit in byte.
  */
 #define TO_MSG_BIT(m, p, i, j) \
-    m[i] |= (((((sword16)p[8 * i + j] << 1) + MLKEM_Q_HALF) / MLKEM_Q) & 1) << j
+    (m)[i] = (byte)((m)[i] | (((((sword16)p[8 * (i) + (j)] << 1) + MLKEM_Q_HALF) / MLKEM_Q) & 1) << (j))
 
 #else
 
@@ -5863,8 +5863,8 @@ void mlkem_from_msg(sword16* p, const byte* msg)
  * @param  [in]   j   Index of bit in byte.
  */
 #define TO_MSG_BIT(m, p, i, j) \
-    (m)[i] |= ((word32)((MLKEM_V31_2 * (p)[8 * (i) + (j)]) + \
-                        MLKEM_V31_HALF) >> 31) << (j)
+    (m)[i] = (byte)((m)[i] | (((MLKEM_V31_2 * (word32)(p)[8 * (i) + (j)]) + \
+                                       MLKEM_V31_HALF) >> 31) << (j))
 
 #endif /* CONV_WITH_DIV */
 
@@ -6041,11 +6041,11 @@ static void mlkem_to_bytes_c(byte* b, sword16* p, int k)
 
     for (j = 0; j < k; j++) {
         for (i = 0; i < MLKEM_N / 2; i++) {
-            word16 t0 = p[2 * i];
-            word16 t1 = p[2 * i + 1];
-            b[3 * i + 0] = (t0 >> 0);
-            b[3 * i + 1] = (t0 >> 8) | t1 << 4;
-            b[3 * i + 2] = (t1 >> 4);
+            word16 t0 = (word16)p[2 * i];
+            word16 t1 = (word16)p[2 * i + 1];
+            b[3 * i + 0] = (byte)(t0 >> 0);
+            b[3 * i + 1] = (byte)((t0 >> 8) | t1 << 4);
+            b[3 * i + 2] = (byte)(t1 >> 4);
         }
         p += MLKEM_N;
         b += WC_ML_KEM_POLY_SIZE;

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -261,6 +261,10 @@ WOLFSSL_API int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst);
 #if defined(OPENSSL_EXTRA) || defined(HAVE_CURL)
 WOLFSSL_API int wc_Sha512Transform(wc_Sha512* sha, const unsigned char* data);
 #endif
+#if defined(WOLFSSL_HAVE_LMS) && !defined(WOLFSSL_LMS_FULL_HASH)
+WOLFSSL_API int wc_Sha512HashBlock(wc_Sha512* sha512, const unsigned char* data,
+    unsigned char* hash);
+#endif
 
 #if !defined(WOLFSSL_NOSHA512_224) && \
    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)


### PR DESCRIPTION
`configure.ac`: add native PQC implementations to `--enable-all-crypto` (and by extension, `--enable-all`).

tested with `wolfssl-multi-test.sh ... check-source-text check-configure` and a couple direct builds with and without linuxkm.

note, Dilithium gated behind `$ENABLED_EXPERIMENTAL` until name conversion to ML-DSA.
