### PR TITLE
Pin Watcom compiler in workflow to 2025-09-01-Build

### DIFF
--- a/.github/workflows/watcomc.yml
+++ b/.github/workflows/watcomc.yml
@@ -62,6 +62,9 @@ jobs:
         uses: open-watcom/setup-watcom@v0
         with:
           version: ${{ matrix.platform.owimage }}
+          tag: 2025-09-01-Build
+          # Currently fixed to this build because of latest compiler error:
+          # file clbrdll.lib(fltuse80): undefined symbol _SetLD80bit_
 
       - name: Checkout wolfSSL
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Pins the Watcom compiler in the  `.github/workflows/watcomc.yml` to the `2025-09-01-Build`.

Note that although the build may be called "2025-09-01 Build", the dash is still needed before "build" even if the entire string is quoted.

Otherwise we're seeing this `undefined symbol _SetLD80bit_` error:

```
Open Watcom Linker Version 2.0 beta Sep  5 2025 02:22:18 (32-bit)
Copyright (c) 2002-2025 The Open Watcom Contributors. All Rights Reserved.
Portions Copyright (c) 1985-2002 Sybase, Inc. All Rights Reserved.
Source code is available under the Sybase Open Watcom Public License.
See https://github.com/open-watcom/open-watcom-v2#readme for details.
loading object files
searching libraries
Error! E2028: _SetLD80bit_ is an undefined reference
creating map file
creating an OS/2 32-bit dynamic link library
file clbrdll.lib(fltuse80): undefined symbol _SetLD80bit_
Error(E42): Last command making (wolfssl.dll) returned a bad status
Error(E02): Make execution terminated
Error(E42): Last command making (CMakeFiles\wolfssl.dir\all) returned a bad status
Error(E02): Make execution terminated
Error(E42): Last command making (all) returned a bad status
Error(E02): Make execution terminated
```

Fixes zd# n/a

# Testing

How did you test?

Manually tested in my dev branch only.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
