### PR TITLE
TLS 1.3 KeyShare: error on duplicate group

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -7873,6 +7873,14 @@ static int TLSX_SetSignatureAlgorithmsCert(TLSX** extensions,
 /* Key Share                                                                  */
 /******************************************************************************/
 
+#ifndef MAX_KEYSHARE_NAMED_GROUPS
+    #if defined(WOLFSSL_HAVE_MLKEM) && !defined(WOLFSSL_MLKEM_NO_MAKE_KEY)
+        #define MAX_KEYSHARE_NAMED_GROUPS    24
+    #else
+        #define MAX_KEYSHARE_NAMED_GROUPS    12
+    #endif
+#endif
+
 #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
 /* Create a key share entry using named Diffie-Hellman parameters group.
  * Generates a key pair.
@@ -9919,13 +9927,15 @@ static int TLSX_KeyShare_Process(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
  * number on error.
  */
 static int TLSX_KeyShareEntry_Parse(const WOLFSSL* ssl, const byte* input,
-            word16 length, KeyShareEntry **kse, TLSX** extensions)
+            word16 length, KeyShareEntry **kse, word16* seenGroups,
+            int* seenGroupsCnt, TLSX** extensions)
 {
     int    ret;
     word16 group;
     word16 keLen;
     int    offset = 0;
     byte*  ke;
+    int    i;
 
     if (length < OPAQUE16_LEN + OPAQUE16_LEN)
         return BUFFER_ERROR;
@@ -9939,6 +9949,19 @@ static int TLSX_KeyShareEntry_Parse(const WOLFSSL* ssl, const byte* input,
         return INVALID_PARAMETER;
     if (keLen > length - offset)
         return BUFFER_ERROR;
+
+    if (seenGroups != NULL) {
+        if (*seenGroupsCnt == MAX_KEYSHARE_NAMED_GROUPS) {
+            return BAD_KEY_SHARE_DATA;
+        }
+        for (i = 0; i < *seenGroupsCnt; i++) {
+            if (seenGroups[i] == group) {
+                return BAD_KEY_SHARE_DATA;
+            }
+        }
+        seenGroups[i] = group;
+        *seenGroupsCnt = i + 1;
+    }
 
 #ifdef WOLFSSL_HAVE_MLKEM
     if ((WOLFSSL_NAMED_GROUP_IS_PQC(group) ||
@@ -10044,6 +10067,8 @@ int TLSX_KeyShare_Parse_ClientHello(const WOLFSSL* ssl,
     int    offset = 0;
     word16 len;
     TLSX*  extension;
+    word16 seenGroups[MAX_KEYSHARE_NAMED_GROUPS];
+    int    seenGroupsCnt = 0;
 
     /* Add a KeyShare extension if it doesn't exist even if peer sent no
      * entries. The presence of this extension signals that the peer can be
@@ -10067,7 +10092,8 @@ int TLSX_KeyShare_Parse_ClientHello(const WOLFSSL* ssl,
 
     while (offset < (int)length) {
         ret = TLSX_KeyShareEntry_Parse(ssl, &input[offset],
-                length - (word16)offset, NULL, extensions);
+                length - (word16)offset, NULL, seenGroups, &seenGroupsCnt,
+                extensions);
         if (ret < 0)
             return ret;
 
@@ -10119,8 +10145,8 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
         }
 
         /* ServerHello contains one key share entry. */
-        len = TLSX_KeyShareEntry_Parse(ssl, input, length, &keyShareEntry,
-                &ssl->extensions);
+        len = TLSX_KeyShareEntry_Parse(ssl, input, length, &keyShareEntry, NULL,
+                NULL, &ssl->extensions);
         if (len != (int)length)
             return BUFFER_ERROR;
 


### PR DESCRIPTION
# Description

Don't allow a KeyShare extension from the client to have more than one entry for any group.

Fixes zd#20405

# Testing

Customer PoC

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
