### PR TITLE
Conditional wolfcrypt-only wc_RNG_GenerateBlock for MSVC

### DIFF
--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -248,7 +248,12 @@ WOLFSSL_API int  wc_FreeRng(WC_RNG* rng);
 /* some older compilers do not like macro function in expression */
 #define wc_RNG_GenerateBlock(rng, b, s) NOT_COMPILED_IN
 #else
-#define wc_RNG_GenerateBlock(rng, b, s) ({(void)rng; (void)b; (void)s; NOT_COMPILED_IN;})
+#ifdef _MSC_VER
+#define wc_RNG_GenerateBlock(rng, b, s) (int)(NOT_COMPILED_IN)
+#else
+#define wc_RNG_GenerateBlock(rng, b, s) \
+        ({(void)rng; (void)b; (void)s; NOT_COMPILED_IN;})
+#endif
 #endif
 #define wc_RNG_GenerateByte(rng, b) NOT_COMPILED_IN
 #define wc_FreeRng(rng) (void)NOT_COMPILED_IN


### PR DESCRIPTION
# Description

Adds alternative syntax for `wc_RNG_GenerateBlock` when `NOT_COMPILED_IN` is desired for Microsoft VC.

When compiling wolfBoot on Visual Studio 2022, the wolfcrypt-only mode encounters an error for the not-compiled-in `wc_RNG_GenerateBlock()` as MSVC apparently does not like the macro expansion syntax and instead gives an unintuitive error for example [here](https://github.com/wolfSSL/wolfssl/blob/4daab8a813464914b1442cada7b2b6c00d7764b2/wolfcrypt/src/ed25519.c#L323):

```
ret = wc_RNG_GenerateBlock(rng, key->k, ED25519_KEY_SIZE);
```

claiming this [error](https://github.com/gojimmypi/wolfBoot/actions/runs/19184900919/job/54849543070#step:12:33):

```
Severity	Code	Description	Project	File	Line	Suppression State	Details
Error	C2059	syntax error: '{'	wolfcrypt	C:\workspace\wolfBoot-gojimmypi\lib\wolfssl\wolfcrypt\src\ed25519.c	323		
```


Fixes zd# n/a

# Testing

Manually tested in wolfBoot. only basic checks here:

```
./autogen.sh
./configure
make
make check  
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
