### PR TITLE
20251015-linuxkm-fixes

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -1452,8 +1452,6 @@
         #define __static_assert(expr, msg, ...) _Static_assert(expr, msg)
     #endif
 
-    #include <wolfssl/wolfcrypt/memory.h>
-
 #ifdef WOLFSSL_TRACK_MEMORY
     #define XMALLOC(s, h, t)     ({(void)(h); (void)(t); wolfSSL_Malloc(s);})
     #ifdef WOLFSSL_XFREE_NO_NULLNESS_CHECK


### PR DESCRIPTION
`linuxkm/linuxkm_wc_port.h`: don't include `wolfssl/wolfcrypt/memory.h` (unneeded and out of order).

tested with `wolfssl-multi-test.sh ... '.*insmod.*'`

