### PR TITLE
Exclude assembly files when WOLFSSL_ARMASM_INLINE is defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1625,6 +1625,14 @@ if(NOT WOLFSSL_INLINE)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_INLINE")
 endif()
 
+add_option("WOLFSSL_ARMASM_INLINE"
+    "Enable ARM assembly inline functions (default: disabled)"
+    "no" "yes;no")
+
+if (WOLFSSL_ARMASM_INLINE)
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_ARMASM_INLINE")
+endif()
+
 # TODO:
 #       - CRL monitor
 #       - User crypto

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -220,6 +220,8 @@ function(generate_build_flags)
         set(BUILD_ARIA "yes" PARENT_SCOPE)
     endif()
     set(BUILD_INLINE ${WOLFSSL_INLINE} PARENT_SCOPE)
+    set(BUILD_ARMASM_INLINE ${WOLFSSL_ARMASM_INLINE} PARENT_SCOPE)
+    set(BUILD_ARM_THUMB ${WOLFSSL_ARMASM_THUMB2} PARENT_SCOPE)
     if(WOLFSSL_OCSP OR WOLFSSL_USER_SETTINGS)
         set(BUILD_OCSP "yes" PARENT_SCOPE)
     endif()
@@ -361,6 +363,22 @@ function(generate_lib_src_list LIB_SOURCES)
 
                    if(BUILD_ARMASM AND BUILD_FIPS_READY)
                         list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-aes.c)
+
+                        if(BUILD_ARMASM_INLINE)
+                             list(APPEND LIB_SOURCES
+                                  wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c)
+                        else()
+                             list(APPEND LIB_SOURCES
+                                  wolfcrypt/src/port/arm/armv8-32-aes-asm.S)
+                        endif()
+
+                        if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                             list(APPEND LIB_SOURCES
+                                  wolfcrypt/src/port/arm/thumb2-aes-asm_c.c)
+                        elseif(BUILD_ARM_THUMB)
+                             list(APPEND LIB_SOURCES
+                                  wolfcrypt/src/port/arm/thumb2-aes-asm.S)
+                        endif()
                    endif()
               endif()
 
@@ -393,9 +411,25 @@ function(generate_lib_src_list LIB_SOURCES)
 
                    if(BUILD_ARMASM AND BUILD_FIPS_READY)
                         list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/armv8-sha512.c
-                             wolfcrypt/src/port/arm/armv8-sha512-asm.S
-                             wolfcrypt/src/port/arm/armv8-32-sha512-asm.S)
+                                  wolfcrypt/src/port/arm/armv8-sha512.c)
+
+                        if(BUILD_ARMASM_INLINE)
+                             list(APPEND LIB_SOURCES
+                                  wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
+                                  wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c)
+                        else()
+                             list(APPEND LIB_SOURCES
+                                  wolfcrypt/src/port/arm/armv8-sha512-asm.S
+                                  wolfcrypt/src/port/arm/armv8-32-sha512-asm.S)
+                        endif()
+
+                        if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                             list(APPEND LIB_SOURCES
+                                  wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c)
+                        elseif(BUILD_ARM_THUMB)
+                             list(APPEND LIB_SOURCES
+                                  wolfcrypt/src/port/arm/thumb2-sha512-asm.S)
+                        endif()
                    endif()
 
                    if(BUILD_INTELASM)
@@ -405,6 +439,26 @@ function(generate_lib_src_list LIB_SOURCES)
 
               if(BUILD_SHA3)
                    list(APPEND LIB_SOURCES wolfcrypt/src/sha3.c)
+
+                   if(BUILD_ARMASM)
+                    if(BUILD_ARMASM_INLINE)
+                            list(APPEND LIB_SOURCES
+                                wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
+                                wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c)
+                    else()
+                            list(APPEND LIB_SOURCES
+                                wolfcrypt/src/port/arm/armv8-sha3-asm.S
+                                wolfcrypt/src/port/arm/armv8-32-sha3-asm.S)
+                    endif()
+
+                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                            list(APPEND LIB_SOURCES
+                                wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c)
+                    elseif(BUILD_ARM_THUMB)
+                            list(APPEND LIB_SOURCES
+                                wolfcrypt/src/port/arm/thumb2-sha3-asm.S)
+                    endif()
+                endif()
 
                    if(BUILD_INTELASM)
                         list(APPEND LIB_SOURCES wolfcrypt/src/sha3_asm.S)
@@ -486,10 +540,28 @@ function(generate_lib_src_list LIB_SOURCES)
          endif()
 
          if(NOT BUILD_FIPS_V2)
+
+              list(APPEND LIB_SOURCES wolfcrypt/src/sha256.c)
+
               if(BUILD_ARMASM)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-sha256.c)
+
+                   if(BUILD_ARMASM_INLINE)
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/armv8-sha256.c
+                             wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c)
+                   else()
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/armv8-sha256-asm.S
+                             wolfcrypt/src/port/arm/armv8-32-sha256-asm.S)
+                    endif()
+                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                         list(APPEND LIB_SOURCES
+                              wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c)
+                    elseif(BUILD_ARM_THUMB)
+                         list(APPEND LIB_SOURCES
+                              wolfcrypt/src/port/arm/thumb2-sha256-asm.S)
+                    endif()
               else()
-                   list(APPEND LIB_SOURCES wolfcrypt/src/sha256.c)
 
                    if(BUILD_INTELASM)
                         list(APPEND LIB_SOURCES wolfcrypt/src/sha256_asm.S)
@@ -555,6 +627,23 @@ function(generate_lib_src_list LIB_SOURCES)
 
                    if(BUILD_ARMASM)
                         list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-aes.c)
+
+                        if(BUILD_ARMASM_INLINE)
+                            list(APPEND LIB_SOURCES
+                                wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c)
+                        else()
+                            list(APPEND LIB_SOURCES
+                                wolfcrypt/src/port/arm/armv8-32-aes-asm.S)
+                        endif()
+
+                        if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                            list(APPEND LIB_SOURCES
+                                wolfcrypt/src/port/arm/thumb2-aes-asm_c.c)
+                        elseif(BUILD_ARM_THUMB)
+                            list(APPEND LIB_SOURCES
+                                wolfcrypt/src/port/arm/thumb2-aes-asm.S)
+                        endif()
+                        
                    endif()
 
                    if(BUILD_AFALG)
@@ -576,13 +665,29 @@ function(generate_lib_src_list LIB_SOURCES)
          endif()
 
          if(NOT BUILD_FIPS_V2 AND BUILD_SHA512)
-              if(BUILD_ARMASM)
-                   list(APPEND LIB_SOURCES
-                        wolfcrypt/src/port/arm/armv8-sha512.c
-                        wolfcrypt/src/port/arm/armv8-sha512-asm.S
-                        wolfcrypt/src/port/arm/armv8-32-sha512-asm.S)
+            list(APPEND LIB_SOURCES wolfcrypt/src/sha512.c)
+
+            if(BUILD_ARMASM)
+                list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-sha512.c)
+
+                    if(BUILD_ARMASM_INLINE)
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
+                             wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c)
+                    else()
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/armv8-sha512-asm.S
+                             wolfcrypt/src/port/arm/armv8-32-sha512-asm.S)
+                    endif()
+                   
+                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                         list(APPEND LIB_SOURCES
+                              wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c)
+                    elseif(BUILD_ARM_THUMB)
+                         list(APPEND LIB_SOURCES
+                              wolfcrypt/src/port/arm/thumb2-sha512-asm.S)
+                    endif()
               else()
-                   list(APPEND LIB_SOURCES wolfcrypt/src/sha512.c)
 
                    if(BUILD_INTELASM)
                         list(APPEND LIB_SOURCES wolfcrypt/src/sha512_asm.S)
@@ -592,6 +697,26 @@ function(generate_lib_src_list LIB_SOURCES)
 
          if(NOT BUILD_FIPS_V2 AND BUILD_SHA3)
               list(APPEND LIB_SOURCES wolfcrypt/src/sha3.c)
+
+              if(BUILD_ARMASM)
+                   if(BUILD_ARMASM_INLINE)
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
+                             wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c)
+                   else()
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/armv8-sha3-asm.S
+                             wolfcrypt/src/port/arm/armv8-32-sha3-asm.S)
+                   endif()
+
+                   if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c)
+                   elseif(BUILD_ARM_THUMB)
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/thumb2-sha3-asm.S)
+                   endif()
+              endif()
 
               if(BUILD_INTELASM)
                    list(APPEND LIB_SOURCES wolfcrypt/src/sha3_asm.S)
@@ -643,7 +768,26 @@ function(generate_lib_src_list LIB_SOURCES)
     if(NOT BUILD_FIPS_RAND)
          if(BUILD_POLY1305)
               if(BUILD_ARMASM)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-poly1305.c)
+                   list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-poly1305.c)
+
+                   if(BUILD_ARMASM_INLINE)
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c)
+                    else()
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/armv8-32-poly1305-asm.S)
+                    endif()
+                   
+                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/thumb2-poly1305.c
+                             wolfcrypt/src/port/arm/thumb2-poly1305-asm_c.c)
+                    elseif(BUILD_ARM_THUMB)
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/thumb2-poly1305.c
+                             wolfcrypt/src/port/arm/thumb2-poly1305-asm.S)
+                    endif()
               endif()
 
               list(APPEND LIB_SOURCES wolfcrypt/src/poly1305.c)
@@ -702,10 +846,29 @@ function(generate_lib_src_list LIB_SOURCES)
          endif()
 
          if(BUILD_CHACHA)
+              list(APPEND LIB_SOURCES wolfcrypt/src/chacha.c)
+
               if(BUILD_ARMASM)
                    list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-chacha.c)
+
+                   if(BUILD_ARMASM_INLINE)
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c)
+                   else()
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/armv8-32-chacha-asm.S)
+                   endif()
+                   
+                   if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                       list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-chacha.c
+                            wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c)
+                   elseif(BUILD_ARM_THUMB)
+                       list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-chacha.c
+                            wolfcrypt/src/port/arm/thumb2-chacha-asm.S)
+                   endif()
               else()
-                   list(APPEND LIB_SOURCES wolfcrypt/src/chacha.c)
 
                    if(BUILD_INTELASM)
                         list(APPEND LIB_SOURCES wolfcrypt/src/chacha_asm.S)
@@ -735,6 +898,25 @@ function(generate_lib_src_list LIB_SOURCES)
 
          if(BUILD_CURVE25519)
               list(APPEND LIB_SOURCES wolfcrypt/src/curve25519.c)
+              if(BUILD_ARMASM)
+                    if (BUILD_ARMASM_INLINE)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
+                            wolfcrypt/src/port/arm/armv8-curve25519_c.c)
+                    else()
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/armv8-32-curve25519.S
+                            wolfcrypt/src/port/arm/armv8-curve25519.S)
+                    endif()
+
+                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-curve25519_c.c)
+                    elseif(BUILD_ARM_THUMB)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-curve25519.S)
+                    endif()
+                endif()
          endif()
 
          if(BUILD_ED25519)
@@ -748,13 +930,7 @@ function(generate_lib_src_list LIB_SOURCES)
                    if(BUILD_INTELASM)
                         list(APPEND LIB_SOURCES wolfcrypt/src/fe_x25519_asm.S)
                    else()
-                        if(BUILD_ARMASM)
-                             list(APPEND LIB_SOURCES
-                                  wolfcrypt/src/port/arm/armv8-32-curve25519.S
-                                  wolfcrypt/src/port/arm/armv8-curve25519.S)
-                        else()
-                             list(APPEND LIB_SOURCES wolfcrypt/src/fe_operations.c)
-                        endif()
+                        list(APPEND LIB_SOURCES wolfcrypt/src/fe_operations.c)
                    endif()
               endif()
          endif()
@@ -769,11 +945,7 @@ function(generate_lib_src_list LIB_SOURCES)
                         if(BUILD_INTELASM)
                              list(APPEND LIB_SOURCES wolfcrypt/src/fe_x25519_asm.S)
                         else()
-                             if(BUILD_ARMASM)
-                                  list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-curve25519.S)
-                             else()
-                                  list(APPEND LIB_SOURCES wolfcrypt/src/fe_operations.c)
-                             endif()
+                            list(APPEND LIB_SOURCES wolfcrypt/src/fe_operations.c)
                         endif()
                    endif()
               endif()
@@ -814,6 +986,26 @@ function(generate_lib_src_list LIB_SOURCES)
          if(BUILD_WC_MLKEM)
               list(APPEND LIB_SOURCES wolfcrypt/src/wc_mlkem.c)
               list(APPEND LIB_SOURCES wolfcrypt/src/wc_mlkem_poly.c)
+
+              if(BUILD_ARMASM)
+                    if(BUILD_ARMASM_INLINE)
+                         list(APPEND LIB_SOURCES
+                              wolfcrypt/src/port/arm/armv8-mlkem-asm_c.c
+                              wolfcrypt/src/port/arm/armv8-32-mlkem-asm_c.c)
+                    else()
+                         list(APPEND LIB_SOURCES
+                              wolfcrypt/src/port/arm/armv8-mlkem-asm.S
+                              wolfcrypt/src/port/arm/armv8-32-mlkem-asm.S)
+                    endif()
+                    
+                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                         list(APPEND LIB_SOURCES
+                              wolfcrypt/src/port/arm/thumb2-mlkem-asm_c.c)
+                    elseif(BUILD_ARM_THUMB)
+                         list(APPEND LIB_SOURCES]
+                              wolfcrypt/src/port/arm/thumb2-mlkem-asm.S)
+                    endif()
+                endif()
 
               if(BUILD_INTELASM)
                    list(APPEND LIB_SOURCES wolfcrypt/src/wc_mlkem_asm.S)

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -23,8 +23,8 @@ function(add_option NAME HELP_STRING DEFAULT VALUES)
     if(DEFINED ${NAME})
         list(FIND VALUES ${${NAME}} IDX)
         #
-        # If the given value isn't in the list of allowed values for the option,
-        # reduce it to yes/no according to CMake's "if" logic:
+        # If the given value isn't in the list of allowed values for the
+        # option, reduce it to yes/no according to CMake's "if" logic:
         # https://cmake.org/cmake/help/latest/command/if.html#basic-expressions
         #
         # This has no functional impact; it just makes the settings in
@@ -336,398 +336,402 @@ endfunction()
 
 function(generate_lib_src_list LIB_SOURCES)
     if(NOT BUILD_FLAGS_GENERATED)
-        message(FATAL_ERROR "Cannot call generate_lib_src_list without calling generate_build_flags first.")
+        message(FATAL_ERROR
+            "Cannot call generate_lib_src_list without calling "
+            "generate_build_flags first.")
     endif()
 
     # Corresponds to src/include.am
     if(BUILD_FIPS)
-         if(BUILD_FIPS_V2)
-              # FIPSv2 first file
-              list(APPEND LIB_SOURCES wolfcrypt/src/wolfcrypt_first.c)
+        if(BUILD_FIPS_V2)
+            # FIPSv2 first file
+            list(APPEND LIB_SOURCES wolfcrypt/src/wolfcrypt_first.c)
 
-              list(APPEND LIB_SOURCES
+            list(APPEND LIB_SOURCES
                 wolfcrypt/src/hmac.c
                 wolfcrypt/src/random.c
                 wolfcrypt/src/sha256.c)
 
-              if(BUILD_RSA)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/rsa.c)
-              endif()
+            if(BUILD_RSA)
+                list(APPEND LIB_SOURCES wolfcrypt/src/rsa.c)
+            endif()
 
-              if(BUILD_ECC)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/ecc.c)
-              endif()
+            if(BUILD_ECC)
+                list(APPEND LIB_SOURCES wolfcrypt/src/ecc.c)
+            endif()
 
-              if(BUILD_AES)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/aes.c)
+            if(BUILD_AES)
+                list(APPEND LIB_SOURCES wolfcrypt/src/aes.c)
 
-                   if(BUILD_ARMASM AND BUILD_FIPS_READY)
-                        list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-aes.c)
+                if(BUILD_ARMASM AND BUILD_FIPS_READY)
+                    list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-aes.c)
 
-                        if(BUILD_ARMASM_INLINE)
-                             list(APPEND LIB_SOURCES
-                                  wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c)
-                        else()
-                             list(APPEND LIB_SOURCES
-                                  wolfcrypt/src/port/arm/armv8-32-aes-asm.S)
-                        endif()
-
-                        if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
-                             list(APPEND LIB_SOURCES
-                                  wolfcrypt/src/port/arm/thumb2-aes-asm_c.c)
-                        elseif(BUILD_ARM_THUMB)
-                             list(APPEND LIB_SOURCES
-                                  wolfcrypt/src/port/arm/thumb2-aes-asm.S)
-                        endif()
-                   endif()
-              endif()
-
-              if(BUILD_AESNI)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/aes_asm.S)
-
-                   if(BUILD_INTELASM)
-                        list(APPEND LIB_SOURCES wolfcrypt/src/aes_gcm_asm.S)
-                   endif()
-              endif()
-
-              if(BUILD_DES3)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/des3.c)
-              endif()
-
-              if(BUILD_SHA)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/sha.c)
-              endif()
-
-              if(BUILD_ARMASM AND BUILD_FIPS_READY)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-sha256.c)
-              endif()
-
-              if(BUILD_INTELASM)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/sha256_asm.S)
-              endif()
-
-              if(BUILD_SHA512)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/sha512.c)
-
-                   if(BUILD_ARMASM AND BUILD_FIPS_READY)
-                        list(APPEND LIB_SOURCES
-                                  wolfcrypt/src/port/arm/armv8-sha512.c)
-
-                        if(BUILD_ARMASM_INLINE)
-                             list(APPEND LIB_SOURCES
-                                  wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
-                                  wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c)
-                        else()
-                             list(APPEND LIB_SOURCES
-                                  wolfcrypt/src/port/arm/armv8-sha512-asm.S
-                                  wolfcrypt/src/port/arm/armv8-32-sha512-asm.S)
-                        endif()
-
-                        if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
-                             list(APPEND LIB_SOURCES
-                                  wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c)
-                        elseif(BUILD_ARM_THUMB)
-                             list(APPEND LIB_SOURCES
-                                  wolfcrypt/src/port/arm/thumb2-sha512-asm.S)
-                        endif()
-                   endif()
-
-                   if(BUILD_INTELASM)
-                        list(APPEND LIB_SOURCES wolfcrypt/src/sha512_asm.S)
-                   endif()
-              endif()
-
-              if(BUILD_SHA3)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/sha3.c)
-
-                   if(BUILD_ARMASM)
                     if(BUILD_ARMASM_INLINE)
-                            list(APPEND LIB_SOURCES
-                                wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
-                                wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c)
                     else()
-                            list(APPEND LIB_SOURCES
-                                wolfcrypt/src/port/arm/armv8-sha3-asm.S
-                                wolfcrypt/src/port/arm/armv8-32-sha3-asm.S)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/armv8-32-aes-asm.S)
                     endif()
 
                     if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
-                            list(APPEND LIB_SOURCES
-                                wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-aes-asm_c.c)
                     elseif(BUILD_ARM_THUMB)
-                            list(APPEND LIB_SOURCES
-                                wolfcrypt/src/port/arm/thumb2-sha3-asm.S)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-aes-asm.S)
+                    endif()
+                endif()
+            endif()
+
+            if(BUILD_AESNI)
+                list(APPEND LIB_SOURCES wolfcrypt/src/aes_asm.S)
+
+                if(BUILD_INTELASM)
+                    list(APPEND LIB_SOURCES wolfcrypt/src/aes_gcm_asm.S)
+                endif()
+            endif()
+
+            if(BUILD_DES3)
+                list(APPEND LIB_SOURCES wolfcrypt/src/des3.c)
+            endif()
+
+            if(BUILD_SHA)
+                list(APPEND LIB_SOURCES wolfcrypt/src/sha.c)
+            endif()
+
+            if(BUILD_ARMASM AND BUILD_FIPS_READY)
+                list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-sha256.c)
+            endif()
+
+            if(BUILD_INTELASM)
+                list(APPEND LIB_SOURCES wolfcrypt/src/sha256_asm.S)
+            endif()
+
+            if(BUILD_SHA512)
+                list(APPEND LIB_SOURCES wolfcrypt/src/sha512.c)
+
+                if(BUILD_ARMASM AND BUILD_FIPS_READY)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-sha512.c)
+
+                    if(BUILD_ARMASM_INLINE)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
+                            wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c)
+                    else()
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/armv8-sha512-asm.S
+                            wolfcrypt/src/port/arm/armv8-32-sha512-asm.S)
+                    endif()
+
+                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c)
+                    elseif(BUILD_ARM_THUMB)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-sha512-asm.S)
                     endif()
                 endif()
 
-                   if(BUILD_INTELASM)
-                        list(APPEND LIB_SOURCES wolfcrypt/src/sha3_asm.S)
-                   endif()
-              endif()
+                if(BUILD_INTELASM)
+                    list(APPEND LIB_SOURCES wolfcrypt/src/sha512_asm.S)
+                endif()
+            endif()
 
-              if(BUILD_DH)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/dh.c)
-              endif()
+            if(BUILD_SHA3)
+                list(APPEND LIB_SOURCES wolfcrypt/src/sha3.c)
 
-              if(BUILD_CMAC)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/cmac.c)
-              endif()
+                if(BUILD_ARMASM)
+                    if(BUILD_ARMASM_INLINE)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
+                            wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c)
+                    else()
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/armv8-sha3-asm.S
+                            wolfcrypt/src/port/arm/armv8-32-sha3-asm.S)
+                    endif()
 
-              list(APPEND LIB_SOURCES
-                   wolfcrypt/src/fips.c
-                   wolfcrypt/src/fips_test.c)
+                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c)
+                    elseif(BUILD_ARM_THUMB)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-sha3-asm.S)
+                    endif()
+                endif()
 
-              # fips last file
-              list(APPEND LIB_SOURCES wolfcrypt/src/wolfcrypt_last.c)
-         endif()
+                if(BUILD_INTELASM)
+                    list(APPEND LIB_SOURCES wolfcrypt/src/sha3_asm.S)
+                endif()
+            endif()
 
-         if(BUILD_FIPS_V5)
-              list(APPEND LIB_SOURCES wolfcrypt/src/wolfcrypt_first.c)
+            if(BUILD_DH)
+                list(APPEND LIB_SOURCES wolfcrypt/src/dh.c)
+            endif()
 
-              list(APPEND LIB_SOURCES
+            if(BUILD_CMAC)
+                list(APPEND LIB_SOURCES wolfcrypt/src/cmac.c)
+            endif()
+
+            list(APPEND LIB_SOURCES
+                wolfcrypt/src/fips.c
+                wolfcrypt/src/fips_test.c)
+
+            # fips last file
+            list(APPEND LIB_SOURCES wolfcrypt/src/wolfcrypt_last.c)
+        endif()
+
+        if(BUILD_FIPS_V5)
+            list(APPEND LIB_SOURCES wolfcrypt/src/wolfcrypt_first.c)
+
+            list(APPEND LIB_SOURCES
                 wolfcrypt/src/hmac.c
                 wolfcrypt/src/random.c
                 wolfcrypt/src/sha256.c)
 
-              list(APPEND LIB_SOURCES
+            list(APPEND LIB_SOURCES
                 wolfcrypt/src/kdf.c)
 
-              if(BUILD_RSA)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/rsa.c)
-              endif()
-         endif()
+            if(BUILD_RSA)
+                list(APPEND LIB_SOURCES wolfcrypt/src/rsa.c)
+            endif()
+        endif()
 
-         if(BUILD_FIPS_RAND)
-              list(APPEND LIB_SOURCES
-                   wolfcrypt/src/wolfcrypt_first.c
-                   wolfcrypt/src/hmac.c
-                   wolfcrypt/src/random.c
-                   wolfcrypt/src/sha256.c
-                   wolfcrypt/src/sha256_asm.S
-                   wolfcrypt/src/fips.c
-                   wolfcrypt/src/fips_test.c
-                   wolfcrypt/src/wolfcrypt_last.c)
-         endif()
+        if(BUILD_FIPS_RAND)
+            list(APPEND LIB_SOURCES
+                wolfcrypt/src/wolfcrypt_first.c
+                wolfcrypt/src/hmac.c
+                wolfcrypt/src/random.c
+                wolfcrypt/src/sha256.c
+                wolfcrypt/src/sha256_asm.S
+                wolfcrypt/src/fips.c
+                wolfcrypt/src/fips_test.c
+                wolfcrypt/src/wolfcrypt_last.c)
+        endif()
     endif()
 
     # For wolfRand, exclude everything else.
     if(NOT BUILD_FIPS_RAND)
-         # For FIPSV2, exclude the wolfCrypt files included above.
-         # For wolfRand, exclude just a couple files.
-         # For old FIPS, keep the wolfCrypt versions of the
-         # CtaoCrypt files included above.
-         if(NOT BUILD_FIPS_V2)
-              list(APPEND LIB_SOURCES wolfcrypt/src/hmac.c)
-         endif()
+        # For FIPSV2, exclude the wolfCrypt files included above.
+        # For wolfRand, exclude just a couple files.
+        # For old FIPS, keep the wolfCrypt versions of the
+        # CtaoCrypt files included above.
+        if(NOT BUILD_FIPS_V2)
+            list(APPEND LIB_SOURCES wolfcrypt/src/hmac.c)
+        endif()
 
-         # CAVP self test
-         if(BUILD_SELFTEST)
-              list(APPEND LIB_SOURCES wolfcrypt/src/selftest.c)
-         endif()
+        # CAVP self test
+        if(BUILD_SELFTEST)
+            list(APPEND LIB_SOURCES wolfcrypt/src/selftest.c)
+        endif()
     endif()
 
     list(APPEND LIB_SOURCES
-         wolfcrypt/src/hash.c
-         wolfcrypt/src/cpuid.c)
+        wolfcrypt/src/hash.c
+        wolfcrypt/src/cpuid.c)
 
     if(NOT BUILD_FIPS_RAND)
-         if(NOT BUILD_FIPS_V5)
-              list(APPEND LIB_SOURCES wolfcrypt/src/kdf.c)
-         endif()
+        if(NOT BUILD_FIPS_V5)
+            list(APPEND LIB_SOURCES wolfcrypt/src/kdf.c)
+        endif()
 
-         if(NOT BUILD_FIPS_V2 AND BUILD_RNG)
-              list(APPEND LIB_SOURCES wolfcrypt/src/random.c)
-         endif()
+        if(NOT BUILD_FIPS_V2 AND BUILD_RNG)
+            list(APPEND LIB_SOURCES wolfcrypt/src/random.c)
+        endif()
 
-         if(NOT BUILD_FIPS_V2)
+        if(NOT BUILD_FIPS_V2)
 
-              list(APPEND LIB_SOURCES wolfcrypt/src/sha256.c)
+            list(APPEND LIB_SOURCES wolfcrypt/src/sha256.c)
 
-              if(BUILD_ARMASM)
+            if(BUILD_ARMASM)
 
-                   if(BUILD_ARMASM_INLINE)
+                if(BUILD_ARMASM_INLINE)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-sha256.c
+                        wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c)
+                else()
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-sha256-asm.S
+                        wolfcrypt/src/port/arm/armv8-32-sha256-asm.S)
+                endif()
+                if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c)
+                elseif(BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-sha256-asm.S)
+                endif()
+            else()
+
+                if(BUILD_INTELASM)
+                    list(APPEND LIB_SOURCES wolfcrypt/src/sha256_asm.S)
+                endif()
+            endif()
+        endif()
+
+        if(BUILD_AFALG)
+            list(APPEND LIB_SOURCES wolfcrypt/src/port/af_alg/afalg_hash.c)
+        endif()
+
+        if(BUILD_WOLFEVENT)
+            list(APPEND LIB_SOURCES wolfcrypt/src/wolfevent.c)
+        endif()
+
+        if(BUILD_ASYNCCRYPT)
+            list(APPEND LIB_SOURCES wolfcrypt/src/async.c)
+        endif()
+
+        if(BUILD_RSA)
+            if(NOT BUILD_FIPS_V2)
+                list(APPEND LIB_SOURCES wolfcrypt/src/rsa.c)
+            endif()
+        endif()
+
+        if(BUILD_SP)
+            if(BUILD_SP_C)
+                list(APPEND LIB_SOURCES
+                    wolfcrypt/src/sp_c32.c
+                    wolfcrypt/src/sp_c64.c)
+            endif()
+
+            if(BUILD_SP_X86_64)
+                list(APPEND LIB_SOURCES wolfcrypt/src/sp_x86_64.c)
+                if(WOLFSSL_X86_64_BUILD_ASM)
+                    list(APPEND LIB_SOURCES wolfcrypt/src/sp_x86_64_asm.S)
+                endif()
+            endif()
+
+            if(NOT BUILD_FIPS_V2 AND BUILD_SP_ARM32)
+                list(APPEND LIB_SOURCES wolfcrypt/src/sp_arm32.c)
+            endif()
+
+            if(BUILD_SP_ARM_THUMB)
+                list(APPEND LIB_SOURCES wolfcrypt/src/sp_armthumb.c)
+            endif()
+
+            if(BUILD_SP_ARM64)
+                list(APPEND LIB_SOURCES wolfcrypt/src/sp_arm64.c)
+            endif()
+
+            if(BUILD_SP_ARM_CORTEX)
+                list(APPEND LIB_SOURCES wolfcrypt/src/sp_cortexm.c)
+            endif()
+        endif()
+        if(BUILD_SP_INT)
+            list(APPEND LIB_SOURCES wolfcrypt/src/sp_int.c)
+        endif()
+
+        if(NOT BUILD_FIPS_V2)
+            if(BUILD_AES)
+                list(APPEND LIB_SOURCES wolfcrypt/src/aes.c)
+
+                if(BUILD_ARMASM)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-aes.c)
+
+                    if(BUILD_ARMASM_INLINE)
                         list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/armv8-sha256.c
-                             wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c)
-                   else()
+                            wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c)
+                    else()
                         list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/armv8-sha256-asm.S
-                             wolfcrypt/src/port/arm/armv8-32-sha256-asm.S)
+                            wolfcrypt/src/port/arm/armv8-32-aes-asm.S)
                     endif()
+
                     if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
-                         list(APPEND LIB_SOURCES
-                              wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-aes-asm_c.c)
                     elseif(BUILD_ARM_THUMB)
-                         list(APPEND LIB_SOURCES
-                              wolfcrypt/src/port/arm/thumb2-sha256-asm.S)
+                        list(APPEND LIB_SOURCES
+                            wolfcrypt/src/port/arm/thumb2-aes-asm.S)
                     endif()
-              else()
 
-                   if(BUILD_INTELASM)
-                        list(APPEND LIB_SOURCES wolfcrypt/src/sha256_asm.S)
-                   endif()
-              endif()
-         endif()
+                endif()
 
-         if(BUILD_AFALG)
-              list(APPEND LIB_SOURCES wolfcrypt/src/port/af_alg/afalg_hash.c)
-         endif()
+                if(BUILD_AFALG)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/af_alg/afalg_aes.c)
+                endif()
+            endif()
+        endif()
 
-         if(BUILD_WOLFEVENT)
-              list(APPEND LIB_SOURCES wolfcrypt/src/wolfevent.c)
-         endif()
+        if(NOT BUILD_FIPS_V2 AND BUILD_CMAC)
+            list(APPEND LIB_SOURCES wolfcrypt/src/cmac.c)
+        endif()
 
-         if(BUILD_ASYNCCRYPT)
-              list(APPEND LIB_SOURCES wolfcrypt/src/async.c)
-         endif()
+        if(NOT BUILD_FIPS_V2 AND BUILD_DES3)
+            list(APPEND LIB_SOURCES wolfcrypt/src/des3.c)
+        endif()
 
-         if(BUILD_RSA)
-               if(NOT BUILD_FIPS_V2)
-                    list(APPEND LIB_SOURCES wolfcrypt/src/rsa.c)
-               endif()
-         endif()
+        if(NOT BUILD_FIPS_V2 AND BUILD_SHA)
+            list(APPEND LIB_SOURCES wolfcrypt/src/sha.c)
+        endif()
 
-         if(BUILD_SP)
-              if(BUILD_SP_C)
-                   list(APPEND LIB_SOURCES
-                        wolfcrypt/src/sp_c32.c
-                        wolfcrypt/src/sp_c64.c)
-              endif()
-
-              if(BUILD_SP_X86_64)
-                    list(APPEND LIB_SOURCES wolfcrypt/src/sp_x86_64.c)
-                    if(WOLFSSL_X86_64_BUILD_ASM)
-                         list(APPEND LIB_SOURCES wolfcrypt/src/sp_x86_64_asm.S)
-                    endif()
-              endif()
-
-              if(NOT BUILD_FIPS_V2 AND BUILD_SP_ARM32)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/sp_arm32.c)
-              endif()
-
-              if(BUILD_SP_ARM_THUMB)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/sp_armthumb.c)
-              endif()
-
-              if(BUILD_SP_ARM64)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/sp_arm64.c)
-              endif()
-
-              if(BUILD_SP_ARM_CORTEX)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/sp_cortexm.c)
-              endif()
-         endif()
-         if(BUILD_SP_INT)
-              list(APPEND LIB_SOURCES wolfcrypt/src/sp_int.c)
-         endif()
-
-         if(NOT BUILD_FIPS_V2)
-              if(BUILD_AES)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/aes.c)
-
-                   if(BUILD_ARMASM)
-                        list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-aes.c)
-
-                        if(BUILD_ARMASM_INLINE)
-                            list(APPEND LIB_SOURCES
-                                wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c)
-                        else()
-                            list(APPEND LIB_SOURCES
-                                wolfcrypt/src/port/arm/armv8-32-aes-asm.S)
-                        endif()
-
-                        if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
-                            list(APPEND LIB_SOURCES
-                                wolfcrypt/src/port/arm/thumb2-aes-asm_c.c)
-                        elseif(BUILD_ARM_THUMB)
-                            list(APPEND LIB_SOURCES
-                                wolfcrypt/src/port/arm/thumb2-aes-asm.S)
-                        endif()
-                        
-                   endif()
-
-                   if(BUILD_AFALG)
-                        list(APPEND LIB_SOURCES wolfcrypt/src/port/af_alg/afalg_aes.c)
-                   endif()
-              endif()
-         endif()
-
-         if(NOT BUILD_FIPS_V2 AND BUILD_CMAC)
-              list(APPEND LIB_SOURCES wolfcrypt/src/cmac.c)
-         endif()
-
-         if(NOT BUILD_FIPS_V2 AND BUILD_DES3)
-              list(APPEND LIB_SOURCES wolfcrypt/src/des3.c)
-         endif()
-
-         if(NOT BUILD_FIPS_V2 AND BUILD_SHA)
-              list(APPEND LIB_SOURCES wolfcrypt/src/sha.c)
-         endif()
-
-         if(NOT BUILD_FIPS_V2 AND BUILD_SHA512)
+        if(NOT BUILD_FIPS_V2 AND BUILD_SHA512)
             list(APPEND LIB_SOURCES wolfcrypt/src/sha512.c)
 
             if(BUILD_ARMASM)
                 list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-sha512.c)
 
-                    if(BUILD_ARMASM_INLINE)
-                        list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
-                             wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c)
-                    else()
-                        list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/armv8-sha512-asm.S
-                             wolfcrypt/src/port/arm/armv8-32-sha512-asm.S)
-                    endif()
-                   
-                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
-                         list(APPEND LIB_SOURCES
-                              wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c)
-                    elseif(BUILD_ARM_THUMB)
-                         list(APPEND LIB_SOURCES
-                              wolfcrypt/src/port/arm/thumb2-sha512-asm.S)
-                    endif()
-              else()
+                if(BUILD_ARMASM_INLINE)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
+                        wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c)
+                else()
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-sha512-asm.S
+                        wolfcrypt/src/port/arm/armv8-32-sha512-asm.S)
+                endif()
 
-                   if(BUILD_INTELASM)
-                        list(APPEND LIB_SOURCES wolfcrypt/src/sha512_asm.S)
-                   endif()
-              endif()
-         endif()
+                if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c)
+                elseif(BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-sha512-asm.S)
+                endif()
+            else()
 
-         if(NOT BUILD_FIPS_V2 AND BUILD_SHA3)
-              list(APPEND LIB_SOURCES wolfcrypt/src/sha3.c)
+                if(BUILD_INTELASM)
+                    list(APPEND LIB_SOURCES wolfcrypt/src/sha512_asm.S)
+                endif()
+            endif()
+        endif()
 
-              if(BUILD_ARMASM)
-                   if(BUILD_ARMASM_INLINE)
-                        list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
-                             wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c)
-                   else()
-                        list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/armv8-sha3-asm.S
-                             wolfcrypt/src/port/arm/armv8-32-sha3-asm.S)
-                   endif()
+        if(NOT BUILD_FIPS_V2 AND BUILD_SHA3)
+            list(APPEND LIB_SOURCES wolfcrypt/src/sha3.c)
 
-                   if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
-                        list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c)
-                   elseif(BUILD_ARM_THUMB)
-                        list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/thumb2-sha3-asm.S)
-                   endif()
-              endif()
+            if(BUILD_ARMASM)
+                if(BUILD_ARMASM_INLINE)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
+                        wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c)
+                else()
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-sha3-asm.S
+                        wolfcrypt/src/port/arm/armv8-32-sha3-asm.S)
+                endif()
 
-              if(BUILD_INTELASM)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/sha3_asm.S)
-              endif()
-         endif()
+                if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c)
+                elseif(BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-sha3-asm.S)
+                endif()
+            endif()
+
+            if(BUILD_INTELASM)
+                list(APPEND LIB_SOURCES wolfcrypt/src/sha3_asm.S)
+            endif()
+        endif()
     endif()
 
     list(APPEND LIB_SOURCES
-         wolfcrypt/src/logging.c
-         wolfcrypt/src/wc_port.c
-         wolfcrypt/src/error.c)
+        wolfcrypt/src/logging.c
+        wolfcrypt/src/wc_port.c
+        wolfcrypt/src/error.c)
 
     if(BUILD_OQS_HELPER)
         list(APPEND LIB_SOURCES
@@ -748,351 +752,351 @@ function(generate_lib_src_list LIB_SOURCES)
     endif()
 
     if(BUILD_MEMORY)
-         list(APPEND LIB_SOURCES wolfcrypt/src/memory.c)
+        list(APPEND LIB_SOURCES wolfcrypt/src/memory.c)
     endif()
 
     if(NOT BUILD_FIPS_RAND)
-         if(NOT BUILD_FIPS_V2 AND BUILD_DH)
-              list(APPEND LIB_SOURCES wolfcrypt/src/dh.c)
-         endif()
+        if(NOT BUILD_FIPS_V2 AND BUILD_DH)
+            list(APPEND LIB_SOURCES wolfcrypt/src/dh.c)
+        endif()
 
-         if(BUILD_ASN)
-              list(APPEND LIB_SOURCES wolfcrypt/src/asn.c)
-         endif()
+        if(BUILD_ASN)
+            list(APPEND LIB_SOURCES wolfcrypt/src/asn.c)
+        endif()
     endif()
 
     if(BUILD_CODING)
-         list(APPEND LIB_SOURCES wolfcrypt/src/coding.c)
+        list(APPEND LIB_SOURCES wolfcrypt/src/coding.c)
     endif()
 
     if(NOT BUILD_FIPS_RAND)
-         if(BUILD_POLY1305)
-              if(BUILD_ARMASM)
-                   list(APPEND LIB_SOURCES
-                        wolfcrypt/src/port/arm/armv8-poly1305.c)
+        if(BUILD_POLY1305)
+            if(BUILD_ARMASM)
+                list(APPEND LIB_SOURCES
+                    wolfcrypt/src/port/arm/armv8-poly1305.c)
 
-                   if(BUILD_ARMASM_INLINE)
-                        list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c)
-                    else()
-                        list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/armv8-32-poly1305-asm.S)
-                    endif()
-                   
-                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
-                        list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/thumb2-poly1305.c
-                             wolfcrypt/src/port/arm/thumb2-poly1305-asm_c.c)
-                    elseif(BUILD_ARM_THUMB)
-                        list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/thumb2-poly1305.c
-                             wolfcrypt/src/port/arm/thumb2-poly1305-asm.S)
-                    endif()
-              endif()
-
-              list(APPEND LIB_SOURCES wolfcrypt/src/poly1305.c)
-
-              if(BUILD_INTELASM)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/poly1305_asm.S)
-              endif()
-         endif()
-
-         if(BUILD_RC4)
-              list(APPEND LIB_SOURCES wolfcrypt/src/arc4.c)
-         endif()
-
-         if(BUILD_MD4)
-              list(APPEND LIB_SOURCES wolfcrypt/src/md4.c)
-         endif()
-
-         if(BUILD_MD5)
-              list(APPEND LIB_SOURCES wolfcrypt/src/md5.c)
-         endif()
-
-         if(BUILD_PWDBASED)
-              list(APPEND LIB_SOURCES
-                   wolfcrypt/src/pwdbased.c
-                   wolfcrypt/src/pkcs12.c)
-         endif()
-
-         if(BUILD_DSA)
-              list(APPEND LIB_SOURCES wolfcrypt/src/dsa.c)
-         endif()
-
-         if(NOT BUILD_FIPS_V2 AND BUILD_AESNI)
-              list(APPEND LIB_SOURCES
-                   wolfcrypt/src/aes_asm.S
-                   wolfcrypt/src/aes_gcm_asm.S)
-         endif()
-
-         if(BUILD_CAMELLIA)
-              list(APPEND LIB_SOURCES wolfcrypt/src/camellia.c)
-         endif()
-
-         if(BUILD_MD2)
-              list(APPEND LIB_SOURCES wolfcrypt/src/md2.c)
-         endif()
-
-         if(BUILD_RIPEMD)
-              list(APPEND LIB_SOURCES wolfcrypt/src/ripemd.c)
-         endif()
-
-         if(BUILD_BLAKE2)
-              list(APPEND LIB_SOURCES wolfcrypt/src/blake2b.c)
-         endif()
-
-         if(BUILD_BLAKE2S)
-              list(APPEND LIB_SOURCES wolfcrypt/src/blake2s.c)
-         endif()
-
-         if(BUILD_CHACHA)
-              list(APPEND LIB_SOURCES wolfcrypt/src/chacha.c)
-
-              if(BUILD_ARMASM)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-chacha.c)
-
-                   if(BUILD_ARMASM_INLINE)
-                        list(APPEND LIB_SOURCES
-                             wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c)
-                   else()
-                        list(APPEND LIB_SOURCES
-                            wolfcrypt/src/port/arm/armv8-32-chacha-asm.S)
-                   endif()
-                   
-                   if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
-                       list(APPEND LIB_SOURCES
-                            wolfcrypt/src/port/arm/thumb2-chacha.c
-                            wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c)
-                   elseif(BUILD_ARM_THUMB)
-                       list(APPEND LIB_SOURCES
-                            wolfcrypt/src/port/arm/thumb2-chacha.c
-                            wolfcrypt/src/port/arm/thumb2-chacha-asm.S)
-                   endif()
-              else()
-
-                   if(BUILD_INTELASM)
-                        list(APPEND LIB_SOURCES wolfcrypt/src/chacha_asm.S)
-                   endif()
-              endif()
-
-              if(BUILD_POLY1305)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/chacha20_poly1305.c)
-              endif()
-         endif()
-
-         if(NOT BUILD_INLINE)
-              list(APPEND LIB_SOURCES wolfcrypt/src/misc.c)
-         endif()
-
-         if(BUILD_FAST_MATH)
-              list(APPEND LIB_SOURCES wolfcrypt/src/tfm.c)
-         endif()
-
-         if(BUILD_SLOW_MATH)
-              list(APPEND LIB_SOURCES wolfcrypt/src/integer.c)
-         endif()
-
-         if(NOT BUILD_FIPS_V2 AND BUILD_ECC)
-              list(APPEND LIB_SOURCES wolfcrypt/src/ecc.c)
-         endif()
-
-         if(BUILD_CURVE25519)
-              list(APPEND LIB_SOURCES wolfcrypt/src/curve25519.c)
-              if(BUILD_ARMASM)
-                    if (BUILD_ARMASM_INLINE)
-                        list(APPEND LIB_SOURCES
-                            wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
-                            wolfcrypt/src/port/arm/armv8-curve25519_c.c)
-                    else()
-                        list(APPEND LIB_SOURCES
-                            wolfcrypt/src/port/arm/armv8-32-curve25519.S
-                            wolfcrypt/src/port/arm/armv8-curve25519.S)
-                    endif()
-
-                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
-                        list(APPEND LIB_SOURCES
-                            wolfcrypt/src/port/arm/thumb2-curve25519_c.c)
-                    elseif(BUILD_ARM_THUMB)
-                        list(APPEND LIB_SOURCES
-                            wolfcrypt/src/port/arm/thumb2-curve25519.S)
-                    endif()
+                if(BUILD_ARMASM_INLINE)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c)
+                else()
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-32-poly1305-asm.S)
                 endif()
-         endif()
 
-         if(BUILD_ED25519)
-              list(APPEND LIB_SOURCES wolfcrypt/src/ed25519.c)
-         endif()
+                if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-poly1305.c
+                        wolfcrypt/src/port/arm/thumb2-poly1305-asm_c.c)
+                elseif(BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-poly1305.c
+                        wolfcrypt/src/port/arm/thumb2-poly1305-asm.S)
+                endif()
+            endif()
 
-         if(BUILD_FEMATH)
-              if(BUILD_CURVE25519_SMALL)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/fe_low_mem.c)
-              else()
-                   if(BUILD_INTELASM)
+            list(APPEND LIB_SOURCES wolfcrypt/src/poly1305.c)
+
+            if(BUILD_INTELASM)
+                list(APPEND LIB_SOURCES wolfcrypt/src/poly1305_asm.S)
+            endif()
+        endif()
+
+        if(BUILD_RC4)
+            list(APPEND LIB_SOURCES wolfcrypt/src/arc4.c)
+        endif()
+
+        if(BUILD_MD4)
+            list(APPEND LIB_SOURCES wolfcrypt/src/md4.c)
+        endif()
+
+        if(BUILD_MD5)
+            list(APPEND LIB_SOURCES wolfcrypt/src/md5.c)
+        endif()
+
+        if(BUILD_PWDBASED)
+            list(APPEND LIB_SOURCES
+                wolfcrypt/src/pwdbased.c
+                wolfcrypt/src/pkcs12.c)
+        endif()
+
+        if(BUILD_DSA)
+            list(APPEND LIB_SOURCES wolfcrypt/src/dsa.c)
+        endif()
+
+        if(NOT BUILD_FIPS_V2 AND BUILD_AESNI)
+            list(APPEND LIB_SOURCES
+                wolfcrypt/src/aes_asm.S
+                wolfcrypt/src/aes_gcm_asm.S)
+        endif()
+
+        if(BUILD_CAMELLIA)
+            list(APPEND LIB_SOURCES wolfcrypt/src/camellia.c)
+        endif()
+
+        if(BUILD_MD2)
+            list(APPEND LIB_SOURCES wolfcrypt/src/md2.c)
+        endif()
+
+        if(BUILD_RIPEMD)
+            list(APPEND LIB_SOURCES wolfcrypt/src/ripemd.c)
+        endif()
+
+        if(BUILD_BLAKE2)
+            list(APPEND LIB_SOURCES wolfcrypt/src/blake2b.c)
+        endif()
+
+        if(BUILD_BLAKE2S)
+            list(APPEND LIB_SOURCES wolfcrypt/src/blake2s.c)
+        endif()
+
+        if(BUILD_CHACHA)
+            list(APPEND LIB_SOURCES wolfcrypt/src/chacha.c)
+
+            if(BUILD_ARMASM)
+                list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-chacha.c)
+
+                if(BUILD_ARMASM_INLINE)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c)
+                else()
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-32-chacha-asm.S)
+                endif()
+
+                if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-chacha.c
+                        wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c)
+                elseif(BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-chacha.c
+                        wolfcrypt/src/port/arm/thumb2-chacha-asm.S)
+                endif()
+            else()
+
+                if(BUILD_INTELASM)
+                    list(APPEND LIB_SOURCES wolfcrypt/src/chacha_asm.S)
+                endif()
+            endif()
+
+            if(BUILD_POLY1305)
+                list(APPEND LIB_SOURCES wolfcrypt/src/chacha20_poly1305.c)
+            endif()
+        endif()
+
+        if(NOT BUILD_INLINE)
+            list(APPEND LIB_SOURCES wolfcrypt/src/misc.c)
+        endif()
+
+        if(BUILD_FAST_MATH)
+            list(APPEND LIB_SOURCES wolfcrypt/src/tfm.c)
+        endif()
+
+        if(BUILD_SLOW_MATH)
+            list(APPEND LIB_SOURCES wolfcrypt/src/integer.c)
+        endif()
+
+        if(NOT BUILD_FIPS_V2 AND BUILD_ECC)
+            list(APPEND LIB_SOURCES wolfcrypt/src/ecc.c)
+        endif()
+
+        if(BUILD_CURVE25519)
+            list(APPEND LIB_SOURCES wolfcrypt/src/curve25519.c)
+            if(BUILD_ARMASM)
+                if (BUILD_ARMASM_INLINE)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
+                        wolfcrypt/src/port/arm/armv8-curve25519_c.c)
+                else()
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-32-curve25519.S
+                        wolfcrypt/src/port/arm/armv8-curve25519.S)
+                endif()
+
+                if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-curve25519_c.c)
+                elseif(BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-curve25519.S)
+                endif()
+            endif()
+        endif()
+
+        if(BUILD_ED25519)
+            list(APPEND LIB_SOURCES wolfcrypt/src/ed25519.c)
+        endif()
+
+        if(BUILD_FEMATH)
+            if(BUILD_CURVE25519_SMALL)
+                list(APPEND LIB_SOURCES wolfcrypt/src/fe_low_mem.c)
+            else()
+                if(BUILD_INTELASM)
+                    list(APPEND LIB_SOURCES wolfcrypt/src/fe_x25519_asm.S)
+                else()
+                    list(APPEND LIB_SOURCES wolfcrypt/src/fe_operations.c)
+                endif()
+            endif()
+        endif()
+
+        if(BUILD_GEMATH)
+            if(BUILD_ED25519_SMALL)
+                list(APPEND LIB_SOURCES wolfcrypt/src/ge_low_mem.c)
+            else()
+                list(APPEND LIB_SOURCES wolfcrypt/src/ge_operations.c)
+
+                if(NOT BUILD_FEMATH)
+                    if(BUILD_INTELASM)
                         list(APPEND LIB_SOURCES wolfcrypt/src/fe_x25519_asm.S)
-                   else()
-                        list(APPEND LIB_SOURCES wolfcrypt/src/fe_operations.c)
-                   endif()
-              endif()
-         endif()
-
-         if(BUILD_GEMATH)
-              if(BUILD_ED25519_SMALL)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/ge_low_mem.c)
-              else()
-                   list(APPEND LIB_SOURCES wolfcrypt/src/ge_operations.c)
-
-                   if(NOT BUILD_FEMATH)
-                        if(BUILD_INTELASM)
-                             list(APPEND LIB_SOURCES wolfcrypt/src/fe_x25519_asm.S)
-                        else()
-                            list(APPEND LIB_SOURCES wolfcrypt/src/fe_operations.c)
-                        endif()
-                   endif()
-              endif()
-         endif()
-
-         if(BUILD_CURVE448)
-              list(APPEND LIB_SOURCES wolfcrypt/src/curve448.c)
-         endif()
-
-         if(BUILD_ED448)
-              list(APPEND LIB_SOURCES wolfcrypt/src/ed448.c)
-         endif()
-
-         if(BUILD_FE448)
-              list(APPEND LIB_SOURCES wolfcrypt/src/fe_448.c)
-         endif()
-
-         if(BUILD_GE448)
-              list(APPEND LIB_SOURCES wolfcrypt/src/ge_448.c)
-
-              if(NOT BUILD_FE448)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/fe_448.c)
-              endif()
-         endif()
-
-         if(BUILD_FALCON)
-              list(APPEND LIB_SOURCES wolfcrypt/src/falcon.c)
-         endif()
-
-         if(BUILD_SPHINCS)
-              list(APPEND LIB_SOURCES wolfcrypt/src/sphincs.c)
-         endif()
-
-         if(BUILD_DILITHIUM)
-              list(APPEND LIB_SOURCES wolfcrypt/src/dilithium.c)
-         endif()
-
-         if(BUILD_WC_MLKEM)
-              list(APPEND LIB_SOURCES wolfcrypt/src/wc_mlkem.c)
-              list(APPEND LIB_SOURCES wolfcrypt/src/wc_mlkem_poly.c)
-
-              if(BUILD_ARMASM)
-                    if(BUILD_ARMASM_INLINE)
-                         list(APPEND LIB_SOURCES
-                              wolfcrypt/src/port/arm/armv8-mlkem-asm_c.c
-                              wolfcrypt/src/port/arm/armv8-32-mlkem-asm_c.c)
                     else()
-                         list(APPEND LIB_SOURCES
-                              wolfcrypt/src/port/arm/armv8-mlkem-asm.S
-                              wolfcrypt/src/port/arm/armv8-32-mlkem-asm.S)
-                    endif()
-                    
-                    if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
-                         list(APPEND LIB_SOURCES
-                              wolfcrypt/src/port/arm/thumb2-mlkem-asm_c.c)
-                    elseif(BUILD_ARM_THUMB)
-                         list(APPEND LIB_SOURCES]
-                              wolfcrypt/src/port/arm/thumb2-mlkem-asm.S)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/fe_operations.c)
                     endif()
                 endif()
+            endif()
+        endif()
 
-              if(BUILD_INTELASM)
-                   list(APPEND LIB_SOURCES wolfcrypt/src/wc_mlkem_asm.S)
-              endif()
-         endif()
+        if(BUILD_CURVE448)
+            list(APPEND LIB_SOURCES wolfcrypt/src/curve448.c)
+        endif()
 
-         if(BUILD_EXT_MLKEM)
-              list(APPEND LIB_SOURCES wolfcrypt/src/ext_mlkem.c)
-         endif()
+        if(BUILD_ED448)
+            list(APPEND LIB_SOURCES wolfcrypt/src/ed448.c)
+        endif()
 
-         if(BUILD_WC_LMS)
-              list(APPEND LIB_SOURCES wolfcrypt/src/wc_lms.c)
-              list(APPEND LIB_SOURCES wolfcrypt/src/wc_lms_impl.c)
-         endif()
+        if(BUILD_FE448)
+            list(APPEND LIB_SOURCES wolfcrypt/src/fe_448.c)
+        endif()
 
-         if(BUILD_WC_XMSS)
-              list(APPEND LIB_SOURCES wolfcrypt/src/wc_xmss.c)
-              list(APPEND LIB_SOURCES wolfcrypt/src/wc_xmss_impl.c)
-         endif()
+        if(BUILD_GE448)
+            list(APPEND LIB_SOURCES wolfcrypt/src/ge_448.c)
 
-         if(BUILD_LIBZ)
-              list(APPEND LIB_SOURCES wolfcrypt/src/compress.c)
-         endif()
+            if(NOT BUILD_FE448)
+                list(APPEND LIB_SOURCES wolfcrypt/src/fe_448.c)
+            endif()
+        endif()
 
-         if(BUILD_PKCS7)
-              list(APPEND LIB_SOURCES wolfcrypt/src/pkcs7.c)
-         endif()
+        if(BUILD_FALCON)
+            list(APPEND LIB_SOURCES wolfcrypt/src/falcon.c)
+        endif()
 
-         if(BUILD_SRP)
-              list(APPEND LIB_SOURCES wolfcrypt/src/srp.c)
-         endif()
+        if(BUILD_SPHINCS)
+            list(APPEND LIB_SOURCES wolfcrypt/src/sphincs.c)
+        endif()
 
-         if(BUILD_AFALG)
-              list(APPEND LIB_SOURCES wolfcrypt/src/port/af_alg/wc_afalg.c)
-         endif()
+        if(BUILD_DILITHIUM)
+            list(APPEND LIB_SOURCES wolfcrypt/src/dilithium.c)
+        endif()
 
-         if(NOT BUILD_CRYPTONLY)
-              # ssl files
-              list(APPEND LIB_SOURCES
-                   src/internal.c
-                   src/wolfio.c
-                   src/keys.c
-                   src/ssl.c
-                   src/ocsp.c
-                   src/tls.c)
+        if(BUILD_WC_MLKEM)
+            list(APPEND LIB_SOURCES wolfcrypt/src/wc_mlkem.c)
+            list(APPEND LIB_SOURCES wolfcrypt/src/wc_mlkem_poly.c)
 
-              if(BUILD_TLS13)
-                   list(APPEND LIB_SOURCES src/tls13.c)
-              endif()
+            if(BUILD_ARMASM)
+                if(BUILD_ARMASM_INLINE)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-mlkem-asm_c.c
+                        wolfcrypt/src/port/arm/armv8-32-mlkem-asm_c.c)
+                else()
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-mlkem-asm.S
+                        wolfcrypt/src/port/arm/armv8-32-mlkem-asm.S)
+                endif()
 
-              if(BUILD_DTLS13)
-                   list(APPEND LIB_SOURCES src/dtls13.c)
-              endif()
+                if(BUILD_ARMASM_INLINE AND BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-mlkem-asm_c.c)
+                elseif(BUILD_ARM_THUMB)
+                    list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/thumb2-mlkem-asm.S)
+                endif()
+            endif()
 
-              if(BUILD_QUIC)
-                   list(APPEND LIB_SOURCES src/quic.c)
-              endif()
+            if(BUILD_INTELASM)
+                list(APPEND LIB_SOURCES wolfcrypt/src/wc_mlkem_asm.S)
+            endif()
+        endif()
 
-              if(BUILD_OCSP)
-                   list(APPEND LIB_SOURCES src/ocsp.c)
-              endif()
+        if(BUILD_EXT_MLKEM)
+            list(APPEND LIB_SOURCES wolfcrypt/src/ext_mlkem.c)
+        endif()
 
-              if(BUILD_CRL)
-                   list(APPEND LIB_SOURCES src/crl.c)
-              endif()
+        if(BUILD_WC_LMS)
+            list(APPEND LIB_SOURCES wolfcrypt/src/wc_lms.c)
+            list(APPEND LIB_SOURCES wolfcrypt/src/wc_lms_impl.c)
+        endif()
 
-              if(BUILD_SNIFFER)
-                   list(APPEND LIB_SOURCES src/sniffer.c)
-              endif()
+        if(BUILD_WC_XMSS)
+            list(APPEND LIB_SOURCES wolfcrypt/src/wc_xmss.c)
+            list(APPEND LIB_SOURCES wolfcrypt/src/wc_xmss_impl.c)
+        endif()
 
-              if(BUILD_DTLS_COMMON)
-                   list(APPEND LIB_SOURCES src/dtls.c)
-              endif()
+        if(BUILD_LIBZ)
+            list(APPEND LIB_SOURCES wolfcrypt/src/compress.c)
+        endif()
 
-              if(BUILD_QUIC)
-                   list(APPEND LIB_SOURCES src/quic.c)
-              endif()
-          endif()
+        if(BUILD_PKCS7)
+            list(APPEND LIB_SOURCES wolfcrypt/src/pkcs7.c)
+        endif()
+
+        if(BUILD_SRP)
+            list(APPEND LIB_SOURCES wolfcrypt/src/srp.c)
+        endif()
+
+        if(BUILD_AFALG)
+            list(APPEND LIB_SOURCES wolfcrypt/src/port/af_alg/wc_afalg.c)
+        endif()
+
+        if(NOT BUILD_CRYPTONLY)
+            # ssl files
+            list(APPEND LIB_SOURCES
+                src/internal.c
+                src/wolfio.c
+                src/keys.c
+                src/ssl.c
+                src/ocsp.c
+                src/tls.c)
+
+            if(BUILD_TLS13)
+                list(APPEND LIB_SOURCES src/tls13.c)
+            endif()
+
+            if(BUILD_DTLS13)
+                list(APPEND LIB_SOURCES src/dtls13.c)
+            endif()
+
+            if(BUILD_QUIC)
+                list(APPEND LIB_SOURCES src/quic.c)
+            endif()
+
+            if(BUILD_OCSP)
+                list(APPEND LIB_SOURCES src/ocsp.c)
+            endif()
+
+            if(BUILD_CRL)
+                list(APPEND LIB_SOURCES src/crl.c)
+            endif()
+
+            if(BUILD_SNIFFER)
+                list(APPEND LIB_SOURCES src/sniffer.c)
+            endif()
+
+            if(BUILD_DTLS_COMMON)
+                list(APPEND LIB_SOURCES src/dtls.c)
+            endif()
+
+            if(BUILD_QUIC)
+                list(APPEND LIB_SOURCES src/quic.c)
+            endif()
+        endif()
     endif()
 
     # Corresponds to wolfcrypt/src/include.am
     if(BUILD_CRYPTOCB)
-           list(APPEND LIB_SOURCES wolfcrypt/src/cryptocb.c)
+        list(APPEND LIB_SOURCES wolfcrypt/src/cryptocb.c)
     endif()
 
     if(BUILD_PKCS11)
-           list(APPEND LIB_SOURCES wolfcrypt/src/wc_pkcs11.c)
+        list(APPEND LIB_SOURCES wolfcrypt/src/wc_pkcs11.c)
     endif()
 
     if(BUILD_DEVCRYPTO)
@@ -1140,7 +1144,7 @@ function(generate_lib_src_list LIB_SOURCES)
     endif()
 
     if(BUILD_HPKE)
-         list(APPEND LIB_SOURCES wolfcrypt/src/hpke.c)
+        list(APPEND LIB_SOURCES wolfcrypt/src/hpke.c)
     endif()
 
     set(LIB_SOURCES ${LIB_SOURCES} PARENT_SCOPE)
@@ -1161,14 +1165,16 @@ endfunction()
 #
 function(set_wolfssl_definitions SEARCH_VALUE RESULT)
     if (${SEARCH_VALUE} STREQUAL "")
-        message(FATAL_ERROR "Function set_wolfssl_definitions cannot have blank SEARCH_VALUE")
+        message(FATAL_ERROR
+            "Function set_wolfssl_definitions cannot have blank SEARCH_VALUE")
     endif()
 
     list(FIND WOLFSSL_DEFINITIONS "${SEARCH_VALUE}" pos)
     string(SUBSTRING "${SEARCH_VALUE}" 0 2 PREFIX_VALUE)
 
     if ("${PREFIX_VALUE}" STREQUAL "-D")
-        message(FATAL_ERROR "Do not specify the -D prefix in set_wolfssl_definitions")
+        message(FATAL_ERROR
+            "Do not specify the -D prefix in set_wolfssl_definitions")
     endif()
 
     if(${pos} EQUAL -1)
@@ -1177,7 +1183,8 @@ function(set_wolfssl_definitions SEARCH_VALUE RESULT)
         message(STATUS "Enabling ${SEARCH_VALUE}")
         list(APPEND WOLFSSL_DEFINITIONS "-D${SEARCH_VALUE}")
         set(${SEARCH_VALUE} 1 PARENT_SCOPE)
-        # override_cache("${SEARCH_VALUE}" "yes") # Need to check that value is settable
+        # override_cache("${SEARCH_VALUE}" "yes")
+        # Need to check that value is settable
         set(${RESULT} 1 PARENT_SCOPE)
         message(STATUS "Enabling ${SEARCH_VALUE} - success")
 
@@ -1194,18 +1201,21 @@ endfunction()
 # Searches WOLFSSL_DEFINITIONS for SEARCH_VALUE
 #   Returns RESULT = 1 (true) if the search value is found
 #
-# Unlike set_wolfssl_definitions(), this function only queries the WOLFSSL_DEFINITIONS.
+# Unlike set_wolfssl_definitions(), this function only queries the
+# WOLFSSL_DEFINITIONS.
 #
 function(get_wolfssl_definitions SEARCH_VALUE RESULT)
     if (${SEARCH_VALUE} STREQUAL "")
-        message(FATAL_ERROR "Function get_wolfssl_definitions cannot have blank SEARCH_VALUE")
+        message(FATAL_ERROR
+            "Function get_wolfssl_definitions cannot have blank SEARCH_VALUE")
     endif()
 
     list(FIND WOLFSSL_DEFINITIONS "${SEARCH_VALUE}" pos)
     string(SUBSTRING "${SEARCH_VALUE}" 0 2 PREFIX_VALUE)
 
     if ("${PREFIX_VALUE}" STREQUAL "-D")
-        message(FATAL_ERROR "Do not specify the -D prefix in get_wolfssl_definitions")
+        message(FATAL_ERROR
+            "Do not specify the -D prefix in get_wolfssl_definitions")
     endif()
 
 


### PR DESCRIPTION
# Description

If WOLFSSL_ARMASM_INLINE is defined with `cmake`, compile with inline `*_c.c`. Otherwise, use `.S` files in build.

Add `BUILD_ARM_THUMB` build option (enabled with WOLFSSL_ARMASM_THUMB2=yes). Compiles `thumb2-*` files from `wolfcrypt/src/port/arm` when enabled.

Reformatted file with Google Gemini. Tabs are 4 spaces, keep lines 80 characters or less.

zd#20314

# Testing

```
mkdir -p out
pushd out
cmake .. -DWOLFSSL_ARMASM_INLINE=yes
cmake --build .

grep -rin "DWOLFSSL_ARMASM_INLINE" .
```
