### PR TITLE
`wolfSSL_AsyncPoll` calls refactor

### DIFF
--- a/examples/async/async_client.c
+++ b/examples/async/async_client.c
@@ -179,20 +179,8 @@ int client_async_test(int argc, char** argv)
     }
 
     /* Connect to wolfSSL on the server side */
-#ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-#endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0)
-                break;
-        }
-    #endif
-        ret = wolfSSL_connect(ssl);
-        err = wolfSSL_get_error(ssl, 0);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_connect(ssl),
+                                ret != WOLFSSL_SUCCESS);
     if (ret != WOLFSSL_SUCCESS) {
         fprintf(stderr, "wolfSSL_connect error %d: %s\n",
                 err, wolfSSL_ERR_error_string(err, errBuff));
@@ -209,20 +197,8 @@ int client_async_test(int argc, char** argv)
     len = strnlen(buff, sizeof(buff));
 
     /* Send the message to the server */
-#ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-#endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0)
-                break;
-        }
-    #endif
-        ret = wolfSSL_write(ssl, buff, (int)len);
-        err = wolfSSL_get_error(ssl, 0);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_write(ssl, buff, (int)len),
+                                ret <= 0);
     if (ret != (int)len) {
         fprintf(stderr, "wolfSSL_write error %d: %s\n",
                 err, wolfSSL_ERR_error_string(err, errBuff));
@@ -231,20 +207,8 @@ int client_async_test(int argc, char** argv)
 
     /* Read the server data into our buff array */
     memset(buff, 0, sizeof(buff));
-#ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-#endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0)
-                break;
-        }
-    #endif
-        ret = wolfSSL_read(ssl, buff, sizeof(buff)-1);
-        err = wolfSSL_get_error(ssl, 0);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_read(ssl, buff, sizeof(buff)-1),
+                                ret <= 0);
     if (ret < 0) {
         fprintf(stderr, "wolfSSL_read error %d: %s\n",
                 err, wolfSSL_ERR_error_string(err, errBuff));

--- a/examples/async/async_server.c
+++ b/examples/async/async_server.c
@@ -243,20 +243,8 @@ int server_async_test(int argc, char** argv)
         wolfSSL_set_fd(ssl, mConnd);
 
         /* Establish TLS connection */
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        err = 0; /* Reset error */
-    #endif
-        do {
-        #ifdef WOLFSSL_ASYNC_CRYPT
-            if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                if (ret < 0)
-                    break;
-            }
-        #endif
-            ret = wolfSSL_accept(ssl);
-            err = wolfSSL_get_error(ssl, 0);
-        } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+        WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_accept(ssl),
+                                    ret != WOLFSSL_SUCCESS);
         if (ret != WOLFSSL_SUCCESS) {
             fprintf(stderr, "wolfSSL_accept error %d: %s\n",
                 err, wolfSSL_ERR_error_string(err, errBuff));
@@ -268,20 +256,8 @@ int server_async_test(int argc, char** argv)
 
         /* Read the client data into our buff array */
         memset(buff, 0, sizeof(buff));
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        err = 0; /* Reset error */
-    #endif
-        do {
-        #ifdef WOLFSSL_ASYNC_CRYPT
-            if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                if (ret < 0)
-                    break;
-            }
-        #endif
-            ret = wolfSSL_read(ssl, buff, sizeof(buff)-1);
-            err = wolfSSL_get_error(ssl, 0);
-        } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+        WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_read(ssl, buff, sizeof(buff)-1),
+                                    ret <= 0);
         if (ret < 0) {
             fprintf(stderr, "wolfSSL_read error %d: %s\n",
                     err, wolfSSL_ERR_error_string(err, errBuff));
@@ -303,20 +279,8 @@ int server_async_test(int argc, char** argv)
         len = strnlen(buff, sizeof(buff));
 
         /* Reply back to the client */
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        err = 0; /* Reset error */
-    #endif
-        do {
-        #ifdef WOLFSSL_ASYNC_CRYPT
-            if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                if (ret < 0)
-                    break;
-            }
-        #endif
-            ret = wolfSSL_write(ssl, buff, (int)len);
-            err = wolfSSL_get_error(ssl, 0);
-        } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+        WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_write(ssl, buff, (int)len),
+                                    ret <= 0);
         if (ret != (int)len) {
             fprintf(stderr, "wolfSSL_write error %d: %s\n",
                     err, wolfSSL_ERR_error_string(err, errBuff));

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -314,19 +314,8 @@ THREAD_RETURN WOLFSSL_THREAD echoserver_test(void* args)
             SetDH(ssl);  /* will repick suites with DHE, higher than PSK */
         #endif
 
-        do {
-            err = 0; /* Reset error */
-            ret = wolfSSL_accept(ssl);
-            if (ret != WOLFSSL_SUCCESS) {
-                err = wolfSSL_get_error(ssl, 0);
-            #ifdef WOLFSSL_ASYNC_CRYPT
-                if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                    ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                    if (ret < 0) break;
-                }
-            #endif
-            }
-        } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+        WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_accept(ssl),
+                                    ret != WOLFSSL_SUCCESS);
         if (ret != WOLFSSL_SUCCESS) {
             fprintf(stderr, "SSL_accept error = %d, %s\n", err,
                 wolfSSL_ERR_error_string((unsigned long)err, buffer));
@@ -354,19 +343,8 @@ THREAD_RETURN WOLFSSL_THREAD echoserver_test(void* args)
         while (1) {
             int echoSz;
 
-            do {
-                err = 0; /* reset error */
-                ret = wolfSSL_read(ssl, command, sizeof(command)-1);
-                if (ret <= 0) {
-                    err = wolfSSL_get_error(ssl, 0);
-                #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                        ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                        if (ret < 0) break;
-                    }
-                #endif
-                }
-            } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+            WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_read(ssl, command, sizeof(command)-1),
+                                        ret <= 0);
             if (ret <= 0) {
                 if (err != WOLFSSL_ERROR_WANT_READ && err != WOLFSSL_ERROR_ZERO_RETURN){
                     fprintf(stderr, "SSL_read echo error %d, %s!\n", err,
@@ -417,19 +395,8 @@ THREAD_RETURN WOLFSSL_THREAD echoserver_test(void* args)
                 }
                 strncpy(command, resp, sizeof(command));
 
-                do {
-                    err = 0; /* reset error */
-                    ret = wolfSSL_write(write_ssl, command, echoSz);
-                    if (ret <= 0) {
-                        err = wolfSSL_get_error(write_ssl, 0);
-                    #ifdef WOLFSSL_ASYNC_CRYPT
-                        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                            ret = wolfSSL_AsyncPoll(write_ssl, WOLF_POLL_FLAG_CHECK_HW);
-                            if (ret < 0) break;
-                        }
-                    #endif
-                    }
-                } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+                WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_write(write_ssl, command, echoSz),
+                                            ret <= 0);
                 if (ret != echoSz) {
                     fprintf(stderr, "SSL_write get error = %d, %s\n", err,
                         wolfSSL_ERR_error_string((unsigned long)err, buffer));
@@ -443,20 +410,8 @@ THREAD_RETURN WOLFSSL_THREAD echoserver_test(void* args)
             LIBCALL_CHECK_RET(fputs(command, fout));
         #endif
 
-            do {
-                err = 0; /* reset error */
-                ret = wolfSSL_write(write_ssl, command, echoSz);
-                if (ret <= 0) {
-                    err = wolfSSL_get_error(write_ssl, 0);
-                #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                        ret = wolfSSL_AsyncPoll(write_ssl, WOLF_POLL_FLAG_CHECK_HW);
-                        if (ret < 0) break;
-                    }
-                #endif
-                }
-            } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
-
+            WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_write(write_ssl, command, echoSz),
+                                        ret <= 0);
             if (ret != echoSz) {
                 fprintf(stderr, "SSL_write echo error = %d, %s\n", err,
                         wolfSSL_ERR_error_string((unsigned long)err, buffer));

--- a/tests/api.c
+++ b/tests/api.c
@@ -8049,19 +8049,8 @@ THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
     }
 #endif
 
-    #ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-    #endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0) { break; } else if (ret == 0) { continue; }
-        }
-    #endif
-        ret = wolfSSL_negotiate(ssl);
-        err = wolfSSL_get_error(ssl, 0);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_negotiate(ssl),
+                                ret != WOLFSSL_SUCCESS);
     if (ret != WOLFSSL_SUCCESS) {
         char buff[WOLFSSL_MAX_ERROR_SZ];
         fprintf(stderr, "error = %d, %s\n", err,
@@ -8274,19 +8263,8 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_loop(void* args)
             goto done;
         }
 
-        #ifdef WOLFSSL_ASYNC_CRYPT
-        err = 0; /* Reset error */
-        #endif
-        do {
-        #ifdef WOLFSSL_ASYNC_CRYPT
-            if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                if (ret < 0) { break; } else if (ret == 0) { continue; }
-            }
-        #endif
-            ret = wolfSSL_accept(ssl);
-            err = wolfSSL_get_error(ssl, 0);
-        } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+        WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_accept(ssl),
+                                    ret != WOLFSSL_SUCCESS);
         if (ret != WOLFSSL_SUCCESS) {
             char buff[WOLFSSL_MAX_ERROR_SZ];
             fprintf(stderr, "error = %d, %s\n", err,
@@ -8511,19 +8489,8 @@ int test_client_nofail(void* args, cbType cb)
         cbf->ssl_ready(ssl);
     }
 
-    #ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-    #endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0) { break; } else if (ret == 0) { continue; }
-        }
-    #endif
-        ret = wolfSSL_negotiate(ssl);
-        err = wolfSSL_get_error(ssl, 0);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_negotiate(ssl),
+                                ret != WOLFSSL_SUCCESS);
     if (ret != WOLFSSL_SUCCESS) {
         char buff[WOLFSSL_MAX_ERROR_SZ];
         fprintf(stderr, "error = %d, %s\n", err,
@@ -8762,19 +8729,8 @@ static void test_client_reuse_WOLFSSLobj(void* args, cbType cb,
         cbf->ssl_ready(ssl);
     }
 
-    #ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-    #endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0) { break; } else if (ret == 0) { continue; }
-        }
-    #endif
-        ret = wolfSSL_connect(ssl);
-        err = wolfSSL_get_error(ssl, 0);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_connect(ssl),
+                                ret != WOLFSSL_SUCCESS);
     if (ret != WOLFSSL_SUCCESS) {
         char buff[WOLFSSL_MAX_ERROR_SZ];
         fprintf(stderr, "error = %d, %s\n", err,
@@ -8826,19 +8782,8 @@ static void test_client_reuse_WOLFSSLobj(void* args, cbType cb,
         goto done;
     }
 
-    #ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-    #endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0) { break; } else if (ret == 0) { continue; }
-        }
-    #endif
-        ret = wolfSSL_connect(ssl);
-        err = wolfSSL_get_error(ssl, 0);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_connect(ssl),
+                                ret != WOLFSSL_SUCCESS);
     if (ret != WOLFSSL_SUCCESS) {
         char buff[WOLFSSL_MAX_ERROR_SZ];
         fprintf(stderr, "error = %d, %s\n", err,
@@ -9081,19 +9026,8 @@ static THREAD_RETURN WOLFSSL_THREAD run_wolfssl_server(void* args)
     if (callbacks->ssl_ready)
         callbacks->ssl_ready(ssl);
 
-#ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-#endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0) { break; } else if (ret == 0) { continue; }
-        }
-    #endif
-        ret = wolfSSL_accept(ssl);
-        err = wolfSSL_get_error(ssl, ret);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_accept(ssl),
+                                ret != WOLFSSL_SUCCESS);
     if (ret != WOLFSSL_SUCCESS) {
         char buff[WOLFSSL_MAX_ERROR_SZ];
         fprintf(stderr, "accept error = %d, %s\n", err,
@@ -9101,37 +9035,15 @@ static THREAD_RETURN WOLFSSL_THREAD run_wolfssl_server(void* args)
         /*err_sys("SSL_accept failed");*/
     }
     else {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        err = 0; /* Reset error */
-    #endif
-        do {
-        #ifdef WOLFSSL_ASYNC_CRYPT
-            if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                if (ret < 0) { break; } else if (ret == 0) { continue; }
-            }
-        #endif
-            idx = wolfSSL_read(ssl, input, sizeof(input)-1);
-            err = wolfSSL_get_error(ssl, idx);
-        } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+        WOLFSSL_ASYNC_WHILE_PENDING(idx = wolfSSL_read(ssl, input, sizeof(input)-1),
+                                    idx <= 0);
         if (idx > 0) {
             input[idx] = 0;
             fprintf(stderr, "Client message: %s\n", input);
         }
 
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        err = 0; /* Reset error */
-    #endif
-        do {
-        #ifdef WOLFSSL_ASYNC_CRYPT
-            if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                if (ret < 0) { break; } else if (ret == 0) { continue; }
-            }
-        #endif
-            ret = wolfSSL_write(ssl, msg, len);
-            err = wolfSSL_get_error(ssl, ret);
-        } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+        WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_write(ssl, msg, len),
+                                    len != ret);
         if (len != ret) {
             goto cleanup;
         }
@@ -9299,19 +9211,8 @@ static void run_wolfssl_client(void* args)
     if (callbacks->ssl_ready)
         callbacks->ssl_ready(ssl);
 
-    #ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-    #endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0) { break; } else if (ret == 0) { continue; }
-        }
-    #endif
-        ret = wolfSSL_connect(ssl);
-        err = wolfSSL_get_error(ssl, ret);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_connect(ssl),
+                                ret != WOLFSSL_SUCCESS);
     if (ret != WOLFSSL_SUCCESS) {
         char buff[WOLFSSL_MAX_ERROR_SZ];
         fprintf(stderr, "error = %d, %s\n", err,
@@ -9319,35 +9220,13 @@ static void run_wolfssl_client(void* args)
         /*err_sys("SSL_connect failed");*/
     }
     else {
-        #ifdef WOLFSSL_ASYNC_CRYPT
-        err = 0; /* Reset error */
-        #endif
-        do {
-        #ifdef WOLFSSL_ASYNC_CRYPT
-            if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                if (ret < 0) { break; } else if (ret == 0) { continue; }
-            }
-        #endif
-            ret = wolfSSL_write(ssl, msg, len);
-            err = wolfSSL_get_error(ssl, ret);
-        } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+        WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_write(ssl, msg, len),
+                                    ret != len);
         if (len != ret)
             goto cleanup;
 
-        #ifdef WOLFSSL_ASYNC_CRYPT
-        err = 0; /* Reset error */
-        #endif
-        do {
-        #ifdef WOLFSSL_ASYNC_CRYPT
-            if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                if (ret < 0) { break; } else if (ret == 0) { continue; }
-            }
-        #endif
-            ret = wolfSSL_read(ssl, input, sizeof(input)-1);
-            err = wolfSSL_get_error(ssl, ret);
-        } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+        WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_read(ssl, input, sizeof(input)-1),
+                                    ret <= 0);
         if (ret > 0) {
             input[ret] = '\0'; /* null term */
             fprintf(stderr, "Server response: %s\n", input);
@@ -27720,49 +27599,17 @@ static int test_wolfSSL_SESSION(void)
     tcp_connect(&sockfd, wolfSSLIP, ready.port, 0, 0, ssl);
     ExpectIntEQ(wolfSSL_set_fd(ssl, sockfd), WOLFSSL_SUCCESS);
 
-    #ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-    #endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0) { break; } else if (ret == 0) { continue; }
-        }
-    #endif
-        ret = wolfSSL_connect(ssl);
-        err = wolfSSL_get_error(ssl, 0);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_connect(ssl),
+                                ret != WOLFSSL_SUCCESS);
     ExpectIntEQ(ret, WOLFSSL_SUCCESS);
 
-    #ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-    #endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0) { break; } else if (ret == 0) { continue; }
-        }
-    #endif
-        ret = wolfSSL_write(ssl, sendGET, (int)XSTRLEN(sendGET));
-        err = wolfSSL_get_error(ssl, 0);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(
+        ret = wolfSSL_write(ssl, sendGET, (int)XSTRLEN(sendGET)),
+        ret <= 0);
     ExpectIntEQ(ret, (int)XSTRLEN(sendGET));
 
-    #ifdef WOLFSSL_ASYNC_CRYPT
-    err = 0; /* Reset error */
-    #endif
-    do {
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-            if (ret < 0) { break; } else if (ret == 0) { continue; }
-        }
-    #endif
-        ret = wolfSSL_read(ssl, msg, sizeof(msg));
-        err = wolfSSL_get_error(ssl, 0);
-    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+    WOLFSSL_ASYNC_WHILE_PENDING(ret = wolfSSL_read(ssl, msg, sizeof(msg)),
+                                ret != 23);
     ExpectIntEQ(ret, 23);
 
     ExpectPtrNE((sess = wolfSSL_get1_session(ssl)), NULL); /* ref count 1 */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -5550,7 +5550,24 @@ WOLFSSL_API void* wolfSSL_get_jobject(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_AsyncPoll(WOLFSSL* ssl, WOLF_EVENT_FLAG flags);
 WOLFSSL_API int wolfSSL_CTX_AsyncPoll(WOLFSSL_CTX* ctx, WOLF_EVENT** events, int maxEvents,
     WOLF_EVENT_FLAG flags, int* eventCount);
+#define WOLFSSL_ASYNC_IF_PENDING                                \
+    if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {                 \
+        ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);  \
+        if (ret < 0) break;                                     \
+    }
+#else
+#define WOLFSSL_ASYNC_IF_PENDING if(0)(void)0;
 #endif /* WOLFSSL_ASYNC_CRYPT */
+
+#define WOLFSSL_ASYNC_WHILE_PENDING(call, cond)                 \
+    do {                                                        \
+        err = 0;                                                \
+        call;                                                   \
+        if (cond) {                                             \
+            err = wolfSSL_get_error(ssl, 0);                    \
+            WOLFSSL_ASYNC_IF_PENDING                            \
+        }                                                       \
+    } while (err == WC_NO_ERR_TRACE(WC_PENDING_E))
 
 typedef void (*Rem_Sess_Cb)(WOLFSSL_CTX*, WOLFSSL_SESSION*);
 


### PR DESCRIPTION
## Description

I've identified 36 occurrences of a ~15 line pattern around calls to `wolfSSL_AsyncPoll` in the code base. I've captured this pattern in a macro and replaced the 36 occurrences with the macro. This refactor results in a net ~400 line deletion from the code base.

## Testing

```
./configure && make check && ./configure --enable-asynccrypt && make check
```