### PR TITLE
Provide default method to get the error string

### DIFF
--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -366,6 +366,7 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define SSL_CTX_set_quiet_shutdown      wolfSSL_CTX_set_quiet_shutdown
 #define SSL_set_quiet_shutdown          wolfSSL_set_quiet_shutdown
 #define SSL_get_error                   wolfSSL_get_error
+#define SSL_strerror                    wolfSSL_ERR_reason_error_string
 #define SSL_set_session                 wolfSSL_set_session
 #define SSL_get_session(x)              wolfSSL_get_session((WOLFSSL*) (x))
 #define SSL_SESSION_get0_peer           wolfSSL_SESSION_get0_peer


### PR DESCRIPTION
# Description

Since no method is provided through the defines on ssl.h, I think this might be important both for traceability and for compatibility to provide an interface similar to what GNUTLS offers.

Fixes zd#

# Testing

No testing is needed to add one define

# Checklist

 - [ X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation

Since it is my first time, is there some pointer to some documentation that tells me how to properly perform the above actions? It is just a one-line change, but maybe something needs to be updated