### PR TITLE
20250919-GetEcDiffieHellmanKea-clang-analyzer-deadcode.DeadStores

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -32307,6 +32307,8 @@ static int GetEcDiffieHellmanKea(WOLFSSL *ssl,
             else {
                 SendAlert(ssl, alert_fatal, illegal_parameter);
             }
+#else
+            (void)ret;
 #endif
             return ECC_PEERKEY_ERROR;
         }
@@ -32349,6 +32351,8 @@ static int GetEcDiffieHellmanKea(WOLFSSL *ssl,
             else {
                 SendAlert(ssl, alert_fatal, illegal_parameter);
             }
+#else
+            (void)ret;
 #endif
             return ECC_PEERKEY_ERROR;
         }


### PR DESCRIPTION
`src/internal.c`: fix `clang-analyzer-deadcode.DeadStores` in `GetEcDiffieHellmanKea()`.

tested with `wolfssl-multi-test.sh ... clang-tidy-all-crypto-no-sha-1 check-source-text-fips-dev`
