### PR TITLE
20250918-25519-low-mem-gates

### DIFF
--- a/wolfcrypt/src/fe_operations.c
+++ b/wolfcrypt/src/fe_operations.c
@@ -24,7 +24,7 @@
  /* Based On Daniel J Bernstein's curve25519 Public Domain ref10 work. */
 
 #if defined(HAVE_CURVE25519) || defined(HAVE_ED25519)
-#if !defined(CURVE25519_SMALL) || !defined(ED25519_SMALL) /* run when not defined to use small memory math */
+#if !defined(CURVE25519_SMALL) && !defined(ED25519_SMALL)
 
 #include <wolfssl/wolfcrypt/fe_operations.h>
 
@@ -1479,5 +1479,5 @@ void fe_cmov(fe f, const fe g, int b)
 }
 #endif
 
-#endif /* !CURVE25519_SMALL || !ED25519_SMALL */
+#endif /* !CURVE25519_SMALL && !ED25519_SMALL */
 #endif /* HAVE_CURVE25519 || HAVE_ED25519 */

--- a/wolfssl/wolfcrypt/fe_operations.h
+++ b/wolfssl/wolfcrypt/fe_operations.h
@@ -119,9 +119,10 @@ WOLFSSL_LOCAL void fe_mul121666(fe h,fe f);
 WOLFSSL_LOCAL void fe_cmov(fe f, const fe g, int b);
 WOLFSSL_LOCAL void fe_pow22523(fe out,const fe z);
 
-/* 64 type needed for SHA512 */
-WOLFSSL_LOCAL sword64 load_3(const unsigned char *in);
-WOLFSSL_LOCAL sword64 load_4(const unsigned char *in);
+#if !defined(CURVE25519_SMALL) && !defined(ED25519_SMALL)
+    WOLFSSL_LOCAL sword64 load_3(const unsigned char *in);
+    WOLFSSL_LOCAL sword64 load_4(const unsigned char *in);
+#endif
 
 #ifdef CURVED25519_ASM
 WOLFSSL_LOCAL void fe_cmov_table(fe* r, fe* base, signed char b);


### PR DESCRIPTION
fix gating in wolfssl/wolfcrypt/fe_operations.h -- gate out load_3() and load_4() when !(CURVE25519_SMALL || ED25519_SMALL);

harmonize low-mem outer gate in `wolfcrypt/src/fe_operations.c` with outer gate in `wolfcrypt/src/fe_low_mem.c`.

tested with `check-source-text-fips-dev` and
```
$ ./configure --enable-curve25519=small --enable-ed25519=small --enable-c89 --enable-32bit CFLAGS='-m32 -Dword64=klsdjfglksdf -Dsword64=kjdfnfgjka'
```
