### PR TITLE
Changes for cppcheck=force-source errors and warnings

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -218,6 +218,10 @@ static void CRL_Entry_free(CRL_Entry* crle, void* heap)
     RevokedCert* next;
 
     WOLFSSL_ENTER("FreeCRL_Entry");
+    if (crle == NULL) {
+        WOLFSSL_MSG("CRL Entry is null");
+        return;
+    }
 
     while (tmp != NULL) {
         next = tmp->next;

--- a/src/crl.c
+++ b/src/crl.c
@@ -1640,7 +1640,7 @@ static int StopMonitor(wolfSSL_CRL_mfd_t mfd)
 
 #ifdef DEBUG_WOLFSSL
 #define SHOW_WINDOWS_ERROR() do {                               \
-    LPVOID lpMsgBuf;                                            \
+    LPVOID lpMsgBuf = NULL;                                     \
     DWORD dw = GetLastError();                                  \
     FormatMessageA(                                             \
         FORMAT_MESSAGE_ALLOCATE_BUFFER |                        \

--- a/src/internal.c
+++ b/src/internal.c
@@ -23598,6 +23598,10 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
     BuildMsgArgs  lcl_args;
 #endif
 
+#ifdef WOLFSSL_DTLS_CID
+    byte cidSz = 0;
+#endif
+
     WOLFSSL_ENTER("BuildMessage");
 
     if (ssl == NULL) {
@@ -23730,14 +23734,11 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                 args->idx      += DTLS_RECORD_EXTRA;
                 args->headerSz += DTLS_RECORD_EXTRA;
         #ifdef WOLFSSL_DTLS_CID
-                if (ssl->options.dtls) {
-                    byte cidSz = 0;
-                    if ((cidSz = DtlsGetCidTxSize(ssl)) > 0) {
-                        args->sz       += cidSz;
-                        args->idx      += cidSz;
-                        args->headerSz += cidSz;
-                        args->sz++; /* real_type. no padding. */
-                    }
+                if ((cidSz = DtlsGetCidTxSize(ssl)) > 0) {
+                    args->sz       += cidSz;
+                    args->idx      += cidSz;
+                    args->headerSz += cidSz;
+                    args->sz++; /* real_type. no padding. */
                 }
         #endif
             }

--- a/src/internal.c
+++ b/src/internal.c
@@ -604,6 +604,9 @@ int IsAtLeastTLSv1_3(const ProtocolVersion pv)
 
 int IsEncryptionOn(const WOLFSSL* ssl, int isSend)
 {
+    if (ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
 #ifdef WOLFSSL_DTLS
     /* For DTLS, epoch 0 is always not encrypted. */
     if (ssl->options.dtls && !isSend) {
@@ -10847,12 +10850,16 @@ static int SendHandshakeMsg(WOLFSSL* ssl, byte* input, word32 inputSz,
 #endif /* !WOLFSSL_NO_TLS12 */
 
 
-/* return bytes received, -1 on error */
+/* return bytes received, WOLFSSL_FATAL_ERROR on error,
+ * or BAD_FUNC_ARG if ssl is null */
 static int wolfSSLReceive(WOLFSSL* ssl, byte* buf, word32 sz)
 {
     int recvd;
     int retryLimit = WOLFSSL_MODE_AUTO_RETRY_ATTEMPTS;
 
+    if (ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
 #ifdef WOLFSSL_QUIC
     if (WOLFSSL_IS_QUIC(ssl)) {
         /* QUIC only "reads" from data provided by the application
@@ -11011,6 +11018,11 @@ void ShrinkInputBuffer(WOLFSSL* ssl, int forcedFree)
 int SendBuffered(WOLFSSL* ssl)
 {
     int retryLimit = WOLFSSL_MODE_AUTO_RETRY_ATTEMPTS;
+
+    if (ssl == NULL) {
+        WOLFSSL_MSG("ssl is null");
+        return BAD_FUNC_ARG;
+    }
 
     if (ssl->CBIOSend == NULL && !WOLFSSL_IS_QUIC(ssl)) {
         WOLFSSL_MSG("Your IO Send callback is null, please set");
@@ -11382,6 +11394,10 @@ int CheckAvailableSize(WOLFSSL *ssl, int size)
 
 int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
 {
+    if (ssl == NULL) {
+        WOLFSSL_MSG("ssl is null");
+        return BAD_FUNC_ARG;
+    }
 #ifdef WOLFSSL_QUIC
     /* QUIC protects messages outside of the TLS scope */
     if (WOLFSSL_IS_QUIC(ssl) && IsAtLeastTLSv1_3(ssl->version))

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6041,11 +6041,13 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
     if (ret == 0 && signer != NULL) {
         ret = FillSigner(signer, cert, type, der);
 
-    #ifndef NO_SKID
-        row = HashSigner(signer->subjectKeyIdHash);
-    #else
-        row = HashSigner(signer->subjectNameHash);
-    #endif
+        if (ret == 0){
+        #ifndef NO_SKID
+            row = HashSigner(signer->subjectKeyIdHash);
+        #else
+            row = HashSigner(signer->subjectNameHash);
+        #endif
+        }
 
     #if defined(WOLFSSL_RENESAS_TSIP_TLS) || defined(WOLFSSL_RENESAS_FSPSM_TLS)
         /* Verify CA by TSIP so that generated tsip key is going to          */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -41359,7 +41359,7 @@ int wc_ParseCertPIV(wc_CertPIV* piv, const byte* buf, word32 totalSz)
     DECL_ASNGETDATA(dataASN, pivCertASN_Length);
     int ret = 0;
     word32 idx;
-    byte info;
+    byte info = 0;
 
     WOLFSSL_ENTER("wc_ParseCertPIV");
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -715,6 +715,11 @@ int SizeASN_Items(const ASNItem* asn, ASNSetData *data, int count, int* encSz)
     WOLFSSL_ENTER("SizeASN_Items");
 #endif
 
+    if (asn == NULL || data == NULL || count <= 0 || encSz == NULL) {
+        WOLFSSL_MSG("bad arguments in SizeASN_Items");
+        return BAD_FUNC_ARG;
+    }
+
     for (i = count - 1; i >= 0; i--) {
         /* Skip this ASN.1 item when encoding. */
         if (data[i].noOut) {

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -1015,13 +1015,13 @@ void* wolfSSL_Malloc(size_t size, void* heap, int type)
             #endif
 
             #ifdef WOLFSSL_DEBUG_MEMORY
-                fprintf(stderr, "[HEAP %p] Alloc: %p -> %u at %s:%d\n", heap,
+                fprintf(stderr, "[HEAP %p] Alloc: %p -> %u at %s:%u\n", heap,
                     res, (word32)size, func, line);
             #endif
         #else
             WOLFSSL_MSG("No heap hint found to use and no malloc");
             #ifdef WOLFSSL_DEBUG_MEMORY
-            fprintf(stderr, "ERROR: at %s:%d\n", func, line);
+            fprintf(stderr, "ERROR: at %s:%u\n", func, line);
             #endif
         #endif /* WOLFSSL_NO_MALLOC */
         #endif /* WOLFSSL_HEAP_TEST */
@@ -1100,7 +1100,7 @@ void* wolfSSL_Malloc(size_t size, void* heap, int type)
 
         #ifdef WOLFSSL_DEBUG_MEMORY
             pt->szUsed = size;
-            fprintf(stderr, "[HEAP %p] Alloc: %p -> %lu at %s:%d\n", heap,
+            fprintf(stderr, "[HEAP %p] Alloc: %p -> %lu at %s:%u\n", heap,
                 pt->buffer, size, func, line);
         #endif
         #ifdef WOLFSSL_STATIC_MEMORY_DEBUG_CALLBACK
@@ -1130,7 +1130,7 @@ void* wolfSSL_Malloc(size_t size, void* heap, int type)
             WOLFSSL_MSG("ERROR ran out of static memory");
             res = NULL;
             #ifdef WOLFSSL_DEBUG_MEMORY
-                fprintf(stderr, "Looking for %lu bytes at %s:%d\n",
+                fprintf(stderr, "Looking for %lu bytes at %s:%u\n",
                     (unsigned long) size, func, line);
             #endif
             #ifdef WOLFSSL_STATIC_MEMORY_DEBUG_CALLBACK
@@ -1167,14 +1167,14 @@ void wolfSSL_Free(void *ptr, void* heap, int type)
 #endif
 {
     int i;
-    wc_Memory* pt;
+    wc_Memory* pt = NULL;
 
     if (ptr) {
         /* check for testing heap hint was set */
     #ifdef WOLFSSL_HEAP_TEST
         if (heap == (void*)WOLFSSL_HEAP_TEST) {
         #ifdef WOLFSSL_DEBUG_MEMORY
-            fprintf(stderr, "[HEAP %p] Free: %p at %s:%d\n", heap, pt, func,
+            fprintf(stderr, "[HEAP %p] Free: %p at %s:%u\n", heap, pt, func,
                 line);
         #endif
             return free(ptr); /* native heap */
@@ -1194,7 +1194,7 @@ void wolfSSL_Free(void *ptr, void* heap, int type)
         #endif
         #ifndef WOLFSSL_NO_MALLOC
             #ifdef WOLFSSL_DEBUG_MEMORY
-            fprintf(stderr, "[HEAP %p] Free: %p at %s:%d\n", heap, pt, func,
+            fprintf(stderr, "[HEAP %p] Free: %p at %s:%u\n", heap, pt, func,
                 line);
             #endif
             #ifdef FREERTOS
@@ -1275,7 +1275,7 @@ void wolfSSL_Free(void *ptr, void* heap, int type)
         #endif
 
         #ifdef WOLFSSL_DEBUG_MEMORY
-            fprintf(stderr, "[HEAP %p] Free: %p -> %u at %s:%d\n", heap,
+            fprintf(stderr, "[HEAP %p] Free: %p -> %u at %s:%u\n", heap,
                 pt->buffer, pt->szUsed, func, line);
         #endif
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1233,7 +1233,7 @@ static WC_INLINE void showPeerEx(WOLFSSL* ssl, int lng_index)
 #if defined(SHOW_CERTS) && defined(KEEP_OUR_CERT) && \
     (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
     ShowX509(wolfSSL_get_certificate(ssl), "our cert info:");
-    printf("Peer verify result = %lu\n", wolfSSL_get_verify_result(ssl));
+    printf("Peer verify result = %ld\n", wolfSSL_get_verify_result(ssl));
 #endif /* SHOW_CERTS && KEEP_OUR_CERT */
     printf("%s %s\n", words[0], wolfSSL_get_version(ssl));
 
@@ -1871,7 +1871,7 @@ static WC_INLINE unsigned int my_psk_client_cb(WOLFSSL* ssl, const char* hint,
     }
 
 #if defined(HAVE_PK_CALLBACKS) && defined(TEST_PK_PSK)
-    WOLFSSL_PKMSG("PSK Client using HW (Len %d, Hint %s)\n", ret, hint);
+    WOLFSSL_PKMSG("PSK Client using HW (Len %u, Hint %s)\n", ret, hint);
     ret = (unsigned int)USE_HW_PSK;
 #endif
 
@@ -1915,7 +1915,7 @@ static WC_INLINE unsigned int my_psk_server_cb(WOLFSSL* ssl, const char* identit
         ret = 32;   /* length of key in octets or 0 for error */
     }
 #if defined(HAVE_PK_CALLBACKS) && defined(TEST_PK_PSK)
-    WOLFSSL_PKMSG("PSK Server using HW (Len %d, Hint %s)\n", ret, identity);
+    WOLFSSL_PKMSG("PSK Server using HW (Len %u, Hint %s)\n", ret, identity);
     ret = (unsigned int)USE_HW_PSK;
 #endif
 
@@ -1954,7 +1954,7 @@ static WC_INLINE unsigned int my_psk_client_tls13_cb(WOLFSSL* ssl,
     ret = 32;   /* length of key in octets or 0 for error */
 
 #if defined(HAVE_PK_CALLBACKS) && defined(TEST_PK_PSK)
-    WOLFSSL_PKMSG("PSK Client TLS 1.3 using HW (Len %d, Hint %s)\n", ret, hint);
+    WOLFSSL_PKMSG("PSK Client TLS 1.3 using HW (Len %u, Hint %s)\n", ret, hint);
     ret = (unsigned int)USE_HW_PSK;
 #endif
 
@@ -1997,7 +1997,7 @@ static WC_INLINE unsigned int my_psk_server_tls13_cb(WOLFSSL* ssl,
     ret = 32;   /* length of key in octets or 0 for error */
 
 #if defined(HAVE_PK_CALLBACKS) && defined(TEST_PK_PSK)
-    WOLFSSL_PKMSG("PSK Server TLS 1.3 using HW (Len %d, Hint %s)\n",
+    WOLFSSL_PKMSG("PSK Server TLS 1.3 using HW (Len %u, Hint %s)\n",
         ret, identity);
     ret = (unsigned int)USE_HW_PSK;
 #endif


### PR DESCRIPTION
# Description

Makes changes when possible to fix` cppcheck=force-source` errors and warnings.

- adds checks for valid arguments (ex. `ssl == NULL`, ret == 0)
- initialize uninitialized variables
- change arguments in printf functions


# Testing

`./configure --enable-all && make check`

Additional testing done by @douzzer (Thank you!)
