### PR TITLE
Ada: fix wrapping of `wolfSSL_ERR_error_string_n`

### DIFF
--- a/wrapper/Ada/tls_server.adb
+++ b/wrapper/Ada/tls_server.adb
@@ -346,6 +346,14 @@ package body Tls_Server with SPARK_Mode is
          WolfSSL.Create_WolfSSL (Context => Ctx, Ssl => Ssl);
          if not WolfSSL.Is_Valid (Ssl) then
             Put_Line ("ERROR: failed to create WOLFSSL object.");
+            declare
+               Error_Message : constant WolfSSL.Error_Message :=
+                 WolfSSL.Error (WolfSSL.Get_Error (Ssl, Result));
+            begin
+               if Result = Success then
+                  Put_Line (Error_Message.Text (1 .. Error_Message.Last));
+               end if;
+            end;
             SPARK_Sockets.Close_Socket (L);
 
             if not DTLS then

--- a/wrapper/Ada/wolfssl.adb
+++ b/wrapper/Ada/wolfssl.adb
@@ -19,6 +19,7 @@
 -- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 --
 
+with Ada.Unchecked_Conversion;
 pragma Warnings (Off, "* is an internal GNAT unit");
 with GNAT.Sockets.Thin_Common;
 pragma Warnings (On, "* is an internal GNAT unit");
@@ -798,10 +799,15 @@ package body WolfSSL is
       S : String (1 .. Error_Message_Index'Last);
       B : Byte_Array (1 .. size_t (Error_Message_Index'Last));
       C : Natural;
+      -- Use unchecked conversion instead of type conversion to mimic C style
+      -- conversion from int to unsigned long, avoiding the Ada overflow check.
+      function To_Unsigned_Long is new Ada.Unchecked_Conversion
+         (Source => long,
+          Target => unsigned_long);
    begin
-      WolfSSL_Error_String (Error => unsigned_long (Code),
+      WolfSSL_Error_String (Error => To_Unsigned_Long (long (Code)),
                             Data  => B,
-                            Size  => unsigned_long (B'Last));
+                            Size  => To_Unsigned_Long (long (B'Last)));
       Interfaces.C.To_Ada (Item     => B,
                            Target   => S,
                            Count    => C,


### PR DESCRIPTION
Use unchecked conversion instead of type conversion to mimic C style conversion from int to unsigned long, avoiding the Ada overflow check that is raised when a negative value is converted to an unsigned type.

# Description

`WolfSSL.Get_Error` raised Constraint_Error (overflow check) when the result parameter was negative.

# Testing

Included use of `WolfSSL.Get_Error` in the example

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
