### PR TITLE
Add SM3 in wolfSSL_HmacCopy

### DIFF
--- a/src/ssl_crypto.c
+++ b/src/ssl_crypto.c
@@ -1606,6 +1606,20 @@ int wolfSSL_HmacCopy(Hmac* dst, Hmac* src)
     #endif /* WOLFSSL_NO_SHA3_512 */
 #endif /* WOLFSSL_SHA3 */
 
+    #ifdef WOLFSSL_SM3
+        case WC_SM3:
+            rc = wc_Sm3Copy(&src->hash.sm3, &dst->hash.sm3);
+        #ifdef WOLFSSL_HMAC_COPY_HASH
+            if (rc == 0) {
+                rc = wc_Sm3Copy(&src->i_hash.sm3, &dst->i_hash.sm3);
+            }
+            if (rc == 0) {
+                rc = wc_Sm3Copy(&src->o_hash.sm3, &dst->o_hash.sm3);
+            }
+        #endif
+            break;
+    #endif /* WOLFSSL_SM3 */
+
         default:
             /* Digest algorithm not supported. */
             rc = BAD_FUNC_ARG;


### PR DESCRIPTION
# Description

The SM3 algorithm is missing in the `wolfSSL_HmacCopy` functionality. This causes #9187.

# Testing

I didn't find any tests for `wolfSSL_HmacCopy` so I only did a manual verification with the reproducer that I had for #9187. The output of the SM3 HMAC matches the one that I get [with this online calculator](https://www.lddgo.net/en/encrypt/hmac).

Let me know if I should add automatic testing or documentation.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
