### PR TITLE
Cleanup debian build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,9 +48,7 @@ AC_SUBST([WOLFSSL_CONFIG_ARGS])
 
 # Store configure options and CFLAGS for debian rules generation
 CONFIGURE_OPTIONS="$ac_configure_args"
-CONFIGURE_CFLAGS="$CFLAGS"
 AC_SUBST([CONFIGURE_OPTIONS])
-AC_SUBST([CONFIGURE_CFLAGS])
 
 # shared library versioning
 # The three numbers in the libwolfssl.so.*.*.* file name. Unfortunately

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -3,7 +3,6 @@
 # Store the configure options and CFLAGS used during ./configure
 # This file is generated from rules.in by the configure script
 CONFIGURE_OPTIONS = @CONFIGURE_OPTIONS@
-CONFIGURE_CFLAGS = @CONFIGURE_CFLAGS@
 ENABLED_FIPS = @ENABLED_FIPS@
 
 # Use debhelper with automatic sequence
@@ -16,18 +15,17 @@ override_dh_auto_configure:
 		--build=$(DEB_BUILD_GNU_TYPE) \
 		--host=$(DEB_HOST_GNU_TYPE) \
 		--prefix=/usr \
-		--mandir=\$${prefix}/share/man \
-		--infodir=\$${prefix}/share/info \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
 		--sysconfdir=/etc \
 		--localstatedir=/var \
-		--libdir=\$${prefix}/lib/$(DEB_HOST_MULTIARCH) \
-		--libexecdir=\$${prefix}/lib/$(DEB_HOST_MULTIARCH) \
+		--libdir=/usr/lib/$(DEB_HOST_MULTIARCH) \
+		--libexecdir=/usr/lib/$(DEB_HOST_MULTIARCH) \
 		--disable-maintainer-mode \
 		--disable-dependency-tracking \
 		--enable-shared \
 		--enable-static \
-		$(CONFIGURE_OPTIONS) \
-		CFLAGS="$(CONFIGURE_CFLAGS)"
+		$(CONFIGURE_OPTIONS)
 
 # Override test to skip them (optional, remove if you want to run tests)
 #override_dh_auto_test:
@@ -50,22 +48,6 @@ override_dh_auto_install:
 	dh_auto_install
 	# Remove .la files (not needed in modern Debian packages)
 	find debian/tmp -name '*.la' -delete
-	# Move libraries to multiarch directory if needed
-	if [ -d debian/tmp/usr/lib ]; then \
-		mkdir -p debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH); \
-		if [ -f debian/tmp/usr/lib/libwolfssl.so.* ]; then \
-			mv debian/tmp/usr/lib/libwolfssl.so.* debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/; \
-		fi; \
-		if [ -f debian/tmp/usr/lib/libwolfssl.so ]; then \
-			mv debian/tmp/usr/lib/libwolfssl.so debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/; \
-		fi; \
-		if [ -f debian/tmp/usr/lib/libwolfssl.a ]; then \
-			mv debian/tmp/usr/lib/libwolfssl.a debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/; \
-		fi; \
-		if [ -d debian/tmp/usr/lib/pkgconfig ]; then \
-			mv debian/tmp/usr/lib/pkgconfig debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/; \
-		fi; \
-	fi
 
 # Set proper permissions and strip symbols
 override_dh_strip:


### PR DESCRIPTION
* CFLAGS get pulled in anyway with configure options, or part of the env, we don't need to add them
* Path handling went wrong in one specific platform test run

# Testing

A few different deb-based platforms on VMs and Docker.