### PR TITLE
20250829-_mlkem_decompress_5_avx2-movzwq

### DIFF
--- a/wolfcrypt/src/wc_mlkem_asm.S
+++ b/wolfcrypt/src/wc_mlkem_asm.S
@@ -15780,7 +15780,7 @@ _mlkem_decompress_5_avx2:
         vpmulhrsw	%ymm1, %ymm0, %ymm0
         vmovdqu	%ymm0, 448(%rdi)
         vmovq	150(%rsi), %xmm0
-        movzxw	158(%rsi), %rdx
+        movzwq	158(%rsi), %rdx
         vpinsrq	$0x01, %rdx, %xmm0, %xmm0
         vinserti128	$0x01, %xmm0, %ymm0, %ymm0
         vpshufb	%ymm2, %ymm0, %ymm0


### PR DESCRIPTION
`wolfcrypt/src/wc_mlkem_asm.S`: in `_mlkem_decompress_5_avx2`, use `movzwq`, not `movzxw`, for portability.

tested with `wolfssl-multi-test.sh ... check-source-text-fips-dev quantum-safe-wolfssl-all-clang-tidy quantum-safe-wolfssl-all-gcc-latest`

merge with https://github.com/wolfSSL/scripts/pull/506
