### PR TITLE
catch wrong option export sizes in ExportOptions() 

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1388,11 +1388,19 @@ static int ExportOptions(WOLFSSL* ssl, byte* exp, word32 len, byte ver,
                 WOLFSSL_MSG("Update DTLS_EXPORT_OPT_SZ and version of export");
                 return DTLS_EXPORT_VER_E;
             }
+            if (idx != TLS_EXPORT_OPT_SZ && type == WOLFSSL_EXPORT_TLS) {
+                WOLFSSL_MSG("Update TLS_EXPORT_OPT_SZ and version of export");
+                return DTLS_EXPORT_VER_E;
+            }
             break;
 
         case WOLFSSL_EXPORT_VERSION:
             if (idx != DTLS_EXPORT_OPT_SZ && type == WOLFSSL_EXPORT_DTLS) {
                 WOLFSSL_MSG("Update DTLS_EXPORT_OPT_SZ and version of export");
+                return DTLS_EXPORT_VER_E;
+            }
+            if (idx != TLS_EXPORT_OPT_SZ && type == WOLFSSL_EXPORT_TLS) {
+                WOLFSSL_MSG("Update TLS_EXPORT_OPT_SZ and version of export");
                 return DTLS_EXPORT_VER_E;
             }
             break;


### PR DESCRIPTION
# Description

these new error checks are triggered by `test_wolfSSL_tls_export()` in tests/api.c 
`test_wolfSSL_tls_export()` calls `wolfSSL_tls_export()` which ends up calling this code.

`TLS_EXPORT_OPT_SZ` needs to be changed from 65 to 66

related to issue https://github.com/wolfSSL/wolfssl/issues/9081

# Testing

I modified the api.c test case as
```
diff --git a/tests/api.c b/tests/api.c
index b615eb0b4..f4086c8ff 100644
--- a/tests/api.c
+++ b/tests/api.c
@@ -11361,11 +11361,10 @@ static int test_wolfSSL_tls_export(void)
 {
     int res = TEST_SKIPPED;
 #if defined(WOLFSSL_SESSION_EXPORT) && !defined(WOLFSSL_NO_TLS12)
-    test_wolfSSL_tls_export_run(WOLFSSL_TLSV1_2);
+    res = test_wolfSSL_tls_export_run(WOLFSSL_TLSV1_2);
     #ifdef WOLFSSL_TLS13
-    test_wolfSSL_tls_export_run(WOLFSSL_TLSV1_3);
+    res = test_wolfSSL_tls_export_run(WOLFSSL_TLSV1_3);
     #endif
-    res = TEST_RES_CHECK(1);
 #endif
 
     return res;
```
and ran `make check` which failed appropriately.  i noted that `"Update TLS_EXPORT_OPT_SZ and version of export"` was printed in `test-suite.log` 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
