### PR TITLE
KDF onestep: hashOutSz err check.

### DIFF
--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -1385,7 +1385,7 @@ int wc_KDA_KDF_onestep(const byte* z, word32 zSz, const byte* fixedInfo,
         return BAD_FUNC_ARG;
 
     hashOutSz = wc_HashGetDigestSize(hashType);
-    if (hashOutSz == WC_NO_ERR_TRACE(HASH_TYPE_E))
+    if (hashOutSz <= 0)
         return BAD_FUNC_ARG;
 
     /* According to SP800_56C, table 1, the max input size (max_H_inputBits)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1466,6 +1466,10 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t nist_sp80056c_kdf_test(void)
         WC_HASH_TYPE_SHA256, output, 16);
     if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_NC;
+    ret = wc_KDA_KDF_onestep((byte*)"secret", sizeof("secret"), NULL, 0, 16,
+        WC_HASH_TYPE_NONE, output, 16);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        return WC_TEST_RET_ENC_NC;
 
     /* allow empty FixedInfo */
     ret = wc_KDA_KDF_onestep((byte*)"secret", sizeof("secret"), NULL, 0, 16,


### PR DESCRIPTION
## Description

Fix err check on hashOutSz.

If WC_HASH_TYPE_NONE was passed to wc_KDA_KDF_onestep, then wc_HashGetDigestSize returned BAD_FUNC_ARG and not HASH_TYPE_E.

Fixes coverity INTEGER_OVERFLOW.

## Testing

Added negative test with WC_HASH_TYPE_NONE, and tested with address sanitizer.

```
./configure --enable-all-crypto CFLAGS="-g -fsanitize=address" && \
  make && ./wolfcrypt/test/testwolfcrypt
```


