### PR TITLE
Fix integer overflow in wolfSSL_writev

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11579,7 +11579,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             WOLFSSL_ENTER("wolfSSL_writev");
 
             for (i = 0; i < iovcnt; i++) {
-                if (!WC_SAFE_SUM_WORD32(sending, iov[i].iov_len, sending))
+                if (!WC_SAFE_SUM_WORD32(sending, (word32)iov[i].iov_len, sending))
                     return BUFFER_E;
             }
 


### PR DESCRIPTION
# Description

The total byte count is accumulated into a 32-bit `word32` and used for allocation, while the copy loop uses the true `iovec` lengths. When the sum exceeds 32 bits, it wraps, under-allocating the buffer and causing an overflow in the subsequent copies.

Fixes zd20646

# Testing

Unused code, visually confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
