### PR TITLE
Define HAVE_CTS for JNI build, used by JCE AES/CTS/NoPadding

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7572,6 +7572,9 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALWAYS_KEEP_SNI"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_TLS13_MIDDLEBOX_COMPAT"
 
+    # Enable openssl compat layer AES-CTS to maintain FIPS compatibility
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_CTS"
+
     # Enable prereqs if not already enabled
     if test "x$ENABLED_DTLS" = "xno"
     then


### PR DESCRIPTION
# Description

This PR defines `HAVE_CTS` in the `--enable-jni` build.

wolfJCE now supports `Cipher.AES/CTS/NoPadding` when `HAVE_CTS` is defined (https://github.com/wolfSSL/wolfcrypt-jni/pull/163). This enables the OpenSSL compatibility layer AES-CTS support instead of `aes.c` support to maintain FIPS compatibility with the Java AES-CTS support.  Enabling `aes.c` AES-CTS would affect the FIPS boundary, while using the compat layer API implements CTS outside the boundary while using AES-CBC mode inside the boundary. 

# Testing

Tested via wolfCrypt JNI/JCE unit tests.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
