### PR TITLE
Please use DEBUG_WOLFSSL not WOLFSSL_DEBUG

### DIFF
--- a/wolfcrypt/src/port/Espressif/esp32_mp.c
+++ b/wolfcrypt/src/port/Espressif/esp32_mp.c
@@ -2154,7 +2154,7 @@ int esp_mp_mulmod(MATH_INT_T* X, MATH_INT_T* Y, MATH_INT_T* M, MATH_INT_T* Z)
         DPORT_REG_WRITE(RSA_MULT_MODE_REG, (mph->hwWords_sz >> 4) - 1);
 #if defined(DEBUG_WOLFSSL)
         ESP_LOGV(TAG, "RSA_MULT_MODE_REG = %d", (mph->hwWords_sz >> 4) - 1);
-#endif /* WOLFSSL_DEBUG */
+#endif /* DEBUG_WOLFSSL */
 
         /* step.2 write X, M, and r_inv into memory.
          * The capacity of each memory block is 128 words.

--- a/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
@@ -317,7 +317,7 @@ static int wc_DevCrypto_AesGcm(Aes* aes, byte* out, byte* in, word32 sz,
                       dir, (byte*)authIn, authInSz, authTag, authTagSz);
     ret = ioctl(aes->ctx.cfd, CIOCAUTHCRYPT, &crt);
     if (ret != 0) {
-        #ifdef WOLFSSL_DEBUG
+        #ifdef DEBUG_WOLFSSL
         if (authInSz > sysconf(_SC_PAGESIZE)) {
             WOLFSSL_MSG("authIn Buffer greater than System Page Size");
         }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -18663,7 +18663,7 @@ static wc_test_ret_t const_byte_ptr_test(const byte* in, word32 *outJ)
     j = *outJ; /* Found index to use in const array. */
 
     if (j == 0) {
-#ifdef WOLFSSL_DEBUG
+#ifdef DEBUG_WOLFSSL
         printf("Testing const byte ptr reference...\n");
 #endif
         /* although j is zero, in[0] does not detect the Illegal instruction */

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -3124,7 +3124,7 @@ static WC_INLINE int wolfSSL_PrintStats(WOLFSSL_MEM_STATS* stats)
         return 0;
     }
 
-    /* print to stderr so is on the same pipe as WOLFSSL_DEBUG */
+    /* print to stderr so is on the same pipe as DEBUG_WOLFSSL */
     fprintf(stderr, "Total mallocs   = %d\n", stats->totalAlloc);
     fprintf(stderr, "Total frees     = %d\n", stats->totalFr);
     fprintf(stderr, "Current mallocs = %d\n", stats->curAlloc);


### PR DESCRIPTION
# Description

I've made this mistake myself on more that one occasion: `WOLFSSL_DEBUG` vs `DEBUG_WOLFSSL`.

The correct macro for wolfSSL debugging is `DEBUG_WOLFSSL`.

I've made some corrections that already exist in the codebase and added this to `settings.h` to avoid future mistakes:

```c
#ifdef WOLFSSL_DEBUG
    #error "Please use DEBUG_WOLFSSL not WOLFSSL_DEBUG"
#endif
```

As for the pattern:

```c
#ifdef DEBUG_WOLFSSL
        printf("Testing something...\n");
#endif
```

It is best to use [WOLFSSL_MSG](https://github.com/wolfSSL/wolfssl/blob/0392ee009feabcb5724b216b0d965b272fa765c7/wolfssl/wolfcrypt/logging.h#L182) from `wolfssl/wolfcrypt/logging.h`.

```c
WOLFSSL_MSG("Testing something...\n");
```

Fixes zd#

# Testing

Manual testing only

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
