### PR TITLE
Add OCSP response issuer certificate callback zd#20415

### DIFF
--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -2484,6 +2484,25 @@ int wolfSSL_CertManagerSetOCSP_Cb(WOLFSSL_CERT_MANAGER* cm, CbOCSPIO ioCb,
     return ret;
 }
 
+WOLFSSL_API int wolfSSL_CertManagerSetOCSPResponseIssuer_Cb(WOLFSSL_CERT_MANAGER* cm,
+        CbOCSPRespCert respCertCb)
+{
+    int ret = WOLFSSL_SUCCESS;
+
+    WOLFSSL_ENTER("wolfSSL_CertManagerSetOCSP_Cb");
+
+    /* Validate parameters. */
+    if (cm == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    if (ret == WOLFSSL_SUCCESS) {
+        /* Set callback into certificate manager. */
+        cm->ocspRespCertCb = respCertCb;
+    }
+
+    return ret;
+}
+
 #endif /* HAVE_OCSP */
 
 #endif /* NO_CERTS */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -39514,6 +39514,7 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
     int ret = 0;
     word32 idx = *ioIndex;
     Signer* ca = NULL;
+    CbOCSPRespCert ocspRespCertCb = (NULL != cm) ? ((WOLFSSL_CERT_MANAGER*)cm)->ocspRespCertCb: NULL;
     int sigValid = 0;
 
     WOLFSSL_ENTER("DecodeBasicOcspResponse");
@@ -39561,6 +39562,11 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
         /* Store reference to certificate BER data. */
         GetASN_GetRef(&dataASN[OCSPBASICRESPASN_IDX_CERTS_SEQ], &resp->cert,
                 &resp->certSz);
+    }
+    /* If no certificate was read from the response data, but an response issuer certificate callback is available. */
+    if ((ret == 0) && (resp->certSz == 0) && (ocspRespCertCb != NULL)) {
+        /* Call callback to obtain issuing certificate data. */
+        resp->certSz = ocspRespCertCb(&resp->cert);
     }
 
     if ((ret == 0) && resp->certSz > 0) {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2696,6 +2696,7 @@ struct WOLFSSL_CERT_MANAGER {
     crlErrorCb      crlCb;                 /* Allow user to override error */
     void*           crlCbCtx;
     CbOCSPIO        ocspIOCb;              /* I/O callback for OCSP lookup */
+    CbOCSPRespCert  ocspRespCertCb;        /* Callback for OCSP response issuer certificate */
     CbOCSPRespFree  ocspRespFreeCb;        /* Frees OCSP Response from IO Cb */
     wolfSSL_Mutex   caLock;                /* CA list lock */
     byte            crlEnabled:1;          /* is CRL on ? */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3749,6 +3749,7 @@ typedef int  (*crlErrorCb)(int ret, WOLFSSL_CRL* crl, WOLFSSL_CERT_MANAGER* cm,
                            void* ctx);
 typedef int  (*CbOCSPIO)(void*, const char*, int,
                                          unsigned char*, int, unsigned char**);
+typedef int (*CbOCSPRespCert)(unsigned char**);
 typedef void (*CbOCSPRespFree)(void*,unsigned char*);
 
 #ifdef HAVE_CRL_IO
@@ -4264,6 +4265,8 @@ WOLFSSL_API void wolfSSL_CTX_SetPerformTlsRecordProcessingCb(WOLFSSL_CTX* ctx,
         WOLFSSL_CERT_MANAGER* cm, const char* url);
     WOLFSSL_API int wolfSSL_CertManagerSetOCSP_Cb(WOLFSSL_CERT_MANAGER* cm,
         CbOCSPIO ioCb, CbOCSPRespFree respFreeCb, void* ioCbCtx);
+    WOLFSSL_API int wolfSSL_CertManagerSetOCSPResponseIssuer_Cb(WOLFSSL_CERT_MANAGER* cm,
+        CbOCSPRespCert respCertCb);
 
     WOLFSSL_API int wolfSSL_CertManagerEnableOCSPStapling(
         WOLFSSL_CERT_MANAGER* cm);


### PR DESCRIPTION
# Description

This adds a callback for retrieving OCSP response issuer certificate data in case no such data is provided in the OCSP response's "certificate" extension. In our use case we have the OCSP response which is signed through an issuer chain, but that certificate is not included in the OCSP response certificate extension. This callback allows the OCSP response verification code to retrieve that certificate from the caller, after which the OCSP issuer verification can be performed.

Fixes zd#20415
Relates to zd#19571

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
