### PR TITLE
Added check in TLX_Parse to check if KeyShare extension is present SupportedGroups must be present too (and viceversa)

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -16737,12 +16737,30 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
         ssl->options.noPskDheKe = 1;
     }
 #endif
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
+    /* RFC 8446 Section 9.2: ClientHello with KeyShare must
+     * contain SupportedGroups and vice-versa. */
+    if (IsAtLeastTLSv1_3(ssl->version) && msgType == client_hello && isRequest) {
+        int hasKeyShare = !IS_OFF(seenType, TLSX_ToSemaphore(TLSX_KEY_SHARE));
+        int hasSupportedGroups = !IS_OFF(seenType, TLSX_ToSemaphore(TLSX_SUPPORTED_GROUPS));
+
+        if (hasKeyShare && !hasSupportedGroups) {
+            WOLFSSL_MSG("ClientHello with KeyShare extension missing required SupportedGroups extension");
+            return MISSING_HANDSHAKE_DATA;
+        }
+        if (hasSupportedGroups && !hasKeyShare) {
+            WOLFSSL_MSG("ClientHello with SupportedGroups extension missing required KeyShare extension");
+            return MISSING_HANDSHAKE_DATA;
+        }
+    }
+#endif
 
     if (ret == 0)
         ret = SNI_VERIFY_PARSE(ssl, isRequest);
     if (ret == 0)
         ret = TCA_VERIFY_PARSE(ssl, isRequest);
 
+    WOLFSSL_LEAVE("Leaving TLSX_Parse", ret);
     return ret;
 }
 


### PR DESCRIPTION
# Description

Added check in TLX_Parse to check if KeyShare extension is present SupportedGroups must be present too (and viceversa)

[From RFC 8446 Section 9.2.](https://datatracker.ietf.org/doc/html/rfc8446#section-9.2)

Addresses https://github.com/wolfSSL/wolfssl/issues/9247
# Testing

From the instructions in https://github.com/wolfSSL/wolfssl/issues/9247.

default config:
`./configure`

run server:
`./build/examples/server/server -v 4 -l 'TLS_AES_128_GCM_SHA256'  -p 3000 --force-curve SECP256R`

send client hello from another window:
`echo "16030300ab010000a703030101010101010101010101010101010101010101010101010101010101010101200303030303030303030303030303030303030303030303030303030303030303000213010100005c000d000600040401080400330047004500170041040c901d423c831ca85e27c73c263ba132721bb9d7a84c4f0380b2a6756fd601331c8870234dec878504c174144fa4b14b66a651691606d8173e55bd37e381569e002b0003020304" | xxd -r -p | nc 127.0.0.1 3000`

with the patch applied it rejects the Client Hello with -422 as error (MISSING_HANDSHAKE_DATA).

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
