### PR TITLE
Fix Coverity issue with WOLFSSL_GENERAL_ALIGNMENT

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -11114,7 +11114,7 @@ static WC_INLINE int GrowAnOutputBuffer(WOLFSSL* ssl,
     bufferStatic* outputBuffer, int size)
 {
     byte* tmp;
-#if WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     byte  hdrSz = ssl->options.dtls ? DTLS_RECORD_HEADER_SZ :
                                       RECORD_HEADER_SZ;
     byte align = WOLFSSL_GENERAL_ALIGNMENT;
@@ -11122,7 +11122,7 @@ static WC_INLINE int GrowAnOutputBuffer(WOLFSSL* ssl,
     const byte align = WOLFSSL_GENERAL_ALIGNMENT;
 #endif
 
-#if WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     /* the encrypted data will be offset from the front of the buffer by
        the header, if the user wants encrypted alignment they need
        to define their alignment requirement */
@@ -11138,7 +11138,7 @@ static WC_INLINE int GrowAnOutputBuffer(WOLFSSL* ssl,
     if (tmp == NULL)
         return MEMORY_E;
 
-#if WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     if (align)
         tmp += align - hdrSz;
 #endif
@@ -11159,7 +11159,7 @@ static WC_INLINE int GrowAnOutputBuffer(WOLFSSL* ssl,
               DYNAMIC_TYPE_OUT_BUFFER);
     }
 
-#if WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     if (align)
         outputBuffer->offset = align - hdrSz;
     else
@@ -11185,7 +11185,7 @@ byte* GetOutputBuffer(WOLFSSL* ssl)
 static WC_INLINE int GrowOutputBuffer(WOLFSSL* ssl, int size)
 {
     byte* tmp;
-#if WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     byte  hdrSz = ssl->options.dtls ? DTLS_RECORD_HEADER_SZ :
                                       RECORD_HEADER_SZ;
     byte align = WOLFSSL_GENERAL_ALIGNMENT;
@@ -11194,7 +11194,7 @@ static WC_INLINE int GrowOutputBuffer(WOLFSSL* ssl, int size)
 #endif
     word32 newSz = 0;
 
-#if WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     /* the encrypted data will be offset from the front of the buffer by
        the header, if the user wants encrypted alignment they need
        to define their alignment requirement */
@@ -11219,7 +11219,7 @@ static WC_INLINE int GrowOutputBuffer(WOLFSSL* ssl, int size)
     if (tmp == NULL)
         return MEMORY_E;
 
-#if WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     if (align)
         tmp += align - hdrSz;
 #endif
@@ -11245,7 +11245,7 @@ static WC_INLINE int GrowOutputBuffer(WOLFSSL* ssl, int size)
     }
     ssl->buffers.outputBuffer.dynamicFlag = 1;
 
-#if WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     if (align)
         ssl->buffers.outputBuffer.offset = align - hdrSz;
     else
@@ -11262,14 +11262,14 @@ static WC_INLINE int GrowOutputBuffer(WOLFSSL* ssl, int size)
 int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength)
 {
     byte* tmp;
-#if defined(WOLFSSL_DTLS) || WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     byte  align = ssl->options.dtls ? WOLFSSL_GENERAL_ALIGNMENT : 0;
     byte  hdrSz = DTLS_RECORD_HEADER_SZ;
 #else
     const byte align = WOLFSSL_GENERAL_ALIGNMENT;
 #endif
 
-#if defined(WOLFSSL_DTLS) || WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     /* the encrypted data will be offset from the front of the buffer by
        the dtls record header, if the user wants encrypted alignment they need
        to define their alignment requirement. in tls we read record header
@@ -11293,7 +11293,7 @@ int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength)
     if (tmp == NULL)
         return MEMORY_E;
 
-#if defined(WOLFSSL_DTLS) || WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     if (align)
         tmp += align - hdrSz;
 #endif
@@ -11322,7 +11322,7 @@ int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength)
     }
 
     ssl->buffers.inputBuffer.dynamicFlag = 1;
-#if defined(WOLFSSL_DTLS) || WOLFSSL_GENERAL_ALIGNMENT > 0
+#if defined(WOLFSSL_DTLS) || (WOLFSSL_GENERAL_ALIGNMENT > 0)
     if (align)
         ssl->buffers.inputBuffer.offset = align - hdrSz;
     else


### PR DESCRIPTION
# Description

Customer's Coverity report indicated dead code in `GrowOutputBuffer` due to a check of `align` after checking `WOLFSSL_GENERAL_ALIGNMENT > 0`

```
#if WOLFSSL_GENERAL_ALIGNMENT > 0
    if (align)
```

This should follow the pattern in other places, where DTLS is checked also:
```
#if defined(WOLFSSL_DTLS) || WOLFSSL_GENERAL_ALIGNMENT > 0
    if (align)
```

Fixes zd20515

# Testing

Coverity confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
