### PR TITLE
20250928-linuxkm-krealloc_node_align_noprof

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -755,7 +755,16 @@
 
         const unsigned char *_ctype;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0)
+        typeof(kmalloc_noprof) *kmalloc_noprof;
+        typeof(krealloc_node_align_noprof) *krealloc_node_align_noprof;
+        typeof(kzalloc_noprof) *kzalloc_noprof;
+        typeof(__kvmalloc_node_noprof) *__kvmalloc_node_noprof;
+        typeof(__kmalloc_cache_noprof) *__kmalloc_cache_noprof;
+        #ifdef HAVE_KVREALLOC
+            typeof(kvrealloc_node_align_noprof) *kvrealloc_node_align_noprof;
+        #endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
         typeof(kmalloc_noprof) *kmalloc_noprof;
         typeof(krealloc_noprof) *krealloc_noprof;
         typeof(kzalloc_noprof) *kzalloc_noprof;
@@ -1036,7 +1045,17 @@
 
     #define _ctype WC_LKM_INDIRECT_SYM(_ctype)
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0)
+    /* see include/linux/alloc_tag.h and include/linux/slab.h */
+    #define kmalloc_noprof WC_LKM_INDIRECT_SYM(kmalloc_noprof)
+    #define krealloc_node_align_noprof WC_LKM_INDIRECT_SYM(krealloc_node_align_noprof)
+    #define kzalloc_noprof WC_LKM_INDIRECT_SYM(kzalloc_noprof)
+    #define __kvmalloc_node_noprof WC_LKM_INDIRECT_SYM(__kvmalloc_node_noprof)
+    #define __kmalloc_cache_noprof WC_LKM_INDIRECT_SYM(__kmalloc_cache_noprof)
+    #ifdef HAVE_KVREALLOC
+        #define kvrealloc_node_align_noprof WC_LKM_INDIRECT_SYM(kvrealloc_node_align_noprof)
+    #endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
     /* see include/linux/alloc_tag.h and include/linux/slab.h */
     #define kmalloc_noprof WC_LKM_INDIRECT_SYM(kmalloc_noprof)
     #define krealloc_noprof WC_LKM_INDIRECT_SYM(krealloc_noprof)

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -956,7 +956,16 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
 
     wolfssl_linuxkm_pie_redirect_table._ctype = _ctype;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0)
+    wolfssl_linuxkm_pie_redirect_table.kmalloc_noprof = kmalloc_noprof;
+    wolfssl_linuxkm_pie_redirect_table.krealloc_node_align_noprof = krealloc_node_align_noprof;
+    wolfssl_linuxkm_pie_redirect_table.kzalloc_noprof = kzalloc_noprof;
+    wolfssl_linuxkm_pie_redirect_table.__kvmalloc_node_noprof = __kvmalloc_node_noprof;
+    wolfssl_linuxkm_pie_redirect_table.__kmalloc_cache_noprof = __kmalloc_cache_noprof;
+#ifdef HAVE_KVREALLOC
+    wolfssl_linuxkm_pie_redirect_table.kvrealloc_node_align_noprof = kvrealloc_node_align_noprof;
+#endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
     wolfssl_linuxkm_pie_redirect_table.kmalloc_noprof = kmalloc_noprof;
     wolfssl_linuxkm_pie_redirect_table.krealloc_noprof = krealloc_noprof;
     wolfssl_linuxkm_pie_redirect_table.kzalloc_noprof = kzalloc_noprof;


### PR DESCRIPTION
`linuxkm/`: accommodate API change from `k[v]realloc_noprof()` to `k[v]realloc_node_align_noprof()` expected in 6.18+ (current linux-next).

tested with `wolfssl-multi-test.sh ... quantum-safe-wolfssl-all-crypto-only-intelasm-fips-dev-linuxkm-next-insmod` with linux-next patched to advertise incremented kernel `PATCHLEVEL`.

See commit 2cd8231796b5e in https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
