### PR TITLE
Regression testing fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -20972,13 +20972,14 @@ static int test_wolfSSL_X509_LOOKUP_load_file(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && defined(HAVE_CRL) && \
-   !defined(NO_FILESYSTEM) && !defined(NO_RSA) && \
+   !defined(NO_FILESYSTEM) && !defined(NO_RSA) && defined(HAVE_ECC) && \
    (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH))
     WOLFSSL_X509_STORE*  store = NULL;
     WOLFSSL_X509_LOOKUP* lookup = NULL;
 
     ExpectNotNull(store = wolfSSL_X509_STORE_new());
     ExpectNotNull(lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file()));
+    /* One RSA and one ECC certificate in file. */
     ExpectIntEQ(wolfSSL_X509_LOOKUP_load_file(lookup, "certs/client-ca.pem",
         X509_FILETYPE_PEM), 1);
     ExpectIntEQ(wolfSSL_X509_LOOKUP_load_file(lookup, "certs/crl/crl2.pem",
@@ -36197,7 +36198,8 @@ static int test_sk_X509(void)
 static int test_sk_X509_CRL(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && defined(HAVE_CRL)
+#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && defined(HAVE_CRL) && \
+    !defined(NO_RSA)
     X509_CRL* crl = NULL;
     XFILE fp = XBADFILE;
     STACK_OF(X509_CRL)* s = NULL;
@@ -36633,7 +36635,7 @@ static int test_X509_REQ(void)
 static int test_wolfSSL_X509_REQ_print(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && \
+#if defined(OPENSSL_ALL) && !defined(NO_RSA) && !defined(NO_CERTS) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_REQ) && !defined(NO_BIO)
     WOLFSSL_X509* req = NULL;
     XFILE fp = XBADFILE;

--- a/tests/api/test_pkcs7.c
+++ b/tests/api/test_pkcs7.c
@@ -2056,7 +2056,7 @@ static int myCEKwrapFunc(PKCS7* pkcs7, byte* cek, word32 cekSz, byte* keyId,
           HAVE_AES_KEYWRAP */
 
 
-#if defined(HAVE_PKCS7) && defined(ASN_BER_TO_DER)
+#if defined(HAVE_PKCS7) && defined(ASN_BER_TO_DER) && !defined(NO_RSA)
 #define MAX_TEST_DECODE_SIZE 6000
 static int test_wc_PKCS7_DecodeEnvelopedData_stream_decrypt_cb(wc_PKCS7* pkcs7,
     const byte* output, word32 outputSz, void* ctx) {
@@ -2088,8 +2088,8 @@ static int test_wc_PKCS7_DecodeEnvelopedData_stream_decrypt_cb(wc_PKCS7* pkcs7,
  */
 int test_wc_PKCS7_DecodeEnvelopedData_stream(void)
 {
-#if defined(HAVE_PKCS7) && defined(ASN_BER_TO_DER)
     EXPECT_DECLS;
+#if defined(HAVE_PKCS7) && defined(ASN_BER_TO_DER) && !defined(NO_RSA)
     PKCS7*      pkcs7 = NULL;
     int ret = 0;
     XFILE f = XBADFILE;
@@ -2139,10 +2139,8 @@ int test_wc_PKCS7_DecodeEnvelopedData_stream(void)
     }
 
     wc_PKCS7_Free(pkcs7);
-    return EXPECT_RESULT();
-#else
-    return TEST_SKIPPED;
 #endif
+    return EXPECT_RESULT();
 } /* END test_wc_PKCS7_DecodeEnvelopedData_stream() */
 
 
@@ -2151,8 +2149,8 @@ int test_wc_PKCS7_DecodeEnvelopedData_stream(void)
  */
 int test_wc_PKCS7_DecodeEnvelopedData_multiple_recipients(void)
 {
-#if defined(HAVE_PKCS7)
     EXPECT_DECLS;
+#if defined(HAVE_PKCS7) && !defined(NO_RSA)
     PKCS7*      pkcs7 = NULL;
     int ret = 0;
     XFILE f = XBADFILE;
@@ -2227,10 +2225,8 @@ int test_wc_PKCS7_DecodeEnvelopedData_multiple_recipients(void)
         pkcs7 = NULL;
     }
 
-    return EXPECT_RESULT();
-#else
-    return TEST_SKIPPED;
 #endif
+    return EXPECT_RESULT();
 } /* END test_wc_PKCS7_DecodeEnvelopedData_multiple_recipients() */
 
 /*


### PR DESCRIPTION
# Description

Adding protection to tests that use RSA and ECC.

# Testing

./configure --disable-shared --enable-keygen --enable-certgen --enable-certreq --enable-certext --enable-ocsp --enable-crl --enable-pwdbased --enable-opensslall --enable-pkcs7 --enable-pkcs12 --disable-rsa --enable-dh --enable-ecc
make
./tests/unit.test --api

./configure --disable-shared --enable-keygen --enable-certgen --enable-certreq --enable-certext --enable-ocsp --enable-crl --enable-pwdbased --enable-opensslall --enable-pkcs7 --enable-pkcs12 --enable-rsa --enable-dh --disable-ecc
make
./tests/unit.test --api

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
