### PR TITLE
WOLFSSL_ERROR_VERBOSE compress

### DIFF
--- a/src/dtls.c
+++ b/src/dtls.c
@@ -899,8 +899,7 @@ static int SendStatelessReply(const WOLFSSL* ssl, WolfSSL_CH* ch, byte isTls13)
                 DTLS_COOKIE_SZ);
 #else
         WOLFSSL_MSG("DTLS1.2 disabled with WOLFSSL_NO_TLS12");
-        WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
-        ret = NOT_COMPILED_IN;
+        ret = WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
 #endif
     }
     return ret;

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -391,8 +391,7 @@ int Dtls13ProcessBufferedMessages(WOLFSSL* ssl)
                     msg->sz, msg->sz);
 #else
             WOLFSSL_MSG("DTLS1.2 disabled with WOLFSSL_NO_TLS12");
-            WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
-            ret = NOT_COMPILED_IN;
+            ret = WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
 #endif
         }
 
@@ -1669,8 +1668,7 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
             case hello_request:
                 if (!w64Equal(ssl->keys.curEpoch64, plainEpoch)) {
                     WOLFSSL_MSG("Msg should be epoch 0");
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                    return SANITY_MSG_E;
+                    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                 }
                 break;
             case encrypted_extensions:
@@ -1684,14 +1682,12 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
                          * will be negotiated.  */
                         if (!w64Equal(ssl->keys.curEpoch64, plainEpoch)) {
                             WOLFSSL_MSG("Msg should be epoch 2 or 0");
-                            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                            return SANITY_MSG_E;
+                            return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                         }
                     }
                     else {
                         WOLFSSL_MSG("Msg should be epoch 2");
-                        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                        return SANITY_MSG_E;
+                        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                     }
                 }
                 break;
@@ -1707,14 +1703,12 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
                              * will be negotiated.  */
                             if (!w64Equal(ssl->keys.curEpoch64, plainEpoch)) {
                                 WOLFSSL_MSG("Msg should be epoch 2 or 0");
-                                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                                return SANITY_MSG_E;
+                                return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                             }
                         }
                         else {
                             WOLFSSL_MSG("Msg should be epoch 2");
-                            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                            return SANITY_MSG_E;
+                            return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                         }
                     }
                 }
@@ -1722,8 +1716,7 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
                     /* Allow epoch 2 in case of rtx */
                     if (!w64GTE(ssl->keys.curEpoch64, hsEpoch)) {
                         WOLFSSL_MSG("Msg should be epoch 2+");
-                        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                        return SANITY_MSG_E;
+                        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                     }
                 }
                 break;
@@ -1733,8 +1726,7 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
             case session_ticket:
                 if (!w64GTE(ssl->keys.curEpoch64, t0Epoch)) {
                     WOLFSSL_MSG("Msg should be epoch 3+");
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                    return SANITY_MSG_E;
+                    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                 }
                 break;
             case end_of_early_data:
@@ -1742,8 +1734,7 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
             case no_shake:
             default:
                 WOLFSSL_MSG("Unknown message type");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                return SANITY_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         }
     }
     return 0;
@@ -3011,21 +3002,18 @@ int Dtls13CheckAEADFailLimit(WOLFSSL* ssl)
             return 0;
         default:
             WOLFSSL_MSG("Unrecognized ciphersuite for AEAD limit check");
-            WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
-            return DECRYPT_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
     }
     if (ssl->dtls13DecryptEpoch == NULL) {
         WOLFSSL_MSG("Dtls13CheckAEADFailLimit: ssl->dtls13DecryptEpoch should "
                     "not be NULL");
-        WOLFSSL_ERROR_VERBOSE(BAD_STATE_E);
-        return BAD_STATE_E;
+        return WOLFSSL_ERROR_VERBOSE(BAD_STATE_E);
     }
     w64Increment(&ssl->dtls13DecryptEpoch->dropCount);
     if (w64GT(ssl->dtls13DecryptEpoch->dropCount, hardLimit)) {
         /* We have reached the hard limit for failed decryptions. */
         WOLFSSL_MSG("Connection exceeded hard AEAD limit");
-        WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
-        return DECRYPT_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
     }
     else if (w64GT(ssl->dtls13DecryptEpoch->dropCount, keyUpdateLimit)) {
         WOLFSSL_MSG("Connection exceeded key update limit. Issuing key update");

--- a/src/internal.c
+++ b/src/internal.c
@@ -2518,8 +2518,7 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     if (ret < 0) {
         WOLFSSL_MSG("Mutex error on CTX init");
         ctx->err = CTX_INIT_MUTEX_E;
-        WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
-        return BAD_MUTEX_E;
+        return WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
     }
 #else
     (void)ret;
@@ -2657,8 +2656,7 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     ctx->cm = wolfSSL_CertManagerNew_ex(heap);
     if (ctx->cm == NULL) {
         WOLFSSL_MSG("Bad Cert Manager New");
-        WOLFSSL_ERROR_VERBOSE(BAD_CERT_MANAGER_ERROR);
-        return BAD_CERT_MANAGER_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(BAD_CERT_MANAGER_ERROR);
     }
     #ifdef OPENSSL_EXTRA
     /* setup WOLFSSL_X509_STORE */
@@ -2695,8 +2693,7 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
 
     if (wc_InitMutex(&ctx->x509_store.lookup.dirs->lock) != 0) {
         WOLFSSL_MSG("Bad mutex init");
-        WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
-        return BAD_MUTEX_E;
+        return WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
     }
     #endif
 #endif
@@ -5277,8 +5274,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
                 ret = wc_RsaPSS_CheckPadding(plain, plainSz, out, (word32)ret,
                                              hashType);
                 if (ret != 0) {
-                    ret = VERIFY_CERT_ERROR;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(VERIFY_CERT_ERROR);
                 }
             }
         }
@@ -5297,8 +5293,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
                                                 mp_count_bits(&key->n));
     #endif
                 if (ret != 0) {
-                    ret = VERIFY_CERT_ERROR;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(VERIFY_CERT_ERROR);
                 }
             }
         }
@@ -5328,8 +5323,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
             if (ret != (int)plainSz || !out ||
                                             XMEMCMP(plain, out, plainSz) != 0) {
                 WOLFSSL_MSG("RSA Signature verification failed");
-                ret = RSA_SIGN_FAULT;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(RSA_SIGN_FAULT);
             }
             else {
                 ret = 0;  /* RSA reset */
@@ -5599,7 +5593,7 @@ int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* out,
             if (ret == 0) {
                 ret = VERIFY_SIGN_ERROR;
             }
-            WOLFSSL_ERROR_VERBOSE(ret);
+            (void)WOLFSSL_ERROR_VERBOSE(ret);
         }
         else {
             ret = 0;
@@ -5797,7 +5791,7 @@ int Sm2wSm3Verify(WOLFSSL* ssl, const byte* id, word32 idSz, const byte* sig,
         }
     }
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     WOLFSSL_LEAVE("Sm2wSm3Verify", ret);
@@ -6549,8 +6543,7 @@ int DhAgree(WOLFSSL* ssl, DhKey* dhKey,
         }
         if (ret != 0) {
             /* translate to valid error (wc_DhCheckPubValue returns MP_VAL -1) */
-            ret = PEER_KEY_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
 
     #ifdef OPENSSL_EXTRA
             SendAlert(ssl, alert_fatal, illegal_parameter);
@@ -6757,8 +6750,7 @@ int InitSSL_Suites(WOLFSSL* ssl)
         /* server certificate must be loaded */
         if (!ssl->buffers.certificate || !ssl->buffers.certificate->buffer) {
             WOLFSSL_MSG("Server missing certificate");
-            WOLFSSL_ERROR_VERBOSE(NO_PRIVATE_KEY);
-            return NO_PRIVATE_KEY;
+            return WOLFSSL_ERROR_VERBOSE(NO_PRIVATE_KEY);
         }
 
         if (!ssl->buffers.key || !ssl->buffers.key->buffer) {
@@ -6775,8 +6767,7 @@ int InitSSL_Suites(WOLFSSL* ssl)
         #endif
             {
                 WOLFSSL_MSG("Server missing private key");
-                WOLFSSL_ERROR_VERBOSE(NO_PRIVATE_KEY);
-                return NO_PRIVATE_KEY;
+                return WOLFSSL_ERROR_VERBOSE(NO_PRIVATE_KEY);
             }
         }
     }
@@ -6862,8 +6853,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1.3 set but not "
                         "allowed and downgrading disabled.");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1.3, Downgrading");
         ssl->version.minor = TLSv1_2_MINOR;
@@ -6874,8 +6864,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1.2 set but not "
                         "allowed and downgrading disabled.");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1.2, Downgrading");
         ssl->version.minor = TLSv1_1_MINOR;
@@ -6885,8 +6874,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1.1 set but not "
                         "allowed and downgrading disabled.");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1.1, Downgrading");
         ssl->options.tls1_1 = 0;
@@ -6897,8 +6885,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1 set but not "
                         "allowed and downgrading disabled.");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1, Downgrading");
         ssl->options.tls    = 0;
@@ -6908,14 +6895,12 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     if (ssl->version.minor == SSLv3_MINOR &&
         (ssl->options.mask & WOLFSSL_OP_NO_SSLv3) == WOLFSSL_OP_NO_SSLv3) {
         WOLFSSL_MSG("\tError, option set to not allow SSLv3");
-        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-        return VERSION_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
     }
 
     if (ssl->version.minor < ssl->options.minDowngrade) {
         WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
-        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-        return VERSION_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
     }
 #endif
 
@@ -7534,8 +7519,7 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
             WOLFSSL_MSG("Bad memory_mutex lock");
             XFREE(ssl->heap, ctx->heap, DYNAMIC_TYPE_SSL);
             ssl->heap = NULL; /* free and set to NULL for IO counter */
-            WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
-            return BAD_MUTEX_E;
+            return WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
         }
     #endif
         if (ctx_hint->memory->maxHa > 0 &&
@@ -7581,8 +7565,7 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         #ifndef SINGLE_THREADED
             if (wc_LockMutex(&(ctx_hint->memory->memory_mutex)) != 0) {
                 WOLFSSL_MSG("Bad memory_mutex lock");
-                WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
-                return BAD_MUTEX_E;
+                return WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
             }
         #endif
             if (SetFixedIO(ctx_hint->memory, &(ssl_hint->inBuf)) != 1) {
@@ -9544,8 +9527,7 @@ int DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch, const byte* data, byte ty
 
     if (msg == NULL || data == NULL || msg->sz != totalLen ||
             fragOffsetEnd > totalLen) {
-        WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
-        return BAD_FUNC_ARG;
+        return WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
     }
 
     if (msg->ready)
@@ -9554,8 +9536,7 @@ int DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch, const byte* data, byte ty
     if (msg->type != no_shake) {
         /* msg is already populated with the correct seq, epoch, and type */
         if (msg->type != type || msg->epoch != epoch || msg->seq != seq) {
-            WOLFSSL_ERROR_VERBOSE(SEQUENCE_ERROR);
-            return SEQUENCE_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(SEQUENCE_ERROR);
         }
         msg->encrypted = msg->encrypted && encrypted;
     }
@@ -9601,8 +9582,7 @@ int DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch, const byte* data, byte ty
                 /* We reached the end of the list. data is after and disjointed
                  * from anything we have received so far. */
                 if (msg->fragBucketListCount >= DTLS_FRAG_POOL_SZ) {
-                    WOLFSSL_ERROR_VERBOSE(DTLS_TOO_MANY_FRAGMENTS_E);
-                    return DTLS_TOO_MANY_FRAGMENTS_E;
+                    return WOLFSSL_ERROR_VERBOSE(DTLS_TOO_MANY_FRAGMENTS_E);
                 }
                 prev->m.m.next =
                         DtlsMsgCreateFragBucket(fragOffset, data, fragSz, heap);
@@ -9614,8 +9594,7 @@ int DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch, const byte* data, byte ty
             else if (prev == NULL && fragOffsetEnd < cur->m.m.offset) {
                     /* This is the new first fragment we have received */
                     if (msg->fragBucketListCount >= DTLS_FRAG_POOL_SZ) {
-                        WOLFSSL_ERROR_VERBOSE(DTLS_TOO_MANY_FRAGMENTS_E);
-                        return DTLS_TOO_MANY_FRAGMENTS_E;
+                        return WOLFSSL_ERROR_VERBOSE(DTLS_TOO_MANY_FRAGMENTS_E);
                     }
                     msg->fragBucketList = DtlsMsgCreateFragBucket(fragOffset, data,
                             fragSz, heap);
@@ -11413,8 +11392,7 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
             case change_cipher_hs:
                 if (encrypted) {
                     WOLFSSL_MSG("Message can not be encrypted");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 break;
             case hello_request:
@@ -11432,16 +11410,14 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
             case key_update:
                 if (!encrypted) {
                     WOLFSSL_MSG("Message always has to be encrypted");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 break;
             case message_hash:
             case no_shake:
             default:
                 WOLFSSL_MSG("Unknown message type");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                return SANITY_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         }
     }
     else {
@@ -11449,8 +11425,7 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
             case client_hello:
                 if ((IsSCR(ssl) || ssl->options.handShakeDone) && !encrypted) {
                     WOLFSSL_MSG("Message has to be encrypted for SCR");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 break;
             case server_hello:
@@ -11468,23 +11443,20 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
                 if (IsSCR(ssl)) {
                     if (!encrypted) {
                         WOLFSSL_MSG("Message has to be encrypted during SCR");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                        return OUT_OF_ORDER_E;
+                        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     }
                 }
                 else if (encrypted) {
                     WOLFSSL_MSG("Message can not be encrypted in regular "
                                 "handshake");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 break;
             case hello_request:
             case finished:
                 if (!encrypted) {
                     WOLFSSL_MSG("Message always has to be encrypted");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 break;
             case key_update:
@@ -11494,8 +11466,7 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
             case no_shake:
             default:
                 WOLFSSL_MSG("Unknown message type");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                return SANITY_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         }
     }
     return 0;
@@ -11527,8 +11498,7 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
                 case end_of_early_data:
                     if (!isLastMsg(ssl, msgSz)) {
                         WOLFSSL_MSG("Message type is not last in record");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                        return OUT_OF_ORDER_E;
+                        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     }
                     break;
                 case session_ticket:
@@ -11547,8 +11517,7 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
                 case no_shake:
                 default:
                     WOLFSSL_MSG("Unknown message type");
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                    return SANITY_MSG_E;
+                    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
             }
         }
         else {
@@ -11558,8 +11527,7 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
                 case hello_verify_request:
                     if (!isLastMsg(ssl, msgSz)) {
                         WOLFSSL_MSG("Message type is not last in record");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                        return OUT_OF_ORDER_E;
+                        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     }
                     break;
                 case server_hello:
@@ -11582,8 +11550,7 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
                 case no_shake:
                 default:
                     WOLFSSL_MSG("Unknown message type");
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                    return SANITY_MSG_E;
+                    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
             }
         }
     }
@@ -11594,8 +11561,7 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
             case hello_verify_request:
                 if (!isLastMsg(ssl, msgSz)) {
                     WOLFSSL_MSG("Message type is not last in record");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 break;
             case server_hello:
@@ -11618,8 +11584,7 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
             case no_shake:
             default:
                 WOLFSSL_MSG("Unknown message type");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                return SANITY_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         }
     }
     return 0;
@@ -12053,28 +12018,24 @@ static int GetRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
         #endif
                    )) {
             WOLFSSL_MSG("SSL version error");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;              /* only use requested version */
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);              /* only use requested version */
         }
     }
 
     /* record layer length check */
 #ifdef HAVE_MAX_FRAGMENT
     if (*size > (ssl->max_fragment + MAX_COMP_EXTRA + MAX_MSG_EXTRA)) {
-        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
-        return LENGTH_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
     }
 #else
     if (*size > (MAX_RECORD_SIZE + MAX_COMP_EXTRA + MAX_MSG_EXTRA)) {
-        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
-        return LENGTH_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
     }
 #endif
 
     if (*size == 0 && rh->type != application_data) {
         WOLFSSL_MSG("0 length, non-app data record.");
-        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
-        return LENGTH_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
     }
 
     /* verify record type here as well */
@@ -12109,8 +12070,7 @@ static int GetRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
             }
 #endif
             WOLFSSL_MSG("Unknown Record Type");
-            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
-            return UNKNOWN_RECORD_TYPE;
+            return WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
     }
 
     /* haven't decrypted this record yet */
@@ -13318,8 +13278,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         MBSTRING_ASC,
                                         (const byte*)dCert->cPwd,
                                         dCert->cPwdLen) != WOLFSSL_SUCCESS) {
-                ret = REQ_ATTRIBUTE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(REQ_ATTRIBUTE_E);
             }
         #endif
         }
@@ -13341,8 +13300,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->contentType,
                                         dCert->contentTypeLen) !=
                 WOLFSSL_SUCCESS) {
-            ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(REQ_ATTRIBUTE_E);
         }
     #endif
     }
@@ -13354,8 +13312,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         MBSTRING_ASC,
                                         (const byte*)dCert->sNum,
                                         dCert->sNumLen) != WOLFSSL_SUCCESS) {
-            ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(REQ_ATTRIBUTE_E);
         }
     }
     if (dCert->unstructuredName) {
@@ -13365,8 +13322,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->unstructuredName,
                                         dCert->unstructuredNameLen)
                 != WOLFSSL_SUCCESS) {
-            ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(REQ_ATTRIBUTE_E);
         }
     }
     if (dCert->surname) {
@@ -13375,8 +13331,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         MBSTRING_ASC,
                                         (const byte*)dCert->surname,
                                         dCert->surnameLen) != WOLFSSL_SUCCESS) {
-            ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(REQ_ATTRIBUTE_E);
         }
     }
     if (dCert->givenName) {
@@ -13385,8 +13340,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         MBSTRING_ASC,
                                         (const byte*)dCert->givenName,
                                         dCert->givenNameLen) != WOLFSSL_SUCCESS) {
-            ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(REQ_ATTRIBUTE_E);
         }
     }
     if (dCert->dnQualifier) {
@@ -13395,8 +13349,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         MBSTRING_ASC,
                                         (const byte*)dCert->dnQualifier,
                                         dCert->dnQualifierLen) != WOLFSSL_SUCCESS) {
-            ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(REQ_ATTRIBUTE_E);
         }
     }
     if (dCert->initials) {
@@ -13405,8 +13358,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         MBSTRING_ASC,
                                         (const byte*)dCert->initials,
                                         dCert->initialsLen) != WOLFSSL_SUCCESS) {
-            ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(REQ_ATTRIBUTE_E);
         }
     }
     #endif /* OPENSSL_ALL */
@@ -13427,8 +13379,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 
     if (x509->issuer.name == NULL || x509->subject.name == NULL) {
         WOLFSSL_MSG("Either init was not called on X509 or programming error");
-        WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
-        return BAD_FUNC_ARG;
+        return WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
     }
 
     x509->version = dCert->version + 1;
@@ -13533,8 +13484,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
             } else {
                 if (!(x509->key.algor->algorithm =
                     wolfSSL_OBJ_nid2obj(oid2nid(dCert->keyOID, oidKeyType)))) {
-                    ret = PUBLIC_KEY_E;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(PUBLIC_KEY_E);
                 }
             }
 
@@ -13542,8 +13492,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
             if (!(x509->key.pkey = wolfSSL_d2i_PUBKEY(NULL,
                                                       &dCert->publicKey,
                                                       dCert->pubKeySize))) {
-                ret = PUBLIC_KEY_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(PUBLIC_KEY_E);
             }
         }
 #endif
@@ -13565,8 +13514,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
         wolfSSL_ASN1_OBJECT_free(x509->algor.algorithm);
         if (!(x509->algor.algorithm =
                 wolfSSL_OBJ_nid2obj(oid2nid(dCert->signatureOID, oidSigType)))) {
-            ret = PUBLIC_KEY_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(PUBLIC_KEY_E);
         }
 #endif
     }
@@ -14392,8 +14340,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int cert_err,
                 if (CheckForAltNames(args->dCert, ssl->param->hostName,
                     (word32)XSTRLEN(ssl->param->hostName), NULL, 0) != 1) {
                     if (cert_err == 0) {
-                        ret = DOMAIN_NAME_MISMATCH;
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        ret = WOLFSSL_ERROR_VERBOSE(DOMAIN_NAME_MISMATCH);
                     }
                 }
             }
@@ -14406,8 +14353,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int cert_err,
                             ssl->param->hostName,
                             (word32)XSTRLEN(ssl->param->hostName), 0) == 0) {
                         if (cert_err == 0) {
-                            ret = DOMAIN_NAME_MISMATCH;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(DOMAIN_NAME_MISMATCH);
                         }
                     }
                 }
@@ -14415,8 +14361,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int cert_err,
         #else
             else {
                 if (cert_err == 0) {
-                    ret = DOMAIN_NAME_MISMATCH;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(DOMAIN_NAME_MISMATCH);
                 }
             }
         #endif /* !WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY */
@@ -14427,8 +14372,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int cert_err,
             (ssl->param != NULL) && (XSTRLEN(ssl->param->ipasc) > 0)) {
             if (CheckIPAddr(args->dCert, ssl->param->ipasc) != 0) {
                 if (cert_err == 0) {
-                    ret = IPADDR_MISMATCH;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(IPADDR_MISMATCH);
                 }
             }
         }
@@ -14519,8 +14463,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int cert_err,
         if (verifyFail) {
             /* induce error if one not present */
             if (cert_err == 0) {
-                ret = VERIFY_CERT_ERROR;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(VERIFY_CERT_ERROR);
             }
 
             /* mark as verify error */
@@ -14762,8 +14705,7 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
                 if (wc_LockMutex(&lookup->dirs->lock) != 0) {
                     WOLFSSL_MSG("wc_LockMutex cdir Lock error");
                     XFREE(filename, NULL, DYNAMIC_TYPE_OPENSSL);
-                    WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
-                    return BAD_MUTEX_E;
+                    return WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
                 }
                 if (ph == NULL) {
                     ph = wolfSSL_BY_DIR_HASH_new();
@@ -15017,8 +14959,7 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                      (word16)ssl->options.minRsaKeySz) {
                 WOLFSSL_MSG(
                     "RSA key size in cert chain error");
-                ret = RSA_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(RSA_KEY_SIZE_E);
             }
             break;
     #endif /* !NO_RSA */
@@ -15029,8 +14970,7 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                      (word16)ssl->options.minEccKeySz) {
                 WOLFSSL_MSG(
                     "ECC key size in cert chain error");
-                ret = ECC_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(ECC_KEY_SIZE_E);
             }
             break;
     #endif /* HAVE_ECC */
@@ -15040,8 +14980,7 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                     ED25519_KEY_SIZE < (word16)ssl->options.minEccKeySz) {
                 WOLFSSL_MSG(
                     "ECC key size in cert chain error");
-                ret = ECC_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(ECC_KEY_SIZE_E);
             }
             break;
     #endif /* HAVE_ED25519 */
@@ -15051,8 +14990,7 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                     ED448_KEY_SIZE < (word16)ssl->options.minEccKeySz) {
                 WOLFSSL_MSG(
                     "ECC key size in cert chain error");
-                ret = ECC_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(ECC_KEY_SIZE_E);
             }
             break;
     #endif /* HAVE_ED448 */
@@ -15061,16 +14999,14 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
             if (ssl->options.minFalconKeySz < 0 ||
                 FALCON_LEVEL1_KEY_SIZE < (word16)ssl->options.minFalconKeySz) {
                 WOLFSSL_MSG("Falcon key size in cert chain error");
-                ret = FALCON_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(FALCON_KEY_SIZE_E);
             }
             break;
         case FALCON_LEVEL5k:
             if (ssl->options.minFalconKeySz < 0 ||
                 FALCON_LEVEL5_KEY_SIZE < (word16)ssl->options.minFalconKeySz) {
                 WOLFSSL_MSG("Falcon key size in cert chain error");
-                ret = FALCON_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(FALCON_KEY_SIZE_E);
             }
             break;
     #endif /* HAVE_FALCON */
@@ -15168,7 +15104,7 @@ static int ProcessPeerCertsChainOCSPStatusCheck(WOLFSSL* ssl)
                     csr->responses[i].buffer,
                     &idx, csr->responses[i].length, i);
             if (ret < 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
+                (void)WOLFSSL_ERROR_VERBOSE(ret);
                 break;
             }
         }
@@ -15198,7 +15134,7 @@ static int ProcessPeerCertsChainCRLCheck(WOLFSSL* ssl, ProcPeerCertArgs* args)
         if (ret != 0)
             DoCrlCallback(cm, ssl, args, &ret);
         if (ret != 0){
-            WOLFSSL_ERROR_VERBOSE(ret);
+            (void)WOLFSSL_ERROR_VERBOSE(ret);
             WOLFSSL_MSG("\tCRL check not ok");
             break;
         }
@@ -15330,8 +15266,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 /* Must be empty when received from server. */
                 if (ssl->options.side == WOLFSSL_CLIENT_END) {
                     if (ctxSz != 0) {
-                        WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E);
-                        ERROR_OUT(INVALID_CERT_CTX_E, exit_ppc);
+                        ERROR_OUT(WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E), exit_ppc);
                     }
                 }
             #endif
@@ -15340,8 +15275,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 if (ssl->options.side == WOLFSSL_SERVER_END) {
                     if (ssl->options.handShakeState != HANDSHAKE_DONE &&
                                                                    ctxSz != 0) {
-                        WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E);
-                        ERROR_OUT(INVALID_CERT_CTX_E, exit_ppc);
+                        ERROR_OUT(WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E), exit_ppc);
                     }
                     else if (ssl->options.handShakeState == HANDSHAKE_DONE) {
                 #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
@@ -15365,8 +15299,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         if (curr == NULL)
                 #endif
                         {
-                            WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E);
-                            ERROR_OUT(INVALID_CERT_CTX_E, exit_ppc);
+                            ERROR_OUT(WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E), exit_ppc);
                         }
                     }
                 }
@@ -15433,8 +15366,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     if (ssl->peerVerifyRet == 0) /* Return first cert error here */
                         ssl->peerVerifyRet =
                                         WOLFSSL_X509_V_ERR_CERT_CHAIN_TOO_LONG;
-                    ret = MAX_CHAIN_ERROR;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(MAX_CHAIN_ERROR);
                     WOLFSSL_MSG("Too many certs for MAX_CHAIN_DEPTH");
                     break; /* break out to avoid reading more certs then buffer
                             * can hold */
@@ -15442,8 +15374,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             #else
                 if (args->totalCerts >= ssl->verifyDepth ||
                         args->totalCerts >= MAX_CHAIN_DEPTH) {
-                    WOLFSSL_ERROR_VERBOSE(MAX_CHAIN_ERROR);
-                    ERROR_OUT(MAX_CHAIN_ERROR, exit_ppc);
+                    ERROR_OUT(WOLFSSL_ERROR_VERBOSE(MAX_CHAIN_ERROR), exit_ppc);
                 }
             #endif
 
@@ -15501,8 +15432,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         certificate, NULL);
                     #endif /* !NO_TLS */
                     if (ret < 0) {
-                        WOLFSSL_ERROR_VERBOSE(ret);
-                        ERROR_OUT(ret, exit_ppc);
+                        ERROR_OUT(WOLFSSL_ERROR_VERBOSE(ret), exit_ppc);
                     }
                 }
             #endif
@@ -15521,14 +15451,12 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                              IsAtLeastTLSv1_3(ssl->version)))) {
                     WOLFSSL_MSG("No peer cert from Client");
                     ret = NO_PEER_CERT;
-                    WOLFSSL_ERROR_VERBOSE(ret);
-                    DoCertFatalAlert(ssl, ret);
+                    DoCertFatalAlert(ssl, WOLFSSL_ERROR_VERBOSE(ret));
                 }
                 else if ((ssl->options.side == WOLFSSL_CLIENT_END) &&
                          IsAtLeastTLSv1_3(ssl->version)) {
                     WOLFSSL_MSG("No peer cert from Server");
-                    ret = NO_PEER_CERT;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(NO_PEER_CERT);
                     SendAlert(ssl, alert_fatal, decode_error);
                 }
             }
@@ -15631,8 +15559,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 &subjectHash, &alreadySigner);
                         }
                         else {
-                            ret = ASN_NO_SIGNER_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(ASN_NO_SIGNER_E);
                         }
                     }
 #endif
@@ -15715,7 +15642,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             }
                         #endif
                             if (ret != 0) {
-                                WOLFSSL_ERROR_VERBOSE(ret);
+                                (void)WOLFSSL_ERROR_VERBOSE(ret);
                                 WOLFSSL_MSG("\tOCSP Lookup not ok");
                             }
                         }
@@ -15754,7 +15681,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 if (ret != 0)
                                     DoCrlCallback(SSL_CM(ssl), ssl, args, &ret);
                                 if (ret != 0) {
-                                    WOLFSSL_ERROR_VERBOSE(ret);
+                                    (void)WOLFSSL_ERROR_VERBOSE(ret);
                                     WOLFSSL_MSG("\tCRL check not ok");
                                 }
                                 if (ret == 0 &&
@@ -15762,7 +15689,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                     ret = ProcessPeerCertsChainCRLCheck(ssl,
                                             args);
                                     if (ret != 0) {
-                                        WOLFSSL_ERROR_VERBOSE(ret);
+                                        (void)WOLFSSL_ERROR_VERBOSE(ret);
                                         WOLFSSL_MSG("\tCRL chain check not ok");
                                         args->fatal = 0;
                                     }
@@ -15779,8 +15706,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         if (ssl->peerVerifyRet == 0) /* Return first cert error here */
                             ssl->peerVerifyRet =
                                          WOLFSSL_X509_V_ERR_CERT_CHAIN_TOO_LONG;
-                        ret = MAX_CHAIN_ERROR;
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        ret = WOLFSSL_ERROR_VERBOSE(MAX_CHAIN_ERROR);
                     }
             #endif
                 #ifdef WOLFSSL_ALT_CERT_CHAINS
@@ -15960,8 +15886,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                        * callback overrides. */
                     if (ret != 0) {
                         if (!ssl->options.verifyNone) {
-                            WOLFSSL_ERROR_VERBOSE(ret);
-                            DoCertFatalAlert(ssl, ret);
+                            DoCertFatalAlert(ssl, WOLFSSL_ERROR_VERBOSE(ret));
                             args->lastErr = ret;
                             break; /* We sent a fatal alert.
                                     * No point continuing. */
@@ -16020,8 +15945,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 &subjectHash, &alreadySigner);
                         }
                         else {
-                            ret = lastErr; /* restore error */
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(lastErr);
                         }
                     }
 #endif
@@ -16162,8 +16086,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 WOLFSSL_MSG(
                                   "Peer sent different cert during scr, fatal");
                                 args->fatal = 1;
-                                ret = SCR_DIFFERENT_CERT_E;
-                                WOLFSSL_ERROR_VERBOSE(ret);
+                                ret = WOLFSSL_ERROR_VERBOSE(SCR_DIFFERENT_CERT_E);
                             }
                         }
                     }
@@ -16211,7 +16134,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             if (ssl->options.tls1_3) {
                                 ret = ProcessPeerCertsChainOCSPStatusCheck(ssl);
                                 if (ret < 0) {
-                                    WOLFSSL_ERROR_VERBOSE(ret);
+                                    (void)WOLFSSL_ERROR_VERBOSE(ret);
                                     goto exit_ppc;
                                 }
                             }
@@ -16296,7 +16219,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         if (args->dCert->ca != NULL) {
                             ret = ProcessPeerCertsChainCRLCheck(ssl, args);
                             if (ret != 0) {
-                                WOLFSSL_ERROR_VERBOSE(ret);
+                                (void)WOLFSSL_ERROR_VERBOSE(ret);
                                 WOLFSSL_MSG("\tCRL chain check not ok");
                                 args->fatal = 0;
                             }
@@ -16339,8 +16262,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     if ((ssl->specs.kea == rsa_kea) &&
                         (ssl->options.side == WOLFSSL_CLIENT_END) &&
                         (args->dCert->extKeyUsage & KEYUSE_KEY_ENCIPHER) == 0) {
-                        ret = KEYUSE_ENCIPHER_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        ret = WOLFSSL_ERROR_VERBOSE(KEYUSE_ENCIPHER_E);
                     }
                     if ((ssl->specs.kea != rsa_kea) &&
                         (ssl->specs.sig_algo == rsa_sa_algo ||
@@ -16348,8 +16270,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                  !ssl->specs.static_ecdh)) &&
                         (args->dCert->extKeyUsage & KEYUSE_DIGITAL_SIG) == 0) {
                         WOLFSSL_MSG("KeyUse Digital Sig not set");
-                        ret = KEYUSE_SIGNATURE_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        ret = WOLFSSL_ERROR_VERBOSE(KEYUSE_SIGNATURE_E);
                     }
                 }
 
@@ -16368,16 +16289,14 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         if ((args->dCert->extExtKeyUsage &
                                 (EXTKEYUSE_ANY | EXTKEYUSE_SERVER_AUTH)) == 0) {
                             WOLFSSL_MSG("ExtKeyUse Server Auth not set");
-                            ret = EXTKEYUSE_AUTH_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(EXTKEYUSE_AUTH_E);
                         }
                     }
                     else {
                         if ((args->dCert->extExtKeyUsage &
                                 (EXTKEYUSE_ANY | EXTKEYUSE_CLIENT_AUTH)) == 0) {
                             WOLFSSL_MSG("ExtKeyUse Client Auth not set");
-                            ret = EXTKEYUSE_AUTH_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(EXTKEYUSE_AUTH_E);
                         }
                     }
                 }
@@ -16424,8 +16343,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 NULL, 0) != 1) {
                             WOLFSSL_MSG("DomainName match on alt names failed");
                             /* try to get peer key still */
-                            ret = DOMAIN_NAME_MISMATCH;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(DOMAIN_NAME_MISMATCH);
                         }
                     }
                     else {
@@ -16439,8 +16357,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 ), 0) == 0)
                         {
                             WOLFSSL_MSG("DomainName match on common name failed");
-                            ret = DOMAIN_NAME_MISMATCH;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(DOMAIN_NAME_MISMATCH);
                         }
                     }
                 #else /* WOLFSSL_ALL_NO_CN_IN_SAN */
@@ -16460,8 +16377,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             WOLFSSL_MSG(
                                 "DomainName match on alt names failed too");
                             /* try to get peer key still */
-                            ret = DOMAIN_NAME_MISMATCH;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(DOMAIN_NAME_MISMATCH);
                         }
                     }
                 #endif /* WOLFSSL_ALL_NO_CN_IN_SAN */
@@ -16490,8 +16406,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         if (keyRet != 0 || wc_RsaPublicKeyDecode(
                                args->dCert->publicKey, &keyIdx, ssl->peerRsaKey,
                                                 args->dCert->pubKeySize) != 0) {
-                            ret = PEER_KEY_ERROR;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
                         }
                         else {
                             ssl->peerRsaKeyPresent = 1;
@@ -16546,8 +16461,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                           !ssl->options.verifyNone &&
                                           wc_RsaEncryptSize(ssl->peerRsaKey)
                                               < ssl->options.minRsaKeySz) {
-                            ret = RSA_KEY_SIZE_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(RSA_KEY_SIZE_E);
                             WOLFSSL_MSG("Peer RSA key is too small");
                         }
                         break;
@@ -16594,8 +16508,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             wc_EccPublicKeyDecode(args->dCert->publicKey, &idx,
                                                 ssl->peerEccDsaKey,
                                                 args->dCert->pubKeySize) != 0) {
-                            ret = PEER_KEY_ERROR;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
                         }
                         else {
                             ssl->peerEccDsaKeyPresent = 1;
@@ -16625,8 +16538,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                               !ssl->options.verifyNone &&
                                               wc_ecc_size(ssl->peerEccDsaKey)
                                               < ssl->options.minEccKeySz) {
-                            ret = ECC_KEY_SIZE_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(ECC_KEY_SIZE_E);
                             WOLFSSL_MSG("Peer ECC key is too small");
                         }
 
@@ -16655,8 +16567,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                      args->dCert->pubKeySize,
                                                      ssl->peerEd25519Key)
                                                                          != 0) {
-                            ret = PEER_KEY_ERROR;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
                         }
                         else {
                             ssl->peerEd25519KeyPresent = 1;
@@ -16681,8 +16592,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         if (ret == 0 && ssl->peerEd25519KeyPresent &&
                                   !ssl->options.verifyNone &&
                                   ED25519_KEY_SIZE < ssl->options.minEccKeySz) {
-                            ret = ECC_KEY_SIZE_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(ECC_KEY_SIZE_E);
                             WOLFSSL_MSG("Peer ECC key is too small");
                         }
 
@@ -16710,8 +16620,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             wc_ed448_import_public(args->dCert->publicKey,
                                     args->dCert->pubKeySize,
                                     ssl->peerEd448Key) != 0) {
-                            ret = PEER_KEY_ERROR;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
                         }
                         else {
                             ssl->peerEd448KeyPresent = 1;
@@ -16736,8 +16645,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         if (ret == 0 && ssl->peerEd448KeyPresent &&
                                !ssl->options.verifyNone &&
                                ED448_KEY_SIZE < ssl->options.minEccKeySz) {
-                            ret = ECC_KEY_SIZE_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(ECC_KEY_SIZE_E);
                             WOLFSSL_MSG("Peer ECC key is too small");
                         }
 
@@ -16777,8 +16685,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             wc_falcon_import_public(args->dCert->publicKey,
                                                     args->dCert->pubKeySize,
                                                     ssl->peerFalconKey) != 0) {
-                            ret = PEER_KEY_ERROR;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
                         }
                         else {
                             ssl->peerFalconKeyPresent = 1;
@@ -16789,8 +16696,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                !ssl->options.verifyNone &&
                                FALCON_MAX_KEY_SIZE <
                                ssl->options.minFalconKeySz) {
-                            ret = FALCON_KEY_SIZE_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            ret = WOLFSSL_ERROR_VERBOSE(FALCON_KEY_SIZE_E);
                             WOLFSSL_MSG("Peer Falcon key is too small");
                         }
                         break;
@@ -16902,8 +16808,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             if (args->untrustedDepth > (ssl->options.verifyDepth + 1)) {
                 if (ssl->peerVerifyRet == 0) /* Return first cert error here */
                     ssl->peerVerifyRet = WOLFSSL_X509_V_ERR_CERT_CHAIN_TOO_LONG;
-                ret = MAX_CHAIN_ERROR;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(MAX_CHAIN_ERROR);
             }
         #endif
 
@@ -17202,7 +17107,7 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 #endif
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
         SendAlert(ssl, alert_fatal, bad_certificate_status_response);
     }
 
@@ -17250,8 +17155,7 @@ static int DoHelloRequest(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     if (ssl->options.side == WOLFSSL_SERVER_END) {
         SendAlert(ssl, alert_fatal, unexpected_message); /* try */
-        WOLFSSL_ERROR_VERBOSE(FATAL_ERROR);
-        return FATAL_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(FATAL_ERROR);
     }
 #ifdef HAVE_SECURE_RENEGOTIATION
     else if (ssl->secure_renegotiation && ssl->secure_renegotiation->enabled) {
@@ -17294,8 +17198,7 @@ int DoFinished(WOLFSSL* ssl, const byte* input, word32* inOutIdx, word32 size,
     if (sniff == NO_SNIFF) {
         if (XMEMCMP(input + *inOutIdx, &ssl->hsHashes->verifyHashes,size) != 0){
             WOLFSSL_MSG("Verify finished error on hashes");
-            WOLFSSL_ERROR_VERBOSE(VERIFY_FINISHED_ERROR);
-            return VERIFY_FINISHED_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_FINISHED_ERROR);
         }
     }
 
@@ -17393,14 +17296,12 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("HelloRequest received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             if (ssl->msgsReceived.got_hello_request) {
                 WOLFSSL_MSG("Duplicate HelloRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_hello_request = 1;
 
@@ -17412,14 +17313,12 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_CLIENT
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("ClientHello received by client");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             if (ssl->msgsReceived.got_client_hello) {
                 WOLFSSL_MSG("Duplicate ClientHello received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_client_hello = 1;
 
@@ -17431,14 +17330,12 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerHello received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             if (ssl->msgsReceived.got_server_hello) {
                 WOLFSSL_MSG("Duplicate ServerHello received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_server_hello = 1;
 
@@ -17450,20 +17347,17 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("HelloVerifyRequest received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             if (ssl->msgsReceived.got_hello_verify_request) {
                 WOLFSSL_MSG("Duplicate HelloVerifyRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             if (ssl->msgsReceived.got_hello_retry_request) {
                 WOLFSSL_MSG("Received HelloVerifyRequest after a "
                             "HelloRetryRequest");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
             ssl->msgsReceived.got_hello_verify_request = 1;
 
@@ -17475,14 +17369,12 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("SessionTicket received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             if (ssl->msgsReceived.got_session_ticket) {
                 WOLFSSL_MSG("Duplicate SessionTicket received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_session_ticket = 1;
 
@@ -17492,8 +17384,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         case certificate:
             if (ssl->msgsReceived.got_certificate) {
                 WOLFSSL_MSG("Duplicate Certificate received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_certificate = 1;
 
@@ -17501,8 +17392,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 if ( ssl->msgsReceived.got_server_hello == 0) {
                     WOLFSSL_MSG("No ServerHello before Cert");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
             }
 #endif
@@ -17510,8 +17400,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 if ( ssl->msgsReceived.got_client_hello == 0) {
                     WOLFSSL_MSG("No ClientHello before Cert");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
             }
 #endif
@@ -17522,26 +17411,22 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("CertificateStatus received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             if (ssl->msgsReceived.got_certificate_status) {
                 WOLFSSL_MSG("Duplicate CertificateStatus received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_certificate_status = 1;
 
             if (ssl->msgsReceived.got_certificate == 0) {
                 WOLFSSL_MSG("No Certificate before CertificateStatus");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
             if (ssl->msgsReceived.got_server_key_exchange != 0) {
                 WOLFSSL_MSG("CertificateStatus after ServerKeyExchange");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
 
             break;
@@ -17552,21 +17437,18 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerKeyExchange received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             if (ssl->msgsReceived.got_server_key_exchange) {
                 WOLFSSL_MSG("Duplicate ServerKeyExchange received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_server_key_exchange = 1;
 
             if (ssl->msgsReceived.got_server_hello == 0) {
                 WOLFSSL_MSG("No ServerHello before ServerKeyExchange");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
 
             break;
@@ -17577,14 +17459,12 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("CertificateRequest received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             if (ssl->msgsReceived.got_certificate_request) {
                 WOLFSSL_MSG("Duplicate CertificateRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_certificate_request = 1;
 
@@ -17596,14 +17476,12 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerHelloDone received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             if (ssl->msgsReceived.got_server_hello_done) {
                 WOLFSSL_MSG("Duplicate ServerHelloDone received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_server_hello_done = 1;
 
@@ -17616,8 +17494,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                 }
                 else {
                     WOLFSSL_MSG("No Certificate before ServerHelloDone");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
             }
             if (ssl->msgsReceived.got_server_key_exchange == 0) {
@@ -17636,8 +17513,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                 }
                 else {
                     WOLFSSL_MSG("No ServerKeyExchange before ServerDone");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
             }
 #if defined(HAVE_CERTIFICATE_STATUS_REQUEST) || \
@@ -17683,8 +17559,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                      !ssl->status_request_v2 &&
 #endif
                                                  SSL_CM(ssl)->ocspMustStaple) {
-                    WOLFSSL_ERROR_VERBOSE(OCSP_CERT_UNKNOWN);
-                    return OCSP_CERT_UNKNOWN;
+                    return WOLFSSL_ERROR_VERBOSE(OCSP_CERT_UNKNOWN);
                 }
             }
 #endif
@@ -17696,21 +17571,18 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_CLIENT
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("CertificateVerify received by client");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             if (ssl->msgsReceived.got_certificate_verify) {
                 WOLFSSL_MSG("Duplicate CertificateVerify received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_certificate_verify = 1;
 
             if ( ssl->msgsReceived.got_certificate == 0) {
                 WOLFSSL_MSG("No Cert before CertVerify");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
             break;
 #endif
@@ -17720,21 +17592,18 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_CLIENT
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("ClientKeyExchange received by client");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             if (ssl->msgsReceived.got_client_key_exchange) {
                 WOLFSSL_MSG("Duplicate ClientKeyExchange received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_client_key_exchange = 1;
 
             if (ssl->msgsReceived.got_client_hello == 0) {
                 WOLFSSL_MSG("No ClientHello before ClientKeyExchange");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
             break;
 #endif
@@ -17742,15 +17611,13 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         case finished:
             if (ssl->msgsReceived.got_finished) {
                 WOLFSSL_MSG("Duplicate Finished received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
 #ifdef WOLFSSL_DTLS
             if (ssl->options.dtls) {
                 if (ssl->keys.curEpoch == 0) {
                     WOLFSSL_MSG("Finished received with epoch 0");
-                    WOLFSSL_ERROR_VERBOSE(SEQUENCE_ERROR);
-                    return SEQUENCE_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(SEQUENCE_ERROR);
                 }
             }
 #endif
@@ -17758,16 +17625,14 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
 
             if (ssl->msgsReceived.got_change_cipher == 0) {
                 WOLFSSL_MSG("Finished received before ChangeCipher");
-                WOLFSSL_ERROR_VERBOSE(NO_CHANGE_CIPHER_E);
-                return NO_CHANGE_CIPHER_E;
+                return WOLFSSL_ERROR_VERBOSE(NO_CHANGE_CIPHER_E);
             }
             break;
 
         case change_cipher_hs:
             if (ssl->msgsReceived.got_change_cipher) {
                 WOLFSSL_MSG("Duplicate ChangeCipher received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             /* DTLS is going to ignore the CCS message if the client key
              * exchange message wasn't received yet. */
@@ -17779,16 +17644,14 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                 if (!ssl->options.resuming) {
                    if (ssl->msgsReceived.got_server_hello_done == 0) {
                         WOLFSSL_MSG("No ServerHelloDone before ChangeCipher");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                        return OUT_OF_ORDER_E;
+                        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                    }
                 }
                 else {
                     if (ssl->msgsReceived.got_server_hello == 0) {
                         WOLFSSL_MSG("No ServerHello before ChangeCipher on "
                                     "Resume");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                        return OUT_OF_ORDER_E;
+                        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     }
                 }
                 #ifdef HAVE_SESSION_TICKET
@@ -17796,12 +17659,10 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                         WOLFSSL_MSG("Expected session ticket missing");
                         #ifdef WOLFSSL_DTLS
                             if (ssl->options.dtls) {
-                                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                                return OUT_OF_ORDER_E;
+                                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                             }
                         #endif
-                        WOLFSSL_ERROR_VERBOSE(SESSION_TICKET_EXPECT_E);
-                        return SESSION_TICKET_EXPECT_E;
+                        return WOLFSSL_ERROR_VERBOSE(SESSION_TICKET_EXPECT_E);
                     }
                 #endif
             }
@@ -17811,8 +17672,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                 if (!ssl->options.resuming &&
                                ssl->msgsReceived.got_client_key_exchange == 0) {
                     WOLFSSL_MSG("No ClientKeyExchange before ChangeCipher");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 #ifndef NO_CERTS
                     if (ssl->options.verifyPeer &&
@@ -17823,12 +17683,10 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                             WOLFSSL_MSG("client didn't send cert verify");
                             #ifdef WOLFSSL_DTLS
                                 if (ssl->options.dtls) {
-                                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                                    return OUT_OF_ORDER_E;
+                                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                                 }
                             #endif
-                            WOLFSSL_ERROR_VERBOSE(NO_PEER_VERIFY);
-                            return NO_PEER_VERIFY;
+                            return WOLFSSL_ERROR_VERBOSE(NO_PEER_VERIFY);
                         }
                     }
                 #endif
@@ -17840,8 +17698,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
 
         default:
             WOLFSSL_MSG("Unknown message type");
-            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-            return SANITY_MSG_E;
+            return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     return 0;
@@ -17865,8 +17722,7 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     /* make sure can read the message */
     if (*inOutIdx + size > totalSz) {
         WOLFSSL_MSG("Incomplete Data");
-        WOLFSSL_ERROR_VERBOSE(INCOMPLETE_DATA);
-        return INCOMPLETE_DATA;
+        return WOLFSSL_ERROR_VERBOSE(INCOMPLETE_DATA);
     }
 
     expectedIdx = *inOutIdx + size +
@@ -17918,8 +17774,7 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     if (ssl->options.handShakeState == HANDSHAKE_DONE && type != hello_request){
         WOLFSSL_MSG("HandShake message after handshake complete");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-        return OUT_OF_ORDER_E;
+        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
     }
 
     if (ssl->options.side == WOLFSSL_CLIENT_END && ssl->options.dtls == 0 &&
@@ -17928,8 +17783,7 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         WOLFSSL_MSG("First server message not server hello or "
                     "hello request");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-        return OUT_OF_ORDER_E;
+        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
     }
 
     if (ssl->options.side == WOLFSSL_CLIENT_END && ssl->options.dtls &&
@@ -17937,16 +17791,14 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             ssl->options.serverState < SERVER_HELLO_COMPLETE) {
         WOLFSSL_MSG("Server hello done received before server hello in DTLS");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-        return OUT_OF_ORDER_E;
+        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
     }
 
     if (ssl->options.side == WOLFSSL_SERVER_END &&
                ssl->options.clientState == NULL_STATE && type != client_hello) {
         WOLFSSL_MSG("First client message not client hello");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-        return OUT_OF_ORDER_E;
+        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
     }
 
     /* above checks handshake state */
@@ -17998,8 +17850,7 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                      * allow for reverting back to a full handshake after the
                      * server has indicated the intention to do a resumption. */
                     (void)SendAlert(ssl, alert_fatal, unexpected_message);
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
 #endif
                 /* This can occur when ssl->sessionSecretCb is set. EAP-FAST
@@ -18180,8 +18031,7 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         WOLFSSL_MSG("Extra data in handshake message");
         if (!ssl->options.dtls)
             SendAlert(ssl, alert_fatal, decode_error);
-        ret = DECODE_E;
-        WOLFSSL_ERROR_VERBOSE(ret);
+        ret = WOLFSSL_ERROR_VERBOSE(DECODE_E);
     }
 
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
@@ -18235,8 +18085,7 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         word32 size;
 
         if (GetHandshakeHeader(ssl,input,inOutIdx,&type, &size, totalSz) != 0) {
-            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
-            return PARSE_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
         }
 
         ret = EarlySanityCheckMsgReceived(ssl, type, size);
@@ -18247,8 +18096,7 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
         if (size > MAX_HANDSHAKE_SZ) {
             WOLFSSL_MSG("Handshake message too large");
-            WOLFSSL_ERROR_VERBOSE(HANDSHAKE_SIZE_ERROR);
-            return HANDSHAKE_SIZE_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(HANDSHAKE_SIZE_ERROR);
         }
 
         return DoHandShakeMsgType(ssl, input, inOutIdx, type, size, totalSz);
@@ -18264,8 +18112,7 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
         if (GetHandshakeHeader(ssl, input, inOutIdx, &type, &size,
                                totalSz) != 0) {
-            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
-            return PARSE_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
         }
 
         ret = EarlySanityCheckMsgReceived(ssl, type,
@@ -18280,8 +18127,7 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
          * nine 2048-bit RSA certificates in the chain. */
         if (size > MAX_HANDSHAKE_SZ) {
             WOLFSSL_MSG("Handshake message too large");
-            WOLFSSL_ERROR_VERBOSE(HANDSHAKE_SIZE_ERROR);
-            return HANDSHAKE_SIZE_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(HANDSHAKE_SIZE_ERROR);
         }
 
         /* size is the size of the certificate message payload */
@@ -19579,8 +19425,7 @@ int ChachaAEADDecrypt(WOLFSSL* ssl, byte* plain, const byte* input,
         WOLFSSL_MSG("MAC did not match");
         if (!ssl->options.dtls)
             SendAlert(ssl, alert_fatal, bad_record_mac);
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-        return VERIFY_MAC_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
     }
 
     /* if the tag was good decrypt message */
@@ -20010,8 +19855,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
 
         default:
             WOLFSSL_MSG("wolfSSL Encrypt programming error");
-            ret = ENCRYPT_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(ENCRYPT_ERROR);
     }
 
 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -20040,8 +19884,7 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
         {
             if (ssl->encrypt.setup == 0) {
                 WOLFSSL_MSG("Encrypt ciphers not setup");
-                WOLFSSL_ERROR_VERBOSE(ENCRYPT_ERROR);
-                return ENCRYPT_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(ENCRYPT_ERROR);
             }
 
         #ifdef WOLFSSL_CIPHER_TEXT_CHECK
@@ -20138,8 +19981,7 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
                     min(sz, sizeof(ssl->encrypt.sanityCheck))) == 0) {
 
                 WOLFSSL_MSG("Encrypt sanity check failed! Glitch?");
-                WOLFSSL_ERROR_VERBOSE(ENCRYPT_ERROR);
-                return ENCRYPT_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(ENCRYPT_ERROR);
             }
             ForceZero(ssl->encrypt.sanityCheck,
                 sizeof(ssl->encrypt.sanityCheck));
@@ -20476,8 +20318,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
 
         default:
             WOLFSSL_MSG("wolfSSL Decrypt programming error");
-            WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
-            ret = DECRYPT_ERROR;
+            ret = WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
     }
 
 #ifdef WOLFSSL_CHECK_MEM_ZERO
@@ -20518,8 +20359,7 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
         {
             if (ssl->decrypt.setup == 0) {
                 WOLFSSL_MSG("Decrypt ciphers not setup");
-                WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
-                return DECRYPT_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
             }
 
         #if defined(BUILD_AESGCM) || defined(HAVE_AESCCM) || defined(HAVE_ARIA)
@@ -20629,8 +20469,7 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
                     ForceZero(ssl->decrypt.nonce, AESGCM_NONCE_SZ);
 
                 if (ret < 0) {
-                    ret = VERIFY_MAC_ERROR;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
                 }
             }
         #endif /* BUILD_AESGCM || HAVE_AESCCM || HAVE_ARIA */
@@ -20642,8 +20481,7 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
                     ForceZero(ssl->decrypt.nonce, GCM_NONCE_SZ);
 
                 if (ret < 0) {
-                    ret = VERIFY_MAC_ERROR;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
                 }
             }
         #endif /* BUILD_AESGCM || HAVE_AESCCM */
@@ -20688,16 +20526,14 @@ static int SanityCheckCipherText(WOLFSSL* ssl, word32 encryptSz)
         if (ssl->options.startedETMRead) {
             if ((encryptSz - MacSize(ssl)) % ssl->specs.block_size) {
                 WOLFSSL_MSG("Block ciphertext not block size");
-                WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
-                return SANITY_CIPHER_E;
+                return WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
             }
         }
         else
 #endif
         if (encryptSz % ssl->specs.block_size) {
             WOLFSSL_MSG("Block ciphertext not block size");
-            WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
-            return SANITY_CIPHER_E;
+            return WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
         }
 
         minLength++;  /* pad byte */
@@ -20718,8 +20554,7 @@ static int SanityCheckCipherText(WOLFSSL* ssl, word32 encryptSz)
 
     if (encryptSz < minLength) {
         WOLFSSL_MSG("Ciphertext not minimum size");
-        WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
-        return SANITY_CIPHER_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
     }
 
     return 0;
@@ -20957,8 +20792,7 @@ static WC_INLINE int GetRounds(int pLen, int padLen, int t)
         /* still compare */
         ssl->hmac(ssl, verify, input, pLen - t, -1, content, 1, PEER_ORDER);
         ConstantCompare(verify, input + pLen - t, t);
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-        return VERIFY_MAC_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
     }
 
     if (PadCheck(input + pLen - (padLen + 1), (byte)padLen, padLen + 1) != 0) {
@@ -20967,8 +20801,7 @@ static WC_INLINE int GetRounds(int pLen, int padLen, int t)
         /* still compare */
         ssl->hmac(ssl, verify, input, pLen - t, -1, content, 1, PEER_ORDER);
         ConstantCompare(verify, input + pLen - t, t);
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-        return VERIFY_MAC_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
     }
 
     PadCheck(dummy, (byte)padLen, MAX_PAD_SIZE - padLen - 1);
@@ -20979,14 +20812,12 @@ static WC_INLINE int GetRounds(int pLen, int padLen, int t)
 
     if (ConstantCompare(verify, input + (pLen - padLen - 1 - t), t) != 0) {
         WOLFSSL_MSG("Verify MAC compare failed");
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-        return VERIFY_MAC_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
     }
 
     /* treat any failure as verify MAC error */
     if (ret != 0) {
-        ret = VERIFY_MAC_ERROR;
-        WOLFSSL_ERROR_VERBOSE(ret);
+        ret = WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
     }
 
     return ret;
@@ -21127,8 +20958,7 @@ int TimingPadVerify(WOLFSSL* ssl, const byte* input, int padLen, int macSz,
 
     /* Treat any failure as verify MAC error. */
     if (ret != 0) {
-        ret = VERIFY_MAC_ERROR;
-        WOLFSSL_ERROR_VERBOSE(ret);
+        ret = WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
     }
 
     return ret;
@@ -21165,8 +20995,7 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
         (w64Equal(ssl->keys.curEpoch64, w64From32(0x0, DTLS13_EPOCH_HANDSHAKE))
                 || w64Equal(ssl->keys.curEpoch64, w64From32(0x0, 0x0))))
     {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 #endif
 
@@ -21212,8 +21041,7 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
         if (sniff == NO_SNIFF) {
             SendAlert(ssl, alert_fatal, unexpected_message);
         }
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-        return OUT_OF_ORDER_E;
+        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
     }
 
 
@@ -21239,8 +21067,7 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
         if (sniff == NO_SNIFF) {
             SendAlert(ssl, alert_fatal, unexpected_message);
         }
-        WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
-        return BUFFER_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
     }
 #ifdef WOLFSSL_EARLY_DATA
     if (ssl->options.side == WOLFSSL_SERVER_END &&
@@ -21582,8 +21409,7 @@ static int DoAlert(WOLFSSL* ssl, byte* input, word32* inOutIdx, int* type)
         if (level != alert_warning || code != close_notify)
             SendAlert(ssl, alert_fatal, unexpected_message);
 #endif
-        WOLFSSL_ERROR_VERBOSE(ALERT_COUNT_E);
-        return ALERT_COUNT_E;
+        return WOLFSSL_ERROR_VERBOSE(ALERT_COUNT_E);
     }
 
     LogAlert(*type);
@@ -21674,13 +21500,11 @@ static int GetInputData(WOLFSSL *ssl, word32 size)
             return WC_NO_ERR_TRACE(WANT_READ);
 
         if (in < 0) {
-            WOLFSSL_ERROR_VERBOSE(SOCKET_ERROR_E);
-            return SOCKET_ERROR_E;
+            return WOLFSSL_ERROR_VERBOSE(SOCKET_ERROR_E);
         }
 
         if (in > inSz) {
-            WOLFSSL_ERROR_VERBOSE(RECV_OVERFLOW_E);
-            return RECV_OVERFLOW_E;
+            return WOLFSSL_ERROR_VERBOSE(RECV_OVERFLOW_E);
         }
 
         if ((word32)in < size) {
@@ -21724,16 +21548,14 @@ static WC_INLINE int VerifyMacEnc(WOLFSSL* ssl, const byte* input, word32 msgSz,
     WOLFSSL_MSG("Verify MAC of Encrypted Data");
 
     if (msgSz < digestSz) {
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-        return VERIFY_MAC_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
     }
     XMEMSET(verify, 0, WC_MAX_DIGEST_SIZE);
 
     ret  = ssl->hmac(ssl, verify, input, msgSz - digestSz, -1, content, 1, PEER_ORDER);
     ret |= ConstantCompare(verify, input + msgSz - digestSz, (int)digestSz);
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-        return VERIFY_MAC_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
     }
 
     return 0;
@@ -21794,12 +21616,10 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
                             (int)pad, content, 1, PEER_ORDER);
             if (ConstantCompare(verify, input + msgSz - digestSz - pad - 1,
                                 (int)digestSz) != 0) {
-                WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-                return VERIFY_MAC_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             }
             if (ret != 0 || badPadLen) {
-                WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-                return VERIFY_MAC_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             }
         }
     }
@@ -21807,12 +21627,10 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
         ret = ssl->hmac(ssl, verify, input, msgSz - digestSz, -1, content, 1,
                         PEER_ORDER);
         if (ConstantCompare(verify, input + msgSz - digestSz, (int)digestSz) != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-            return VERIFY_MAC_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         }
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-            return VERIFY_MAC_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         }
     }
 #endif /* !WOLFSSL_NO_TLS12 && !WOLFSSL_AEAD_ONLY */
@@ -22242,8 +22060,7 @@ static int DoProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                 if (ssl->buffers.inputBuffer.buffer[
                           ssl->buffers.inputBuffer.idx + OPAQUE16_LEN] != OLD_HELLO_ID) {
                     WOLFSSL_MSG("Not a valid old client hello");
-                    WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
-                    return PARSE_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
                 }
 
                 if (ssl->buffers.inputBuffer.buffer[
@@ -22251,8 +22068,7 @@ static int DoProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                     ssl->buffers.inputBuffer.buffer[
                           ssl->buffers.inputBuffer.idx + OPAQUE24_LEN] != DTLS_MAJOR) {
                     WOLFSSL_MSG("Not a valid version in old client hello");
-                    WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
-                    return PARSE_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
                 }
 
                 /* how many bytes need ProcessOldClientHello */
@@ -22356,8 +22172,7 @@ default:
                                         ssl->curRL.type != application_data &&
                                         ssl->curRL.type != change_cipher_spec) {
                 SendAlert(ssl, alert_fatal, unexpected_message);
-                WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
-                return PARSE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
             }
 #endif
 
@@ -22449,8 +22264,7 @@ default:
                     if (!ssl->options.dtls)
                         SendAlert(ssl, alert_fatal, bad_record_mac);
                 #endif
-                    WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
-                    return DECRYPT_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
                 }
                 ssl->keys.encryptSz    = ssl->curSize;
             }
@@ -22571,8 +22385,7 @@ default:
                             SendAlert(ssl, alert_fatal, bad_record_mac);
                     #endif
                         WOLFSSL_MSG("VerifyMac failed");
-                        WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
-                        return DECRYPT_ERROR;
+                        return WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
                     }
                 }
 
@@ -22686,8 +22499,7 @@ default:
             #if defined(WOLFSSL_EXTRA_ALERTS) && !defined(WOLFSSL_NO_ETM_ALERT)
                     SendAlert(ssl, alert_fatal, record_overflow);
             #endif
-                    WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
-                    return BUFFER_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
                 }
             }
             else
@@ -22704,8 +22516,7 @@ default:
 #if defined(WOLFSSL_TLS13) || defined(WOLFSSL_EXTRA_ALERTS)
                 SendAlert(ssl, alert_fatal, record_overflow);
 #endif
-                WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
-                return BUFFER_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
             }
 
             WOLFSSL_MSG("received record layer msg");
@@ -22844,35 +22655,30 @@ default:
                         word32 i = ssl->buffers.inputBuffer.idx;
                         if (ssl->options.handShakeState == HANDSHAKE_DONE) {
                             SendAlert(ssl, alert_fatal, unexpected_message);
-                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
-                            return UNKNOWN_RECORD_TYPE;
+                            return WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                         }
                         if (ssl->curSize != 1 ||
                                       ssl->buffers.inputBuffer.buffer[i] != 1) {
                             SendAlert(ssl, alert_fatal, unexpected_message);
-                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
-                            return UNKNOWN_RECORD_TYPE;
+                            return WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                         }
                         ssl->buffers.inputBuffer.idx++;
                         if (ssl->options.side == WOLFSSL_SERVER_END &&
                                 !ssl->msgsReceived.got_client_hello) {
                             /* Can't appear before CH */
                             SendAlert(ssl, alert_fatal, unexpected_message);
-                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
-                            return UNKNOWN_RECORD_TYPE;
+                            return WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                         }
                         if (!ssl->msgsReceived.got_change_cipher) {
                             ssl->msgsReceived.got_change_cipher = 1;
                         }
                         else {
                             SendAlert(ssl, alert_fatal, illegal_parameter);
-                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
-                            return UNKNOWN_RECORD_TYPE;
+                            return WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                         }
                         if (ssl->keys.decryptedCur == 1) {
                             SendAlert(ssl, alert_fatal, unexpected_message);
-                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
-                            return UNKNOWN_RECORD_TYPE;
+                            return WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                         }
                         break;
                     }
@@ -22883,14 +22689,12 @@ default:
                             ssl->buffers.inputBuffer.length ||
                             ssl->curSize < 1) {
                         WOLFSSL_MSG("ChangeCipher msg too short");
-                        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
-                        return LENGTH_ERROR;
+                        return WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
                     }
                     if (ssl->buffers.inputBuffer.buffer[
                             ssl->buffers.inputBuffer.idx] != 1) {
                         WOLFSSL_MSG("ChangeCipher msg wrong value");
-                        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
-                        return LENGTH_ERROR;
+                        return WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
                     }
 
                     if (IsEncryptionOn(ssl, 0) && ssl->options.handShakeDone) {
@@ -22900,8 +22704,7 @@ default:
 
                     if (ssl->curSize != 1) {
                         WOLFSSL_MSG("Malicious or corrupted ChangeCipher msg");
-                        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
-                        return LENGTH_ERROR;
+                        return WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
                     }
 
                     ssl->buffers.inputBuffer.idx++;
@@ -23000,8 +22803,7 @@ default:
                     #ifdef WOLFSSL_TLS13
                         if (ssl->keys.keyUpdateRespond) {
                             WOLFSSL_MSG("No KeyUpdate from peer seen");
-                            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                            return SANITY_MSG_E;
+                            return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                         }
                     #endif
                 #endif
@@ -23110,8 +22912,7 @@ default:
                     }
                     else {
                         WOLFSSL_MSG("\tBuffer advanced not enough error");
-                        WOLFSSL_ERROR_VERBOSE(FATAL_ERROR);
-                        return FATAL_ERROR;
+                        return WOLFSSL_ERROR_VERBOSE(FATAL_ERROR);
                     }
                 }
             }
@@ -23138,8 +22939,7 @@ default:
             continue;
         default:
             WOLFSSL_MSG("Bad process input state, programming error");
-            WOLFSSL_ERROR_VERBOSE(INPUT_CASE_ERROR);
-            return INPUT_CASE_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(INPUT_CASE_ERROR);
         }
     }
 }
@@ -23343,8 +23143,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         /* in buffer */
         ret |= wc_Md5Update(&md5, in, sz);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-            return VERIFY_MAC_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         }
         ret = wc_Md5Final(&md5, result);
     #ifdef WOLFSSL_ASYNC_CRYPT
@@ -23354,8 +23153,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-            return VERIFY_MAC_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         }
 
         /* outer */
@@ -23363,8 +23161,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret |= wc_Md5Update(&md5, PAD2, padSz);
         ret |= wc_Md5Update(&md5, result, digestSz);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-            return VERIFY_MAC_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         }
         ret =  wc_Md5Final(&md5, digest);
     #ifdef WOLFSSL_ASYNC_CRYPT
@@ -23374,8 +23171,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-            return VERIFY_MAC_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         }
 
         wc_Md5Free(&md5);
@@ -23393,8 +23189,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         /* in buffer */
         ret |= wc_ShaUpdate(&sha, in, sz);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-            return VERIFY_MAC_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         }
         ret = wc_ShaFinal(&sha, result);
     #ifdef WOLFSSL_ASYNC_CRYPT
@@ -23404,8 +23199,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-            return VERIFY_MAC_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         }
 
         /* outer */
@@ -23413,8 +23207,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret |= wc_ShaUpdate(&sha, PAD2, padSz);
         ret |= wc_ShaUpdate(&sha, result, digestSz);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-            return VERIFY_MAC_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         }
         ret =  wc_ShaFinal(&sha, digest);
     #ifdef WOLFSSL_ASYNC_CRYPT
@@ -23424,8 +23217,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
-            return VERIFY_MAC_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         }
 
         wc_ShaFree(&sha);
@@ -24020,7 +23812,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
             ret = args->sz;
         }
         else {
-            WOLFSSL_ERROR_VERBOSE(ret);
+            (void)WOLFSSL_ERROR_VERBOSE(ret);
         }
 
         /* Final cleanup */
@@ -24153,7 +23945,7 @@ exit_buildmsg:
         ret = (int)args->sz;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     /* Final cleanup */
@@ -30189,7 +29981,7 @@ int DecodePrivateKey(WOLFSSL *ssl, word32* length)
 
 exit_dpk:
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -30627,7 +30419,7 @@ exit_dapk:
 #endif
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -31208,16 +31000,14 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
         if (ssl->options.dtls) {
             if (pv.major != DTLS_MAJOR || pv.minor == DTLS_BOGUS_MINOR) {
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
             lowerVersion = pv.minor > ssl->version.minor;
             higherVersion = pv.minor < ssl->version.minor;
         }
         else {
             if (pv.major != SSLv3_MAJOR) {
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
             lowerVersion = pv.minor < ssl->version.minor;
             higherVersion = pv.minor > ssl->version.minor;
@@ -31225,8 +31015,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
         if (higherVersion) {
             WOLFSSL_MSG("Server using higher version, fatal error");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         }
         if (lowerVersion) {
             WOLFSSL_MSG("server using lower version");
@@ -31234,14 +31023,12 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             /* Check for downgrade attack. */
             if (!ssl->options.downgrade) {
                 WOLFSSL_MSG("\tno downgrade allowed, fatal error");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
             if ((!ssl->options.dtls && pv.minor < ssl->options.minDowngrade) ||
                 (ssl->options.dtls && pv.minor > ssl->options.minDowngrade)) {
                 WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
 
             #ifdef HAVE_SECURE_RENEGOTIATION
@@ -31249,8 +31036,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                                          ssl->secure_renegotiation->enabled &&
                                          ssl->options.handShakeDone) {
                     WOLFSSL_MSG("Server changed version during scr");
-                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                    return VERSION_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 }
             #endif /* HAVE_SECURE_RENEGOTIATION */
 
@@ -31282,8 +31068,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                     break;
                 default:
                     WOLFSSL_MSG("\tbad minor version");
-                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                    return VERSION_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 }
         }
 
@@ -31320,14 +31105,12 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 (ssl->options.mask & WOLFSSL_OP_NO_SSLv3) ==
                 WOLFSSL_OP_NO_SSLv3) {
                 WOLFSSL_MSG("\tError, option set to not allow SSLv3");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
 
             if (ssl->version.minor < ssl->options.minDowngrade) {
                 WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
         }
 
@@ -31411,8 +31194,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             if (ssl->options.cipherSuite0 != cs0 ||
                 ssl->options.cipherSuite  != cs1) {
                 WOLFSSL_MSG("Server changed cipher suite during scr");
-                WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
-                return MATCH_SUITE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
             }
         }
         else
@@ -31430,8 +31212,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             }
             if (!found) {
                 WOLFSSL_MSG("ServerHello did not use cipher suite from ClientHello");
-                WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
-                return MATCH_SUITE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
             }
         }
 #endif /* !WOLFSSL_NO_STRICT_CIPHER_SUITE */
@@ -31448,8 +31229,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
         if (compression != NO_COMPRESSION && !ssl->options.usingCompression) {
             WOLFSSL_MSG("Server forcing compression w/o support");
-            WOLFSSL_ERROR_VERBOSE(COMPRESSION_ERROR);
-            return COMPRESSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(COMPRESSION_ERROR);
         }
 
         if (compression != ZLIB_COMPRESSION && ssl->options.usingCompression) {
@@ -31577,8 +31357,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             ret = ssl->sessionSecretCb(ssl, ssl->session->masterSecret,
                                               &secretSz, ssl->sessionSecretCtx);
             if (ret != 0 || secretSz != SECRET_LEN) {
-                WOLFSSL_ERROR_VERBOSE(SESSION_SECRET_CB_E);
-                return SESSION_SECRET_CB_E;
+                return WOLFSSL_ERROR_VERBOSE(SESSION_SECRET_CB_E);
             }
         }
 #endif /* HAVE_SECRET_CALLBACK */
@@ -31608,8 +31387,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 if (XMEMCMP(down, tls13Downgrade, TLS13_DOWNGRADE_SZ) == 0 &&
                                                      (vers == 0 || vers == 1)) {
                     SendAlert(ssl, alert_fatal, illegal_parameter);
-                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                    return VERSION_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 }
             }
             else
@@ -31623,8 +31401,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 if (XMEMCMP(down, tls13Downgrade, TLS13_DOWNGRADE_SZ) == 0 &&
                                                                     vers == 0) {
                     SendAlert(ssl, alert_fatal, illegal_parameter);
-                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                    return VERSION_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 }
             }
         }
@@ -31633,8 +31410,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 if (SetCipherSpecs(ssl) == 0) {
                     if (!HaveUniqueSessionObj(ssl)) {
                         WOLFSSL_MSG("Unable to have unique session object");
-                        WOLFSSL_ERROR_VERBOSE(MEMORY_ERROR);
-                        return MEMORY_ERROR;
+                        return WOLFSSL_ERROR_VERBOSE(MEMORY_ERROR);
                     }
 
                     XMEMCPY(ssl->arrays->masterSecret,
@@ -31658,8 +31434,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 }
                 else {
                     WOLFSSL_MSG("Unsupported cipher suite, DoServerHello");
-                    WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
-                    return UNSUPPORTED_SUITE;
+                    return WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
                 }
             }
             else {
@@ -31750,13 +31525,11 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             #ifdef HAVE_PK_CALLBACKS
                 if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)) {
                     WOLFSSL_MSG("Using PK for client private key");
-                    WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-                    return INVALID_PARAMETER;
+                    return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
                 }
             #endif
                 if (ssl->buffers.key && ssl->buffers.key->buffer) {
-                    WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-                    return INVALID_PARAMETER;
+                    return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
                 }
             }
             *inOutIdx += len;
@@ -31860,8 +31633,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             if (ret == 1) {
                 if ((wolfSSL_use_certificate(ssl, x509) != WOLFSSL_SUCCESS) ||
                     (wolfSSL_use_PrivateKey(ssl, pkey) != WOLFSSL_SUCCESS)) {
-                    WOLFSSL_ERROR_VERBOSE(CLIENT_CERT_CB_ERROR);
-                    return CLIENT_CERT_CB_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(CLIENT_CERT_CB_ERROR);
                 }
                 wolfSSL_X509_free(x509);
                 x509 = NULL;
@@ -32272,7 +32044,7 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
 
 exit_gdpk:
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
     return ret;
 }
@@ -33340,7 +33112,7 @@ exit_dske:
     FreeKeyExchange(ssl);
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
     return ret;
 }
@@ -34596,7 +34368,7 @@ exit_scke:
     FreeKeyExchange(ssl);
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
     return ret;
 }
@@ -35169,7 +34941,7 @@ exit_scv:
     FreeKeyExchange(ssl);
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -35245,8 +35017,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     if (ssl->expect_session_ticket == 0) {
         WOLFSSL_MSG("Unexpected session ticket");
-        WOLFSSL_ERROR_VERBOSE(SESSION_TICKET_EXPECT_E);
-        return SESSION_TICKET_EXPECT_E;
+        return WOLFSSL_ERROR_VERBOSE(SESSION_TICKET_EXPECT_E);
     }
 
     if (OPAQUE32_LEN > size)
@@ -37465,7 +37236,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         FreeKeyExchange(ssl);
 
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(ret);
+            (void)WOLFSSL_ERROR_VERBOSE(ret);
         }
 
         return ret;
@@ -37678,8 +37449,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
         }
 
-        WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
-        return MATCH_SUITE_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
 
     }
 
@@ -37997,8 +37767,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 ssl->options.clientState = CLIENT_KEYEXCHANGE_COMPLETE;
             }
             if (ret != 0)
-                WOLFSSL_ERROR_VERBOSE(ret);
-            WOLFSSL_LEAVE("HandleTlsResumption", ret);
+            WOLFSSL_LEAVE("HandleTlsResumption", WOLFSSL_ERROR_VERBOSE(ret));
             return ret;
         }
 #endif /* HAVE_SECRET_CALLBACK */
@@ -38041,8 +37810,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             #ifdef WOLFSSL_EXTRA_ALERTS
                 SendAlert(ssl, alert_fatal, handshake_failure);
             #endif
-                ret = EXT_MASTER_SECRET_NEEDED_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(EXT_MASTER_SECRET_NEEDED_E);
             }
         }
         else {
@@ -38061,8 +37829,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             #ifdef WOLFSSL_EXTRA_ALERTS
                 SendAlert(ssl, alert_fatal, illegal_parameter);
             #endif
-                ret = UNSUPPORTED_SUITE;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
             }
         #endif
 
@@ -38079,8 +37846,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             else if (ret == 0) {
                 if (MatchSuite(ssl, clSuites) < 0) {
                     WOLFSSL_MSG("Unsupported cipher suite, ClientHello");
-                    ret = UNSUPPORTED_SUITE;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
                 }
             }
             if (ret == 0) {
@@ -38730,7 +38496,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         WOLFSSL_END(WC_FUNC_CLIENT_HELLO_DO);
 
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(ret);
+            (void)WOLFSSL_ERROR_VERBOSE(ret);
         }
 
         return ret;
@@ -39206,7 +38972,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         FreeKeyExchange(ssl);
 
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(ret);
+            (void)WOLFSSL_ERROR_VERBOSE(ret);
         }
 
         return ret;
@@ -39565,8 +39331,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #ifdef WOLFSSL_CHECK_MEM_ZERO
         wc_MemZero_Check(it, sizeof(InternalTicket));
 #endif
-        WOLFSSL_ERROR_VERBOSE(ret);
-        return ret;
+        return WOLFSSL_ERROR_VERBOSE(ret);
 
     }
 
@@ -39584,7 +39349,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (len > SESSION_TICKET_LEN ||
             len < (word32)(WOLFSSL_INTERNAL_TICKET_LEN +
                            WOLFSSL_TICKET_FIXED_SZ)) {
-            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_MSG_SZ);
+            (void)WOLFSSL_ERROR_VERBOSE(BAD_TICKET_MSG_SZ);
             return WOLFSSL_TICKET_RET_REJECT;
         }
 
@@ -39593,7 +39358,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         /* decrypt */
         ato16(et->enc_len, &inLen);
         if (inLen > WOLFSSL_TICKET_ENC_SZ) {
-            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_MSG_SZ);
+            (void)WOLFSSL_ERROR_VERBOSE(BAD_TICKET_MSG_SZ);
             return WOLFSSL_TICKET_RET_REJECT;
         }
         outLen = (int)inLen;   /* may be reduced by user padding */
@@ -39609,7 +39374,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #endif
                         ) {
             /* Use BAD_TICKET_ENCRYPT to signal missing ticket callback */
-            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_ENCRYPT);
+            (void)WOLFSSL_ERROR_VERBOSE(BAD_TICKET_ENCRYPT);
             ret = WOLFSSL_TICKET_RET_REJECT;
         }
         else {
@@ -39627,14 +39392,13 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
         #endif /* WOLFSSL_ASYNC_CRYPT */
             if (ret != WOLFSSL_TICKET_RET_CREATE) {
-                WOLFSSL_ERROR_VERBOSE(BAD_TICKET_KEY_CB_SZ);
+                (void)WOLFSSL_ERROR_VERBOSE(BAD_TICKET_KEY_CB_SZ);
                 return WOLFSSL_TICKET_RET_REJECT;
             }
         }
         if (outLen > (int)inLen || outLen < (int)WOLFSSL_INTERNAL_TICKET_LEN) {
             WOLFSSL_MSG("Bad user ticket decrypt len");
-            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_KEY_CB_SZ);
-            return BAD_TICKET_KEY_CB_SZ;
+            return WOLFSSL_ERROR_VERBOSE(BAD_TICKET_KEY_CB_SZ);
         }
         *it = (InternalTicket*)et->enc_ticket;
         return ret;

--- a/src/keys.c
+++ b/src/keys.c
@@ -118,8 +118,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         /* server side verified before SetCipherSpecs call */
         if (VerifyClientSuite(havePSK, cipherSuite0, cipherSuite) != 1) {
             WOLFSSL_MSG("SetCipherSpecs() client has an unusable suite");
-            WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
-            return UNSUPPORTED_SUITE;
+            return WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
         }
     }
 #endif /* NO_WOLFSSL_CLIENT */
@@ -2307,8 +2306,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
 
     default:
         WOLFSSL_MSG("Unsupported cipher suite, SetCipherSpecs");
-        WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
-        return UNSUPPORTED_SUITE;
+        return WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
     }  /* switch */
     }  /* if ECC / Normal suites else */
 

--- a/src/pk.c
+++ b/src/pk.c
@@ -1868,7 +1868,7 @@ int wolfSSL_RSA_LoadDer_ex(WOLFSSL_RSA* rsa, const unsigned char* derBuf,
             else {
                  WOLFSSL_ERROR_MSG("RsaPublicKeyDecode failed");
             }
-            WOLFSSL_ERROR_VERBOSE(res);
+            (void)WOLFSSL_ERROR_VERBOSE(res);
             ret = WOLFSSL_FATAL_ERROR;
         }
     }
@@ -6336,12 +6336,12 @@ int wolfSSL_DSA_LoadDer_ex(WOLFSSL_DSA* dsa, const unsigned char* derBuf,
     }
 
     if (ret < 0 && opt == WOLFSSL_DSA_LOAD_PRIVATE) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
         WOLFSSL_MSG("DsaPrivateKeyDecode failed");
         return WOLFSSL_FATAL_ERROR;
     }
     else if (ret < 0 && opt == WOLFSSL_DSA_LOAD_PUBLIC) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
         WOLFSSL_MSG("DsaPublicKeyDecode failed");
         return WOLFSSL_FATAL_ERROR;
     }
@@ -16874,4 +16874,3 @@ int wolfSSL_PEM_write_PKCS8PrivateKey(XFILE f, WOLFSSL_EVP_PKEY* pkey,
  ******************************************************************************/
 
 #endif /* !WOLFSSL_PK_INCLUDED */
-

--- a/src/tls.c
+++ b/src/tls.c
@@ -158,8 +158,7 @@ int BuildTlsHandshakeHash(WOLFSSL* ssl, byte* hash, word32* hashLen)
 #endif
 
     if (ret != 0) {
-        ret = BUILD_MSG_ERROR;
-        WOLFSSL_ERROR_VERBOSE(ret);
+        ret = WOLFSSL_ERROR_VERBOSE(BUILD_MSG_ERROR);
     }
 
     return ret;
@@ -220,8 +219,7 @@ int BuildTlsFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
         ForceZero(handshake_hash, hashSz);
 #else
         /* Pseudo random function must be enabled in the configuration. */
-        ret = PRF_MISSING;
-        WOLFSSL_ERROR_VERBOSE(ret);
+        ret = WOLFSSL_ERROR_VERBOSE(PRF_MISSING);
         WOLFSSL_MSG("Pseudo-random function is not enabled");
 
         (void)side;
@@ -421,8 +419,7 @@ static int _DeriveTlsKeys(byte* key_dig, word32 key_dig_len,
     PRIVATE_KEY_LOCK();
 #else
     /* Pseudo random function must be enabled in the configuration. */
-    ret = PRF_MISSING;
-    WOLFSSL_ERROR_VERBOSE(ret);
+    ret = WOLFSSL_ERROR_VERBOSE(PRF_MISSING);
     WOLFSSL_MSG("Pseudo-random function is not enabled");
 
     (void)key_dig;
@@ -1608,8 +1605,7 @@ int TLSX_HandleUnsupportedExtension(WOLFSSL* ssl);
 int TLSX_HandleUnsupportedExtension(WOLFSSL* ssl)
 {
     SendAlert(ssl, alert_fatal, unsupported_extension);
-    WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_EXTENSION);
-    return UNSUPPORTED_EXTENSION;
+    return WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_EXTENSION);
 }
 
 #else
@@ -1833,8 +1829,7 @@ static int ALPN_find_match(WOLFSSL *ssl, TLSX **pextension,
         }
         else {
             SendAlert(ssl, alert_fatal, no_application_protocol);
-            WOLFSSL_ERROR_VERBOSE(UNKNOWN_ALPN_PROTOCOL_NAME_E);
-            return UNKNOWN_ALPN_PROTOCOL_NAME_E;
+            return WOLFSSL_ERROR_VERBOSE(UNKNOWN_ALPN_PROTOCOL_NAME_E);
         }
     }
 
@@ -1872,8 +1867,7 @@ int ALPN_Select(WOLFSSL *ssl)
             default:
                 WOLFSSL_MSG("ALPN cb no match and fatal");
                 SendAlert(ssl, alert_fatal, no_application_protocol);
-                WOLFSSL_ERROR_VERBOSE(UNKNOWN_ALPN_PROTOCOL_NAME_E);
-                return UNKNOWN_ALPN_PROTOCOL_NAME_E;
+                return WOLFSSL_ERROR_VERBOSE(UNKNOWN_ALPN_PROTOCOL_NAME_E);
         }
     }
     else
@@ -2023,15 +2017,13 @@ int TLSX_ALPN_GetRequest(TLSX* extensions, void** data, word16 *dataSz)
     extension = TLSX_Find(extensions, TLSX_APPLICATION_LAYER_PROTOCOL);
     if (extension == NULL) {
         WOLFSSL_MSG("TLS extension not found");
-        WOLFSSL_ERROR_VERBOSE(WOLFSSL_ALPN_NOT_FOUND);
-        return WOLFSSL_ALPN_NOT_FOUND;
+        return WOLFSSL_ERROR_VERBOSE(WOLFSSL_ALPN_NOT_FOUND);
     }
 
     alpn = (ALPN *)extension->data;
     if (alpn == NULL) {
         WOLFSSL_MSG("ALPN extension not found");
-        WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
-        return WOLFSSL_FATAL_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
     }
 
     if (alpn->negotiated != 1) {
@@ -2039,20 +2031,17 @@ int TLSX_ALPN_GetRequest(TLSX* extensions, void** data, word16 *dataSz)
         /* consider as an error */
         if (alpn->options & WOLFSSL_ALPN_FAILED_ON_MISMATCH) {
             WOLFSSL_MSG("No protocol match with peer -> Failed");
-            WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
-            return WOLFSSL_FATAL_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
         }
 
         /* continue without negotiated protocol */
         WOLFSSL_MSG("No protocol match with peer -> Continue");
-        WOLFSSL_ERROR_VERBOSE(WOLFSSL_ALPN_NOT_FOUND);
-        return WOLFSSL_ALPN_NOT_FOUND;
+        return WOLFSSL_ERROR_VERBOSE(WOLFSSL_ALPN_NOT_FOUND);
     }
 
     if (alpn->next != NULL) {
         WOLFSSL_MSG("Only one protocol name must be accepted");
-        WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
-        return WOLFSSL_FATAL_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
     }
 
     *data = alpn->protocol_name;
@@ -2384,8 +2373,7 @@ static int TLSX_SNI_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     }
     else if (!(sni->options & WOLFSSL_SNI_CONTINUE_ON_MISMATCH)) {
         SendAlert(ssl, alert_fatal, unrecognized_name);
-        WOLFSSL_ERROR_VERBOSE(UNKNOWN_SNI_HOST_NAME_E);
-        return UNKNOWN_SNI_HOST_NAME_E;
+        return WOLFSSL_ERROR_VERBOSE(UNKNOWN_SNI_HOST_NAME_E);
     }
 #else
     (void)input;
@@ -2424,8 +2412,7 @@ static int TLSX_SNI_VerifyParse(WOLFSSL* ssl,  byte isRequest)
                 }
 
                 SendAlert(ssl, alert_fatal, handshake_failure);
-                WOLFSSL_ERROR_VERBOSE(SNI_ABSENT_ERROR);
-                return SNI_ABSENT_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SNI_ABSENT_ERROR);
             }
         }
 
@@ -2435,8 +2422,7 @@ static int TLSX_SNI_VerifyParse(WOLFSSL* ssl,  byte isRequest)
                     continue;
 
                 SendAlert(ssl, alert_fatal, handshake_failure);
-                WOLFSSL_ERROR_VERBOSE(SNI_ABSENT_ERROR);
-                return SNI_ABSENT_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SNI_ABSENT_ERROR);
             }
         }
     #endif /* NO_WOLFSSL_SERVER */
@@ -2553,8 +2539,7 @@ int TLSX_SNI_GetFromBuffer(const byte* clientHello, word32 helloSz,
             if (len16 != 0) /* session_id_length must be 0 */
                 return BUFFER_ERROR;
 
-            WOLFSSL_ERROR_VERBOSE(SNI_UNSUPPORTED);
-            return SNI_UNSUPPORTED;
+            return WOLFSSL_ERROR_VERBOSE(SNI_UNSUPPORTED);
         }
 
         return BUFFER_ERROR;
@@ -2564,8 +2549,7 @@ int TLSX_SNI_GetFromBuffer(const byte* clientHello, word32 helloSz,
         return BUFFER_ERROR;
 
     if (clientHello[offset++] < TLSv1_MINOR) {
-        WOLFSSL_ERROR_VERBOSE(SNI_UNSUPPORTED);
-        return SNI_UNSUPPORTED;
+        return WOLFSSL_ERROR_VERBOSE(SNI_UNSUPPORTED);
     }
 
     ato16(clientHello + offset, &len16);
@@ -2948,8 +2932,7 @@ static int TLSX_TCA_Parse(WOLFSSL* ssl, const byte* input, word16 length,
                 offset += idSz;
                 break;
             default:
-                WOLFSSL_ERROR_VERBOSE(TCA_INVALID_ID_TYPE);
-                return TCA_INVALID_ID_TYPE;
+                return WOLFSSL_ERROR_VERBOSE(TCA_INVALID_ID_TYPE);
         }
 
         /* Find the type/ID in the TCA list. */
@@ -2981,8 +2964,7 @@ static int TLSX_TCA_VerifyParse(WOLFSSL* ssl, byte isRequest)
 
         if (extension && !extension->resp) {
             SendAlert(ssl, alert_fatal, handshake_failure);
-            WOLFSSL_ERROR_VERBOSE(TCA_ABSENT_ERROR);
-            return TCA_ABSENT_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(TCA_ABSENT_ERROR);
         }
     #else
         WOLFSSL_MSG("No response received for trusted_ca_keys.  Continuing.");
@@ -3075,8 +3057,7 @@ static int TLSX_MFL_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 
         default:
             SendAlert(ssl, alert_fatal, illegal_parameter);
-            WOLFSSL_ERROR_VERBOSE(UNKNOWN_MAX_FRAG_LEN_E);
-            return UNKNOWN_MAX_FRAG_LEN_E;
+            return WOLFSSL_ERROR_VERBOSE(UNKNOWN_MAX_FRAG_LEN_E);
     }
     if (ssl->session != NULL) {
         ssl->session->mfl = *input;
@@ -3567,8 +3548,7 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, const byte* input, word16 length,
             if (OPAQUE8_LEN + OPAQUE24_LEN > length)
                 ret = BUFFER_ERROR;
             if (ret == 0 && input[offset++] != WOLFSSL_CSR_OCSP) {
-                ret = BAD_CERTIFICATE_STATUS_ERROR;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(BAD_CERTIFICATE_STATUS_ERROR);
             }
             if (ret == 0) {
                 c24to32(input + offset, &resp_length);
@@ -3716,8 +3696,7 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, const byte* input, word16 length,
             /* process OCSP request in certificate chain */
             if ((ret = ProcessChainOCSPRequest(ssl)) != 0) {
                 WOLFSSL_MSG("Process Cert Chain OCSP request failed");
-                WOLFSSL_ERROR_VERBOSE(ret);
-                return ret;
+                return WOLFSSL_ERROR_VERBOSE(ret);
             }
         #endif
         }
@@ -3767,8 +3746,7 @@ int TLSX_CSR_InitRequest_ex(TLSX* extensions, DecodedCert* cert,
                     csr->requests++;
                 }
                 else {
-                    WOLFSSL_ERROR_VERBOSE(MAX_CERT_EXTENSIONS_ERR);
-                    return MAX_CERT_EXTENSIONS_ERR;
+                    return WOLFSSL_ERROR_VERBOSE(MAX_CERT_EXTENSIONS_ERR);
                 }
             }
             break;
@@ -3824,8 +3802,7 @@ int TLSX_CSR_ForceRequest(WOLFSSL* ssl)
                                               &csr->request.ocsp[0], NULL, NULL);
                 }
                 else {
-                    WOLFSSL_ERROR_VERBOSE(OCSP_LOOKUP_FAIL);
-                    return OCSP_LOOKUP_FAIL;
+                    return WOLFSSL_ERROR_VERBOSE(OCSP_LOOKUP_FAIL);
                 }
         }
     }
@@ -4363,8 +4340,7 @@ int TLSX_CSR2_ForceRequest(WOLFSSL* ssl)
                                           &csr2->request.ocsp[csr2->requests-1], NULL, NULL);
                 }
                 else {
-                    WOLFSSL_ERROR_VERBOSE(OCSP_LOOKUP_FAIL);
-                    return OCSP_LOOKUP_FAIL;
+                    return WOLFSSL_ERROR_VERBOSE(OCSP_LOOKUP_FAIL);
                 }
         }
     }
@@ -6128,7 +6104,7 @@ static int TLSX_SecureRenegotiation_Parse(WOLFSSL* ssl, const byte* input,
     }
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
         SendAlert(ssl, alert_fatal, handshake_failure);
     }
 
@@ -6272,8 +6248,7 @@ static int TLSX_SessionTicket_Parse(WOLFSSL* ssl, const byte* input,
 #endif
 
         if (length > SESSION_TICKET_LEN) {
-            ret = BAD_TICKET_MSG_SZ;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(BAD_TICKET_MSG_SZ);
         } else if (IsAtLeastTLSv1_3(ssl->version)) {
             WOLFSSL_MSG("Process client ticket rejected, TLS 1.3 no support");
             ssl->options.rejectTicket = 1;
@@ -6433,8 +6408,7 @@ static int TLSX_EncryptThenMac_GetSize(byte msgType, word16* pSz)
     (void)pSz;
 
     if (msgType != client_hello && msgType != server_hello) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     /* Empty extension */
@@ -6460,8 +6434,7 @@ static int TLSX_EncryptThenMac_Write(void* data, byte* output, byte msgType,
     (void)pSz;
 
     if (msgType != client_hello && msgType != server_hello) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     /* Empty extension */
@@ -6489,8 +6462,7 @@ static int TLSX_EncryptThenMac_Parse(WOLFSSL* ssl, const byte* input,
     (void)input;
 
     if (msgType != client_hello && msgType != server_hello) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     /* Empty extension */
@@ -6511,8 +6483,7 @@ static int TLSX_EncryptThenMac_Parse(WOLFSSL* ssl, const byte* input,
 
     /* Server Hello */
     if (ssl->options.disallowEncThenMac) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     ssl->options.encThenMac = 1;
@@ -6906,8 +6877,7 @@ static int TLSX_SupportedVersions_GetSize(void* data, byte msgType, word16* pSz)
         *pSz += OPAQUE16_LEN;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     return 0;
@@ -7020,8 +6990,7 @@ static int TLSX_SupportedVersions_Write(void* data, byte* output,
         *pSz += OPAQUE16_LEN;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     return 0;
@@ -7117,8 +7086,7 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
             /* No common supported version was negotiated */
             SendAlert((WOLFSSL*)ssl, alert_fatal,
                       wolfssl_alert_protocol_version);
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         }
         pv->minor = clientGreatestMinor;
         if (versionIsAtLeast(isDtls, clientGreatestMinor, tls13minor)) {
@@ -7149,14 +7117,12 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
         minor = input[OPAQUE8_LEN];
 
         if (major != ssl->ctx->method->version.major) {
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         }
 
         /* Can't downgrade with this extension below TLS v1.3. */
         if (versionIsLesser(isDtls, minor, tls13minor)) {
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         }
 
         /* Version is TLS v1.2 to handle downgrading from TLS v1.3+. */
@@ -7167,21 +7133,18 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
 
         /* No upgrade allowed. */
         if (versionIsLesser(isDtls, ssl->version.minor, minor)) {
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         }
 
         /* Check downgrade. */
         if (versionIsGreater(isDtls, ssl->version.minor, minor)) {
             if (!ssl->options.downgrade) {
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
 
             if (versionIsLesser(
                     isDtls, minor, ssl->options.minDowngrade)) {
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
 
             /* Downgrade the version. */
@@ -7189,8 +7152,7 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
         }
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     return 0;
@@ -7255,8 +7217,7 @@ static int TLSX_Cookie_GetSize(Cookie* cookie, byte msgType, word16* pSz)
         *pSz += OPAQUE16_LEN + cookie->len;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
     return 0;
 }
@@ -7280,8 +7241,7 @@ static int TLSX_Cookie_Write(Cookie* cookie, byte* output, byte msgType,
         *pSz += OPAQUE16_LEN + cookie->len;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
     return 0;
 }
@@ -7304,8 +7264,7 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     Cookie* cookie;
 
     if (msgType != client_hello && msgType != hello_retry_request) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     /* Message contains length and Cookie which must be at least one byte
@@ -7335,15 +7294,13 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
         else
 #endif
         {
-            WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
-            return HRR_COOKIE_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
         }
     }
 
     cookie = (Cookie*)extension->data;
     if (cookie->len != len || XMEMCMP(cookie->data, input + idx, len) != 0) {
-        WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
-        return HRR_COOKIE_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
     }
 
     /* Request seen. */
@@ -8052,8 +8009,7 @@ static int TLSX_KeyShare_GenDhKey(WOLFSSL *ssl, KeyShareEntry* kse)
     (void)ssl;
     (void)kse;
 
-    ret = NOT_COMPILED_IN;
-    WOLFSSL_ERROR_VERBOSE(ret);
+    ret = WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
 #endif
 
     return ret;
@@ -8114,8 +8070,7 @@ static int TLSX_KeyShare_GenX25519Key(WOLFSSL *ssl, KeyShareEntry* kse)
         kse->pubKeyLen = CURVE25519_KEYSIZE;
         if (wc_curve25519_export_public_ex(key, kse->pubKey, &kse->pubKeyLen,
                                                   EC25519_LITTLE_ENDIAN) != 0) {
-            ret = ECC_EXPORT_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(ECC_EXPORT_ERROR);
         }
         kse->pubKeyLen = CURVE25519_KEYSIZE; /* always CURVE25519_KEYSIZE */
     }
@@ -8140,8 +8095,7 @@ static int TLSX_KeyShare_GenX25519Key(WOLFSSL *ssl, KeyShareEntry* kse)
     (void)ssl;
     (void)kse;
 
-    ret = NOT_COMPILED_IN;
-    WOLFSSL_ERROR_VERBOSE(ret);
+    ret = WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
 #endif /* HAVE_CURVE25519 */
 
     return ret;
@@ -8225,8 +8179,7 @@ static int TLSX_KeyShare_GenX448Key(WOLFSSL *ssl, KeyShareEntry* kse)
     (void)ssl;
     (void)kse;
 
-    ret = NOT_COMPILED_IN;
-    WOLFSSL_ERROR_VERBOSE(ret);
+    ret = WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
 #endif /* HAVE_CURVE448 */
 
     return ret;
@@ -8281,8 +8234,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
         #endif /* !NO_ECC_SECP */
     #endif
         default:
-            WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
-            return BAD_FUNC_ARG;
+            return WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
     }
 
     if (kse->key == NULL) {
@@ -8359,8 +8311,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
         /* Export public key. */
         PRIVATE_KEY_UNLOCK();
         if (wc_ecc_export_x963(eccKey, kse->pubKey, &kse->pubKeyLen) != 0) {
-            ret = ECC_EXPORT_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(ECC_EXPORT_ERROR);
         }
         PRIVATE_KEY_LOCK();
     }
@@ -8384,8 +8335,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
     (void)ssl;
     (void)kse;
 
-    ret = NOT_COMPILED_IN;
-    WOLFSSL_ERROR_VERBOSE(ret);
+    ret = WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
 #endif /* HAVE_ECC && HAVE_ECC_KEY_EXPORT */
 
     return ret;
@@ -9059,15 +9009,13 @@ static int TLSX_KeyShare_ProcessDh(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
             break;
     }
     if (params == NULL) {
-        WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
-        return PEER_KEY_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
     }
     pSz = params->p_len;
 #else
     ret = wc_DhGetNamedKeyParamSize(keyShareEntry->group, &pSz, NULL, NULL);
     if (ret != 0 || pSz == 0) {
-        WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
-        return PEER_KEY_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
     }
 #endif
 
@@ -9146,8 +9094,7 @@ static int TLSX_KeyShare_ProcessDh(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
 #else
     (void)ssl;
     (void)keyShareEntry;
-    ret = PEER_KEY_ERROR;
-    WOLFSSL_ERROR_VERBOSE(ret);
+    ret = WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
 #endif
     return ret;
 }
@@ -9198,16 +9145,14 @@ static int TLSX_KeyShare_ProcessX25519_ex(WOLFSSL* ssl,
 
     if (wc_curve25519_check_public(keyShareEntry->ke, keyShareEntry->keLen,
                                                   EC25519_LITTLE_ENDIAN) != 0) {
-        ret = ECC_PEERKEY_ERROR;
-        WOLFSSL_ERROR_VERBOSE(ret);
+        ret = WOLFSSL_ERROR_VERBOSE(ECC_PEERKEY_ERROR);
     }
 
     if (ret == 0) {
         if (wc_curve25519_import_public_ex(keyShareEntry->ke,
                                             keyShareEntry->keLen, peerX25519Key,
                                             EC25519_LITTLE_ENDIAN) != 0) {
-            ret = ECC_PEERKEY_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(ECC_PEERKEY_ERROR);
         }
     }
 
@@ -9235,8 +9180,7 @@ static int TLSX_KeyShare_ProcessX25519_ex(WOLFSSL* ssl,
     (void)ssOutput;
     (void)ssOutSz;
 
-    ret = PEER_KEY_ERROR;
-    WOLFSSL_ERROR_VERBOSE(ret);
+    ret = WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
 #endif /* HAVE_CURVE25519 */
 
     return ret;
@@ -9302,16 +9246,14 @@ static int TLSX_KeyShare_ProcessX448_ex(WOLFSSL* ssl,
 
     if (wc_curve448_check_public(keyShareEntry->ke, keyShareEntry->keLen,
                                                     EC448_LITTLE_ENDIAN) != 0) {
-        ret = ECC_PEERKEY_ERROR;
-        WOLFSSL_ERROR_VERBOSE(ret);
+        ret = WOLFSSL_ERROR_VERBOSE(ECC_PEERKEY_ERROR);
     }
 
     if (ret == 0) {
         if (wc_curve448_import_public_ex(keyShareEntry->ke,
                                               keyShareEntry->keLen, peerX448Key,
                                               EC448_LITTLE_ENDIAN) != 0) {
-            ret = ECC_PEERKEY_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(ECC_PEERKEY_ERROR);
         }
     }
 
@@ -9335,8 +9277,7 @@ static int TLSX_KeyShare_ProcessX448_ex(WOLFSSL* ssl,
     (void)ssOutput;
     (void)ssOutSz;
 
-    ret = PEER_KEY_ERROR;
-    WOLFSSL_ERROR_VERBOSE(ret);
+    ret = WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
 #endif /* HAVE_CURVE448 */
 
     return ret;
@@ -9408,8 +9349,7 @@ static int TLSX_KeyShare_ProcessEcc_ex(WOLFSSL* ssl,
     #endif
         default:
             /* unsupported curve */
-            WOLFSSL_ERROR_VERBOSE(ECC_PEERKEY_ERROR);
-            return ECC_PEERKEY_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(ECC_PEERKEY_ERROR);
     }
 
 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -9450,8 +9390,7 @@ static int TLSX_KeyShare_ProcessEcc_ex(WOLFSSL* ssl,
             ret = wc_ecc_import_x963_ex(keyShareEntry->ke, keyShareEntry->keLen,
                                 ssl->peerEccKey, curveId);
             if (ret != 0) {
-                ret = ECC_PEERKEY_ERROR;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(ECC_PEERKEY_ERROR);
             }
         }
 
@@ -9497,8 +9436,7 @@ static int TLSX_KeyShare_ProcessEcc_ex(WOLFSSL* ssl,
     (void)ssOutput;
     (void)ssOutSz;
 
-    ret = PEER_KEY_ERROR;
-    WOLFSSL_ERROR_VERBOSE(ret);
+    ret = WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
 #endif /* HAVE_ECC */
 
     return ret;
@@ -10108,14 +10046,12 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 
         /* Check the selected group was supported by ClientHello extensions. */
         if (!TLSX_SupportedGroups_Find(ssl, group, ssl->extensions)) {
-            WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
-            return BAD_KEY_SHARE_DATA;
+            return WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
         }
 
         /* Check if the group was sent. */
         if (!TLSX_KeyShare_Find(ssl, group)) {
-            WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
-            return BAD_KEY_SHARE_DATA;
+            return WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
         }
 
         /* ServerHello contains one key share entry. */
@@ -10130,8 +10066,7 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
             && keyShareEntry->privKey == NULL
         #endif
         )) {
-            WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
-            return BAD_KEY_SHARE_DATA;
+            return WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
         }
 
         /* Process the entry to calculate the secret. */
@@ -10154,15 +10089,13 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
             /* Check the selected group was supported by ClientHello extensions.
              */
             if (!TLSX_SupportedGroups_Find(ssl, group, ssl->extensions)) {
-                WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
-                return BAD_KEY_SHARE_DATA;
+                return WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
             }
 
             /* Make sure KeyShare for server requested group was not sent in
              * ClientHello. */
             if (TLSX_KeyShare_Find(ssl, group)) {
-                WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
-                return BAD_KEY_SHARE_DATA;
+                return WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
             }
 
             /* Clear out unusable key shares. */
@@ -10177,8 +10110,7 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     }
     else {
         /* Not a message type that is allowed to have this extension. */
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     return ret;
@@ -10924,8 +10856,7 @@ int TLSX_KeyShare_SetSupported(const WOLFSSL* ssl, TLSX** extensions)
         }
         if (name == WOLFSSL_NAMED_GROUP_INVALID) {
             /* No group selected or specified by the server */
-            WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
-            return BAD_KEY_SHARE_DATA;
+            return WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
         }
     }
     else {
@@ -10940,8 +10871,7 @@ int TLSX_KeyShare_SetSupported(const WOLFSSL* ssl, TLSX** extensions)
         /* We should not be computing keys if we are only going to advertise
          * our choice here. */
         if (kse != NULL && kse->lastRet == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
-            return BAD_KEY_SHARE_DATA;
+            return WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
         }
     }
     #endif
@@ -10963,8 +10893,7 @@ int TLSX_KeyShare_SetSupported(const WOLFSSL* ssl, TLSX** extensions)
 
     (void)ssl;
 
-    WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
-    ret = NOT_COMPILED_IN;
+    ret = WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
 #endif
 
     return ret;
@@ -11410,8 +11339,7 @@ static int TLSX_PreSharedKey_GetSize(PreSharedKey* list, byte msgType,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-    return SANITY_MSG_E;
+    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
 }
 
 /* The number of bytes to be written for the binders.
@@ -11427,8 +11355,7 @@ int TLSX_PreSharedKey_GetSizeBinders(PreSharedKey* list, byte msgType,
     word16 len;
 
     if (msgType != client_hello) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     /* Length of all binders. */
@@ -11459,8 +11386,7 @@ int TLSX_PreSharedKey_WriteBinders(PreSharedKey* list, byte* output,
     word16 len;
 
     if (msgType != client_hello) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     /* Skip length of all binders. */
@@ -11539,8 +11465,7 @@ static int TLSX_PreSharedKey_Write(PreSharedKey* list, byte* output,
         for (i=0; list != NULL && !list->chosen; i++)
             list = list->next;
         if (list == NULL) {
-            WOLFSSL_ERROR_VERBOSE(BUILD_MSG_ERROR);
-            return BUILD_MSG_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(BUILD_MSG_ERROR);
         }
 
         /* The index of the identity chosen by the server from the list supplied
@@ -11550,8 +11475,7 @@ static int TLSX_PreSharedKey_Write(PreSharedKey* list, byte* output,
         *pSz += OPAQUE16_LEN;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-        return SANITY_MSG_E;
+        return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     return 0;
@@ -11693,8 +11617,7 @@ static int TLSX_PreSharedKey_Parse(WOLFSSL* ssl, const byte* input,
         for (; list != NULL && idx > 0; idx--)
             list = list->next;
         if (list == NULL) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-            return PSK_KEY_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
         }
         list->chosen = 1;
 
@@ -11705,8 +11628,7 @@ static int TLSX_PreSharedKey_Parse(WOLFSSL* ssl, const byte* input,
                ssl->options.cipherSuite   != ssl->session->cipherSuite        ||
                ssl->session->version.major != ssl->ctx->method->version.major ||
                ssl->session->version.minor != ssl->ctx->method->version.minor) {
-                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-               return PSK_KEY_ERROR;
+               return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
            }
         }
     #endif
@@ -11714,8 +11636,7 @@ static int TLSX_PreSharedKey_Parse(WOLFSSL* ssl, const byte* input,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-    return SANITY_MSG_E;
+    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
 }
 
 /* Create a new pre-shared key and put it into the list.
@@ -11897,8 +11818,7 @@ static int TLSX_PskKeModes_GetSize(byte modes, byte msgType, word16* pSz)
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-    return SANITY_MSG_E;
+    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
 }
 
 /* Writes the PSK KE modes extension into the output buffer.
@@ -11929,8 +11849,7 @@ static int TLSX_PskKeModes_Write(byte modes, byte* output, byte msgType,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-    return SANITY_MSG_E;
+    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
 }
 
 int TLSX_PskKeyModes_Parse_Modes(const byte* input, word16 length, byte msgType,
@@ -11963,8 +11882,7 @@ int TLSX_PskKeyModes_Parse_Modes(const byte* input, word16 length, byte msgType,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-    return SANITY_MSG_E;
+    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
 }
 
 /* Parse the PSK KE modes extension.
@@ -11987,7 +11905,7 @@ static int TLSX_PskKeModes_Parse(WOLFSSL* ssl, const byte* input, word16 length,
         ret = TLSX_PskKeyModes_Use(ssl, modes);
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -12054,8 +11972,7 @@ static int TLSX_PostHandAuth_GetSize(byte msgType, word16* pSz)
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-    return SANITY_MSG_E;
+    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
 }
 
 /* Writes the Post-Handshake Authentication extension into the output buffer.
@@ -12075,8 +11992,7 @@ static int TLSX_PostHandAuth_Write(byte* output, byte msgType, word16* pSz)
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-    return SANITY_MSG_E;
+    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
 }
 
 /* Parse the Post-Handshake Authentication extension.
@@ -12102,8 +12018,7 @@ static int TLSX_PostHandAuth_Parse(WOLFSSL* ssl, const byte* input,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-    return SANITY_MSG_E;
+    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
 }
 
 /* Create a new Post-handshake authentication object in the extensions.
@@ -12161,8 +12076,7 @@ static int TLSX_EarlyData_GetSize(byte msgType, word16* pSz)
     else if (msgType == session_ticket)
         *pSz += OPAQUE32_LEN;
     else {
-        ret = SANITY_MSG_E;
-        WOLFSSL_ERROR_VERBOSE(ret);
+        ret = WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     return ret;
@@ -12188,8 +12102,7 @@ static int TLSX_EarlyData_Write(word32 maxSz, byte* output, byte msgType,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-    return SANITY_MSG_E;
+    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
 }
 
 /* Parse the Early Data Indicator extension.
@@ -12230,8 +12143,7 @@ static int TLSX_EarlyData_Parse(WOLFSSL* ssl, const byte* input, word16 length,
          * Index is plus one to handle 'not set' value of 0.
          */
         if (ssl->options.pskIdIndex != 1) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-            return PSK_KEY_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
         }
 
         if (ssl->options.side == WOLFSSL_CLIENT_END) {
@@ -12252,8 +12164,7 @@ static int TLSX_EarlyData_Parse(WOLFSSL* ssl, const byte* input, word16 length,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-    return SANITY_MSG_E;
+    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
 }
 
 /* Use the data to create a new Early Data object in the extensions.
@@ -16081,8 +15992,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
 #if defined(WOLFSSL_TLS13) && (defined(HAVE_SESSION_TICKET) || !defined(NO_PSK))
         if (msgType == client_hello && pskDone) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-            return PSK_KEY_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
         }
 #endif
 
@@ -16194,8 +16104,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                 if (IsAtLeastTLSv1_3(ssl->version)) {
                     if (msgType != client_hello &&
                         msgType != encrypted_extensions) {
-                        WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                        return EXT_NOT_ALLOWED;
+                        return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     }
                 }
                 else
@@ -16203,8 +16112,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                 {
                     if (msgType != client_hello &&
                         msgType != server_hello) {
-                        WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                        return EXT_NOT_ALLOWED;
+                        return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     }
                 }
                 ret = MFL_PARSE(ssl, input + offset, size, isRequest);
@@ -16235,16 +16143,14 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                 if (IsAtLeastTLSv1_3(ssl->version)) {
                     if (msgType != client_hello &&
                         msgType != encrypted_extensions) {
-                        WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                        return EXT_NOT_ALLOWED;
+                        return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     }
                 }
                 else
 #endif
                 {
                     if (msgType != client_hello) {
-                        WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                        return EXT_NOT_ALLOWED;
+                        return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     }
                 }
                 ret = EC_PARSE(ssl, input + offset, size, isRequest,
@@ -16255,8 +16161,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                 WOLFSSL_MSG("CKS extension received");
                 if (msgType != client_hello &&
                      msgType != encrypted_extensions) {
-                        WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                        return EXT_NOT_ALLOWED;
+                        return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                 }
                 ret = TLSX_CKS_Parse(ssl, (byte *)(input + offset), size,
                                      &ssl->extensions);
@@ -16274,8 +16179,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 #endif
                 if (msgType != client_hello &&
                     msgType != server_hello) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                    return EXT_NOT_ALLOWED;
+                    return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                 }
 
                 ret = PF_PARSE(ssl, input + offset, size, isRequest);
@@ -16495,8 +16399,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
                 if (msgType != client_hello &&
                     msgType != server_hello) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                    return EXT_NOT_ALLOWED;
+                    return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                 }
 
                 ret = PSK_PARSE(ssl, input + offset, size, msgType);
@@ -16513,8 +16416,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                     break;
 
                 if (msgType != client_hello) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                    return EXT_NOT_ALLOWED;
+                    return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                 }
 
                 ret = PKM_PARSE(ssl, input + offset, size, msgType);
@@ -16533,8 +16435,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
                 if (msgType != client_hello && msgType != session_ticket &&
                     msgType != encrypted_extensions) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                    return EXT_NOT_ALLOWED;
+                    return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                 }
                 ret = EDI_PARSE(ssl, input + offset, size, msgType);
                 break;
@@ -16551,8 +16452,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                     break;
 
                 if (msgType != client_hello) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                    return EXT_NOT_ALLOWED;
+                    return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                 }
 
                 ret = PHA_PARSE(ssl, input + offset, size, msgType);
@@ -16571,8 +16471,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
                 if (msgType != client_hello &&
                         msgType != certificate_request) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                    return EXT_NOT_ALLOWED;
+                    return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                 }
 
                 ret = SAC_PARSE(ssl, input + offset, size, isRequest);
@@ -16591,8 +16490,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
                 if (msgType != client_hello &&
                         msgType != certificate_request) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                    return EXT_NOT_ALLOWED;
+                    return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                 }
 
                 ret = CAN_PARSE(ssl, input + offset, size, isRequest);
@@ -16611,8 +16509,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
                 if (msgType != client_hello && msgType != server_hello &&
                         msgType != hello_retry_request) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
-                    return EXT_NOT_ALLOWED;
+                    return WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                 }
     #endif
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -634,8 +634,7 @@ static int DeriveEarlyTrafficSecret(WOLFSSL* ssl, byte* key, int side)
         ret = ssl->tls13SecretCb(ssl, CLIENT_EARLY_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #ifdef OPENSSL_EXTRA
@@ -643,8 +642,7 @@ static int DeriveEarlyTrafficSecret(WOLFSSL* ssl, byte* key, int side)
         ret = ssl->tls13KeyLogCb(ssl, CLIENT_EARLY_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #endif /* OPENSSL_EXTRA */
@@ -692,8 +690,7 @@ static int DeriveClientHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, CLIENT_HANDSHAKE_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #ifdef OPENSSL_EXTRA
@@ -701,8 +698,7 @@ static int DeriveClientHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, CLIENT_HANDSHAKE_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #endif /* OPENSSL_EXTRA */
@@ -749,8 +745,7 @@ static int DeriveServerHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, SERVER_HANDSHAKE_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #ifdef OPENSSL_EXTRA
@@ -758,8 +753,7 @@ static int DeriveServerHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, SERVER_HANDSHAKE_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #endif /* OPENSSL_EXTRA */
@@ -806,8 +800,7 @@ static int DeriveClientTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, CLIENT_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #ifdef OPENSSL_EXTRA
@@ -815,8 +808,7 @@ static int DeriveClientTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, CLIENT_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #endif /* OPENSSL_EXTRA */
@@ -863,8 +855,7 @@ static int DeriveServerTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, SERVER_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #ifdef OPENSSL_EXTRA
@@ -872,8 +863,7 @@ static int DeriveServerTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, SERVER_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #endif /* OPENSSL_EXTRA */
@@ -909,8 +899,7 @@ static int DeriveExporterSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, EXPORTER_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #ifdef OPENSSL_EXTRA
@@ -918,8 +907,7 @@ static int DeriveExporterSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, EXPORTER_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
-            return TLS13_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
         }
     }
 #endif /* OPENSSL_EXTRA */
@@ -1672,7 +1660,7 @@ end:
 #endif
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -2960,8 +2948,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
     if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         #ifndef WOLFSSL_EARLY_DATA
         if (ret < 0) {
-            ret = VERIFY_MAC_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         }
         #endif
         return ret;
@@ -3185,7 +3172,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
     }
 
     if (ret < 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -3432,7 +3419,7 @@ exit_buildmsg:
         ret = (int)args->sz;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     /* Final cleanup */
@@ -3808,8 +3795,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
 
     if (!HaveUniqueSessionObj(ssl)) {
         WOLFSSL_MSG("Unable to have unique session object");
-        WOLFSSL_ERROR_VERBOSE(MEMORY_ERROR);
-        return MEMORY_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(MEMORY_ERROR);
     }
 
     suite[0] = ssl->options.cipherSuite0;
@@ -3824,8 +3810,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
             /* Ensure cipher suite is supported or changed suite to one with
              * the same MAC algorithm. */
             if (!FindSuiteSSL(ssl, suite)) {
-                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-                return PSK_KEY_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             }
 
             ssl->options.cipherSuite0 = suite[0];
@@ -3893,8 +3878,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
                 if (idlen > MAX_PSK_KEY_LEN) {
                     wolfSSL_FreeSession(ssl->ctx, psksession);
                     WOLFSSL_MSG("psk key length is too long");
-                    WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-                    return PSK_KEY_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                 }
 
                 ssl->arrays->psk_keySz = (word32)idlen;
@@ -3933,8 +3917,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
 
                 /* Ensure PSK and negotiated cipher suites have same hash. */
                 if (SuiteMac(pskCS) != SuiteMac(suite)) {
-                    WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-                    return PSK_KEY_ERROR;
+                    return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                 }
                 /* Negotiated cipher suite is to be used - update PSK. */
                 psk->cipherSuite0 = suite[0];
@@ -3952,8 +3935,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
                     &cipherName);
             if (GetCipherSuiteFromName(cipherName, &cipherSuite0,
                             &cipherSuite, NULL, NULL, &cipherSuiteFlags) != 0) {
-                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-                return PSK_KEY_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             }
             ssl->options.cipherSuite0 = cipherSuite0;
             ssl->options.cipherSuite  = cipherSuite;
@@ -3969,8 +3951,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
         if (ssl->arrays->psk_keySz == 0 ||
                 (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
             (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-            return PSK_KEY_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
         }
 
         ret = SetCipherSpecs(ssl);
@@ -3982,8 +3963,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
 
         if (!clientHello && (psk->cipherSuite0 != suite[0] ||
                              psk->cipherSuite  != suite[1])) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-            return PSK_KEY_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
         }
 
         if (!clientHello) {
@@ -4328,8 +4308,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
         else
     #endif
         {
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         }
     }
 #endif
@@ -5162,8 +5141,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     if (args->pv.major != ssl->version.major ||
         args->pv.minor != tls12minor) {
         SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
-        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-        return VERSION_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
     }
 
     /* Random and session id length check */
@@ -5178,8 +5156,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (ssl->msgsReceived.got_hello_verify_request) {
             WOLFSSL_MSG("Received HelloRetryRequest after a "
                         "HelloVerifyRequest");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         }
 
         /* A HelloRetryRequest comes in as an ServerHello for MiddleBox compat.
@@ -5187,8 +5164,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
          * Don't allow more than one HelloRetryRequest or ServerHello.
          */
         if (ssl->msgsReceived.got_hello_retry_request) {
-            WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-            return DUPLICATE_MSG_E;
+            return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
         }
     }
     args->extMsgType = *extMsgType;
@@ -5227,8 +5203,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     b = input[args->idx++];
     if (b != 0) {
         WOLFSSL_MSG("Must be no compression types in list");
-        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-        return INVALID_PARAMETER;
+        return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
     }
 
     if ((args->idx - args->begin) + OPAQUE16_LEN > helloSz) {
@@ -5286,8 +5261,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 WOLFSSL_MSG("Server trying to downgrade to version less than "
                             "TLS v1.3");
                 SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || \
     defined(WOLFSSL_WPAS_SMALL)
@@ -5297,23 +5271,20 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 == WOLFSSL_OP_NO_TLSv1_2)
             {
                 WOLFSSL_MSG("\tOption set to not allow TLSv1.2");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
 #endif
 
             if (!ssl->options.dtls &&
                 args->pv.minor < ssl->options.minDowngrade) {
                 SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
 
             if (ssl->options.dtls &&
                 args->pv.minor > ssl->options.minDowngrade) {
                 SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
 
             ssl->version.minor = args->pv.minor;
@@ -5399,8 +5370,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ret = ssl->sessionSecretCb(ssl, ssl->session->masterSecret,
                                    &secretSz, ssl->sessionSecretCtx);
         if (ret != 0 || secretSz != SECRET_LEN) {
-            WOLFSSL_ERROR_VERBOSE(SESSION_SECRET_CB_E);
-            return SESSION_SECRET_CB_E;
+            return WOLFSSL_ERROR_VERBOSE(SESSION_SECRET_CB_E);
         }
     }
 #endif /* HAVE_SECRET_CALLBACK */
@@ -5432,8 +5402,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ret = DoServerHello(ssl, input, inOutIdx, helloSz);
 #else
         WOLFSSL_MSG("Client using higher version, fatal error");
-        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-        ret = VERSION_ERROR;
+        ret = WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
 #endif
 
         WOLFSSL_LEAVE("DoTls13ServerHello", ret);
@@ -5452,23 +5421,20 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     if (ssl->options.tls13MiddleBoxCompat) {
         if (args->sessIdSz == 0) {
             WOLFSSL_MSG("args->sessIdSz == 0");
-            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-            return INVALID_PARAMETER;
+            return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         }
         if (ssl->session->sessionIDSz != 0) {
             if (ssl->session->sessionIDSz != args->sessIdSz ||
                 XMEMCMP(ssl->session->sessionID, args->sessId,
                     args->sessIdSz) != 0) {
                 WOLFSSL_MSG("session id doesn't match");
-                WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-                return INVALID_PARAMETER;
+                return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             }
         }
         else if (XMEMCMP(ssl->arrays->clientRandom, args->sessId,
                 args->sessIdSz) != 0) {
             WOLFSSL_MSG("session id doesn't match client random");
-            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-            return INVALID_PARAMETER;
+            return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         }
     }
     else
@@ -5477,8 +5443,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     if (WOLFSSL_IS_QUIC(ssl)) {
         if (args->sessIdSz != 0) {
             WOLFSSL_MSG("args->sessIdSz != 0");
-            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-            return INVALID_PARAMETER;
+            return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         }
     }
     else
@@ -5487,8 +5452,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         XMEMCMP(ssl->session->sessionID, args->sessId, args->sessIdSz) != 0))
     {
         WOLFSSL_MSG("Server sent different session id");
-        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-        return INVALID_PARAMETER;
+        return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
     }
 
     ret = SetCipherSpecs(ssl);
@@ -5520,16 +5484,14 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     /* Check that the negotiated ciphersuite matches protocol version. */
     if (ssl->options.cipherSuite0 != TLS13_BYTE) {
         WOLFSSL_MSG("Server sent non-TLS13 cipher suite in TLS 1.3 packet");
-        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-        return INVALID_PARAMETER;
+        return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
     }
 
     suite[0] = ssl->options.cipherSuite0;
     suite[1] = ssl->options.cipherSuite;
     if (!FindSuiteSSL(ssl, suite)) {
         WOLFSSL_MSG("Cipher suite not supported on client");
-        WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
-        return MATCH_SUITE_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
     }
 
 #if defined(HAVE_ECH)
@@ -5790,8 +5752,7 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
             ) {
         if (PickHashSigAlgo(ssl, peerSuites.hashSigAlgo,
                             peerSuites.hashSigAlgoSz, 0) != 0) {
-            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-            return INVALID_PARAMETER;
+            return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         }
         ssl->options.sendVerify = SEND_CERT;
     }
@@ -5801,8 +5762,7 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
 #else
         WOLFSSL_MSG("Certificate required but none set on client");
         SendAlert(ssl, alert_fatal, illegal_parameter);
-        WOLFSSL_ERROR_VERBOSE(NO_CERT_ERROR);
-        return NO_CERT_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(NO_CERT_ERROR);
 #endif
     }
 
@@ -5914,8 +5874,7 @@ int FindPskSuite(const WOLFSSL* ssl, PreSharedKey* psk, byte* psk_key,
         if (*psk_keySz > MAX_PSK_KEY_LEN &&
             *((int*)psk_keySz) != WC_NO_ERR_TRACE(USE_HW_PSK)) {
             WOLFSSL_MSG("Key len too long in FindPsk()");
-            ret = PSK_KEY_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             *found = 0;
         }
         if (ret == 0) {
@@ -5976,8 +5935,7 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, const byte* suite, int* err)
 
         /* PSK age is always zero. */
         if (psk->ticketAge != 0) {
-            ret = PSK_KEY_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
         }
         if (ret == 0) {
             /* Set PSK ciphersuite into SSL. */
@@ -6166,8 +6124,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
             return ret;
         if (binderLen != current->binderLen ||
                              XMEMCMP(binder, current->binder, binderLen) != 0) {
-            WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
-            return BAD_BINDER;
+            return WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
         }
 
         /* This PSK works, no need to try any more. */
@@ -6182,8 +6139,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
         if (ssl->buffers.certChainCnt != 0)
             return 0;
     #endif
-        WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
-        return BAD_BINDER;
+        return WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
 #else
         return 0;
 #endif
@@ -6237,8 +6193,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
 
     /* Extensions pushed on stack/list and PSK must be last. */
     if (ssl->extensions != ext) {
-        WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-        return PSK_KEY_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
     }
 
     /* Assume we are going to resume with a pre-shared key. */
@@ -6333,8 +6288,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         /* Get the PSK key exchange modes the client wants to negotiate. */
         ext = TLSX_Find(ssl->extensions, TLSX_PSK_KEY_EXCHANGE_MODES);
         if (ext == NULL) {
-            WOLFSSL_ERROR_VERBOSE(MISSING_HANDSHAKE_DATA);
-            return MISSING_HANDSHAKE_DATA;
+            return WOLFSSL_ERROR_VERBOSE(MISSING_HANDSHAKE_DATA);
         }
         modes = ext->val;
 
@@ -6356,8 +6310,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         {
             if ((modes & (1 << PSK_KE)) == 0) {
                 WOLFSSL_MSG("psk_ke mode does not allow key share");
-                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
-                return PSK_KEY_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             }
             ssl->options.noPskDheKe = 1;
             ssl->arrays->preMasterSz = 0;
@@ -6371,8 +6324,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         if (ssl->buffers.certChainCnt != 0)
             return 0;
     #endif
-        WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
-        return BAD_BINDER;
+        return WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
     }
 #endif
 
@@ -6444,8 +6396,7 @@ int TlsCheckCookie(const WOLFSSL* ssl, const byte* cookie, word16 cookieSz)
         return ret;
 
     if (ConstantCompare(cookie + cookieSz, mac, macSz) != 0) {
-        WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
-        return HRR_COOKIE_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
     }
     return cookieSz;
 }
@@ -7328,7 +7279,7 @@ exit_dch:
     WOLFSSL_END(WC_FUNC_CLIENT_HELLO_DO);
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
 #if defined(HAVE_ECH)
@@ -9816,7 +9767,7 @@ exit_scv:
 #endif
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -10836,7 +10787,7 @@ exit_dcv:
     else
 #endif /* WOLFSSL_ASYNC_CRYPT */
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
 
         if (ret != WC_NO_ERR_TRACE(INVALID_PARAMETER)) {
             SendAlert(ssl, alert_fatal, decrypt_error);
@@ -10987,8 +10938,7 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 XMEMCMP(input + *inOutIdx, mac, size) != 0){
             WOLFSSL_MSG("Verify finished error on hashes");
             SendAlert(ssl, alert_fatal, decrypt_error);
-            WOLFSSL_ERROR_VERBOSE(VERIFY_FINISHED_ERROR);
-            return VERIFY_FINISHED_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(VERIFY_FINISHED_ERROR);
         }
     }
 
@@ -11162,8 +11112,7 @@ static int SendTls13Finished(WOLFSSL* ssl)
         int sendSz = BuildTls13Message(ssl, output, outputSz, input,
                                    headerSz + finishedSz, handshake, 1, 0, 0);
         if (sendSz < 0) {
-            WOLFSSL_ERROR_VERBOSE(BUILD_MSG_ERROR);
-            return BUILD_MSG_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(BUILD_MSG_ERROR);
         }
 
         #if defined(WOLFSSL_CALLBACKS) || defined(OPENSSL_EXTRA)
@@ -11437,8 +11386,7 @@ static int DoTls13KeyUpdate(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             ssl->keys.keyUpdateRespond = 1;
             break;
         default:
-            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-            return INVALID_PARAMETER;
+            return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
     }
 
     /* Move index to byte after message. */
@@ -11577,8 +11525,7 @@ static int DoTls13EndOfEarlyData(WOLFSSL* ssl, const byte* input,
     if (ssl->earlyData == no_early_data) {
         WOLFSSL_MSG("EndOfEarlyData received unexpectedly");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-        return OUT_OF_ORDER_E;
+        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
     }
 
     ssl->earlyData = done_early_data;
@@ -11658,8 +11605,7 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
     ato32(input + *inOutIdx, &lifetime);
     *inOutIdx += SESSION_HINT_SZ;
     if (lifetime > MAX_LIFETIME) {
-        WOLFSSL_ERROR_VERBOSE(SERVER_HINT_ERROR);
-        return SERVER_HINT_ERROR;
+        return WOLFSSL_ERROR_VERBOSE(SERVER_HINT_ERROR);
     }
 
     /* Age add. */
@@ -11676,8 +11622,7 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
     (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
     if (nonceLength > MAX_TICKET_NONCE_STATIC_SZ) {
         WOLFSSL_MSG("Nonce length not supported");
-        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
-        return INVALID_PARAMETER;
+        return WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
     }
 #endif /* WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3) */
     *inOutIdx += 1;
@@ -12086,30 +12031,26 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on SERVER side. */
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("ClientHello received by client");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             /* Check state. */
             if (ssl->options.clientState >= CLIENT_HELLO_COMPLETE) {
                 WOLFSSL_MSG("ClientHello received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
             /* Check previously seen. */
             /* Initial and after HelloRetryRequest - no more than 2. */
             if (ssl->msgsReceived.got_client_hello == 2) {
                 WOLFSSL_MSG("Too many ClientHello received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             /* Second only after HelloRetryRequest seen. */
             if (ssl->msgsReceived.got_client_hello == 1 &&
                 ssl->options.serverState !=
                                           SERVER_HELLO_RETRY_REQUEST_COMPLETE) {
                 WOLFSSL_MSG("Duplicate ClientHello received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_client_hello++;
 
@@ -12122,15 +12063,13 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerHello received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             /* Check state. */
             if (ssl->options.serverState >= SERVER_HELLO_COMPLETE) {
                 WOLFSSL_MSG("ServerHello received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
             /* Check previously seen. */
             /* Only once after ClientHello.
@@ -12139,8 +12078,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
              */
             if (ssl->msgsReceived.got_server_hello) {
                 WOLFSSL_MSG("Duplicate ServerHello received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_server_hello = 1;
 
@@ -12153,8 +12091,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("NewSessionTicket received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             /* Check state. */
@@ -12162,15 +12099,13 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only allowed after server's Finished message. */
             if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("NewSessionTicket received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
         #else
             /* Only allowed after client's Finished message. */
             if (ssl->options.clientState < CLIENT_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("NewSessionTicket received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
         #endif
             /* Many SessionTickets can be sent. */
@@ -12186,27 +12121,23 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on SERVER side. */
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("EndOfEarlyData received by client");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             /* Check state. */
             /* Only after server's Finished and before client's Finished. */
             if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("EndOfEarlyData received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
             if (ssl->options.clientState >= CLIENT_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("EndOfEarlyData received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
             /* Check previously seen. */
             if (ssl->msgsReceived.got_end_of_early_data) {
                 WOLFSSL_MSG("Too many EndOfEarlyData received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_end_of_early_data = 1;
 
@@ -12220,8 +12151,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("EncryptedExtensions received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             /* Check state. */
@@ -12231,14 +12161,12 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
              */
             if (ssl->options.serverState != SERVER_HELLO_COMPLETE) {
                 WOLFSSL_MSG("EncryptedExtensions received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
             /* Check previously seen. */
             if (ssl->msgsReceived.got_encrypted_extensions) {
                 WOLFSSL_MSG("Duplicate EncryptedExtensions received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_encrypted_extensions = 1;
 
@@ -12257,8 +12185,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 ssl->options.serverState !=
                                          SERVER_ENCRYPTED_EXTENSIONS_COMPLETE) {
                 WOLFSSL_MSG("Certificate received out of order - Client");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
         #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
             /* Server's authenticating with PSK must not send this. */
@@ -12266,8 +12193,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                              ssl->options.serverState == SERVER_CERT_COMPLETE &&
                              ssl->options.pskNegotiated) {
                 WOLFSSL_MSG("Certificate received while using PSK");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                return SANITY_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
             }
         #endif
     #endif
@@ -12279,15 +12205,13 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 ssl->options.clientState != CLIENT_HELLO_COMPLETE &&
                 ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("Certificate received out of order - Server");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
     #endif
             /* Check previously seen. */
             if (ssl->msgsReceived.got_certificate) {
                 WOLFSSL_MSG("Duplicate Certificate received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_certificate = 1;
 
@@ -12299,8 +12223,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("CertificateRequest received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
         #endif
             /* Check state. */
@@ -12310,8 +12233,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.serverState !=
                                          SERVER_ENCRYPTED_EXTENSIONS_COMPLETE) {
                 WOLFSSL_MSG("CertificateRequest received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
         #else
             /* Valid when sent after EncryptedExtensions and before Certificate
@@ -12322,16 +12244,14 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                        (ssl->options.serverState < SERVER_FINISHED_COMPLETE ||
                         ssl->options.clientState != CLIENT_FINISHED_COMPLETE)) {
                 WOLFSSL_MSG("CertificateRequest received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
         #endif
         #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
             /* Server's authenticating with PSK must not send this. */
             if (ssl->options.pskNegotiated) {
                 WOLFSSL_MSG("CertificateRequest received while using PSK");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                return SANITY_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
             }
         #endif
             /* Check previously seen. */
@@ -12339,16 +12259,14 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only once during handshake. */
             if (ssl->msgsReceived.got_certificate_request) {
                 WOLFSSL_MSG("Duplicate CertificateRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
         #else
             /* Only once during handshake. */
             if (ssl->msgsReceived.got_certificate_request &&
                 ssl->options.clientState != CLIENT_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("Duplicate CertificateRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
         #endif
             ssl->msgsReceived.got_certificate_request = 1;
@@ -12364,15 +12282,13 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 if (ssl->options.serverState != SERVER_CERT_COMPLETE) {
                     WOLFSSL_MSG("No Cert before CertVerify");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
             #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
                 /* Server's authenticating with PSK must not send this. */
                 if (ssl->options.pskNegotiated) {
                     WOLFSSL_MSG("CertificateVerify received while using PSK");
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                    return SANITY_MSG_E;
+                    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                 }
             #endif
             }
@@ -12383,27 +12299,23 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 /* Server must have sent Finished message. */
                 if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                     WOLFSSL_MSG("CertificateVerify received out of order");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 /* Valid only directly after a Certificate message. */
                 if (ssl->options.clientState < CLIENT_HELLO_COMPLETE) {
                     WOLFSSL_MSG("CertificateVerify before ClientHello done");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 if (!ssl->msgsReceived.got_certificate) {
                     WOLFSSL_MSG("No Cert before CertificateVerify");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
             }
     #endif
             /* Check previously seen. */
             if (ssl->msgsReceived.got_certificate_verify) {
                 WOLFSSL_MSG("Duplicate CertificateVerify received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_certificate_verify = 1;
 
@@ -12417,8 +12329,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 /* After sending ClientHello */
                 if (ssl->options.clientState < CLIENT_HELLO_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - clientState");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 /* Must have seen certificate and verify from server except when
                  * using PSK. */
@@ -12427,16 +12338,14 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                     if (ssl->options.serverState !=
                                          SERVER_ENCRYPTED_EXTENSIONS_COMPLETE) {
                         WOLFSSL_MSG("Finished received out of order - PSK");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                        return OUT_OF_ORDER_E;
+                        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     }
                 }
                 else
             #endif
                 if (ssl->options.serverState != SERVER_CERT_VERIFY_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - serverState");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
             }
         #endif
@@ -12445,13 +12354,11 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - serverState");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 if (ssl->options.clientState < CLIENT_HELLO_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - clientState");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
             #ifdef WOLFSSL_EARLY_DATA
                 if (ssl->earlyData == process_early_data &&
@@ -12459,8 +12366,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                     !ssl->options.dtls
                     /* QUIC does not use EndOfEarlyData records */
                     && !WOLFSSL_IS_QUIC(ssl)) {
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
             #endif
             }
@@ -12480,8 +12386,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                                            !ssl->msgsReceived.got_certificate) {
                     WOLFSSL_MSG("Finished received out of order - "
                                 "missing Certificate message");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 /* Mutual authentication on server requires a certificate from
                  * peer. Verify peer set on client side requires a certificate
@@ -12492,8 +12397,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                      ssl->options.verifyPeer)) && !ssl->options.havePeerCert) {
                     WOLFSSL_MSG("Finished received out of order - "
                                 "no valid certificate");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
                 /* Must have received a valid CertificateVerify if verifying
                  * peer and got a peer certificate.
@@ -12502,15 +12406,13 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                     ssl->options.havePeerCert && !ssl->options.havePeerVerify) {
                     WOLFSSL_MSG("Finished received out of order - "
                                 "Certificate message but no CertificateVerify");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                    return OUT_OF_ORDER_E;
+                    return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 }
             }
             /* Check previously seen. */
             if (ssl->msgsReceived.got_finished) {
                 WOLFSSL_MSG("Duplicate Finished received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_finished = 1;
 
@@ -12524,8 +12426,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
              */
             if (!ssl->msgsReceived.got_finished) {
                 WOLFSSL_MSG("No KeyUpdate before Finished");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
             /* Multiple KeyUpdates can be sent. */
             break;
@@ -12533,47 +12434,40 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
         case hello_verify_request:
             if (!ssl->options.dtls) {
                 WOLFSSL_MSG("HelloVerifyRequest when not in DTLS");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
             if (ssl->msgsReceived.got_hello_verify_request) {
                 WOLFSSL_MSG("Duplicate HelloVerifyRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             ssl->msgsReceived.got_hello_verify_request = 1;
             if (ssl->msgsReceived.got_hello_retry_request) {
                 WOLFSSL_MSG(
                     "Both HelloVerifyRequest and HelloRetryRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
-                return DUPLICATE_MSG_E;
+                return WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             }
             if (ssl->options.serverState >=
                     SERVER_HELLO_RETRY_REQUEST_COMPLETE ||
                 ssl->options.connectState != CLIENT_HELLO_SENT) {
                 WOLFSSL_MSG("HelloVerifyRequest received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-                return OUT_OF_ORDER_E;
+                return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             }
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("HelloVerifyRequest received on the server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
-                return SIDE_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
             }
             if (!ssl->options.downgrade ||
                 ssl->options.minDowngrade < DTLSv1_2_MINOR) {
                 WOLFSSL_MSG(
                     "HelloVerifyRequest received but not DTLSv1.2 allowed");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
             break;
 #endif /* WOLFSSL_DTLS13 && !WOLFSSL_NO_TLS12*/
 
         default:
             WOLFSSL_MSG("Unknown message type");
-            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-            return SANITY_MSG_E;
+            return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     }
 
     return 0;
@@ -12635,8 +12529,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             type != certificate && type != key_update && type != finished) {
         WOLFSSL_MSG("HandShake message after handshake complete");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-        return OUT_OF_ORDER_E;
+        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
     }
 
     if (ssl->options.side == WOLFSSL_CLIENT_END &&
@@ -12648,16 +12541,14 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         ) {
         WOLFSSL_MSG("First server message not server hello");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-        return OUT_OF_ORDER_E;
+        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
     }
 
     if (ssl->options.side == WOLFSSL_SERVER_END &&
                ssl->options.clientState == NULL_STATE && type != client_hello) {
         WOLFSSL_MSG("First client message not client hello");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
-        return OUT_OF_ORDER_E;
+        return WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
     }
 
     /* above checks handshake state */
@@ -12994,8 +12885,7 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         if (GetHandshakeHeader(ssl, input, inOutIdx, &type, &size,
                                                                 totalSz) != 0) {
             SendAlert(ssl, alert_fatal, unexpected_message);
-            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
-            return PARSE_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
         }
 
         ret = EarlySanityCheckMsgReceived(ssl, type, size);
@@ -13016,8 +12906,7 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
         if (GetHandshakeHeader(ssl, input, inOutIdx, &type, &size,
                                totalSz) != 0) {
-            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
-            return PARSE_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
         }
 
         ret = EarlySanityCheckMsgReceived(ssl, type,
@@ -13032,8 +12921,7 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
          * nine 2048-bit RSA certificates in the chain. */
         if (size > MAX_HANDSHAKE_SZ) {
             WOLFSSL_MSG("Handshake message too large");
-            WOLFSSL_ERROR_VERBOSE(HANDSHAKE_SIZE_ERROR);
-            return HANDSHAKE_SIZE_ERROR;
+            return WOLFSSL_ERROR_VERBOSE(HANDSHAKE_SIZE_ERROR);
         }
 
         /* size is the size of the certificate message payload */
@@ -13300,8 +13188,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
                     return wolfSSL_connect(ssl);
     #endif
                 WOLFSSL_MSG("Client using higher version, fatal error");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             }
 
             ssl->options.connectState = HELLO_AGAIN;
@@ -13401,8 +13288,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
             /* CLIENT: check peer authentication. */
             if (!ssl->options.peerAuthGood) {
                 WOLFSSL_MSG("Server authentication did not happen");
-                WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
-                return WOLFSSL_FATAL_ERROR;
+                return WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
             }
         #ifndef NO_CERTS
             if (!ssl->options.resuming && ssl->options.sendVerify) {
@@ -13483,8 +13369,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
             if (ssl->hsDoneCb != NULL) {
                 int cbret = ssl->hsDoneCb(ssl, ssl->hsDoneCtx);
                 if (cbret < 0) {
-                    ssl->error = cbret;
-                    WOLFSSL_ERROR_VERBOSE(ssl->error);
+                    ssl->error = WOLFSSL_ERROR_VERBOSE(cbret);
                     WOLFSSL_MSG("HandShake Done Cb don't continue error");
                     return WOLFSSL_FATAL_ERROR;
                 }

--- a/src/x509.c
+++ b/src/x509.c
@@ -5763,7 +5763,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_X509_get_pubkey(WOLFSSL_X509* x509)
                                             &idx, (ecc_key*)key->ecc->internal,
                                             key->pkey_sz);
                 if (ret < 0) {
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    (void)WOLFSSL_ERROR_VERBOSE(ret);
                     WOLFSSL_MSG("wc_EccPublicKeyDecode failed");
                     wolfSSL_EVP_PKEY_free(key);
                     return NULL;
@@ -10860,7 +10860,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
     }
     else {
         WOLFSSL_MSG("Subject Key ID too large");
-        WOLFSSL_ERROR_VERBOSE(BUFFER_E);
+        (void)WOLFSSL_ERROR_VERBOSE(BUFFER_E);
         return WOLFSSL_FAILURE;
     }
 
@@ -10881,7 +10881,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
     }
     else {
         WOLFSSL_MSG("Auth Key ID too large");
-        WOLFSSL_ERROR_VERBOSE(BUFFER_E);
+        (void)WOLFSSL_ERROR_VERBOSE(BUFFER_E);
         return WOLFSSL_FAILURE;
     }
 
@@ -10905,7 +10905,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
     if (x509->rawCRLInfo != NULL) {
         if (x509->rawCRLInfoSz > CTC_MAX_CRLINFO_SZ) {
             WOLFSSL_MSG("CRL Info too large");
-            WOLFSSL_ERROR_VERBOSE(BUFFER_E);
+            (void)WOLFSSL_ERROR_VERBOSE(BUFFER_E);
             return WOLFSSL_FAILURE;
         }
         XMEMCPY(cert->crlInfo, x509->rawCRLInfo, x509->rawCRLInfoSz);
@@ -10981,7 +10981,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
         if (serialSz > EXTERNAL_SERIAL_SIZE ||
                 serialSz > CTC_SERIAL_SIZE) {
             WOLFSSL_MSG("Serial size too large error");
-            WOLFSSL_ERROR_VERBOSE(BUFFER_E);
+            (void)WOLFSSL_ERROR_VERBOSE(BUFFER_E);
             return WOLFSSL_FAILURE;
         }
         XMEMCPY(cert->serial, serial, serialSz);
@@ -11210,7 +11210,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_RsaPublicKeyDecode(x509->pubKey.buffer, &idx, rsa,
                                                            x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
+                (void)WOLFSSL_ERROR_VERBOSE(ret);
                 wc_FreeRsaKey(rsa);
                 XFREE(rsa, NULL, DYNAMIC_TYPE_RSA);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11239,7 +11239,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_EccPublicKeyDecode(x509->pubKey.buffer, &idx, ecc,
                                                            x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
+                (void)WOLFSSL_ERROR_VERBOSE(ret);
                 wc_ecc_free(ecc);
                 XFREE(ecc, NULL, DYNAMIC_TYPE_ECC);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11268,7 +11268,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_DsaPublicKeyDecode(x509->pubKey.buffer, &idx, dsa,
                                                            x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
+                (void)WOLFSSL_ERROR_VERBOSE(ret);
                 wc_FreeDsaKey(dsa);
                 XFREE(dsa, NULL, DYNAMIC_TYPE_DSA);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11307,7 +11307,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_Falcon_PublicKeyDecode(x509->pubKey.buffer, &idx, falcon,
                                             x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
+                (void)WOLFSSL_ERROR_VERBOSE(ret);
                 wc_falcon_free(falcon);
                 XFREE(falcon, NULL, DYNAMIC_TYPE_FALCON);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11371,7 +11371,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_Dilithium_PublicKeyDecode(x509->pubKey.buffer, &idx,
                                     dilithium, x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
+                (void)WOLFSSL_ERROR_VERBOSE(ret);
                 wc_dilithium_free(dilithium);
                 XFREE(dilithium, NULL, DYNAMIC_TYPE_DILITHIUM);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11430,7 +11430,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_Sphincs_PublicKeyDecode(x509->pubKey.buffer, &idx, sphincs,
                                              x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
+                (void)WOLFSSL_ERROR_VERBOSE(ret);
                 wc_sphincs_free(sphincs);
                 XFREE(sphincs, NULL, DYNAMIC_TYPE_SPHINCS);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11463,8 +11463,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             wc_FreeRng(&rng);
         }
         if (ret <= 0) {
-            WOLFSSL_ERROR_VERBOSE(ret);
-            ret = WOLFSSL_FAILURE;
+            (void)WOLFSSL_ERROR_VERBOSE(ret) = WOLFSSL_FAILURE;
             goto cleanup;
         }
 
@@ -15409,7 +15408,7 @@ int wolfSSL_X509_REQ_add1_attr_by_NID(WOLFSSL_X509 *req,
         }
         else {
             WOLFSSL_MSG("Challenge password too long");
-            WOLFSSL_ERROR_VERBOSE(BUFFER_E);
+            (void)WOLFSSL_ERROR_VERBOSE(BUFFER_E);
             return WOLFSSL_FAILURE;
         }
         break;
@@ -15418,7 +15417,7 @@ int wolfSSL_X509_REQ_add1_attr_by_NID(WOLFSSL_X509 *req,
             len = (int)XSTRLEN((char*)bytes);
         if (len + 1 > EXTERNAL_SERIAL_SIZE) {
             WOLFSSL_MSG("SerialNumber too long");
-            WOLFSSL_ERROR_VERBOSE(BUFFER_E);
+            (void)WOLFSSL_ERROR_VERBOSE(BUFFER_E);
             return WOLFSSL_FAILURE;
         }
         XMEMCPY(req->serial, bytes, len);

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -2835,8 +2835,7 @@ static WARN_UNUSED_RESULT int wc_AesEncrypt(
     r = aes->rounds >> 1;
 
     if (r > 7 || r == 0) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
-        return KEYUSAGE_E;
+        return WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
     }
 
 #ifdef WOLFSSL_AESNI
@@ -2871,8 +2870,7 @@ static WARN_UNUSED_RESULT int wc_AesEncrypt(
             return 0;
         #else
             WOLFSSL_MSG("AES-ECB encrypt with bad alignment");
-            WOLFSSL_ERROR_VERBOSE(BAD_ALIGN_E);
-            return BAD_ALIGN_E;
+            return WOLFSSL_ERROR_VERBOSE(BAD_ALIGN_E);
         #endif
         }
 
@@ -3619,8 +3617,7 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
     r = aes->rounds >> 1;
 
     if (r > 7 || r == 0) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
-        return KEYUSAGE_E;
+        return WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
     }
 
 #ifdef WOLFSSL_AESNI
@@ -5753,8 +5750,7 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         blocks = sz / WC_AES_BLOCK_SIZE;
 #ifdef WOLFSSL_AES_CBC_LENGTH_CHECKS
         if (sz % WC_AES_BLOCK_SIZE) {
-            WOLFSSL_ERROR_VERBOSE(BAD_LENGTH_E);
-            return BAD_LENGTH_E;
+            return WOLFSSL_ERROR_VERBOSE(BAD_LENGTH_E);
         }
 #endif
 
@@ -5853,8 +5849,7 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
                 }
             #else
                 WOLFSSL_MSG("AES-CBC encrypt with bad alignment");
-                WOLFSSL_ERROR_VERBOSE(BAD_ALIGN_E);
-                ret = BAD_ALIGN_E;
+                ret = WOLFSSL_ERROR_VERBOSE(BAD_ALIGN_E);
             #endif
             } else {
                 AES_CBC_encrypt_AESNI(in, out, (byte*)aes->reg, sz, (byte*)aes->key,

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3411,8 +3411,7 @@ static int GetExplicitVersion(const byte* input, word32* inOutIdx, int* version,
             /* check if version is expected value rfc 5280 4.1 {0, 1, 2} */
             if (*version > MAX_X509_VERSION || *version < MIN_X509_VERSION) {
                 WOLFSSL_MSG("Unexpected certificate version");
-                WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
-                ret = ASN_VERSION_E;
+                ret = WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
             }
         }
         return ret;
@@ -6527,8 +6526,7 @@ static int CheckCurve(word32 oid)
     /* Check for error or zero length OID size (can't get OID for encoding). */
     if ((ret < 0) || (oidSz == 0)) {
         WOLFSSL_MSG("CheckCurve not found");
-        WOLFSSL_ERROR_VERBOSE(ECC_CURVE_OID_E);
-        ret = ECC_CURVE_OID_E;
+        ret = WOLFSSL_ERROR_VERBOSE(ECC_CURVE_OID_E);
     }
 
     /* Return ECC set id or error code. */
@@ -7091,8 +7089,7 @@ static int GetOID(const byte* input, word32* inOutIdx, word32* oid,
         if ((ret == 0) && (checkOid != NULL) && ((checkOidSz != actualOidSz) ||
                 (XMEMCMP(actualOid, checkOid, checkOidSz) != 0))) {
             WOLFSSL_MSG("OID Check Failed");
-            WOLFSSL_ERROR_VERBOSE(ASN_UNKNOWN_OID_E);
-            ret = ASN_UNKNOWN_OID_E;
+            ret = WOLFSSL_ERROR_VERBOSE(ASN_UNKNOWN_OID_E);
         }
     }
 #endif /* NO_VERIFY_OID */
@@ -8591,14 +8588,13 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
                  * values are the same. This is dereferencing RsaKey */
                 if (mp_cmp(&(a->n), &(b->n)) != MP_EQ ||
                     mp_cmp(&(a->e), &(b->e)) != MP_EQ) {
-                    ret = MP_CMP_E;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(MP_CMP_E);
                 }
                 else
                     ret = 1;
             }
             else {
-                WOLFSSL_ERROR_VERBOSE(ret);
+                (void)WOLFSSL_ERROR_VERBOSE(ret);
             }
         }
         wc_FreeRsaKey(b);
@@ -8667,14 +8663,14 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
                         ret = 1;
                     }
                     else {
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        (void)WOLFSSL_ERROR_VERBOSE(ret);
                     }
                 }
                 ForceZero(privDer, privSz);
             }
         }
         else {
-            WOLFSSL_ERROR_VERBOSE(ret);
+            (void)WOLFSSL_ERROR_VERBOSE(ret);
         }
         wc_ecc_free(key_pair);
     #ifdef WOLFSSL_SMALL_STACK
@@ -8722,12 +8718,12 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
                     ret = 1;
                 }
                 else {
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    (void)WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
         }
         else {
-            WOLFSSL_ERROR_VERBOSE(ret);
+            (void)WOLFSSL_ERROR_VERBOSE(ret);
         }
         wc_ed25519_free(key_pair);
     #ifdef WOLFSSL_SMALL_STACK
@@ -8772,12 +8768,12 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
                     ret = 1;
                 }
                 else {
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    (void)WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
         }
         else {
-            WOLFSSL_ERROR_VERBOSE(ret);
+            (void)WOLFSSL_ERROR_VERBOSE(ret);
         }
         wc_ed448_free(key_pair);
     #ifdef WOLFSSL_SMALL_STACK
@@ -8833,12 +8829,12 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
                     ret = 1;
                 }
                 else {
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    (void)WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
         }
         else {
-            WOLFSSL_ERROR_VERBOSE(ret);
+            (void)WOLFSSL_ERROR_VERBOSE(ret);
         }
         wc_falcon_free(key_pair);
     #ifdef WOLFSSL_SMALL_STACK
@@ -14241,8 +14237,7 @@ static int GetCertKey(DecodedCert* cert, const byte* source, word32* inOutIdx,
     #endif /* NO_DSA */
         default:
             WOLFSSL_MSG("Unknown or not compiled in key OID");
-            WOLFSSL_ERROR_VERBOSE(ASN_UNKNOWN_OID_E);
-            ret = ASN_UNKNOWN_OID_E;
+            ret = WOLFSSL_ERROR_VERBOSE(ASN_UNKNOWN_OID_E);
     }
 
     /* Return index after public key. */
@@ -15297,8 +15292,7 @@ static int GetRDN(DecodedCert* cert, char* full, word32* idx, int* nid,
     /* Other OIDs that start with the same values. */
     else if (oidSz == sizeof(dcOid) && XMEMCMP(oid, dcOid, oidSz-1) == 0) {
         WOLFSSL_MSG("Unknown pilot attribute type");
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-        ret = ASN_PARSE_E;
+        ret = WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
     }
     else if (oidSz == ASN_JOI_PREFIX_SZ + 1 &&
                          XMEMCMP(oid, ASN_JOI_PREFIX, ASN_JOI_PREFIX_SZ) == 0) {
@@ -16871,8 +16865,7 @@ static int GetDateInfo(const byte* source, word32* idx, const byte** pDate,
     format = source[*idx];
     *idx += 1;
     if (format != ASN_UTC_TIME && format != ASN_GENERALIZED_TIME) {
-        WOLFSSL_ERROR_VERBOSE(ASN_TIME_E);
-        return ASN_TIME_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_TIME_E);
     }
 
     /* get length */
@@ -16959,12 +16952,10 @@ static int GetDate(DecodedCert* cert, int dateType, int verify, int maxIdx)
             (! AsnSkipDateCheck) &&
             !XVALIDATE_DATE(date, format, dateType)) {
         if (dateType == ASN_BEFORE) {
-            WOLFSSL_ERROR_VERBOSE(ASN_BEFORE_DATE_E);
-            return ASN_BEFORE_DATE_E;
+            return WOLFSSL_ERROR_VERBOSE(ASN_BEFORE_DATE_E);
         }
         else {
-            WOLFSSL_ERROR_VERBOSE(ASN_AFTER_DATE_E);
-            return ASN_AFTER_DATE_E;
+            return WOLFSSL_ERROR_VERBOSE(ASN_AFTER_DATE_E);
         }
     }
 #else
@@ -18421,7 +18412,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_RsaPublicKeyDecode(key, &idx, sigCtx->key.rsa,
                                                                  keySz)) != 0) {
                         WOLFSSL_MSG("ASN Key decode error RSA");
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        (void)WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                     XMEMCPY(sigCtx->sigCpy, sig, sigSz);
@@ -18463,7 +18454,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_DsaPublicKeyDecode(key, &idx, sigCtx->key.dsa,
                                                                  keySz)) != 0) {
                         WOLFSSL_MSG("ASN Key decode error DSA");
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        (void)WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                     if (sigSz != DSA_160_SIG_SIZE &&
@@ -18521,7 +18512,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                                                                          keySz);
                     if (ret < 0) {
                         WOLFSSL_MSG("ASN Key import error ECC");
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        (void)WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -18549,7 +18540,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_ed25519_import_public(key, keySz,
                                                     sigCtx->key.ed25519)) < 0) {
                         WOLFSSL_MSG("ASN Key import error ED25519");
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        (void)WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -18576,7 +18567,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_ed448_import_public(key, keySz,
                                                       sigCtx->key.ed448)) < 0) {
                         WOLFSSL_MSG("ASN Key import error ED448");
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        (void)WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -18610,7 +18601,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_Falcon_PublicKeyDecode(key, &idx,
                         sigCtx->key.falcon, keySz)) < 0) {
                         WOLFSSL_MSG("ASN Key import error Falcon Level 1");
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        (void)WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                     break;
@@ -18639,7 +18630,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_Falcon_PublicKeyDecode(key, &idx,
                         sigCtx->key.falcon, keySz)) < 0) {
                         WOLFSSL_MSG("ASN Key import error Falcon Level 5");
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        (void)WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                     break;
@@ -18881,8 +18872,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
             #endif /* HAVE_SPHINCS */
                 default:
                     WOLFSSL_MSG("Verify Key type unknown");
-                    ret = ASN_UNKNOWN_OID_E;
-                    WOLFSSL_ERROR_VERBOSE(ret);
+                    ret = WOLFSSL_ERROR_VERBOSE(ASN_UNKNOWN_OID_E);
                     break;
             } /* switch (keyOID) */
 
@@ -18962,7 +18952,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     }
                     else {
                         WOLFSSL_MSG("SM2wSM3 create digest failed");
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        (void)WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                     ret = wc_ecc_sm2_verify_hash(sig, sigSz, sigCtx->digest,
@@ -18985,7 +18975,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                         }
                         else {
                             WOLFSSL_MSG("SM2wSM3 create digest failed");
-                            WOLFSSL_ERROR_VERBOSE(ret);
+                            (void)WOLFSSL_ERROR_VERBOSE(ret);
                             goto exit_cs;
                         }
                         ret = wc_ecc_sm2_verify_hash(sig, sigSz, sigCtx->digest,
@@ -19091,8 +19081,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
 
             if (ret < 0) {
                 /* treat all errors as ASN_SIG_CONFIRM_E */
-                ret = ASN_SIG_CONFIRM_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(ASN_SIG_CONFIRM_E);
                 goto exit_cs;
             }
 
@@ -19162,8 +19151,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     }
                     else {
                         WOLFSSL_MSG("RSA SSL verify match encode error");
-                        ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        ret = WOLFSSL_ERROR_VERBOSE(ASN_SIG_CONFIRM_E);
                     }
 
                 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
@@ -19180,8 +19168,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     }
                     else {
                         WOLFSSL_MSG("DSA Verify didn't match");
-                        ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        ret = WOLFSSL_ERROR_VERBOSE(ASN_SIG_CONFIRM_E);
                     }
                     break;
                 }
@@ -19197,8 +19184,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     }
                     else {
                         WOLFSSL_MSG("ECC Verify didn't match");
-                        ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        ret = WOLFSSL_ERROR_VERBOSE(ASN_SIG_CONFIRM_E);
                     }
                     break;
                 }
@@ -19211,8 +19197,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     }
                     else {
                         WOLFSSL_MSG("ED25519 Verify didn't match");
-                        ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        ret = WOLFSSL_ERROR_VERBOSE(ASN_SIG_CONFIRM_E);
                     }
                     break;
                 }
@@ -19225,8 +19210,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     }
                     else {
                         WOLFSSL_MSG("ED448 Verify didn't match");
-                        ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        ret = WOLFSSL_ERROR_VERBOSE(ASN_SIG_CONFIRM_E);
                     }
                     break;
                 }
@@ -19239,8 +19223,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     }
                     else {
                         WOLFSSL_MSG("FALCON_LEVEL1 Verify didn't match");
-                        ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        ret = WOLFSSL_ERROR_VERBOSE(ASN_SIG_CONFIRM_E);
                     }
                     break;
                 }
@@ -19251,8 +19234,7 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     }
                     else {
                         WOLFSSL_MSG("FALCON_LEVEL5 Verify didn't match");
-                        ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
+                        ret = WOLFSSL_ERROR_VERBOSE(ASN_SIG_CONFIRM_E);
                     }
                     break;
                 }
@@ -19740,8 +19722,7 @@ static int DecodeOtherHelper(ASNGetData* dataASN, DecodedCert* cert, int oid)
             buf    = (const char*)dataASN[OTHERNAMEASN_IDX_UPN].data.ref.data;
             break;
         default:
-            WOLFSSL_ERROR_VERBOSE(ASN_UNKNOWN_OID_E);
-            ret = ASN_UNKNOWN_OID_E;
+            ret = WOLFSSL_ERROR_VERBOSE(ASN_UNKNOWN_OID_E);
             break;
     }
 
@@ -19903,15 +19884,13 @@ static int DecodeGeneralName(const byte* input, word32* inOutIdx, byte tag,
             /* test hier-part is empty */
             if (i == 0 || i == len) {
                 WOLFSSL_MSG("\tEmpty or malformed URI");
-                WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
-                return ASN_ALT_NAME_E;
+                return WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
             }
 
             /* test if scheme is missing  */
             if (input[idx + (word32)i] != ':') {
                 WOLFSSL_MSG("\tAlt Name must be absolute URI");
-                WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
-                return ASN_ALT_NAME_E;
+                return WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
             }
         }
     #endif
@@ -20198,8 +20177,7 @@ static int DecodeAltNames(const byte* input, word32 sz, DecodedCert* cert)
         /* RFC 5280 4.2.1.6.  Subject Alternative Name
            If the subjectAltName extension is present, the sequence MUST
            contain at least one entry. */
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-        return ASN_PARSE_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
     }
 
 #ifdef OPENSSL_ALL
@@ -20374,23 +20352,20 @@ static int DecodeAltNames(const byte* input, word32 sz, DecodedCert* cert)
                     }
                     if (input[idx + i] == '/') {
                         WOLFSSL_MSG("\tAlt Name must be absolute URI");
-                        WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
-                        return ASN_ALT_NAME_E;
+                        return WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                     }
                 }
 
                 /* test hier-part is empty */
                 if (i == 0 || i == (word32)strLen) {
                     WOLFSSL_MSG("\tEmpty or malformed URI");
-                    WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
-                    return ASN_ALT_NAME_E;
+                    return WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                 }
 
                 /* test if scheme is missing */
                 if (input[idx + i] != ':') {
                     WOLFSSL_MSG("\tAlt Name must be absolute URI");
-                    WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
-                    return ASN_ALT_NAME_E;
+                    return WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                 }
             }
         #endif
@@ -20602,8 +20577,7 @@ static int DecodeAltNames(const byte* input, word32 sz, DecodedCert* cert)
         /* RFC 5280 4.2.1.6.  Subject Alternative Name
            If the subjectAltName extension is present, the sequence MUST
            contain at least one entry. */
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-        ret = ASN_PARSE_E;
+        ret = WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
     }
     if (ret == 0) {
     #ifdef OPENSSL_ALL
@@ -20727,8 +20701,7 @@ int DecodeBasicCaConstraint(const byte* input, int sz, byte *isCa,
     if (ret < 0)
         return ret;
     else if (ret > WOLFSSL_MAX_PATH_LEN) {
-        WOLFSSL_ERROR_VERBOSE(ASN_PATHLEN_SIZE_E);
-        return ASN_PATHLEN_SIZE_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_PATHLEN_SIZE_E);
     }
 
     *pathLength = (word16)ret;
@@ -20761,18 +20734,15 @@ int DecodeBasicCaConstraint(const byte* input, int sz, byte *isCa,
 #if !defined(ASN_TEMPLATE_SKIP_ISCA_CHECK) && \
     !defined(WOLFSSL_ALLOW_ENCODING_CA_FALSE)
         if ((dataASN[BASICCONSASN_IDX_CA].length != 0) && (!innerIsCA)) {
-            WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-            ret = ASN_PARSE_E;
+            ret = WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         }
 #endif
         /* Path length must be a 7-bit value. */
         if ((ret == 0) && (*pathLength >= (1 << 7))) {
-            WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-            ret = ASN_PARSE_E;
+            ret = WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         }
         if ((ret == 0) && *pathLength > WOLFSSL_MAX_PATH_LEN) {
-            WOLFSSL_ERROR_VERBOSE(ASN_PATHLEN_SIZE_E);
-            ret = ASN_PATHLEN_SIZE_E;
+            ret = WOLFSSL_ERROR_VERBOSE(ASN_PATHLEN_SIZE_E);
         }
         /* Store CA boolean and whether a path length was seen. */
         if (ret == 0) {
@@ -21075,8 +21045,7 @@ static int DecodeCrlDist(const byte* input, word32 sz, DecodedCert* cert)
                      &reason);
              /* First bit (LSB) unused and eight other bits defined. */
              if ((ret == 0) && ((reason >> 9) || (reason & 0x01))) {
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-                ret = ASN_PARSE_E;
+                ret = WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
              }
         }
     #endif
@@ -22433,8 +22402,7 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
                                 cert->extCertPoliciesNb], MAX_CERTPOL_SZ,
                                 input + idx, length) <= 0) {
                 WOLFSSL_MSG("\tCouldn't decode CertPolicy");
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-                return ASN_PARSE_E;
+                return WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
             }
         #ifndef WOLFSSL_DUP_CERTPOL
             /* From RFC 5280 section 4.2.1.4 "A certificate policy OID MUST
@@ -22448,8 +22416,7 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
                             MAX_CERTPOL_SZ) == 0) {
                     WOLFSSL_MSG("Duplicate policy OIDs not allowed");
                     WOLFSSL_MSG("Use WOLFSSL_DUP_CERTPOL if wanted");
-                    WOLFSSL_ERROR_VERBOSE(CERTPOLICIES_E);
-                    return CERTPOLICIES_E;
+                    return WOLFSSL_ERROR_VERBOSE(CERTPOLICIES_E);
                 }
             }
         #endif /* !WOLFSSL_DUP_CERTPOL */
@@ -22538,8 +22505,7 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
                     cert->extCertPolicies[cert->extCertPoliciesNb],
                     MAX_CERTPOL_SZ, data, length) <= 0) {
                 WOLFSSL_MSG("\tCouldn't decode CertPolicy");
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-                ret = ASN_PARSE_E;
+                ret = WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
             }
         }
         #ifndef WOLFSSL_DUP_CERTPOL
@@ -22554,8 +22520,7 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
                         MAX_CERTPOL_SZ) == 0) {
                 WOLFSSL_MSG("Duplicate policy OIDs not allowed");
                 WOLFSSL_MSG("Use WOLFSSL_DUP_CERTPOL if wanted");
-                WOLFSSL_ERROR_VERBOSE(CERTPOLICIES_E);
-                ret = CERTPOLICIES_E;
+                ret = WOLFSSL_ERROR_VERBOSE(CERTPOLICIES_E);
             }
         }
         #endif /* !WOLFSSL_DUP_CERTPOL */
@@ -22624,8 +22589,7 @@ static int DecodeSubjDirAttr(const byte* input, word32 sz, DecodedCert* cert)
         /* RFC 5280 4.2.1.8.  Subject Directory Attributes
            If the subjectDirectoryAttributes extension is present, the
            sequence MUST contain at least one entry. */
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-        return ASN_PARSE_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
     }
 
     /* length is the length of the list contents */
@@ -22751,8 +22715,7 @@ static int DecodeSubjInfoAcc(const byte* input, word32 sz, DecodedCert* cert)
         /* RFC 5280 4.2.2.2.  Subject Information Access
            If the subjectInformationAccess extension is present, the
            sequence MUST contain at least one entry. */
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-        return ASN_PARSE_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
     }
 
     /* Per fpkx-x509-cert-profile-common... section 5.3.
@@ -23119,8 +23082,7 @@ int DecodeExtensionType(const byte* input, word32 length, word32 oid,
             WOLFSSL_MSG("Certificate Policy extension not supported.");
             #ifndef WOLFSSL_NO_ASN_STRICT
             if (critical) {
-                WOLFSSL_ERROR_VERBOSE(ASN_CRIT_EXT_E);
-                ret = ASN_CRIT_EXT_E;
+                ret = WOLFSSL_ERROR_VERBOSE(ASN_CRIT_EXT_E);
             }
             #endif
         #endif
@@ -23153,8 +23115,7 @@ int DecodeExtensionType(const byte* input, word32 length, word32 oid,
                 which MUST be used only in a CA certificate" */
             if (!cert->isCA) {
                 WOLFSSL_MSG("Name constraints allowed only for CA certs");
-                WOLFSSL_ERROR_VERBOSE(ASN_NAME_INVALID_E);
-                ret = ASN_NAME_INVALID_E;
+                ret = WOLFSSL_ERROR_VERBOSE(ASN_NAME_INVALID_E);
             }
         #endif
             VERIFY_AND_SET_OID(cert->extNameConstraintSet);
@@ -23237,8 +23198,7 @@ int DecodeExtensionType(const byte* input, word32 length, word32 oid,
              * extension to allow caller to accept it with the verify
              * callback. */
             if (critical) {
-                WOLFSSL_ERROR_VERBOSE(ASN_CRIT_EXT_E);
-                ret = ASN_CRIT_EXT_E;
+                ret = WOLFSSL_ERROR_VERBOSE(ASN_CRIT_EXT_E);
             }
         #endif
             break;
@@ -23838,8 +23798,7 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
     /* Check version is valid/supported - can't be negative. */
     if ((ret == 0) && (version > MAX_X509_VERSION)) {
         WOLFSSL_MSG("Unexpected certificate version");
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-        ret = ASN_PARSE_E;
+        ret = WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
     }
     if (ret == 0) {
         int i;
@@ -23926,21 +23885,18 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
         /* Make sure 'signature' and 'signatureAlgorithm' are the same. */
         if (dataASN[X509CERTASN_IDX_SIGALGO_OID].data.oid.sum
                 != cert->signatureOID) {
-            WOLFSSL_ERROR_VERBOSE(ASN_SIG_OID_E);
-            ret = ASN_SIG_OID_E;
+            ret = WOLFSSL_ERROR_VERBOSE(ASN_SIG_OID_E);
         }
         /* Parameters not allowed after ECDSA or EdDSA algorithm OID. */
         else if (IsSigAlgoECC(cert->signatureOID)) {
         #ifndef WOLFSSL_ECC_SIGALG_PARAMS_NULL_ALLOWED
             if (dataASN[X509CERTASN_IDX_SIGALGO_PARAMS_NULL].tag != 0) {
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-                ret = ASN_PARSE_E;
+                ret = WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
             }
         #endif
         #ifdef WC_RSA_PSS
             if (dataASN[X509CERTASN_IDX_SIGALGO_PARAMS].tag != 0) {
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-                ret = ASN_PARSE_E;
+                ret = WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
             }
         #endif
         }
@@ -23952,8 +23908,7 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
 
             /* Parameters only with RSA PSS. */
             if (oid != CTC_RSASSAPSS) {
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-                ret = ASN_PARSE_E;
+                ret = WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
             }
             if (ret == 0) {
                 const byte* tbsParams;
@@ -23975,8 +23930,7 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
                         cert->source);
                 if ((tbsParamsSz != sigAlgParamsSz) ||
                         (XMEMCMP(tbsParams, sigAlgParams, tbsParamsSz) != 0)) {
-                    WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-                    ret = ASN_PARSE_E;
+                    ret = WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
                 }
             }
             if (ret == 0) {
@@ -24006,8 +23960,7 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
         /* Certificate extensions were only defined in version 2. */
         if (cert->version < 2) {
             WOLFSSL_MSG("\tv1 and v2 certs not allowed extensions");
-            WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
-            ret = ASN_VERSION_E;
+            ret = WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
         }
     #endif
         if (ret == 0) {
@@ -25008,7 +24961,7 @@ static int CheckCertSignature_ex(const byte* cert, word32 certSz, void* heap,
                 sigParamsSz, NULL);
         }
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(ret);
+            (void)WOLFSSL_ERROR_VERBOSE(ret);
             WOLFSSL_MSG("Confirm signature failed");
         }
     }
@@ -25687,8 +25640,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                         break;
                     default:
                         WOLFSSL_MSG("Unsupported attribute type");
-                        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-                        return ASN_PARSE_E;
+                        return WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
                     }
                 }
             }
@@ -25699,8 +25651,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
         #ifndef ALLOW_V1_EXTENSIONS
             if (cert->version < 2) {
                 WOLFSSL_MSG("\tv1 and v2 certs not allowed extensions");
-                WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
-                return ASN_VERSION_E;
+                return WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
             }
         #endif
 
@@ -25748,8 +25699,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                 && !cert->isCSR
 #endif
                 ) {
-            WOLFSSL_ERROR_VERBOSE(ASN_SIG_OID_E);
-            return ASN_SIG_OID_E;
+            return WOLFSSL_ERROR_VERBOSE(ASN_SIG_OID_E);
         }
 #else
 #ifdef WOLFSSL_CERT_REQ
@@ -25770,8 +25720,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                     ret = 0;
             }
             else if (ret < 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
-                return ret;
+                return WOLFSSL_ERROR_VERBOSE(ret);
             }
 #if defined(HAVE_RPK)
             if (cert->isRPK) {
@@ -25787,8 +25736,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
          *   key usage extension MUST NOT be asserted. */
         if (!cert->isCA && cert->extKeyUsageSet &&
                 (cert->extKeyUsage & KEYUSE_KEY_CERT_SIGN) != 0) {
-            WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
-            return KEYUSAGE_E;
+            return WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
         }
     #endif
 
@@ -25806,8 +25754,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                     cert->extSubjKeyId, HashIdAlg(cert->signatureOID));
             }
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
-                return ret;
+                return WOLFSSL_ERROR_VERBOSE(ret);
             }
         }
     #endif /* !NO_SKID */
@@ -25886,8 +25833,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                     if (verify != NO_VERIFY) {
                         WOLFSSL_MSG("\tNon-entity cert, maxPathLen is 0");
                         WOLFSSL_MSG("\tmaxPathLen status: ERROR");
-                        WOLFSSL_ERROR_VERBOSE(ASN_PATHLEN_INV_E);
-                        return ASN_PATHLEN_INV_E;
+                        return WOLFSSL_ERROR_VERBOSE(ASN_PATHLEN_INV_E);
                     }
                 }
                 else {
@@ -25989,8 +25935,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                     if (ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
                         WOLFSSL_MSG("Confirm signature failed");
                     }
-                    WOLFSSL_ERROR_VERBOSE(ret);
-                    return ret;
+                    return WOLFSSL_ERROR_VERBOSE(ret);
                 }
 
             #ifdef WOLFSSL_DUAL_ALG_CERTS
@@ -26021,8 +25966,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
 
                         if (ret != 0) {
                             WOLFSSL_MSG("Confirm alternative signature failed");
-                            WOLFSSL_ERROR_VERBOSE(ret);
-                            return ret;
+                            return WOLFSSL_ERROR_VERBOSE(ret);
                         }
                         else {
                             WOLFSSL_MSG("Alt signature has been verified!");
@@ -26038,8 +25982,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                  * name constraints */
                 if (!ConfirmNameConstraints(cert->ca, cert)) {
                     WOLFSSL_MSG("Confirm name constraint failed");
-                    WOLFSSL_ERROR_VERBOSE(ASN_NAME_INVALID_E);
-                    return ASN_NAME_INVALID_E;
+                    return WOLFSSL_ERROR_VERBOSE(ASN_NAME_INVALID_E);
                 }
             }
         #endif /* IGNORE_NAME_CONSTRAINTS */
@@ -26062,8 +26005,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                 if (ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
                     WOLFSSL_MSG("Confirm signature failed");
                 }
-                WOLFSSL_ERROR_VERBOSE(ret);
-                return ret;
+                return WOLFSSL_ERROR_VERBOSE(ret);
             }
 
         #ifdef WOLFSSL_DUAL_ALG_CERTS
@@ -26094,8 +26036,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
 
                     if (ret != 0) {
                         WOLFSSL_MSG("Confirm alternative signature failed");
-                        WOLFSSL_ERROR_VERBOSE(ret);
-                        return ret;
+                        return WOLFSSL_ERROR_VERBOSE(ret);
                     }
                     else {
                         WOLFSSL_MSG("Alt signature has been verified!");
@@ -26113,13 +26054,12 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
             /* ret needs to be self-signer error for openssl compatibility */
             if (cert->selfSigned) {
-                WOLFSSL_ERROR_VERBOSE(ASN_SELF_SIGNED_E);
-                return ASN_SELF_SIGNED_E;
+                return WOLFSSL_ERROR_VERBOSE(ASN_SELF_SIGNED_E);
             }
             else
 #endif
             {
-                WOLFSSL_ERROR_VERBOSE(ASN_NO_SIGNER_E);
+                (void)WOLFSSL_ERROR_VERBOSE(ASN_NO_SIGNER_E);
                 WOLFSSL_MSG_CERT("Consider using WOLFSSL_ALT_CERT_CHAINS.");
                 return ASN_NO_SIGNER_E;
             }
@@ -26385,8 +26325,7 @@ int SetSerialNumber(const byte* sn, word32 snSz, byte* output,
     /* RFC 5280 - 4.1.2.2:
      *   Serial numbers must be a positive value (and not zero) */
     if (snSzInt == 0) {
-        WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
-        return BAD_FUNC_ARG;
+        return WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
     }
 
     if (sn[0] & 0x80)
@@ -26464,8 +26403,7 @@ int wc_GetSerialNumber(const byte* input, word32* inOutIdx,
 
     if (*serialSz > EXTERNAL_SERIAL_SIZE || *serialSz <= 0) {
         WOLFSSL_MSG("Serial size bad");
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-        return ASN_PARSE_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
     }
 
     /* return serial */
@@ -27192,8 +27130,7 @@ int wc_DerToPemEx(const byte* der, word32 derSz, byte* output, word32 outSz,
         outLen = 0;
         if ((err = Base64_Encode(der, derSz, NULL, (word32*)&outLen))
                 != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
-            WOLFSSL_ERROR_VERBOSE(err);
-            return err;
+            return WOLFSSL_ERROR_VERBOSE(err);
         }
         return (int)headerLen + (int)footerLen + outLen;
     }
@@ -27229,8 +27166,7 @@ int wc_DerToPemEx(const byte* der, word32 derSz, byte* output, word32 outSz,
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(footer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
-        WOLFSSL_ERROR_VERBOSE(err);
-        return err;
+        return WOLFSSL_ERROR_VERBOSE(err);
     }
     i += outLen;
 
@@ -27588,8 +27524,7 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
 
         if (!info || !info->passwd_cb) {
             WOLFSSL_MSG("No password callback set");
-            WOLFSSL_ERROR_VERBOSE(NO_PASSWORD);
-            return NO_PASSWORD;
+            return WOLFSSL_ERROR_VERBOSE(NO_PASSWORD);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -27628,8 +27563,7 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
                     }
                 }
             #else
-                WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
-                ret = NOT_COMPILED_IN;
+                ret = WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
             #endif
             }
             /* decrypt the key */
@@ -27637,8 +27571,7 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
                 if (passwordSz == 0) {
                     /* The key is encrypted but does not have a password */
                     WOLFSSL_MSG("No password for encrypted key");
-                    WOLFSSL_ERROR_VERBOSE(NO_PASSWORD);
-                    ret = NO_PASSWORD;
+                    ret = WOLFSSL_ERROR_VERBOSE(NO_PASSWORD);
                 }
                 else {
                 #if ((defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_DES3)) || \
@@ -29938,8 +29871,7 @@ static int EncodeName(EncodedName* name, const char* nameStr,
     /* Restrict country code size */
     if (type == ASN_COUNTRY_NAME && strLen != CTC_COUNTRY_SIZE) {
         WOLFSSL_MSG("Country code size error");
-        WOLFSSL_ERROR_VERBOSE(ASN_COUNTRY_SIZE_E);
-        return ASN_COUNTRY_SIZE_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_COUNTRY_SIZE_E);
     }
 
     secondSz = SetLength(strLen, secondLen);
@@ -32261,7 +32193,7 @@ exit_ms:
     certSignCtx->state = CERTSIGN_STATE_BEGIN;
 
     if (ret < 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
+        (void)WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -40657,8 +40589,7 @@ int VerifyCRL_Signature(SignatureCtx* sigCtx, const byte* toBeSigned,
 #ifndef IGNORE_KEY_EXTENSIONS
     if ((ca->keyUsage & KEYUSE_CRL_SIGN) == 0) {
         WOLFSSL_MSG("CA cannot sign CRLs");
-        WOLFSSL_ERROR_VERBOSE(ASN_CRL_NO_SIGNER_E);
-        return ASN_CRL_NO_SIGNER_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_CRL_NO_SIGNER_E);
     }
 #endif /* IGNORE_KEY_EXTENSIONS */
 
@@ -40667,8 +40598,7 @@ int VerifyCRL_Signature(SignatureCtx* sigCtx, const byte* toBeSigned,
                          ca->pubKeySize, ca->keyOID, signature, sigSz,
                          signatureOID, sigParams, (word32)sigParamsSz, NULL) != 0) {
         WOLFSSL_MSG("CRL Confirm signature failed");
-        WOLFSSL_ERROR_VERBOSE(ASN_CRL_CONFIRM_E);
-        return ASN_CRL_CONFIRM_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_CRL_CONFIRM_E);
     }
 
     return 0;
@@ -40720,8 +40650,7 @@ static int PaseCRL_CheckSignature(DecodedCRL* dcrl, const byte* sigParams,
 
     if (ca == NULL) {
         WOLFSSL_MSG("Did NOT find CRL issuer CA");
-        ret = ASN_CRL_NO_SIGNER_E;
-        WOLFSSL_ERROR_VERBOSE(ret);
+        ret = WOLFSSL_ERROR_VERBOSE(ASN_CRL_NO_SIGNER_E);
     }
 
     if (ret == 0) {
@@ -40818,8 +40747,7 @@ static int ParseCRL_CertList(RevokedCert* rcert, DecodedCRL* dcrl,
             (! AsnSkipDateCheck) &&
             !XVALIDATE_DATE(dcrl->nextDate, dcrl->nextDateFormat, ASN_AFTER)) {
             WOLFSSL_MSG("CRL after date is no longer valid");
-            WOLFSSL_ERROR_VERBOSE(CRL_CERT_DATE_ERR);
-            return CRL_CERT_DATE_ERR;
+            return WOLFSSL_ERROR_VERBOSE(CRL_CERT_DATE_ERR);
         }
 #else
         (void)verify;
@@ -41339,8 +41267,7 @@ int ParseCRL(RevokedCert* rcert, DecodedCRL* dcrl, const byte* buff, word32 sz,
 
     if (ca == NULL) {
         WOLFSSL_MSG("Did NOT find CRL issuer CA");
-        ret = ASN_CRL_NO_SIGNER_E;
-        WOLFSSL_ERROR_VERBOSE(ret);
+        ret = WOLFSSL_ERROR_VERBOSE(ASN_CRL_NO_SIGNER_E);
         goto end;
     }
 
@@ -41480,8 +41407,7 @@ end:
                 (! AsnSkipDateCheck) &&
                  !XVALIDATE_DATE(dcrl->nextDate, dcrl->nextDateFormat, ASN_AFTER)) {
                 WOLFSSL_MSG("CRL after date is no longer valid");
-                ret = CRL_CERT_DATE_ERR;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(CRL_CERT_DATE_ERR);
             }
         }
     }
@@ -43100,15 +43026,13 @@ static int DecodeAcertGeneralName(const byte* input, word32* inOutIdx,
             /* test hier-part is empty */
             if (i == 0 || i == len) {
                 WOLFSSL_MSG("\tEmpty or malformed URI");
-                WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
-                return ASN_ALT_NAME_E;
+                return WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
             }
 
             /* test if scheme is missing  */
             if (input[idx + (word32)i] != ':') {
                 WOLFSSL_MSG("\tAlt Name must be absolute URI");
-                WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
-                return ASN_ALT_NAME_E;
+                return WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
             }
         }
     #endif
@@ -43678,8 +43602,7 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
     if (version > MAX_X509_VERSION) {
         FREE_ASNGETDATA(dataASN, acert->heap);
         WOLFSSL_MSG("Unexpected attribute certificate version");
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-        return ASN_PARSE_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
     }
 
     acert->version = version;
@@ -43724,8 +43647,7 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
     /* Make sure 'signature' and 'signatureAlgorithm' are the same. */
     if (dataASN[ACERT_IDX_SIGALGO_OID].data.oid.sum != acert->signatureOID) {
         FREE_ASNGETDATA(dataASN, acert->heap);
-        WOLFSSL_ERROR_VERBOSE(ASN_SIG_OID_E);
-        return ASN_SIG_OID_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_SIG_OID_E);
     }
 
     /* Parameters not allowed after ECDSA or EdDSA algorithm OID. */
@@ -43736,8 +43658,7 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
     #endif
             ) {
             FREE_ASNGETDATA(dataASN, acert->heap);
-            WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-            return ASN_PARSE_E;
+            return WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         }
     }
 
@@ -43753,8 +43674,7 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
         /* Parameters only with RSA PSS. */
         if (oid != CTC_RSASSAPSS) {
             FREE_ASNGETDATA(dataASN, acert->heap);
-            WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-            return ASN_PARSE_E;
+            return WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         }
 
         /* Check RSA PSS parameters are the same. */
@@ -43771,8 +43691,7 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
             (XMEMCMP(acParams, sigAlgParams, acParamsSz) != 0)) {
 
             FREE_ASNGETDATA(dataASN, acert->heap);
-            WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
-            return ASN_PARSE_E;
+            return WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         }
 
         /* Store RSA PSS parameters for use in signature verification. */

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -505,8 +505,7 @@ int wc_HmacSetKey_ex(Hmac* hmac, int type, const byte* key, word32 length,
      */
     if (!allowFlag) {
         if (length < HMAC_FIPS_MIN_KEY) {
-            WOLFSSL_ERROR_VERBOSE(HMAC_MIN_KEYLEN_E);
-            return HMAC_MIN_KEYLEN_E;
+            return WOLFSSL_ERROR_VERBOSE(HMAC_MIN_KEYLEN_E);
         }
     }
 

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -729,8 +729,7 @@ int wc_d2i_PKCS12(const byte* der, word32 derSz, WC_PKCS12* pkcs12)
 
     if (version != WC_PKCS12_VERSION_DEFAULT) {
         WOLFSSL_MSG("PKCS12 unsupported version!");
-        WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
-        return ASN_VERSION_E;
+        return WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
     }
 
     if ((ret = GetSequence(der, &idx, &size, totalSz)) < 0) {

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -10562,8 +10562,7 @@ static int wc_PKCS7_DecryptKtri(wc_PKCS7* pkcs7, byte* in, word32 inSz,
                                     XFREE(privKey, pkcs7->heap,
                                                     DYNAMIC_TYPE_TMP_BUFFER);
                             #endif
-                            WOLFSSL_ERROR_VERBOSE(MEMORY_E);
-                            return MEMORY_E;
+                            return WOLFSSL_ERROR_VERBOSE(MEMORY_E);
                         }
 
                         keySz = wc_RsaPrivateDecrypt_ex(encryptedKey,

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -26245,8 +26245,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 static int wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 {
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
-        return KEYUSAGE_E;
+        return WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
     }
 
 #ifdef MAX3266X_CB /* Can do a basic ECB block */
@@ -26273,8 +26272,7 @@ static int wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 static int wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 {
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
-        return KEYUSAGE_E;
+        return WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
     }
 
 #ifdef MAX3266X_CB /* Can do a basic ECB block */
@@ -26329,8 +26327,7 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
-        return KEYUSAGE_E;
+        return WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
     }
 
     if (sz == 0) {
@@ -26370,8 +26367,7 @@ int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
-        return KEYUSAGE_E;
+        return WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
     }
 
     if (sz == 0) {
@@ -26416,8 +26412,7 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
-        return KEYUSAGE_E;
+        return WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
     }
     #ifdef WOLF_CRYPTO_CB
         #ifndef WOLF_CRYPTO_CB_FIND
@@ -26997,8 +26992,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
-        return KEYUSAGE_E;
+        return WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
     }
 
 #ifdef WOLF_CRYPTO_CB

--- a/wolfcrypt/src/port/xilinx/xil-aesgcm.c
+++ b/wolfcrypt/src/port/xilinx/xil-aesgcm.c
@@ -80,8 +80,7 @@ static WC_INLINE int aligned_xmalloc(byte** buf, byte** aligned, void* heap, wor
     return 0;
 #else
     WOLFSSL_MSG("AES-ECB encrypt with bad alignment");
-    WOLFSSL_ERROR_VERBOSE(BAD_ALIGN_E);
-    return BAD_ALIGN_E;
+    return WOLFSSL_ERROR_VERBOSE(BAD_ALIGN_E);
 #endif
 }
 

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -255,12 +255,10 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
 
     /* use file's salt for key derivation, hex decode first */
     if (Base16_Decode(info->iv, info->ivSz, info->iv, &info->ivSz) != 0) {
-        WOLFSSL_ERROR_VERBOSE(BUFFER_E);
-        return BUFFER_E;
+        return WOLFSSL_ERROR_VERBOSE(BUFFER_E);
     }
     if (info->ivSz < PKCS5_SALT_SZ) {
-        WOLFSSL_ERROR_VERBOSE(BUFFER_E);
-        return BUFFER_E;
+        return WOLFSSL_ERROR_VERBOSE(BUFFER_E);
     }
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -491,8 +489,7 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
         default:
             WOLFSSL_MSG("Unknown/Unsupported encrypt/decrypt id");
             (void)shaOid;
-            ret = ALGO_ID_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
+            ret = WOLFSSL_ERROR_VERBOSE(ALGO_ID_E);
     }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -560,8 +557,7 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
     #endif /* HAVE_PKCS12 */
             default:
                 WOLFSSL_MSG("Unknown/Unsupported PKCS version");
-                ret = ALGO_ID_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(ALGO_ID_E);
         } /* switch (version) */
     }
 
@@ -714,8 +710,7 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
 
             default:
                 WOLFSSL_MSG("Unknown/Unsupported encrypt/decryption algorithm");
-                ret = ALGO_ID_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
+                ret = WOLFSSL_ERROR_VERBOSE(ALGO_ID_E);
         }
     }
 

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -436,9 +436,9 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
           OPENSSL_EXTRA */
 
 #ifdef WOLFSSL_VERBOSE_ERRORS
-#define WOLFSSL_ERROR_VERBOSE(e) WOLFSSL_ERROR(e)
+#define WOLFSSL_ERROR_VERBOSE(e) (WOLFSSL_ERROR(e),e)
 #else
-#define WOLFSSL_ERROR_VERBOSE(e) (void)(e)
+#define WOLFSSL_ERROR_VERBOSE(e) (e)
 #endif /* WOLFSSL_VERBOSE_ERRORS */
 
 #ifdef HAVE_STACK_SIZE_VERBOSE
@@ -587,4 +587,3 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
 }
 #endif
 #endif /* WOLFSSL_LOGGING_H */
-


### PR DESCRIPTION
# Description

this commit removes ~600 lines from the code base. it compresses lines like:

```diff
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                    return SANITY_MSG_E;
+                    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
```
by tweaking the `WOLFSSL_ERROR_VERBOSE` macro like so:
```diff
 #ifdef WOLFSSL_VERBOSE_ERRORS
-#define WOLFSSL_ERROR_VERBOSE(e) WOLFSSL_ERROR(e)
+#define WOLFSSL_ERROR_VERBOSE(e) (WOLFSSL_ERROR(e),e)
 #else
-#define WOLFSSL_ERROR_VERBOSE(e) (void)(e)
+#define WOLFSSL_ERROR_VERBOSE(e) (e)
 #endif /* WOLFSSL_VERBOSE_ERRORS */
```

# Testing

`./configure && make check`
