### PR TITLE
TLS 1.3 Cookie Hash: use stronger hash if no SHA-256

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -306,7 +306,7 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
     int         ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hashAlgo) {
-#ifndef NO_WOLFSSL_SHA256
+#ifndef NO_SHA256
         case sha256_mac:
             ret = wc_InitSha256_ex(&digest.sha256, ssl->heap, ssl->devId);
             if (ret == 0) {
@@ -3601,14 +3601,21 @@ int CreateCookieExt(const WOLFSSL* ssl, byte* hash, word16 hashSz,
         cookieSz += OPAQUE16_LEN;
     }
 
-#if !defined(NO_SHA) && defined(NO_SHA256)
-    cookieType = SHA;
-    macSz = WC_SHA_DIGEST_SIZE;
-#endif /* NO_SHA */
 #ifndef NO_SHA256
     cookieType = WC_SHA256;
     macSz = WC_SHA256_DIGEST_SIZE;
-#endif /* NO_SHA256 */
+#elif defined(WOLFSSL_SHA384)
+    cookieType = WC_SHA384;
+    macSz = WC_SHA384_DIGEST_SIZE;
+#elif defined(WOLFSSL_TLS13_SHA512)
+    cookieType = WC_SHA512;
+    macSz = WC_SHA512_DIGEST_SIZE;
+#elif defined(WOLFSSL_SM3)
+    cookieType = WC_SM3;
+    macSz = WC_SM3_DIGEST_SIZE;
+#else
+    #error "No digest to available to use with HMAC for cookies."
+#endif /* NO_SHA */
 
     ret = wc_HmacInit(&cookieHmac, ssl->heap, ssl->devId);
     if (ret == 0) {
@@ -6456,14 +6463,21 @@ int TlsCheckCookie(const WOLFSSL* ssl, const byte* cookie, word16 cookieSz)
         return COOKIE_ERROR;
     }
 
-#if !defined(NO_SHA) && defined(NO_SHA256)
-    cookieType = SHA;
-    macSz = WC_SHA_DIGEST_SIZE;
-#endif /* NO_SHA */
 #ifndef NO_SHA256
     cookieType = WC_SHA256;
     macSz = WC_SHA256_DIGEST_SIZE;
-#endif /* NO_SHA256 */
+#elif defined(WOLFSSL_SHA384)
+    cookieType = WC_SHA384;
+    macSz = WC_SHA384_DIGEST_SIZE;
+#elif defined(WOLFSSL_TLS13_SHA512)
+    cookieType = WC_SHA512;
+    macSz = WC_SHA512_DIGEST_SIZE;
+#elif defined(WOLFSSL_SM3)
+    cookieType = WC_SM3;
+    macSz = WC_SM3_DIGEST_SIZE;
+#else
+    #error "No digest to available to use with HMAC for cookies."
+#endif /* NO_SHA */
 
     if (cookieSz < ssl->specs.hash_size + macSz)
         return HRR_COOKIE_ERROR;
@@ -8389,7 +8403,7 @@ int CreateRSAEncodedSig(byte* sig, byte* sigData, int sigDataSz,
 
     /* Digest the signature data. */
     switch (hashAlgo) {
-#ifndef NO_WOLFSSL_SHA256
+#ifndef NO_SHA256
         case sha256_mac:
             ret = wc_InitSha256(&digest.sha256);
             if (ret == 0) {
@@ -8454,7 +8468,7 @@ static int CreateECCEncodedSig(byte* sigData, int sigDataSz, int hashAlgo)
 
     /* Digest the signature data. */
     switch (hashAlgo) {
-#ifndef NO_WOLFSSL_SHA256
+#ifndef NO_SHA256
         case sha256_mac:
             ret = wc_InitSha256(&digest.sha256);
             if (ret == 0) {
@@ -13608,12 +13622,17 @@ int wolfSSL_send_hrr_cookie(WOLFSSL* ssl, const unsigned char* secret,
         return SIDE_ERROR;
 
     if (secretSz == 0) {
-    #if !defined(NO_SHA) && defined(NO_SHA256)
-        secretSz = WC_SHA_DIGEST_SIZE;
-    #endif /* NO_SHA */
     #ifndef NO_SHA256
         secretSz = WC_SHA256_DIGEST_SIZE;
-    #endif /* NO_SHA256 */
+    #elif defined(WOLFSSL_SHA384)
+        secretSz = WC_SHA384_DIGEST_SIZE;
+    #elif defined(WOLFSSL_TLS13_SHA512)
+        secretSz = WC_SHA512_DIGEST_SIZE;
+    #elif defined(WOLFSSL_SM3)
+        secretSz = WC_SM3_DIGEST_SIZE;
+    #else
+        #error "No digest to available to use with HMAC for cookies."
+    #endif /* NO_SHA */
     }
 
     if (secretSz != ssl->buffers.tls13CookieSecret.length) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -3172,7 +3172,8 @@ static int test_wolfSSL_CertManagerLoadCABufferType(void)
 {
     EXPECT_DECLS;
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_TLS) && \
-    !defined(NO_RSA) && !defined(WOLFSSL_TEST_APPLE_NATIVE_CERT_VALIDATION)
+    !defined(NO_RSA) && !defined(NO_SHA256) && \
+    !defined(WOLFSSL_TEST_APPLE_NATIVE_CERT_VALIDATION)
 #if defined(WOLFSSL_PEM_TO_DER)
     const char* ca_cert = "./certs/ca-cert.pem";
     const char* int1_cert = "./certs/intermediate/ca-int-cert.pem";
@@ -5125,11 +5126,13 @@ static int test_wolfSSL_CertRsaPss(void)
      (HAVE_FIPS_VERSION > 2))) && (!defined(HAVE_SELFTEST) || \
      (defined(HAVE_SELFTEST_VERSION) && (HAVE_SELFTEST_VERSION > 2)))
     XFILE f = XBADFILE;
+#ifndef NO_SHA256
     const char* rsaPssSha256Cert = "./certs/rsapss/ca-rsapss.der";
 #ifdef WOLFSSL_PEM_TO_DER
     const char* rsaPssRootSha256Cert = "./certs/rsapss/root-rsapss.pem";
 #else
     const char* rsaPssRootSha256Cert = "./certs/rsapss/root-rsapss.der";
+#endif
 #endif
 #if defined(WOLFSSL_SHA384) && defined(WOLFSSL_PSS_LONG_SALT) && \
     RSA_MAX_SIZE >= 3072
@@ -5148,13 +5151,16 @@ static int test_wolfSSL_CertRsaPss(void)
     WOLFSSL_CERT_MANAGER* cm = NULL;
 
     ExpectNotNull(cm = wolfSSL_CertManagerNew());
+#ifndef NO_SHA256
     ExpectIntEQ(WOLFSSL_SUCCESS,
         wolfSSL_CertManagerLoadCA(cm, rsaPssRootSha256Cert, NULL));
+#endif
 #if defined(WOLFSSL_SHA384) && RSA_MAX_SIZE >= 3072
     ExpectIntEQ(WOLFSSL_SUCCESS,
         wolfSSL_CertManagerLoadCA(cm, rsaPssRootSha384Cert, NULL));
 #endif
 
+#ifndef NO_SHA256
     ExpectTrue((f = XFOPEN(rsaPssSha256Cert, "rb")) != XBADFILE);
     ExpectIntGT(bytes = (int)XFREAD(buf, 1, sizeof(buf), f), 0);
     if (f != XBADFILE) {
@@ -5164,6 +5170,7 @@ static int test_wolfSSL_CertRsaPss(void)
     wc_InitDecodedCert(&cert, buf, (word32)bytes, NULL);
     ExpectIntEQ(wc_ParseCert(&cert, CERT_TYPE, VERIFY, cm), 0);
     wc_FreeDecodedCert(&cert);
+#endif
 
 #if defined(WOLFSSL_SHA384) && defined(WOLFSSL_PSS_LONG_SALT) && \
     RSA_MAX_SIZE >= 3072
@@ -5177,6 +5184,9 @@ static int test_wolfSSL_CertRsaPss(void)
 #endif
 
     wolfSSL_CertManagerFree(cm);
+
+    (void)buf;
+    (void)bytes;
 #endif
 
     return EXPECT_RESULT();
@@ -9455,6 +9465,8 @@ cleanup:
 
 static int test_wolfSSL_read_write(void)
 {
+    EXPECT_DECLS;
+#ifndef NO_SHA256
     /* The unit testing for read and write shall happen simultaneously, since
      * one can't do anything with one without the other. (Except for a failure
      * test case.) This function will call all the others that will set up,
@@ -9478,7 +9490,6 @@ static int test_wolfSSL_read_write(void)
     func_args client_args;
     func_args server_args;
     THREAD_TYPE serverThread;
-    EXPECT_DECLS;
 
     XMEMSET(&client_args, 0, sizeof(func_args));
     XMEMSET(&server_args, 0, sizeof(func_args));
@@ -9510,7 +9521,7 @@ static int test_wolfSSL_read_write(void)
 #ifdef WOLFSSL_TIRTOS
     fdOpenSession(Task_self());
 #endif
-
+#endif
     return EXPECT_RESULT();
 }
 
@@ -25149,7 +25160,8 @@ static int test_wolfSSL_check_domain(void)
 }
 
 #endif /* OPENSSL_EXTRA && HAVE_SSL_MEMIO_TESTS_DEPENDENCIES */
-#if defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && !defined(OPENSSL_COMPATIBLE_DEFAULTS)
+#if defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(OPENSSL_COMPATIBLE_DEFAULTS) && !defined(NO_SHA256)
 static const char* dn = NULL;
 static int test_wolfSSL_check_domain_basic_client_ssl(WOLFSSL* ssl)
 {
@@ -27846,8 +27858,8 @@ static int test_wolfSSL_SESSION(void)
 {
     EXPECT_DECLS;
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && \
-    !defined(NO_RSA) && defined(HAVE_IO_TESTS_DEPENDENCIES) && \
-    !defined(NO_SESSION_CACHE)
+    !defined(NO_RSA) && !defined(NO_SHA256) && \
+    defined(HAVE_IO_TESTS_DEPENDENCIES) && !defined(NO_SESSION_CACHE)
     WOLFSSL*     ssl = NULL;
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL_SESSION* sess = NULL;
@@ -37634,7 +37646,7 @@ static int test_X509_LOOKUP_add_dir(void)
  *----------------------------------------------------------------------------*/
 #if !defined(NO_CERTS) && (!defined(NO_WOLFSSL_CLIENT) || \
                    !defined(WOLFSSL_NO_CLIENT_AUTH)) && !defined(NO_FILESYSTEM)
-#if !defined(NO_RSA) || defined(HAVE_ECC)
+#if (!defined(NO_RSA) || defined(HAVE_ECC)) && !defined(NO_SHA256)
 /* Use the Cert Manager(CM) API to generate the error ASN_SIG_CONFIRM_E */
 #ifndef WOLFSSL_TEST_APPLE_NATIVE_CERT_VALIDATION
 static int verify_sig_cm(const char* ca, byte* cert_buf, size_t cert_sz,
@@ -42012,6 +42024,7 @@ static int test_wolfSSL_dtls_stateless(void)
 #ifdef HAVE_CERT_CHAIN_VALIDATION
 #ifndef WOLFSSL_TEST_APPLE_NATIVE_CERT_VALIDATION
 #ifdef WOLFSSL_PEM_TO_DER
+#ifndef NO_SHA256
 static int load_ca_into_cm(WOLFSSL_CERT_MANAGER* cm, char* certA)
 {
     int ret;
@@ -42189,10 +42202,12 @@ static int test_chainJ(WOLFSSL_CERT_MANAGER* cm)
 
     return ret;
 }
+#endif
 
 static int test_various_pathlen_chains(void)
 {
     EXPECT_DECLS;
+#ifndef NO_SHA256
     WOLFSSL_CERT_MANAGER* cm = NULL;
 
     /* Test chain G (large chain with varying pathLens) */
@@ -42245,6 +42260,7 @@ static int test_various_pathlen_chains(void)
     ExpectNotNull(cm = wolfSSL_CertManagerNew());
     ExpectIntEQ(wolfSSL_CertManagerUnloadCAs(cm), WOLFSSL_SUCCESS);
     wolfSSL_CertManagerFree(cm);
+#endif
 
     return EXPECT_RESULT();
 }
@@ -47276,7 +47292,8 @@ static int test_dtls13_bad_epoch_ch(void)
      (!defined(NO_OLD_TLS) && ((!defined(NO_AES) && !defined(NO_AES_CBC)) || \
       !defined(NO_DES3))) || !defined(WOLFSSL_NO_TLS12)) && \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
-    defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && !defined(NO_SESSION_CACHE)
+    defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(NO_SESSION_CACHE) && !defined(NO_SHA256)
 static int test_short_session_id_ssl_ready(WOLFSSL* ssl)
 {
     EXPECT_DECLS;
@@ -48581,8 +48598,9 @@ static int test_certreq_sighash_algos(void)
     EXPECT_DECLS;
 #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
     !defined(WOLFSSL_MAX_STRENGTH) && defined(HAVE_ECC) && \
-    defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256) && \
-    defined(HAVE_AES_CBC) && !defined(WOLFSSL_NO_TLS12)
+    !defined(NO_SHA256) && defined(WOLFSSL_SHA384) && \
+    defined(WOLFSSL_AES_256) && defined(HAVE_AES_CBC) && \
+    !defined(WOLFSSL_NO_TLS12)
     WOLFSSL_CTX *ctx_c = NULL;
     WOLFSSL_CTX *ctx_s = NULL;
     WOLFSSL *ssl_c = NULL;
@@ -49447,7 +49465,8 @@ static int test_self_signed_stapling(void)
 static int test_tls_multi_handshakes_one_record(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && !defined(WOLFSSL_NO_TLS12)
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(WOLFSSL_NO_TLS12) && !defined(NO_SHA256)
     struct test_memio_ctx test_ctx;
     WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
     WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
@@ -49652,7 +49671,8 @@ static int test_read_write_hs(void)
 {
 
     EXPECT_DECLS;
-#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && !defined(WOLFSSL_NO_TLS12)
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(WOLFSSL_NO_TLS12) && !defined(NO_SHA256)
     WOLFSSL_CTX *ctx_s = NULL, *ctx_c = NULL;
     WOLFSSL *ssl_s = NULL, *ssl_c = NULL;
     struct test_memio_ctx test_ctx;
@@ -49931,7 +49951,8 @@ static int test_get_signature_nid(void)
 }
 
 #ifndef WOLFSSL_TEST_APPLE_NATIVE_CERT_VALIDATION
-#if !defined(NO_CERTS) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
+#if !defined(NO_CERTS) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(NO_SHA256)
 static word32 test_tls_cert_store_unchanged_HashCaTable(Signer** caTable)
 {
 #ifndef NO_MD5
@@ -50024,7 +50045,8 @@ static int test_tls_cert_store_unchanged_ssl_ready(WOLFSSL* ssl)
 static int test_tls_cert_store_unchanged(void)
 {
     EXPECT_DECLS;
-#if !defined(NO_CERTS) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
+#if !defined(NO_CERTS) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(NO_SHA256)
     test_ssl_cbf client_cbf;
     test_ssl_cbf server_cbf;
     int i;
@@ -50255,7 +50277,7 @@ static int test_wolfSSL_SSLDisableRead(void)
 static int test_wolfSSL_inject(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES)
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && !defined(NO_SHA256)
     size_t i;
     struct {
         method_provider client_meth;
@@ -50683,6 +50705,7 @@ TEST_CASE testCases[] = {
 #endif
 
     TEST_DECL(test_EVP_PKEY_rsa),
+    TEST_DECL(test_wc_RsaPSS_DigitalSignVerify),
     TEST_DECL(test_EVP_PKEY_ec),
     TEST_DECL(test_wolfSSL_EVP_PKEY_encrypt),
     TEST_DECL(test_wolfSSL_EVP_PKEY_sign_verify_rsa),
@@ -51026,7 +51049,6 @@ TEST_CASE testCases[] = {
     defined(WOLFSSL_PEM_TO_DER)
     TEST_DECL(test_various_pathlen_chains),
 #endif
-TEST_DECL(test_wc_RsaPSS_DigitalSignVerify),
 
     /*********************************
      * SSL/TLS API tests
@@ -51072,7 +51094,7 @@ TEST_DECL(test_wc_RsaPSS_DigitalSignVerify),
 #if !defined(NO_CERTS) && (!defined(NO_WOLFSSL_CLIENT) || \
     !defined(WOLFSSL_NO_CLIENT_AUTH)) && !defined(NO_FILESYSTEM) && \
     !defined(WOLFSSL_TEST_APPLE_NATIVE_CERT_VALIDATION) && \
-    (!defined(NO_RSA) || defined(HAVE_ECC))
+    (!defined(NO_RSA) || defined(HAVE_ECC)) && !defined(NO_SHA256)
     /* Use the Cert Manager(CM) API to generate the error ASN_SIG_CONFIRM_E */
     /* Bad certificate signature tests */
     TEST_DECL(test_EccSigFailure_cm),

--- a/tests/api/test_dtls.c
+++ b/tests/api/test_dtls.c
@@ -1247,7 +1247,8 @@ int test_dtls_record_cross_boundaries(void)
 }
 #endif /* defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS) */
 
-#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && !defined(WOLFSSL_NO_TLS12)
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(WOLFSSL_NO_TLS12) && !defined(NO_SHA256)
 /* This test that the DTLS record boundary check doesn't interfere with TLS
  * records processing */
 int test_records_span_network_boundaries(void)

--- a/tests/api/test_pkcs12.c
+++ b/tests/api/test_pkcs12.c
@@ -42,7 +42,7 @@ int test_wc_i2d_PKCS12(void)
     EXPECT_DECLS;
 #if !defined(NO_ASN) && !defined(NO_PWDBASED) && defined(HAVE_PKCS12) \
     && !defined(NO_FILESYSTEM) && !defined(NO_RSA) \
-    && !defined(NO_AES) && !defined(NO_SHA)
+    && !defined(NO_AES) && !defined(NO_SHA) && !defined(NO_SHA256)
     WC_PKCS12* pkcs12 = NULL;
     unsigned char der[FOURK_BUF * 2];
     unsigned char* pt;
@@ -163,6 +163,7 @@ int test_wc_PKCS12_create(void)
 {
     EXPECT_DECLS;
 
+#ifndef NO_SHA256
     EXPECT_TEST(test_wc_PKCS12_create_once(-1, -1));
 #if !defined(NO_RC4) && !defined(NO_SHA)
     EXPECT_TEST(test_wc_PKCS12_create_once(PBE_SHA1_RC4_128, PBE_SHA1_RC4_128));
@@ -187,6 +188,7 @@ int test_wc_PKCS12_create(void)
 #if defined(HAVE_AES_CBC) && !defined(NO_AES) && !defined(NO_AES_256) && \
     !defined(NO_SHA) && defined(WOLFSSL_ASN_TEMPLATE) && !defined(NO_DES3)
     EXPECT_TEST(test_wc_PKCS12_create_once(PBE_AES256_CBC, PBE_SHA1_DES3));
+#endif
 #endif
 
     (void) test_wc_PKCS12_create_once;

--- a/tests/api/test_rsa.c
+++ b/tests/api/test_rsa.c
@@ -106,8 +106,9 @@ int test_wc_RsaPrivateKeyDecode(void)
 int test_wc_RsaPublicKeyDecode(void)
 {
     EXPECT_DECLS;
-#if !defined(NO_RSA) && (defined(USE_CERT_BUFFERS_1024) || \
-        defined(USE_CERT_BUFFERS_2048)) && !defined(HAVE_FIPS)
+#if !defined(NO_RSA) && !defined(NO_SHA256) && \
+        (defined(USE_CERT_BUFFERS_1024) || defined(USE_CERT_BUFFERS_2048)) && \
+        !defined(HAVE_FIPS)
     RsaKey keyPub;
     byte*  tmp = NULL;
     word32 idx = 0;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -18611,7 +18611,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t random_test(void)
         0xa1, 0x80, 0x18, 0x3a, 0x07, 0xdf, 0xae, 0x17
     };
 
-    byte output[WC_SHA256_DIGEST_SIZE * 4];
+    byte output[32 * 4];
     wc_test_ret_t ret;
     WOLFSSL_ENTER("random_test");
 
@@ -20628,7 +20628,9 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
 #ifdef WOLFSSL_SHA224
                                  WC_MGF1SHA224,
 #endif
+#ifndef NO_SHA256
                                  WC_MGF1SHA256,
+#endif
 #ifdef WOLFSSL_SHA384
                                  WC_MGF1SHA384,
 #endif
@@ -20643,7 +20645,9 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
 #ifdef WOLFSSL_SHA224
                                  WC_HASH_TYPE_SHA224,
 #endif
+#ifndef NO_SHA256
                                  WC_HASH_TYPE_SHA256,
+#endif
 #ifdef WOLFSSL_SHA384
                                  WC_HASH_TYPE_SHA384,
 #endif
@@ -28297,6 +28301,7 @@ typedef struct {
  * serverHelloRandom, serverFinishedRandom, and clietnFinishedRandom
  * hashed together. */
 static const Tls13KdfTestVector tls13KdfTestVectors[] = {
+#ifndef NO_SHA256
 { /* 1 */
     WC_HASH_TYPE_SHA256, 35, 35,
     { /* PSK */
@@ -28520,6 +28525,7 @@ static const Tls13KdfTestVector tls13KdfTestVectors[] = {
         0xa5, 0x7c, 0x50, 0x14, 0xfd, 0xe7, 0x5f, 0x8b, 0xd3, 0x2f, 0xdc, 0x9b,
         0xa9, 0x93, 0x22, 0x19, 0xe6, 0xf2, 0x0c, 0xd8 }
 },
+#endif
 #ifdef WOLFSSL_SHA384
 { /* 26 */
     WC_HASH_TYPE_SHA384, 35, 35,
@@ -32339,6 +32345,7 @@ done:
     !defined(NO_ECC_SIGN)
 static wc_test_ret_t ecc_sig_test(WC_RNG* rng, ecc_key* key)
 {
+#ifndef NO_SHA256
     wc_test_ret_t ret;
     word32  sigSz;
     int     size;
@@ -32383,6 +32390,10 @@ static wc_test_ret_t ecc_sig_test(WC_RNG* rng, ecc_key* key)
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
     TEST_SLEEP();
+#else
+    (void)rng;
+    (void)key;
+#endif
 
     return 0;
 }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4459,7 +4459,7 @@ WOLFSSL_LOCAL int BuildCertHashes(const WOLFSSL* ssl, Hashes* hashes);
 
 #ifdef WOLFSSL_TLS13
 typedef union Digest {
-#ifndef NO_WOLFSSL_SHA256
+#ifndef NO_SHA256
     wc_Sha256 sha256;
 #endif
 #ifdef WOLFSSL_SHA384


### PR DESCRIPTION
# Description

Order of preference, based on algorithms compiled in, to use with HMAC for TLS 1.3 cookie:
  1. SHA-256
  2. SHA-384
  3. SHA-512
  4. SM3

Make code compile and unittest pass when SHA-256 not compiled in. Certificates used for testing require SHA-256 so handshake testing fails.

Fixes zd#20505

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
