### PR TITLE
Update Espressif workflow to pin latest to ESP-IDF v5.5

### DIFF
--- a/.github/workflows/docker-Espressif.yml
+++ b/.github/workflows/docker-Espressif.yml
@@ -19,7 +19,9 @@ jobs:
     # This should be a safe limit for the tests to run.
     timeout-minutes: 12
     container:
-      image: espressif/idf:latest
+      # The latest stable release is v5.5
+      image: espressif/idf:release-v5.5
+      # image: espressif/idf:latest # The "latest" has breaking changes for ESP-IDF V6
     steps:
       - uses: actions/checkout@v4
       - name: Initialize Espressif IDE and build examples


### PR DESCRIPTION
# Description

There are breaking changes in the regularly updated Espressif ESP-IDF "Latest"  v6 from https://github.com/espressif/esp-idf/

This PR updates the [local workflow docker-Espressif test](https://github.com/wolfSSL/wolfssl/blob/master/.github/workflows/docker-Espressif.yml) to pin to the latest stable release: currently v5.5.

Fixes zd#

# Testing

How did you test?
 
https://github.com/gojimmypi/wolfssl/actions/runs/18200867757

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
