### PR TITLE
ForceZero change for WOLFSSL_CHECK_MEM_ZERO

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -59,6 +59,7 @@ jobs:
           '--enable-lms=small,verify-only --enable-xmss=small,verify-only',
           '--disable-sys-ca-certs',
           '--enable-all CPPFLAGS=-DWOLFSSL_DEBUG_CERTS ',
+          '--enable-all CFLAGS="-DWOLFSSL_CHECK_MEM_ZERO"',
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/src/internal.c
+++ b/src/internal.c
@@ -11004,7 +11004,7 @@ void ShrinkInputBuffer(WOLFSSL* ssl, int forcedFree)
     }
 
     ForceZero(ssl->buffers.inputBuffer.buffer,
-        ssl->buffers.inputBuffer.length);
+        ssl->buffers.inputBuffer.bufferSize);
     XFREE(ssl->buffers.inputBuffer.buffer - ssl->buffers.inputBuffer.offset,
           ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
     ssl->buffers.inputBuffer.buffer = ssl->buffers.inputBuffer.staticBuffer;

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -302,7 +302,9 @@ void wc_MemZero_Check(void* addr, size_t len)
                 fprintf(stderr, "\n[MEM_ZERO] %s:%p + %ld is not zero\n",
                     memZero[i].name, memZero[i].addr, j);
                 fprintf(stderr, "[MEM_ZERO] Checking %p:%ld\n", addr, len);
+            #ifndef TEST_ALWAYS_RUN_TO_END
                 abort();
+            #endif
             }
         }
         /* Update next index to write to. */

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -212,7 +212,7 @@ static wolfSSL_Mutex zeroMutex WOLFSSL_MUTEX_INITIALIZER_CLAUSE(zeroMutex);
 
 /* Initialize the table of addresses and the mutex.
  */
-void wc_MemZero_Init()
+void wc_MemZero_Init(void)
 {
     /* Clear the table to more easily see what is valid. */
     XMEMSET(memZero, 0, sizeof(memZero));
@@ -226,7 +226,7 @@ void wc_MemZero_Init()
 
 /* Free the mutex and check we have not any uncheck addresses.
  */
-void wc_MemZero_Free()
+void wc_MemZero_Free(void)
 {
     /* Free mutex. */
 #ifndef WOLFSSL_MUTEX_INITIALIZER


### PR DESCRIPTION
# Description

Changes call to `ForceZero()` in `ShrinkInputBuffer()` to use `bufferSize` instead of `length`. Allows call to `wc_MemZero_Check()` in `XFREE()` to run without aborting early.

Adds macro guard to prevent aborting early if `TEST_ALWAYS_RUN_TO_END` is defined.

Adds configuration `--enable-all CFLAGS="-DWOLFSSL_CHECK_MEM_ZERO"` to `os-check.yml`

Fixes Github issue  #9128 

# Testing

```
./configure --enable-all CFLAGS="-DWOLFSSL_CHECK_MEM_ZERO" && make
make check

# single test, number retrieved from ./tests/unit.text --list
./tests/unit.test -1157
```


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
