### PR TITLE
SSL_read_ex() ... will return 1 for success or 0 for failure

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3368,7 +3368,7 @@ int wolfSSL_read(WOLFSSL* ssl, void* data, int sz)
 }
 
 
-/* returns 0 on failure and on no read */
+/* returns 0 on failure and 1 on read */
 int wolfSSL_read_ex(WOLFSSL* ssl, void* data, size_t sz, size_t* rd)
 {
     int ret;
@@ -3388,8 +3388,7 @@ int wolfSSL_read_ex(WOLFSSL* ssl, void* data, size_t sz, size_t* rd)
         *rd = (size_t)ret;
     }
 
-    if (ret <= 0) ret = 0;
-    return ret;
+    return ret > 0 ? 1 : 0;
 }
 
 #ifdef WOLFSSL_MULTICAST


### PR DESCRIPTION
# Description

`wolfSSL_read_ex()` was returning bytes read instead of success/failure.

see [man page for SSL_read_ex](https://manpages.ubuntu.com/manpages/lunar/man3/SSL_read_ex.3ssl.html) for compatible behaviour

# Testing

without this change:
```
$ ./tests/unit.test 2>&1 |grep wolfSSL_read_ex -B1 -A1
ERROR - tests/api.c line 9470 failed with:
    expected: wolfSSL_read_ex(ssl_s, buf, sizeof(buf), &count) == WOLFSSL_SUCCESS
    result:   5 != 1
```
with this change
```
$ ./tests/unit.test 2>&1 |grep wolfSSL_read_ex -B1 -A1
[no output]
```

note the relevant test (`tests/api.c:test_wolfSSL_read_write_ex()`) fails but force returns `TEST_SUCCESS`