### PR TITLE
Improve original implementation on SetAsymKeyDer() and the test

### DIFF
--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -24,10 +24,12 @@
 
 #include <tests/api/api_decl.h>
 
+int test_SetAsymKeyDer(void);
 int test_SetShortInt(void);
 int test_wc_IndexSequenceOf(void);
 
 #define TEST_ASN_DECLS                                              \
+    TEST_DECL_GROUP("asn", test_SetAsymKeyDer),                     \
     TEST_DECL_GROUP("asn", test_SetShortInt),                       \
     TEST_DECL_GROUP("asn", test_wc_IndexSequenceOf)
 

--- a/tests/api/test_mldsa.c
+++ b/tests/api/test_mldsa.c
@@ -3004,13 +3004,8 @@ int test_wc_dilithium_der(void)
 
     ExpectIntEQ(wc_Dilithium_PrivateKeyToDer(NULL, NULL,
         0                     ), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-#ifndef WOLFSSL_ASN_TEMPLATE
-    ExpectIntEQ(wc_Dilithium_PrivateKeyToDer(key , NULL,
-        0                     ), BAD_FUNC_ARG);
-#else
     ExpectIntGT(wc_Dilithium_PrivateKeyToDer(key , NULL,
         0                     ), 0);
-#endif
     ExpectIntEQ(wc_Dilithium_PrivateKeyToDer(NULL, der ,
         0                     ), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_Dilithium_PrivateKeyToDer(NULL, NULL,
@@ -3020,23 +3015,13 @@ int test_wc_dilithium_der(void)
     ExpectIntEQ(wc_Dilithium_PrivateKeyToDer(key , der ,
         0                     ), WC_NO_ERR_TRACE(BUFFER_E));
     /* Get length only. */
-#ifndef WOLFSSL_ASN_TEMPLATE
-    ExpectIntEQ(wc_Dilithium_PrivateKeyToDer(key , NULL,
-        DILITHIUM_MAX_DER_SIZE), BAD_FUNC_ARG);
-#else
     ExpectIntEQ(wc_Dilithium_PrivateKeyToDer(key , NULL,
         DILITHIUM_MAX_DER_SIZE), privDerLen);
-#endif
 
     ExpectIntEQ(wc_Dilithium_KeyToDer(NULL, NULL, 0                     ),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-#ifndef WOLFSSL_ASN_TEMPLATE
-    ExpectIntEQ(wc_Dilithium_KeyToDer(key , NULL, 0                     ),
-        BAD_FUNC_ARG);
-#else
     ExpectIntGT(wc_Dilithium_KeyToDer(key , NULL, 0                     ),
         0           );
-#endif
     ExpectIntEQ(wc_Dilithium_KeyToDer(NULL, der , 0                     ),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_Dilithium_KeyToDer(NULL, NULL, DILITHIUM_MAX_DER_SIZE),
@@ -3046,13 +3031,8 @@ int test_wc_dilithium_der(void)
     ExpectIntEQ(wc_Dilithium_KeyToDer(key , der , 0                     ),
         WC_NO_ERR_TRACE(BUFFER_E));
     /* Get length only. */
-#ifndef WOLFSSL_ASN_TEMPLATE
-    ExpectIntEQ(wc_Dilithium_KeyToDer(key , NULL, DILITHIUM_MAX_DER_SIZE),
-        BAD_FUNC_ARG);
-#else
     ExpectIntEQ(wc_Dilithium_KeyToDer(key , NULL, DILITHIUM_MAX_DER_SIZE),
         keyDerLen);
-#endif
 
     ExpectIntEQ(wc_Dilithium_PublicKeyDecode(NULL, NULL, NULL, 0        ),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
@@ -3101,25 +3081,15 @@ int test_wc_dilithium_der(void)
     idx = 0;
     ExpectIntEQ(wc_Dilithium_PublicKeyDecode(der, &idx, key, len), 0);
 
-#ifndef WOLFSSL_ASN_TEMPLATE
-    ExpectIntEQ(len = wc_Dilithium_PrivateKeyToDer(key, der,
-        DILITHIUM_MAX_DER_SIZE), BAD_FUNC_ARG);
-#else
     ExpectIntEQ(len = wc_Dilithium_PrivateKeyToDer(key, der,
         DILITHIUM_MAX_DER_SIZE), privDerLen);
     idx = 0;
     ExpectIntEQ(wc_Dilithium_PrivateKeyDecode(der, &idx, key, len), 0);
-#endif
 
-#ifndef WOLFSSL_ASN_TEMPLATE
-    ExpectIntEQ(len = wc_Dilithium_KeyToDer(key, der, DILITHIUM_MAX_DER_SIZE),
-        BAD_FUNC_ARG);
-#else
     ExpectIntEQ(len = wc_Dilithium_KeyToDer(key, der, DILITHIUM_MAX_DER_SIZE),
         keyDerLen);
     idx = 0;
     ExpectIntEQ(wc_Dilithium_PrivateKeyDecode(der, &idx, key, len), 0);
-#endif
 
 
     wc_dilithium_free(key);
@@ -3127,8 +3097,6 @@ int test_wc_dilithium_der(void)
 
     XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-
-    (void)keyDerLen;
 #endif
     return EXPECT_RESULT();
 }

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2763,7 +2763,7 @@ WOLFSSL_LOCAL int DecodeAsymKey(const byte* input, word32* inOutIdx,
 #endif
 
 #ifdef WC_ENABLE_ASYM_KEY_EXPORT
-WOLFSSL_LOCAL int SetAsymKeyDer(const byte* privKey, word32 privKeyLen,
+WOLFSSL_TEST_VIS int SetAsymKeyDer(const byte* privKey, word32 privKeyLen,
     const byte* pubKey, word32 pubKeyLen, byte* output, word32 outLen,
     int keyType);
 #endif


### PR DESCRIPTION
# Description

This PR improves original (=not template) implementation on `SetAsymKeyDer()` to export longer key length than 127.
The test are also added at the same time.

# Testing

./configure --enable-wolfclu && make test
./configure --enable-wolfclu --enable-asn=original && make test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
