### PR TITLE
20250926-fips-optest-tweaks

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -86,6 +86,10 @@ MAX_STACK_FRAME_SIZE=$(shell echo $$(( $(KERNEL_THREAD_STACK_SIZE) / 4)))
 
 libwolfssl-y := $(WOLFSSL_OBJ_FILES) linuxkm/module_hooks.o linuxkm/module_exports.o
 
+ifeq "$(FIPS_OPTEST)" "1"
+libwolfssl-y += linuxkm/optest-140-3/linuxkm_optest_wrapper.o
+endif
+
 WOLFSSL_CFLAGS_NO_VECTOR_INSNS := $(CFLAGS_SIMD_DISABLE) $(CFLAGS_FPU_DISABLE)
 ifeq "$(ENABLED_ASM)" "yes"
     WOLFSSL_CFLAGS_YES_VECTOR_INSNS := $(CFLAGS_SIMD_ENABLE) $(CFLAGS_FPU_DISABLE) $(CFLAGS_AUTO_VECTORIZE_DISABLE)

--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -35,6 +35,9 @@ WOLFSSL_CFLAGS=-DHAVE_CONFIG_H -I$(SRC_TOP) -DBUILDING_WOLFSSL $(AM_CPPFLAGS) $(
 ifdef KERNEL_EXTRA_CFLAGS
     WOLFSSL_CFLAGS += $(KERNEL_EXTRA_CFLAGS)
 endif
+ifeq "$(FIPS_OPTEST)" "1"
+    WOLFSSL_CFLAGS += -DFIPS_OPTEST
+endif
 
 WOLFSSL_ASFLAGS=-DHAVE_CONFIG_H -I$(SRC_TOP) -DBUILDING_WOLFSSL $(AM_CCASFLAGS) $(CCASFLAGS)
 
@@ -130,6 +133,10 @@ GENERATE_RELOC_TAB := $(READELF) --wide -r libwolfssl.ko |				\
 	    print "~0U };\nconst size_t wc_linuxkm_pie_reloc_tab_length = sizeof wc_linuxkm_pie_reloc_tab / sizeof wc_linuxkm_pie_reloc_tab[0];";\
 	}'
 
+ifeq "$(V)" "1"
+    vflag := --verbose
+endif
+
 .PHONY: libwolfssl.ko
 libwolfssl.ko:
 	@if test -z '$(KERNEL_ROOT)'; then echo '$$KERNEL_ROOT is unset' >&2; exit 1; fi
@@ -137,9 +144,12 @@ libwolfssl.ko:
 	@if test -z '$(src_libwolfssl_la_OBJECTS)'; then echo '$$src_libwolfssl_la_OBJECTS is unset.' >&2; exit 1; fi
         # after commit 9a0ebe5011 (6.10), sources must be in $(obj).  work around this by making links to all needed sources:
 	@mkdir -p '$(MODULE_TOP)/linuxkm'
-	@test '$(MODULE_TOP)/module_hooks.c' -ef '$(MODULE_TOP)/linuxkm/module_hooks.c' || cp --verbose --no-dereference --symbolic-link --no-clobber '$(MODULE_TOP)'/*.[ch] '$(MODULE_TOP)/linuxkm/'
-	@test '$(SRC_TOP)/wolfcrypt/src/wc_port.c' -ef '$(MODULE_TOP)/wolfcrypt/src/wc_port.c' || cp --verbose --no-dereference --symbolic-link --no-clobber --recursive '$(SRC_TOP)/wolfcrypt' '$(MODULE_TOP)/'
-	@test '$(SRC_TOP)/src/wolfio.c' -ef '$(MODULE_TOP)/src/wolfio.c' || cp --verbose --no-dereference --symbolic-link --no-clobber --recursive '$(SRC_TOP)/src' '$(MODULE_TOP)/'
+	@test '$(MODULE_TOP)/module_hooks.c' -ef '$(MODULE_TOP)/linuxkm/module_hooks.c' || cp $(vflag) --no-dereference --symbolic-link --no-clobber '$(MODULE_TOP)'/*.[ch] '$(MODULE_TOP)/linuxkm/'
+	@test '$(SRC_TOP)/wolfcrypt/src/wc_port.c' -ef '$(MODULE_TOP)/wolfcrypt/src/wc_port.c' || cp $(vflag) --no-dereference --symbolic-link --no-clobber --recursive '$(SRC_TOP)/wolfcrypt' '$(MODULE_TOP)/'
+	@test '$(SRC_TOP)/src/wolfio.c' -ef '$(MODULE_TOP)/src/wolfio.c' || cp $(vflag) --no-dereference --symbolic-link --no-clobber --recursive '$(SRC_TOP)/src' '$(MODULE_TOP)/'
+ifeq "$(FIPS_OPTEST)" "1"
+	@test '$(SRC_TOP)/../fips/optest-140-3/linuxkm_optest_wrapper.c' -ef '$(MODULE_TOP)/linuxkm/optest-140-3/linuxkm_optest_wrapper.c' || cp $(vflag) --no-dereference --symbolic-link --no-clobber --recursive '$(SRC_TOP)/../fips/optest-140-3' '$(MODULE_TOP)/linuxkm'
+endif
 ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
 	@$(eval RELOC_TMP := $(shell mktemp "$(MAKE_TMPDIR)/wc_linuxkm_pie_reloc_tab.c.XXXXXX"))
 	@[[ -f wc_linuxkm_pie_reloc_tab.c ]] || echo -e "const unsigned int wc_linuxkm_pie_reloc_tab[] = { ~0U };\nconst size_t wc_linuxkm_pie_reloc_tab_length = 1;" > wc_linuxkm_pie_reloc_tab.c

--- a/linuxkm/module_exports.c.template
+++ b/linuxkm/module_exports.c.template
@@ -46,6 +46,7 @@
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/cpuid.h>
 #include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/md2.h>

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -371,6 +371,10 @@ int wc_linuxkm_GenerateSeed_IntelRD(struct OS_Seed* os, byte* output, word32 sz)
     #include "linuxkm/x86_vector_register_glue.c"
 #endif
 
+#ifdef FIPS_OPTEST
+extern int linuxkm_op_test_wrapper(void);
+#endif
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
 static int __init wolfssl_init(void)
 #else
@@ -586,6 +590,10 @@ static int wolfssl_init(void)
 #endif
         );
 #endif /* HAVE_FIPS && FIPS_VERSION3_GT(5,2,0) */
+
+#ifdef FIPS_OPTEST
+    (void)linuxkm_op_test_wrapper();
+#endif
 
 #ifndef NO_CRYPT_TEST
     ret = wolfcrypt_test(NULL);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -79,7 +79,7 @@
 #endif
 #endif
 
-const byte const_byte_array[] = "A+Gd\0\0\0";
+static const byte const_byte_array[] = "A+Gd\0\0\0";
 #define CBPTR_EXPECTED 'A'
 
 #if defined(WOLFSSL_TRACK_MEMORY_VERBOSE) && !defined(WOLFSSL_STATIC_MEMORY)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2152,6 +2152,9 @@ WOLFSSL_LOCAL int DoFinished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 WOLFSSL_LOCAL int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                            word32 size, word32 totalSz, int sniff);
 #endif
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define DoApplicationData wolfSSL_DoApplicationData
+#endif
 WOLFSSL_TEST_VIS int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                     int sniff);
 /* TLS v1.3 needs these */
@@ -2365,6 +2368,9 @@ typedef struct CipherSuite {
 #endif
 } CipherSuite;
 
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define InitSuitesHashSigAlgo wolfSSL_InitSuitesHashSigAlgo
+#endif
 WOLFSSL_TEST_VIS void InitSuitesHashSigAlgo(byte* hashSigAlgo, int have,
                                        int tls1_2, int keySz, word16* len);
 WOLFSSL_LOCAL int AllocateCtxSuites(WOLFSSL_CTX* ctx);
@@ -4659,6 +4665,9 @@ WOLFSSL_LOCAL WOLFSSL_SESSION* wolfSSL_GetSession(
     WOLFSSL* ssl, byte* masterSecret, byte restoreSessionCerts);
 WOLFSSL_LOCAL void SetupSession(WOLFSSL* ssl);
 WOLFSSL_LOCAL void AddSession(WOLFSSL* ssl);
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define AddSessionToCache wolfSSL_AddSessionToCache
+#endif
 WOLFSSL_TEST_VIS int AddSessionToCache(WOLFSSL_CTX* ctx,
     WOLFSSL_SESSION* addSession, const byte* id, byte idSz, int* sessionIndex,
     int side, word16 useTicket, ClientSession** clientCacheEntry);
@@ -6716,6 +6725,11 @@ WOLFSSL_LOCAL word32 MacSize(const WOLFSSL* ssl);
 #endif
 
 #ifdef WOLFSSL_DTLS
+    #ifdef WOLFSSL_API_PREFIX_MAP
+        #define DtlsMsgListDelete wolfSSL_DtlsMsgListDelete
+        #define DtlsMsgFind wolfSSL_DtlsMsgFind
+        #define DtlsMsgStore wolfSSL_DtlsMsgStore
+    #endif /* WOLFSSL_API_PREFIX_MAP */
     WOLFSSL_LOCAL DtlsMsg* DtlsMsgNew(word32 sz, byte tx, void* heap);
     WOLFSSL_LOCAL void DtlsMsgDelete(DtlsMsg* item, void* heap);
     WOLFSSL_TEST_VIS void DtlsMsgListDelete(DtlsMsg* head, void* heap);
@@ -6917,6 +6931,9 @@ WOLFSSL_LOCAL int BuildMessage(WOLFSSL* ssl, byte* output, int outSz,
                         int sizeOnly, int asyncOkay, int epochOrder);
 
 #ifdef WOLFSSL_TLS13
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define BuildTls13Message wolfSSL_BuildTls13Message
+#endif
 WOLFSSL_TEST_VIS int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                int inSz, int type, int hashOutput, int sizeOnly, int asyncOkay);
 WOLFSSL_LOCAL int Tls13UpdateKeys(WOLFSSL* ssl);

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -310,6 +310,9 @@ WOLFSSL_API int wolfSSL_ECDSA_verify(int type, const unsigned char *digest,
 
 
 #if defined HAVE_ECC && (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define EccEnumToNID wolfSSL_EccEnumToNID
+#endif
 WOLFSSL_API int EccEnumToNID(int n);
 #endif
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2074,6 +2074,32 @@ WOLFSSL_API int wc_BerToDer(const byte* ber, word32 berSz, byte* der,
 WOLFSSL_LOCAL int StreamOctetString(const byte* inBuf, word32 inBufSz,
     byte* out, word32* outSz, word32* idx);
 
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define FreeAltNames wc_FreeAltNames
+    #define AltNameNew wc_AltNameNew
+    #define AltNameDup wc_AltNameDup
+    #ifndef IGNORE_NAME_CONSTRAINTS
+        #define FreeNameSubtrees wc_FreeNameSubtrees
+    #endif
+    #define InitDecodedCert wc_AsnApi_InitDecodedCert
+    #define FreeDecodedCert wc_AsnApi_FreeDecodedCert
+    #define ParseCert wc_AsnApi_ParseCert
+    #define AddSignature wc_AddSignature
+    #define ToTraditional wc_ToTraditional
+    #define ToTraditional_ex wc_ToTraditional_ex
+    #define UnTraditionalEnc wc_UnTraditionalEnc
+    #define TraditionalEnc_ex wc_TraditionalEnc_ex
+    #define TraditionalEnc wc_TraditionalEnc
+    #define SetName wc_SetName
+    #define GetShortInt wc_GetShortInt
+    #define SetShortInt wc_SetShortInt
+    #define GetLength wc_GetLength
+    #define GetASNInt wc_GetASNInt
+    #define GetASNTag wc_GetASNTag
+    #define SetAlgoID wc_SetAlgoID
+    #define SetAsymKeyDer wc_SetAsymKeyDer
+#endif /* WOLFSSL_API_PREFIX_MAP */
+
 WOLFSSL_ASN_API void FreeAltNames(DNS_entry* altNames, void* heap);
 WOLFSSL_ASN_API DNS_entry* AltNameNew(void* heap);
 WOLFSSL_ASN_API DNS_entry* AltNameDup(DNS_entry* from, void* heap);

--- a/wolfssl/wolfcrypt/blake2.h
+++ b/wolfssl/wolfcrypt/blake2.h
@@ -34,10 +34,16 @@
 
 /* call old functions if using fips for the sake of hmac @wc_fips */
 #ifdef HAVE_FIPS
-    /* Since hmac can call blake functions provide original calls */
-    #define wc_InitBlake2b   InitBlake2b
-    #define wc_Blake2bUpdate Blake2bUpdate
-    #define wc_Blake2bFinal  Blake2bFinal
+    #ifdef WOLFSSL_API_PREFIX_MAP
+        #define InitBlake2b   wc_InitBlake2b
+        #define Blake2bUpdate wc_Blake2bUpdate
+        #define Blake2bFinal  wc_Blake2bFinal
+    #else
+        /* Since hmac can call blake functions provide original calls */
+        #define wc_InitBlake2b   InitBlake2b
+        #define wc_Blake2bUpdate Blake2bUpdate
+        #define wc_Blake2bFinal  Blake2bFinal
+    #endif
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/coding.h
+++ b/wolfssl/wolfcrypt/coding.h
@@ -32,6 +32,10 @@
     extern "C" {
 #endif
 
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define Base64_Decode wc_Base64_Decode
+    #define Base64_Decode_nonCT wc_Base64_Decode_nonCT
+#endif
 
 WOLFSSL_API int Base64_Decode(const byte* in, word32 inLen, byte* out,
                                word32* outLen);
@@ -53,6 +57,12 @@ WOLFSSL_API int Base64_Decode_nonCT(const byte* in, word32 inLen, byte* out,
         WC_ESC_NL_ENC,        /* use escape sequence encoding   */
         WC_NO_NL_ENC          /* no encoding at all             */
     }; /* Encoding types */
+
+    #ifdef WOLFSSL_API_PREFIX_MAP
+        #define Base64_Encode wc_Base64_Encode
+        #define Base64_EncodeEsc wc_Base64_EncodeEsc
+        #define Base64_Encode_NoNl wc_Base64_Encode_NoNl
+    #endif
 
     /* encode isn't */
     WOLFSSL_API
@@ -76,13 +86,17 @@ WOLFSSL_API int Base64_Decode_nonCT(const byte* in, word32 inLen, byte* out,
 #endif
 
 #ifdef WOLFSSL_BASE16
+    #ifdef WOLFSSL_API_PREFIX_MAP
+        #define Base16_Decode wc_Base16_Decode
+        #define Base16_Encode wc_Base16_Encode
+    #endif
     WOLFSSL_API
     int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen);
     WOLFSSL_API
     int Base16_Encode(const byte* in, word32 inLen, byte* out, word32* outLen);
 #endif
 
- WOLFSSL_LOCAL int Base64_SkipNewline(const byte* in, word32* inLen,
+WOLFSSL_LOCAL int Base64_SkipNewline(const byte* in, word32* inLen,
             word32* outJ);
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/cpuid.h
+++ b/wolfssl/wolfcrypt/cpuid.h
@@ -131,8 +131,14 @@ typedef word32 cpuid_flags_t;
             return 0;
     }
 
-
     /* Public APIs to modify flags. */
+
+    #ifdef WOLFSSL_API_PREFIX_MAP
+        #define cpuid_select_flags wc_cpuid_select_flags
+        #define cpuid_set_flag wc_cpuid_set_flag
+        #define cpuid_clear_flag wc_cpuid_clear_flag
+    #endif /* WOLFSSL_API_PREFIX_MAP */
+
     WOLFSSL_API void cpuid_select_flags(cpuid_flags_t flags);
     WOLFSSL_API void cpuid_set_flag(cpuid_flags_t flag);
     WOLFSSL_API void cpuid_clear_flag(cpuid_flags_t flag);

--- a/wolfssl/wolfcrypt/md5.h
+++ b/wolfssl/wolfcrypt/md5.h
@@ -31,7 +31,12 @@
 
 #ifndef NO_MD5
 
-#ifdef HAVE_FIPS
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define InitMd5   wc_InitMd5
+    #define Md5Update wc_Md5Update
+    #define Md5Final  wc_Md5Final
+    #define Md5Hash   wc_Md5Hash
+#elif defined(HAVE_FIPS)
     #define wc_InitMd5   InitMd5
     #define wc_Md5Update Md5Update
     #define wc_Md5Final  Md5Final

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3656,7 +3656,12 @@ extern void uITRON4_free(void *p) ;
 
 /* Linux Kernel Module */
 #ifdef WOLFSSL_LINUXKM
-    #define WOLFSSL_KERNEL_MODE
+    #ifndef WOLFSSL_KERNEL_MODE
+        #define WOLFSSL_KERNEL_MODE
+    #endif
+    #ifndef WOLFSSL_API_PREFIX_MAP
+        #define WOLFSSL_API_PREFIX_MAP
+    #endif
     #ifdef WOLFSSL_LINUXKM_VERBOSE_DEBUG
         #define WOLFSSL_KERNEL_VERBOSE_DEBUG
     #endif
@@ -3691,15 +3696,17 @@ extern void uITRON4_free(void *p) ;
     #ifndef WOLFSSL_OLD_PRIME_CHECK
         #define WOLFSSL_OLD_PRIME_CHECK
     #endif
+    #ifdef LINUXKM_LKCAPI_REGISTER
+        #ifndef WC_TEST_EXPORT_SUBTESTS
+            #define WC_TEST_EXPORT_SUBTESTS
+        #endif
+    #endif
     #ifndef WOLFSSL_TEST_SUBROUTINE
-        #ifdef LINUXKM_LKCAPI_REGISTER
+        #ifdef WC_TEST_EXPORT_SUBTESTS
             #define WOLFSSL_TEST_SUBROUTINE
         #else
             #define WOLFSSL_TEST_SUBROUTINE static
         #endif
-    #endif
-    #ifdef LINUXKM_LKCAPI_REGISTER
-        #define WC_TEST_EXPORT_SUBTESTS
     #endif
     #undef HAVE_PTHREAD
     /* linuxkm uses linux/string.h, included by linuxkm_wc_port.h. */
@@ -4048,8 +4055,7 @@ extern void uITRON4_free(void *p) ;
     #undef HAVE_XCHACHA
 #endif
 
-#if !defined(WOLFCRYPT_ONLY) && \
-    (!defined(WOLFSSL_NO_TLS12) || defined(HAVE_KEYING_MATERIAL))
+#if !defined(NO_KDF) && !defined(NO_HMAC)
     #undef  WOLFSSL_HAVE_PRF
     #define WOLFSSL_HAVE_PRF
 #endif
@@ -4065,7 +4071,7 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 #if defined(WOLFCRYPT_ONLY) && defined(WOLFSSL_RSA_VERIFY_ONLY) && \
-    defined(WC_NO_RSA_OAEP)
+    defined(WC_NO_RSA_OAEP) && !defined(HAVE_ECC)
     #undef  WOLFSSL_NO_CT_OPS
     #define WOLFSSL_NO_CT_OPS
 #endif

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -963,6 +963,154 @@ typedef sp_int_digit mp_digit;
  * Function prototypes.
  */
 
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define sp_init wc_sp_init
+    #define sp_init_size wc_sp_init_size
+    #define sp_init_multi wc_sp_init_multi
+    #define sp_free wc_sp_free
+    #define sp_grow wc_sp_grow
+
+    #define sp_zero wc_sp_zero
+    #define sp_clear wc_sp_clear
+    #define sp_forcezero wc_sp_forcezero
+    #define sp_init_copy wc_sp_init_copy
+
+    #define sp_copy wc_sp_copy
+    #define sp_exch wc_sp_exch
+    #define sp_cond_swap_ct wc_sp_cond_swap_ct
+    #define sp_cond_swap_ct_ex wc_sp_cond_swap_ct_ex
+
+    #ifdef WOLFSSL_SP_INT_NEGATIVE
+        #define sp_abs wc_sp_abs
+    #endif
+    #ifdef WOLFSSL_SP_MATH_ALL
+        #define sp_cmp_mag wc_sp_cmp_mag
+    #endif
+    #define sp_cmp wc_sp_cmp
+    #define sp_cmp_ct wc_sp_cmp_ct
+
+    #define sp_is_bit_set wc_sp_is_bit_set
+    #define sp_count_bits wc_sp_count_bits
+    #if defined(HAVE_ECC) && defined(HAVE_COMP_KEY)
+        #define sp_cnt_lsb wc_sp_cnt_lsb
+    #endif
+    #define sp_leading_bit wc_sp_leading_bit
+    #define sp_set_bit wc_sp_set_bit
+    #define sp_2expt wc_sp_2expt
+
+    #define sp_set wc_sp_set
+    #define sp_set_int wc_sp_set_int
+    #define sp_cmp_d wc_sp_cmp_d
+    #define sp_add_d wc_sp_add_d
+    #define sp_sub_d wc_sp_sub_d
+    #define sp_mul_d wc_sp_mul_d
+    #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+        defined(WOLFSSL_KEY_GEN) || defined(HAVE_COMP_KEY) || \
+        defined(WC_MP_TO_RADIX)
+        #define sp_div_d wc_sp_div_d
+    #endif
+    #if defined(WOLFSSL_SP_MATH_ALL) || (defined(HAVE_ECC) && \
+        defined(HAVE_COMP_KEY)) || defined(OPENSSL_EXTRA)
+        #define sp_mod_d wc_sp_mod_d
+    #endif
+    #if defined(WOLFSSL_SP_MATH_ALL) && defined(HAVE_ECC)
+        #define sp_div_2_mod_ct wc_sp_div_2_mod_ct
+        #define sp_div_2 wc_sp_div_2
+    #endif
+
+    #define sp_add wc_sp_add
+    #define sp_sub wc_sp_sub
+    #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+        (!defined(WOLFSSL_SP_MATH) && defined(WOLFSSL_CUSTOM_CURVES)) || \
+        defined(WOLFCRYPT_HAVE_ECCSI) || defined(WOLFCRYPT_HAVE_SAKKE)
+        #define sp_addmod wc_sp_addmod
+    #endif
+    #if defined(WOLFSSL_SP_MATH_ALL) && (!defined(WOLFSSL_RSA_VERIFY_ONLY) || \
+        defined(HAVE_ECC))
+        #define sp_submod wc_sp_submod
+    #endif
+    #if defined(WOLFSSL_SP_MATH_ALL) && defined(HAVE_ECC)
+        #define sp_submod_ct wc_sp_submod_ct
+        #define sp_addmod_ct wc_sp_addmod_ct
+    #endif
+    #if defined(WOLFSSL_SP_MATH_ALL) && defined(HAVE_ECC)
+        #define sp_xor_ct wc_sp_xor_ct
+    #endif
+
+    #define sp_lshd wc_sp_lshd
+    #ifdef WOLFSSL_SP_MATH_ALL
+        #define sp_rshd wc_sp_rshd
+    #endif
+    #define sp_rshb wc_sp_rshb
+
+    #if defined(WOLFSSL_SP_MATH_ALL) || !defined(NO_DH) || defined(HAVE_ECC) || \
+        (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY) && \
+         !defined(WOLFSSL_RSA_PUBLIC_ONLY))
+        #define sp_div wc_sp_div
+    #endif
+    #define sp_mod wc_sp_mod
+
+    #define sp_mul wc_sp_mul
+    #define sp_mulmod wc_sp_mulmod
+
+    #define sp_invmod wc_sp_invmod
+    #if defined(WOLFSSL_SP_MATH_ALL) && defined(HAVE_ECC)
+        #define sp_invmod_mont_ct wc_sp_invmod_mont_ct
+    #endif
+
+    #define sp_exptmod_ex wc_sp_exptmod_ex
+    #define sp_exptmod wc_sp_exptmod
+    #if defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_HAVE_SP_DH)
+        #define sp_exptmod_nct wc_sp_exptmod_nct
+    #endif
+
+    #if defined(WOLFSSL_SP_MATH_ALL) || defined(OPENSSL_ALL)
+        #define sp_div_2d wc_sp_div_2d
+        #define sp_mul_2d wc_sp_mul_2d
+    #endif
+    #if defined(WOLFSSL_SP_MATH_ALL) || defined(HAVE_ECC) || defined(OPENSSL_ALL)
+        #define sp_mod_2d wc_sp_mod_2d
+    #endif
+
+    #define sp_sqr wc_sp_sqr
+    #define sp_sqrmod wc_sp_sqrmod
+
+    #define sp_mont_red_ex wc_sp_mont_red_ex
+    #define sp_mont_setup wc_sp_mont_setup
+    #define sp_mont_norm wc_sp_mont_norm
+
+    #define sp_unsigned_bin_size wc_sp_unsigned_bin_size
+    #define sp_read_unsigned_bin wc_sp_read_unsigned_bin
+    #define sp_to_unsigned_bin wc_sp_to_unsigned_bin
+    #define sp_to_unsigned_bin_len wc_sp_to_unsigned_bin_len
+    #define sp_to_unsigned_bin_len_ct wc_sp_to_unsigned_bin_len_ct
+    #ifdef WOLFSSL_SP_MATH_ALL
+        #define sp_to_unsigned_bin_at_pos wc_sp_to_unsigned_bin_at_pos
+    #endif
+
+    #define sp_read_radix wc_sp_read_radix
+    #define sp_tohex wc_sp_tohex
+    #define sp_todecimal wc_sp_todecimal
+    #if defined(WOLFSSL_SP_MATH_ALL) || defined(WC_MP_TO_RADIX)
+        #define sp_toradix wc_sp_toradix
+        #define sp_radix_size wc_sp_radix_size
+    #endif
+
+    #define sp_rand_prime wc_sp_rand_prime
+    #define sp_prime_is_prime wc_sp_prime_is_prime
+    #define sp_prime_is_prime_ex wc_sp_prime_is_prime_ex
+    #if !defined(NO_RSA) || defined(WOLFSSL_KEY_GEN)
+        #define sp_gcd wc_sp_gcd
+    #endif
+    #if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN) && \
+        (!defined(WC_RSA_BLINDING) || defined(HAVE_FIPS) || defined(HAVE_SELFTEST))
+        #define sp_lcm wc_sp_lcm
+    #endif
+
+    #define CheckRunTimeFastMath wc_CheckRunTimeFastMath
+
+#endif /* WOLFSSL_API_PREFIX_MAP */
+
 MP_API int sp_init(sp_int* a);
 MP_API int sp_init_size(sp_int* a, unsigned int size);
 MP_API int sp_init_multi(sp_int* n1, sp_int* n2, sp_int* n3, sp_int* n4,

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1440,6 +1440,9 @@ enum {
 };
 
 
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define CheckRunTimeSettings wc_CheckRunTimeSettings
+#endif
 WOLFSSL_API word32 CheckRunTimeSettings(void);
 
 /* If user uses RSA, DH, DSA, or ECC math lib directly then fast math and long

--- a/wolfssl/wolfcrypt/wolfmath.h
+++ b/wolfssl/wolfcrypt/wolfmath.h
@@ -83,6 +83,15 @@ This library provides big integer math functions.
 
 #if !defined(NO_BIG_INT)
 /* common math functions */
+
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define mp_get_digit_count wc_mp_get_digit_count
+    #define mp_get_digit wc_mp_get_digit
+    #define mp_get_rand_digit wc_mp_get_rand_digit
+    #define mp_cond_copy wc_mp_cond_copy
+    #define mp_rand wc_mp_rand
+#endif /* WOLFSSL_API_PREFIX_MAP */
+
 MP_API int mp_get_digit_count(const mp_int* a);
 MP_API mp_digit mp_get_digit(const mp_int* a, int n);
 MP_API int mp_get_rand_digit(WC_RNG* rng, mp_digit* d);


### PR DESCRIPTION
add `WOLFSSL_API_PREFIX_MAP` -- when defined, exported symbols otherwise missing `wc_` or `wolfSSL_` prefixes are remapped with the appropriate prefix;

define `WOLFSSL_API_PREFIX_MAP` in `WOLFSSL_LINUXKM` setup in `settings.h`;

fix gates on `WOLFSSL_HAVE_PRF` and `WOLFSSL_NO_CT_OPS` setup in `settings.h`;

`linuxkm/`: add support for `FIPS_OPTEST`.
