### PR TITLE
20250825-linuxkm-IntelRDseed64_r-burn-buf

### DIFF
--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -323,6 +323,7 @@ static WC_INLINE int IntelRDseed64_r(word64* rnd)
         WC_SANITIZE_DISABLE();
         *rnd ^= buf; /* deliberately retain any garbage passed in the dest buffer. */
         WC_SANITIZE_ENABLE();
+        buf = 0;
     }
     return 0;
 }


### PR DESCRIPTION
`linuxkm/module_hooks.c`: in `IntelRDseed64_r()`, burn `buf` after each use to protect against info leakage.

tested with `wolfssl-multi-test.sh ... check-source-text`
