### PR TITLE
Add assembly introspection for RISC-V and PPC32

### DIFF
--- a/wolfcrypt/src/wolfmath.c
+++ b/wolfcrypt/src/wolfmath.c
@@ -513,7 +513,8 @@ const char *wc_GetMathInfo(void)
     #endif
 
     /* ARM Assembly speedups */
-    #if defined(WOLFSSL_ARMASM) || defined(USE_INTEL_SPEEDUP)
+    #if defined(WOLFSSL_ARMASM) || defined(USE_INTEL_SPEEDUP) || \
+        defined(WOLFSSL_RISCV_ASM) || defined(WOLFSSL_PPC32_ASM)
         "\n\tAssembly Speedups:"
 
         #ifdef WOLFSSL_ARMASM
@@ -533,7 +534,7 @@ const char *wc_GetMathInfo(void)
             #ifdef WOLFSSL_ARM_ARCH
                 " ARM ARCH=" WC_STRINGIFY(WOLFSSL_ARM_ARCH)
             #endif
-        #endif
+        #endif /* WOLFSSL_ARMASM */
 
         #ifdef USE_INTEL_SPEEDUP
             " INTELASM"
@@ -541,6 +542,50 @@ const char *wc_GetMathInfo(void)
                 " AES"
             #endif
         #endif
+
+        #ifdef WOLFSSL_RISCV_ASM
+            " RISCVASM"
+            #ifdef WOLFSSL_RISCV_BASE_BIT_MANIPULATION
+                " REV8"
+            #endif
+            #ifdef WOLFSSL_RISCV_CARRYLESS
+                " CLMUL CLMULH"
+            #endif
+            #ifdef WOLFSSL_RISCV_BIT_MANIPULATION
+                " PACK"
+            #endif
+            #ifdef WOLFSSL_RISCV_BIT_MANIPULATION_TERNARY
+                " FSL FSR FSRI CMOV CMIX"
+            #endif
+            #ifdef WOLFSSL_RISCV_VECTOR_BASE_BIT_MANIPULATION
+                " VBREV8"
+            #endif
+            #ifdef WOLFSSL_RISCV_VECTOR_CARRYLESS
+                " VCLMUL VCLMULH"
+            #endif
+            #ifdef WOLFSSL_RISCV_VECTOR_GCM
+                " VGMUL VHHSH"
+            #endif
+            #ifdef WOLFSSL_RISCV_VECTOR_CRYPTO_ASM
+                " Vector AES SHA-2"
+            #endif
+            #ifdef WOLFSSL_RISCV_SCALAR_CRYPTO_ASM
+                " AES encrypt/decrpyt SHA-2"
+            #endif
+        #endif /* WOLFSSL_RISCV_ASM */
+
+        #ifdef WOLFSSL_PPC32_ASM
+            " PPC32ASM"
+            #ifdef WOLFSSL_PPC32_ASM_INLINE
+                " INLINE"
+            #endif
+            #ifdef WOLFSSL_PPC32_ASM_SMALL
+                " SMALL"
+            #endif
+            #ifdef WOLFSSL_PPC32_ASM_SPE
+                " SPE"
+            #endif
+        #endif /* WOLFSSL_PPC32_ASM */
 
         #ifdef WOLFSSL_USE_ALIGN
             " ALIGN"


### PR DESCRIPTION
# Description

Add assembly introspection for RISC-V and PPC32.

# Testing

HiFive Unleashed at 1.4GHz using `--enable-riscv-asm --enable-sp=yes`

```
root@HiFiveU:~/wolfssl# ./wolfcrypt/benchmark/benchmark 
------------------------------------------------------------------------------
 wolfSSL version 5.8.2
------------------------------------------------------------------------------
Math: 	Multi-Precision: Wolf(SP) word-size=64 bits=4096 sp_int.c
	Single Precision: ecc 256 384 521 rsa/dh 2048 3072 4096 sp_c64.c
	Assembly Speedups: RISCVASM ALIGN
wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
RNG                         10 MiB took 1.462 seconds,    6.838 MiB/s
AES-128-CBC-enc             15 MiB took 1.095 seconds,   13.699 MiB/s
AES-128-CBC-dec             15 MiB took 1.099 seconds,   13.653 MiB/s
AES-192-CBC-enc             15 MiB took 1.273 seconds,   11.787 MiB/s
AES-192-CBC-dec             15 MiB took 1.272 seconds,   11.791 MiB/s
AES-256-CBC-enc             15 MiB took 1.443 seconds,   10.398 MiB/s
AES-256-CBC-dec             15 MiB took 1.450 seconds,   10.346 MiB/s
AES-128-GCM-enc             10 MiB took 1.191 seconds,    8.399 MiB/s
AES-128-GCM-dec             10 MiB took 1.196 seconds,    8.362 MiB/s
AES-192-GCM-enc             10 MiB took 1.313 seconds,    7.617 MiB/s
AES-192-GCM-dec             10 MiB took 1.313 seconds,    7.619 MiB/s
AES-256-GCM-enc             10 MiB took 1.426 seconds,    7.012 MiB/s
AES-256-GCM-dec             10 MiB took 1.426 seconds,    7.013 MiB/s
GMAC Table 4-bit            23 MiB took 1.034 seconds,   22.247 MiB/s
CHACHA                      35 MiB took 1.165 seconds,   30.035 MiB/s
CHA-POLY                    25 MiB took 1.150 seconds,   21.733 MiB/s
POLY1305                    80 MiB took 1.018 seconds,   78.617 MiB/s
SHA                         25 MiB took 1.062 seconds,   23.533 MiB/s
SHA-256                     20 MiB took 1.294 seconds,   15.462 MiB/s
SHA-384                     25 MiB took 1.085 seconds,   23.031 MiB/s
SHA-512                     25 MiB took 1.085 seconds,   23.037 MiB/s
SHA-512/224                 25 MiB took 1.085 seconds,   23.033 MiB/s
SHA-512/256                 25 MiB took 1.085 seconds,   23.038 MiB/s
SHA3-224                    20 MiB took 1.074 seconds,   18.617 MiB/s
SHA3-256                    20 MiB took 1.133 seconds,   17.659 MiB/s
SHA3-384                    15 MiB took 1.094 seconds,   13.713 MiB/s
SHA3-512                    10 MiB took 1.039 seconds,    9.628 MiB/s
HMAC-SHA                    25 MiB took 1.061 seconds,   23.552 MiB/s
HMAC-SHA256                 20 MiB took 1.294 seconds,   15.459 MiB/s
HMAC-SHA384                 25 MiB took 1.086 seconds,   23.013 MiB/s
HMAC-SHA512                 25 MiB took 1.088 seconds,   22.986 MiB/s
PBKDF2                       2 KiB took 1.007 seconds,    1.893 KiB/s
RSA     2048   public      1200 ops took 1.035 sec, avg 0.862 ms, 1159.948 ops/sec
RSA     2048  private       100 ops took 4.597 sec, avg 45.970 ms, 21.753 ops/sec
DH      2048  key gen        55 ops took 1.007 sec, avg 18.309 ms, 54.617 ops/sec
DH      2048    agree       100 ops took 1.827 sec, avg 18.271 ms, 54.731 ops/sec
ECC   [      SECP256R1]   256  key gen       700 ops took 1.061 sec, avg 1.515 ms, 659.872 ops/sec
ECDHE [      SECP256R1]   256    agree       500 ops took 1.249 sec, avg 2.499 ms, 400.211 ops/sec
ECDSA [      SECP256R1]   256     sign       600 ops took 1.118 sec, avg 1.863 ms, 536.644 ops/sec
ECDSA [      SECP256R1]   256   verify       400 ops took 1.124 sec, avg 2.809 ms, 355.992 ops/sec
Benchmark complete
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
