### PR TITLE
Remove missing workflow strategy, run only for wolfssl owner

### DIFF
--- a/.github/workflows/macos-apple-native-cert-validation.yml
+++ b/.github/workflows/macos-apple-native-cert-validation.yml
@@ -14,8 +14,7 @@ concurrency:
 
 jobs:
   make_check:
-    strategy:
-      fail-fast: false
+    if: github.repository_owner == 'wolfssl'
     runs-on: macos-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 5


### PR DESCRIPTION
# Description

Added standard `if: github.repository_owner == 'wolfssl'` that is used in other workflows.

While there, noticed this warning, so removed the strategy keyword since there's no matrix:

<img width="973" height="189" alt="image" src="https://github.com/user-attachments/assets/8d151469-3528-491d-aab2-9275c83f7089" />


Fixes zd#

# Testing

How did you test?

Since the repo owner restriction was changed, this test only runs by default in the wolfssl repo.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
