### PR TITLE
escaped 'tag' characters in markdown files

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ NOTE: * wolfSSL is now GPLv3 instead of GPLv2
             * MD5 is now disabled by default
 
 
-PR stands for Pull Request, and PR <NUMBER> references a GitHub pull request number where the code change was added.
+PR stands for Pull Request, and PR \<NUMBER> references a GitHub pull request number where the code change was added.
 
 ## Vulnerabilities
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ NOTE: * wolfSSL is now GPLv3 instead of GPLv2
             * MD5 is now disabled by default
 
 
-PR stands for Pull Request, and PR <NUMBER> references a GitHub pull request number where the code change was added.
+PR stands for Pull Request, and PR \<NUMBER> references a GitHub pull request number where the code change was added.
 
 ## Vulnerabilities
 


### PR DESCRIPTION
# Description
Revealing some not-displayed text in `README.md`
More explanations (which references this pr#) sent to `support@wolfssl.com`

# Testing

irrelevant

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ x] updated appropriate READMEs
 - [ ] Updated manual and documentation
