### PR TITLE
KCAPI ECC: initialize mp_ints

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6211,9 +6211,10 @@ int wc_ecc_init_ex(ecc_key* key, void* heap, int devId)
 
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
     key->slot = ATECC_INVALID_SLOT;
-#elif defined(WOLFSSL_KCAPI_ECC)
-    key->handle = NULL;
 #else
+#if defined(WOLFSSL_KCAPI_ECC)
+    key->handle = NULL;
+#endif
 #ifdef ALT_ECC_SIZE
     key->pubkey.x = (mp_int*)&key->pubkey.xyz[0];
     key->pubkey.y = (mp_int*)&key->pubkey.xyz[1];


### PR DESCRIPTION
# Description

Was not initializing mp_ints and it is needed now.

Fixes zd#20591

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
