### PR TITLE
20250805-clang-and-linuxkm-fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -3045,7 +3045,7 @@ static int test_wolfSSL_CertManagerAPI(void)
     EXPECT_DECLS;
 #ifndef NO_CERTS
     WOLFSSL_CERT_MANAGER* cm = NULL;
-    unsigned char c;
+    unsigned char c = 0;
 
     ExpectNotNull(cm = wolfSSL_CertManagerNew_ex(NULL));
 


### PR DESCRIPTION
`tests/api.c`: fix `-Wuninitialized-const-pointer` in `test_wolfSSL_CertManagerAPI()`;

`wolfcrypt/benchmark/benchmark.c`:

* use `WC_RELAX_LONG_LOOP()` as default definition of `TEST_SLEEP()`, and remove `WC_RELAX_LONG_LOOP()` from `bench_stats_sym_finish()`/`bench_stats_asym_finish_ex()`;
* when `WOLFSSL_LINUXKM` but !`WOLFSSL_LINUXKM_USE_SAVE_VECTOR_REGISTERS`, properly wrap `kernel_fpu_begin`...`end` around floating point ops.

fixes
```
tests/api.c:3059:59: error: variable 'c' is uninitialized when passed as a const pointer argument here [-Werror,-Wuninitialized-const-pointer]
 3059 |     ExpectIntEQ(wolfSSL_CertManagerLoadCABuffer_ex(NULL, &c, 1,
      |                                                           ^
```
