### PR TITLE
Detect if WOLFSSL_MAX_ERROR_SZ is too small

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2866,7 +2866,7 @@ static wc_test_ret_t _SaveDerAndPem(const byte* der, int derSz,
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t error_test(void)
 {
     const char* errStr;
-    char        out[WOLFSSL_MAX_ERROR_SZ];
+    char        out[WOLFSSL_MAX_ERROR_SZ]; /* test fails if too small, < 64 */
     const char* unknownStr = wc_GetErrorString(0);
 
 #ifdef NO_ERROR_STRINGS

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1199,7 +1199,13 @@ enum {
 };
 
 /* max error buffer string size */
-#ifndef WOLFSSL_MAX_ERROR_SZ
+#ifdef WOLFSSL_MAX_ERROR_SZ
+    #if  WOLFSSL_MAX_ERROR_SZ < 64
+        /* If too small, the error_test() will fail.
+         * See fixed length strings returned in wc_GetErrorString() */
+        #error WOLFSSL_MAX_ERROR_SZ must be at least length of longest message
+    #endif
+#else
     #define WOLFSSL_MAX_ERROR_SZ 80
 #endif
 


### PR DESCRIPTION
# Description

Adds a wolfSSL debug message when `WOLFSSL_MAX_ERROR_SZ` is too small. The string comparison will otherwise fail:

```c
        errStr = wc_GetErrorString(i);
        wc_ErrorString(i, out);
        if (XSTRCMP(errStr, out) != 0) {
            WOLFSSL_MSG("errStr does not match output");
            return WC_TEST_RET_ENC_I(-i);
        }
```

As the root cause is not immediately intuitive, this message may help. Perhaps a hard compile-time error instead?

See fixed length strings returned in [wc_GetErrorString()](https://github.com/wolfSSL/wolfssl/blob/ae760923e353a71b8a6641165ed79b3758c55393/wolfcrypt/src/error.c#L36).

Fixes zd# n/a

# Testing

How did you test?

Minimal testing on embedded device.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
