### PR TITLE
Add support for certificate_authorities extension in ClientHello

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -15323,7 +15323,7 @@ void wolfSSL_set_client_CA_list(WOLFSSL* ssl,
 /*!
     \ingroup TLS
     \brief On the server, this retrieves the list previously set via
-    wolfSSL_set_client_CA_list. If none was set, returns the list previosusly
+    wolfSSL_set_client_CA_list. If none was set, returns the list previously
     set via wolfSSL_CTX_set_client_CA_list. If no list at all was set, returns
     NULL.
 
@@ -15426,7 +15426,7 @@ void wolfSSL_set0_CA_list(WOLFSSL *ssl,
 /*!
     \ingroup TLS
     \brief This retrieves the list previously set via wolfSSL_set0_CA_list. If
-    none was set, returns the list previosusly set via
+    none was set, returns the list previously set via
     wolfSSL_CTX_set0_CA_list. If no list at all was set, returns NULL.
 
     \param [in] ssl Pointer to the WOLFSSL object

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -15259,6 +15259,239 @@ const unsigned char* wolfSSL_dtls_cid_parse(const unsigned char* msg,
 
 /*!
     \ingroup TLS
+    \brief On the server, this sets a list of CA names to be sent to clients in
+    certificate requests as a hint for which CA's are supported by the server.
+
+    On the client, this function has no effect.
+
+    \param [in] ctx Pointer to the wolfSSL context
+    \param [in] names List of names to be set
+
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+void wolfSSL_CTX_set_client_CA_list(WOLFSSL_CTX* ctx,
+                                    WOLF_STACK_OF(WOLFSSL_X509_NAME)* names);
+
+/*!
+    \ingroup TLS
+    \brief This retrieves the list previously set via
+     wolfSSL_CTX_set_client_CA_list, or NULL if no list has been set.
+
+    \param [in] ctx Pointer to the wolfSSL context
+    \return A stack of WOLFSSL_X509_NAMEs containing the CA names
+
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+WOLFSSL_STACK *wolfSSL_CTX_get_client_CA_list(
+        const WOLFSSL_CTX *ctx);
+
+/*!
+    \ingroup TLS
+    \brief Same as wolfSSL_CTX_set_client_CA_list, but specific to a session.
+    If a CA list is set on both the context and the session, the list on the
+    session is used.
+
+    \param [in] ssl Pointer to the WOLFSSL object
+    \param [in] names List of names to be set.
+
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+void wolfSSL_set_client_CA_list(WOLFSSL* ssl,
+                                    WOLF_STACK_OF(WOLFSSL_X509_NAME)* names);
+
+/*!
+    \ingroup TLS
+    \brief On the server, this retrieves the list previously set via
+    wolfSSL_set_client_CA_list. If none was set, returns the list previosusly
+    set via wolfSSL_CTX_set_client_CA_list. If no list at all was set, returns
+    NULL.
+
+    On the client, this retrieves the list that was received from the server,
+    or NULL if none was received. wolfSSL_CTX_set_cert_cb can be used to
+    register a callback to dynamically load certificates when a certificate
+    request is received from the server.
+
+    \param [in] ssl Pointer to the WOLFSSL object
+    \return A stack of WOLFSSL_X509_NAMEs containing the CA names
+
+    \sa wolfSSL_CTX_set_cert_cb
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+WOLFSSL_STACK* wolfSSL_get_client_CA_list(
+            const WOLFSSL* ssl);
+
+/*!
+    \ingroup TLS
+    \brief This function sets a list of CA names to be sent to the peer as a
+    hint for which CA's are supported for its authentication.
+
+    In TLS >= 1.3, this is supported in both directions between the client and
+    the server. On the server, the CA names will be sent as part of a
+    CertificateRequest, making this function an equivalent of *_set_client_CA_list;
+    on the client, these are sent as part of ClientHello.
+
+    In TLS < 1.3, sending CA names from the client to the server is not
+    supported, therefore this function is equivalent to
+    wolfSSL_CTX_set_client_CA_list.
+
+    Note that the lists set via *_set_client_CA_list and *_set0_CA_list are
+    separate internally, i.e. calling *_get_client_CA_list will not retrieve a
+    list set via *_set0_CA_list and vice versa. If both are set, the server will
+    ignore *_set0_CA_list when sending CA names to the client.
+
+    \param [in] ctx Pointer to the wolfSSL context
+    \param [in] names List of names to be set
+
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+void wolfSSL_CTX_set0_CA_list(WOLFSSL_CTX *ctx,
+        WOLF_STACK_OF(WOLFSSL_X509_NAME)* names);
+
+/*!
+    \ingroup TLS
+    \brief This retrieves the list previously set via
+    wolfSSL_CTX_set0_CA_list, or NULL if no list has been set.
+
+    \param [in] ctx Pointer to the wolfSSL context
+    \return A stack of WOLFSSL_X509_NAMEs containing the CA names
+
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+WOLFSSL_STACK *wolfSSL_CTX_get0_CA_list(
+        const WOLFSSL_CTX *ctx);
+
+/*!
+    \ingroup TLS
+    \brief Same as wolfSSL_CTX_set0_CA_list, but specific to a session.
+    If a CA list is set on both the context and the session, the list on the
+    session is used.
+
+    \param [in] ssl Pointer to the WOLFSSL object
+    \param [in] names List of names to be set.
+
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+void wolfSSL_set0_CA_list(WOLFSSL *ssl,
+        WOLF_STACK_OF(WOLFSSL_X509_NAME) *names);
+
+/*!
+    \ingroup TLS
+    \brief This retrieves the list previously set via wolfSSL_set0_CA_list. If
+    none was set, returns the list previosusly set via
+    wolfSSL_CTX_set0_CA_list. If no list at all was set, returns NULL.
+
+    \param [in] ssl Pointer to the WOLFSSL object
+    \return A stack of WOLFSSL_X509_NAMEs containing the CA names
+
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+WOLFSSL_STACK *wolfSSL_get0_CA_list(
+        const WOLFSSL *ssl);
+
+/*!
+    \ingroup TLS
+    \brief This returns the CA list received from the peer.
+
+    On the client, this is the list sent by the server in a CertificateRequest,
+    and this function is equivalent to wolfSSL_get_client_CA_list.
+
+    On the server, this is the list sent by the client in the ClientHello message
+    in TLS >= 1.3; in TLS < 1.3, the function always returns NULL on the server
+    side.
+
+    wolfSSL_CTX_set_cert_cb can be used to register a callback to dynamically
+    load certificates when a CA list is received from the peer.
+
+    \param [in] ssl Pointer to the WOLFSSL object
+    \return A stack of WOLFSSL_X509_NAMEs containing the CA names
+
+    \sa wolfSSL_CTX_set_cert_cb
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+*/
+WOLFSSL_STACK *wolfSSL_get0_peer_CA_list(const WOLFSSL *ssl);
+
+/*!
+    \ingroup TLS
+    \brief This function sets a callback that will be called whenever a
+    certificate is about to be used, to allow the application to inspect, set
+    or clear any certificates, for example to react to a CA list sent from the
+    peer.
+
+    \param [in] ctx Pointer to the wolfSSL context
+    \param [in] cb Function pointer to the callback
+    \param [in] arg Pointer that will be passed to the callback
+
+    \sa wolfSSL_get0_peer_CA_list
+    \sa wolfSSL_get_client_CA_list
+*/
+void wolfSSL_CTX_set_cert_cb(WOLFSSL_CTX* ctx,
+    int (*cb)(WOLFSSL *, void *), void *arg);
+
+/*!
+    \ingroup TLS
 
     \brief This function returns the raw list of ciphersuites and signature
     algorithms offered by the client. The lists are only stored and returned

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12529,8 +12529,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         return ctx->client_ca_names;
     }
 
-    /* On server side: returns the CA's set via *_set_client_CA_list();
-     * On client side: returns the CA's received from server -- same as
+    /* On server side: returns the CAs set via *_set_client_CA_list();
+     * On client side: returns the CAs received from server -- same as
      * wolfSSL_get0_peer_CA_list() */
     WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_get_client_CA_list(
             const WOLFSSL* ssl)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12276,7 +12276,28 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             ssl->client_ca_names = names;
         }
     }
-#endif
+
+    void wolfSSL_CTX_set0_CA_list(WOLFSSL_CTX* ctx,
+                                  WOLF_STACK_OF(WOLFSSL_X509_NAME)* names)
+    {
+        WOLFSSL_ENTER("wolfSSL_CTX_set0_CA_list");
+        if (ctx != NULL) {
+            wolfSSL_sk_X509_NAME_pop_free(ctx->ca_names, NULL);
+            ctx->ca_names = names;
+        }
+    }
+
+    void wolfSSL_set0_CA_list(WOLFSSL* ssl,
+                              WOLF_STACK_OF(WOLFSSL_X509_NAME)* names)
+    {
+        WOLFSSL_ENTER("wolfSSL_set0_CA_list");
+        if (ssl != NULL) {
+            if (ssl->ca_names != ssl->ctx->ca_names)
+                wolfSSL_sk_X509_NAME_pop_free(ssl->ca_names, NULL);
+            ssl->ca_names = names;
+        }
+    }
+#endif /* WOLFSSL_NO_CA_NAMES */
 
 #ifdef OPENSSL_EXTRA
     /* registers client cert callback, called during handshake if server
@@ -12508,8 +12529,9 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         return ctx->client_ca_names;
     }
 
-    /* returns the CA's set on server side or the CA's sent from server when
-     * on client side */
+    /* On server side: returns the CA's set via *_set_client_CA_list();
+     * On client side: returns the CA's received from server -- same as
+     * wolfSSL_get0_peer_CA_list() */
     WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_get_client_CA_list(
             const WOLFSSL* ssl)
     {
@@ -12520,28 +12542,56 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             return NULL;
         }
 
+        if (ssl->options.side == WOLFSSL_CLIENT_END)
+            return ssl->peer_ca_names;
+        else
+            return SSL_CLIENT_CA_NAMES(ssl);
+    }
+
+    WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_CTX_get0_CA_list(
+            const WOLFSSL_CTX *ctx)
+    {
+        WOLFSSL_ENTER("wolfSSL_CTX_get0_CA_list");
+
+        if (ctx == NULL) {
+            WOLFSSL_MSG("Bad argument passed to wolfSSL_CTX_get0_CA_list");
+            return NULL;
+        }
+
+        return ctx->ca_names;
+    }
+
+    /* Always returns the CA's set via *_set0_CA_list */
+    WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_get0_CA_list(const WOLFSSL *ssl)
+    {
+        WOLFSSL_ENTER("wolfSSL_get0_CA_list");
+
+        if (ssl == NULL) {
+            WOLFSSL_MSG("Bad argument passed to wolfSSL_get0_CA_list");
+            return NULL;
+        }
+
         return SSL_CA_NAMES(ssl);
     }
 
+    /* Always returns the CA's received from the peer */
+    WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_get0_peer_CA_list(
+            const WOLFSSL* ssl)
+    {
+        WOLFSSL_ENTER("wolfSSL_get0_peer_CA_list");
+
+        if (ssl == NULL) {
+            WOLFSSL_MSG("Bad argument passed to wolfSSL_get0_peer_CA_list");
+            return NULL;
+        }
+
+        return ssl->peer_ca_names;
+    }
+
     #if !defined(NO_CERTS)
-    int wolfSSL_CTX_add_client_CA(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
+    static int add_to_CA_list(WOLFSSL_STACK* ca_names, WOLFSSL_X509* x509)
     {
         WOLFSSL_X509_NAME *nameCopy = NULL;
-
-        WOLFSSL_ENTER("wolfSSL_CTX_add_client_CA");
-
-        if (ctx == NULL || x509 == NULL){
-            WOLFSSL_MSG("Bad argument");
-            return WOLFSSL_FAILURE;
-        }
-
-        if (ctx->client_ca_names == NULL) {
-            ctx->client_ca_names = wolfSSL_sk_X509_NAME_new(NULL);
-            if (ctx->client_ca_names == NULL) {
-                WOLFSSL_MSG("wolfSSL_sk_X509_NAME_new error");
-                return WOLFSSL_FAILURE;
-            }
-        }
 
         nameCopy = wolfSSL_X509_NAME_dup(wolfSSL_X509_get_subject_name(x509));
         if (nameCopy == NULL) {
@@ -12549,7 +12599,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             return WOLFSSL_FAILURE;
         }
 
-        if (wolfSSL_sk_X509_NAME_push(ctx->client_ca_names, nameCopy) <= 0) {
+        if (wolfSSL_sk_X509_NAME_push(ca_names, nameCopy) <= 0) {
             WOLFSSL_MSG("wolfSSL_sk_X509_NAME_push error");
             wolfSSL_X509_NAME_free(nameCopy);
             return WOLFSSL_FAILURE;
@@ -12557,7 +12607,75 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
         return WOLFSSL_SUCCESS;
     }
-    #endif
+
+    int wolfSSL_CTX_add_client_CA(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
+    {
+        WOLFSSL_ENTER("wolfSSL_CTX_add_client_CA");
+        if (ctx == NULL || x509 == NULL) {
+            WOLFSSL_MSG("Bad argument");
+            return WOLFSSL_FAILURE;
+        }
+        if (ctx->client_ca_names == NULL) {
+            ctx->client_ca_names = wolfSSL_sk_X509_NAME_new(NULL);
+            if (ctx->client_ca_names == NULL) {
+                WOLFSSL_MSG("wolfSSL_sk_X509_NAME_new error");
+                return WOLFSSL_FAILURE;
+            }
+        }
+        return add_to_CA_list(ctx->client_ca_names, x509);
+    }
+
+    int wolfSSL_add_client_CA(WOLFSSL* ssl, WOLFSSL_X509* x509)
+    {
+        WOLFSSL_ENTER("wolfSSL_add_client_CA");
+        if (ssl == NULL || x509 == NULL) {
+            WOLFSSL_MSG("Bad argument");
+            return WOLFSSL_FAILURE;
+        }
+        if (SSL_CLIENT_CA_NAMES(ssl) == NULL) {
+            ssl->client_ca_names = wolfSSL_sk_X509_NAME_new(NULL);
+            if (ssl->client_ca_names == NULL) {
+                WOLFSSL_MSG("wolfSSL_sk_X509_NAME_new error");
+                return WOLFSSL_FAILURE;
+            }
+        }
+        return add_to_CA_list(SSL_CLIENT_CA_NAMES(ssl), x509);
+    }
+
+    int wolfSSL_CTX_add1_to_CA_list(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
+    {
+        WOLFSSL_ENTER("wolfSSL_CTX_add1_to_CA_list");
+        if (ctx == NULL || x509 == NULL) {
+            WOLFSSL_MSG("Bad argument");
+            return WOLFSSL_FAILURE;
+        }
+        if (ctx->ca_names == NULL) {
+            ctx->ca_names = wolfSSL_sk_X509_NAME_new(NULL);
+            if (ctx->ca_names == NULL) {
+                WOLFSSL_MSG("wolfSSL_sk_X509_NAME_new error");
+                return WOLFSSL_FAILURE;
+            }
+        }
+        return add_to_CA_list(ctx->ca_names, x509);
+    }
+
+    int wolfSSL_add1_to_CA_list(WOLFSSL* ssl, WOLFSSL_X509* x509)
+    {
+        WOLFSSL_ENTER("wolfSSL_add1_to_CA_list");
+        if (ssl == NULL || x509 == NULL) {
+            WOLFSSL_MSG("Bad argument");
+            return WOLFSSL_FAILURE;
+        }
+        if (SSL_CA_NAMES(ssl) == NULL) {
+            ssl->ca_names = wolfSSL_sk_X509_NAME_new(NULL);
+            if (ssl->ca_names == NULL) {
+                WOLFSSL_MSG("wolfSSL_sk_X509_NAME_new error");
+                return WOLFSSL_FAILURE;
+            }
+        }
+        return add_to_CA_list(SSL_CA_NAMES(ssl), x509);
+    }
+    #endif /* !NO_CERTS */
 
     #ifndef NO_BIO
         #if !defined(NO_RSA) && !defined(NO_CERTS)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12632,14 +12632,14 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             WOLFSSL_MSG("Bad argument");
             return WOLFSSL_FAILURE;
         }
-        if (SSL_CLIENT_CA_NAMES(ssl) == NULL) {
+        if (ssl->client_ca_names == NULL) {
             ssl->client_ca_names = wolfSSL_sk_X509_NAME_new(NULL);
             if (ssl->client_ca_names == NULL) {
                 WOLFSSL_MSG("wolfSSL_sk_X509_NAME_new error");
                 return WOLFSSL_FAILURE;
             }
         }
-        return add_to_CA_list(SSL_CLIENT_CA_NAMES(ssl), x509);
+        return add_to_CA_list(ssl->client_ca_names, x509);
     }
 
     int wolfSSL_CTX_add1_to_CA_list(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
@@ -12666,14 +12666,14 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             WOLFSSL_MSG("Bad argument");
             return WOLFSSL_FAILURE;
         }
-        if (SSL_CA_NAMES(ssl) == NULL) {
+        if (ssl->ca_names == NULL) {
             ssl->ca_names = wolfSSL_sk_X509_NAME_new(NULL);
             if (ssl->ca_names == NULL) {
                 WOLFSSL_MSG("wolfSSL_sk_X509_NAME_new error");
                 return WOLFSSL_FAILURE;
             }
         }
-        return add_to_CA_list(SSL_CA_NAMES(ssl), x509);
+        return add_to_CA_list(ssl->ca_names, x509);
     }
     #endif /* !NO_CERTS */
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -14717,7 +14717,8 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
 #endif
 #ifdef WOLFSSL_TLS13
     #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CA_NAMES)
-        if (IsAtLeastTLSv1_3(ssl->version)) {
+        if (IsAtLeastTLSv1_3(ssl->version) &&
+                SSL_PRIORITY_CA_NAMES(ssl) != NULL) {
             WOLFSSL_MSG("Adding certificate authorities extension");
             if ((ret = TLSX_Push(&ssl->extensions,
                     TLSX_CERTIFICATE_AUTHORITIES, ssl, ssl->heap)) != 0) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5765,11 +5765,6 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
     if (ssl->toInfoOn) AddLateName("CertificateRequest", &ssl->timeoutInfo);
 #endif
 
-#ifdef OPENSSL_EXTRA
-    if ((ret = CertSetupCbWrapper(ssl)) != 0)
-        return ret;
-#endif
-
     if (OPAQUE8_LEN > size)
         return BUFFER_ERROR;
 
@@ -5813,6 +5808,11 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
         return ret;
     }
     *inOutIdx += len;
+
+#ifdef OPENSSL_EXTRA
+    if ((ret = CertSetupCbWrapper(ssl)) != 0)
+        return ret;
+#endif
 
     if ((ssl->buffers.certificate && ssl->buffers.certificate->buffer &&
         ((ssl->buffers.key && ssl->buffers.key->buffer)

--- a/tests/api.c
+++ b/tests/api.c
@@ -51074,6 +51074,8 @@ TEST_DECL(test_wc_RsaPSS_DigitalSignVerify),
 #endif
     TEST_DECL(test_tls_ems_downgrade),
     TEST_DECL(test_wolfSSL_DisableExtendedMasterSecret),
+    TEST_DECL(test_certificate_authorities_certificate_request),
+    TEST_DECL(test_certificate_authorities_client_hello),
     TEST_DECL(test_wolfSSL_wolfSSL_UseSecureRenegotiation),
     TEST_DECL(test_wolfSSL_SCR_Reconnect),
     TEST_DECL(test_tls_ext_duplicate),

--- a/tests/api/test_tls_ext.c
+++ b/tests/api/test_tls_ext.c
@@ -194,6 +194,12 @@ int test_certificate_authorities_certificate_request(void) {
         WOLF_STACK_OF(X509_NAME) *names1 = NULL, *names2 = NULL;
         X509_NAME *name = NULL;
         struct client_cb_arg cb_arg = { NULL, NULL };
+        const char *expected_names[] = {
+            "/C=US/ST=Montana/L=Bozeman/O=wolfSSL_2048/OU=Programming-2048"
+                "/CN=www.wolfssl.com/emailAddress=info@wolfssl.com",
+            "/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting"
+                "/CN=www.wolfssl.com/emailAddress=info@wolfssl.com"
+        };
 
         if (EXPECT_FAIL())
             break;
@@ -278,9 +284,9 @@ int test_certificate_authorities_certificate_request(void) {
 
         if (EXPECT_SUCCESS()) {
             ExpectStrEQ(wolfSSL_sk_X509_NAME_value(cb_arg.names1, 0)->name,
-                    wolfSSL_sk_X509_NAME_value(names1, 0)->name);
+                    expected_names[0]);
             ExpectStrEQ(wolfSSL_sk_X509_NAME_value(cb_arg.names1, 1)->name,
-                    wolfSSL_sk_X509_NAME_value(names1, 1)->name);
+                    expected_names[1]);
         }
 
         wolfSSL_shutdown(ssl_cli);
@@ -343,6 +349,12 @@ int test_certificate_authorities_client_hello(void) {
         WOLF_STACK_OF(X509_NAME) *cb_arg = NULL;
         WOLF_STACK_OF(X509_NAME) *names1 = NULL, *names2 = NULL;
         X509_NAME *name = NULL;
+        const char *expected_names[] = {
+            "/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting"
+                "/CN=www.wolfssl.com/emailAddress=info@wolfssl.com",
+            "/C=US/ST=Montana/L=Bozeman/O=wolfSSL_2048/OU=Programming-2048"
+                "/CN=www.wolfssl.com/emailAddress=info@wolfssl.com"
+        };
 
         if (EXPECT_FAIL())
             break;
@@ -380,9 +392,9 @@ int test_certificate_authorities_client_hello(void) {
 
         if (EXPECT_SUCCESS()) {
             ExpectStrEQ(wolfSSL_sk_X509_NAME_value(cb_arg, 0)->name,
-                    wolfSSL_sk_X509_NAME_value(names1, 0)->name);
+                    expected_names[0]);
             ExpectStrEQ(wolfSSL_sk_X509_NAME_value(cb_arg, 1)->name,
-                    wolfSSL_sk_X509_NAME_value(names1, 1)->name);
+                    expected_names[1]);
         }
 
         wolfSSL_shutdown(ssl_cli);

--- a/tests/api/test_tls_ext.c
+++ b/tests/api/test_tls_ext.c
@@ -127,3 +127,305 @@ int test_wolfSSL_DisableExtendedMasterSecret(void)
 #endif
     return EXPECT_RESULT();
 }
+
+
+struct client_cb_arg {
+    WOLF_STACK_OF(X509_NAME) *names1;
+    WOLF_STACK_OF(X509_NAME) *names2;
+};
+
+static int certificate_authorities_client_cb(WOLFSSL *ssl, void *_arg) {
+    struct client_cb_arg *arg = (struct client_cb_arg *)_arg;
+    arg->names1 = wolfSSL_get_client_CA_list(ssl);
+    arg->names2 = wolfSSL_get0_peer_CA_list(ssl);
+
+    if (!wolfSSL_use_certificate_file(ssl, cliCertFile, SSL_FILETYPE_PEM))
+        return 0;
+    if (!wolfSSL_use_PrivateKey_file(ssl, cliKeyFile, SSL_FILETYPE_PEM))
+        return 0;
+    return 1;
+}
+
+int test_certificate_authorities_certificate_request(void) {
+    EXPECT_DECLS;
+#if !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(WOLFSSL_NO_CA_NAMES) && !defined(NO_BIO) && \
+    !defined(NO_CERTS) && (defined(OPENSSL_EXTRA) || \
+            defined(OPENSSL_EXTRA_SMALL))
+    struct test_params {
+        method_provider client_meth;
+        method_provider server_meth;
+        int             doUdp;
+    } params[] = {
+#ifdef WOLFSSL_TLS13
+        /* TLS 1.3 uses certificate_authorities extension */
+        {wolfTLSv1_3_client_method, wolfTLSv1_3_server_method, 0},
+#endif
+#ifndef WOLFSSL_NO_TLS12
+        /* TLS 1.2 directly embeds CA names in CertificateRequest */
+        {wolfTLSv1_2_client_method, wolfTLSv1_2_server_method, 0},
+#endif
+#ifdef WOLFSSL_DTLS13
+        {wolfDTLSv1_3_client_method, wolfDTLSv1_3_server_method, 1},
+#endif
+#ifdef WOLFSSL_DTLS
+        {wolfDTLSv1_2_client_method, wolfDTLSv1_2_server_method, 1},
+#endif
+    };
+    size_t i;
+
+    for (i = 0; i < sizeof(params) / sizeof(*params); i++) {
+        WOLFSSL_CTX *ctx;
+        WOLFSSL *ssl;
+        WOLF_STACK_OF(X509_NAME) *names1 = NULL, *names2 = NULL;
+        X509_NAME *name;
+
+        ExpectNotNull(ctx = wolfSSL_CTX_new(params[i].server_meth()));
+
+        names1 = wolfSSL_load_client_CA_file(cliCertFile);
+        ExpectNotNull(names1);
+        names2 = wolfSSL_load_client_CA_file(caCertFile);
+        ExpectNotNull(names2);
+        ExpectNotNull(name = wolfSSL_sk_X509_NAME_value(names2, 0));
+        ExpectIntEQ(2, wolfSSL_sk_X509_NAME_push(names1, name));
+        if (EXPECT_FAIL()) {
+            wolfSSL_X509_NAME_free(name);
+            name = NULL;
+        }
+        names2 = wolfSSL_load_client_CA_file(caCertFile);
+        ExpectNotNull(names2);
+
+        /* Check that client_CA_list and CA_list are separate internally */
+        wolfSSL_CTX_set_client_CA_list(ctx, names1);
+        wolfSSL_CTX_set0_CA_list(ctx, names2);
+        ExpectNotNull(names1 = wolfSSL_CTX_get_client_CA_list(ctx));
+        ExpectNotNull(names2 = wolfSSL_CTX_get0_CA_list(ctx));
+        ExpectIntEQ(2, wolfSSL_sk_X509_NAME_num(names1));
+        ExpectIntEQ(1, wolfSSL_sk_X509_NAME_num(names2));
+
+        /* Create ssl */
+        ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+                    SSL_FILETYPE_PEM));
+        ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+                    SSL_FILETYPE_PEM));
+        ExpectNotNull(ssl = wolfSSL_new(ctx));
+
+        /* Check that get_client_CA_list and get0_CA_list on ssl return same as
+         * ctx when not set */
+        ExpectNotNull(names1 = wolfSSL_get_client_CA_list(ssl));
+        ExpectNotNull(names2 = wolfSSL_get0_CA_list(ssl));
+        ExpectIntEQ(2, wolfSSL_sk_X509_NAME_num(names1));
+        ExpectIntEQ(1, wolfSSL_sk_X509_NAME_num(names2));
+
+        /* Same checks as before, but on ssl rather than ctx */
+        names1 = wolfSSL_load_client_CA_file(cliCertFile);
+        ExpectNotNull(names1);
+        names2 = wolfSSL_load_client_CA_file(caCertFile);
+        ExpectNotNull(names2);
+        ExpectNotNull(name = wolfSSL_sk_X509_NAME_value(names2, 0));
+        ExpectIntEQ(2, wolfSSL_sk_X509_NAME_push(names1, name));
+        if (EXPECT_FAIL()) {
+            wolfSSL_X509_NAME_free(name);
+            name = NULL;
+        }
+        names2 = wolfSSL_load_client_CA_file(caCertFile);
+        ExpectNotNull(names2);
+
+        wolfSSL_set_client_CA_list(ssl, names1);
+        wolfSSL_set0_CA_list(ssl, names2);
+        ExpectNotNull(names1 = wolfSSL_get_client_CA_list(ssl));
+        ExpectNotNull(names2 = wolfSSL_get0_CA_list(ssl));
+        ExpectIntEQ(2, wolfSSL_sk_X509_NAME_num(names1));
+        ExpectIntEQ(1, wolfSSL_sk_X509_NAME_num(names2));
+
+#if !defined(SINGLE_THREADED) && defined(SESSION_CERTS)
+        {
+            tcp_ready ready;
+            func_args server_args;
+            callback_functions server_cb;
+            THREAD_TYPE server_thread;
+            WOLFSSL *ssl_client = NULL;
+            WOLFSSL_CTX *ctx_client = NULL;
+            SOCKET_T sockfd = 0;
+            struct client_cb_arg client_cb_arg = { NULL, NULL };
+
+            StartTCP();
+            InitTcpReady(&ready);
+            XMEMSET(&server_args, 0, sizeof(func_args));
+            XMEMSET(&server_cb, 0, sizeof(callback_functions));
+
+            server_args.signal = &ready;
+            server_args.callbacks = &server_cb;
+
+            server_cb.ctx = ctx;
+            server_cb.isSharedCtx = 1;
+            server_cb.doUdp = params[i].doUdp;
+
+            ExpectIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_load_verify_locations(ctx,
+                        cliCertFile, NULL));
+
+            start_thread(test_server_nofail, &server_args, &server_thread);
+            wait_tcp_ready(&server_args);
+
+            tcp_connect(&sockfd, wolfSSLIP, server_args.signal->port,
+                    params[i].doUdp, 0, NULL);
+            if (params[i].doUdp)
+                udp_connect(&sockfd, wolfSSLIP, server_args.signal->port);
+
+            ExpectNotNull(ctx_client = wolfSSL_CTX_new(
+                        params[i].client_meth()));
+            ExpectIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_load_verify_locations(
+                        ctx_client, caCertFile, NULL));
+            /* Certs will be loaded in callback */
+            wolfSSL_CTX_set_cert_cb(ctx_client,
+                    certificate_authorities_client_cb, &client_cb_arg);
+
+            ExpectNotNull(ssl_client = wolfSSL_new(ctx_client));
+            ExpectIntEQ(WOLFSSL_SUCCESS, wolfSSL_set_fd(ssl_client, sockfd));
+            ExpectIntEQ(WOLFSSL_SUCCESS, wolfSSL_connect(ssl_client));
+
+            ExpectNotNull(client_cb_arg.names1);
+            ExpectNotNull(client_cb_arg.names2);
+            ExpectIntEQ(2, wolfSSL_sk_X509_NAME_num(client_cb_arg.names1));
+            ExpectIntEQ(2, wolfSSL_sk_X509_NAME_num(client_cb_arg.names2));
+
+            wolfSSL_shutdown(ssl_client);
+            wolfSSL_free(ssl_client);
+            wolfSSL_CTX_free(ctx_client);
+
+            CloseSocket(sockfd);
+
+            join_thread(server_thread);
+            FreeTcpReady(&ready);
+        }
+#endif
+        wolfSSL_free(ssl);
+        wolfSSL_CTX_free(ctx);
+    }
+#endif
+    return EXPECT_RESULT();
+}
+
+
+static int certificate_authorities_server_cb(WOLFSSL *ssl, void *_arg) {
+    int *names_num = (int *)_arg;
+    WOLF_STACK_OF(X509_NAME) *names = wolfSSL_get0_peer_CA_list(ssl);
+    *names_num = wolfSSL_sk_X509_NAME_num(names);
+    if (!wolfSSL_use_certificate_file(ssl, svrCertFile, SSL_FILETYPE_PEM))
+        return 0;
+    if (!wolfSSL_use_PrivateKey_file(ssl, svrKeyFile, SSL_FILETYPE_PEM))
+        return 0;
+    return 1;
+}
+
+int test_certificate_authorities_client_hello(void) {
+    EXPECT_DECLS;
+#if !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(WOLFSSL_NO_CA_NAMES) && !defined(NO_BIO) && \
+    !defined(NO_CERTS) && (defined(OPENSSL_EXTRA) || \
+            defined(OPENSSL_EXTRA_SMALL))
+
+    struct test_params {
+        method_provider client_meth;
+        method_provider server_meth;
+        int             doUdp;
+    } params[] = {
+    /* TLS >= 1.3 only */
+#ifdef WOLFSSL_TLS13
+        {wolfTLSv1_3_client_method, wolfTLSv1_3_server_method, 0},
+#endif
+#ifdef WOLFSSL_DTLS13
+        {wolfDTLSv1_3_client_method, wolfDTLSv1_3_server_method, 1},
+#endif
+    };
+    size_t i;
+
+    for (i = 0; i < sizeof(params) / sizeof(*params); i++) {
+        WOLFSSL_CTX *ctx;
+        int server_cb_arg;
+
+        ExpectNotNull(ctx = wolfSSL_CTX_new(params[i].server_meth()));
+        wolfSSL_CTX_set_cert_cb(ctx, certificate_authorities_server_cb,
+                &server_cb_arg);
+
+#if !defined(SINGLE_THREADED) && defined(SESSION_CERTS)
+        {
+            tcp_ready ready;
+            func_args server_args;
+            callback_functions server_cb;
+            THREAD_TYPE server_thread;
+            WOLFSSL *ssl_client = NULL;
+            WOLFSSL_CTX *ctx_client = NULL;
+            SOCKET_T sockfd = 0;
+            WOLF_STACK_OF(X509_NAME) *names1 = NULL, *names2 = NULL;
+            X509_NAME *name;
+
+            StartTCP();
+            InitTcpReady(&ready);
+            XMEMSET(&server_args, 0, sizeof(func_args));
+            XMEMSET(&server_cb, 0, sizeof(callback_functions));
+
+
+            server_args.signal = &ready;
+            server_args.callbacks = &server_cb;
+
+            server_cb.ctx = ctx;
+            server_cb.isSharedCtx = 1;
+            server_cb.doUdp = params[i].doUdp;
+
+            start_thread(test_server_nofail, &server_args, &server_thread);
+            wait_tcp_ready(&server_args);
+
+            tcp_connect(&sockfd, wolfSSLIP, server_args.signal->port,
+                    params[i].doUdp, 0, NULL);
+            if (params[i].doUdp)
+                udp_connect(&sockfd, wolfSSLIP, server_args.signal->port);
+
+            ExpectNotNull(ctx_client = wolfSSL_CTX_new(
+                        params[i].client_meth()));
+            ExpectIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_load_verify_locations(
+                        ctx_client, caCertFile, NULL));
+
+            ExpectNotNull(ssl_client = wolfSSL_new(ctx_client));
+
+            AssertTrue(wolfSSL_use_certificate_file(ssl_client, cliCertFile,
+                    SSL_FILETYPE_PEM));
+            AssertTrue(wolfSSL_use_PrivateKey_file(ssl_client, cliKeyFile,
+                    SSL_FILETYPE_PEM));
+
+            names1 = wolfSSL_load_client_CA_file(caCertFile);
+            ExpectNotNull(names1);
+            names2 = wolfSSL_load_client_CA_file(cliCertFile);
+            ExpectNotNull(names2);
+            ExpectNotNull(name = wolfSSL_sk_X509_NAME_value(names2, 0));
+            ExpectIntEQ(2, wolfSSL_sk_X509_NAME_push(names1, name));
+            if (EXPECT_FAIL()) {
+                wolfSSL_X509_NAME_free(name);
+                name = NULL;
+            }
+            names2 = wolfSSL_load_client_CA_file(cliCertFile);
+            ExpectNotNull(names2);
+
+            /* verify that set0_CA_list takes precedence */
+            wolfSSL_set0_CA_list(ssl_client, names1);
+            wolfSSL_CTX_set0_CA_list(ctx_client, names2);
+
+            ExpectIntEQ(WOLFSSL_SUCCESS, wolfSSL_set_fd(ssl_client, sockfd));
+            ExpectIntEQ(WOLFSSL_SUCCESS, wolfSSL_connect(ssl_client));
+
+            wolfSSL_shutdown(ssl_client);
+            wolfSSL_free(ssl_client);
+            wolfSSL_CTX_free(ctx_client);
+
+            CloseSocket(sockfd);
+
+            join_thread(server_thread);
+            FreeTcpReady(&ready);
+        }
+#endif
+        ExpectIntEQ(2, server_cb_arg);
+        wolfSSL_CTX_free(ctx);
+    }
+#endif
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_tls_ext.h
+++ b/tests/api/test_tls_ext.h
@@ -24,5 +24,7 @@
 
 int test_tls_ems_downgrade(void);
 int test_wolfSSL_DisableExtendedMasterSecret(void);
+int test_certificate_authorities_certificate_request(void);
+int test_certificate_authorities_client_hello(void);
 
 #endif /* TESTS_API_TEST_TLS_EMS_H */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1098,11 +1098,14 @@
     #define SSL_CA_NAMES(ssl) ((ssl)->ca_names != NULL ? \
         (ssl)->ca_names : \
         (ssl)->ctx->ca_names)
-    /* On the server, client_ca_names has priority over ca_names if both are set */
-    #define SSL_PRIORITY_CA_NAMES(ssl) (((ssl)->options.side == WOLFSSL_SERVER_END && \
+    /* On the server, client_ca_names has priority over ca_names if both are
+     * set. This mimics OpenSSL's API:
+     * https://docs.openssl.org/3.6/man3/SSL_CTX_set0_CA_list/ */
+    #define SSL_PRIORITY_CA_NAMES(ssl) \
+        (((ssl)->options.side == WOLFSSL_SERVER_END && \
         SSL_CLIENT_CA_NAMES(ssl) != NULL) ? \
-        SSL_CLIENT_CA_NAMES(ssl) : \
-        SSL_CA_NAMES(ssl))
+            SSL_CLIENT_CA_NAMES(ssl) : \
+            SSL_CA_NAMES(ssl))
 #else
     #undef  WOLFSSL_NO_CA_NAMES
     #define WOLFSSL_NO_CA_NAMES

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1044,6 +1044,8 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 
 #define SSL_CTX_get_client_CA_list      wolfSSL_CTX_get_client_CA_list
 #define SSL_CTX_set_client_CA_list      wolfSSL_CTX_set_client_CA_list
+#define SSL_CTX_get0_CA_list            wolfSSL_CTX_get0_CA_list
+#define SSL_CTX_set0_CA_list            wolfSSL_CTX_set0_CA_list
 #define SSL_CTX_set_client_cert_cb      wolfSSL_CTX_set_client_cert_cb
 #define SSL_CTX_set_cert_store          wolfSSL_CTX_set_cert_store
 #ifdef OPENSSL_ALL
@@ -1054,6 +1056,9 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define SSL_CTX_get_cert_store(x)       wolfSSL_CTX_get_cert_store ((x))
 #define SSL_get_client_CA_list          wolfSSL_get_client_CA_list
 #define SSL_set_client_CA_list          wolfSSL_set_client_CA_list
+#define SSL_get0_CA_list                wolfSSL_get0_CA_list
+#define SSL_set0_CA_list                wolfSSL_set0_CA_list
+#define SSL_get0_peer_CA_list           wolfSSL_get0_peer_CA_list
 #define SSL_get_ex_data_X509_STORE_CTX_idx wolfSSL_get_ex_data_X509_STORE_CTX_idx
 #define SSL_get_ex_data                 wolfSSL_get_ex_data
 
@@ -1743,6 +1748,9 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 
 #ifdef OPENSSL_EXTRA
 #define SSL_CTX_add_client_CA           wolfSSL_CTX_add_client_CA
+#define SSL_add_client_CA               wolfSSL_add_client_CA
+#define SSL_CTX_add1_to_CA_list         wolfSSL_CTX_add1_to_CA_list
+#define SSL_add1_to_CA_list             wolfSSL_add1_to_CA_list
 #define SSL_CTX_set_srp_password        wolfSSL_CTX_set_srp_password
 #define SSL_CTX_set_srp_username        wolfSSL_CTX_set_srp_username
 #define SSL_CTX_set_srp_strength        wolfSSL_CTX_set_srp_strength

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2425,6 +2425,17 @@ WOLFSSL_API void wolfSSL_set_client_CA_list(WOLFSSL* ssl,
                                                WOLF_STACK_OF(WOLFSSL_X509_NAME)*);
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_get_client_CA_list(
             const WOLFSSL* ssl);
+
+WOLFSSL_API void wolfSSL_CTX_set0_CA_list(WOLFSSL_CTX *ctx,
+        WOLF_STACK_OF(WOLFSSL_X509_NAME)* names);
+WOLFSSL_API void wolfSSL_set0_CA_list(WOLFSSL *ssl,
+        WOLF_STACK_OF(WOLFSSL_X509_NAME) *names);
+WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_NAME) *wolfSSL_CTX_get0_CA_list(
+        const WOLFSSL_CTX *ctx);
+WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_NAME) *wolfSSL_get0_CA_list(
+        const WOLFSSL *ssl);
+WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_NAME) *wolfSSL_get0_peer_CA_list(
+        const WOLFSSL *ssl);
 #endif /* !WOLFSSL_NO_CA_NAMES */
 
 typedef int (*client_cert_cb)(WOLFSSL *ssl, WOLFSSL_X509 **x509,
@@ -2536,6 +2547,9 @@ WOLFSSL_API long wolfSSL_CTX_set_tlsext_status_arg(WOLFSSL_CTX* ctx, void* arg);
 WOLFSSL_API long wolfSSL_CTX_set_tlsext_opaque_prf_input_callback_arg(
         WOLFSSL_CTX* ctx, void* arg);
 WOLFSSL_API int  wolfSSL_CTX_add_client_CA(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509);
+WOLFSSL_API int  wolfSSL_add_client_CA(WOLFSSL *ssl, WOLFSSL_X509 *x509);
+WOLFSSL_API int  wolfSSL_CTX_add1_to_CA_list(WOLFSSL_CTX *ctx, WOLFSSL_X509 *x509);
+WOLFSSL_API int  wolfSSL_add1_to_CA_list(WOLFSSL *ssl, WOLFSSL_X509 *x509);
 WOLFSSL_API int  wolfSSL_CTX_set_srp_password(WOLFSSL_CTX* ctx, char* password);
 WOLFSSL_API int  wolfSSL_CTX_set_srp_username(WOLFSSL_CTX* ctx, char* username);
 WOLFSSL_API int  wolfSSL_CTX_set_srp_strength(WOLFSSL_CTX *ctx, int strength);


### PR DESCRIPTION
# Description

This adds support for the [certificate_authorities](https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.4) TLS 1.3 extension in `ClientHello`, allowing clients to inform servers about the certificate authorities they support for server authentication. Also adds some Doxygen documentation for a few related previously undocumented functions.

Fixes zd#20401

# Testing

```
./configure --enable-all && make check
```

# Checklist

 - [X] added tests
 - [X] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
