### PR TITLE
initialize values used by unsigned bin

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -18077,6 +18077,9 @@ int sp_read_unsigned_bin(sp_int* a, const byte* in, word32 inSz)
             a->dp[j++] = *(sp_int_digit*)(in + i - (SP_WORD_SIZEOF - 1));
         }
     #else
+        for (i = 0; i < (int)a->used; i++) {
+            a->dp[i] = 0;
+        }
         /* Construct digit from required number of bytes. */
         for (i = (int)(inSz-1); i >= SP_WORD_SIZEOF - 1; i -= SP_WORD_SIZEOF) {
             a->dp[j]  = ((sp_int_digit)in[i - 0] <<  0)


### PR DESCRIPTION
# Description

Adds loop to initialize `a->dp[i]` to 0 in `sp_read_unsigned_bin()` for `a->used`.

# Testing

`./configure && make check`

