### PR TITLE
20250826-more-wc_linuxkm_normalize_relocations

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -653,14 +653,7 @@
         #error "compiling -fPIE requires PIE redirect table."
     #endif
 
-    #ifdef USE_WOLFSSL_LINUXKM_PIE_REDIRECT_TABLE
-
-#ifdef CONFIG_MIPS
-    #undef __ARCH_MEMCMP_NO_REDIRECT
-    #undef memcmp
-    extern int memcmp(const void *s1, const void *s2, size_t n);
-#endif
-
+    #ifdef HAVE_LINUXKM_PIE_SUPPORT
     extern const u8
         __wc_text_start[],
         __wc_text_end[],
@@ -677,6 +670,15 @@
         size_t text_in_len,
         u8 *text_out,
         ssize_t *cur_index_p);
+    #endif /* HAVE_LINUXKM_PIE_SUPPORT */
+
+    #ifdef USE_WOLFSSL_LINUXKM_PIE_REDIRECT_TABLE
+
+#ifdef CONFIG_MIPS
+    #undef __ARCH_MEMCMP_NO_REDIRECT
+    #undef memcmp
+    extern int memcmp(const void *s1, const void *s2, size_t n);
+#endif
 
     struct wolfssl_linuxkm_pie_redirect_table {
         typeof(wc_linuxkm_normalize_relocations) *wc_linuxkm_normalize_relocations;


### PR DESCRIPTION
`linuxkm/module_hooks.c`: in `wc_linuxkm_normalize_relocations()`, allow non-text
  relocations 1 byte outside the destination segment, and when
  `DEBUG_LINUXKM_PIE_SUPPORT`, tally the relocation counts by segment for final info
  report;

`linuxkm/module_hooks.c` and `linuxkm/linuxkm_wc_port.h`: tweak gating on
  `wc_linuxkm_normalize_relocations()` and related -- ifdef
  `HAVE_LINUXKM_PIE_SUPPORT`, not ifdef `USE_WOLFSSL_LINUXKM_PIE_REDIRECT_TABLE` --
  for consistency+clarity.

tested with
```
wolfssl-multi-test.sh ... 
check-source-text
linuxkm-aescbc-cryptonly-noasm-fips-v5-strict-dyn-hash-LKCAPI-yes-twc-insmod
quantum-safe-wolfssl-all-crypto-only-intelasm-fips-dev-linuxkm-next-insmod
```

fixes
```
[    1.520340] found non-wolfcrypt relocation at text offset 0x2a1fd to addr 0xc049b01f, text=c03fd000-c044d000, rodata=c047a180-c0489180, rwdata=c049b020-c049c020, bss=c04a13c0-c04a23c0
```
in `linuxkm-aescbc-cryptonly-noasm-fips-v5-strict-dyn-hash-LKCAPI-yes-twc-insmod`.
