### PR TITLE
Fix STM32 benchmark endless loop after 1 hour

### DIFF
--- a/IDE/STM32Cube/wolfssl_example.c
+++ b/IDE/STM32Cube/wolfssl_example.c
@@ -1830,7 +1830,7 @@ double current_time(void)
     (void) date;
 
     /* return seconds.milliseconds */
-    return ((double) time.Hours * 24) + ((double) time.Minutes * 60)
+    return ((double) time.Hours * 3600) + ((double) time.Minutes * 60)
             + (double) time.Seconds + ((double) subsec / 1000);
 }
 #endif /* HAL_RTC_MODULE_ENABLED */


### PR DESCRIPTION
If the STM32 has an RTC, this is used to time the execution of each benchmark item. It was only multiplying hours by 24 to get seconds, so after one hour the amount of seconds went to less than 3600. Therefore the benchmark thought negative time elapsed and would never end.

# Testing

Found with a 1 hour run on the wolfDemo prototype board. Tested on that.