### PR TITLE
Fix workflow for latest ESP-IDF for espressif examples

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/template/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/template/CMakeLists.txt
@@ -7,6 +7,19 @@ message(STATUS "Begin project ${CMAKE_PROJECT_NAME}")
 
 cmake_minimum_required(VERSION 3.16)
 
+# For the main project using ESP-IDF version 6 or greater.
+# Numerous "dangerous relocation: call8: call target out of range: memcpy" errors encountered
+# So we'll allow long calls with the `-mlongcalls` compiler option for all components.
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET STREQUAL "esp32s3")
+        message(STATUS "Adding mlongcalls")
+        add_compile_options(-mlongcalls)
+        add_link_options(-mlongcalls)
+        set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -mlongcalls")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mlongcalls")
+    endif()
+endif()
+
 # Optional no watchdog typically used for test & benchmark
 if (idf_target STREQUAL "esp8266" OR IDF_TARGET STREQUAL "esp8266" OR IDF_VERSION_MAJOR VERSION_LESS "5.0")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_ESP_NO_WATCHDOG=1")
@@ -143,6 +156,16 @@ if(0)
 endif()
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# Once the project is loaded, next check for ESP-IDF version 6 or greater.
+# Numerous "dangerous relocation: call8: call target out of range: memcpy" errors encountered
+# So we'll allow long calls with the `-mlongcalls` compiler option for all components.
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET STREQUAL "esp32s3")
+        message(STATUS "mlongcalls for all components")
+        idf_build_set_property(COMPILE_OPTIONS "-mlongcalls" APPEND)
+    endif()
+endif()
 
 project(wolfssl_template)
 message(STATUS "end project")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/CMakeLists.txt
@@ -7,6 +7,19 @@ message(STATUS "Begin project ${CMAKE_PROJECT_NAME}")
 
 cmake_minimum_required(VERSION 3.16)
 
+# For the main project using ESP-IDF version 6 or greater.
+# Numerous "dangerous relocation: call8: call target out of range: memcpy" errors encountered
+# So we'll allow long calls with the `-mlongcalls` compiler option for all components.
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET STREQUAL "esp32s3")
+        message(STATUS "Adding mlongcalls")
+        add_compile_options(-mlongcalls)
+        add_link_options(-mlongcalls)
+        set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -mlongcalls")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mlongcalls")
+    endif()
+endif()
+
 # Optional no watchdog typically used for test & benchmark
 if (idf_target STREQUAL "esp8266" OR IDF_TARGET STREQUAL "esp8266" OR IDF_VERSION_MAJOR VERSION_LESS "5.0")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_ESP_NO_WATCHDOG=1")
@@ -143,6 +156,16 @@ if(0)
 endif()
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# Once the project is loaded, next check for ESP-IDF version 6 or greater.
+# Numerous "dangerous relocation: call8: call target out of range: memcpy" errors encountered
+# So we'll allow long calls with the `-mlongcalls` compiler option for all components.
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET STREQUAL "esp32s3")
+        message(STATUS "mlongcalls for all components")
+        idf_build_set_property(COMPILE_OPTIONS "-mlongcalls" APPEND)
+    endif()
+endif()
 
 project(wolfssl_benchmark)
 message(STATUS "end project")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/CMakeLists.txt
@@ -7,6 +7,19 @@ message(STATUS "Begin project ${CMAKE_PROJECT_NAME}")
 
 cmake_minimum_required(VERSION 3.16)
 
+# For the main project using ESP-IDF version 6 or greater.
+# Numerous "dangerous relocation: call8: call target out of range: memcpy" errors encountered
+# So we'll allow long calls with the `-mlongcalls` compiler option for all components.
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET STREQUAL "esp32s3")
+        message(STATUS "Adding mlongcalls")
+        add_compile_options(-mlongcalls)
+        add_link_options(-mlongcalls)
+        set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -mlongcalls")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mlongcalls")
+    endif()
+endif()
+
 # Optional no watchdog typically used for test & benchmark
 if (idf_target STREQUAL "esp8266" OR IDF_TARGET STREQUAL "esp8266" OR IDF_VERSION_MAJOR VERSION_LESS "5.0")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_ESP_NO_WATCHDOG=1")
@@ -143,6 +156,16 @@ if(0)
 endif()
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# Once the project is loaded, next check for ESP-IDF version 6 or greater.
+# Numerous "dangerous relocation: call8: call target out of range: memcpy" errors encountered
+# So we'll allow long calls with the `-mlongcalls` compiler option for all components.
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET STREQUAL "esp32s3")
+        message(STATUS "mlongcalls for all components")
+        idf_build_set_property(COMPILE_OPTIONS "-mlongcalls" APPEND)
+    endif()
+endif()
 
 project(wolfssl_client)
 message(STATUS "end project")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/CMakeLists.txt
@@ -7,6 +7,19 @@ message(STATUS "Begin project ${CMAKE_PROJECT_NAME}")
 
 cmake_minimum_required(VERSION 3.16)
 
+# For the main project using ESP-IDF version 6 or greater.
+# Numerous "dangerous relocation: call8: call target out of range: memcpy" errors encountered
+# So we'll allow long calls with the `-mlongcalls` compiler option for all components.
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET STREQUAL "esp32s3")
+        message(STATUS "Adding mlongcalls")
+        add_compile_options(-mlongcalls)
+        add_link_options(-mlongcalls)
+        set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -mlongcalls")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mlongcalls")
+    endif()
+endif()
+
 # Optional no watchdog typically used for test & benchmark
 if (idf_target STREQUAL "esp8266" OR IDF_TARGET STREQUAL "esp8266" OR IDF_VERSION_MAJOR VERSION_LESS "5.0")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_ESP_NO_WATCHDOG=1")
@@ -143,6 +156,16 @@ if(0)
 endif()
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# Once the project is loaded, next check for ESP-IDF version 6 or greater.
+# Numerous "dangerous relocation: call8: call target out of range: memcpy" errors encountered
+# So we'll allow long calls with the `-mlongcalls` compiler option for all components.
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET STREQUAL "esp32s3")
+        message(STATUS "mlongcalls for all components")
+        idf_build_set_property(COMPILE_OPTIONS "-mlongcalls" APPEND)
+    endif()
+endif()
 
 project(wolfssl_server)
 message(STATUS "end project")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/CMakeLists.txt
@@ -7,6 +7,19 @@ message(STATUS "Begin project ${CMAKE_PROJECT_NAME}")
 
 cmake_minimum_required(VERSION 3.16)
 
+# For the main project using ESP-IDF version 6 or greater.
+# Numerous "dangerous relocation: call8: call target out of range: memcpy" errors encountered
+# So we'll allow long calls with the `-mlongcalls` compiler option for all components.
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET STREQUAL "esp32s3")
+        message(STATUS "Adding mlongcalls")
+        add_compile_options(-mlongcalls)
+        add_link_options(-mlongcalls)
+        set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -mlongcalls")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mlongcalls")
+    endif()
+endif()
+
 # Optional no watchdog typically used for test & benchmark
 if (idf_target STREQUAL "esp8266" OR IDF_TARGET STREQUAL "esp8266" OR IDF_VERSION_MAJOR VERSION_LESS "5.0")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_ESP_NO_WATCHDOG=1")
@@ -143,6 +156,16 @@ if(0)
 endif()
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# Once the project is loaded, next check for ESP-IDF version 6 or greater.
+# Numerous "dangerous relocation: call8: call target out of range: memcpy" errors encountered
+# So we'll allow long calls with the `-mlongcalls` compiler option for all components.
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET STREQUAL "esp32s3")
+        message(STATUS "mlongcalls for all components")
+        idf_build_set_property(COMPILE_OPTIONS "-mlongcalls" APPEND)
+    endif()
+endif()
 
 project(wolfssl_test)
 message(STATUS "end project")

--- a/wolfcrypt/src/port/Espressif/esp_sdk_mem_lib.c
+++ b/wolfcrypt/src/port/Espressif/esp_sdk_mem_lib.c
@@ -119,6 +119,9 @@ extern wc_ptr_t _heap_end[];
 #define IRAMF2_START      ((void*)(0x4010C000))
 #define IRAMF2_END        ((void*)(0x4010C000 + 0x4000))
 
+#if defined(ESP_IDF_VERSION) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+    /* Skipping for ESP-IDF v6.0 */
+#else
 enum sdk_memory_segment
 {
     /* Ensure this list exactly matches order in sdk_memory_segment_text */
@@ -187,10 +190,14 @@ int sdk_log_meminfo(enum sdk_memory_segment m, void* start, void* end)
     }
     return ESP_OK;
 }
+#endif
 
 /* Show all known linker memory segment names, starting & ending addresses. */
 int sdk_init_meminfo(void)
 {
+#if defined(ESP_IDF_VERSION) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+    ESP_LOGI(TAG, "sdk_init_meminfo not available for ESP-IDF V6.0");
+#else
     void* sample_heap_var;
     int sample_stack_var = 0;
 
@@ -238,6 +245,7 @@ int sdk_init_meminfo(void)
         sdk_var_whereis("sample_heap_var", sample_heap_var);
         free(sample_heap_var);
     }
+#endif
     return ESP_OK;
 }
 
@@ -245,6 +253,9 @@ int sdk_init_meminfo(void)
 esp_err_t sdk_var_whereis(const char* v_name, void* v)
 {
     esp_err_t ret = ESP_FAIL;
+#if defined(ESP_IDF_VERSION) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
+    ESP_LOGI(TAG, "sdk_var_whereis not available for ESP-IDF V6.0");
+#else
 
     for (enum sdk_memory_segment m = 0 ;m < SDK_MEMORY_SEGMENT_COUNT; m++) {
         if (v >= sdk_memory_segment_start[m] &&
@@ -257,6 +268,7 @@ esp_err_t sdk_var_whereis(const char* v_name, void* v)
                 }
             }
     }
+#endif
 
     if (ret == ESP_FAIL) {
         ESP_LOGW(TAG, "%s not found in known memory map: %p", v_name, v);


### PR DESCRIPTION
# Description

The Espressif examples began failing today in [GitHub workflow](https://github.com/wolfSSL/wolfssl/blob/master/.github/workflows/docker-Espressif.yml) with the "docker latest" image. (un-released ESP-IDF v6.0, latest stable is [v5.5](https://github.com/espressif/esp-idf/releases/tag/v5.5))

The core compiler problem was some diagnostic memory tools. As a brute-force solution to get workflow working again, I've simply disabled the features for ESP-IDF v6.0 in the  `esp_sdk_mem_lib.c` file.

Unexpected, and not reproduced locally - was a massive number of linker errors:

```
dangerous relocation: call8: call target out of range: memset
```
 ... as [seen](https://github.com/gojimmypi/wolfssl/actions/runs/17249795425/job/48948886517#step:4:16765) in one of the prior workflows. This was resolved with conditional CMake criteria for only the Xtensa devices and only on the ESP-IDF v6.0 using a `-mlongcalls` compiler options: once for the main application, and then again for all components.

Fixes zd# n/a

# Testing

See my https://github.com/gojimmypi/wolfssl/actions/workflows/docker-Espressif.yml

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
