### PR TITLE
HKDF cryptocb

### DIFF
--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -174,7 +174,7 @@ static const char* GetCryptoCbCmdTypeStr(int type)
 }
 #endif
 
-#ifdef HAVE_HKDF
+#if defined(HAVE_HKDF) && !defined(NO_HMAC)
 static const char* GetKdfTypeStr(int type)
 {
     switch (type) {
@@ -251,7 +251,7 @@ void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
             GetCryptoCbCmdTypeStr(info->cmd.type), info->cmd.type);
     }
 #endif
-#ifdef HAVE_HKDF
+#if defined(HAVE_HKDF) && !defined(NO_HMAC)
     else if (info->algo_type == WC_ALGO_TYPE_KDF) {
         printf("Crypto CB: %s %s (%d)\n", GetAlgoTypeStr(info->algo_type),
                GetKdfTypeStr(info->kdf.type), info->kdf.type);
@@ -1964,7 +1964,7 @@ int wc_CryptoCb_DefaultDevID(void)
     return ret;
 }
 
-#ifdef HAVE_HKDF
+#if defined(HAVE_HKDF) && !defined(NO_HMAC)
 int wc_CryptoCb_Hkdf(int hashType, const byte* inKey, word32 inKeySz,
                      const byte* salt, word32 saltSz, const byte* info,
                      word32 infoSz, byte* out, word32 outSz, int devId)
@@ -1996,6 +1996,6 @@ int wc_CryptoCb_Hkdf(int hashType, const byte* inKey, word32 inKeySz,
 
     return wc_CryptoCb_TranslateErrorCode(ret);
 }
-#endif /* HAVE_HKDF */
+#endif /* HAVE_HKDF && !NO_HMAC */
 
 #endif /* WOLF_CRYPTO_CB */

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -80,6 +80,8 @@ static const char* GetAlgoTypeStr(int algo)
         case WC_ALGO_TYPE_HMAC:   return "HMAC";
         case WC_ALGO_TYPE_CMAC:   return "CMAC";
         case WC_ALGO_TYPE_CERT:   return "Cert";
+        case WC_ALGO_TYPE_KDF:
+            return "KDF";
     }
     return NULL;
 }
@@ -172,6 +174,17 @@ static const char* GetCryptoCbCmdTypeStr(int type)
 }
 #endif
 
+#ifdef HAVE_HKDF
+static const char* GetKdfTypeStr(int type)
+{
+    switch (type) {
+        case WC_KDF_TYPE_HKDF:
+            return "HKDF";
+    }
+    return NULL;
+}
+#endif
+
 void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
 {
     if (info == NULL)
@@ -236,6 +249,12 @@ void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
         printf("Crypto CB: %s %s (%d)\n",
             GetAlgoTypeStr(info->algo_type),
             GetCryptoCbCmdTypeStr(info->cmd.type), info->cmd.type);
+    }
+#endif
+#ifdef HAVE_HKDF
+    else if (info->algo_type == WC_ALGO_TYPE_KDF) {
+        printf("Crypto CB: %s %s (%d)\n", GetAlgoTypeStr(info->algo_type),
+               GetKdfTypeStr(info->kdf.type), info->kdf.type);
     }
 #endif
     else {
@@ -1944,5 +1963,39 @@ int wc_CryptoCb_DefaultDevID(void)
 
     return ret;
 }
+
+#ifdef HAVE_HKDF
+int wc_CryptoCb_Hkdf(int hashType, const byte* inKey, word32 inKeySz,
+                     const byte* salt, word32 saltSz, const byte* info,
+                     word32 infoSz, byte* out, word32 outSz, int devId)
+{
+    int       ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
+    CryptoCb* dev;
+
+    /* Find registered callback device */
+    dev = wc_CryptoCb_FindDevice(devId, WC_ALGO_TYPE_KDF);
+
+    if (dev && dev->cb) {
+        wc_CryptoInfo cryptoInfo;
+        XMEMSET(&cryptoInfo, 0, sizeof(cryptoInfo));
+
+        cryptoInfo.algo_type         = WC_ALGO_TYPE_KDF;
+        cryptoInfo.kdf.type          = WC_KDF_TYPE_HKDF;
+        cryptoInfo.kdf.hkdf.hashType = hashType;
+        cryptoInfo.kdf.hkdf.inKey    = inKey;
+        cryptoInfo.kdf.hkdf.inKeySz  = inKeySz;
+        cryptoInfo.kdf.hkdf.salt     = salt;
+        cryptoInfo.kdf.hkdf.saltSz   = saltSz;
+        cryptoInfo.kdf.hkdf.info     = info;
+        cryptoInfo.kdf.hkdf.infoSz   = infoSz;
+        cryptoInfo.kdf.hkdf.out      = out;
+        cryptoInfo.kdf.hkdf.outSz    = outSz;
+
+        ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
+    }
+
+    return wc_CryptoCb_TranslateErrorCode(ret);
+}
+#endif /* HAVE_HKDF */
 
 #endif /* WOLF_CRYPTO_CB */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -27897,8 +27897,13 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hkdf_test(void)
     L = (int)sizeof(okm1);
 
 #ifndef NO_SHA
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
     ret = wc_HKDF_ex(WC_SHA, ikm1, (word32)sizeof(ikm1), NULL, 0, NULL, 0,
-        okm1, (word32)L, HEAP_HINT, devId);
+                     okm1, (word32)L, HEAP_HINT, devId);
+#else
+    ret = wc_HKDF(WC_SHA, ikm1, (word32)sizeof(ikm1), NULL, 0, NULL, 0,
+                  okm1, (word32)L);
+#endif
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
@@ -27908,8 +27913,13 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hkdf_test(void)
 #ifndef HAVE_FIPS
     /* fips can't have key size under 14 bytes, salt is key too */
     L = (int)sizeof(okm1);
-    ret = wc_HKDF_ex(WC_SHA, ikm1, 11, salt1, (word32)sizeof(salt1),
-        info1, (word32)sizeof(info1), okm1, (word32)L, HEAP_HINT, devId);
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
+    ret = wc_HKDF_ex(WC_SHA, ikm1, 11, salt1, (word32)sizeof(salt1), info1,
+                     (word32)sizeof(info1), okm1, (word32)L, HEAP_HINT, devId);
+#else
+    ret = wc_HKDF(WC_SHA, ikm1, 11, salt1, (word32)sizeof(salt1), info1,
+                  (word32)sizeof(info1), okm1, (word32)L);
+#endif
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
@@ -27919,8 +27929,13 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hkdf_test(void)
 #endif /* !NO_SHA */
 
 #ifndef NO_SHA256
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
     ret = wc_HKDF_ex(WC_SHA256, ikm1, (word32)sizeof(ikm1), NULL, 0, NULL, 0,
         okm1, (word32)L, HEAP_HINT, devId);
+#else
+    ret = wc_HKDF(WC_SHA256, ikm1, (word32)sizeof(ikm1), NULL, 0, NULL, 0,
+                     okm1, (word32)L);
+#endif
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
@@ -60810,12 +60825,21 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
     else if (info->algo_type == WC_ALGO_TYPE_KDF) {
         if (info->kdf.type == WC_KDF_TYPE_HKDF) {
             /* Redirect to software implementation for testing */
+
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
             ret = wc_HKDF_ex(info->kdf.hkdf.hashType,
                            info->kdf.hkdf.inKey, info->kdf.hkdf.inKeySz,
                            info->kdf.hkdf.salt, info->kdf.hkdf.saltSz,
                            info->kdf.hkdf.info, info->kdf.hkdf.infoSz,
                            info->kdf.hkdf.out, info->kdf.hkdf.outSz,
                            NULL, INVALID_DEVID);
+#else
+            ret = wc_HKDF(info->kdf.hkdf.hashType,
+                          info->kdf.hkdf.inKey, info->kdf.hkdf.inKeySz,
+                          info->kdf.hkdf.salt, info->kdf.hkdf.saltSz,
+                          info->kdf.hkdf.info, info->kdf.hkdf.infoSz,
+                          info->kdf.hkdf.out, info->kdf.hkdf.outSz);
+#endif
         }
     }
 #endif /* HAVE_HKDF && !NO_HMAC */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -27897,7 +27897,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hkdf_test(void)
     L = (int)sizeof(okm1);
 
 #ifndef NO_SHA
-#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
+#if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0))
     ret = wc_HKDF_ex(WC_SHA, ikm1, (word32)sizeof(ikm1), NULL, 0, NULL, 0,
                      okm1, (word32)L, HEAP_HINT, devId);
 #else
@@ -27913,7 +27913,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hkdf_test(void)
 #ifndef HAVE_FIPS
     /* fips can't have key size under 14 bytes, salt is key too */
     L = (int)sizeof(okm1);
-#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
+#if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0))
     ret = wc_HKDF_ex(WC_SHA, ikm1, 11, salt1, (word32)sizeof(salt1), info1,
                      (word32)sizeof(info1), okm1, (word32)L, HEAP_HINT, devId);
 #else
@@ -27929,7 +27929,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hkdf_test(void)
 #endif /* !NO_SHA */
 
 #ifndef NO_SHA256
-#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
+#if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0))
     ret = wc_HKDF_ex(WC_SHA256, ikm1, (word32)sizeof(ikm1), NULL, 0, NULL, 0,
         okm1, (word32)L, HEAP_HINT, devId);
 #else
@@ -27944,9 +27944,15 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hkdf_test(void)
 
 #ifndef HAVE_FIPS
     /* fips can't have key size under 14 bytes, salt is key too */
+#if !defined(HAVE_SELFTEST)
     ret = wc_HKDF_ex(WC_SHA256, ikm1, (word32)sizeof(ikm1),
         salt1, (word32)sizeof(salt1), info1, (word32)sizeof(info1), okm1,
         (word32)L, HEAP_HINT, devId);
+#else
+    ret = wc_HKDF(WC_SHA256, ikm1, (word32)sizeof(ikm1), salt1,
+                  (word32)sizeof(salt1), info1, (word32)sizeof(info1), okm1,
+                  (word32)L);
+#endif
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
@@ -60826,7 +60832,7 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
         if (info->kdf.type == WC_KDF_TYPE_HKDF) {
             /* Redirect to software implementation for testing */
 
-#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
+#if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0))
             ret = wc_HKDF_ex(info->kdf.hkdf.hashType,
                            info->kdf.hkdf.inKey, info->kdf.hkdf.inKeySz,
                            info->kdf.hkdf.salt, info->kdf.hkdf.saltSz,

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -60806,7 +60806,7 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
         info->cmac.cmac->devId = devIdArg;
     }
 #endif /* WOLFSSL_CMAC && !(NO_AES) && WOLFSSL_AES_DIRECT */
-#ifdef HAVE_HKDF
+#if defined(HAVE_HKDF) && !defined(NO_HMAC)
     else if (info->algo_type == WC_ALGO_TYPE_KDF) {
         if (info->kdf.type == WC_KDF_TYPE_HKDF) {
             /* Redirect to software implementation for testing */
@@ -60818,7 +60818,7 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
                            NULL, INVALID_DEVID);
         }
     }
-#endif /* HAVE_HKDF */
+#endif /* HAVE_HKDF && !NO_HMAC */
 
     (void)devIdArg;
     (void)myCtx;

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -468,6 +468,29 @@ typedef struct wc_CryptoInfo {
         void *ctx;
     } cmd;
 #endif
+#ifdef HAVE_HKDF
+    struct {
+        int type; /* enum wc_KdfType */
+#ifdef HAVE_ANONYMOUS_INLINE_AGGREGATES
+        union {
+#endif
+            struct {                  /* HKDF one-shot */
+                int         hashType; /* WC_SHA256, etc. */
+                const byte* inKey;    /* Input keying material */
+                word32      inKeySz;
+                const byte* salt; /* Optional salt */
+                word32      saltSz;
+                const byte* info; /* Optional info */
+                word32      infoSz;
+                byte*       out; /* Output key material */
+                word32      outSz;
+            } hkdf;
+            /* Future KDF type structures here */
+#ifdef HAVE_ANONYMOUS_INLINE_AGGREGATES
+        };
+#endif
+    } kdf;
+#endif
 #ifdef HAVE_ANONYMOUS_INLINE_AGGREGATES
     };
 #endif
@@ -665,6 +688,14 @@ WOLFSSL_LOCAL int wc_CryptoCb_Sha3Hash(wc_Sha3* sha3, int type, const byte* in,
 WOLFSSL_LOCAL int wc_CryptoCb_Hmac(Hmac* hmac, int macType, const byte* in,
     word32 inSz, byte* digest);
 #endif /* !NO_HMAC */
+
+#ifdef HAVE_HKDF
+WOLFSSL_LOCAL int wc_CryptoCb_Hkdf(int hashType, const byte* inKey,
+                                   word32 inKeySz, const byte* salt,
+                                   word32 saltSz, const byte* info,
+                                   word32 infoSz, byte* out, word32 outSz,
+                                   int devId);
+#endif
 
 #ifndef WC_NO_RNG
 WOLFSSL_LOCAL int wc_CryptoCb_RandomBlock(WC_RNG* rng, byte* out, word32 sz);

--- a/wolfssl/wolfcrypt/hmac.h
+++ b/wolfssl/wolfcrypt/hmac.h
@@ -216,6 +216,10 @@ WOLFSSL_API int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
                     const byte* salt, word32 saltSz,
                     const byte* info, word32 infoSz,
                     byte* out, word32 outSz);
+WOLFSSL_API int wc_HKDF_ex(int type, const byte* inKey, word32 inKeySz,
+                       const byte* salt, word32 saltSz,
+                       const byte* info, word32 infoSz,
+                       byte* out, word32 outSz, void* heap, int devId);
 
 #endif /* HAVE_HKDF */
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1220,8 +1220,16 @@ enum wc_AlgoType {
     WC_ALGO_TYPE_HMAC = 6,
     WC_ALGO_TYPE_CMAC = 7,
     WC_ALGO_TYPE_CERT = 8,
+    WC_ALGO_TYPE_KDF = 9,
 
-    WC_ALGO_TYPE_MAX = WC_ALGO_TYPE_CERT
+    WC_ALGO_TYPE_MAX = WC_ALGO_TYPE_KDF
+};
+
+/* KDF types */
+enum wc_KdfType {
+    WC_KDF_TYPE_NONE = 0,
+    WC_KDF_TYPE_HKDF = 1
+    /* Future: WC_KDF_TYPE_PBKDF2 = 2, WC_KDF_TYPE_SCRYPT = 3, etc. */
 };
 
 /* hash types */


### PR DESCRIPTION
# Description

Adds one-shot cryptoCb for HKDF, ensuring the entire KDF operation is offloaded.

# Testing

Added support for using `devId`s in `hkdf_test() such that `cryptocb_test()` will exercise it

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
