### PR TITLE
wc_FreeRng called multiple times in wolfSSL_CTX_set_srp_password

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12848,19 +12848,16 @@ cleanup:
                                 srp_g, sizeof(srp_g)/sizeof(srp_g[0]),
                                 salt, sizeof(salt)/sizeof(salt[0])) < 0){
                 WOLFSSL_MSG("wc_SrpSetParam failed");
-                wc_FreeRng(&rng);
                 return WOLFSSL_FAILURE;
             }
             r = wc_SrpSetPassword(ctx->srp, (const byte*)password,
                                   (word32)XSTRLEN(password));
             if (r < 0) {
                 WOLFSSL_MSG("wc_SrpSetPassword failed.");
-                wc_FreeRng(&rng);
                 return WOLFSSL_FAILURE;
             }
             XFREE(ctx->srp_password, NULL, DYNAMIC_TYPE_SRP);
             ctx->srp_password = NULL;
-            wc_FreeRng(&rng);
         } else {
             /* save password for wolfSSL_set_srp_username */
             XFREE(ctx->srp_password, ctx->heap, DYNAMIC_TYPE_SRP);


### PR DESCRIPTION
# Description

in `wolfSSL_CTX_set_srp_password()`, `wc_FreeRng()` is called right after `wc_RNG_GenerateBlock()` so the later calls to it are double-frees

# Testing

`./configure --enable-opensslextra --enable-srp --enable-all && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
