### PR TITLE
20250908-WOLFSSL_TEXT_SEGMENT_CANONICALIZER

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -665,6 +665,13 @@
     #endif
 
     #ifdef HAVE_LINUXKM_PIE_SUPPORT
+
+    #ifndef WOLFSSL_TEXT_SEGMENT_CANONICALIZER
+        #define WOLFSSL_TEXT_SEGMENT_CANONICALIZER(text_in, text_in_len, text_out, cur_index_p) \
+            wc_linuxkm_normalize_relocations(text_in, text_in_len, text_out, cur_index_p)
+        #define WOLFSSL_TEXT_SEGMENT_CANONICALIZER_BUFSIZ 8192
+    #endif
+
     extern const u8
         __wc_text_start[],
         __wc_text_end[],


### PR DESCRIPTION
`linuxkm/linuxkm_wc_port.h`: when `HAVE_LINUXKM_PIE_SUPPORT`, map
  `WOLFSSL_TEXT_SEGMENT_CANONICALIZER()` to `wc_linuxkm_normalize_relocations()`, and
  define `WOLFSSL_TEXT_SEGMENT_CANONICALIZER_BUFSIZ` to `8192`.

`linuxkm/module_hooks.c`: in `wc_linuxkm_normalize_relocations()`, add checks for
  out-of-order offsets.

tested with
```
FIPS_DEV_BRANCH=local:master wolfssl-multi-test.sh ... --test-uncommitted ...
check-source-text-fips-dev
linuxkm-fips-v5-vanilla-insmod-wolfguard-cust3
linuxkm-fips-v6-insmod-wolfguard-cust3
quantum-safe-wolfssl-all-crypto-only-intelasm-fips-dev-linuxkm-next-insmod
linuxkm-fips-dev-insmod-wolfguard
```

with the ad-hoc FIPS v5 and v6 patches in wolfssl-multi-test.sh updated with https://github.com/wolfSSL/fips/pull/353.
