### PR TITLE
Update Renesas FSP version on RA6M4

### DIFF
--- a/IDE/Renesas/e2studio/RA6M4/test/.cproject
+++ b/IDE/Renesas/e2studio/RA6M4/test/.cproject
@@ -87,6 +87,7 @@
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.std.1084991557" name="Language standard" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.std" useByScannerDiscovery="true" value="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.std.c99" valueType="enumerated"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths.2023903025" name="Include paths (-I)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths" useByScannerDiscovery="true" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/key_data}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/Debug}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/../common&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/../../../../../&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/src}&quot;"/>

--- a/IDE/Renesas/e2studio/RA6M4/test/src/test_main.c
+++ b/IDE/Renesas/e2studio/RA6M4/test/src/test_main.c
@@ -50,19 +50,6 @@ void abort(void);
  int sce_crypt_test();
 #endif
 
-void R_BSP_WarmStart(bsp_warm_start_event_t event);
-
-/* the function is called just before main() to set up pins */
-/* this needs to be called to setup IO Port */
-void R_BSP_WarmStart (bsp_warm_start_event_t event)
-{
-
-    if (BSP_WARM_START_POST_C == event) {
-        /* C runtime environment and system clocks are setup. */
-        /* Configure pins. */
-        R_IOPORT_Open(&g_ioport_ctrl, g_ioport.p_cfg);
-    }
-}
 
 #if defined(TLS_CLIENT)
 


### PR DESCRIPTION
# Description

Periodically FSP version update for RA (RA6M4)
FSP version is now v6.1.0 which is the latest as of 2025.08.30

# Testing

Run RA6M4 example including wolfCrypt, benchmark and TLS client

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
