### PR TITLE
Disable WOLFSSL_OLD_OID_SUM on Python builds

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3646,14 +3646,6 @@ extern void uITRON4_free(void *p) ;
     #endif
 #endif
 
-#ifdef WOLFSSL_PYTHON
-    /* Need to use old OID sum algorithm until OSP patches, in particular to
-     * tests, for all versions reflect the new OID sum value. */
-    #undef WOLFSSL_OLD_OID_SUM
-    #define WOLFSSL_OLD_OID_SUM
-#endif
-
-
 /* Linux Kernel Module */
 #ifdef WOLFSSL_LINUXKM
     #ifndef WOLFSSL_KERNEL_MODE


### PR DESCRIPTION
# Description

This makes sure `WOLFSSL_OLD_OID_SUM` is no longer enabled when building with `WOLFSSL_PYTHON`. After wolfSSL/osp#303 that option is no longer needed for the CPython tests to pass.

# Testing

```
./configure --enable-all
./configure --enable-python
```