### PR TITLE
20251023-FIPS-autotools-fix

### DIFF
--- a/src/include.am
+++ b/src/include.am
@@ -848,7 +848,7 @@ if BUILD_RC2
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/rc2.c
 endif
 
-if !BUILD_FIPS_V6
+if !BUILD_FIPS_V6_PLUS
 if BUILD_SP
 if BUILD_SP_C32
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_c32.c
@@ -878,7 +878,7 @@ if BUILD_SP_ARM_CORTEX
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_cortexm.c
 endif
 endif BUILD_SP
-endif !BUILD_FIPS_V6
+endif !BUILD_FIPS_V6_PLUS
 
 if BUILD_SP_INT
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_int.c


### PR DESCRIPTION
`src/include.am`: fix gate flub, `!BUILD_FIPS_V6` -> `!BUILD_FIPS_V6_PLUS`, around sp-asm files (covered earlier for FIPS).

tested with `wolfssl-multi-test.sh ... quantum-safe-fips-dev-wolfssl-all-intelasm-sp-asm-helgrind all-crypto-openssl-extra-coexist-fips-dev`
