### PR TITLE
20250916-linuxkm-fixes

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -131,6 +131,9 @@ ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
     # using inline retpolines leads to "unannotated intra-function call"
     # warnings from objtool without this:
     $(WOLFCRYPT_PIE_FILES): OBJECT_FILES_NON_STANDARD := y
+    ifdef FORCE_GLOBAL_OBJTOOL_OFF
+        undefine CONFIG_OBJTOOL
+    endif
 endif
 
 ifdef KERNEL_EXTRA_CFLAGS_REMOVE
@@ -194,7 +197,7 @@ endif
 	@cd "$(obj)" || exit $$?
 	$(LD) -relocatable -o wolfcrypt_test_link.o $(WOLFCRYPT_PIE_FILES) || exit $$?
 	undefined=$$($(NM) --undefined-only wolfcrypt_test_link.o) || exit $$?
-	GOT_relocs=$$($(READELF) --relocs --wide wolfcrypt_test_link.o | egrep '^[^ ]+ +[^ ]+ +[^ ]*GOT[^ ]* ') || [ $$? = 1 ] || exit 2
+	GOT_relocs=$$($(READELF) --relocs --wide wolfcrypt_test_link.o | grep -E '^[^ ]+ +[^ ]+ +[^ ]*GOT[^ ]* ') || [ $$? = 1 ] || exit 2
 	rm wolfcrypt_test_link.o
 	if [ -n "$$undefined" ]; then
 	    echo "wolfCrypt container has unresolved symbols:" 1>&2

--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -179,8 +179,6 @@ ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
 
 LDFLAGS_libwolfssl.o += -T $(src)/wolfcrypt.lds
 
-rename-pie-text-and-data-sections: $(WOLFSSL_OBJ_TARGETS)
-
 ifndef NM
     NM := nm
 endif
@@ -189,31 +187,30 @@ ifndef OBJCOPY
     OBJCOPY := objcopy
 endif
 
-.PHONY: rename-pie-text-and-data-sections
-rename-pie-text-and-data-sections:
-ifneq "$(quiet)" "silent_"
-	@echo -n '  Checking wolfCrypt for unresolved symbols and forbidden relocations... '
-endif
-	@cd "$(obj)" || exit $$?
-	$(LD) -relocatable -o wolfcrypt_test_link.o $(WOLFCRYPT_PIE_FILES) || exit $$?
-	undefined=$$($(NM) --undefined-only wolfcrypt_test_link.o) || exit $$?
-	GOT_relocs=$$($(READELF) --relocs --wide wolfcrypt_test_link.o | grep -E '^[^ ]+ +[^ ]+ +[^ ]*GOT[^ ]* ') || [ $$? = 1 ] || exit 2
-	rm wolfcrypt_test_link.o
-	if [ -n "$$undefined" ]; then
-	    echo "wolfCrypt container has unresolved symbols:" 1>&2
-	    echo "$$undefined" 1>&2
-	    exit 1
-	fi
-	if [ -n "$$GOT_relocs" ]; then
-	    echo "wolfCrypt container has GOT relocations (non-local function address used as operand?):" 1>&2
-	    echo "$$GOT_relocs" 1>&2
-	    exit 1
-	fi
-ifneq "$(quiet)" "silent_"
-	echo 'OK.'
-endif
-	cd "$(obj)" || exit $$?
-	for file in $(WOLFCRYPT_PIE_FILES); do
+RENAME_PIE_TEXT_AND_DATA_SECTIONS := \
+	if [[ "$(quiet)" != "silent_" ]]; then \
+	    echo -n '  Checking wolfCrypt for unresolved symbols and forbidden relocations... '; \
+	fi; \
+	cd "$(obj)" || exit $$?; \
+	$(LD) -relocatable -o wolfcrypt_test_link.o $(WOLFCRYPT_PIE_FILES) || exit $$?; \
+	undefined=$$($(NM) --undefined-only wolfcrypt_test_link.o) || exit $$?; \
+	GOT_relocs=$$($(READELF) --relocs --wide wolfcrypt_test_link.o | grep -E '^[^ ]+ +[^ ]+ +[^ ]*GOT[^ ]* ') || [ $$? = 1 ] || exit 2; \
+	rm wolfcrypt_test_link.o; \
+	if [ -n "$$undefined" ]; then \
+	    echo "wolfCrypt container has unresolved symbols:" 1>&2; \
+	    echo "$$undefined" 1>&2; \
+	    exit 1; \
+	fi; \
+	if [ -n "$$GOT_relocs" ]; then \
+	    echo "wolfCrypt container has GOT relocations (non-local function address used as operand?):" 1>&2; \
+	    echo "$$GOT_relocs" 1>&2; \
+	    exit 1; \
+	fi; \
+	if [[ "$(quiet)" != "silent_" ]]; then \
+	    echo 'OK.'; \
+	fi; \
+	cd "$(obj)" || exit $$?; \
+	for file in $(WOLFCRYPT_PIE_FILES); do			\
 	    $(OBJCOPY) --rename-section .text=.text.wolfcrypt	\
 	    --rename-section .text.unlikely=.text.wolfcrypt	\
 	    --rename-section .rodata=.rodata.wolfcrypt		\
@@ -223,8 +220,8 @@ endif
 	    --rename-section .rodata.cst32=.rodata.wolfcrypt	\
 	    --rename-section .data=.data.wolfcrypt		\
 	    --rename-section .data.rel.local=.data.wolfcrypt    \
-	    --rename-section .bss=.bss.wolfcrypt "$$file" || exit $$?
-	done
+	    --rename-section .bss=.bss.wolfcrypt "$$file" || exit $$?; \
+	done; \
 	[ "$(KERNEL_ARCH_X86)" != "yes" ] ||			\
 	{ $(READELF) --sections --syms --wide $(WOLFCRYPT_PIE_FILES) |	\
 	$(AWK) -v obj="$(obj)" '					\
@@ -298,19 +295,16 @@ endif
 		} else {						\
 		    exit(0);						\
 	    }}'; } || \
-	{ echo 'Error: symbol(s) missed by containerization.' >&2; exit 1; }
-ifneq "$(quiet)" "silent_"
-	echo '  wolfCrypt .{text,data,rodata} sections containerized to .{text,data,rodata}.wolfcrypt'
+	{ echo 'Error: symbol(s) missed by containerization.' >&2; exit 1; }; \
+	if [[ "$(quiet)" != "silent_" ]]; then \
+	    echo '  wolfCrypt .{text,data,rodata} sections containerized to .{text,data,rodata}.wolfcrypt'; \
+	fi
 endif
-
-$(obj)/linuxkm/module_exports.c: rename-pie-text-and-data-sections
-
-endif
-
 
 # auto-generate the exported symbol list, leveraging the WOLFSSL_API visibility tags.
 # exclude symbols that don't match wc_* or wolf*.
 $(obj)/linuxkm/module_exports.c: $(src)/module_exports.c.template $(WOLFSSL_OBJ_TARGETS) $(obj)/linuxkm/module_hooks.o
+	@$(RENAME_PIE_TEXT_AND_DATA_SECTIONS)
 	@cp $< $@ || exit $$?
 	if [[ "$${VERSION}" -gt 6 || ("$${VERSION}" -eq 6 && "$${PATCHLEVEL}" -ge 13) ]]; then
 	    # use ASCII octal escape to avoid syntax disruption in the awk script.

--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -18,6 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
+.ONESHELL:
 SHELL=bash
 
 all: libwolfssl.ko libwolfssl.ko.signed
@@ -96,8 +97,6 @@ ifndef MAKE_TMPDIR
     MAKE_TMPDIR := $(TMPDIR)
 endif
 
-libwolfssl.ko: libwolfssl.o
-
 GENERATE_RELOC_TAB := $(READELF) --wide -r libwolfssl.ko |				\
 	$(AWK) 'BEGIN {									\
 	    n=0;									\
@@ -131,21 +130,25 @@ GENERATE_RELOC_TAB := $(READELF) --wide -r libwolfssl.ko |				\
 	    print "~0U };\nconst size_t wc_linuxkm_pie_reloc_tab_length = sizeof wc_linuxkm_pie_reloc_tab / sizeof wc_linuxkm_pie_reloc_tab[0];";\
 	}'
 
-libwolfssl.o:
+.PHONY: libwolfssl.ko
+libwolfssl.ko:
 	@if test -z '$(KERNEL_ROOT)'; then echo '$$KERNEL_ROOT is unset' >&2; exit 1; fi
 	@if test -z '$(AM_CFLAGS)$(CFLAGS)'; then echo '$$AM_CFLAGS and $$CFLAGS are both unset.' >&2; exit 1; fi
 	@if test -z '$(src_libwolfssl_la_OBJECTS)'; then echo '$$src_libwolfssl_la_OBJECTS is unset.' >&2; exit 1; fi
         # after commit 9a0ebe5011 (6.10), sources must be in $(obj).  work around this by making links to all needed sources:
 	@mkdir -p '$(MODULE_TOP)/linuxkm'
-	@test '$(MODULE_TOP)/module_hooks.c' -ef '$(MODULE_TOP)/linuxkm/module_hooks.c' || cp --no-dereference --symbolic-link --no-clobber '$(MODULE_TOP)'/*.[ch] '$(MODULE_TOP)/linuxkm/'
-	@test '$(SRC_TOP)/wolfcrypt/src/wc_port.c' -ef '$(MODULE_TOP)/wolfcrypt/src/wc_port.c' || cp --no-dereference --symbolic-link --no-clobber --recursive '$(SRC_TOP)/wolfcrypt' '$(MODULE_TOP)/'
-	@test '$(SRC_TOP)/src/wolfio.c' -ef '$(MODULE_TOP)/src/wolfio.c' || cp --no-dereference --symbolic-link --no-clobber --recursive '$(SRC_TOP)/src' '$(MODULE_TOP)/'
+	@test '$(MODULE_TOP)/module_hooks.c' -ef '$(MODULE_TOP)/linuxkm/module_hooks.c' || cp --verbose --no-dereference --symbolic-link --no-clobber '$(MODULE_TOP)'/*.[ch] '$(MODULE_TOP)/linuxkm/'
+	@test '$(SRC_TOP)/wolfcrypt/src/wc_port.c' -ef '$(MODULE_TOP)/wolfcrypt/src/wc_port.c' || cp --verbose --no-dereference --symbolic-link --no-clobber --recursive '$(SRC_TOP)/wolfcrypt' '$(MODULE_TOP)/'
+	@test '$(SRC_TOP)/src/wolfio.c' -ef '$(MODULE_TOP)/src/wolfio.c' || cp --verbose --no-dereference --symbolic-link --no-clobber --recursive '$(SRC_TOP)/src' '$(MODULE_TOP)/'
 ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
-	@echo -e "const unsigned int wc_linuxkm_pie_reloc_tab[] = { ~0U };\nconst size_t wc_linuxkm_pie_reloc_tab_length = 1;" > wc_linuxkm_pie_reloc_tab.c
-	+$(MAKE) ARCH='$(KERNEL_ARCH)' $(OVERRIDE_PATHS) $(CROSS_COMPILE) -C '$(KERNEL_ROOT)' M='$(MODULE_TOP)' $(KBUILD_EXTRA_FLAGS) CC_FLAGS_FTRACE=
-	@$(GENERATE_RELOC_TAB) > wc_linuxkm_pie_reloc_tab.c
-	+$(MAKE) ARCH='$(KERNEL_ARCH)' $(OVERRIDE_PATHS) $(CROSS_COMPILE) -C '$(KERNEL_ROOT)' M='$(MODULE_TOP)' $(KBUILD_EXTRA_FLAGS) CC_FLAGS_FTRACE=
 	@$(eval RELOC_TMP := $(shell mktemp "$(MAKE_TMPDIR)/wc_linuxkm_pie_reloc_tab.c.XXXXXX"))
+	@[[ -f wc_linuxkm_pie_reloc_tab.c ]] || echo -e "const unsigned int wc_linuxkm_pie_reloc_tab[] = { ~0U };\nconst size_t wc_linuxkm_pie_reloc_tab_length = 1;" > wc_linuxkm_pie_reloc_tab.c
+	@if [[ -f libwolfssl.ko ]]; then touch -r libwolfssl.ko "$(RELOC_TMP)"; fi
+	+$(MAKE) ARCH='$(KERNEL_ARCH)' $(OVERRIDE_PATHS) $(CROSS_COMPILE) -C '$(KERNEL_ROOT)' M='$(MODULE_TOP)' $(KBUILD_EXTRA_FLAGS) CC_FLAGS_FTRACE=
+	# if the above make didn't build a fresh libwolfssl.ko, then the module is already up to date and we leave it untouched, assuring stability for purposes of module-update-fips-hash.
+	@if [[ ! libwolfssl.ko -nt "$(RELOC_TMP)" ]]; then rm "$(RELOC_TMP)"; exit 0; fi
+	@$(GENERATE_RELOC_TAB) >| wc_linuxkm_pie_reloc_tab.c
+	+$(MAKE) ARCH='$(KERNEL_ARCH)' $(OVERRIDE_PATHS) $(CROSS_COMPILE) -C '$(KERNEL_ROOT)' M='$(MODULE_TOP)' $(KBUILD_EXTRA_FLAGS) CC_FLAGS_FTRACE=
 	@$(GENERATE_RELOC_TAB) >| $(RELOC_TMP)
 	@if diff wc_linuxkm_pie_reloc_tab.c $(RELOC_TMP); then echo " Relocation table is stable."; else echo "PIE failed: relocation table is unstable." 1>&2; rm $(RELOC_TMP); exit 1; fi
 	@rm $(RELOC_TMP)


### PR DESCRIPTION
`linuxkm/Makefile` and `linuxkm/Kbuild`:

* refactor `.PHONY` Kbuild target `rename-pie-text-and-data-sections` into macro `RENAME_PIE_TEXT_AND_DATA_SECTIONS`, and execute it conditional on `module_exports.c` regeneration;

* use `.ONESHELL` in the wrapper `Makefile` too, and rework the changes in bf5536d6b8 such that the recursive make is always executed, but will leave the target untouched if it was already up-to-date relative to its dependencies.

these tweaks fix the module build to restore automatic rebuild when dependencies are updated.

`linuxkm/Kbuild`: add support for `FORCE_GLOBAL_OBJTOOL_OFF`.

tested with
```
wolfssl-multi-test.sh ...
check-source-text-fips-dev
linuxkm-fips-v5-vanilla-dist-insmod-cust3
'.*linuxkm.*'
'.*insmod.*'
```

test run currently at `38 of 97`, all green -- will update when tests are complete.
