### PR TITLE
Remove the `NO_WRITE_TEMP_FILES` test.c logic added in #9194

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2765,10 +2765,6 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 
 #endif /* NO_MAIN_DRIVER */
 
-#if defined(WOLF_CRYPTO_CB_ONLY_ECC) || defined(WOLF_CRYPTO_CB_ONLY_RSA)
-    #undef  NO_WRITE_TEMP_FILES
-    #define NO_WRITE_TEMP_FILES
-#endif
 
 /* helper to save DER, convert to PEM and save PEM */
 #if !defined(NO_ASN) && (defined(HAVE_ECC) || !defined(NO_DSA) || \


### PR DESCRIPTION
# Description

Remove the `NO_WRITE_TEMP_FILES` test.c logic added in #9194

# Testing

Could not reproduce in wolfHSM or with `./configure --enable-cryptocb CFLAGS="-DWOLF_CRYPTO_CB_ONLY_RSA -DWOLF_CRYPTO_CB_ONLY_ECC" --disable-filesystem --enable-keygen && make check`


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
