### PR TITLE
20250922-linuxkm-ignore-WOLFSSL_DH_GEN_PUB

### DIFF
--- a/linuxkm/lkcapi_dh_glue.c
+++ b/linuxkm/lkcapi_dh_glue.c
@@ -36,9 +36,8 @@
 #endif
 
 #if defined(LINUXKM_LKCAPI_REGISTER_DH) && \
-    (!defined(WOLFSSL_DH_EXTRA) ||         \
-     !defined(WOLFSSL_DH_GEN_PUB))
-     /* not supported without WOLFSSL_DH_EXTRA && WOLFSSL_DH_GEN_PUB */
+    !defined(WOLFSSL_DH_EXTRA)
+     /* not supported without WOLFSSL_DH_EXTRA */
     #undef LINUXKM_LKCAPI_REGISTER_DH
 
     #if defined(LINUXKM_LKCAPI_REGISTER_ALL_KCONFIG) && defined(CONFIG_CRYPTO_DH)


### PR DESCRIPTION
`linuxkm/lkcapi_dh_glue.c`: don't test for `WOLFSSL_DH_GEN_PUB` -- assume that `wc_DhGeneratePublic()` will be available when `defined(WOLFSSL_DH_EXTRA)`, and fail at compile time if not.

tested with `wolfssl-multi-test.sh ... '.*linuxkm.*fips-v5.*' '.*fips-v5.*insmod.*'` updated with:
```
    setting up FIPS "v5-linuxkm"... done [fips="WCv5.2.4-KRNL-CHKIN" (c9f4dcbbc2), wolfCrypt="WCv5.2.3-DHGENPUB-r2" (7f75407e7c)]
```
