### PR TITLE
Fix non constant compare of TLS 1.3 binder, check for negative dst_len in wc_XChaCha20Poly1305_crypt_oneshot.

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -6201,7 +6201,8 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
         if (ret != 0)
             return ret;
         if (binderLen != current->binderLen ||
-                             XMEMCMP(binder, current->binder, binderLen) != 0) {
+                             ConstantCompare(binder, current->binder,
+                                binderLen) != 0) {
             WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
             return BAD_BINDER;
         }

--- a/wolfcrypt/src/chacha20_poly1305.c
+++ b/wolfcrypt/src/chacha20_poly1305.c
@@ -401,7 +401,7 @@ static WC_INLINE int wc_XChaCha20Poly1305_crypt_oneshot(
         goto out;
     }
 
-    if ((long int)dst_space < dst_len) {
+    if (dst_len <= 0 || (long int)dst_space < dst_len) {
         ret = BUFFER_E;
         goto out;
     }


### PR DESCRIPTION
# Description

Fixes zd#20543 zd#20544

# Testing

Reporter to confirm fixes.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
