### PR TITLE
address undefined shift behavior and overflow

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -27553,6 +27553,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t scrypt_test(void)
         return WC_TEST_RET_ENC_EC(ret);
     if (XMEMCMP(derived, verify4, sizeof(verify4)) != 0)
         return WC_TEST_RET_ENC_NC;
+
+    ret = wc_scrypt(derived,(byte*)"pleaseletmein", 13,
+                    (byte*)"SodiumChloride", 14, 22, 8, 1, sizeof(derived));
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        return WC_TEST_RET_ENC_EC(ret);
 #endif
 #else
 #ifdef SCRYPT_TEST_ALL


### PR DESCRIPTION
# Description

address undefined shift behavior and overflow in `pwdbased.c`. Cast `1 << cost * bSz` to avoid 32-bit overflow. Reject parameter combinations where (1 << cost) * bSz would exceed SCRYPT_WORD32_MAX.

Add test case for `cost = 22` and `blockSize = 8`

address zd#20508
Shoutout to Luigino Camastra, Aisle Research for the report. Thank you!

# Testing

`./configure --enable-scrypt --enable-opensslextra && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
