### PR TITLE
20250807-redo-PR8900

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -14208,7 +14208,7 @@ static int _sp_exptmod_nct(const sp_int* b, const sp_int* e, const sp_int* m,
         winBits = 6;
     }
     else if (bits <= 21) {
-        winBits = 1;
+        winBits = 2;
     }
     else if (bits <= 36) {
         winBits = 3;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -14207,6 +14207,9 @@ static int _sp_exptmod_nct(const sp_int* b, const sp_int* e, const sp_int* m,
     if (bits > 450) {
         winBits = 6;
     }
+    else if (bits <= 21) {
+        winBits = 1;
+    }
     else if (bits <= 36) {
         winBits = 3;
     }


### PR DESCRIPTION
Revert "SP int: modular exponentiation constant time" (fixes regression in benchmark "RSA,2048,public").

This reverts commit 219509d7d9874e0d25c65c7c1e620bcb19adf898 (#8900).

`wolfcrypt/src/sp_int.c`: in `_sp_exptmod_nct()`, use 2 bit window if `bits <= 21`.

see ZD#20090

fixes
```
[benchmark-wolfcrypt-intelasm-all] [1 of 3] [339f7efbf4]
    1 asym alg(s) not fast enough in any trial:
      RSA,2048,public -- best trial 85.42% of baseline, Z+141.30
```
```
[benchmark-wolfcrypt-intelasm-all-clang] [2 of 3] [339f7efbf4]
    1 asym alg(s) not fast enough in any trial:
      RSA,2048,public -- best trial 84.84% of baseline, Z+9.29
```
```
[benchmark-wolfcrypt-noasm-all-clang] [3 of 3] [339f7efbf4]
    1 asym alg(s) not fast enough in any trial:
      RSA,2048,public -- best trial 87.43% of baseline, Z+26.42
```
