### PR TITLE
Exclude wolfssl certs_test.h from Espressif user_settings.h

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
@@ -1058,8 +1058,9 @@ Turn on timer debugging (used when CPU cycles not available)
             #error "USE_CERT_BUFFERS_1024 is already defined. Pick one."
         #endif
 
-        /* Be sure to include in app when using example certs: */
-        #include <wolfssl/certs_test.h>
+        /* Be sure to include in app, not here, when using example certs: */
+        /* #include <wolfssl/certs_test.h> */
+        /* Including certs_test.h here may cause conflict in wolfssh certs. */
 
         #define USE_CERT_BUFFERS_256
         #define CTX_CA_CERT          ca_cert_der_2048
@@ -1085,8 +1086,9 @@ Turn on timer debugging (used when CPU cycles not available)
             #error "USE_CERT_BUFFERS_2048 is already defined. Pick one."
         #endif
 
-        /* Be sure to include in app when using example certs: */
-        #include <wolfssl/certs_test.h>
+        /* Be sure to include in app, not here, when using example certs: */
+        /* #include <wolfssl/certs_test.h> */
+        /* Including certs_test.h here may cause conflict in wolfssh certs. */
 
         #define USE_CERT_BUFFERS_256
         #define CTX_CA_CERT          ca_cert_der_1024

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/include/user_settings.h
@@ -1058,8 +1058,9 @@ Turn on timer debugging (used when CPU cycles not available)
             #error "USE_CERT_BUFFERS_1024 is already defined. Pick one."
         #endif
 
-        /* Be sure to include in app when using example certs: */
-        #include <wolfssl/certs_test.h>
+        /* Be sure to include in app, not here, when using example certs: */
+        /* #include <wolfssl/certs_test.h> */
+        /* Including certs_test.h here may cause conflict in wolfssh certs. */
 
         #define USE_CERT_BUFFERS_256
         #define CTX_CA_CERT          ca_cert_der_2048
@@ -1085,8 +1086,9 @@ Turn on timer debugging (used when CPU cycles not available)
             #error "USE_CERT_BUFFERS_2048 is already defined. Pick one."
         #endif
 
-        /* Be sure to include in app when using example certs: */
-        #include <wolfssl/certs_test.h>
+        /* Be sure to include in app, not here, when using example certs: */
+        /* #include <wolfssl/certs_test.h> */
+        /* Including certs_test.h here may cause conflict in wolfssh certs. */
 
         #define USE_CERT_BUFFERS_256
         #define CTX_CA_CERT          ca_cert_der_1024

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/include/user_settings.h
@@ -1058,8 +1058,9 @@ Turn on timer debugging (used when CPU cycles not available)
             #error "USE_CERT_BUFFERS_1024 is already defined. Pick one."
         #endif
 
-        /* Be sure to include in app when using example certs: */
-        #include <wolfssl/certs_test.h>
+        /* Be sure to include in app, not here, when using example certs: */
+        /* #include <wolfssl/certs_test.h> */
+        /* Including certs_test.h here may cause conflict in wolfssh certs. */
 
         #define USE_CERT_BUFFERS_256
         #define CTX_CA_CERT          ca_cert_der_2048
@@ -1085,8 +1086,9 @@ Turn on timer debugging (used when CPU cycles not available)
             #error "USE_CERT_BUFFERS_2048 is already defined. Pick one."
         #endif
 
-        /* Be sure to include in app when using example certs: */
-        #include <wolfssl/certs_test.h>
+        /* Be sure to include in app, not here, when using example certs: */
+        /* #include <wolfssl/certs_test.h> */
+        /* Including certs_test.h here may cause conflict in wolfssh certs. */
 
         #define USE_CERT_BUFFERS_256
         #define CTX_CA_CERT          ca_cert_der_1024

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/include/user_settings.h
@@ -1058,8 +1058,9 @@ Turn on timer debugging (used when CPU cycles not available)
             #error "USE_CERT_BUFFERS_1024 is already defined. Pick one."
         #endif
 
-        /* Be sure to include in app when using example certs: */
-        #include <wolfssl/certs_test.h>
+        /* Be sure to include in app, not here, when using example certs: */
+        /* #include <wolfssl/certs_test.h> */
+        /* Including certs_test.h here may cause conflict in wolfssh certs. */
 
         #define USE_CERT_BUFFERS_256
         #define CTX_CA_CERT          ca_cert_der_2048
@@ -1085,8 +1086,9 @@ Turn on timer debugging (used when CPU cycles not available)
             #error "USE_CERT_BUFFERS_2048 is already defined. Pick one."
         #endif
 
-        /* Be sure to include in app when using example certs: */
-        #include <wolfssl/certs_test.h>
+        /* Be sure to include in app, not here, when using example certs: */
+        /* #include <wolfssl/certs_test.h> */
+        /* Including certs_test.h here may cause conflict in wolfssh certs. */
 
         #define USE_CERT_BUFFERS_256
         #define CTX_CA_CERT          ca_cert_der_1024

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/include/user_settings.h
@@ -1058,8 +1058,9 @@ Turn on timer debugging (used when CPU cycles not available)
             #error "USE_CERT_BUFFERS_1024 is already defined. Pick one."
         #endif
 
-        /* Be sure to include in app when using example certs: */
-        #include <wolfssl/certs_test.h>
+        /* Be sure to include in app, not here, when using example certs: */
+        /* #include <wolfssl/certs_test.h> */
+        /* Including certs_test.h here may cause conflict in wolfssh certs. */
 
         #define USE_CERT_BUFFERS_256
         #define CTX_CA_CERT          ca_cert_der_2048
@@ -1085,8 +1086,9 @@ Turn on timer debugging (used when CPU cycles not available)
             #error "USE_CERT_BUFFERS_2048 is already defined. Pick one."
         #endif
 
-        /* Be sure to include in app when using example certs: */
-        #include <wolfssl/certs_test.h>
+        /* Be sure to include in app, not here, when using example certs: */
+        /* #include <wolfssl/certs_test.h> */
+        /* Including certs_test.h here may cause conflict in wolfssh certs. */
 
         #define USE_CERT_BUFFERS_256
         #define CTX_CA_CERT          ca_cert_der_1024


### PR DESCRIPTION
# Description

Excludes examplec file `wolfssl/certs_test.h` from being included in Espressif `user_settings.h` file, introduced in https://github.com/wolfSSL/wolfssl/pull/8813 .

See https://github.com/wolfSSL/wolfssh/issues/826#issuecomment-3212080879 .

The critical file needing the exclusion is the `template` reference example, used when publishing [Managed Components](https://components.espressif.com/components/wolfssl/wolfssl/versions/5.8.2/readme). All examples updated here for consistency.

Note that I plan to publish an updated Espressif Managed Component for wolfssl: version `5.8.2~1`. The new version number will _not_ comply with [Semantic Versioning](https://semver.org/). (note that's a tilde between the 2 and 1, not a minus sign). See instead the [Espressif Versioning Documentation](https://docs.espressif.com/projects/idf-component-manager/en/latest/reference/versioning.html). The tilde is used for a version _revision_.



Fixes zd# n/a

# Testing

How did you test?

Manually confirmed all examples still build properly.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
