### PR TITLE
20250819-debug-trace-errcodes-dist-artifacts

### DIFF
--- a/wolfssl/include.am
+++ b/wolfssl/include.am
@@ -8,6 +8,8 @@ include wolfssl/openssl/include.am
 endif
 
 EXTRA_DIST+= wolfssl/sniffer_error.rc
+EXTRA_DIST+= wolfssl/debug-trace-error-codes.h
+EXTRA_DIST+= wolfssl/debug-untrace-error-codes.h
 
 nobase_include_HEADERS+= \
                          wolfssl/error-ssl.h \
@@ -36,6 +38,3 @@ endif
 
 wolfssl/debug-trace-error-codes.h wolfssl/debug-untrace-error-codes.h: wolfssl/wolfcrypt/error-crypt.h wolfssl/error-ssl.h
 	@support/gen-debug-trace-error-codes.sh
-
-DISTCLEANFILES += wolfssl/debug-trace-error-codes.h \
-                  wolfssl/debug-untrace-error-codes.h


### PR DESCRIPTION
`wolfssl/include.am`: include `wolfssl/debug-trace-error-codes.h` and `wolfssl/debug-untrace-error-codes.h` in dist archives.

tested with `wolfssl-multi-test.sh ... check-source-text check-configure` and by `make dist` checking the generated archive for the added artifacts.
