### PR TITLE
Fix documentation typo for wc_ed25519_export_public.

### DIFF
--- a/doc/dox_comments/header_files/ed25519.h
+++ b/doc/dox_comments/header_files/ed25519.h
@@ -767,7 +767,7 @@ int wc_ed25519_import_private_key_ex(const byte* priv, word32 privSz,
 /*!
     \ingroup ED25519
 
-    \brief This function exports the private key from an ed25519_key
+    \brief This function exports the public key from an ed25519_key
     structure. It stores the public key in the buffer out, and sets the bytes
     written to this buffer in outLen.
 


### PR DESCRIPTION
# Description

Fixes #8354

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [X] Updated manual and documentation
