### PR TITLE
WOLFSSL_ERROR_VERBOSE compress

### DIFF
--- a/src/dtls.c
+++ b/src/dtls.c
@@ -899,7 +899,6 @@ static int SendStatelessReply(const WOLFSSL* ssl, WolfSSL_CH* ch, byte isTls13)
                 DTLS_COOKIE_SZ);
 #else
         WOLFSSL_MSG("DTLS1.2 disabled with WOLFSSL_NO_TLS12");
-        WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
         ret = NOT_COMPILED_IN;
 #endif
     }

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -391,7 +391,6 @@ int Dtls13ProcessBufferedMessages(WOLFSSL* ssl)
                     msg->sz, msg->sz);
 #else
             WOLFSSL_MSG("DTLS1.2 disabled with WOLFSSL_NO_TLS12");
-            WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
             ret = NOT_COMPILED_IN;
 #endif
         }
@@ -1669,7 +1668,6 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
             case hello_request:
                 if (!w64Equal(ssl->keys.curEpoch64, plainEpoch)) {
                     WOLFSSL_MSG("Msg should be epoch 0");
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                     return SANITY_MSG_E;
                 }
                 break;
@@ -1684,13 +1682,11 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
                          * will be negotiated.  */
                         if (!w64Equal(ssl->keys.curEpoch64, plainEpoch)) {
                             WOLFSSL_MSG("Msg should be epoch 2 or 0");
-                            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                             return SANITY_MSG_E;
                         }
                     }
                     else {
                         WOLFSSL_MSG("Msg should be epoch 2");
-                        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                         return SANITY_MSG_E;
                     }
                 }
@@ -1707,13 +1703,11 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
                              * will be negotiated.  */
                             if (!w64Equal(ssl->keys.curEpoch64, plainEpoch)) {
                                 WOLFSSL_MSG("Msg should be epoch 2 or 0");
-                                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                                 return SANITY_MSG_E;
                             }
                         }
                         else {
                             WOLFSSL_MSG("Msg should be epoch 2");
-                            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                             return SANITY_MSG_E;
                         }
                     }
@@ -1722,7 +1716,6 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
                     /* Allow epoch 2 in case of rtx */
                     if (!w64GTE(ssl->keys.curEpoch64, hsEpoch)) {
                         WOLFSSL_MSG("Msg should be epoch 2+");
-                        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                         return SANITY_MSG_E;
                     }
                 }
@@ -1733,7 +1726,6 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
             case session_ticket:
                 if (!w64GTE(ssl->keys.curEpoch64, t0Epoch)) {
                     WOLFSSL_MSG("Msg should be epoch 3+");
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                     return SANITY_MSG_E;
                 }
                 break;
@@ -1742,7 +1734,6 @@ int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
             case no_shake:
             default:
                 WOLFSSL_MSG("Unknown message type");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                 return SANITY_MSG_E;
         }
     }
@@ -3011,20 +3002,17 @@ int Dtls13CheckAEADFailLimit(WOLFSSL* ssl)
             return 0;
         default:
             WOLFSSL_MSG("Unrecognized ciphersuite for AEAD limit check");
-            WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
             return DECRYPT_ERROR;
     }
     if (ssl->dtls13DecryptEpoch == NULL) {
         WOLFSSL_MSG("Dtls13CheckAEADFailLimit: ssl->dtls13DecryptEpoch should "
                     "not be NULL");
-        WOLFSSL_ERROR_VERBOSE(BAD_STATE_E);
         return BAD_STATE_E;
     }
     w64Increment(&ssl->dtls13DecryptEpoch->dropCount);
     if (w64GT(ssl->dtls13DecryptEpoch->dropCount, hardLimit)) {
         /* We have reached the hard limit for failed decryptions. */
         WOLFSSL_MSG("Connection exceeded hard AEAD limit");
-        WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
         return DECRYPT_ERROR;
     }
     else if (w64GT(ssl->dtls13DecryptEpoch->dropCount, keyUpdateLimit)) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -39584,7 +39584,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (len > SESSION_TICKET_LEN ||
             len < (word32)(WOLFSSL_INTERNAL_TICKET_LEN +
                            WOLFSSL_TICKET_FIXED_SZ)) {
-            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_MSG_SZ);
+            WOLF_MSG(wolfSSL_ERR_reason_error_string(BAD_TICKET_MSG_SZ));
             return WOLFSSL_TICKET_RET_REJECT;
         }
 
@@ -39593,7 +39593,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         /* decrypt */
         ato16(et->enc_len, &inLen);
         if (inLen > WOLFSSL_TICKET_ENC_SZ) {
-            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_MSG_SZ);
+            WOLF_MSG(wolfSSL_ERR_reason_error_string(BAD_TICKET_MSG_SZ));
             return WOLFSSL_TICKET_RET_REJECT;
         }
         outLen = (int)inLen;   /* may be reduced by user padding */
@@ -39608,8 +39608,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         (ssl->options.mask & WOLFSSL_OP_NO_TICKET) != 0)
 #endif
                         ) {
-            /* Use BAD_TICKET_ENCRYPT to signal missing ticket callback */
-            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_ENCRYPT);
+            WOLF_MSG("Missing ticket callback")
             ret = WOLFSSL_TICKET_RET_REJECT;
         }
         else {
@@ -39627,7 +39626,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
         #endif /* WOLFSSL_ASYNC_CRYPT */
             if (ret != WOLFSSL_TICKET_RET_CREATE) {
-                WOLFSSL_ERROR_VERBOSE(BAD_TICKET_KEY_CB_SZ);
+                WOLF_MSG(wolfSSL_ERR_reason_error_string(BAD_TICKET_KEY_CB_SZ));
                 return WOLFSSL_TICKET_RET_REJECT;
             }
         }

--- a/src/internal.c
+++ b/src/internal.c
@@ -39327,7 +39327,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         (ssl->options.mask & WOLFSSL_OP_NO_TICKET) != 0)
 #endif
                         ) {
-            WOLFSSL_MSG("Missing ticket callback")
+            WOLFSSL_MSG("Missing ticket callback");
             ret = WOLFSSL_TICKET_RET_REJECT;
         }
         else {

--- a/src/internal.c
+++ b/src/internal.c
@@ -15330,7 +15330,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 /* Must be empty when received from server. */
                 if (ssl->options.side == WOLFSSL_CLIENT_END) {
                     if (ctxSz != 0) {
-                        WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E);
                         ERROR_OUT(INVALID_CERT_CTX_E, exit_ppc);
                     }
                 }
@@ -15340,7 +15339,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 if (ssl->options.side == WOLFSSL_SERVER_END) {
                     if (ssl->options.handShakeState != HANDSHAKE_DONE &&
                                                                    ctxSz != 0) {
-                        WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E);
                         ERROR_OUT(INVALID_CERT_CTX_E, exit_ppc);
                     }
                     else if (ssl->options.handShakeState == HANDSHAKE_DONE) {
@@ -15365,7 +15363,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         if (curr == NULL)
                 #endif
                         {
-                            WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E);
                             ERROR_OUT(INVALID_CERT_CTX_E, exit_ppc);
                         }
                     }
@@ -15442,7 +15439,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             #else
                 if (args->totalCerts >= ssl->verifyDepth ||
                         args->totalCerts >= MAX_CHAIN_DEPTH) {
-                    WOLFSSL_ERROR_VERBOSE(MAX_CHAIN_ERROR);
                     ERROR_OUT(MAX_CHAIN_ERROR, exit_ppc);
                 }
             #endif
@@ -37996,8 +37992,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 ssl->options.peerAuthGood = (ret == 0);
                 ssl->options.clientState = CLIENT_KEYEXCHANGE_COMPLETE;
             }
-            if (ret != 0)
-                WOLFSSL_ERROR_VERBOSE(ret);
             WOLFSSL_LEAVE("HandleTlsResumption", ret);
             return ret;
         }

--- a/src/internal.c
+++ b/src/internal.c
@@ -2518,7 +2518,6 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     if (ret < 0) {
         WOLFSSL_MSG("Mutex error on CTX init");
         ctx->err = CTX_INIT_MUTEX_E;
-        WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
         return BAD_MUTEX_E;
     }
 #else
@@ -2657,7 +2656,6 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     ctx->cm = wolfSSL_CertManagerNew_ex(heap);
     if (ctx->cm == NULL) {
         WOLFSSL_MSG("Bad Cert Manager New");
-        WOLFSSL_ERROR_VERBOSE(BAD_CERT_MANAGER_ERROR);
         return BAD_CERT_MANAGER_ERROR;
     }
     #ifdef OPENSSL_EXTRA
@@ -2695,7 +2693,6 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
 
     if (wc_InitMutex(&ctx->x509_store.lookup.dirs->lock) != 0) {
         WOLFSSL_MSG("Bad mutex init");
-        WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
         return BAD_MUTEX_E;
     }
     #endif
@@ -5278,7 +5275,6 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
                                              hashType);
                 if (ret != 0) {
                     ret = VERIFY_CERT_ERROR;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
         }
@@ -5298,7 +5294,6 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
     #endif
                 if (ret != 0) {
                     ret = VERIFY_CERT_ERROR;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
         }
@@ -5329,7 +5324,6 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
                                             XMEMCMP(plain, out, plainSz) != 0) {
                 WOLFSSL_MSG("RSA Signature verification failed");
                 ret = RSA_SIGN_FAULT;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
             else {
                 ret = 0;  /* RSA reset */
@@ -5599,7 +5593,6 @@ int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* out,
             if (ret == 0) {
                 ret = VERIFY_SIGN_ERROR;
             }
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
         else {
             ret = 0;
@@ -5795,9 +5788,6 @@ int Sm2wSm3Verify(WOLFSSL* ssl, const byte* id, word32 idSz, const byte* sig,
         if (ret == 0 && ssl->eccVerifyRes == 0) {
             ret = VERIFY_SIGN_ERROR;
         }
-    }
-    if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     WOLFSSL_LEAVE("Sm2wSm3Verify", ret);
@@ -6550,7 +6540,6 @@ int DhAgree(WOLFSSL* ssl, DhKey* dhKey,
         if (ret != 0) {
             /* translate to valid error (wc_DhCheckPubValue returns MP_VAL -1) */
             ret = PEER_KEY_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
 
     #ifdef OPENSSL_EXTRA
             SendAlert(ssl, alert_fatal, illegal_parameter);
@@ -6757,7 +6746,6 @@ int InitSSL_Suites(WOLFSSL* ssl)
         /* server certificate must be loaded */
         if (!ssl->buffers.certificate || !ssl->buffers.certificate->buffer) {
             WOLFSSL_MSG("Server missing certificate");
-            WOLFSSL_ERROR_VERBOSE(NO_PRIVATE_KEY);
             return NO_PRIVATE_KEY;
         }
 
@@ -6775,7 +6763,6 @@ int InitSSL_Suites(WOLFSSL* ssl)
         #endif
             {
                 WOLFSSL_MSG("Server missing private key");
-                WOLFSSL_ERROR_VERBOSE(NO_PRIVATE_KEY);
                 return NO_PRIVATE_KEY;
             }
         }
@@ -6862,7 +6849,6 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1.3 set but not "
                         "allowed and downgrading disabled.");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1.3, Downgrading");
@@ -6874,7 +6860,6 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1.2 set but not "
                         "allowed and downgrading disabled.");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1.2, Downgrading");
@@ -6885,7 +6870,6 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1.1 set but not "
                         "allowed and downgrading disabled.");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1.1, Downgrading");
@@ -6897,7 +6881,6 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1 set but not "
                         "allowed and downgrading disabled.");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1, Downgrading");
@@ -6908,13 +6891,11 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     if (ssl->version.minor == SSLv3_MINOR &&
         (ssl->options.mask & WOLFSSL_OP_NO_SSLv3) == WOLFSSL_OP_NO_SSLv3) {
         WOLFSSL_MSG("\tError, option set to not allow SSLv3");
-        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         return VERSION_ERROR;
     }
 
     if (ssl->version.minor < ssl->options.minDowngrade) {
         WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
-        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         return VERSION_ERROR;
     }
 #endif
@@ -7534,7 +7515,6 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
             WOLFSSL_MSG("Bad memory_mutex lock");
             XFREE(ssl->heap, ctx->heap, DYNAMIC_TYPE_SSL);
             ssl->heap = NULL; /* free and set to NULL for IO counter */
-            WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
             return BAD_MUTEX_E;
         }
     #endif
@@ -7581,7 +7561,6 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         #ifndef SINGLE_THREADED
             if (wc_LockMutex(&(ctx_hint->memory->memory_mutex)) != 0) {
                 WOLFSSL_MSG("Bad memory_mutex lock");
-                WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
                 return BAD_MUTEX_E;
             }
         #endif
@@ -9544,7 +9523,6 @@ int DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch, const byte* data, byte ty
 
     if (msg == NULL || data == NULL || msg->sz != totalLen ||
             fragOffsetEnd > totalLen) {
-        WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
         return BAD_FUNC_ARG;
     }
 
@@ -9554,7 +9532,6 @@ int DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch, const byte* data, byte ty
     if (msg->type != no_shake) {
         /* msg is already populated with the correct seq, epoch, and type */
         if (msg->type != type || msg->epoch != epoch || msg->seq != seq) {
-            WOLFSSL_ERROR_VERBOSE(SEQUENCE_ERROR);
             return SEQUENCE_ERROR;
         }
         msg->encrypted = msg->encrypted && encrypted;
@@ -9601,7 +9578,6 @@ int DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch, const byte* data, byte ty
                 /* We reached the end of the list. data is after and disjointed
                  * from anything we have received so far. */
                 if (msg->fragBucketListCount >= DTLS_FRAG_POOL_SZ) {
-                    WOLFSSL_ERROR_VERBOSE(DTLS_TOO_MANY_FRAGMENTS_E);
                     return DTLS_TOO_MANY_FRAGMENTS_E;
                 }
                 prev->m.m.next =
@@ -9614,7 +9590,6 @@ int DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch, const byte* data, byte ty
             else if (prev == NULL && fragOffsetEnd < cur->m.m.offset) {
                     /* This is the new first fragment we have received */
                     if (msg->fragBucketListCount >= DTLS_FRAG_POOL_SZ) {
-                        WOLFSSL_ERROR_VERBOSE(DTLS_TOO_MANY_FRAGMENTS_E);
                         return DTLS_TOO_MANY_FRAGMENTS_E;
                     }
                     msg->fragBucketList = DtlsMsgCreateFragBucket(fragOffset, data,
@@ -11413,7 +11388,6 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
             case change_cipher_hs:
                 if (encrypted) {
                     WOLFSSL_MSG("Message can not be encrypted");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 break;
@@ -11432,7 +11406,6 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
             case key_update:
                 if (!encrypted) {
                     WOLFSSL_MSG("Message always has to be encrypted");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 break;
@@ -11440,7 +11413,6 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
             case no_shake:
             default:
                 WOLFSSL_MSG("Unknown message type");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                 return SANITY_MSG_E;
         }
     }
@@ -11449,7 +11421,6 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
             case client_hello:
                 if ((IsSCR(ssl) || ssl->options.handShakeDone) && !encrypted) {
                     WOLFSSL_MSG("Message has to be encrypted for SCR");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 break;
@@ -11468,14 +11439,12 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
                 if (IsSCR(ssl)) {
                     if (!encrypted) {
                         WOLFSSL_MSG("Message has to be encrypted during SCR");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                         return OUT_OF_ORDER_E;
                     }
                 }
                 else if (encrypted) {
                     WOLFSSL_MSG("Message can not be encrypted in regular "
                                 "handshake");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 break;
@@ -11483,7 +11452,6 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
             case finished:
                 if (!encrypted) {
                     WOLFSSL_MSG("Message always has to be encrypted");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 break;
@@ -11494,7 +11462,6 @@ int MsgCheckEncryption(WOLFSSL* ssl, byte type, byte encrypted)
             case no_shake:
             default:
                 WOLFSSL_MSG("Unknown message type");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                 return SANITY_MSG_E;
         }
     }
@@ -11527,7 +11494,6 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
                 case end_of_early_data:
                     if (!isLastMsg(ssl, msgSz)) {
                         WOLFSSL_MSG("Message type is not last in record");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                         return OUT_OF_ORDER_E;
                     }
                     break;
@@ -11547,7 +11513,6 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
                 case no_shake:
                 default:
                     WOLFSSL_MSG("Unknown message type");
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                     return SANITY_MSG_E;
             }
         }
@@ -11558,7 +11523,6 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
                 case hello_verify_request:
                     if (!isLastMsg(ssl, msgSz)) {
                         WOLFSSL_MSG("Message type is not last in record");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                         return OUT_OF_ORDER_E;
                     }
                     break;
@@ -11582,7 +11546,6 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
                 case no_shake:
                 default:
                     WOLFSSL_MSG("Unknown message type");
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                     return SANITY_MSG_E;
             }
         }
@@ -11594,7 +11557,6 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
             case hello_verify_request:
                 if (!isLastMsg(ssl, msgSz)) {
                     WOLFSSL_MSG("Message type is not last in record");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 break;
@@ -11618,7 +11580,6 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
             case no_shake:
             default:
                 WOLFSSL_MSG("Unknown message type");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                 return SANITY_MSG_E;
         }
     }
@@ -12053,7 +12014,6 @@ static int GetRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
         #endif
                    )) {
             WOLFSSL_MSG("SSL version error");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;              /* only use requested version */
         }
     }
@@ -12061,19 +12021,16 @@ static int GetRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
     /* record layer length check */
 #ifdef HAVE_MAX_FRAGMENT
     if (*size > (ssl->max_fragment + MAX_COMP_EXTRA + MAX_MSG_EXTRA)) {
-        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
         return LENGTH_ERROR;
     }
 #else
     if (*size > (MAX_RECORD_SIZE + MAX_COMP_EXTRA + MAX_MSG_EXTRA)) {
-        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
         return LENGTH_ERROR;
     }
 #endif
 
     if (*size == 0 && rh->type != application_data) {
         WOLFSSL_MSG("0 length, non-app data record.");
-        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
         return LENGTH_ERROR;
     }
 
@@ -12109,7 +12066,6 @@ static int GetRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
             }
 #endif
             WOLFSSL_MSG("Unknown Record Type");
-            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
             return UNKNOWN_RECORD_TYPE;
     }
 
@@ -13319,7 +13275,6 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->cPwd,
                                         dCert->cPwdLen) != WOLFSSL_SUCCESS) {
                 ret = REQ_ATTRIBUTE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
         #endif
         }
@@ -13342,7 +13297,6 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         dCert->contentTypeLen) !=
                 WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
     #endif
     }
@@ -13355,7 +13309,6 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->sNum,
                                         dCert->sNumLen) != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     if (dCert->unstructuredName) {
@@ -13366,7 +13319,6 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         dCert->unstructuredNameLen)
                 != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     if (dCert->surname) {
@@ -13376,7 +13328,6 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->surname,
                                         dCert->surnameLen) != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     if (dCert->givenName) {
@@ -13386,7 +13337,6 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->givenName,
                                         dCert->givenNameLen) != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     if (dCert->dnQualifier) {
@@ -13396,7 +13346,6 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->dnQualifier,
                                         dCert->dnQualifierLen) != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     if (dCert->initials) {
@@ -13406,7 +13355,6 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->initials,
                                         dCert->initialsLen) != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     #endif /* OPENSSL_ALL */
@@ -13427,7 +13375,6 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 
     if (x509->issuer.name == NULL || x509->subject.name == NULL) {
         WOLFSSL_MSG("Either init was not called on X509 or programming error");
-        WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
         return BAD_FUNC_ARG;
     }
 
@@ -13534,7 +13481,6 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
                 if (!(x509->key.algor->algorithm =
                     wolfSSL_OBJ_nid2obj(oid2nid(dCert->keyOID, oidKeyType)))) {
                     ret = PUBLIC_KEY_E;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
 
@@ -13543,7 +13489,6 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
                                                       &dCert->publicKey,
                                                       dCert->pubKeySize))) {
                 ret = PUBLIC_KEY_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
         }
 #endif
@@ -13566,7 +13511,6 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
         if (!(x509->algor.algorithm =
                 wolfSSL_OBJ_nid2obj(oid2nid(dCert->signatureOID, oidSigType)))) {
             ret = PUBLIC_KEY_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
 #endif
     }
@@ -14393,7 +14337,6 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int cert_err,
                     (word32)XSTRLEN(ssl->param->hostName), NULL, 0) != 1) {
                     if (cert_err == 0) {
                         ret = DOMAIN_NAME_MISMATCH;
-                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                 }
             }
@@ -14407,7 +14350,6 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int cert_err,
                             (word32)XSTRLEN(ssl->param->hostName), 0) == 0) {
                         if (cert_err == 0) {
                             ret = DOMAIN_NAME_MISMATCH;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                 }
@@ -14416,7 +14358,6 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int cert_err,
             else {
                 if (cert_err == 0) {
                     ret = DOMAIN_NAME_MISMATCH;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
         #endif /* !WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY */
@@ -14428,7 +14369,6 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int cert_err,
             if (CheckIPAddr(args->dCert, ssl->param->ipasc) != 0) {
                 if (cert_err == 0) {
                     ret = IPADDR_MISMATCH;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
         }
@@ -14520,7 +14460,6 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int cert_err,
             /* induce error if one not present */
             if (cert_err == 0) {
                 ret = VERIFY_CERT_ERROR;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
 
             /* mark as verify error */
@@ -14762,7 +14701,6 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
                 if (wc_LockMutex(&lookup->dirs->lock) != 0) {
                     WOLFSSL_MSG("wc_LockMutex cdir Lock error");
                     XFREE(filename, NULL, DYNAMIC_TYPE_OPENSSL);
-                    WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
                     return BAD_MUTEX_E;
                 }
                 if (ph == NULL) {
@@ -15018,7 +14956,6 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 WOLFSSL_MSG(
                     "RSA key size in cert chain error");
                 ret = RSA_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
     #endif /* !NO_RSA */
@@ -15030,7 +14967,6 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 WOLFSSL_MSG(
                     "ECC key size in cert chain error");
                 ret = ECC_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
     #endif /* HAVE_ECC */
@@ -15041,7 +14977,6 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 WOLFSSL_MSG(
                     "ECC key size in cert chain error");
                 ret = ECC_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
     #endif /* HAVE_ED25519 */
@@ -15052,7 +14987,6 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 WOLFSSL_MSG(
                     "ECC key size in cert chain error");
                 ret = ECC_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
     #endif /* HAVE_ED448 */
@@ -15062,7 +14996,6 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 FALCON_LEVEL1_KEY_SIZE < (word16)ssl->options.minFalconKeySz) {
                 WOLFSSL_MSG("Falcon key size in cert chain error");
                 ret = FALCON_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
         case FALCON_LEVEL5k:
@@ -15070,7 +15003,6 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 FALCON_LEVEL5_KEY_SIZE < (word16)ssl->options.minFalconKeySz) {
                 WOLFSSL_MSG("Falcon key size in cert chain error");
                 ret = FALCON_KEY_SIZE_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
     #endif /* HAVE_FALCON */
@@ -15168,7 +15100,6 @@ static int ProcessPeerCertsChainOCSPStatusCheck(WOLFSSL* ssl)
                     csr->responses[i].buffer,
                     &idx, csr->responses[i].length, i);
             if (ret < 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
                 break;
             }
         }
@@ -15198,7 +15129,6 @@ static int ProcessPeerCertsChainCRLCheck(WOLFSSL* ssl, ProcPeerCertArgs* args)
         if (ret != 0)
             DoCrlCallback(cm, ssl, args, &ret);
         if (ret != 0){
-            WOLFSSL_ERROR_VERBOSE(ret);
             WOLFSSL_MSG("\tCRL check not ok");
             break;
         }
@@ -15431,7 +15361,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         ssl->peerVerifyRet =
                                         WOLFSSL_X509_V_ERR_CERT_CHAIN_TOO_LONG;
                     ret = MAX_CHAIN_ERROR;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                     WOLFSSL_MSG("Too many certs for MAX_CHAIN_DEPTH");
                     break; /* break out to avoid reading more certs then buffer
                             * can hold */
@@ -15497,7 +15426,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         certificate, NULL);
                     #endif /* !NO_TLS */
                     if (ret < 0) {
-                        WOLFSSL_ERROR_VERBOSE(ret);
                         ERROR_OUT(ret, exit_ppc);
                     }
                 }
@@ -15517,14 +15445,12 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                              IsAtLeastTLSv1_3(ssl->version)))) {
                     WOLFSSL_MSG("No peer cert from Client");
                     ret = NO_PEER_CERT;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                     DoCertFatalAlert(ssl, ret);
                 }
                 else if ((ssl->options.side == WOLFSSL_CLIENT_END) &&
                          IsAtLeastTLSv1_3(ssl->version)) {
                     WOLFSSL_MSG("No peer cert from Server");
                     ret = NO_PEER_CERT;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                     SendAlert(ssl, alert_fatal, decode_error);
                 }
             }
@@ -15628,7 +15554,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         }
                         else {
                             ret = ASN_NO_SIGNER_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
 #endif
@@ -15711,7 +15636,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             }
                         #endif
                             if (ret != 0) {
-                                WOLFSSL_ERROR_VERBOSE(ret);
                                 WOLFSSL_MSG("\tOCSP Lookup not ok");
                             }
                         }
@@ -15750,7 +15674,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 if (ret != 0)
                                     DoCrlCallback(SSL_CM(ssl), ssl, args, &ret);
                                 if (ret != 0) {
-                                    WOLFSSL_ERROR_VERBOSE(ret);
                                     WOLFSSL_MSG("\tCRL check not ok");
                                 }
                                 if (ret == 0 &&
@@ -15758,7 +15681,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                     ret = ProcessPeerCertsChainCRLCheck(ssl,
                                             args);
                                     if (ret != 0) {
-                                        WOLFSSL_ERROR_VERBOSE(ret);
                                         WOLFSSL_MSG("\tCRL chain check not ok");
                                         args->fatal = 0;
                                     }
@@ -15776,7 +15698,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             ssl->peerVerifyRet =
                                          WOLFSSL_X509_V_ERR_CERT_CHAIN_TOO_LONG;
                         ret = MAX_CHAIN_ERROR;
-                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
             #endif
                 #ifdef WOLFSSL_ALT_CERT_CHAINS
@@ -15956,7 +15877,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                        * callback overrides. */
                     if (ret != 0) {
                         if (!ssl->options.verifyNone) {
-                            WOLFSSL_ERROR_VERBOSE(ret);
                             DoCertFatalAlert(ssl, ret);
                             args->lastErr = ret;
                             break; /* We sent a fatal alert.
@@ -16017,7 +15937,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         }
                         else {
                             ret = lastErr; /* restore error */
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
 #endif
@@ -16159,7 +16078,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                   "Peer sent different cert during scr, fatal");
                                 args->fatal = 1;
                                 ret = SCR_DIFFERENT_CERT_E;
-                                WOLFSSL_ERROR_VERBOSE(ret);
                             }
                         }
                     }
@@ -16207,7 +16125,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             if (ssl->options.tls1_3) {
                                 ret = ProcessPeerCertsChainOCSPStatusCheck(ssl);
                                 if (ret < 0) {
-                                    WOLFSSL_ERROR_VERBOSE(ret);
                                     goto exit_ppc;
                                 }
                             }
@@ -16292,7 +16209,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         if (args->dCert->ca != NULL) {
                             ret = ProcessPeerCertsChainCRLCheck(ssl, args);
                             if (ret != 0) {
-                                WOLFSSL_ERROR_VERBOSE(ret);
                                 WOLFSSL_MSG("\tCRL chain check not ok");
                                 args->fatal = 0;
                             }
@@ -16336,7 +16252,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         (ssl->options.side == WOLFSSL_CLIENT_END) &&
                         (args->dCert->extKeyUsage & KEYUSE_KEY_ENCIPHER) == 0) {
                         ret = KEYUSE_ENCIPHER_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                     if ((ssl->specs.kea != rsa_kea) &&
                         (ssl->specs.sig_algo == rsa_sa_algo ||
@@ -16345,7 +16260,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         (args->dCert->extKeyUsage & KEYUSE_DIGITAL_SIG) == 0) {
                         WOLFSSL_MSG("KeyUse Digital Sig not set");
                         ret = KEYUSE_SIGNATURE_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                 }
 
@@ -16365,7 +16279,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 (EXTKEYUSE_ANY | EXTKEYUSE_SERVER_AUTH)) == 0) {
                             WOLFSSL_MSG("ExtKeyUse Server Auth not set");
                             ret = EXTKEYUSE_AUTH_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                     else {
@@ -16373,7 +16286,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 (EXTKEYUSE_ANY | EXTKEYUSE_CLIENT_AUTH)) == 0) {
                             WOLFSSL_MSG("ExtKeyUse Client Auth not set");
                             ret = EXTKEYUSE_AUTH_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                 }
@@ -16421,7 +16333,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             WOLFSSL_MSG("DomainName match on alt names failed");
                             /* try to get peer key still */
                             ret = DOMAIN_NAME_MISMATCH;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                     else {
@@ -16436,7 +16347,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         {
                             WOLFSSL_MSG("DomainName match on common name failed");
                             ret = DOMAIN_NAME_MISMATCH;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                 #else /* WOLFSSL_ALL_NO_CN_IN_SAN */
@@ -16457,7 +16367,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 "DomainName match on alt names failed too");
                             /* try to get peer key still */
                             ret = DOMAIN_NAME_MISMATCH;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                 #endif /* WOLFSSL_ALL_NO_CN_IN_SAN */
@@ -16487,7 +16396,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                args->dCert->publicKey, &keyIdx, ssl->peerRsaKey,
                                                 args->dCert->pubKeySize) != 0) {
                             ret = PEER_KEY_ERROR;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                         else {
                             ssl->peerRsaKeyPresent = 1;
@@ -16543,7 +16451,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                           wc_RsaEncryptSize(ssl->peerRsaKey)
                                               < ssl->options.minRsaKeySz) {
                             ret = RSA_KEY_SIZE_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                             WOLFSSL_MSG("Peer RSA key is too small");
                         }
                         break;
@@ -16591,7 +16498,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                 ssl->peerEccDsaKey,
                                                 args->dCert->pubKeySize) != 0) {
                             ret = PEER_KEY_ERROR;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                         else {
                             ssl->peerEccDsaKeyPresent = 1;
@@ -16622,7 +16528,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                               wc_ecc_size(ssl->peerEccDsaKey)
                                               < ssl->options.minEccKeySz) {
                             ret = ECC_KEY_SIZE_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                             WOLFSSL_MSG("Peer ECC key is too small");
                         }
 
@@ -16652,7 +16557,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                      ssl->peerEd25519Key)
                                                                          != 0) {
                             ret = PEER_KEY_ERROR;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                         else {
                             ssl->peerEd25519KeyPresent = 1;
@@ -16678,7 +16582,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                   !ssl->options.verifyNone &&
                                   ED25519_KEY_SIZE < ssl->options.minEccKeySz) {
                             ret = ECC_KEY_SIZE_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                             WOLFSSL_MSG("Peer ECC key is too small");
                         }
 
@@ -16707,7 +16610,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                     args->dCert->pubKeySize,
                                     ssl->peerEd448Key) != 0) {
                             ret = PEER_KEY_ERROR;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                         else {
                             ssl->peerEd448KeyPresent = 1;
@@ -16733,7 +16635,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                !ssl->options.verifyNone &&
                                ED448_KEY_SIZE < ssl->options.minEccKeySz) {
                             ret = ECC_KEY_SIZE_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                             WOLFSSL_MSG("Peer ECC key is too small");
                         }
 
@@ -16774,7 +16675,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                     args->dCert->pubKeySize,
                                                     ssl->peerFalconKey) != 0) {
                             ret = PEER_KEY_ERROR;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                         else {
                             ssl->peerFalconKeyPresent = 1;
@@ -16786,7 +16686,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                FALCON_MAX_KEY_SIZE <
                                ssl->options.minFalconKeySz) {
                             ret = FALCON_KEY_SIZE_E;
-                            WOLFSSL_ERROR_VERBOSE(ret);
                             WOLFSSL_MSG("Peer Falcon key is too small");
                         }
                         break;
@@ -16899,7 +16798,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 if (ssl->peerVerifyRet == 0) /* Return first cert error here */
                     ssl->peerVerifyRet = WOLFSSL_X509_V_ERR_CERT_CHAIN_TOO_LONG;
                 ret = MAX_CHAIN_ERROR;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
         #endif
 
@@ -17198,7 +17096,6 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 #endif
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
         SendAlert(ssl, alert_fatal, bad_certificate_status_response);
     }
 
@@ -17246,7 +17143,6 @@ static int DoHelloRequest(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     if (ssl->options.side == WOLFSSL_SERVER_END) {
         SendAlert(ssl, alert_fatal, unexpected_message); /* try */
-        WOLFSSL_ERROR_VERBOSE(FATAL_ERROR);
         return FATAL_ERROR;
     }
 #ifdef HAVE_SECURE_RENEGOTIATION
@@ -17290,7 +17186,6 @@ int DoFinished(WOLFSSL* ssl, const byte* input, word32* inOutIdx, word32 size,
     if (sniff == NO_SNIFF) {
         if (XMEMCMP(input + *inOutIdx, &ssl->hsHashes->verifyHashes,size) != 0){
             WOLFSSL_MSG("Verify finished error on hashes");
-            WOLFSSL_ERROR_VERBOSE(VERIFY_FINISHED_ERROR);
             return VERIFY_FINISHED_ERROR;
         }
     }
@@ -17389,13 +17284,11 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("HelloRequest received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_hello_request) {
                 WOLFSSL_MSG("Duplicate HelloRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_hello_request = 1;
@@ -17408,13 +17301,11 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_CLIENT
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("ClientHello received by client");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_client_hello) {
                 WOLFSSL_MSG("Duplicate ClientHello received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_client_hello = 1;
@@ -17427,13 +17318,11 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerHello received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_server_hello) {
                 WOLFSSL_MSG("Duplicate ServerHello received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_server_hello = 1;
@@ -17446,19 +17335,16 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("HelloVerifyRequest received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_hello_verify_request) {
                 WOLFSSL_MSG("Duplicate HelloVerifyRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             if (ssl->msgsReceived.got_hello_retry_request) {
                 WOLFSSL_MSG("Received HelloVerifyRequest after a "
                             "HelloRetryRequest");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
             ssl->msgsReceived.got_hello_verify_request = 1;
@@ -17471,13 +17357,11 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("SessionTicket received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_session_ticket) {
                 WOLFSSL_MSG("Duplicate SessionTicket received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_session_ticket = 1;
@@ -17488,7 +17372,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         case certificate:
             if (ssl->msgsReceived.got_certificate) {
                 WOLFSSL_MSG("Duplicate Certificate received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate = 1;
@@ -17497,7 +17380,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 if ( ssl->msgsReceived.got_server_hello == 0) {
                     WOLFSSL_MSG("No ServerHello before Cert");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -17506,7 +17388,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 if ( ssl->msgsReceived.got_client_hello == 0) {
                     WOLFSSL_MSG("No ClientHello before Cert");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -17518,25 +17399,21 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("CertificateStatus received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_certificate_status) {
                 WOLFSSL_MSG("Duplicate CertificateStatus received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate_status = 1;
 
             if (ssl->msgsReceived.got_certificate == 0) {
                 WOLFSSL_MSG("No Certificate before CertificateStatus");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             if (ssl->msgsReceived.got_server_key_exchange != 0) {
                 WOLFSSL_MSG("CertificateStatus after ServerKeyExchange");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
 
@@ -17548,20 +17425,17 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerKeyExchange received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_server_key_exchange) {
                 WOLFSSL_MSG("Duplicate ServerKeyExchange received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_server_key_exchange = 1;
 
             if (ssl->msgsReceived.got_server_hello == 0) {
                 WOLFSSL_MSG("No ServerHello before ServerKeyExchange");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
 
@@ -17573,13 +17447,11 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("CertificateRequest received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_certificate_request) {
                 WOLFSSL_MSG("Duplicate CertificateRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate_request = 1;
@@ -17592,13 +17464,11 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerHelloDone received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_server_hello_done) {
                 WOLFSSL_MSG("Duplicate ServerHelloDone received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_server_hello_done = 1;
@@ -17612,7 +17482,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                 }
                 else {
                     WOLFSSL_MSG("No Certificate before ServerHelloDone");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -17632,7 +17501,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                 }
                 else {
                     WOLFSSL_MSG("No ServerKeyExchange before ServerDone");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -17679,7 +17547,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                      !ssl->status_request_v2 &&
 #endif
                                                  SSL_CM(ssl)->ocspMustStaple) {
-                    WOLFSSL_ERROR_VERBOSE(OCSP_CERT_UNKNOWN);
                     return OCSP_CERT_UNKNOWN;
                 }
             }
@@ -17692,20 +17559,17 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_CLIENT
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("CertificateVerify received by client");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_certificate_verify) {
                 WOLFSSL_MSG("Duplicate CertificateVerify received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate_verify = 1;
 
             if ( ssl->msgsReceived.got_certificate == 0) {
                 WOLFSSL_MSG("No Cert before CertVerify");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             break;
@@ -17716,20 +17580,17 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_CLIENT
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("ClientKeyExchange received by client");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_client_key_exchange) {
                 WOLFSSL_MSG("Duplicate ClientKeyExchange received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_client_key_exchange = 1;
 
             if (ssl->msgsReceived.got_client_hello == 0) {
                 WOLFSSL_MSG("No ClientHello before ClientKeyExchange");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             break;
@@ -17738,14 +17599,12 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         case finished:
             if (ssl->msgsReceived.got_finished) {
                 WOLFSSL_MSG("Duplicate Finished received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
 #ifdef WOLFSSL_DTLS
             if (ssl->options.dtls) {
                 if (ssl->keys.curEpoch == 0) {
                     WOLFSSL_MSG("Finished received with epoch 0");
-                    WOLFSSL_ERROR_VERBOSE(SEQUENCE_ERROR);
                     return SEQUENCE_ERROR;
                 }
             }
@@ -17754,7 +17613,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
 
             if (ssl->msgsReceived.got_change_cipher == 0) {
                 WOLFSSL_MSG("Finished received before ChangeCipher");
-                WOLFSSL_ERROR_VERBOSE(NO_CHANGE_CIPHER_E);
                 return NO_CHANGE_CIPHER_E;
             }
             break;
@@ -17762,7 +17620,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         case change_cipher_hs:
             if (ssl->msgsReceived.got_change_cipher) {
                 WOLFSSL_MSG("Duplicate ChangeCipher received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             /* DTLS is going to ignore the CCS message if the client key
@@ -17775,7 +17632,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                 if (!ssl->options.resuming) {
                    if (ssl->msgsReceived.got_server_hello_done == 0) {
                         WOLFSSL_MSG("No ServerHelloDone before ChangeCipher");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                         return OUT_OF_ORDER_E;
                    }
                 }
@@ -17783,7 +17639,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                     if (ssl->msgsReceived.got_server_hello == 0) {
                         WOLFSSL_MSG("No ServerHello before ChangeCipher on "
                                     "Resume");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                         return OUT_OF_ORDER_E;
                     }
                 }
@@ -17792,11 +17647,9 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                         WOLFSSL_MSG("Expected session ticket missing");
                         #ifdef WOLFSSL_DTLS
                             if (ssl->options.dtls) {
-                                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                                 return OUT_OF_ORDER_E;
                             }
                         #endif
-                        WOLFSSL_ERROR_VERBOSE(SESSION_TICKET_EXPECT_E);
                         return SESSION_TICKET_EXPECT_E;
                     }
                 #endif
@@ -17807,7 +17660,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                 if (!ssl->options.resuming &&
                                ssl->msgsReceived.got_client_key_exchange == 0) {
                     WOLFSSL_MSG("No ClientKeyExchange before ChangeCipher");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 #ifndef NO_CERTS
@@ -17819,11 +17671,9 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                             WOLFSSL_MSG("client didn't send cert verify");
                             #ifdef WOLFSSL_DTLS
                                 if (ssl->options.dtls) {
-                                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                                     return OUT_OF_ORDER_E;
                                 }
                             #endif
-                            WOLFSSL_ERROR_VERBOSE(NO_PEER_VERIFY);
                             return NO_PEER_VERIFY;
                         }
                     }
@@ -17836,7 +17686,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
 
         default:
             WOLFSSL_MSG("Unknown message type");
-            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
             return SANITY_MSG_E;
     }
 
@@ -17861,7 +17710,6 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     /* make sure can read the message */
     if (*inOutIdx + size > totalSz) {
         WOLFSSL_MSG("Incomplete Data");
-        WOLFSSL_ERROR_VERBOSE(INCOMPLETE_DATA);
         return INCOMPLETE_DATA;
     }
 
@@ -17914,7 +17762,6 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     if (ssl->options.handShakeState == HANDSHAKE_DONE && type != hello_request){
         WOLFSSL_MSG("HandShake message after handshake complete");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -17924,7 +17771,6 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         WOLFSSL_MSG("First server message not server hello or "
                     "hello request");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -17933,7 +17779,6 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             ssl->options.serverState < SERVER_HELLO_COMPLETE) {
         WOLFSSL_MSG("Server hello done received before server hello in DTLS");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -17941,7 +17786,6 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                ssl->options.clientState == NULL_STATE && type != client_hello) {
         WOLFSSL_MSG("First client message not client hello");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -17994,7 +17838,6 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                      * allow for reverting back to a full handshake after the
                      * server has indicated the intention to do a resumption. */
                     (void)SendAlert(ssl, alert_fatal, unexpected_message);
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
 #endif
@@ -18177,7 +18020,6 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         if (!ssl->options.dtls)
             SendAlert(ssl, alert_fatal, decode_error);
         ret = DECODE_E;
-        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
@@ -18231,7 +18073,6 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         word32 size;
 
         if (GetHandshakeHeader(ssl,input,inOutIdx,&type, &size, totalSz) != 0) {
-            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
             return PARSE_ERROR;
         }
 
@@ -18243,7 +18084,6 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
         if (size > MAX_HANDSHAKE_SZ) {
             WOLFSSL_MSG("Handshake message too large");
-            WOLFSSL_ERROR_VERBOSE(HANDSHAKE_SIZE_ERROR);
             return HANDSHAKE_SIZE_ERROR;
         }
 
@@ -18260,7 +18100,6 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
         if (GetHandshakeHeader(ssl, input, inOutIdx, &type, &size,
                                totalSz) != 0) {
-            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
             return PARSE_ERROR;
         }
 
@@ -18276,7 +18115,6 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
          * nine 2048-bit RSA certificates in the chain. */
         if (size > MAX_HANDSHAKE_SZ) {
             WOLFSSL_MSG("Handshake message too large");
-            WOLFSSL_ERROR_VERBOSE(HANDSHAKE_SIZE_ERROR);
             return HANDSHAKE_SIZE_ERROR;
         }
 
@@ -19575,7 +19413,6 @@ int ChachaAEADDecrypt(WOLFSSL* ssl, byte* plain, const byte* input,
         WOLFSSL_MSG("MAC did not match");
         if (!ssl->options.dtls)
             SendAlert(ssl, alert_fatal, bad_record_mac);
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
 
@@ -20007,7 +19844,6 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
         default:
             WOLFSSL_MSG("wolfSSL Encrypt programming error");
             ret = ENCRYPT_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
     }
 
 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -20036,7 +19872,6 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
         {
             if (ssl->encrypt.setup == 0) {
                 WOLFSSL_MSG("Encrypt ciphers not setup");
-                WOLFSSL_ERROR_VERBOSE(ENCRYPT_ERROR);
                 return ENCRYPT_ERROR;
             }
 
@@ -20134,7 +19969,6 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
                     min(sz, sizeof(ssl->encrypt.sanityCheck))) == 0) {
 
                 WOLFSSL_MSG("Encrypt sanity check failed! Glitch?");
-                WOLFSSL_ERROR_VERBOSE(ENCRYPT_ERROR);
                 return ENCRYPT_ERROR;
             }
             ForceZero(ssl->encrypt.sanityCheck,
@@ -20472,7 +20306,6 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
 
         default:
             WOLFSSL_MSG("wolfSSL Decrypt programming error");
-            WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
             ret = DECRYPT_ERROR;
     }
 
@@ -20514,7 +20347,6 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
         {
             if (ssl->decrypt.setup == 0) {
                 WOLFSSL_MSG("Decrypt ciphers not setup");
-                WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
                 return DECRYPT_ERROR;
             }
 
@@ -20626,7 +20458,6 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
 
                 if (ret < 0) {
                     ret = VERIFY_MAC_ERROR;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
         #endif /* BUILD_AESGCM || HAVE_AESCCM || HAVE_ARIA */
@@ -20639,7 +20470,6 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
 
                 if (ret < 0) {
                     ret = VERIFY_MAC_ERROR;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
         #endif /* BUILD_AESGCM || HAVE_AESCCM */
@@ -20684,7 +20514,6 @@ static int SanityCheckCipherText(WOLFSSL* ssl, word32 encryptSz)
         if (ssl->options.startedETMRead) {
             if ((encryptSz - MacSize(ssl)) % ssl->specs.block_size) {
                 WOLFSSL_MSG("Block ciphertext not block size");
-                WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
                 return SANITY_CIPHER_E;
             }
         }
@@ -20692,7 +20521,6 @@ static int SanityCheckCipherText(WOLFSSL* ssl, word32 encryptSz)
 #endif
         if (encryptSz % ssl->specs.block_size) {
             WOLFSSL_MSG("Block ciphertext not block size");
-            WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
             return SANITY_CIPHER_E;
         }
 
@@ -20714,7 +20542,6 @@ static int SanityCheckCipherText(WOLFSSL* ssl, word32 encryptSz)
 
     if (encryptSz < minLength) {
         WOLFSSL_MSG("Ciphertext not minimum size");
-        WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
         return SANITY_CIPHER_E;
     }
 
@@ -20953,7 +20780,6 @@ static WC_INLINE int GetRounds(int pLen, int padLen, int t)
         /* still compare */
         ssl->hmac(ssl, verify, input, pLen - t, -1, content, 1, PEER_ORDER);
         ConstantCompare(verify, input + pLen - t, t);
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
 
@@ -20963,7 +20789,6 @@ static WC_INLINE int GetRounds(int pLen, int padLen, int t)
         /* still compare */
         ssl->hmac(ssl, verify, input, pLen - t, -1, content, 1, PEER_ORDER);
         ConstantCompare(verify, input + pLen - t, t);
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
 
@@ -20975,14 +20800,12 @@ static WC_INLINE int GetRounds(int pLen, int padLen, int t)
 
     if (ConstantCompare(verify, input + (pLen - padLen - 1 - t), t) != 0) {
         WOLFSSL_MSG("Verify MAC compare failed");
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
 
     /* treat any failure as verify MAC error */
     if (ret != 0) {
         ret = VERIFY_MAC_ERROR;
-        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -21124,7 +20947,6 @@ int TimingPadVerify(WOLFSSL* ssl, const byte* input, int padLen, int macSz,
     /* Treat any failure as verify MAC error. */
     if (ret != 0) {
         ret = VERIFY_MAC_ERROR;
-        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -21161,7 +20983,6 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
         (w64Equal(ssl->keys.curEpoch64, w64From32(0x0, DTLS13_EPOCH_HANDSHAKE))
                 || w64Equal(ssl->keys.curEpoch64, w64From32(0x0, 0x0))))
     {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 #endif
@@ -21208,7 +21029,6 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
         if (sniff == NO_SNIFF) {
             SendAlert(ssl, alert_fatal, unexpected_message);
         }
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -21235,7 +21055,6 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
         if (sniff == NO_SNIFF) {
             SendAlert(ssl, alert_fatal, unexpected_message);
         }
-        WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
         return BUFFER_ERROR;
     }
 #ifdef WOLFSSL_EARLY_DATA
@@ -21578,7 +21397,6 @@ static int DoAlert(WOLFSSL* ssl, byte* input, word32* inOutIdx, int* type)
         if (level != alert_warning || code != close_notify)
             SendAlert(ssl, alert_fatal, unexpected_message);
 #endif
-        WOLFSSL_ERROR_VERBOSE(ALERT_COUNT_E);
         return ALERT_COUNT_E;
     }
 
@@ -21670,12 +21488,10 @@ static int GetInputData(WOLFSSL *ssl, word32 size)
             return WC_NO_ERR_TRACE(WANT_READ);
 
         if (in < 0) {
-            WOLFSSL_ERROR_VERBOSE(SOCKET_ERROR_E);
             return SOCKET_ERROR_E;
         }
 
         if (in > inSz) {
-            WOLFSSL_ERROR_VERBOSE(RECV_OVERFLOW_E);
             return RECV_OVERFLOW_E;
         }
 
@@ -21720,7 +21536,6 @@ static WC_INLINE int VerifyMacEnc(WOLFSSL* ssl, const byte* input, word32 msgSz,
     WOLFSSL_MSG("Verify MAC of Encrypted Data");
 
     if (msgSz < digestSz) {
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
     XMEMSET(verify, 0, WC_MAX_DIGEST_SIZE);
@@ -21728,7 +21543,6 @@ static WC_INLINE int VerifyMacEnc(WOLFSSL* ssl, const byte* input, word32 msgSz,
     ret  = ssl->hmac(ssl, verify, input, msgSz - digestSz, -1, content, 1, PEER_ORDER);
     ret |= ConstantCompare(verify, input + msgSz - digestSz, (int)digestSz);
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
 
@@ -21790,11 +21604,9 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
                             (int)pad, content, 1, PEER_ORDER);
             if (ConstantCompare(verify, input + msgSz - digestSz - pad - 1,
                                 (int)digestSz) != 0) {
-                WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
                 return VERIFY_MAC_ERROR;
             }
             if (ret != 0 || badPadLen) {
-                WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
                 return VERIFY_MAC_ERROR;
             }
         }
@@ -21803,11 +21615,9 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
         ret = ssl->hmac(ssl, verify, input, msgSz - digestSz, -1, content, 1,
                         PEER_ORDER);
         if (ConstantCompare(verify, input + msgSz - digestSz, (int)digestSz) != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
     }
@@ -22238,7 +22048,6 @@ static int DoProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                 if (ssl->buffers.inputBuffer.buffer[
                           ssl->buffers.inputBuffer.idx + OPAQUE16_LEN] != OLD_HELLO_ID) {
                     WOLFSSL_MSG("Not a valid old client hello");
-                    WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
                     return PARSE_ERROR;
                 }
 
@@ -22247,7 +22056,6 @@ static int DoProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                     ssl->buffers.inputBuffer.buffer[
                           ssl->buffers.inputBuffer.idx + OPAQUE24_LEN] != DTLS_MAJOR) {
                     WOLFSSL_MSG("Not a valid version in old client hello");
-                    WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
                     return PARSE_ERROR;
                 }
 
@@ -22352,7 +22160,6 @@ default:
                                         ssl->curRL.type != application_data &&
                                         ssl->curRL.type != change_cipher_spec) {
                 SendAlert(ssl, alert_fatal, unexpected_message);
-                WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
                 return PARSE_ERROR;
             }
 #endif
@@ -22445,7 +22252,6 @@ default:
                     if (!ssl->options.dtls)
                         SendAlert(ssl, alert_fatal, bad_record_mac);
                 #endif
-                    WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
                     return DECRYPT_ERROR;
                 }
                 ssl->keys.encryptSz    = ssl->curSize;
@@ -22567,7 +22373,6 @@ default:
                             SendAlert(ssl, alert_fatal, bad_record_mac);
                     #endif
                         WOLFSSL_MSG("VerifyMac failed");
-                        WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
                         return DECRYPT_ERROR;
                     }
                 }
@@ -22682,7 +22487,6 @@ default:
             #if defined(WOLFSSL_EXTRA_ALERTS) && !defined(WOLFSSL_NO_ETM_ALERT)
                     SendAlert(ssl, alert_fatal, record_overflow);
             #endif
-                    WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
                     return BUFFER_ERROR;
                 }
             }
@@ -22700,7 +22504,6 @@ default:
 #if defined(WOLFSSL_TLS13) || defined(WOLFSSL_EXTRA_ALERTS)
                 SendAlert(ssl, alert_fatal, record_overflow);
 #endif
-                WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
                 return BUFFER_ERROR;
             }
 
@@ -22840,13 +22643,11 @@ default:
                         word32 i = ssl->buffers.inputBuffer.idx;
                         if (ssl->options.handShakeState == HANDSHAKE_DONE) {
                             SendAlert(ssl, alert_fatal, unexpected_message);
-                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                             return UNKNOWN_RECORD_TYPE;
                         }
                         if (ssl->curSize != 1 ||
                                       ssl->buffers.inputBuffer.buffer[i] != 1) {
                             SendAlert(ssl, alert_fatal, unexpected_message);
-                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                             return UNKNOWN_RECORD_TYPE;
                         }
                         ssl->buffers.inputBuffer.idx++;
@@ -22854,7 +22655,6 @@ default:
                                 !ssl->msgsReceived.got_client_hello) {
                             /* Can't appear before CH */
                             SendAlert(ssl, alert_fatal, unexpected_message);
-                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                             return UNKNOWN_RECORD_TYPE;
                         }
                         if (!ssl->msgsReceived.got_change_cipher) {
@@ -22862,12 +22662,10 @@ default:
                         }
                         else {
                             SendAlert(ssl, alert_fatal, illegal_parameter);
-                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                             return UNKNOWN_RECORD_TYPE;
                         }
                         if (ssl->keys.decryptedCur == 1) {
                             SendAlert(ssl, alert_fatal, unexpected_message);
-                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                             return UNKNOWN_RECORD_TYPE;
                         }
                         break;
@@ -22879,13 +22677,11 @@ default:
                             ssl->buffers.inputBuffer.length ||
                             ssl->curSize < 1) {
                         WOLFSSL_MSG("ChangeCipher msg too short");
-                        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
                         return LENGTH_ERROR;
                     }
                     if (ssl->buffers.inputBuffer.buffer[
                             ssl->buffers.inputBuffer.idx] != 1) {
                         WOLFSSL_MSG("ChangeCipher msg wrong value");
-                        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
                         return LENGTH_ERROR;
                     }
 
@@ -22896,7 +22692,6 @@ default:
 
                     if (ssl->curSize != 1) {
                         WOLFSSL_MSG("Malicious or corrupted ChangeCipher msg");
-                        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
                         return LENGTH_ERROR;
                     }
 
@@ -22996,7 +22791,6 @@ default:
                     #ifdef WOLFSSL_TLS13
                         if (ssl->keys.keyUpdateRespond) {
                             WOLFSSL_MSG("No KeyUpdate from peer seen");
-                            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                             return SANITY_MSG_E;
                         }
                     #endif
@@ -23106,7 +22900,6 @@ default:
                     }
                     else {
                         WOLFSSL_MSG("\tBuffer advanced not enough error");
-                        WOLFSSL_ERROR_VERBOSE(FATAL_ERROR);
                         return FATAL_ERROR;
                     }
                 }
@@ -23134,7 +22927,6 @@ default:
             continue;
         default:
             WOLFSSL_MSG("Bad process input state, programming error");
-            WOLFSSL_ERROR_VERBOSE(INPUT_CASE_ERROR);
             return INPUT_CASE_ERROR;
         }
     }
@@ -23339,7 +23131,6 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         /* in buffer */
         ret |= wc_Md5Update(&md5, in, sz);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
         ret = wc_Md5Final(&md5, result);
@@ -23350,7 +23141,6 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
 
@@ -23359,7 +23149,6 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret |= wc_Md5Update(&md5, PAD2, padSz);
         ret |= wc_Md5Update(&md5, result, digestSz);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
         ret =  wc_Md5Final(&md5, digest);
@@ -23370,7 +23159,6 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
 
@@ -23389,7 +23177,6 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         /* in buffer */
         ret |= wc_ShaUpdate(&sha, in, sz);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
         ret = wc_ShaFinal(&sha, result);
@@ -23400,7 +23187,6 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
 
@@ -23409,7 +23195,6 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret |= wc_ShaUpdate(&sha, PAD2, padSz);
         ret |= wc_ShaUpdate(&sha, result, digestSz);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
         ret =  wc_ShaFinal(&sha, digest);
@@ -23420,7 +23205,6 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
 
@@ -24015,9 +23799,6 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
         if (ret == 0) {
             ret = args->sz;
         }
-        else {
-            WOLFSSL_ERROR_VERBOSE(ret);
-        }
 
         /* Final cleanup */
         FreeBuildMsgArgs(ssl, args);
@@ -24147,9 +23928,6 @@ exit_buildmsg:
     /* return sz on success */
     if (ret == 0) {
         ret = (int)args->sz;
-    }
-    else {
-        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     /* Final cleanup */
@@ -30184,9 +29962,6 @@ int DecodePrivateKey(WOLFSSL *ssl, word32* length)
     (void)length;
 
 exit_dpk:
-    if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
 
     return ret;
 }
@@ -30622,9 +30397,6 @@ exit_dapk:
     }
 #endif
 
-    if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
 
     return ret;
 }
@@ -31204,7 +30976,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
         if (ssl->options.dtls) {
             if (pv.major != DTLS_MAJOR || pv.minor == DTLS_BOGUS_MINOR) {
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
             lowerVersion = pv.minor > ssl->version.minor;
@@ -31212,7 +30983,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         }
         else {
             if (pv.major != SSLv3_MAJOR) {
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
             lowerVersion = pv.minor < ssl->version.minor;
@@ -31221,7 +30991,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
         if (higherVersion) {
             WOLFSSL_MSG("Server using higher version, fatal error");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
         if (lowerVersion) {
@@ -31230,13 +30999,11 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             /* Check for downgrade attack. */
             if (!ssl->options.downgrade) {
                 WOLFSSL_MSG("\tno downgrade allowed, fatal error");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
             if ((!ssl->options.dtls && pv.minor < ssl->options.minDowngrade) ||
                 (ssl->options.dtls && pv.minor > ssl->options.minDowngrade)) {
                 WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 
@@ -31245,7 +31012,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                                          ssl->secure_renegotiation->enabled &&
                                          ssl->options.handShakeDone) {
                     WOLFSSL_MSG("Server changed version during scr");
-                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                     return VERSION_ERROR;
                 }
             #endif /* HAVE_SECURE_RENEGOTIATION */
@@ -31278,7 +31044,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                     break;
                 default:
                     WOLFSSL_MSG("\tbad minor version");
-                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                     return VERSION_ERROR;
                 }
         }
@@ -31316,13 +31081,11 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 (ssl->options.mask & WOLFSSL_OP_NO_SSLv3) ==
                 WOLFSSL_OP_NO_SSLv3) {
                 WOLFSSL_MSG("\tError, option set to not allow SSLv3");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 
             if (ssl->version.minor < ssl->options.minDowngrade) {
                 WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
         }
@@ -31407,7 +31170,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             if (ssl->options.cipherSuite0 != cs0 ||
                 ssl->options.cipherSuite  != cs1) {
                 WOLFSSL_MSG("Server changed cipher suite during scr");
-                WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
                 return MATCH_SUITE_ERROR;
             }
         }
@@ -31426,7 +31188,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             }
             if (!found) {
                 WOLFSSL_MSG("ServerHello did not use cipher suite from ClientHello");
-                WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
                 return MATCH_SUITE_ERROR;
             }
         }
@@ -31444,7 +31205,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
         if (compression != NO_COMPRESSION && !ssl->options.usingCompression) {
             WOLFSSL_MSG("Server forcing compression w/o support");
-            WOLFSSL_ERROR_VERBOSE(COMPRESSION_ERROR);
             return COMPRESSION_ERROR;
         }
 
@@ -31573,7 +31333,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             ret = ssl->sessionSecretCb(ssl, ssl->session->masterSecret,
                                               &secretSz, ssl->sessionSecretCtx);
             if (ret != 0 || secretSz != SECRET_LEN) {
-                WOLFSSL_ERROR_VERBOSE(SESSION_SECRET_CB_E);
                 return SESSION_SECRET_CB_E;
             }
         }
@@ -31604,7 +31363,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 if (XMEMCMP(down, tls13Downgrade, TLS13_DOWNGRADE_SZ) == 0 &&
                                                      (vers == 0 || vers == 1)) {
                     SendAlert(ssl, alert_fatal, illegal_parameter);
-                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                     return VERSION_ERROR;
                 }
             }
@@ -31619,7 +31377,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 if (XMEMCMP(down, tls13Downgrade, TLS13_DOWNGRADE_SZ) == 0 &&
                                                                     vers == 0) {
                     SendAlert(ssl, alert_fatal, illegal_parameter);
-                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                     return VERSION_ERROR;
                 }
             }
@@ -31629,7 +31386,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 if (SetCipherSpecs(ssl) == 0) {
                     if (!HaveUniqueSessionObj(ssl)) {
                         WOLFSSL_MSG("Unable to have unique session object");
-                        WOLFSSL_ERROR_VERBOSE(MEMORY_ERROR);
                         return MEMORY_ERROR;
                     }
 
@@ -31654,7 +31410,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 }
                 else {
                     WOLFSSL_MSG("Unsupported cipher suite, DoServerHello");
-                    WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
                     return UNSUPPORTED_SUITE;
                 }
             }
@@ -31746,12 +31501,10 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             #ifdef HAVE_PK_CALLBACKS
                 if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)) {
                     WOLFSSL_MSG("Using PK for client private key");
-                    WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
                     return INVALID_PARAMETER;
                 }
             #endif
                 if (ssl->buffers.key && ssl->buffers.key->buffer) {
-                    WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
                     return INVALID_PARAMETER;
                 }
             }
@@ -31856,7 +31609,6 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             if (ret == 1) {
                 if ((wolfSSL_use_certificate(ssl, x509) != WOLFSSL_SUCCESS) ||
                     (wolfSSL_use_PrivateKey(ssl, pkey) != WOLFSSL_SUCCESS)) {
-                    WOLFSSL_ERROR_VERBOSE(CLIENT_CERT_CB_ERROR);
                     return CLIENT_CERT_CB_ERROR;
                 }
                 wolfSSL_X509_free(x509);
@@ -32267,9 +32019,6 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
 #endif /* HAVE_FFDHE */
 
 exit_gdpk:
-    if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
     return ret;
 }
 #endif
@@ -33335,9 +33084,6 @@ exit_dske:
     /* Final cleanup */
     FreeKeyExchange(ssl);
 
-    if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
     return ret;
 }
 
@@ -34591,9 +34337,6 @@ exit_scke:
 #endif
     FreeKeyExchange(ssl);
 
-    if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
     return ret;
 }
 
@@ -35164,9 +34907,6 @@ exit_scv:
 #endif
     FreeKeyExchange(ssl);
 
-    if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
 
     return ret;
 }
@@ -35241,7 +34981,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     if (ssl->expect_session_ticket == 0) {
         WOLFSSL_MSG("Unexpected session ticket");
-        WOLFSSL_ERROR_VERBOSE(SESSION_TICKET_EXPECT_E);
         return SESSION_TICKET_EXPECT_E;
     }
 
@@ -37460,9 +37199,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     #endif
         FreeKeyExchange(ssl);
 
-        if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(ret);
-        }
 
         return ret;
     }
@@ -37674,7 +37410,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
         }
 
-        WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
         return MATCH_SUITE_ERROR;
 
     }
@@ -38036,7 +37771,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 SendAlert(ssl, alert_fatal, handshake_failure);
             #endif
                 ret = EXT_MASTER_SECRET_NEEDED_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
         }
         else {
@@ -38056,7 +37790,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 SendAlert(ssl, alert_fatal, illegal_parameter);
             #endif
                 ret = UNSUPPORTED_SUITE;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
         #endif
 
@@ -38074,7 +37807,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 if (MatchSuite(ssl, clSuites) < 0) {
                     WOLFSSL_MSG("Unsupported cipher suite, ClientHello");
                     ret = UNSUPPORTED_SUITE;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
             if (ret == 0) {
@@ -38723,9 +38455,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         WOLFSSL_LEAVE("DoClientHello", ret);
         WOLFSSL_END(WC_FUNC_CLIENT_HELLO_DO);
 
-        if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(ret);
-        }
 
         return ret;
     }
@@ -39199,9 +38928,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         /* Final cleanup */
         FreeKeyExchange(ssl);
 
-        if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(ret);
-        }
 
         return ret;
     }
@@ -39559,7 +39285,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #ifdef WOLFSSL_CHECK_MEM_ZERO
         wc_MemZero_Check(it, sizeof(InternalTicket));
 #endif
-        WOLFSSL_ERROR_VERBOSE(ret);
         return ret;
 
     }
@@ -39626,7 +39351,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
         if (outLen > (int)inLen || outLen < (int)WOLFSSL_INTERNAL_TICKET_LEN) {
             WOLFSSL_MSG("Bad user ticket decrypt len");
-            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_KEY_CB_SZ);
             return BAD_TICKET_KEY_CB_SZ;
         }
         *it = (InternalTicket*)et->enc_ticket;

--- a/src/internal.c
+++ b/src/internal.c
@@ -39303,7 +39303,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (len > SESSION_TICKET_LEN ||
             len < (word32)(WOLFSSL_INTERNAL_TICKET_LEN +
                            WOLFSSL_TICKET_FIXED_SZ)) {
-            WOLF_MSG(wolfSSL_ERR_reason_error_string(BAD_TICKET_MSG_SZ));
+            WOLFSSL_MSG(wolfSSL_ERR_reason_error_string(BAD_TICKET_MSG_SZ));
             return WOLFSSL_TICKET_RET_REJECT;
         }
 
@@ -39312,7 +39312,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         /* decrypt */
         ato16(et->enc_len, &inLen);
         if (inLen > WOLFSSL_TICKET_ENC_SZ) {
-            WOLF_MSG(wolfSSL_ERR_reason_error_string(BAD_TICKET_MSG_SZ));
+            WOLFSSL_MSG(wolfSSL_ERR_reason_error_string(BAD_TICKET_MSG_SZ));
             return WOLFSSL_TICKET_RET_REJECT;
         }
         outLen = (int)inLen;   /* may be reduced by user padding */
@@ -39327,7 +39327,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         (ssl->options.mask & WOLFSSL_OP_NO_TICKET) != 0)
 #endif
                         ) {
-            WOLF_MSG("Missing ticket callback")
+            WOLFSSL_MSG("Missing ticket callback")
             ret = WOLFSSL_TICKET_RET_REJECT;
         }
         else {
@@ -39345,7 +39345,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
         #endif /* WOLFSSL_ASYNC_CRYPT */
             if (ret != WOLFSSL_TICKET_RET_CREATE) {
-                WOLF_MSG(wolfSSL_ERR_reason_error_string(BAD_TICKET_KEY_CB_SZ));
+                WOLFSSL_MSG(wolfSSL_ERR_reason_error_string(BAD_TICKET_KEY_CB_SZ));
                 return WOLFSSL_TICKET_RET_REJECT;
             }
         }

--- a/src/keys.c
+++ b/src/keys.c
@@ -118,7 +118,6 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         /* server side verified before SetCipherSpecs call */
         if (VerifyClientSuite(havePSK, cipherSuite0, cipherSuite) != 1) {
             WOLFSSL_MSG("SetCipherSpecs() client has an unusable suite");
-            WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
             return UNSUPPORTED_SUITE;
         }
     }
@@ -2307,7 +2306,6 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
 
     default:
         WOLFSSL_MSG("Unsupported cipher suite, SetCipherSpecs");
-        WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
         return UNSUPPORTED_SUITE;
     }  /* switch */
     }  /* if ECC / Normal suites else */

--- a/src/pk.c
+++ b/src/pk.c
@@ -6335,12 +6335,10 @@ int wolfSSL_DSA_LoadDer_ex(WOLFSSL_DSA* dsa, const unsigned char* derBuf,
     }
 
     if (ret < 0 && opt == WOLFSSL_DSA_LOAD_PRIVATE) {
-        WOLFSSL_ERROR_VERBOSE(ret);
         WOLFSSL_MSG("DsaPrivateKeyDecode failed");
         return WOLFSSL_FATAL_ERROR;
     }
     else if (ret < 0 && opt == WOLFSSL_DSA_LOAD_PUBLIC) {
-        WOLFSSL_ERROR_VERBOSE(ret);
         WOLFSSL_MSG("DsaPublicKeyDecode failed");
         return WOLFSSL_FATAL_ERROR;
     }
@@ -16873,4 +16871,3 @@ int wolfSSL_PEM_write_PKCS8PrivateKey(XFILE f, WOLFSSL_EVP_PKEY* pkey,
  ******************************************************************************/
 
 #endif /* !WOLFSSL_PK_INCLUDED */
-

--- a/src/pk.c
+++ b/src/pk.c
@@ -1868,7 +1868,6 @@ int wolfSSL_RSA_LoadDer_ex(WOLFSSL_RSA* rsa, const unsigned char* derBuf,
             else {
                  WOLFSSL_ERROR_MSG("RsaPublicKeyDecode failed");
             }
-            WOLFSSL_ERROR_VERBOSE(res);
             ret = WOLFSSL_FATAL_ERROR;
         }
     }

--- a/src/tls.c
+++ b/src/tls.c
@@ -159,7 +159,6 @@ int BuildTlsHandshakeHash(WOLFSSL* ssl, byte* hash, word32* hashLen)
 
     if (ret != 0) {
         ret = BUILD_MSG_ERROR;
-        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -221,7 +220,6 @@ int BuildTlsFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
 #else
         /* Pseudo random function must be enabled in the configuration. */
         ret = PRF_MISSING;
-        WOLFSSL_ERROR_VERBOSE(ret);
         WOLFSSL_MSG("Pseudo-random function is not enabled");
 
         (void)side;
@@ -422,7 +420,6 @@ static int _DeriveTlsKeys(byte* key_dig, word32 key_dig_len,
 #else
     /* Pseudo random function must be enabled in the configuration. */
     ret = PRF_MISSING;
-    WOLFSSL_ERROR_VERBOSE(ret);
     WOLFSSL_MSG("Pseudo-random function is not enabled");
 
     (void)key_dig;
@@ -1608,7 +1605,6 @@ int TLSX_HandleUnsupportedExtension(WOLFSSL* ssl);
 int TLSX_HandleUnsupportedExtension(WOLFSSL* ssl)
 {
     SendAlert(ssl, alert_fatal, unsupported_extension);
-    WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_EXTENSION);
     return UNSUPPORTED_EXTENSION;
 }
 
@@ -1833,7 +1829,6 @@ static int ALPN_find_match(WOLFSSL *ssl, TLSX **pextension,
         }
         else {
             SendAlert(ssl, alert_fatal, no_application_protocol);
-            WOLFSSL_ERROR_VERBOSE(UNKNOWN_ALPN_PROTOCOL_NAME_E);
             return UNKNOWN_ALPN_PROTOCOL_NAME_E;
         }
     }
@@ -1872,7 +1867,6 @@ int ALPN_Select(WOLFSSL *ssl)
             default:
                 WOLFSSL_MSG("ALPN cb no match and fatal");
                 SendAlert(ssl, alert_fatal, no_application_protocol);
-                WOLFSSL_ERROR_VERBOSE(UNKNOWN_ALPN_PROTOCOL_NAME_E);
                 return UNKNOWN_ALPN_PROTOCOL_NAME_E;
         }
     }
@@ -2023,14 +2017,12 @@ int TLSX_ALPN_GetRequest(TLSX* extensions, void** data, word16 *dataSz)
     extension = TLSX_Find(extensions, TLSX_APPLICATION_LAYER_PROTOCOL);
     if (extension == NULL) {
         WOLFSSL_MSG("TLS extension not found");
-        WOLFSSL_ERROR_VERBOSE(WOLFSSL_ALPN_NOT_FOUND);
         return WOLFSSL_ALPN_NOT_FOUND;
     }
 
     alpn = (ALPN *)extension->data;
     if (alpn == NULL) {
         WOLFSSL_MSG("ALPN extension not found");
-        WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
         return WOLFSSL_FATAL_ERROR;
     }
 
@@ -2039,19 +2031,16 @@ int TLSX_ALPN_GetRequest(TLSX* extensions, void** data, word16 *dataSz)
         /* consider as an error */
         if (alpn->options & WOLFSSL_ALPN_FAILED_ON_MISMATCH) {
             WOLFSSL_MSG("No protocol match with peer -> Failed");
-            WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
             return WOLFSSL_FATAL_ERROR;
         }
 
         /* continue without negotiated protocol */
         WOLFSSL_MSG("No protocol match with peer -> Continue");
-        WOLFSSL_ERROR_VERBOSE(WOLFSSL_ALPN_NOT_FOUND);
         return WOLFSSL_ALPN_NOT_FOUND;
     }
 
     if (alpn->next != NULL) {
         WOLFSSL_MSG("Only one protocol name must be accepted");
-        WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
         return WOLFSSL_FATAL_ERROR;
     }
 
@@ -2384,7 +2373,6 @@ static int TLSX_SNI_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     }
     else if (!(sni->options & WOLFSSL_SNI_CONTINUE_ON_MISMATCH)) {
         SendAlert(ssl, alert_fatal, unrecognized_name);
-        WOLFSSL_ERROR_VERBOSE(UNKNOWN_SNI_HOST_NAME_E);
         return UNKNOWN_SNI_HOST_NAME_E;
     }
 #else
@@ -2424,7 +2412,6 @@ static int TLSX_SNI_VerifyParse(WOLFSSL* ssl,  byte isRequest)
                 }
 
                 SendAlert(ssl, alert_fatal, handshake_failure);
-                WOLFSSL_ERROR_VERBOSE(SNI_ABSENT_ERROR);
                 return SNI_ABSENT_ERROR;
             }
         }
@@ -2435,7 +2422,6 @@ static int TLSX_SNI_VerifyParse(WOLFSSL* ssl,  byte isRequest)
                     continue;
 
                 SendAlert(ssl, alert_fatal, handshake_failure);
-                WOLFSSL_ERROR_VERBOSE(SNI_ABSENT_ERROR);
                 return SNI_ABSENT_ERROR;
             }
         }
@@ -2553,7 +2539,6 @@ int TLSX_SNI_GetFromBuffer(const byte* clientHello, word32 helloSz,
             if (len16 != 0) /* session_id_length must be 0 */
                 return BUFFER_ERROR;
 
-            WOLFSSL_ERROR_VERBOSE(SNI_UNSUPPORTED);
             return SNI_UNSUPPORTED;
         }
 
@@ -2564,7 +2549,6 @@ int TLSX_SNI_GetFromBuffer(const byte* clientHello, word32 helloSz,
         return BUFFER_ERROR;
 
     if (clientHello[offset++] < TLSv1_MINOR) {
-        WOLFSSL_ERROR_VERBOSE(SNI_UNSUPPORTED);
         return SNI_UNSUPPORTED;
     }
 
@@ -2948,7 +2932,6 @@ static int TLSX_TCA_Parse(WOLFSSL* ssl, const byte* input, word16 length,
                 offset += idSz;
                 break;
             default:
-                WOLFSSL_ERROR_VERBOSE(TCA_INVALID_ID_TYPE);
                 return TCA_INVALID_ID_TYPE;
         }
 
@@ -2981,7 +2964,6 @@ static int TLSX_TCA_VerifyParse(WOLFSSL* ssl, byte isRequest)
 
         if (extension && !extension->resp) {
             SendAlert(ssl, alert_fatal, handshake_failure);
-            WOLFSSL_ERROR_VERBOSE(TCA_ABSENT_ERROR);
             return TCA_ABSENT_ERROR;
         }
     #else
@@ -3075,7 +3057,6 @@ static int TLSX_MFL_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 
         default:
             SendAlert(ssl, alert_fatal, illegal_parameter);
-            WOLFSSL_ERROR_VERBOSE(UNKNOWN_MAX_FRAG_LEN_E);
             return UNKNOWN_MAX_FRAG_LEN_E;
     }
     if (ssl->session != NULL) {
@@ -3568,7 +3549,6 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, const byte* input, word16 length,
                 ret = BUFFER_ERROR;
             if (ret == 0 && input[offset++] != WOLFSSL_CSR_OCSP) {
                 ret = BAD_CERTIFICATE_STATUS_ERROR;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
             if (ret == 0) {
                 c24to32(input + offset, &resp_length);
@@ -3716,7 +3696,6 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, const byte* input, word16 length,
             /* process OCSP request in certificate chain */
             if ((ret = ProcessChainOCSPRequest(ssl)) != 0) {
                 WOLFSSL_MSG("Process Cert Chain OCSP request failed");
-                WOLFSSL_ERROR_VERBOSE(ret);
                 return ret;
             }
         #endif
@@ -3767,7 +3746,6 @@ int TLSX_CSR_InitRequest_ex(TLSX* extensions, DecodedCert* cert,
                     csr->requests++;
                 }
                 else {
-                    WOLFSSL_ERROR_VERBOSE(MAX_CERT_EXTENSIONS_ERR);
                     return MAX_CERT_EXTENSIONS_ERR;
                 }
             }
@@ -3824,7 +3802,6 @@ int TLSX_CSR_ForceRequest(WOLFSSL* ssl)
                                               &csr->request.ocsp[0], NULL, NULL);
                 }
                 else {
-                    WOLFSSL_ERROR_VERBOSE(OCSP_LOOKUP_FAIL);
                     return OCSP_LOOKUP_FAIL;
                 }
         }
@@ -4363,7 +4340,6 @@ int TLSX_CSR2_ForceRequest(WOLFSSL* ssl)
                                           &csr2->request.ocsp[csr2->requests-1], NULL, NULL);
                 }
                 else {
-                    WOLFSSL_ERROR_VERBOSE(OCSP_LOOKUP_FAIL);
                     return OCSP_LOOKUP_FAIL;
                 }
         }
@@ -6128,7 +6104,6 @@ static int TLSX_SecureRenegotiation_Parse(WOLFSSL* ssl, const byte* input,
     }
 
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
         SendAlert(ssl, alert_fatal, handshake_failure);
     }
 
@@ -6273,7 +6248,6 @@ static int TLSX_SessionTicket_Parse(WOLFSSL* ssl, const byte* input,
 
         if (length > SESSION_TICKET_LEN) {
             ret = BAD_TICKET_MSG_SZ;
-            WOLFSSL_ERROR_VERBOSE(ret);
         } else if (IsAtLeastTLSv1_3(ssl->version)) {
             WOLFSSL_MSG("Process client ticket rejected, TLS 1.3 no support");
             ssl->options.rejectTicket = 1;
@@ -6433,7 +6407,6 @@ static int TLSX_EncryptThenMac_GetSize(byte msgType, word16* pSz)
     (void)pSz;
 
     if (msgType != client_hello && msgType != server_hello) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -6460,7 +6433,6 @@ static int TLSX_EncryptThenMac_Write(void* data, byte* output, byte msgType,
     (void)pSz;
 
     if (msgType != client_hello && msgType != server_hello) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -6489,7 +6461,6 @@ static int TLSX_EncryptThenMac_Parse(WOLFSSL* ssl, const byte* input,
     (void)input;
 
     if (msgType != client_hello && msgType != server_hello) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -6511,7 +6482,6 @@ static int TLSX_EncryptThenMac_Parse(WOLFSSL* ssl, const byte* input,
 
     /* Server Hello */
     if (ssl->options.disallowEncThenMac) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -6906,7 +6876,6 @@ static int TLSX_SupportedVersions_GetSize(void* data, byte msgType, word16* pSz)
         *pSz += OPAQUE16_LEN;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -7020,7 +6989,6 @@ static int TLSX_SupportedVersions_Write(void* data, byte* output,
         *pSz += OPAQUE16_LEN;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -7117,7 +7085,6 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
             /* No common supported version was negotiated */
             SendAlert((WOLFSSL*)ssl, alert_fatal,
                       wolfssl_alert_protocol_version);
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
         pv->minor = clientGreatestMinor;
@@ -7149,13 +7116,11 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
         minor = input[OPAQUE8_LEN];
 
         if (major != ssl->ctx->method->version.major) {
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
 
         /* Can't downgrade with this extension below TLS v1.3. */
         if (versionIsLesser(isDtls, minor, tls13minor)) {
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
 
@@ -7167,20 +7132,17 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
 
         /* No upgrade allowed. */
         if (versionIsLesser(isDtls, ssl->version.minor, minor)) {
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
 
         /* Check downgrade. */
         if (versionIsGreater(isDtls, ssl->version.minor, minor)) {
             if (!ssl->options.downgrade) {
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 
             if (versionIsLesser(
                     isDtls, minor, ssl->options.minDowngrade)) {
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 
@@ -7189,7 +7151,6 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
         }
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -7255,7 +7216,6 @@ static int TLSX_Cookie_GetSize(Cookie* cookie, byte msgType, word16* pSz)
         *pSz += OPAQUE16_LEN + cookie->len;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
     return 0;
@@ -7280,7 +7240,6 @@ static int TLSX_Cookie_Write(Cookie* cookie, byte* output, byte msgType,
         *pSz += OPAQUE16_LEN + cookie->len;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
     return 0;
@@ -7304,7 +7263,6 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     Cookie* cookie;
 
     if (msgType != client_hello && msgType != hello_retry_request) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -7335,14 +7293,12 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
         else
 #endif
         {
-            WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
             return HRR_COOKIE_ERROR;
         }
     }
 
     cookie = (Cookie*)extension->data;
     if (cookie->len != len || XMEMCMP(cookie->data, input + idx, len) != 0) {
-        WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
         return HRR_COOKIE_ERROR;
     }
 
@@ -8061,7 +8017,6 @@ static int TLSX_KeyShare_GenDhKey(WOLFSSL *ssl, KeyShareEntry* kse)
     (void)kse;
 
     ret = NOT_COMPILED_IN;
-    WOLFSSL_ERROR_VERBOSE(ret);
 #endif
 
     return ret;
@@ -8123,7 +8078,6 @@ static int TLSX_KeyShare_GenX25519Key(WOLFSSL *ssl, KeyShareEntry* kse)
         if (wc_curve25519_export_public_ex(key, kse->pubKey, &kse->pubKeyLen,
                                                   EC25519_LITTLE_ENDIAN) != 0) {
             ret = ECC_EXPORT_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
         kse->pubKeyLen = CURVE25519_KEYSIZE; /* always CURVE25519_KEYSIZE */
     }
@@ -8149,7 +8103,6 @@ static int TLSX_KeyShare_GenX25519Key(WOLFSSL *ssl, KeyShareEntry* kse)
     (void)kse;
 
     ret = NOT_COMPILED_IN;
-    WOLFSSL_ERROR_VERBOSE(ret);
 #endif /* HAVE_CURVE25519 */
 
     return ret;
@@ -8234,7 +8187,6 @@ static int TLSX_KeyShare_GenX448Key(WOLFSSL *ssl, KeyShareEntry* kse)
     (void)kse;
 
     ret = NOT_COMPILED_IN;
-    WOLFSSL_ERROR_VERBOSE(ret);
 #endif /* HAVE_CURVE448 */
 
     return ret;
@@ -8289,7 +8241,6 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
         #endif /* !NO_ECC_SECP */
     #endif
         default:
-            WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
             return BAD_FUNC_ARG;
     }
 
@@ -8368,7 +8319,6 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
         PRIVATE_KEY_UNLOCK();
         if (wc_ecc_export_x963(eccKey, kse->pubKey, &kse->pubKeyLen) != 0) {
             ret = ECC_EXPORT_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
         PRIVATE_KEY_LOCK();
     }
@@ -8393,7 +8343,6 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
     (void)kse;
 
     ret = NOT_COMPILED_IN;
-    WOLFSSL_ERROR_VERBOSE(ret);
 #endif /* HAVE_ECC && HAVE_ECC_KEY_EXPORT */
 
     return ret;
@@ -9067,14 +9016,12 @@ static int TLSX_KeyShare_ProcessDh(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
             break;
     }
     if (params == NULL) {
-        WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
         return PEER_KEY_ERROR;
     }
     pSz = params->p_len;
 #else
     ret = wc_DhGetNamedKeyParamSize(keyShareEntry->group, &pSz, NULL, NULL);
     if (ret != 0 || pSz == 0) {
-        WOLFSSL_ERROR_VERBOSE(PEER_KEY_ERROR);
         return PEER_KEY_ERROR;
     }
 #endif
@@ -9155,7 +9102,6 @@ static int TLSX_KeyShare_ProcessDh(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
     (void)ssl;
     (void)keyShareEntry;
     ret = PEER_KEY_ERROR;
-    WOLFSSL_ERROR_VERBOSE(ret);
 #endif
     return ret;
 }
@@ -9207,7 +9153,6 @@ static int TLSX_KeyShare_ProcessX25519_ex(WOLFSSL* ssl,
     if (wc_curve25519_check_public(keyShareEntry->ke, keyShareEntry->keLen,
                                                   EC25519_LITTLE_ENDIAN) != 0) {
         ret = ECC_PEERKEY_ERROR;
-        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     if (ret == 0) {
@@ -9215,7 +9160,6 @@ static int TLSX_KeyShare_ProcessX25519_ex(WOLFSSL* ssl,
                                             keyShareEntry->keLen, peerX25519Key,
                                             EC25519_LITTLE_ENDIAN) != 0) {
             ret = ECC_PEERKEY_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
 
@@ -9244,7 +9188,6 @@ static int TLSX_KeyShare_ProcessX25519_ex(WOLFSSL* ssl,
     (void)ssOutSz;
 
     ret = PEER_KEY_ERROR;
-    WOLFSSL_ERROR_VERBOSE(ret);
 #endif /* HAVE_CURVE25519 */
 
     return ret;
@@ -9311,7 +9254,6 @@ static int TLSX_KeyShare_ProcessX448_ex(WOLFSSL* ssl,
     if (wc_curve448_check_public(keyShareEntry->ke, keyShareEntry->keLen,
                                                     EC448_LITTLE_ENDIAN) != 0) {
         ret = ECC_PEERKEY_ERROR;
-        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     if (ret == 0) {
@@ -9319,7 +9261,6 @@ static int TLSX_KeyShare_ProcessX448_ex(WOLFSSL* ssl,
                                               keyShareEntry->keLen, peerX448Key,
                                               EC448_LITTLE_ENDIAN) != 0) {
             ret = ECC_PEERKEY_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
 
@@ -9344,7 +9285,6 @@ static int TLSX_KeyShare_ProcessX448_ex(WOLFSSL* ssl,
     (void)ssOutSz;
 
     ret = PEER_KEY_ERROR;
-    WOLFSSL_ERROR_VERBOSE(ret);
 #endif /* HAVE_CURVE448 */
 
     return ret;
@@ -9416,7 +9356,6 @@ static int TLSX_KeyShare_ProcessEcc_ex(WOLFSSL* ssl,
     #endif
         default:
             /* unsupported curve */
-            WOLFSSL_ERROR_VERBOSE(ECC_PEERKEY_ERROR);
             return ECC_PEERKEY_ERROR;
     }
 
@@ -9459,7 +9398,6 @@ static int TLSX_KeyShare_ProcessEcc_ex(WOLFSSL* ssl,
                                 ssl->peerEccKey, curveId);
             if (ret != 0) {
                 ret = ECC_PEERKEY_ERROR;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
         }
 
@@ -9506,7 +9444,6 @@ static int TLSX_KeyShare_ProcessEcc_ex(WOLFSSL* ssl,
     (void)ssOutSz;
 
     ret = PEER_KEY_ERROR;
-    WOLFSSL_ERROR_VERBOSE(ret);
 #endif /* HAVE_ECC */
 
     return ret;
@@ -10138,13 +10075,11 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 
         /* Check the selected group was supported by ClientHello extensions. */
         if (!TLSX_SupportedGroups_Find(ssl, group, ssl->extensions)) {
-            WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
             return BAD_KEY_SHARE_DATA;
         }
 
         /* Check if the group was sent. */
         if (!TLSX_KeyShare_Find(ssl, group)) {
-            WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
             return BAD_KEY_SHARE_DATA;
         }
 
@@ -10160,7 +10095,6 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
             && keyShareEntry->privKey == NULL
         #endif
         )) {
-            WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
             return BAD_KEY_SHARE_DATA;
         }
 
@@ -10184,14 +10118,12 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
             /* Check the selected group was supported by ClientHello extensions.
              */
             if (!TLSX_SupportedGroups_Find(ssl, group, ssl->extensions)) {
-                WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
                 return BAD_KEY_SHARE_DATA;
             }
 
             /* Make sure KeyShare for server requested group was not sent in
              * ClientHello. */
             if (TLSX_KeyShare_Find(ssl, group)) {
-                WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
                 return BAD_KEY_SHARE_DATA;
             }
 
@@ -10207,7 +10139,6 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     }
     else {
         /* Not a message type that is allowed to have this extension. */
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -10954,7 +10885,6 @@ int TLSX_KeyShare_SetSupported(const WOLFSSL* ssl, TLSX** extensions)
         }
         if (name == WOLFSSL_NAMED_GROUP_INVALID) {
             /* No group selected or specified by the server */
-            WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
             return BAD_KEY_SHARE_DATA;
         }
     }
@@ -10970,7 +10900,6 @@ int TLSX_KeyShare_SetSupported(const WOLFSSL* ssl, TLSX** extensions)
         /* We should not be computing keys if we are only going to advertise
          * our choice here. */
         if (kse != NULL && kse->lastRet == WC_NO_ERR_TRACE(WC_PENDING_E)) {
-            WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
             return BAD_KEY_SHARE_DATA;
         }
     }
@@ -10993,7 +10922,6 @@ int TLSX_KeyShare_SetSupported(const WOLFSSL* ssl, TLSX** extensions)
 
     (void)ssl;
 
-    WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
     ret = NOT_COMPILED_IN;
 #endif
 
@@ -11440,7 +11368,6 @@ static int TLSX_PreSharedKey_GetSize(PreSharedKey* list, byte msgType,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     return SANITY_MSG_E;
 }
 
@@ -11457,7 +11384,6 @@ int TLSX_PreSharedKey_GetSizeBinders(PreSharedKey* list, byte msgType,
     word16 len;
 
     if (msgType != client_hello) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -11489,7 +11415,6 @@ int TLSX_PreSharedKey_WriteBinders(PreSharedKey* list, byte* output,
     word16 len;
 
     if (msgType != client_hello) {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -11569,7 +11494,6 @@ static int TLSX_PreSharedKey_Write(PreSharedKey* list, byte* output,
         for (i=0; list != NULL && !list->chosen; i++)
             list = list->next;
         if (list == NULL) {
-            WOLFSSL_ERROR_VERBOSE(BUILD_MSG_ERROR);
             return BUILD_MSG_ERROR;
         }
 
@@ -11580,7 +11504,6 @@ static int TLSX_PreSharedKey_Write(PreSharedKey* list, byte* output,
         *pSz += OPAQUE16_LEN;
     }
     else {
-        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
         return SANITY_MSG_E;
     }
 
@@ -11723,7 +11646,6 @@ static int TLSX_PreSharedKey_Parse(WOLFSSL* ssl, const byte* input,
         for (; list != NULL && idx > 0; idx--)
             list = list->next;
         if (list == NULL) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             return PSK_KEY_ERROR;
         }
         list->chosen = 1;
@@ -11735,7 +11657,6 @@ static int TLSX_PreSharedKey_Parse(WOLFSSL* ssl, const byte* input,
                ssl->options.cipherSuite   != ssl->session->cipherSuite        ||
                ssl->session->version.major != ssl->ctx->method->version.major ||
                ssl->session->version.minor != ssl->ctx->method->version.minor) {
-                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                return PSK_KEY_ERROR;
            }
         }
@@ -11744,7 +11665,6 @@ static int TLSX_PreSharedKey_Parse(WOLFSSL* ssl, const byte* input,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     return SANITY_MSG_E;
 }
 
@@ -11927,7 +11847,6 @@ static int TLSX_PskKeModes_GetSize(byte modes, byte msgType, word16* pSz)
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     return SANITY_MSG_E;
 }
 
@@ -11959,7 +11878,6 @@ static int TLSX_PskKeModes_Write(byte modes, byte* output, byte msgType,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     return SANITY_MSG_E;
 }
 
@@ -11993,7 +11911,6 @@ int TLSX_PskKeyModes_Parse_Modes(const byte* input, word16 length, byte msgType,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     return SANITY_MSG_E;
 }
 
@@ -12016,9 +11933,6 @@ static int TLSX_PskKeModes_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     if (ret == 0)
         ret = TLSX_PskKeyModes_Use(ssl, modes);
 
-    if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
 
     return ret;
 }
@@ -12084,7 +11998,6 @@ static int TLSX_PostHandAuth_GetSize(byte msgType, word16* pSz)
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     return SANITY_MSG_E;
 }
 
@@ -12105,7 +12018,6 @@ static int TLSX_PostHandAuth_Write(byte* output, byte msgType, word16* pSz)
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     return SANITY_MSG_E;
 }
 
@@ -12132,7 +12044,6 @@ static int TLSX_PostHandAuth_Parse(WOLFSSL* ssl, const byte* input,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     return SANITY_MSG_E;
 }
 
@@ -12192,7 +12103,6 @@ static int TLSX_EarlyData_GetSize(byte msgType, word16* pSz)
         *pSz += OPAQUE32_LEN;
     else {
         ret = SANITY_MSG_E;
-        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -12218,7 +12128,6 @@ static int TLSX_EarlyData_Write(word32 maxSz, byte* output, byte msgType,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     return SANITY_MSG_E;
 }
 
@@ -12260,7 +12169,6 @@ static int TLSX_EarlyData_Parse(WOLFSSL* ssl, const byte* input, word16 length,
          * Index is plus one to handle 'not set' value of 0.
          */
         if (ssl->options.pskIdIndex != 1) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             return PSK_KEY_ERROR;
         }
 
@@ -12282,7 +12190,6 @@ static int TLSX_EarlyData_Parse(WOLFSSL* ssl, const byte* input, word16 length,
         return 0;
     }
 
-    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
     return SANITY_MSG_E;
 }
 
@@ -16111,7 +16018,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
 #if defined(WOLFSSL_TLS13) && (defined(HAVE_SESSION_TICKET) || !defined(NO_PSK))
         if (msgType == client_hello && pskDone) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             return PSK_KEY_ERROR;
         }
 #endif
@@ -16227,7 +16133,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                 if (IsAtLeastTLSv1_3(ssl->version)) {
                     if (msgType != client_hello &&
                         msgType != encrypted_extensions) {
-                        WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                         return EXT_NOT_ALLOWED;
                     }
                 }
@@ -16236,7 +16141,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                 {
                     if (msgType != client_hello &&
                         msgType != server_hello) {
-                        WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                         return EXT_NOT_ALLOWED;
                     }
                 }
@@ -16268,7 +16172,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                 if (IsAtLeastTLSv1_3(ssl->version)) {
                     if (msgType != client_hello &&
                         msgType != encrypted_extensions) {
-                        WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                         return EXT_NOT_ALLOWED;
                     }
                 }
@@ -16276,7 +16179,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 #endif
                 {
                     if (msgType != client_hello) {
-                        WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                         return EXT_NOT_ALLOWED;
                     }
                 }
@@ -16288,7 +16190,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                 WOLFSSL_MSG("CKS extension received");
                 if (msgType != client_hello &&
                      msgType != encrypted_extensions) {
-                        WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                         return EXT_NOT_ALLOWED;
                 }
                 ret = TLSX_CKS_Parse(ssl, (byte *)(input + offset), size,
@@ -16307,7 +16208,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 #endif
                 if (msgType != client_hello &&
                     msgType != server_hello) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     return EXT_NOT_ALLOWED;
                 }
 
@@ -16528,7 +16428,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
                 if (msgType != client_hello &&
                     msgType != server_hello) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     return EXT_NOT_ALLOWED;
                 }
 
@@ -16546,7 +16445,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                     break;
 
                 if (msgType != client_hello) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     return EXT_NOT_ALLOWED;
                 }
 
@@ -16566,7 +16464,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
                 if (msgType != client_hello && msgType != session_ticket &&
                     msgType != encrypted_extensions) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     return EXT_NOT_ALLOWED;
                 }
                 ret = EDI_PARSE(ssl, input + offset, size, msgType);
@@ -16584,7 +16481,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                     break;
 
                 if (msgType != client_hello) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     return EXT_NOT_ALLOWED;
                 }
 
@@ -16604,7 +16500,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
                 if (msgType != client_hello &&
                         msgType != certificate_request) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     return EXT_NOT_ALLOWED;
                 }
 
@@ -16624,7 +16519,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
                 if (msgType != client_hello &&
                         msgType != certificate_request) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     return EXT_NOT_ALLOWED;
                 }
 
@@ -16644,7 +16538,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
                 if (msgType != client_hello && msgType != server_hello &&
                         msgType != hello_retry_request) {
-                    WOLFSSL_ERROR_VERBOSE(EXT_NOT_ALLOWED);
                     return EXT_NOT_ALLOWED;
                 }
     #endif

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -634,7 +634,6 @@ static int DeriveEarlyTrafficSecret(WOLFSSL* ssl, byte* key, int side)
         ret = ssl->tls13SecretCb(ssl, CLIENT_EARLY_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -643,7 +642,6 @@ static int DeriveEarlyTrafficSecret(WOLFSSL* ssl, byte* key, int side)
         ret = ssl->tls13KeyLogCb(ssl, CLIENT_EARLY_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -692,7 +690,6 @@ static int DeriveClientHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, CLIENT_HANDSHAKE_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -701,7 +698,6 @@ static int DeriveClientHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, CLIENT_HANDSHAKE_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -749,7 +745,6 @@ static int DeriveServerHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, SERVER_HANDSHAKE_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -758,7 +753,6 @@ static int DeriveServerHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, SERVER_HANDSHAKE_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -806,7 +800,6 @@ static int DeriveClientTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, CLIENT_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -815,7 +808,6 @@ static int DeriveClientTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, CLIENT_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -863,7 +855,6 @@ static int DeriveServerTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, SERVER_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -872,7 +863,6 @@ static int DeriveServerTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, SERVER_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -909,7 +899,6 @@ static int DeriveExporterSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, EXPORTER_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -918,7 +907,6 @@ static int DeriveExporterSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, EXPORTER_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -1671,9 +1659,6 @@ end:
     wc_MemZero_Check(key_dig, MAX_PRF_DIG);
 #endif
 
-    if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
 
     return ret;
 }
@@ -2961,7 +2946,6 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
         #ifndef WOLFSSL_EARLY_DATA
         if (ret < 0) {
             ret = VERIFY_MAC_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
         #endif
         return ret;
@@ -3184,9 +3168,6 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
             break;
     }
 
-    if (ret < 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
 
     return ret;
 }
@@ -3430,9 +3411,6 @@ exit_buildmsg:
     /* return sz on success */
     if (ret == 0) {
         ret = (int)args->sz;
-    }
-    else {
-        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     /* Final cleanup */
@@ -3808,7 +3786,6 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
 
     if (!HaveUniqueSessionObj(ssl)) {
         WOLFSSL_MSG("Unable to have unique session object");
-        WOLFSSL_ERROR_VERBOSE(MEMORY_ERROR);
         return MEMORY_ERROR;
     }
 
@@ -3824,7 +3801,6 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
             /* Ensure cipher suite is supported or changed suite to one with
              * the same MAC algorithm. */
             if (!FindSuiteSSL(ssl, suite)) {
-                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                 return PSK_KEY_ERROR;
             }
 
@@ -3893,7 +3869,6 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
                 if (idlen > MAX_PSK_KEY_LEN) {
                     wolfSSL_FreeSession(ssl->ctx, psksession);
                     WOLFSSL_MSG("psk key length is too long");
-                    WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                     return PSK_KEY_ERROR;
                 }
 
@@ -3933,7 +3908,6 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
 
                 /* Ensure PSK and negotiated cipher suites have same hash. */
                 if (SuiteMac(pskCS) != SuiteMac(suite)) {
-                    WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                     return PSK_KEY_ERROR;
                 }
                 /* Negotiated cipher suite is to be used - update PSK. */
@@ -3952,7 +3926,6 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
                     &cipherName);
             if (GetCipherSuiteFromName(cipherName, &cipherSuite0,
                             &cipherSuite, NULL, NULL, &cipherSuiteFlags) != 0) {
-                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                 return PSK_KEY_ERROR;
             }
             ssl->options.cipherSuite0 = cipherSuite0;
@@ -3969,7 +3942,6 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
         if (ssl->arrays->psk_keySz == 0 ||
                 (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
             (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             return PSK_KEY_ERROR;
         }
 
@@ -3982,7 +3954,6 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
 
         if (!clientHello && (psk->cipherSuite0 != suite[0] ||
                              psk->cipherSuite  != suite[1])) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             return PSK_KEY_ERROR;
         }
 
@@ -4364,7 +4335,6 @@ int SendTls13ClientHello(WOLFSSL* ssl)
         else
     #endif
         {
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
     }
@@ -5198,7 +5168,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     if (args->pv.major != ssl->version.major ||
         args->pv.minor != tls12minor) {
         SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
-        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         return VERSION_ERROR;
     }
 
@@ -5214,7 +5183,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (ssl->msgsReceived.got_hello_verify_request) {
             WOLFSSL_MSG("Received HelloRetryRequest after a "
                         "HelloVerifyRequest");
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
 
@@ -5223,7 +5191,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
          * Don't allow more than one HelloRetryRequest or ServerHello.
          */
         if (ssl->msgsReceived.got_hello_retry_request) {
-            WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             return DUPLICATE_MSG_E;
         }
     }
@@ -5263,7 +5230,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     b = input[args->idx++];
     if (b != 0) {
         WOLFSSL_MSG("Must be no compression types in list");
-        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         return INVALID_PARAMETER;
     }
 
@@ -5322,7 +5288,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 WOLFSSL_MSG("Server trying to downgrade to version less than "
                             "TLS v1.3");
                 SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || \
@@ -5333,7 +5298,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 == WOLFSSL_OP_NO_TLSv1_2)
             {
                 WOLFSSL_MSG("\tOption set to not allow TLSv1.2");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 #endif
@@ -5341,14 +5305,12 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             if (!ssl->options.dtls &&
                 args->pv.minor < ssl->options.minDowngrade) {
                 SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 
             if (ssl->options.dtls &&
                 args->pv.minor > ssl->options.minDowngrade) {
                 SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 
@@ -5435,7 +5397,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ret = ssl->sessionSecretCb(ssl, ssl->session->masterSecret,
                                    &secretSz, ssl->sessionSecretCtx);
         if (ret != 0 || secretSz != SECRET_LEN) {
-            WOLFSSL_ERROR_VERBOSE(SESSION_SECRET_CB_E);
             return SESSION_SECRET_CB_E;
         }
     }
@@ -5468,7 +5429,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ret = DoServerHello(ssl, input, inOutIdx, helloSz);
 #else
         WOLFSSL_MSG("Client using higher version, fatal error");
-        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         ret = VERSION_ERROR;
 #endif
 
@@ -5488,7 +5448,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     if (ssl->options.tls13MiddleBoxCompat) {
         if (args->sessIdSz == 0) {
             WOLFSSL_MSG("args->sessIdSz == 0");
-            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             return INVALID_PARAMETER;
         }
         if (ssl->session->sessionIDSz != 0) {
@@ -5496,14 +5455,12 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 XMEMCMP(ssl->session->sessionID, args->sessId,
                     args->sessIdSz) != 0) {
                 WOLFSSL_MSG("session id doesn't match");
-                WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
                 return INVALID_PARAMETER;
             }
         }
         else if (XMEMCMP(ssl->arrays->clientRandom, args->sessId,
                 args->sessIdSz) != 0) {
             WOLFSSL_MSG("session id doesn't match client random");
-            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             return INVALID_PARAMETER;
         }
     }
@@ -5513,7 +5470,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     if (WOLFSSL_IS_QUIC(ssl)) {
         if (args->sessIdSz != 0) {
             WOLFSSL_MSG("args->sessIdSz != 0");
-            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             return INVALID_PARAMETER;
         }
     }
@@ -5523,7 +5479,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         XMEMCMP(ssl->session->sessionID, args->sessId, args->sessIdSz) != 0))
     {
         WOLFSSL_MSG("Server sent different session id");
-        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         return INVALID_PARAMETER;
     }
 
@@ -5556,7 +5511,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     /* Check that the negotiated ciphersuite matches protocol version. */
     if (ssl->options.cipherSuite0 != TLS13_BYTE) {
         WOLFSSL_MSG("Server sent non-TLS13 cipher suite in TLS 1.3 packet");
-        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         return INVALID_PARAMETER;
     }
 
@@ -5564,7 +5518,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     suite[1] = ssl->options.cipherSuite;
     if (!FindSuiteSSL(ssl, suite)) {
         WOLFSSL_MSG("Cipher suite not supported on client");
-        WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
         return MATCH_SUITE_ERROR;
     }
 
@@ -5826,7 +5779,6 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
             ) {
         if (PickHashSigAlgo(ssl, peerSuites.hashSigAlgo,
                             peerSuites.hashSigAlgoSz, 0) != 0) {
-            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             return INVALID_PARAMETER;
         }
         ssl->options.sendVerify = SEND_CERT;
@@ -5837,7 +5789,6 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
 #else
         WOLFSSL_MSG("Certificate required but none set on client");
         SendAlert(ssl, alert_fatal, illegal_parameter);
-        WOLFSSL_ERROR_VERBOSE(NO_CERT_ERROR);
         return NO_CERT_ERROR;
 #endif
     }
@@ -5951,7 +5902,6 @@ int FindPskSuite(const WOLFSSL* ssl, PreSharedKey* psk, byte* psk_key,
             *((int*)psk_keySz) != WC_NO_ERR_TRACE(USE_HW_PSK)) {
             WOLFSSL_MSG("Key len too long in FindPsk()");
             ret = PSK_KEY_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
             *found = 0;
         }
         if (ret == 0) {
@@ -6013,7 +5963,6 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, const byte* suite, int* err)
         /* PSK age is always zero. */
         if (psk->ticketAge != 0) {
             ret = PSK_KEY_ERROR;
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
         if (ret == 0) {
             /* Set PSK ciphersuite into SSL. */
@@ -6202,7 +6151,6 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
             return ret;
         if (binderLen != current->binderLen ||
                              XMEMCMP(binder, current->binder, binderLen) != 0) {
-            WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
             return BAD_BINDER;
         }
 
@@ -6218,7 +6166,6 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
         if (ssl->buffers.certChainCnt != 0)
             return 0;
     #endif
-        WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
         return BAD_BINDER;
 #else
         return 0;
@@ -6273,7 +6220,6 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
 
     /* Extensions pushed on stack/list and PSK must be last. */
     if (ssl->extensions != ext) {
-        WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
         return PSK_KEY_ERROR;
     }
 
@@ -6369,7 +6315,6 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         /* Get the PSK key exchange modes the client wants to negotiate. */
         ext = TLSX_Find(ssl->extensions, TLSX_PSK_KEY_EXCHANGE_MODES);
         if (ext == NULL) {
-            WOLFSSL_ERROR_VERBOSE(MISSING_HANDSHAKE_DATA);
             return MISSING_HANDSHAKE_DATA;
         }
         modes = ext->val;
@@ -6392,7 +6337,6 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         {
             if ((modes & (1 << PSK_KE)) == 0) {
                 WOLFSSL_MSG("psk_ke mode does not allow key share");
-                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                 return PSK_KEY_ERROR;
             }
             ssl->options.noPskDheKe = 1;
@@ -6407,7 +6351,6 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         if (ssl->buffers.certChainCnt != 0)
             return 0;
     #endif
-        WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
         return BAD_BINDER;
     }
 #endif
@@ -6480,7 +6423,6 @@ int TlsCheckCookie(const WOLFSSL* ssl, const byte* cookie, word16 cookieSz)
         return ret;
 
     if (ConstantCompare(cookie + cookieSz, mac, macSz) != 0) {
-        WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
         return HRR_COOKIE_ERROR;
     }
     return cookieSz;
@@ -7363,9 +7305,6 @@ exit_dch:
 #endif
     WOLFSSL_END(WC_FUNC_CLIENT_HELLO_DO);
 
-    if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
 
 #if defined(HAVE_ECH)
     if (ret == 0 && echX != NULL &&
@@ -9851,9 +9790,6 @@ exit_scv:
     FreeAsyncCtx(ssl, 0);
 #endif
 
-    if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
 
     return ret;
 }
@@ -10886,7 +10822,6 @@ exit_dcv:
     else
 #endif /* WOLFSSL_ASYNC_CRYPT */
     if (ret != 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
 
         if (ret != WC_NO_ERR_TRACE(INVALID_PARAMETER)) {
             SendAlert(ssl, alert_fatal, decrypt_error);
@@ -11037,7 +10972,6 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 XMEMCMP(input + *inOutIdx, mac, size) != 0){
             WOLFSSL_MSG("Verify finished error on hashes");
             SendAlert(ssl, alert_fatal, decrypt_error);
-            WOLFSSL_ERROR_VERBOSE(VERIFY_FINISHED_ERROR);
             return VERIFY_FINISHED_ERROR;
         }
     }
@@ -11212,7 +11146,6 @@ static int SendTls13Finished(WOLFSSL* ssl)
         int sendSz = BuildTls13Message(ssl, output, outputSz, input,
                                    headerSz + finishedSz, handshake, 1, 0, 0);
         if (sendSz < 0) {
-            WOLFSSL_ERROR_VERBOSE(BUILD_MSG_ERROR);
             return BUILD_MSG_ERROR;
         }
 
@@ -11487,7 +11420,6 @@ static int DoTls13KeyUpdate(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             ssl->keys.keyUpdateRespond = 1;
             break;
         default:
-            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             return INVALID_PARAMETER;
     }
 
@@ -11627,7 +11559,6 @@ static int DoTls13EndOfEarlyData(WOLFSSL* ssl, const byte* input,
     if (ssl->earlyData == no_early_data) {
         WOLFSSL_MSG("EndOfEarlyData received unexpectedly");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -11708,7 +11639,6 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
     ato32(input + *inOutIdx, &lifetime);
     *inOutIdx += SESSION_HINT_SZ;
     if (lifetime > MAX_LIFETIME) {
-        WOLFSSL_ERROR_VERBOSE(SERVER_HINT_ERROR);
         return SERVER_HINT_ERROR;
     }
 
@@ -11726,7 +11656,6 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
     (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
     if (nonceLength > MAX_TICKET_NONCE_STATIC_SZ) {
         WOLFSSL_MSG("Nonce length not supported");
-        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         return INVALID_PARAMETER;
     }
 #endif /* WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3) */
@@ -12136,21 +12065,18 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on SERVER side. */
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("ClientHello received by client");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             /* Check state. */
             if (ssl->options.clientState >= CLIENT_HELLO_COMPLETE) {
                 WOLFSSL_MSG("ClientHello received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             /* Check previously seen. */
             /* Initial and after HelloRetryRequest - no more than 2. */
             if (ssl->msgsReceived.got_client_hello == 2) {
                 WOLFSSL_MSG("Too many ClientHello received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             /* Second only after HelloRetryRequest seen. */
@@ -12158,7 +12084,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 ssl->options.serverState !=
                                           SERVER_HELLO_RETRY_REQUEST_COMPLETE) {
                 WOLFSSL_MSG("Duplicate ClientHello received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_client_hello++;
@@ -12172,14 +12097,12 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerHello received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             /* Check state. */
             if (ssl->options.serverState >= SERVER_HELLO_COMPLETE) {
                 WOLFSSL_MSG("ServerHello received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             /* Check previously seen. */
@@ -12189,7 +12112,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
              */
             if (ssl->msgsReceived.got_server_hello) {
                 WOLFSSL_MSG("Duplicate ServerHello received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_server_hello = 1;
@@ -12203,7 +12125,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("NewSessionTicket received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
@@ -12212,14 +12133,12 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only allowed after server's Finished message. */
             if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("NewSessionTicket received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
         #else
             /* Only allowed after client's Finished message. */
             if (ssl->options.clientState < CLIENT_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("NewSessionTicket received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
         #endif
@@ -12236,7 +12155,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on SERVER side. */
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("EndOfEarlyData received by client");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
@@ -12244,18 +12162,15 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only after server's Finished and before client's Finished. */
             if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("EndOfEarlyData received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             if (ssl->options.clientState >= CLIENT_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("EndOfEarlyData received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             /* Check previously seen. */
             if (ssl->msgsReceived.got_end_of_early_data) {
                 WOLFSSL_MSG("Too many EndOfEarlyData received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_end_of_early_data = 1;
@@ -12270,7 +12185,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("EncryptedExtensions received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
@@ -12281,13 +12195,11 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
              */
             if (ssl->options.serverState != SERVER_HELLO_COMPLETE) {
                 WOLFSSL_MSG("EncryptedExtensions received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             /* Check previously seen. */
             if (ssl->msgsReceived.got_encrypted_extensions) {
                 WOLFSSL_MSG("Duplicate EncryptedExtensions received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_encrypted_extensions = 1;
@@ -12307,7 +12219,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 ssl->options.serverState !=
                                          SERVER_ENCRYPTED_EXTENSIONS_COMPLETE) {
                 WOLFSSL_MSG("Certificate received out of order - Client");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
         #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
@@ -12316,7 +12227,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                              ssl->options.serverState == SERVER_CERT_COMPLETE &&
                              ssl->options.pskNegotiated) {
                 WOLFSSL_MSG("Certificate received while using PSK");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                 return SANITY_MSG_E;
             }
         #endif
@@ -12329,14 +12239,12 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 ssl->options.clientState != CLIENT_HELLO_COMPLETE &&
                 ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("Certificate received out of order - Server");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
     #endif
             /* Check previously seen. */
             if (ssl->msgsReceived.got_certificate) {
                 WOLFSSL_MSG("Duplicate Certificate received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate = 1;
@@ -12349,7 +12257,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("CertificateRequest received by server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
@@ -12360,7 +12267,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.serverState !=
                                          SERVER_ENCRYPTED_EXTENSIONS_COMPLETE) {
                 WOLFSSL_MSG("CertificateRequest received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
         #else
@@ -12372,7 +12278,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                        (ssl->options.serverState < SERVER_FINISHED_COMPLETE ||
                         ssl->options.clientState != CLIENT_FINISHED_COMPLETE)) {
                 WOLFSSL_MSG("CertificateRequest received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
         #endif
@@ -12380,7 +12285,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Server's authenticating with PSK must not send this. */
             if (ssl->options.pskNegotiated) {
                 WOLFSSL_MSG("CertificateRequest received while using PSK");
-                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                 return SANITY_MSG_E;
             }
         #endif
@@ -12389,7 +12293,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only once during handshake. */
             if (ssl->msgsReceived.got_certificate_request) {
                 WOLFSSL_MSG("Duplicate CertificateRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
         #else
@@ -12397,7 +12300,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->msgsReceived.got_certificate_request &&
                 ssl->options.clientState != CLIENT_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("Duplicate CertificateRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
         #endif
@@ -12414,14 +12316,12 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 if (ssl->options.serverState != SERVER_CERT_COMPLETE) {
                     WOLFSSL_MSG("No Cert before CertVerify");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
                 /* Server's authenticating with PSK must not send this. */
                 if (ssl->options.pskNegotiated) {
                     WOLFSSL_MSG("CertificateVerify received while using PSK");
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                     return SANITY_MSG_E;
                 }
             #endif
@@ -12433,18 +12333,15 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 /* Server must have sent Finished message. */
                 if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                     WOLFSSL_MSG("CertificateVerify received out of order");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 /* Valid only directly after a Certificate message. */
                 if (ssl->options.clientState < CLIENT_HELLO_COMPLETE) {
                     WOLFSSL_MSG("CertificateVerify before ClientHello done");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 if (!ssl->msgsReceived.got_certificate) {
                     WOLFSSL_MSG("No Cert before CertificateVerify");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -12452,7 +12349,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Check previously seen. */
             if (ssl->msgsReceived.got_certificate_verify) {
                 WOLFSSL_MSG("Duplicate CertificateVerify received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate_verify = 1;
@@ -12467,7 +12363,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 /* After sending ClientHello */
                 if (ssl->options.clientState < CLIENT_HELLO_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - clientState");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 /* Must have seen certificate and verify from server except when
@@ -12477,7 +12372,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                     if (ssl->options.serverState !=
                                          SERVER_ENCRYPTED_EXTENSIONS_COMPLETE) {
                         WOLFSSL_MSG("Finished received out of order - PSK");
-                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                         return OUT_OF_ORDER_E;
                     }
                 }
@@ -12485,7 +12379,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             #endif
                 if (ssl->options.serverState != SERVER_CERT_VERIFY_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - serverState");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -12495,12 +12388,10 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - serverState");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 if (ssl->options.clientState < CLIENT_HELLO_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - clientState");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             #ifdef WOLFSSL_EARLY_DATA
@@ -12509,7 +12400,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                     !ssl->options.dtls
                     /* QUIC does not use EndOfEarlyData records */
                     && !WOLFSSL_IS_QUIC(ssl)) {
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             #endif
@@ -12530,7 +12420,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                                            !ssl->msgsReceived.got_certificate) {
                     WOLFSSL_MSG("Finished received out of order - "
                                 "missing Certificate message");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 /* Mutual authentication on server requires a certificate from
@@ -12542,7 +12431,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                      ssl->options.verifyPeer)) && !ssl->options.havePeerCert) {
                     WOLFSSL_MSG("Finished received out of order - "
                                 "no valid certificate");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 /* Must have received a valid CertificateVerify if verifying
@@ -12552,14 +12440,12 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                     ssl->options.havePeerCert && !ssl->options.havePeerVerify) {
                     WOLFSSL_MSG("Finished received out of order - "
                                 "Certificate message but no CertificateVerify");
-                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
             /* Check previously seen. */
             if (ssl->msgsReceived.got_finished) {
                 WOLFSSL_MSG("Duplicate Finished received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_finished = 1;
@@ -12574,7 +12460,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
              */
             if (!ssl->msgsReceived.got_finished) {
                 WOLFSSL_MSG("No KeyUpdate before Finished");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             /* Multiple KeyUpdates can be sent. */
@@ -12583,38 +12468,32 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
         case hello_verify_request:
             if (!ssl->options.dtls) {
                 WOLFSSL_MSG("HelloVerifyRequest when not in DTLS");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             if (ssl->msgsReceived.got_hello_verify_request) {
                 WOLFSSL_MSG("Duplicate HelloVerifyRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_hello_verify_request = 1;
             if (ssl->msgsReceived.got_hello_retry_request) {
                 WOLFSSL_MSG(
                     "Both HelloVerifyRequest and HelloRetryRequest received");
-                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             if (ssl->options.serverState >=
                     SERVER_HELLO_RETRY_REQUEST_COMPLETE ||
                 ssl->options.connectState != CLIENT_HELLO_SENT) {
                 WOLFSSL_MSG("HelloVerifyRequest received out of order");
-                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("HelloVerifyRequest received on the server");
-                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
             if (!ssl->options.downgrade ||
                 ssl->options.minDowngrade < DTLSv1_2_MINOR) {
                 WOLFSSL_MSG(
                     "HelloVerifyRequest received but not DTLSv1.2 allowed");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
             break;
@@ -12622,7 +12501,6 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
 
         default:
             WOLFSSL_MSG("Unknown message type");
-            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
             return SANITY_MSG_E;
     }
 
@@ -12685,7 +12563,6 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             type != certificate && type != key_update && type != finished) {
         WOLFSSL_MSG("HandShake message after handshake complete");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -12698,7 +12575,6 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         ) {
         WOLFSSL_MSG("First server message not server hello");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -12706,7 +12582,6 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                ssl->options.clientState == NULL_STATE && type != client_hello) {
         WOLFSSL_MSG("First client message not client hello");
         SendAlert(ssl, alert_fatal, unexpected_message);
-        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -13044,7 +12919,6 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         if (GetHandshakeHeader(ssl, input, inOutIdx, &type, &size,
                                                                 totalSz) != 0) {
             SendAlert(ssl, alert_fatal, unexpected_message);
-            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
             return PARSE_ERROR;
         }
 
@@ -13066,7 +12940,6 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
         if (GetHandshakeHeader(ssl, input, inOutIdx, &type, &size,
                                totalSz) != 0) {
-            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
             return PARSE_ERROR;
         }
 
@@ -13082,7 +12955,6 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
          * nine 2048-bit RSA certificates in the chain. */
         if (size > MAX_HANDSHAKE_SZ) {
             WOLFSSL_MSG("Handshake message too large");
-            WOLFSSL_ERROR_VERBOSE(HANDSHAKE_SIZE_ERROR);
             return HANDSHAKE_SIZE_ERROR;
         }
 
@@ -13350,7 +13222,6 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
                     return wolfSSL_connect(ssl);
     #endif
                 WOLFSSL_MSG("Client using higher version, fatal error");
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 
@@ -13451,7 +13322,6 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
             /* CLIENT: check peer authentication. */
             if (!ssl->options.peerAuthGood) {
                 WOLFSSL_MSG("Server authentication did not happen");
-                WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
                 return WOLFSSL_FATAL_ERROR;
             }
         #ifndef NO_CERTS
@@ -13534,7 +13404,6 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
                 int cbret = ssl->hsDoneCb(ssl, ssl->hsDoneCtx);
                 if (cbret < 0) {
                     ssl->error = cbret;
-                    WOLFSSL_ERROR_VERBOSE(ssl->error);
                     WOLFSSL_MSG("HandShake Done Cb don't continue error");
                     return WOLFSSL_FATAL_ERROR;
                 }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3973,7 +3973,6 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
         /* Get the PSK key exchange modes the client wants to negotiate. */
         ext = TLSX_Find(ssl->extensions, TLSX_PSK_KEY_EXCHANGE_MODES);
         if (ext == NULL) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             return PSK_KEY_ERROR;
         }
         modes = ext->val;
@@ -3986,12 +3985,10 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
         if (((modes & (1 << PSK_DHE_KE)) != 0) && (!ssl->options.noPskDheKe) &&
                                                 (kse != NULL) && kse->derived) {
             if ((kse->session != 0) && (kse->session != kse->group)) {
-                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                 return PSK_KEY_ERROR;
             }
         }
         else if (ssl->options.onlyPskDheKe) {
-            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             return PSK_KEY_ERROR;
         }
         else if (ssl->options.noPskDheKe) {

--- a/src/x509.c
+++ b/src/x509.c
@@ -10860,7 +10860,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
     }
     else {
         WOLFSSL_MSG("Subject Key ID too large");
-        WOLFSSL_ERROR_VERBOSE(BUFFER_E);
         return WOLFSSL_FAILURE;
     }
 
@@ -10905,7 +10904,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
     if (x509->rawCRLInfo != NULL) {
         if (x509->rawCRLInfoSz > CTC_MAX_CRLINFO_SZ) {
             WOLFSSL_MSG("CRL Info too large");
-            WOLFSSL_ERROR_VERBOSE(BUFFER_E);
             return WOLFSSL_FAILURE;
         }
         XMEMCPY(cert->crlInfo, x509->rawCRLInfo, x509->rawCRLInfoSz);
@@ -10981,7 +10979,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
         if (serialSz > EXTERNAL_SERIAL_SIZE ||
                 serialSz > CTC_SERIAL_SIZE) {
             WOLFSSL_MSG("Serial size too large error");
-            WOLFSSL_ERROR_VERBOSE(BUFFER_E);
             return WOLFSSL_FAILURE;
         }
         XMEMCPY(cert->serial, serial, serialSz);
@@ -15409,7 +15406,6 @@ int wolfSSL_X509_REQ_add1_attr_by_NID(WOLFSSL_X509 *req,
         }
         else {
             WOLFSSL_MSG("Challenge password too long");
-            WOLFSSL_ERROR_VERBOSE(BUFFER_E);
             return WOLFSSL_FAILURE;
         }
         break;
@@ -15418,7 +15414,6 @@ int wolfSSL_X509_REQ_add1_attr_by_NID(WOLFSSL_X509 *req,
             len = (int)XSTRLEN((char*)bytes);
         if (len + 1 > EXTERNAL_SERIAL_SIZE) {
             WOLFSSL_MSG("SerialNumber too long");
-            WOLFSSL_ERROR_VERBOSE(BUFFER_E);
             return WOLFSSL_FAILURE;
         }
         XMEMCPY(req->serial, bytes, len);

--- a/src/x509.c
+++ b/src/x509.c
@@ -10880,7 +10880,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
     }
     else {
         WOLFSSL_MSG("Auth Key ID too large");
-        WOLFSSL_ERROR_VERBOSE(BUFFER_E);
         return WOLFSSL_FAILURE;
     }
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -5763,7 +5763,6 @@ WOLFSSL_EVP_PKEY* wolfSSL_X509_get_pubkey(WOLFSSL_X509* x509)
                                             &idx, (ecc_key*)key->ecc->internal,
                                             key->pkey_sz);
                 if (ret < 0) {
-                    WOLFSSL_ERROR_VERBOSE(ret);
                     WOLFSSL_MSG("wc_EccPublicKeyDecode failed");
                     wolfSSL_EVP_PKEY_free(key);
                     return NULL;
@@ -11206,7 +11205,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_RsaPublicKeyDecode(x509->pubKey.buffer, &idx, rsa,
                                                            x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
                 wc_FreeRsaKey(rsa);
                 XFREE(rsa, NULL, DYNAMIC_TYPE_RSA);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11235,7 +11233,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_EccPublicKeyDecode(x509->pubKey.buffer, &idx, ecc,
                                                            x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
                 wc_ecc_free(ecc);
                 XFREE(ecc, NULL, DYNAMIC_TYPE_ECC);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11264,7 +11261,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_DsaPublicKeyDecode(x509->pubKey.buffer, &idx, dsa,
                                                            x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
                 wc_FreeDsaKey(dsa);
                 XFREE(dsa, NULL, DYNAMIC_TYPE_DSA);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11303,7 +11299,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_Falcon_PublicKeyDecode(x509->pubKey.buffer, &idx, falcon,
                                             x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
                 wc_falcon_free(falcon);
                 XFREE(falcon, NULL, DYNAMIC_TYPE_FALCON);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11367,7 +11362,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_Dilithium_PublicKeyDecode(x509->pubKey.buffer, &idx,
                                     dilithium, x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
                 wc_dilithium_free(dilithium);
                 XFREE(dilithium, NULL, DYNAMIC_TYPE_DILITHIUM);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11426,7 +11420,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             ret = wc_Sphincs_PublicKeyDecode(x509->pubKey.buffer, &idx, sphincs,
                                              x509->pubKey.length);
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
                 wc_sphincs_free(sphincs);
                 XFREE(sphincs, NULL, DYNAMIC_TYPE_SPHINCS);
                 XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -11459,7 +11452,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             wc_FreeRng(&rng);
         }
         if (ret <= 0) {
-            WOLFSSL_ERROR_VERBOSE(ret);
             ret = WOLFSSL_FAILURE;
             goto cleanup;
         }

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -2926,7 +2926,6 @@ static WARN_UNUSED_RESULT int wc_AesEncrypt(
     r = aes->rounds >> 1;
 
     if (r > 7 || r == 0) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
         return KEYUSAGE_E;
     }
 
@@ -2962,7 +2961,6 @@ static WARN_UNUSED_RESULT int wc_AesEncrypt(
             return 0;
         #else
             WOLFSSL_MSG("AES-ECB encrypt with bad alignment");
-            WOLFSSL_ERROR_VERBOSE(BAD_ALIGN_E);
             return BAD_ALIGN_E;
         #endif
         }
@@ -3710,7 +3708,6 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
     r = aes->rounds >> 1;
 
     if (r > 7 || r == 0) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
         return KEYUSAGE_E;
     }
 
@@ -5983,7 +5980,6 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         blocks = sz / WC_AES_BLOCK_SIZE;
 #ifdef WOLFSSL_AES_CBC_LENGTH_CHECKS
         if (sz % WC_AES_BLOCK_SIZE) {
-            WOLFSSL_ERROR_VERBOSE(BAD_LENGTH_E);
             return BAD_LENGTH_E;
         }
 #endif
@@ -6083,7 +6079,6 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
                 }
             #else
                 WOLFSSL_MSG("AES-CBC encrypt with bad alignment");
-                WOLFSSL_ERROR_VERBOSE(BAD_ALIGN_E);
                 ret = BAD_ALIGN_E;
             #endif
             } else {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3435,7 +3435,6 @@ static int GetExplicitVersion(const byte* input, word32* inOutIdx, int* version,
             /* check if version is expected value rfc 5280 4.1 {0, 1, 2} */
             if (*version > MAX_X509_VERSION || *version < MIN_X509_VERSION) {
                 WOLFSSL_MSG("Unexpected certificate version");
-                WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
                 ret = ASN_VERSION_E;
             }
         }
@@ -6551,7 +6550,6 @@ static int CheckCurve(word32 oid)
     /* Check for error or zero length OID size (can't get OID for encoding). */
     if ((ret < 0) || (oidSz == 0)) {
         WOLFSSL_MSG("CheckCurve not found");
-        WOLFSSL_ERROR_VERBOSE(ECC_CURVE_OID_E);
         ret = ECC_CURVE_OID_E;
     }
 
@@ -7115,7 +7113,6 @@ static int GetOID(const byte* input, word32* inOutIdx, word32* oid,
         if ((ret == 0) && (checkOid != NULL) && ((checkOidSz != actualOidSz) ||
                 (XMEMCMP(actualOid, checkOid, checkOidSz) != 0))) {
             WOLFSSL_MSG("OID Check Failed");
-            WOLFSSL_ERROR_VERBOSE(ASN_UNKNOWN_OID_E);
             ret = ASN_UNKNOWN_OID_E;
         }
     }
@@ -8616,13 +8613,9 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
                 if (mp_cmp(&(a->n), &(b->n)) != MP_EQ ||
                     mp_cmp(&(a->e), &(b->e)) != MP_EQ) {
                     ret = MP_CMP_E;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
                 else
                     ret = 1;
-            }
-            else {
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
         }
         wc_FreeRsaKey(b);
@@ -8690,15 +8683,9 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
                     if ((ret = wc_ecc_check_key(key_pair)) == 0) {
                         ret = 1;
                     }
-                    else {
-                        WOLFSSL_ERROR_VERBOSE(ret);
-                    }
                 }
                 ForceZero(privDer, privSz);
             }
-        }
-        else {
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
         wc_ecc_free(key_pair);
     #ifdef WOLFSSL_SMALL_STACK
@@ -8745,13 +8732,7 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
                 if ((ret = wc_ed25519_check_key(key_pair)) == 0) {
                     ret = 1;
                 }
-                else {
-                    WOLFSSL_ERROR_VERBOSE(ret);
-                }
             }
-        }
-        else {
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
         wc_ed25519_free(key_pair);
     #ifdef WOLFSSL_SMALL_STACK
@@ -8795,13 +8776,7 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
                 if ((ret = wc_ed448_check_key(key_pair)) == 0) {
                     ret = 1;
                 }
-                else {
-                    WOLFSSL_ERROR_VERBOSE(ret);
-                }
             }
-        }
-        else {
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
         wc_ed448_free(key_pair);
     #ifdef WOLFSSL_SMALL_STACK
@@ -8856,13 +8831,7 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
                 if ((ret = wc_falcon_check_key(key_pair)) == 0) {
                     ret = 1;
                 }
-                else {
-                    WOLFSSL_ERROR_VERBOSE(ret);
-                }
             }
-        }
-        else {
-            WOLFSSL_ERROR_VERBOSE(ret);
         }
         wc_falcon_free(key_pair);
     #ifdef WOLFSSL_SMALL_STACK
@@ -14265,7 +14234,6 @@ static int GetCertKey(DecodedCert* cert, const byte* source, word32* inOutIdx,
     #endif /* NO_DSA */
         default:
             WOLFSSL_MSG("Unknown or not compiled in key OID");
-            WOLFSSL_ERROR_VERBOSE(ASN_UNKNOWN_OID_E);
             ret = ASN_UNKNOWN_OID_E;
     }
 
@@ -15321,7 +15289,6 @@ static int GetRDN(DecodedCert* cert, char* full, word32* idx, int* nid,
     /* Other OIDs that start with the same values. */
     else if (oidSz == sizeof(dcOid) && XMEMCMP(oid, dcOid, oidSz-1) == 0) {
         WOLFSSL_MSG("Unknown pilot attribute type");
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         ret = ASN_PARSE_E;
     }
     else if (oidSz == ASN_JOI_PREFIX_SZ + 1 &&
@@ -16895,7 +16862,6 @@ static int GetDateInfo(const byte* source, word32* idx, const byte** pDate,
     format = source[*idx];
     *idx += 1;
     if (format != ASN_UTC_TIME && format != ASN_GENERALIZED_TIME) {
-        WOLFSSL_ERROR_VERBOSE(ASN_TIME_E);
         return ASN_TIME_E;
     }
 
@@ -16983,11 +16949,9 @@ static int GetDate(DecodedCert* cert, int dateType, int verify, int maxIdx)
             (! AsnSkipDateCheck) &&
             !XVALIDATE_DATE(date, format, dateType)) {
         if (dateType == ASN_BEFORE) {
-            WOLFSSL_ERROR_VERBOSE(ASN_BEFORE_DATE_E);
             return ASN_BEFORE_DATE_E;
         }
         else {
-            WOLFSSL_ERROR_VERBOSE(ASN_AFTER_DATE_E);
             return ASN_AFTER_DATE_E;
         }
     }
@@ -18445,7 +18409,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_RsaPublicKeyDecode(key, &idx, sigCtx->key.rsa,
                                                                  keySz)) != 0) {
                         WOLFSSL_MSG("ASN Key decode error RSA");
-                        WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                     XMEMCPY(sigCtx->sigCpy, sig, sigSz);
@@ -18487,7 +18450,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_DsaPublicKeyDecode(key, &idx, sigCtx->key.dsa,
                                                                  keySz)) != 0) {
                         WOLFSSL_MSG("ASN Key decode error DSA");
-                        WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                     if (sigSz != DSA_160_SIG_SIZE &&
@@ -18545,7 +18507,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                                                                          keySz);
                     if (ret < 0) {
                         WOLFSSL_MSG("ASN Key import error ECC");
-                        WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -18573,7 +18534,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_ed25519_import_public(key, keySz,
                                                     sigCtx->key.ed25519)) < 0) {
                         WOLFSSL_MSG("ASN Key import error ED25519");
-                        WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -18600,7 +18560,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_ed448_import_public(key, keySz,
                                                       sigCtx->key.ed448)) < 0) {
                         WOLFSSL_MSG("ASN Key import error ED448");
-                        WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -18634,7 +18593,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_Falcon_PublicKeyDecode(key, &idx,
                         sigCtx->key.falcon, keySz)) < 0) {
                         WOLFSSL_MSG("ASN Key import error Falcon Level 1");
-                        WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                     break;
@@ -18663,7 +18621,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     if ((ret = wc_Falcon_PublicKeyDecode(key, &idx,
                         sigCtx->key.falcon, keySz)) < 0) {
                         WOLFSSL_MSG("ASN Key import error Falcon Level 5");
-                        WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                     break;
@@ -18906,7 +18863,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                 default:
                     WOLFSSL_MSG("Verify Key type unknown");
                     ret = ASN_UNKNOWN_OID_E;
-                    WOLFSSL_ERROR_VERBOSE(ret);
                     break;
             } /* switch (keyOID) */
 
@@ -18986,7 +18942,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     }
                     else {
                         WOLFSSL_MSG("SM2wSM3 create digest failed");
-                        WOLFSSL_ERROR_VERBOSE(ret);
                         goto exit_cs;
                     }
                     ret = wc_ecc_sm2_verify_hash(sig, sigSz, sigCtx->digest,
@@ -19009,7 +18964,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                         }
                         else {
                             WOLFSSL_MSG("SM2wSM3 create digest failed");
-                            WOLFSSL_ERROR_VERBOSE(ret);
                             goto exit_cs;
                         }
                         ret = wc_ecc_sm2_verify_hash(sig, sigSz, sigCtx->digest,
@@ -19116,7 +19070,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
             if (ret < 0) {
                 /* treat all errors as ASN_SIG_CONFIRM_E */
                 ret = ASN_SIG_CONFIRM_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
                 goto exit_cs;
             }
 
@@ -19187,7 +19140,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     else {
                         WOLFSSL_MSG("RSA SSL verify match encode error");
                         ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
 
                 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
@@ -19205,7 +19157,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     else {
                         WOLFSSL_MSG("DSA Verify didn't match");
                         ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                     break;
                 }
@@ -19222,7 +19173,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     else {
                         WOLFSSL_MSG("ECC Verify didn't match");
                         ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                     break;
                 }
@@ -19236,7 +19186,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     else {
                         WOLFSSL_MSG("ED25519 Verify didn't match");
                         ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                     break;
                 }
@@ -19250,7 +19199,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     else {
                         WOLFSSL_MSG("ED448 Verify didn't match");
                         ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                     break;
                 }
@@ -19264,7 +19212,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     else {
                         WOLFSSL_MSG("FALCON_LEVEL1 Verify didn't match");
                         ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                     break;
                 }
@@ -19276,7 +19223,6 @@ int ConfirmSignature(SignatureCtx* sigCtx,
                     else {
                         WOLFSSL_MSG("FALCON_LEVEL5 Verify didn't match");
                         ret = ASN_SIG_CONFIRM_E;
-                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                     break;
                 }
@@ -19764,7 +19710,6 @@ static int DecodeOtherHelper(ASNGetData* dataASN, DecodedCert* cert, int oid)
             buf    = (const char*)dataASN[OTHERNAMEASN_IDX_UPN].data.ref.data;
             break;
         default:
-            WOLFSSL_ERROR_VERBOSE(ASN_UNKNOWN_OID_E);
             ret = ASN_UNKNOWN_OID_E;
             break;
     }
@@ -19927,14 +19872,12 @@ static int DecodeGeneralName(const byte* input, word32* inOutIdx, byte tag,
             /* test hier-part is empty */
             if (i == 0 || i == len) {
                 WOLFSSL_MSG("\tEmpty or malformed URI");
-                WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                 return ASN_ALT_NAME_E;
             }
 
             /* test if scheme is missing  */
             if (input[idx + (word32)i] != ':') {
                 WOLFSSL_MSG("\tAlt Name must be absolute URI");
-                WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                 return ASN_ALT_NAME_E;
             }
         }
@@ -20222,7 +20165,6 @@ static int DecodeAltNames(const byte* input, word32 sz, DecodedCert* cert)
         /* RFC 5280 4.2.1.6.  Subject Alternative Name
            If the subjectAltName extension is present, the sequence MUST
            contain at least one entry. */
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         return ASN_PARSE_E;
     }
 
@@ -20398,7 +20340,6 @@ static int DecodeAltNames(const byte* input, word32 sz, DecodedCert* cert)
                     }
                     if (input[idx + i] == '/') {
                         WOLFSSL_MSG("\tAlt Name must be absolute URI");
-                        WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                         return ASN_ALT_NAME_E;
                     }
                 }
@@ -20406,14 +20347,12 @@ static int DecodeAltNames(const byte* input, word32 sz, DecodedCert* cert)
                 /* test hier-part is empty */
                 if (i == 0 || i == (word32)strLen) {
                     WOLFSSL_MSG("\tEmpty or malformed URI");
-                    WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                     return ASN_ALT_NAME_E;
                 }
 
                 /* test if scheme is missing */
                 if (input[idx + i] != ':') {
                     WOLFSSL_MSG("\tAlt Name must be absolute URI");
-                    WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                     return ASN_ALT_NAME_E;
                 }
             }
@@ -20626,7 +20565,6 @@ static int DecodeAltNames(const byte* input, word32 sz, DecodedCert* cert)
         /* RFC 5280 4.2.1.6.  Subject Alternative Name
            If the subjectAltName extension is present, the sequence MUST
            contain at least one entry. */
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         ret = ASN_PARSE_E;
     }
     if (ret == 0) {
@@ -20751,7 +20689,6 @@ int DecodeBasicCaConstraint(const byte* input, int sz, byte *isCa,
     if (ret < 0)
         return ret;
     else if (ret > WOLFSSL_MAX_PATH_LEN) {
-        WOLFSSL_ERROR_VERBOSE(ASN_PATHLEN_SIZE_E);
         return ASN_PATHLEN_SIZE_E;
     }
 
@@ -20785,17 +20722,14 @@ int DecodeBasicCaConstraint(const byte* input, int sz, byte *isCa,
 #if !defined(ASN_TEMPLATE_SKIP_ISCA_CHECK) && \
     !defined(WOLFSSL_ALLOW_ENCODING_CA_FALSE)
         if ((dataASN[BASICCONSASN_IDX_CA].length != 0) && (!innerIsCA)) {
-            WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
             ret = ASN_PARSE_E;
         }
 #endif
         /* Path length must be a 7-bit value. */
         if ((ret == 0) && (*pathLength >= (1 << 7))) {
-            WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
             ret = ASN_PARSE_E;
         }
         if ((ret == 0) && *pathLength > WOLFSSL_MAX_PATH_LEN) {
-            WOLFSSL_ERROR_VERBOSE(ASN_PATHLEN_SIZE_E);
             ret = ASN_PATHLEN_SIZE_E;
         }
         /* Store CA boolean and whether a path length was seen. */
@@ -21099,7 +21033,6 @@ static int DecodeCrlDist(const byte* input, word32 sz, DecodedCert* cert)
                      &reason);
              /* First bit (LSB) unused and eight other bits defined. */
              if ((ret == 0) && ((reason >> 9) || (reason & 0x01))) {
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
                 ret = ASN_PARSE_E;
              }
         }
@@ -22457,7 +22390,6 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
                                 cert->extCertPoliciesNb], MAX_CERTPOL_SZ,
                                 input + idx, length) <= 0) {
                 WOLFSSL_MSG("\tCouldn't decode CertPolicy");
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
                 return ASN_PARSE_E;
             }
         #ifndef WOLFSSL_DUP_CERTPOL
@@ -22472,7 +22404,6 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
                             MAX_CERTPOL_SZ) == 0) {
                     WOLFSSL_MSG("Duplicate policy OIDs not allowed");
                     WOLFSSL_MSG("Use WOLFSSL_DUP_CERTPOL if wanted");
-                    WOLFSSL_ERROR_VERBOSE(CERTPOLICIES_E);
                     return CERTPOLICIES_E;
                 }
             }
@@ -22562,7 +22493,6 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
                     cert->extCertPolicies[cert->extCertPoliciesNb],
                     MAX_CERTPOL_SZ, data, length) <= 0) {
                 WOLFSSL_MSG("\tCouldn't decode CertPolicy");
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
                 ret = ASN_PARSE_E;
             }
         }
@@ -22578,7 +22508,6 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
                         MAX_CERTPOL_SZ) == 0) {
                 WOLFSSL_MSG("Duplicate policy OIDs not allowed");
                 WOLFSSL_MSG("Use WOLFSSL_DUP_CERTPOL if wanted");
-                WOLFSSL_ERROR_VERBOSE(CERTPOLICIES_E);
                 ret = CERTPOLICIES_E;
             }
         }
@@ -22648,7 +22577,6 @@ static int DecodeSubjDirAttr(const byte* input, word32 sz, DecodedCert* cert)
         /* RFC 5280 4.2.1.8.  Subject Directory Attributes
            If the subjectDirectoryAttributes extension is present, the
            sequence MUST contain at least one entry. */
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         return ASN_PARSE_E;
     }
 
@@ -22775,7 +22703,6 @@ static int DecodeSubjInfoAcc(const byte* input, word32 sz, DecodedCert* cert)
         /* RFC 5280 4.2.2.2.  Subject Information Access
            If the subjectInformationAccess extension is present, the
            sequence MUST contain at least one entry. */
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         return ASN_PARSE_E;
     }
 
@@ -23143,7 +23070,6 @@ int DecodeExtensionType(const byte* input, word32 length, word32 oid,
             WOLFSSL_MSG("Certificate Policy extension not supported.");
             #ifndef WOLFSSL_NO_ASN_STRICT
             if (critical) {
-                WOLFSSL_ERROR_VERBOSE(ASN_CRIT_EXT_E);
                 ret = ASN_CRIT_EXT_E;
             }
             #endif
@@ -23177,7 +23103,6 @@ int DecodeExtensionType(const byte* input, word32 length, word32 oid,
                 which MUST be used only in a CA certificate" */
             if (!cert->isCA) {
                 WOLFSSL_MSG("Name constraints allowed only for CA certs");
-                WOLFSSL_ERROR_VERBOSE(ASN_NAME_INVALID_E);
                 ret = ASN_NAME_INVALID_E;
             }
         #endif
@@ -23261,7 +23186,6 @@ int DecodeExtensionType(const byte* input, word32 length, word32 oid,
              * extension to allow caller to accept it with the verify
              * callback. */
             if (critical) {
-                WOLFSSL_ERROR_VERBOSE(ASN_CRIT_EXT_E);
                 ret = ASN_CRIT_EXT_E;
             }
         #endif
@@ -23862,7 +23786,6 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
     /* Check version is valid/supported - can't be negative. */
     if ((ret == 0) && (version > MAX_X509_VERSION)) {
         WOLFSSL_MSG("Unexpected certificate version");
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         ret = ASN_PARSE_E;
     }
     if (ret == 0) {
@@ -23950,20 +23873,17 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
         /* Make sure 'signature' and 'signatureAlgorithm' are the same. */
         if (dataASN[X509CERTASN_IDX_SIGALGO_OID].data.oid.sum
                 != cert->signatureOID) {
-            WOLFSSL_ERROR_VERBOSE(ASN_SIG_OID_E);
             ret = ASN_SIG_OID_E;
         }
         /* Parameters not allowed after ECDSA or EdDSA algorithm OID. */
         else if (IsSigAlgoECC(cert->signatureOID)) {
         #ifndef WOLFSSL_ECC_SIGALG_PARAMS_NULL_ALLOWED
             if (dataASN[X509CERTASN_IDX_SIGALGO_PARAMS_NULL].tag != 0) {
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
                 ret = ASN_PARSE_E;
             }
         #endif
         #ifdef WC_RSA_PSS
             if (dataASN[X509CERTASN_IDX_SIGALGO_PARAMS].tag != 0) {
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
                 ret = ASN_PARSE_E;
             }
         #endif
@@ -23976,7 +23896,6 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
 
             /* Parameters only with RSA PSS. */
             if (oid != CTC_RSASSAPSS) {
-                WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
                 ret = ASN_PARSE_E;
             }
             if (ret == 0) {
@@ -23999,7 +23918,6 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
                         cert->source);
                 if ((tbsParamsSz != sigAlgParamsSz) ||
                         (XMEMCMP(tbsParams, sigAlgParams, tbsParamsSz) != 0)) {
-                    WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
                     ret = ASN_PARSE_E;
                 }
             }
@@ -24030,7 +23948,6 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
         /* Certificate extensions were only defined in version 2. */
         if (cert->version < 2) {
             WOLFSSL_MSG("\tv1 and v2 certs not allowed extensions");
-            WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
             ret = ASN_VERSION_E;
         }
     #endif
@@ -25032,7 +24949,6 @@ static int CheckCertSignature_ex(const byte* cert, word32 certSz, void* heap,
                 sigParamsSz, NULL);
         }
         if (ret != 0) {
-            WOLFSSL_ERROR_VERBOSE(ret);
             WOLFSSL_MSG("Confirm signature failed");
         }
     }
@@ -25711,7 +25627,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                         break;
                     default:
                         WOLFSSL_MSG("Unsupported attribute type");
-                        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
                         return ASN_PARSE_E;
                     }
                 }
@@ -25723,7 +25638,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
         #ifndef ALLOW_V1_EXTENSIONS
             if (cert->version < 2) {
                 WOLFSSL_MSG("\tv1 and v2 certs not allowed extensions");
-                WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
                 return ASN_VERSION_E;
             }
         #endif
@@ -25772,7 +25686,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                 && !cert->isCSR
 #endif
                 ) {
-            WOLFSSL_ERROR_VERBOSE(ASN_SIG_OID_E);
             return ASN_SIG_OID_E;
         }
 #else
@@ -25794,7 +25707,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                     ret = 0;
             }
             else if (ret < 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
                 return ret;
             }
 #if defined(HAVE_RPK)
@@ -25811,7 +25723,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
          *   key usage extension MUST NOT be asserted. */
         if (!cert->isCA && cert->extKeyUsageSet &&
                 (cert->extKeyUsage & KEYUSE_KEY_CERT_SIGN) != 0) {
-            WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
             return KEYUSAGE_E;
         }
     #endif
@@ -25830,7 +25741,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                     cert->extSubjKeyId, HashIdAlg(cert->signatureOID));
             }
             if (ret != 0) {
-                WOLFSSL_ERROR_VERBOSE(ret);
                 return ret;
             }
         }
@@ -25910,7 +25820,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                     if (verify != NO_VERIFY) {
                         WOLFSSL_MSG("\tNon-entity cert, maxPathLen is 0");
                         WOLFSSL_MSG("\tmaxPathLen status: ERROR");
-                        WOLFSSL_ERROR_VERBOSE(ASN_PATHLEN_INV_E);
                         return ASN_PATHLEN_INV_E;
                     }
                 }
@@ -26013,7 +25922,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                     if (ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
                         WOLFSSL_MSG("Confirm signature failed");
                     }
-                    WOLFSSL_ERROR_VERBOSE(ret);
                     return ret;
                 }
 
@@ -26045,7 +25953,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
 
                         if (ret != 0) {
                             WOLFSSL_MSG("Confirm alternative signature failed");
-                            WOLFSSL_ERROR_VERBOSE(ret);
                             return ret;
                         }
                         else {
@@ -26062,7 +25969,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                  * name constraints */
                 if (!ConfirmNameConstraints(cert->ca, cert)) {
                     WOLFSSL_MSG("Confirm name constraint failed");
-                    WOLFSSL_ERROR_VERBOSE(ASN_NAME_INVALID_E);
                     return ASN_NAME_INVALID_E;
                 }
             }
@@ -26086,7 +25992,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                 if (ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
                     WOLFSSL_MSG("Confirm signature failed");
                 }
-                WOLFSSL_ERROR_VERBOSE(ret);
                 return ret;
             }
 
@@ -26118,7 +26023,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
 
                     if (ret != 0) {
                         WOLFSSL_MSG("Confirm alternative signature failed");
-                        WOLFSSL_ERROR_VERBOSE(ret);
                         return ret;
                     }
                     else {
@@ -26137,7 +26041,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
             /* ret needs to be self-signer error for openssl compatibility */
             if (cert->selfSigned) {
-                WOLFSSL_ERROR_VERBOSE(ASN_SELF_SIGNED_E);
                 return ASN_SELF_SIGNED_E;
             }
             else
@@ -26408,7 +26311,6 @@ int SetSerialNumber(const byte* sn, word32 snSz, byte* output,
     /* RFC 5280 - 4.1.2.2:
      *   Serial numbers must be a positive value (and not zero) */
     if (snSzInt == 0) {
-        WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
         return BAD_FUNC_ARG;
     }
 
@@ -26487,7 +26389,6 @@ int wc_GetSerialNumber(const byte* input, word32* inOutIdx,
 
     if (*serialSz > EXTERNAL_SERIAL_SIZE || *serialSz <= 0) {
         WOLFSSL_MSG("Serial size bad");
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         return ASN_PARSE_E;
     }
 
@@ -27215,7 +27116,6 @@ int wc_DerToPemEx(const byte* der, word32 derSz, byte* output, word32 outSz,
         outLen = 0;
         if ((err = Base64_Encode(der, derSz, NULL, (word32*)&outLen))
                 != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
-            WOLFSSL_ERROR_VERBOSE(err);
             return err;
         }
         return (int)headerLen + (int)footerLen + outLen;
@@ -27252,7 +27152,6 @@ int wc_DerToPemEx(const byte* der, word32 derSz, byte* output, word32 outSz,
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(footer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
-        WOLFSSL_ERROR_VERBOSE(err);
         return err;
     }
     i += outLen;
@@ -27611,7 +27510,6 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
 
         if (!info || !info->passwd_cb) {
             WOLFSSL_MSG("No password callback set");
-            WOLFSSL_ERROR_VERBOSE(NO_PASSWORD);
             return NO_PASSWORD;
         }
 
@@ -27651,7 +27549,6 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
                     }
                 }
             #else
-                WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
                 ret = NOT_COMPILED_IN;
             #endif
             }
@@ -27660,7 +27557,6 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
                 if (passwordSz == 0) {
                     /* The key is encrypted but does not have a password */
                     WOLFSSL_MSG("No password for encrypted key");
-                    WOLFSSL_ERROR_VERBOSE(NO_PASSWORD);
                     ret = NO_PASSWORD;
                 }
                 else {
@@ -29961,7 +29857,6 @@ static int EncodeName(EncodedName* name, const char* nameStr,
     /* Restrict country code size */
     if (type == ASN_COUNTRY_NAME && strLen != CTC_COUNTRY_SIZE) {
         WOLFSSL_MSG("Country code size error");
-        WOLFSSL_ERROR_VERBOSE(ASN_COUNTRY_SIZE_E);
         return ASN_COUNTRY_SIZE_E;
     }
 
@@ -32283,9 +32178,6 @@ exit_ms:
     /* reset state */
     certSignCtx->state = CERTSIGN_STATE_BEGIN;
 
-    if (ret < 0) {
-        WOLFSSL_ERROR_VERBOSE(ret);
-    }
 
     return ret;
 }
@@ -40679,7 +40571,6 @@ int VerifyCRL_Signature(SignatureCtx* sigCtx, const byte* toBeSigned,
 #ifndef IGNORE_KEY_EXTENSIONS
     if ((ca->keyUsage & KEYUSE_CRL_SIGN) == 0) {
         WOLFSSL_MSG("CA cannot sign CRLs");
-        WOLFSSL_ERROR_VERBOSE(ASN_CRL_NO_SIGNER_E);
         return ASN_CRL_NO_SIGNER_E;
     }
 #endif /* IGNORE_KEY_EXTENSIONS */
@@ -40689,7 +40580,6 @@ int VerifyCRL_Signature(SignatureCtx* sigCtx, const byte* toBeSigned,
                          ca->pubKeySize, ca->keyOID, signature, sigSz,
                          signatureOID, sigParams, (word32)sigParamsSz, NULL) != 0) {
         WOLFSSL_MSG("CRL Confirm signature failed");
-        WOLFSSL_ERROR_VERBOSE(ASN_CRL_CONFIRM_E);
         return ASN_CRL_CONFIRM_E;
     }
 
@@ -40743,7 +40633,6 @@ static int PaseCRL_CheckSignature(DecodedCRL* dcrl, const byte* sigParams,
     if (ca == NULL) {
         WOLFSSL_MSG("Did NOT find CRL issuer CA");
         ret = ASN_CRL_NO_SIGNER_E;
-        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     if (ret == 0) {
@@ -40840,7 +40729,6 @@ static int ParseCRL_CertList(RevokedCert* rcert, DecodedCRL* dcrl,
             (! AsnSkipDateCheck) &&
             !XVALIDATE_DATE(dcrl->nextDate, dcrl->nextDateFormat, ASN_AFTER)) {
             WOLFSSL_MSG("CRL after date is no longer valid");
-            WOLFSSL_ERROR_VERBOSE(CRL_CERT_DATE_ERR);
             return CRL_CERT_DATE_ERR;
         }
 #else
@@ -41362,7 +41250,6 @@ int ParseCRL(RevokedCert* rcert, DecodedCRL* dcrl, const byte* buff, word32 sz,
     if (ca == NULL) {
         WOLFSSL_MSG("Did NOT find CRL issuer CA");
         ret = ASN_CRL_NO_SIGNER_E;
-        WOLFSSL_ERROR_VERBOSE(ret);
         goto end;
     }
 
@@ -41503,7 +41390,6 @@ end:
                  !XVALIDATE_DATE(dcrl->nextDate, dcrl->nextDateFormat, ASN_AFTER)) {
                 WOLFSSL_MSG("CRL after date is no longer valid");
                 ret = CRL_CERT_DATE_ERR;
-                WOLFSSL_ERROR_VERBOSE(ret);
             }
         }
     }
@@ -43122,14 +43008,12 @@ static int DecodeAcertGeneralName(const byte* input, word32* inOutIdx,
             /* test hier-part is empty */
             if (i == 0 || i == len) {
                 WOLFSSL_MSG("\tEmpty or malformed URI");
-                WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                 return ASN_ALT_NAME_E;
             }
 
             /* test if scheme is missing  */
             if (input[idx + (word32)i] != ':') {
                 WOLFSSL_MSG("\tAlt Name must be absolute URI");
-                WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                 return ASN_ALT_NAME_E;
             }
         }
@@ -43700,7 +43584,6 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
     if (version > MAX_X509_VERSION) {
         FREE_ASNGETDATA(dataASN, acert->heap);
         WOLFSSL_MSG("Unexpected attribute certificate version");
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
         return ASN_PARSE_E;
     }
 
@@ -43746,7 +43629,6 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
     /* Make sure 'signature' and 'signatureAlgorithm' are the same. */
     if (dataASN[ACERT_IDX_SIGALGO_OID].data.oid.sum != acert->signatureOID) {
         FREE_ASNGETDATA(dataASN, acert->heap);
-        WOLFSSL_ERROR_VERBOSE(ASN_SIG_OID_E);
         return ASN_SIG_OID_E;
     }
 
@@ -43758,7 +43640,6 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
     #endif
             ) {
             FREE_ASNGETDATA(dataASN, acert->heap);
-            WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
             return ASN_PARSE_E;
         }
     }
@@ -43775,7 +43656,6 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
         /* Parameters only with RSA PSS. */
         if (oid != CTC_RSASSAPSS) {
             FREE_ASNGETDATA(dataASN, acert->heap);
-            WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
             return ASN_PARSE_E;
         }
 
@@ -43793,7 +43673,6 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
             (XMEMCMP(acParams, sigAlgParams, acParamsSz) != 0)) {
 
             FREE_ASNGETDATA(dataASN, acert->heap);
-            WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
             return ASN_PARSE_E;
         }
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -26143,7 +26143,6 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
             else
 #endif
             {
-                WOLFSSL_ERROR_VERBOSE(ASN_NO_SIGNER_E);
                 WOLFSSL_MSG_CERT("Consider using WOLFSSL_ALT_CERT_CHAINS.");
                 return ASN_NO_SIGNER_E;
             }

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -505,7 +505,6 @@ int wc_HmacSetKey_ex(Hmac* hmac, int type, const byte* key, word32 length,
      */
     if (!allowFlag) {
         if (length < HMAC_FIPS_MIN_KEY) {
-            WOLFSSL_ERROR_VERBOSE(HMAC_MIN_KEYLEN_E);
             return HMAC_MIN_KEYLEN_E;
         }
     }

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -253,7 +253,8 @@ void WOLFSSL_START(int funcNum)
     if (funcNum < WC_FUNC_COUNT) {
         double now = current_time(0) * 1000.0;
     #ifdef WOLFSSL_FUNC_TIME_LOG
-        fprintf(stderr, "%17.3f: START - %s\n", now, wc_func_name[funcNum]);
+        WOLFSSL_DEBUG_PRINTF("%17.3f: START - %s\n",
+                             now, wc_func_name[funcNum]);
     #endif
         wc_func_start[funcNum] = now;
     }
@@ -265,7 +266,8 @@ void WOLFSSL_END(int funcNum)
         double now = current_time(0) * 1000.0;
         wc_func_time[funcNum] += now - wc_func_start[funcNum];
     #ifdef WOLFSSL_FUNC_TIME_LOG
-        fprintf(stderr, "%17.3f: END   - %s\n", now, wc_func_name[funcNum]);
+        WOLFSSL_DEBUG_PRINTF("%17.3f: END   - %s\n",
+                             now, wc_func_name[funcNum]);
     #endif
     }
 }
@@ -278,11 +280,11 @@ void WOLFSSL_TIME(int count)
     for (i = 0; i < WC_FUNC_COUNT; i++) {
         if (wc_func_time[i] > 0) {
             avg = wc_func_time[i] / count;
-            fprintf(stderr, "%8.3f ms: %s\n", avg, wc_func_name[i]);
+            WOLFSSL_DEBUG_PRINTF("%8.3f ms: %s\n", avg, wc_func_name[i]);
             total += avg;
         }
     }
-    fprintf(stderr, "%8.3f ms\n", total);
+    WOLFSSL_DEBUG_PRINTF("%8.3f ms\n", total);
 }
 #endif
 
@@ -1850,36 +1852,21 @@ static int backtrace_callback(void *data, uintptr_t pc, const char *filename,
         *(int *)data = 1;
         return 0;
     }
-#ifdef NO_STDIO_FILESYSTEM
-    printf("    #%d %p in %s %s:%d\n", (*(int *)data)++, (void *)pc,
-           function, filename, lineno);
-#else
-    fprintf(stderr, "    #%d %p in %s %s:%d\n", (*(int *)data)++, (void *)pc,
-            function, filename, lineno);
-#endif
+    WOLFSSL_DEBUG_PRINTF("    #%d %p in %s %s:%d\n", (*(int *)data)++,
+                         (void *)pc, function, filename, lineno);
     return 0;
 }
 
 static void backtrace_error(void *data, const char *msg, int errnum) {
     (void)data;
-#ifdef NO_STDIO_FILESYSTEM
-    printf("ERR TRACE: error %d while backtracing: %s", errnum, msg);
-#else
-    fprintf(stderr, "ERR TRACE: error %d while backtracing: %s", errnum, msg);
-#endif
+    WOLFSSL_DEBUG_PRINTF("ERR TRACE: error %d while backtracing: %s",
+                         errnum, msg);
 }
 
 static void backtrace_creation_error(void *data, const char *msg, int errnum) {
     (void)data;
-#ifdef NO_STDIO_FILESYSTEM
-    printf("ERR TRACE: internal error %d "
+    WOLFSSL_DEBUG_PRINTF("ERR TRACE: internal error %d "
             "while initializing backtrace facility: %s", errnum, msg);
-    printf("ERR TRACE: internal error "
-           "while initializing backtrace facility");
-#else
-    fprintf(stderr, "ERR TRACE: internal error %d "
-            "while initializing backtrace facility: %s", errnum, msg);
-#endif
 }
 
 static int backtrace_init(struct backtrace_state **backtrace_state) {

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -729,7 +729,6 @@ int wc_d2i_PKCS12(const byte* der, word32 derSz, WC_PKCS12* pkcs12)
 
     if (version != WC_PKCS12_VERSION_DEFAULT) {
         WOLFSSL_MSG("PKCS12 unsupported version!");
-        WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
         return ASN_VERSION_E;
     }
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -10562,7 +10562,6 @@ static int wc_PKCS7_DecryptKtri(wc_PKCS7* pkcs7, byte* in, word32 inSz,
                                     XFREE(privKey, pkcs7->heap,
                                                     DYNAMIC_TYPE_TMP_BUFFER);
                             #endif
-                            WOLFSSL_ERROR_VERBOSE(MEMORY_E);
                             return MEMORY_E;
                         }
 

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -26245,7 +26245,6 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 static int wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 {
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
         return KEYUSAGE_E;
     }
 
@@ -26273,7 +26272,6 @@ static int wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 static int wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 {
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
         return KEYUSAGE_E;
     }
 
@@ -26329,7 +26327,6 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
         return KEYUSAGE_E;
     }
 
@@ -26370,7 +26367,6 @@ int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
         return KEYUSAGE_E;
     }
 
@@ -26416,7 +26412,6 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
         return KEYUSAGE_E;
     }
     #ifdef WOLF_CRYPTO_CB
@@ -26997,7 +26992,6 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if (aes->rounds != 10 && aes->rounds != 12 && aes->rounds != 14) {
-        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
         return KEYUSAGE_E;
     }
 

--- a/wolfcrypt/src/port/xilinx/xil-aesgcm.c
+++ b/wolfcrypt/src/port/xilinx/xil-aesgcm.c
@@ -80,7 +80,6 @@ static WC_INLINE int aligned_xmalloc(byte** buf, byte** aligned, void* heap, wor
     return 0;
 #else
     WOLFSSL_MSG("AES-ECB encrypt with bad alignment");
-    WOLFSSL_ERROR_VERBOSE(BAD_ALIGN_E);
     return BAD_ALIGN_E;
 #endif
 }

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -255,11 +255,9 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
 
     /* use file's salt for key derivation, hex decode first */
     if (Base16_Decode(info->iv, info->ivSz, info->iv, &info->ivSz) != 0) {
-        WOLFSSL_ERROR_VERBOSE(BUFFER_E);
         return BUFFER_E;
     }
     if (info->ivSz < PKCS5_SALT_SZ) {
-        WOLFSSL_ERROR_VERBOSE(BUFFER_E);
         return BUFFER_E;
     }
 
@@ -492,7 +490,6 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
             WOLFSSL_MSG("Unknown/Unsupported encrypt/decrypt id");
             (void)shaOid;
             ret = ALGO_ID_E;
-            WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -561,7 +558,6 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
             default:
                 WOLFSSL_MSG("Unknown/Unsupported PKCS version");
                 ret = ALGO_ID_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
         } /* switch (version) */
     }
 
@@ -715,7 +711,6 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
             default:
                 WOLFSSL_MSG("Unknown/Unsupported encrypt/decryption algorithm");
                 ret = ALGO_ID_E;
-                WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
 

--- a/wolfcrypt/src/wc_mlkem_asm.S
+++ b/wolfcrypt/src/wc_mlkem_asm.S
@@ -15780,7 +15780,7 @@ _mlkem_decompress_5_avx2:
         vpmulhrsw	%ymm1, %ymm0, %ymm0
         vmovdqu	%ymm0, 448(%rdi)
         vmovq	150(%rsi), %xmm0
-        movzxw	158(%rsi), %rdx
+        movzwq	158(%rsi), %rdx
         vpinsrq	$0x01, %rdx, %xmm0, %xmm0
         vinserti128	$0x01, %xmm0, %ymm0, %ymm0
         vpshufb	%ymm2, %ymm0, %ymm0

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -349,22 +349,12 @@ WOLFSSL_ABI WOLFSSL_API const char* wc_GetErrorString(int error);
         #endif
     #endif
     #ifndef WC_ERR_TRACE
-        #ifdef NO_STDIO_FILESYSTEM
-        #define WC_ERR_TRACE(label)                           \
-            ( printf("ERR TRACE: %s L %d %s (%d)\n",          \
-                      __FILE__, __LINE__, #label, label),     \
-              WOLFSSL_DEBUG_BACKTRACE_RENDER_CLAUSE,          \
-              label                                           \
+        #define WC_ERR_TRACE(label)                                \
+            ( WOLFSSL_DEBUG_PRINTF("ERR TRACE: %s L %d %s (%d)\n", \
+                      __FILE__, __LINE__, #label, label),          \
+              WOLFSSL_DEBUG_BACKTRACE_RENDER_CLAUSE,               \
+              label                                                \
             )
-        #else
-        #define WC_ERR_TRACE(label)                           \
-            ( fprintf(stderr,                                 \
-                      "ERR TRACE: %s L %d %s (%d)\n",         \
-                      __FILE__, __LINE__, #label, label),     \
-              WOLFSSL_DEBUG_BACKTRACE_RENDER_CLAUSE,          \
-              label                                           \
-            )
-        #endif
     #endif
     #include <wolfssl/debug-trace-error-codes.h>
 #else

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -550,6 +550,8 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
     #define WOLFSSL_DEBUG_PRINTF_FN printk
 #elif defined(WOLFSSL_RENESAS_RA6M4)
     #define WOLFSSL_DEBUG_PRINTF_FN myprintf
+#elif defined(NO_STDIO_FILESYSTEM)
+    #define WOLFSSL_DEBUG_PRINTF_FN printf
 #else
     #define WOLFSSL_DEBUG_PRINTF_FN fprintf
     #define WOLFSSL_DEBUG_PRINTF_FIRST_ARGS stderr,
@@ -561,14 +563,8 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
 
 #if defined(WOLFSSL_DEBUG_PRINTF_FN) && !defined(WOLFSSL_DEBUG_PRINTF)
     #if defined(WOLF_NO_VARIADIC_MACROS)
-        #if defined(WOLFSSL_ESPIDF)
-            /* ESP-IDF supports variadic. Do not use WOLF_NO_VARIADIC_MACROS.
-             * This is only for WOLF_NO_VARIADIC_MACROS testing: */
-            #define WOLFSSL_DEBUG_PRINTF(a) \
-                WOLFSSL_DEBUG_PRINTF_FN(WOLFSSL_DEBUG_PRINTF_FIRST_ARGS a)
-        #else
-            /* no variadic not defined for this platform */
-        #endif
+        #define WOLFSSL_DEBUG_PRINTF(a) \
+            WOLFSSL_DEBUG_PRINTF_FN(WOLFSSL_DEBUG_PRINTF_FIRST_ARGS a)
     #else
         #define WOLFSSL_DEBUG_PRINTF(...) \
             WOLFSSL_DEBUG_PRINTF_FN(WOLFSSL_DEBUG_PRINTF_FIRST_ARGS __VA_ARGS__)

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -435,12 +435,6 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
 #endif /* DEBUG_WOLFSSL | OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY ||
           OPENSSL_EXTRA */
 
-#ifdef WOLFSSL_VERBOSE_ERRORS
-#define WOLFSSL_ERROR_VERBOSE(e) WOLFSSL_ERROR(e)
-#else
-#define WOLFSSL_ERROR_VERBOSE(e) (void)(e)
-#endif /* WOLFSSL_VERBOSE_ERRORS */
-
 #ifdef HAVE_STACK_SIZE_VERBOSE
     extern WOLFSSL_API THREAD_LS_T unsigned char *StackSizeCheck_myStack;
     extern WOLFSSL_API THREAD_LS_T size_t StackSizeCheck_stackSize;

--- a/wrapper/Ada/tls_server.adb
+++ b/wrapper/Ada/tls_server.adb
@@ -346,6 +346,14 @@ package body Tls_Server with SPARK_Mode is
          WolfSSL.Create_WolfSSL (Context => Ctx, Ssl => Ssl);
          if not WolfSSL.Is_Valid (Ssl) then
             Put_Line ("ERROR: failed to create WOLFSSL object.");
+            declare
+               Error_Message : constant WolfSSL.Error_Message :=
+                 WolfSSL.Error (WolfSSL.Get_Error (Ssl, Result));
+            begin
+               if Result = Success then
+                  Put_Line (Error_Message.Text (1 .. Error_Message.Last));
+               end if;
+            end;
             SPARK_Sockets.Close_Socket (L);
 
             if not DTLS then

--- a/wrapper/Ada/wolfssl.adb
+++ b/wrapper/Ada/wolfssl.adb
@@ -19,6 +19,7 @@
 -- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 --
 
+with Ada.Unchecked_Conversion;
 pragma Warnings (Off, "* is an internal GNAT unit");
 with GNAT.Sockets.Thin_Common;
 pragma Warnings (On, "* is an internal GNAT unit");
@@ -798,10 +799,15 @@ package body WolfSSL is
       S : String (1 .. Error_Message_Index'Last);
       B : Byte_Array (1 .. size_t (Error_Message_Index'Last));
       C : Natural;
+      -- Use unchecked conversion instead of type conversion to mimic C style
+      -- conversion from int to unsigned long, avoiding the Ada overflow check.
+      function To_Unsigned_Long is new Ada.Unchecked_Conversion
+         (Source => long,
+          Target => unsigned_long);
    begin
-      WolfSSL_Error_String (Error => unsigned_long (Code),
+      WolfSSL_Error_String (Error => To_Unsigned_Long (long (Code)),
                             Data  => B,
-                            Size  => unsigned_long (B'Last));
+                            Size  => To_Unsigned_Long (long (B'Last)));
       Interfaces.C.To_Ada (Item     => B,
                            Target   => S,
                            Count    => C,


### PR DESCRIPTION
# Description

this commit removes ~600 lines from the code base. it compresses lines like:

```diff
-                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
-                    return SANITY_MSG_E;
+                    return WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
```
by tweaking the `WOLFSSL_ERROR_VERBOSE` macro like so:
```diff
 #ifdef WOLFSSL_VERBOSE_ERRORS
-#define WOLFSSL_ERROR_VERBOSE(e) WOLFSSL_ERROR(e)
+#define WOLFSSL_ERROR_VERBOSE(e) (WOLFSSL_ERROR(e),e)
 #else
-#define WOLFSSL_ERROR_VERBOSE(e) (void)(e)
+#define WOLFSSL_ERROR_VERBOSE(e) (e)
 #endif /* WOLFSSL_VERBOSE_ERRORS */
```

# Testing

`./configure && make check && ./configure --enable-all && make check`
