### PR TITLE
20250910-linuxkm-even-more-OBJECT_FILES_NON_STANDARD

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -130,9 +130,7 @@ ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
     $(obj)/linuxkm/module_hooks.o: ccflags-y += $(PIE_SUPPORT_FLAGS)
     # using inline retpolines leads to "unannotated intra-function call"
     # warnings from objtool without this:
-    ifneq "$(CONFIG_MITIGATION_RETPOLINE)$(CONFIG_MITIGATION_RETHUNK)" ""
-        $(WOLFCRYPT_PIE_FILES): OBJECT_FILES_NON_STANDARD := y
-    endif
+    $(WOLFCRYPT_PIE_FILES): OBJECT_FILES_NON_STANDARD := y
 endif
 
 ifdef KERNEL_EXTRA_CFLAGS_REMOVE


### PR DESCRIPTION
`linuxkm/Kbuild`: when `ENABLED_LINUXKM_PIE`, always set `$(WOLFCRYPT_PIE_FILES): OBJECT_FILES_NON_STANDARD := y`, as before.  completes reversion of 04834680d5.

tested with
```
wolfssl-multi-test.sh ...
linuxkm-fips-v6-dist-insmod-cust4
linuxkm-fips-v6-dist-insmod-cust1
linuxkm-fips-v6-dist-insmod-cust5
```
