### PR TITLE
update wolfSSL_get_SessionTicket to be able to return ticket length

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -11971,11 +11971,13 @@ int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx);
     \ingroup IO
 
     \brief This function copies the ticket member of the Session structure to
-    the buffer.
+    the buffer. If buf is NULL and bufSz is non-NULL, bufSz will be set to the
+    ticket length.
 
     \return SSL_SUCCESS returned if the function executed without error.
-    \return BAD_FUNC_ARG returned if one of the arguments was NULL or if the
-    bufSz argument was 0.
+    \return BAD_FUNC_ARG returned if ssl or bufSz is NULL, or if bufSz
+    is non-NULL and buf is NULL
+
 
     \param ssl a pointer to a WOLFSSL structure, created using wolfSSL_new().
     \param buf a byte pointer representing the memory buffer.

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4292,7 +4292,15 @@ int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx)
 
 int wolfSSL_get_SessionTicket(WOLFSSL* ssl, byte* buf, word32* bufSz)
 {
-    if (ssl == NULL || buf == NULL || bufSz == NULL || *bufSz == 0)
+    if (ssl == NULL || bufSz == NULL)
+        return BAD_FUNC_ARG;
+
+    if (*bufSz == 0 && buf == NULL) {
+        *bufSz = ssl->session->ticketLen;
+        return LENGTH_ONLY_E;
+    }
+
+    if (buf == NULL)
         return BAD_FUNC_ARG;
 
     if (ssl->session->ticketLen <= *bufSz) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -27863,6 +27863,7 @@ static int test_wolfSSL_SESSION(void)
         const char* ticket = "This is a session ticket";
         char buf[64] = {0};
         word32 bufSz = (word32)sizeof(buf);
+        word32 retSz = 0;
 
         ExpectIntEQ(WOLFSSL_SUCCESS,
             wolfSSL_set_SessionTicket(ssl, (byte *)ticket,
@@ -27870,6 +27871,10 @@ static int test_wolfSSL_SESSION(void)
         ExpectIntEQ(WOLFSSL_SUCCESS,
             wolfSSL_get_SessionTicket(ssl, (byte *)buf, &bufSz));
         ExpectStrEQ(ticket, buf);
+
+        /* return ticket length if buffer parameter is null */
+        wolfSSL_get_SessionTicket(ssl, NULL, &retSz);
+        ExpectIntEQ(bufSz, retSz);
     }
 #endif
 


### PR DESCRIPTION
# Description

Allow `wolfSSL_get_SessionTicket()` to retrieve the session ticket length if buffer is null but `dataSz` is not null. Used in JNI wrapper to adjust byte array size. This change does not modify the function signature.

zd#20208

# Testing

`./configure --enable-jni --enable-session-ticket`

# Checklist

 - [x] added tests
 - [x] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
