### PR TITLE
cryptocb: sha512_family: try specific digest length hashtype first

### DIFF
--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -1753,7 +1753,7 @@ int wc_CryptoCb_Sha512Hash(wc_Sha512* sha512, const byte* in,
           cryptoInfo.hash.type = WC_HASH_TYPE_SHA512_224;
           ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
           ret = wc_CryptoCb_TranslateErrorCode(ret);
-          if (ret != CRYPTOCB_UNAVAILABLE)
+          if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         }
 #endif
@@ -1762,7 +1762,7 @@ int wc_CryptoCb_Sha512Hash(wc_Sha512* sha512, const byte* in,
           cryptoInfo.hash.type = WC_HASH_TYPE_SHA512_256;
           ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
           ret = wc_CryptoCb_TranslateErrorCode(ret);
-          if (ret != CRYPTOCB_UNAVAILABLE)
+          if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         }
 #endif

--- a/wolfcrypt/src/port/arm/armv8-sha512.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512.c
@@ -543,7 +543,7 @@ int wc_Sha512Update(wc_Sha512* sha512, const byte* data, word32 len)
     if (sha512->devId != INVALID_DEVID)
     #endif
     {
-        int ret = wc_CryptoCb_Sha512Hash(sha512, data, len, NULL);
+        int ret = wc_CryptoCb_Sha512Hash(sha512, data, len, NULL, 0);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
@@ -675,10 +675,8 @@ static int Sha512_Family_Final(wc_Sha512* sha512, byte* hash,
     if (sha512->devId != INVALID_DEVID)
     #endif
     {
-        byte localHash[WC_SHA512_DIGEST_SIZE];
-        ret = wc_CryptoCb_Sha512Hash(sha512, NULL, 0, localHash);
+        ret = wc_CryptoCb_Sha512Hash(sha512, NULL, 0, hash, digestSz);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
-            XMEMCPY(hash, localHash, digestSz);
             return ret;
         }
         /* fall-through when unavailable */

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -1192,7 +1192,7 @@ int wc_Sha512Update(wc_Sha512* sha512, const byte* data, word32 len)
     if (sha512->devId != INVALID_DEVID)
     #endif
     {
-        int ret = wc_CryptoCb_Sha512Hash(sha512, data, len, NULL);
+        int ret = wc_CryptoCb_Sha512Hash(sha512, data, len, NULL, 0);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
@@ -1429,10 +1429,8 @@ static int Sha512_Family_Final(wc_Sha512* sha512, byte* hash, size_t digestSz,
     if (sha512->devId != INVALID_DEVID)
     #endif
     {
-        byte localHash[WC_SHA512_DIGEST_SIZE];
-        ret = wc_CryptoCb_Sha512Hash(sha512, NULL, 0, localHash);
+        ret = wc_CryptoCb_Sha512Hash(sha512, NULL, 0, hash, digestSz);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
-            XMEMCPY(hash, localHash, digestSz);
             return ret;
         }
         /* fall-through when unavailable */

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -676,7 +676,7 @@ WOLFSSL_LOCAL int wc_CryptoCb_Sha384Hash(wc_Sha384* sha384, const byte* in,
 #endif
 #ifdef WOLFSSL_SHA512
 WOLFSSL_LOCAL int wc_CryptoCb_Sha512Hash(wc_Sha512* sha512, const byte* in,
-    word32 inSz, byte* digest);
+    word32 inSz, byte* digest, size_t digestSz);
 #endif
 
 #ifdef WOLFSSL_SHA3


### PR DESCRIPTION
If the cryptocb provider supports specific SHA512/224 and SHA512/256 hashtype, this commit allows to:

1. avoid a copy
2. do not touch the output buffer outside of the cryptocb handler

2 might be important for cryptocb provider that needs special handling of memory buffer (DMA, memory mapping).

