### PR TITLE
20250905-linuxkm-pie-cst32

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -217,6 +217,7 @@ endif
 	    --rename-section .rodata.str1.1=.rodata.wolfcrypt	\
 	    --rename-section .rodata.str1.8=.rodata.wolfcrypt	\
 	    --rename-section .rodata.cst16=.rodata.wolfcrypt	\
+	    --rename-section .rodata.cst32=.rodata.wolfcrypt	\
 	    --rename-section .data=.data.wolfcrypt		\
 	    --rename-section .data.rel.local=.data.wolfcrypt    \
 	    --rename-section .bss=.bss.wolfcrypt "$$file" || exit $$?


### PR DESCRIPTION
`linuxkm/Kbuild`: for PIE containerization, add `.rodata.cst32` to the move list.

tested with
```
wolfssl-multi-test.sh ...
linuxkm-mainline-plus-wireguard
linuxkm-mainline-aesni-pie-gcc-latest-insmod
linuxkm-crypto-fuzzer-aesni-pie-no-WC_C_DYNAMIC_FALLBACK-gcc-latest-insmod
linuxkm-mainline-intelasm-sp-asm-pie-gcc-latest-insmod
pr-check
```
with mainline kernel 6.17-rc4 (which exposed the issue)
