### PR TITLE
fe_operations.h: fix MISRA rule 8.2 violations by naming function prototype parameters

### DIFF
--- a/wolfssl/wolfcrypt/fe_operations.h
+++ b/wolfssl/wolfcrypt/fe_operations.h
@@ -63,12 +63,12 @@ Bounds on each t[i] vary depending on context.
 #if defined(CURVE25519_SMALL) || defined(ED25519_SMALL)
     #define F25519_SIZE 32
 
-    WOLFSSL_LOCAL void lm_copy(byte*, const byte*);
-    WOLFSSL_LOCAL void lm_add(byte*, const byte*, const byte*);
-    WOLFSSL_LOCAL void lm_sub(byte*, const byte*, const byte*);
-    WOLFSSL_LOCAL void lm_neg(byte*,const byte*);
-    WOLFSSL_LOCAL void lm_invert(byte*, const byte*);
-    WOLFSSL_LOCAL void lm_mul(byte*,const byte*,const byte*);
+    WOLFSSL_LOCAL void lm_copy(byte* x, const byte* a);
+    WOLFSSL_LOCAL void lm_add(byte* r, const byte* a, const byte* b);
+    WOLFSSL_LOCAL void lm_sub(byte* r, const byte* a, const byte* b);
+    WOLFSSL_LOCAL void lm_neg(byte* r,const byte* a);
+    WOLFSSL_LOCAL void lm_invert(byte* r, const byte* x);
+    WOLFSSL_LOCAL void lm_mul(byte* r,const byte* a, const byte* b);
 #endif
 
 


### PR DESCRIPTION
# Description

This was a super-low-hanging-fruit opportunity to avoid MISRA rule 8.2 violations by simply naming function parameters in the function prototypes.

# Testing

Unit tested.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
