### PR TITLE
20250923-wc_XChaCha20Poly1305_crypt_oneshot-empty-message

### DIFF
--- a/wolfcrypt/src/chacha20_poly1305.c
+++ b/wolfcrypt/src/chacha20_poly1305.c
@@ -401,7 +401,7 @@ static WC_INLINE int wc_XChaCha20Poly1305_crypt_oneshot(
         goto out;
     }
 
-    if (dst_len <= 0 || (long int)dst_space < dst_len) {
+    if (dst_len < 0 || (long int)dst_space < dst_len) {
         ret = BUFFER_E;
         goto out;
     }


### PR DESCRIPTION
`wolfcrypt/src/chacha20_poly1305.c`: in `wc_XChaCha20Poly1305_crypt_oneshot()`, allow empty message.

see https://github.com/wolfSSL/wolfssl/pull/9223
