### PR TITLE
Update HAProxy build-vtest: fix v3.1.0 and add v3.2.0

### DIFF
--- a/.github/workflows/haproxy.yml
+++ b/.github/workflows/haproxy.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        haproxy_ref: [ 'v3.1.0' ]
+        haproxy_ref: [ 'v3.1.0', 'v3.2.0']
     steps:
     - name: Install test dependencies
       run: |
@@ -81,6 +81,13 @@ jobs:
     - name: Build haproxy
       working-directory: build-dir/haproxy-${{matrix.haproxy_ref}}
       run: make clean && make TARGET=linux-glibc USE_OPENSSL_WOLFSSL=1 SSL_LIB=$GITHUB_WORKSPACE/build-dir/lib SSL_INC=$GITHUB_WORKSPACE/build-dir/include ADDLIB=-Wl,-rpath,$GITHUB_WORKSPACE/build-dir/lib CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
+
+      # wlallemand/VTest used in v3.1.0 is no longer available
+    - name: Patch build-vtest.sh for v3.1.0
+      if: matrix.haproxy_ref == 'v3.1.0'
+      working-directory: build-dir/haproxy-${{ matrix.haproxy_ref }}/scripts
+      run: |
+        sed -i 's|https://github.com/wlallemand/VTest/archive/refs/heads/haproxy-sd_notify.tar.gz|https://github.com/vtest/VTest2/archive/main.tar.gz|' build-vtest.sh
 
     - name: Build haproxy vtest
       working-directory: build-dir/haproxy-${{matrix.haproxy_ref}}


### PR DESCRIPTION
# Description

The PR fixes the currently failing GitHub action for [workflows/haproxy.yml](https://github.com/wolfSSL/wolfssl/blob/master/.github/workflows/haproxy.yml)

The `build-vtest.sh`  in the HAProxy [v3.1.0 scripts directory](https://github.com/haproxy/haproxy/tree/v3.1.0/scripts) refers to the 3rd party [wlallemand/vtest](https://github.com/haproxy/haproxy/blob/v3.1.0/scripts/build-vtest.sh#L5C31-L5C41) repo which [no longer exists](https://github.com/wlallemand/VTest). 

The [error](https://github.com/wolfSSL/wolfssl/actions/runs/16728219656/job/47352019539?pr=9054#logs) we see is because we [call that build-vtest.sh](https://github.com/wolfSSL/wolfssl/blob/c22c37df09f23f64b9f9cce830a15dcd4d02f803/.github/workflows/haproxy.yml#L87) in our  `haproxy.yml` workflow file.

It appears we only need the "haproxy-sd_notify.tar.gz" file, but where to find that, now that the source repo is gone?

I'm assuming the current [https://github.com/vtest/VTest2/archive/main.tar.gz](https://github.com/haproxy/haproxy/blob/8afd3e588d09f16313b4f9ea1b1a87f829e9b75e/scripts/build-vtest.sh#L5) is appropriate for the v3.1.0 tests.

While there, I also added HAProxy v3.2.0 support.

Thanks @JacobBarthelmeh for the suggested fix enclosed.

Fixes zd#  n/a

# Testing

How did you test?

See [my sample](https://github.com/gojimmypi/wolfssl/actions/runs/16732276369/job/47363061142)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
