### PR TITLE
Change test order: random_test after SHA tests

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1706,13 +1706,6 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
         TEST_PASS("asn      test passed!\n");
 #endif
 
-#ifndef WC_NO_RNG
-    if ( (ret = random_test()) != 0)
-        TEST_FAIL("RANDOM   test failed!\n", ret);
-    else
-        TEST_PASS("RANDOM   test passed!\n");
-#endif /* WC_NO_RNG */
-
 #ifndef NO_MD5
     if ( (ret = md5_test()) != 0)
         TEST_FAIL("MD5      test failed!\n", ret);
@@ -1796,6 +1789,13 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
     else
         TEST_PASS("SHA-3    test passed!\n");
 #endif
+
+#ifndef WC_NO_RNG
+    if ((ret = random_test()) != 0)
+        TEST_FAIL("RANDOM   test failed!\n", ret);
+    else
+        TEST_PASS("RANDOM   test passed!\n");
+#endif /* WC_NO_RNG */
 
 #ifdef WOLFSSL_SHAKE128
     if ( (ret = shake128_test()) != 0)


### PR DESCRIPTION
# Description

The wolfcrypt random number function use SHA. This PR moves the `random_test()` after the SHA tests.

Otherwise, where there's a SHA failure (e.g. hardware accelerators), the random number test failure reason is not intuitive.

Fixes zd#

# Testing

```
./autogen.sh
./configure --enable-all
make
./wolfcrypt/test/testwolfcrypt
```

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
