### PR TITLE
Check for NO_THREAD_LS before assigning THREAD_LS_T

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -423,7 +423,7 @@ enum {
 #endif
 
 /* set up thread local storage if available */
-#ifdef HAVE_THREAD_LS
+#if defined(HAVE_THREAD_LS) && !defined(NO_THREAD_LS)
     #if defined(_MSC_VER) || defined(__WATCOMC__)
         #define THREAD_LS_T __declspec(thread)
     /* Thread local storage only in FreeRTOS v8.2.1 and higher */


### PR DESCRIPTION
# Description

FIPS uses NO_THREAD_LS to disable the feature, while wolfSSL configure by default sets `--enable-threadlocal`, which defines `HAVE_THREAD_LS`, which is checked in `settings.h` and then defines `THREAD_LS_T`.

Fixes zd20520

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
