### PR TITLE
20250911-linuxkm-dont-undefine-CONFIG_OBJTOOL

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -130,8 +130,9 @@ ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
     $(obj)/linuxkm/module_hooks.o: ccflags-y += $(PIE_SUPPORT_FLAGS)
     # using inline retpolines leads to "unannotated intra-function call"
     # warnings from objtool without this:
-    undefine CONFIG_OBJTOOL
-    $(WOLFCRYPT_PIE_FILES): OBJECT_FILES_NON_STANDARD := y
+    ifneq "$(CONFIG_MITIGATION_RETPOLINE)$(CONFIG_MITIGATION_RETHUNK)" ""
+        $(WOLFCRYPT_PIE_FILES): OBJECT_FILES_NON_STANDARD := y
+    endif
 endif
 
 ifdef KERNEL_EXTRA_CFLAGS_REMOVE


### PR DESCRIPTION
`linuxkm/Kbuild`: don't `undefine CONFIG_OBJTOOL` (breaks FIPS hash stability on some target kernels/configs);

add config-based gate on `$(WOLFCRYPT_PIE_FILES): OBJECT_FILES_NON_STANDARD := y`.

tested with
```
wolfssl-multi-test.sh ...
check-source-text-fips-dev
linuxkm-fips-v5-strict-dist-insmod-cust2
linuxkm-fips-v5-vanilla-dist-insmod-cust3
```
