### PR TITLE
20251002-misc-clang-tidy-and-fips-fixes

### DIFF
--- a/tests/api/test_dtls.c
+++ b/tests/api/test_dtls.c
@@ -1533,7 +1533,7 @@ int test_dtls_bogus_finished_epoch_zero(void)
     test_memio_clear_buffer(&test_ctx, 0);
     ExpectIntEQ(test_memio_inject_message(&test_ctx, 1,
             (const char*)server_hello_done_message, sizeof(server_hello_done_message)), 0);
-    wolfSSL_connect(ssl_c);
+    ExpectIntEQ(wolfSSL_connect(ssl_c), -1);
 
     /* verifying no ClientHello replay occurred,
      * buffer should empty since we exit early on

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -23616,10 +23616,12 @@ static wc_test_ret_t dh_ffdhe_test(WC_RNG *rng, int name)
 
     /* wc_DhGeneratePublic_fips() was added in 5.2.3, but some customers are
      * building with configure scripts that set version to 5.2.1, but with 5.2.3
-     * wolfCrypt sources.
+     * wolfCrypt sources.  5.3.0 is used for both fips-v5-ready and v5-kcapi,
+     * and are also missing wc_DhGeneratePublic().
      */
 #if !(defined(HAVE_SELFTEST) || \
       (defined(HAVE_FIPS) && FIPS_VERSION3_LT(5,2,3)) || \
+      FIPS_VERSION3_EQ(5,3,0) || \
       FIPS_VERSION3_EQ(6,0,0) || \
       defined(NO_WC_DHGENERATEPUBLIC))
 
@@ -23654,7 +23656,7 @@ static wc_test_ret_t dh_ffdhe_test(WC_RNG *rng, int name)
     if (pubSz != pubSz2 || XMEMCMP(pub, pub2, pubSz)) {
         ERROR_OUT(WC_TEST_RET_ENC_NC, done);
     }
-#endif /* !(HAVE_SELFTEST || FIPS <5.2.3 || FIPS == 6.0.0 || NO_WC_DHGENERATEPUBLIC */
+#endif /* !(NO_WC_DHGENERATEPUBLIC || HAVE_SELFTEST || FIPS <5.2.3 || == 5.3.0 || == 6.0.0 */
 
 #if (defined(WOLFSSL_HAVE_SP_DH) || defined(USE_FAST_MATH)) && \
     !defined(HAVE_INTEL_QA)


### PR DESCRIPTION
`tests/api/test_dtls.c`: add missing `ExpectIntEQ()` around `wolfSSL_connect()` in `test_dtls_bogus_finished_epoch_zero()`;

`wolfcrypt/test/test.c`: fix gate for `wc_DhGeneratePublic()` test in `dh_ffdhe_test()` to properly exclude 5.3.0.

tested with
```
wolfssl-multi-test.sh ...
clang-tidy-all-sp-all
fips-140-3-v5-ready-optest-acvp-intelasm
fips-140-3-dev-kcapi
```
and with `super-quick-check` in progress.
