### PR TITLE
SHA-2: No hash raw

### DIFF
--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -905,13 +905,6 @@ static int InitSha256(wc_Sha256* sha256)
                                kAlgorithm_SSS_SHA256);
         return ret;
     }
-    int wc_Sha256FinalRaw(wc_Sha256* sha256, byte* hash)
-    {
-        int ret = 0;
-        ret = se050_hash_final(&sha256->se050Ctx, hash, WC_SHA256_DIGEST_SIZE,
-                               kAlgorithm_SSS_SHA256);
-        return ret;
-    }
 
 #elif defined(WOLFSSL_AFALG_HASH)
     /* implemented in wolfcrypt/src/port/af_alg/afalg_hash.c */

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -1632,13 +1632,6 @@ int wc_Sha512Transform(wc_Sha512* sha, const unsigned char* data)
                                kAlgorithm_SSS_SHA384);
         return ret;
     }
-    int wc_Sha384FinalRaw(wc_Sha384* sha384, byte* hash)
-    {
-        int ret = 0;
-        ret = se050_hash_final(&sha384->se050Ctx, hash, WC_SHA384_DIGEST_SIZE,
-                               kAlgorithm_SSS_SHA384);
-        return ret;
-    }
 
 #elif defined(WOLFSSL_SILABS_SHA384)
     /* functions defined in wolfcrypt/src/port/silabs/silabs_hash.c */

--- a/wolfssl/wolfcrypt/port/nxp/se050_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/se050_port.h
@@ -50,6 +50,9 @@
     #endif
 #endif
 
+#undef  WOLFSSL_NO_HASH_RAW
+#define WOLFSSL_NO_HASH_RAW
+
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
# Description

Implementation of FinalRaw for SE050 was not usable - TLS_hmac did not produce valid results.
Removed implementations and defining WOLFSSL_NO_HASH_RAW to compile to not require FinalRaw APIs.

Fixes zd#20625

# Testing

CI Loop

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
