### PR TITLE
double free -- should be o_hash

### DIFF
--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -1415,7 +1415,7 @@ void wc_HmacFree(Hmac* hmac)
             wc_Sm3Free(&hmac->hash.sm3);
         #ifdef WOLFSSL_HMAC_COPY_HASH
             wc_Sm3Free(&hmac->i_hash.sm3);
-            wc_Sm3Free(&hmac->i_hash.sm3);
+            wc_Sm3Free(&hmac->o_hash.sm3);
         #endif
             break;
     #endif


### PR DESCRIPTION
# Description

fix a double free() of `hmac->i_hash.sm3`

Fixes https://github.com/wolfSSL/wolfssl/pull/9190

# Testing

`./configure --enable-sm3 --enable-hmac-copy`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
