### PR TITLE
RSA API: use const pointers and clean up some comments

### DIFF
--- a/doc/dox_comments/header_files/rsa.h
+++ b/doc/dox_comments/header_files/rsa.h
@@ -61,7 +61,7 @@ int  wc_InitRsaKey(RsaKey* key, void* heap);
     \code
     RsaKey enc;
     unsigned char* id = (unsigned char*)"RSA2048";
-    int len = 6;
+    int len = 7;
     int devId = 1;
     int ret;
     ret = wc_CryptoDev_RegisterDevice(devId, wc_Pkcs11_CryptoDevCb,
@@ -173,7 +173,7 @@ int  wc_FreeRsaKey(RsaKey* key);
     \sa wc_RsaPublicEncrypt
     \sa wc_RsaPrivateDecrypt
 */
-int wc_RsaDirect(byte* in, word32 inLen, byte* out, word32* outSz,
+int wc_RsaDirect(const byte* in, word32 inLen, byte* out, word32* outSz,
         RsaKey* key, int type, WC_RNG* rng);
 
 /*!
@@ -1471,10 +1471,10 @@ int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
     \brief This function generates a RSA private key of length size (in bits)
     and given exponent (e). It then stores this key in the provided RsaKey
     structure, so that it may be used for encryption/decryption. A secure
-    number to use for e is 65537. size is required to be greater than
-    RSA_MIN_SIZE and less than RSA_MAX_SIZE. For this function to be
-    available, the option WOLFSSL_KEY_GEN must be enabled at compile time.
-    This can be accomplished with --enable-keygen if using ./configure.
+    number to use for e is 65537. size is required to be greater than or equal
+    to RSA_MIN_SIZE and less than or equal to RSA_MAX_SIZE. For this function
+    to be available, the option WOLFSSL_KEY_GEN must be enabled at compile
+    time.  This can be accomplished with --enable-keygen if using ./configure.
 
     \return 0 Returned upon successfully generating a RSA private key
     \return BAD_FUNC_ARG Returned if any of the input arguments are NULL,

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -297,7 +297,7 @@ int mp_to_unsigned_bin_at_pos(int x, mp_int *t, unsigned char *b)
 }
 
 /* store in unsigned [big endian] format */
-int mp_to_unsigned_bin (mp_int * a, unsigned char *b)
+int mp_to_unsigned_bin (const mp_int * a, unsigned char *b)
 {
   int     x, res;
   mp_int  t;
@@ -335,7 +335,7 @@ int mp_to_unsigned_bin_len(mp_int * a, unsigned char *b, int c)
 }
 
 /* creates "a" then copies b into it */
-int mp_init_copy (mp_int * a, mp_int * b)
+int mp_init_copy (mp_int * a, const mp_int * b)
 {
   int     res;
 

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -721,7 +721,7 @@ static int stm32_get_from_mp_int(uint8_t *dst, const mp_int *a, int sz)
         XMEMSET(dst, 0, offset);
 
     /* convert mp_int to array of bytes */
-    res = mp_to_unsigned_bin((mp_int*)a, dst + offset);
+    res = mp_to_unsigned_bin(a, dst + offset);
     return res;
 }
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2934,7 +2934,7 @@ static int wc_RsaFunctionAsync(const byte* in, word32 inLen, byte* out,
 /* Performs direct RSA computation without padding. The input and output must
  * match the key size (ex: 2048-bits = 256 bytes). Returns the size of the
  * output on success or negative value on failure. */
-int wc_RsaDirect(byte* in, word32 inLen, byte* out, word32* outSz,
+int wc_RsaDirect(const byte* in, word32 inLen, byte* out, word32* outSz,
         RsaKey* key, int type, WC_RNG* rng)
 {
     int ret;
@@ -4002,7 +4002,7 @@ int wc_RsaPSS_VerifyInline_ex(byte* in, word32 inLen, byte** out,
  * key    Public RSA key.
  * returns the length of the PSS data on success and negative indicates failure.
  */
-int wc_RsaPSS_Verify(byte* in, word32 inLen, byte* out, word32 outLen,
+int wc_RsaPSS_Verify(const byte* in, word32 inLen, byte* out, word32 outLen,
                      enum wc_HashType hash, int mgf, RsaKey* key)
 {
 #ifndef WOLFSSL_PSS_SALT_LEN_DISCOVER
@@ -4027,7 +4027,7 @@ int wc_RsaPSS_Verify(byte* in, word32 inLen, byte* out, word32 outLen,
  *          indicates salt length is determined from the data.
  * returns the length of the PSS data on success and negative indicates failure.
  */
-int wc_RsaPSS_Verify_ex(byte* in, word32 inLen, byte* out, word32 outLen,
+int wc_RsaPSS_Verify_ex(const byte* in, word32 inLen, byte* out, word32 outLen,
                         enum wc_HashType hash, int mgf, int saltLen,
                         RsaKey* key)
 {
@@ -4062,7 +4062,7 @@ int wc_RsaPSS_Verify_ex(byte* in, word32 inLen, byte* out, word32 outLen,
  * NULL is passed in to in or sig or inSz is not the same as the hash
  * algorithm length and 0 on success.
  */
-int wc_RsaPSS_CheckPadding(const byte* in, word32 inSz, byte* sig,
+int wc_RsaPSS_CheckPadding(const byte* in, word32 inSz, const byte* sig,
                            word32 sigSz, enum wc_HashType hashType)
 {
 #ifndef WOLFSSL_PSS_SALT_LEN_DISCOVER
@@ -4087,7 +4087,7 @@ int wc_RsaPSS_CheckPadding(const byte* in, word32 inSz, byte* sig,
  * NULL is passed in to in or sig or inSz is not the same as the hash
  * algorithm length and 0 on success.
  */
-int wc_RsaPSS_CheckPadding_ex2(const byte* in, word32 inSz, byte* sig,
+int wc_RsaPSS_CheckPadding_ex2(const byte* in, word32 inSz, const byte* sig,
                                word32 sigSz, enum wc_HashType hashType,
                                int saltLen, int bits, void* heap)
 {
@@ -4186,7 +4186,7 @@ int wc_RsaPSS_CheckPadding_ex2(const byte* in, word32 inSz, byte* sig,
     (void)heap; /* unused if memory is disabled */
     return ret;
 }
-int wc_RsaPSS_CheckPadding_ex(const byte* in, word32 inSz, byte* sig,
+int wc_RsaPSS_CheckPadding_ex(const byte* in, word32 inSz, const byte* sig,
                                word32 sigSz, enum wc_HashType hashType,
                                int saltLen, int bits)
 {
@@ -4257,7 +4257,7 @@ int wc_RsaPSS_VerifyCheckInline(byte* in, word32 inLen, byte** out,
  * key    Public RSA key.
  * returns the length of the PSS data on success and negative indicates failure.
  */
-int wc_RsaPSS_VerifyCheck(byte* in, word32 inLen, byte* out, word32 outLen,
+int wc_RsaPSS_VerifyCheck(const byte* in, word32 inLen, byte* out, word32 outLen,
                           const byte* digest, word32 digestLen,
                           enum wc_HashType hash, int mgf,
                           RsaKey* key)
@@ -4383,7 +4383,7 @@ int wc_RsaEncryptSize(const RsaKey* key)
 
 #ifndef WOLFSSL_RSA_VERIFY_ONLY
 /* flatten RsaKey structure into individual elements (e, n) */
-int wc_RsaFlattenPublicKey(RsaKey* key, byte* e, word32* eSz, byte* n,
+int wc_RsaFlattenPublicKey(const RsaKey* key, byte* e, word32* eSz, byte* n,
                                                                    word32* nSz)
 {
     int sz, ret;
@@ -4413,7 +4413,7 @@ int wc_RsaFlattenPublicKey(RsaKey* key, byte* e, word32* eSz, byte* n,
 #endif
 
 #ifndef WOLFSSL_RSA_VERIFY_ONLY
-static int RsaGetValue(mp_int* in, byte* out, word32* outSz)
+static int RsaGetValue(const mp_int* in, byte* out, word32* outSz)
 {
     word32 sz;
     int ret = 0;
@@ -4434,7 +4434,7 @@ static int RsaGetValue(mp_int* in, byte* out, word32* outSz)
 }
 
 
-int wc_RsaExportKey(RsaKey* key,
+int wc_RsaExportKey(const RsaKey* key,
                     byte* e, word32* eSz, byte* n, word32* nSz,
                     byte* d, word32* dSz, byte* p, word32* pSz,
                     byte* q, word32* qSz)

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -4184,7 +4184,7 @@ int fp_to_unsigned_bin_at_pos(int x, fp_int *t, unsigned char *b)
 #endif
 }
 
-int fp_to_unsigned_bin(fp_int *a, unsigned char *b)
+int fp_to_unsigned_bin(const fp_int *a, unsigned char *b)
 {
   int     x;
 #ifndef WOLFSSL_SMALL_STACK
@@ -4882,7 +4882,7 @@ int mp_to_unsigned_bin_at_pos(int x, fp_int *t, unsigned char *b)
 }
 
 /* store in unsigned [big endian] format */
-int mp_to_unsigned_bin (mp_int * a, unsigned char *b)
+int mp_to_unsigned_bin(const mp_int * a, unsigned char *b)
 {
   return fp_to_unsigned_bin(a,b);
 }
@@ -4968,14 +4968,14 @@ void fp_copy(const fp_int *a, fp_int *b)
     }
 }
 
-int mp_init_copy(fp_int * a, fp_int * b)
+int mp_init_copy(fp_int * a, const fp_int * b)
 {
     fp_init_copy(a, b);
     return MP_OKAY;
 }
 
 /* Copy (dst = a) from (src = b) */
-void fp_init_copy(fp_int *a, fp_int* b)
+void fp_init_copy(fp_int *a, const fp_int* b)
 {
     if (a != b) {
         fp_init(a);

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -307,7 +307,7 @@ typedef int ltm_prime_callback(unsigned char *dst, int len, void *dat);
 extern const char *mp_s_rmap;
 #endif
 
-/* 6 functions needed by Rsa */
+/* functions needed by Rsa */
 MP_API int  mp_init (mp_int * a);
 MP_API void mp_clear (mp_int * a);
 MP_API void mp_free (mp_int * a);
@@ -315,7 +315,7 @@ MP_API void mp_forcezero(mp_int * a);
 MP_API int  mp_unsigned_bin_size(const mp_int * a);
 MP_API int  mp_read_unsigned_bin (mp_int * a, const unsigned char *b, int c);
 MP_API int  mp_to_unsigned_bin_at_pos(int x, mp_int *t, unsigned char *b);
-MP_API int  mp_to_unsigned_bin (mp_int * a, unsigned char *b);
+MP_API int  mp_to_unsigned_bin(const mp_int * a, unsigned char *b);
 #define mp_to_unsigned_bin_len_ct mp_to_unsigned_bin_len
 MP_API int  mp_to_unsigned_bin_len(mp_int * a, unsigned char *b, int c);
 MP_API int  mp_exptmod (mp_int * G, mp_int * X, mp_int * P, mp_int * Y);
@@ -326,7 +326,7 @@ MP_API int  mp_exptmod_ex (mp_int * G, mp_int * X, int digits, mp_int * P,
 /* functions added to support above needed, removed TOOM and KARATSUBA */
 MP_API int  mp_count_bits (const mp_int * a);
 MP_API int  mp_leading_bit (mp_int * a);
-MP_API int  mp_init_copy (mp_int * a, mp_int * b);
+MP_API int  mp_init_copy (mp_int * a, const mp_int * b);
 MP_API int  mp_copy (const mp_int * a, mp_int * b);
 MP_API int  mp_grow (mp_int * a, int size);
 MP_API int  mp_div_2d (mp_int * a, int b, mp_int * c, mp_int * d);

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -352,28 +352,28 @@ WOLFSSL_API int  wc_RsaPSS_VerifyInline(byte* in, word32 inLen, byte** out,
 WOLFSSL_API int  wc_RsaPSS_VerifyInline_ex(byte* in, word32 inLen, byte** out,
                                            enum wc_HashType hash, int mgf,
                                            int saltLen, RsaKey* key);
-WOLFSSL_API int  wc_RsaPSS_Verify(byte* in, word32 inLen, byte* out,
+WOLFSSL_API int  wc_RsaPSS_Verify(const byte* in, word32 inLen, byte* out,
                                   word32 outLen, enum wc_HashType hash, int mgf,
                                   RsaKey* key);
-WOLFSSL_API int  wc_RsaPSS_Verify_ex(byte* in, word32 inLen, byte* out,
+WOLFSSL_API int  wc_RsaPSS_Verify_ex(const byte* in, word32 inLen, byte* out,
                                      word32 outLen, enum wc_HashType hash,
                                      int mgf, int saltLen, RsaKey* key);
-WOLFSSL_API int  wc_RsaPSS_CheckPadding(const byte* in, word32 inLen, byte* sig,
-                                        word32 sigSz,
+WOLFSSL_API int  wc_RsaPSS_CheckPadding(const byte* in, word32 inLen,
+                                        const byte* sig, word32 sigSz,
                                         enum wc_HashType hashType);
 WOLFSSL_API int  wc_RsaPSS_CheckPadding_ex(const byte* in, word32 inLen,
-                                           byte* sig, word32 sigSz,
+                                           const byte* sig, word32 sigSz,
                                            enum wc_HashType hashType,
                                            int saltLen, int bits);
 WOLFSSL_API int  wc_RsaPSS_CheckPadding_ex2(const byte* in, word32 inLen,
-                                           byte* sig, word32 sigSz,
+                                           const byte* sig, word32 sigSz,
                                            enum wc_HashType hashType,
                                            int saltLen, int bits, void* heap);
 WOLFSSL_API int  wc_RsaPSS_VerifyCheckInline(byte* in, word32 inLen, byte** out,
                                const byte* digest, word32 digentLen,
                                enum wc_HashType hash, int mgf,
                                RsaKey* key);
-WOLFSSL_API int  wc_RsaPSS_VerifyCheck(byte* in, word32 inLen,
+WOLFSSL_API int  wc_RsaPSS_VerifyCheck(const byte* in, word32 inLen,
                                byte* out, word32 outLen,
                                const byte* digest, word32 digestLen,
                                enum wc_HashType hash, int mgf,
@@ -440,15 +440,15 @@ WOLFSSL_API int  wc_RsaPrivateDecryptInline_ex(byte* in, word32 inLen,
                       byte** out, RsaKey* key, int type, enum wc_HashType hash,
                       int mgf, byte* label, word32 labelSz);
 #if defined(WC_RSA_DIRECT) || defined(WC_RSA_NO_PADDING) || defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-WOLFSSL_API int wc_RsaDirect(byte* in, word32 inLen, byte* out, word32* outSz,
+WOLFSSL_API int wc_RsaDirect(const byte* in, word32 inLen, byte* out, word32* outSz,
                    RsaKey* key, int type, WC_RNG* rng);
 #endif
 
 #endif /* HAVE_FIPS */
 
-WOLFSSL_API int  wc_RsaFlattenPublicKey(RsaKey* key, byte* e, word32* eSz,
+WOLFSSL_API int  wc_RsaFlattenPublicKey(const RsaKey* key, byte* e, word32* eSz,
                                         byte* n, word32* nSz);
-WOLFSSL_API int wc_RsaExportKey(RsaKey* key,
+WOLFSSL_API int wc_RsaExportKey(const RsaKey* key,
                                 byte* e, word32* eSz,
                                 byte* n, word32* nSz,
                                 byte* d, word32* dSz,

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -520,7 +520,7 @@ int fp_set_bit (fp_int * a, fp_digit b);
 
 /* copy from a to b */
 void fp_copy(const fp_int *a, fp_int *b);
-void fp_init_copy(fp_int *a, fp_int *b);
+void fp_init_copy(fp_int *a, const fp_int *b);
 
 /* clamp digits */
 #define fp_clamp(a)   { while ((a)->used && (a)->dp[(a)->used-1] == 0) --((a)->used); (a)->sign = (a)->used ? (a)->sign : FP_ZPOS; }
@@ -727,7 +727,7 @@ int fp_leading_bit(fp_int *a);
 
 int fp_unsigned_bin_size(const fp_int *a);
 int fp_read_unsigned_bin(fp_int *a, const unsigned char *b, int c);
-int fp_to_unsigned_bin(fp_int *a, unsigned char *b);
+int fp_to_unsigned_bin(const fp_int *a, unsigned char *b);
 int fp_to_unsigned_bin_len_ct(fp_int *a, unsigned char *out, int outSz);
 int fp_to_unsigned_bin_len(fp_int *a, unsigned char *b, int c);
 int fp_to_unsigned_bin_at_pos(int x, fp_int *t, unsigned char *b);
@@ -813,7 +813,7 @@ int  fp_sqr_comba64(fp_int *a, fp_int *b);
 #define mp_tohex(M, S)     mp_toradix((M), (S), MP_RADIX_HEX)
 
 MP_API int  mp_init (mp_int * a);
-MP_API int  mp_init_copy(fp_int * a, fp_int * b);
+MP_API int  mp_init_copy(fp_int * a, const fp_int * b);
 MP_API void mp_clear (mp_int * a);
 MP_API void mp_free (mp_int * a);
 MP_API void mp_forcezero (mp_int * a);
@@ -850,7 +850,7 @@ MP_API int  mp_cmp_d(mp_int *a, mp_digit b);
 MP_API int  mp_unsigned_bin_size(const mp_int * a);
 MP_API int  mp_read_unsigned_bin (mp_int * a, const unsigned char *b, int c);
 MP_API int  mp_to_unsigned_bin_at_pos(int x, mp_int *t, unsigned char *b);
-MP_API int  mp_to_unsigned_bin (mp_int * a, unsigned char *b);
+MP_API int  mp_to_unsigned_bin(const mp_int * a, unsigned char *b);
 MP_API int  mp_to_unsigned_bin_len_ct(mp_int * a, unsigned char *b, int c);
 MP_API int  mp_to_unsigned_bin_len(mp_int * a, unsigned char *b, int c);
 


### PR DESCRIPTION
# Description

RSA API: use const pointers and clean up some comments

Note: this was mainly driven by creating the Rust wrapper and trying to avoid needing mutable references in some Rust APIs when a non-mutable reference could be used.

# Testing

Local build and CI tests.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
