### PR TITLE
Fix: Avoids hostap checkout on cache hit

### DIFF
--- a/.github/workflows/hostap-vm.yml
+++ b/.github/workflows/hostap-vm.yml
@@ -79,6 +79,7 @@ jobs:
           lookup-only: true
 
       - name: Checkout hostap
+        if: steps.cache.outputs.cache-hit != 'true'
         run: git clone git://w1.fi/hostap.git hostap
 
   build_uml_linux:


### PR DESCRIPTION
This change prevents the hostap repository from being cloned
unnecessarily when the cache is hit, improving workflow efficiency.
