### PR TITLE
curl: support --enable-curl=tiny option.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8185,6 +8185,14 @@ then
         ENABLED_TICKET_NONCE_MALLOC="yes"
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_TICKET_NONCE_MALLOC"
     fi
+elif test "$ENABLED_CURL" = "tiny"
+then
+    if test "x$ENABLED_OPENSSLEXTRA" = "xno"
+    then
+        ENABLED_OPENSSLEXTRA="x509small"
+    fi
+
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_CURL"
 fi
 
 if test "$ENABLED_PSK" = "no" && test "$ENABLED_LEANPSK" = "no" \

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -6529,7 +6529,7 @@ static const byte kTlsServerStr[SIZEOF_SENDER+1] = { 0x53, 0x52, 0x56, 0x52, 0x0
 static const byte kTlsClientFinStr[FINISHED_LABEL_SZ + 1] = "client finished";
 static const byte kTlsServerFinStr[FINISHED_LABEL_SZ + 1] = "server finished";
 
-#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || defined(HAVE_CURL)
 typedef struct {
     int name_len;
     const char *name;
@@ -6539,7 +6539,7 @@ typedef struct {
 extern const WOLF_EC_NIST_NAME kNistCurves[];
 WOLFSSL_LOCAL int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx,
         const char* names, byte curves_only);
-#endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
+#endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL || HAVE_CURL */
 
 /* internal functions */
 WOLFSSL_LOCAL int SendChangeCipher(WOLFSSL* ssl);


### PR DESCRIPTION
## Description

A tiny change that allows wolfSSL x509 small + HAVE_CURL to support tiny-curl-8.4.0 default build. 

## Testing

Build wolfssl with:

```
./configure --enable-curl=tiny && make && sudo make install
```

Build tiny-curl-8.4.0 with:
```
./configure --with-wolfssl && make
```

Result of tiny-curl `make test` with wolfssl --enable-curl=tiny:
```
test 3201...OK (1291 out of 1291, remaining: 00:00, took 1.071s, duration: 37:26)
TESTDONE: 1646 tests were considered during 2247 seconds.
TESTDONE: 1189 tests out of 1193 reported OK: 99%

TESTFAIL: These test cases failed: 1119 1165 1167 1474
```
The same with normal wolfssl --enable-curl on master:
```
test 3201...OK (1407 out of 1407, remaining: 00:00, took 1.074s, duration: 38:01)
TESTDONE: 1646 tests were considered during 2282 seconds.
TESTDONE: 1303 tests out of 1307 reported OK: 99%

TESTFAIL: These test cases failed: 1119 1165 1167 1474 
```