### PR TITLE
ssl internal: log preMasterSecret Memory error msg.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7396,6 +7396,7 @@ int ReinitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         ssl->arrays->preMasterSecret = (byte*)XMALLOC(ENCRYPT_LEN, ssl->heap,
             DYNAMIC_TYPE_SECRET);
         if (ssl->arrays->preMasterSecret == NULL) {
+            WOLFSSL_MSG("preMasterSecret Memory error");
             return MEMORY_E;
         }
 #ifdef WOLFSSL_CHECK_MEM_ZERO


### PR DESCRIPTION
# Description

In ReinitSSL we were not logging if `ssl->arrays->preMasterSecret == NULL`, but we were for other memory errors.

Fixes zd#20472
