### PR TITLE
Fix running tests in FIPS mode with hash DRBG disabled.

### DIFF
--- a/tests/api/test_random.c
+++ b/tests/api/test_random.c
@@ -325,8 +325,8 @@ int test_wc_RNG_TestSeed(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_HASHDRBG) && \
-    !(defined(HAVE_FIPS) || defined(HAVE_SELFTEST)) || \
-    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))
+    (!(defined(HAVE_FIPS) || defined(HAVE_SELFTEST)) || \
+    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)))
     byte seed[16];
     byte i;
 


### PR DESCRIPTION
# Description

Fixes zd#20595

# Testing

Built in tests, customer confirmed fix

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
