### PR TITLE
20250812-Base64_Decode-outLen-bounds-fix

### DIFF
--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -259,7 +259,8 @@ int Base64_Decode_nonCT(const byte* in, word32 inLen, byte* out, word32* outLen)
     if (out && *outLen > i)
         out[i]= '\0';
 
-    *outLen = i; /* Note, does not reflect terminating null, if any. */
+    /* Note, *outLen won't reflect the optional terminating null. */
+    *outLen = i;
 
     return 0;
 }
@@ -346,7 +347,8 @@ int Base64_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
     if (out && *outLen > i)
         out[i]= '\0';
 
-    *outLen = i; /* Note, does not reflect terminating null, if any. */
+    /* Note, *outLen won't reflect the optional terminating null. */
+    *outLen = i;
 
     return 0;
 }

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -171,12 +171,8 @@ int Base64_Decode_nonCT(const byte* in, word32 inLen, byte* out, word32* outLen)
 {
     word32 i = 0;
     word32 j = 0;
-    word32 plainSz = inLen - ((inLen + (BASE64_LINE_SZ - 1)) / BASE64_LINE_SZ );
     int ret;
     const byte maxIdx = BASE64DECODE_TABLE_SZ + BASE64_MIN - 1;
-
-    plainSz = (plainSz * 3 + 3) / 4;
-    if (plainSz > *outLen) return BAD_FUNC_ARG;
 
     while (inLen > 3) {
         int pad3 = 0;
@@ -233,7 +229,7 @@ int Base64_Decode_nonCT(const byte* in, word32 inLen, byte* out, word32* outLen)
 
         if (i + 1 + !pad3 + !pad4 > *outLen) {
             WOLFSSL_MSG("Bad Base64 Decode out buffer, too small");
-            return BAD_FUNC_ARG;
+            return BUFFER_E;
         }
 
         e1 = Base64_Char2Val_by_table(e1);
@@ -263,7 +259,7 @@ int Base64_Decode_nonCT(const byte* in, word32 inLen, byte* out, word32* outLen)
     if (out && *outLen > i)
         out[i]= '\0';
 
-    *outLen = i;
+    *outLen = i; /* Note, does not reflect terminating null, if any. */
 
     return 0;
 }
@@ -274,11 +270,7 @@ int Base64_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
 {
     word32 i = 0;
     word32 j = 0;
-    word32 plainSz = inLen - ((inLen + (BASE64_LINE_SZ - 1)) / BASE64_LINE_SZ );
     int ret;
-
-    plainSz = (plainSz * 3 + 3) / 4;
-    if (plainSz > *outLen) return BAD_FUNC_ARG;
 
     while (inLen > 3) {
         int pad3 = 0;
@@ -324,7 +316,7 @@ int Base64_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
 
         if (i + 1 + !pad3 + !pad4 > *outLen) {
             WOLFSSL_MSG("Bad Base64 Decode out buffer, too small");
-            return BAD_FUNC_ARG;
+            return BUFFER_E;
         }
 
         e1 = Base64_Char2Val_CT(e1);
@@ -354,7 +346,7 @@ int Base64_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
     if (out && *outLen > i)
         out[i]= '\0';
 
-    *outLen = i;
+    *outLen = i; /* Note, does not reflect terminating null, if any. */
 
     return 0;
 }
@@ -630,7 +622,7 @@ int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
         return BAD_FUNC_ARG;
 
     if (*outLen < (inLen / 2))
-        return BAD_FUNC_ARG;
+        return BUFFER_E;
 
     while (inLen) {
         byte b  = (byte)(in[inIdx++] - BASE16_MIN);  /* 0 starts at 0x30 */


### PR DESCRIPTION
`wolfcrypt/src/coding.c`: in `Base64_Decode_nonCT()` and `Base64_Decode()`, remove overly restrictive preamble check on `outLen`; return `BUFFER_E`, not `BAD_FUNC_ARG`, when output buffer is too short (similarly fixed in `Base16_Decode()`);

`wolfcrypt/test/test.c`: add `N_BYTE_TEST()` and test vectors to test all input and output length scenarios.

This PR fixes decoding to a destination binary buffer sized exactly for the expected decoded output length.  Before this PR, decoding a base64 encoding of 32 bytes back to a 32 byte buffer would incorrectly fail with `BAD_FUNC_ARG`.
