### PR TITLE
20251024-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10969,23 +10969,12 @@ AM_CONDITIONAL([BUILD_FIPS],[test "x$ENABLED_FIPS" = "xyes"])
 AC_SUBST([ENABLED_FIPS])
 AM_CONDITIONAL([BUILD_FIPS_V1],[test "$HAVE_FIPS_VERSION" = 1])
 AM_CONDITIONAL([BUILD_FIPS_V2],[test "$HAVE_FIPS_VERSION" = 2 && test "$HAVE_FIPS_VERSION_MINOR" = 0])
+AM_CONDITIONAL([BUILD_FIPS_V2_PLUS],[test "$HAVE_FIPS_VERSION" -ge 2 ])
 AM_CONDITIONAL([BUILD_FIPS_RAND],[test "$HAVE_FIPS_VERSION" = 2 && test "$HAVE_FIPS_VERSION_MINOR" = 1])
 AM_CONDITIONAL([BUILD_FIPS_V5],[test "$HAVE_FIPS_VERSION" = 5])
 AM_CONDITIONAL([BUILD_FIPS_V5_PLUS],[test "$HAVE_FIPS_VERSION" -ge 5])
 AM_CONDITIONAL([BUILD_FIPS_V6],[test $HAVE_FIPS_VERSION = 6])
 AM_CONDITIONAL([BUILD_FIPS_V6_PLUS],[test $HAVE_FIPS_VERSION -ge 6])
-
-if test "$HAVE_FIPS_VERSION" = 5 || test $HAVE_FIPS_VERSION = 6
-then
-    ARMASM_DIST_SOURCES='wolfcrypt/src/port/arm/armv8-aes.c wolfcrypt/src/port/arm/armv8-sha256.c wolfcrypt/src/port/arm/armv8-sha512.c'
-else
-    ARMASM_DIST_SOURCES='wolfcrypt/src/port/arm/armv8-aes-asm_c.c wolfcrypt/src/port/arm/armv8-aes-asm.S wolfcrypt/src/port/arm/armv8-sha256-asm_c.c wolfcrypt/src/port/arm/armv8-sha256-asm.S'
-fi
-
-AC_SUBST([ARMASM_DIST_SOURCES])
-
-AM_CONDITIONAL([BUILD_FIPS_CURRENT],[test "$HAVE_FIPS_VERSION" -ge 2 ])
-    # BUILD_FIPS_CURRENT is for builds after cert 2425.
 AM_CONDITIONAL([BUILD_SIPHASH],[test "x$ENABLED_SIPHASH" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_CMAC],[test "x$ENABLED_CMAC" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_SELFTEST],[test "x$ENABLED_SELFTEST" = "xyes"])

--- a/src/include.am
+++ b/src/include.am
@@ -48,6 +48,7 @@ if BUILD_FIPS_V5
     NEW_ARMASM_AES_ASM_S :=
     NEW_ARMASM_SHA256_ASM_C :=
     NEW_ARMASM_SHA256_ASM_S :=
+    ARMASM_SHA256_C :=
 else
 if BUILD_FIPS_V6
     LEGACY_ARMASM_AES_C := wolfcrypt/src/port/arm/armv8-aes.c
@@ -57,6 +58,7 @@ if BUILD_FIPS_V6
     NEW_ARMASM_AES_ASM_S :=
     NEW_ARMASM_SHA256_ASM_C :=
     NEW_ARMASM_SHA256_ASM_S :=
+    ARMASM_SHA256_C :=
 else
     LEGACY_ARMASM_AES_C :=
     LEGACY_ARMASM_SHA256_C :=
@@ -65,6 +67,7 @@ else
     NEW_ARMASM_AES_ASM_S := wolfcrypt/src/port/arm/armv8-aes-asm.S
     NEW_ARMASM_SHA256_ASM_C := wolfcrypt/src/port/arm/armv8-sha256-asm_c.c
     NEW_ARMASM_SHA256_ASM_S := wolfcrypt/src/port/arm/armv8-sha256-asm.S
+    ARMASM_SHA256_C := wolfcrypt/src/sha256.c
 endif !BUILD_FIPS_V6
 endif !BUILD_FIPS_V5
 
@@ -249,6 +252,7 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha.c
 endif
 
 if BUILD_ARMASM_NEON
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += $(ARMASM_SHA256_C)
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += $(LEGACY_ARMASM_SHA256_C)
 if BUILD_ARMASM_INLINE
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += $(NEW_ARMASM_SHA256_ASM_C)
@@ -259,6 +263,7 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-a
 endif !BUILD_ARMASM_INLINE
 else
 if BUILD_ARMASM
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += $(ARMASM_SHA256_C)
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += $(LEGACY_ARMASM_SHA256_C)
 if BUILD_ARMASM_INLINE
 if BUILD_ARM_NONTHUMB
@@ -481,6 +486,7 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha.c
 endif
 
 if BUILD_ARMASM_NEON
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += $(ARMASM_SHA256_C)
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += $(LEGACY_ARMASM_SHA256_C)
 if BUILD_ARMASM_INLINE
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += $(NEW_ARMASM_SHA256_ASM_C)
@@ -491,6 +497,7 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-a
 endif !BUILD_ARMASM_INLINE
 else
 if BUILD_ARMASM
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += $(ARMASM_SHA256_C)
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += $(LEGACY_ARMASM_SHA256_C)
 if BUILD_ARMASM_INLINE
 if BUILD_ARM_NONTHUMB
@@ -730,11 +737,11 @@ if !BUILD_FIPS_RAND
 # For wolfRand, exclude just a couple files.
 # For old FIPS, keep the wolfCrypt versions of the
 # CtaoCrypt files included above.
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_HMAC
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/hmac.c
 endif
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 
 # CAVP self test
 if BUILD_SELFTEST
@@ -759,13 +766,13 @@ endif
 endif !BUILD_FIPS_V6_PLUS
 endif !BUILD_FIPS_V5
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_RNG
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/random.c
 endif
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha256.c
 if BUILD_ARMASM_NEON
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += $(LEGACY_ARMASM_SHA256_C)
@@ -815,7 +822,7 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/ppc32/ppc32-sha256-as
 endif !BUILD_PPC32_ASM_INLINE
 endif BUILD_PPC32_ASM
 
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 
 if BUILD_AFALG
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/af_alg/afalg_hash.c
@@ -839,9 +846,9 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/async.c
 endif
 
 if BUILD_RSA
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/rsa.c
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 endif
 
 if BUILD_RC2
@@ -884,7 +891,7 @@ if BUILD_SP_INT
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_int.c
 endif
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_AES
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes.c
 if BUILD_CUDA
@@ -941,13 +948,13 @@ if BUILD_RISCV_ASM
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/riscv/riscv-64-aes.c
 endif BUILD_RISCV_ASM
 endif BUILD_AES
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_CMAC
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/cmac.c
 endif
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 
 if !BUILD_FIPS_V2
 if BUILD_DES3
@@ -955,13 +962,13 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/des3.c
 endif BUILD_DES3
 endif !BUILD_FIPS_V2
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_SHA
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha.c
 endif
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_SHA512
 if BUILD_RISCV_ASM
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/riscv/riscv-64-sha512.c
@@ -1019,9 +1026,9 @@ endif !BUILD_ARMASM
 endif !BUILD_ARMASM_NEON
 endif !BUILD_RISCV_ASM
 endif BUILD_SHA512
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_SHA3
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha3.c
 if BUILD_ARMASM_NEON
@@ -1057,9 +1064,9 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha3_asm.S
 endif
 endif
 endif
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_SM2
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sm2.c
 if BUILD_SP
@@ -1092,9 +1099,9 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_sm2_cortexm.c
 endif
 endif BUILD_SP
 endif BUILD_SM2
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_SM3
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sm3.c
 if !BUILD_X86_ASM
@@ -1103,13 +1110,13 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sm3_asm.S
 endif
 endif
 endif BUILD_SM3
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_SM4
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sm4.c
 endif BUILD_SM4
-endif !BUILD_FIPS_CURRENT
+endif !BUILD_FIPS_V2_PLUS
 
 endif !BUILD_FIPS_RAND
 
@@ -1139,7 +1146,7 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/memory.c
 endif
 
 if !BUILD_FIPS_RAND
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_DH
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/dh.c
 endif
@@ -1218,7 +1225,7 @@ if BUILD_DSA
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/dsa.c
 endif
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_AESNI
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes_asm.S
 if BUILD_X86_ASM
@@ -1306,7 +1313,7 @@ if BUILD_HEAPMATH
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/integer.c
 endif
 
-if !BUILD_FIPS_CURRENT
+if !BUILD_FIPS_V2_PLUS
 if BUILD_ECC
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ecc.c
 endif
@@ -1388,7 +1395,7 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_x25519_asm.S
 endif !BUILD_X86_ASM
 else
 if BUILD_ARMASM
-if !BUILD_FIPS_V6
+if !BUILD_FIPS_V6_PLUS
 if BUILD_ARMASM_NEON
 if BUILD_ARMASM_INLINE
 if BUILD_ARM_32
@@ -1432,7 +1439,7 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519
 endif
 endif !BUILD_ARMASM_INLINE
 endif !BUILD_ARMASM_NEON
-endif !BUILD_FIPS_V6
+endif !BUILD_FIPS_V6_PLUS
 else
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_operations.c
 endif !BUILD_ARMASM
@@ -1448,7 +1455,7 @@ if !BUILD_X86_ASM
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_x25519_asm.S
 endif !BUILD_X86_ASM
 else
-if !BUILD_FIPS_V6
+if !BUILD_FIPS_V6_PLUS
 if BUILD_ARMASM
 if BUILD_ARMASM_NEON
 if BUILD_ARMASM_INLINE
@@ -1476,7 +1483,7 @@ endif !BUILD_ARMASM_NEON
 else
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_operations.c
 endif !BUILD_ARMASM
-endif !BUILD_FIPS_V6
+endif !BUILD_FIPS_V6_PLUS
 endif !BUILD_CURVE25519_INTELASM
 endif !BUILD_FEMATH
 endif BUILD_GEMATH
@@ -1583,4 +1590,3 @@ if BUILD_ARIA
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/aria/aria-crypt.c
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/aria/aria-cryptocb.c
 endif
-

--- a/tests/api/test_aes.c
+++ b/tests/api/test_aes.c
@@ -719,6 +719,13 @@ static int test_wc_AesCbcEncryptDecrypt_MultiBlocks(Aes* aes, byte* key,
     word32 keyLen, byte* iv, byte* expected)
 {
     EXPECT_DECLS;
+#ifdef WOLFSSL_KCAPI
+    (void)aes;
+    (void)key;
+    (void)keyLen;
+    (void)iv;
+    (void)expected;
+#else /* !WOLFSSL_KCAPI */
     int sz;
     int cnt;
     WC_DECLARE_VAR(plain, byte, CBC_LEN, NULL);
@@ -775,6 +782,7 @@ static int test_wc_AesCbcEncryptDecrypt_MultiBlocks(Aes* aes, byte* key,
     WC_FREE_VAR(plain, NULL);
     WC_FREE_VAR(cipher, NULL);
     WC_FREE_VAR(decrypted, NULL);
+#endif /* !WOLFSSL_KCAPI */
     return EXPECT_RESULT();
 }
 
@@ -1862,8 +1870,9 @@ int test_wc_AesCtsEncryptDecrypt(void)
  ******************************************************************************/
 
 #if !defined(NO_AES) && defined(WOLFSSL_AES_COUNTER) && \
-    (!defined(HAVE_FIPS) || !defined(HAVE_FIPS_VERSION) || \
-        (HAVE_FIPS_VERSION > 6)) && !defined(HAVE_SELFTEST)
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)) && \
+    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_AFALG) && \
+    !defined(WOLFSSL_KCAPI)
 static int test_wc_AesCtrSetKey_BadArgs(Aes* aes, byte* key, word32 keyLen,
     byte* iv)
 {
@@ -1889,7 +1898,10 @@ static int test_wc_AesCtrSetKey_WithKey(Aes* aes, byte* key, word32 keyLen,
 
     return EXPECT_RESULT();
 }
-#endif
+#endif /* !NO_AES && WOLFSSL_AES_COUNTER &&       */
+       /* (!HAVE_FIPS || FIPS_VERSION_GE(7,0)) && */
+       /* !HAVE_SELFTEST && !WOLFSSL_AFALG &&     */
+       /* !WOLFSSL_KCAPI */
 
 /*
  * Testing function for wc_AesCtrSetKey().
@@ -1898,8 +1910,9 @@ int test_wc_AesCtrSetKey(void)
 {
     EXPECT_DECLS;
 #if !defined(NO_AES) && defined(WOLFSSL_AES_COUNTER) && \
-    (!defined(HAVE_FIPS) || !defined(HAVE_FIPS_VERSION) || \
-        (HAVE_FIPS_VERSION > 6)) && !defined(HAVE_SELFTEST)
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)) && \
+    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_AFALG) && \
+    !defined(WOLFSSL_KCAPI)
     Aes  aes;
     byte key16[] = {
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
@@ -1970,7 +1983,11 @@ int test_wc_AesCtrSetKey(void)
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
     wc_AesFree(&aes);
-#endif
+#endif /* !NO_AES && WOLFSSL_AES_COUNTER &&       */
+       /* (!HAVE_FIPS || FIPS_VERSION_GE(7,0)) && */
+       /* !HAVE_SELFTEST && !WOLFSSL_AFALG &&     */
+       /* !WOLFSSL_KCAPI */
+
     return EXPECT_RESULT();
 } /* END test_wc_AesCtrSetKey */
 
@@ -1990,8 +2007,9 @@ static int test_wc_AesCtrEncrypt_BadArgs(Aes* aes, byte* key,
     XMEMSET(cipher, 0, WC_AES_BLOCK_SIZE);
     XMEMSET(decrypted, 0, WC_AES_BLOCK_SIZE);
 
-#if (!defined(HAVE_FIPS) || !defined(HAVE_FIPS_VERSION) || \
-        (HAVE_FIPS_VERSION > 6)) && !defined(HAVE_SELFTEST)
+#if (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)) && \
+    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_AFALG) && \
+    !defined(WOLFSSL_KCAPI)
     ExpectIntEQ(wc_AesCtrSetKey(aes, key, keyLen, iv, AES_ENCRYPTION), 0);
 #else
     ExpectIntEQ(wc_AesSetKey(aes, key, keyLen, iv, AES_ENCRYPTION), 0);
@@ -2026,8 +2044,9 @@ static int test_wc_AesCtrEncrypt_WithKey(Aes* aes, byte* key,
     XMEMSET(cipher, 0, WC_AES_BLOCK_SIZE * 2);
     XMEMSET(decrypted, 0, WC_AES_BLOCK_SIZE * 2);
 
-#if (!defined(HAVE_FIPS) || !defined(HAVE_FIPS_VERSION) || \
-        (HAVE_FIPS_VERSION > 6)) && !defined(HAVE_SELFTEST)
+#if (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)) && \
+    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_AFALG) && \
+    !defined(WOLFSSL_KCAPI)
     ExpectIntEQ(wc_AesCtrSetKey(aes, key, keyLen, iv, AES_ENCRYPTION), 0);
 #else
     ExpectIntEQ(wc_AesSetKey(aes, key, keyLen, iv, AES_ENCRYPTION), 0);
@@ -2035,8 +2054,9 @@ static int test_wc_AesCtrEncrypt_WithKey(Aes* aes, byte* key,
     ExpectIntEQ(wc_AesCtrEncrypt(aes, cipher, vector, vector_len), 0);
     ExpectBufEQ(cipher, vector_enc, vector_len);
     /* Decrypt with wc_AesCtrEncrypt() */
-#if (!defined(HAVE_FIPS) || !defined(HAVE_FIPS_VERSION) || \
-        (HAVE_FIPS_VERSION > 6)) && !defined(HAVE_SELFTEST)
+#if (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)) && \
+    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_AFALG) && \
+    !defined(WOLFSSL_KCAPI)
     ExpectIntEQ(wc_AesCtrSetKey(aes, key, keyLen, iv, AES_ENCRYPTION), 0);
 #else
     ExpectIntEQ(wc_AesSetKey(aes, key, keyLen, iv, AES_ENCRYPTION), 0);
@@ -2051,6 +2071,13 @@ static int test_wc_AesCtrEncrypt_Chunking(Aes* aes, byte* key,
     word32 keyLen, byte* iv, byte* expected)
 {
     EXPECT_DECLS;
+#if defined(WOLFSSL_AFALG) || defined(WOLFSSL_KCAPI)
+    (void)aes;
+    (void)key;
+    (void)keyLen;
+    (void)iv;
+    (void)expected;
+#else
     int sz;
     int cnt;
     WC_DECLARE_VAR(plain, byte, CTR_LEN, NULL);
@@ -2077,8 +2104,8 @@ static int test_wc_AesCtrEncrypt_Chunking(Aes* aes, byte* key,
     XMEMSET(cipher, 0, CTR_LEN);
     XMEMSET(decrypted, 0, CTR_LEN);
 
-#if (!defined(HAVE_FIPS) || !defined(HAVE_FIPS_VERSION) || \
-        (HAVE_FIPS_VERSION > 6)) && !defined(HAVE_SELFTEST)
+#if (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)) && \
+    !defined(HAVE_SELFTEST)
     ExpectIntEQ(wc_AesCtrSetKey(aes, key, keyLen, NULL, AES_ENCRYPTION), 0);
 #else
     ExpectIntEQ(wc_AesSetKey(aes, key, keyLen, NULL, AES_ENCRYPTION), 0);
@@ -2103,11 +2130,13 @@ static int test_wc_AesCtrEncrypt_Chunking(Aes* aes, byte* key,
 #ifdef HAVE_AES_DECRYPT
     WC_FREE_VAR(decrypted, NULL);
 #endif
+#endif /* !WOLFSSL_AFALG && !WOLFSSL_KCAPI */
     return EXPECT_RESULT();
 }
 
-#if (!defined(HAVE_FIPS) || !defined(HAVE_FIPS_VERSION) || \
-        (HAVE_FIPS_VERSION > 6)) && !defined(HAVE_SELFTEST)
+#if (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)) && \
+    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_AFALG) && \
+    !defined(WOLFSSL_KCAPI)
 static int test_wc_AesCtrEncrypt_SameBuffer(Aes* aes, byte* key,
     word32 keyLen, byte* iv, byte* expected)
 {
@@ -2296,8 +2325,9 @@ int test_wc_AesCtrEncryptDecrypt(void)
 
     EXPECT_TEST(test_wc_AesCtrEncrypt_Chunking(&aes, key, keyLen, iv,
         expected));
-#if (!defined(HAVE_FIPS) || !defined(HAVE_FIPS_VERSION) || \
-        (HAVE_FIPS_VERSION > 6)) && !defined(HAVE_SELFTEST)
+#if (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)) && \
+    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_AFALG) && \
+    !defined(WOLFSSL_KCAPI)
     EXPECT_TEST(test_wc_AesCtrEncrypt_SameBuffer(&aes, key, keyLen, iv,
         expected));
 #endif
@@ -2406,7 +2436,8 @@ int test_wc_AesGcmSetKey(void)
 int test_wc_AesGcmEncryptDecrypt_Sizes(void)
 {
     EXPECT_DECLS;
-#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AES_256)
+#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AES_256) && \
+    !defined(WOLFSSL_AFALG) && !defined(WOLFSSL_KCAPI)
     #define GCM_LEN     (WC_AES_BLOCK_SIZE * 16)
     byte expTagShort[WC_AES_BLOCK_SIZE][WC_AES_BLOCK_SIZE] = {
         {

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -117,7 +117,8 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
     #pragma warning(disable: 4127)
 #endif
 
-#if !defined(WOLFSSL_ARMASM) && FIPS_VERSION3_GE(6,0,0)
+#if (!defined(WOLFSSL_ARMASM) && FIPS_VERSION3_GE(6,0,0)) || \
+    FIPS_VERSION3_GE(7,0,0)
     const unsigned int wolfCrypt_FIPS_aes_ro_sanity[2] =
                                                      { 0x1a2b3c4d, 0x00000002 };
     int wolfCrypt_FIPS_AES_sanity(void)
@@ -7454,6 +7455,12 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c,
     }                                                   \
     while (0)
 #endif /* WOLFSSL_AESGCM_STREAM */
+
+#ifdef WOLFSSL_ARMASM
+#define GCM_GMULT_LEN(gcm, x, a, len) \
+    GCM_gmult_len(x, (const byte**)((gcm)->M0), a, len)
+#endif
+
 #elif defined(GCM_TABLE)
 
 #if !defined(__aarch64__) && defined(WOLFSSL_ARMASM) && \

--- a/wolfcrypt/src/port/af_alg/afalg_aes.c
+++ b/wolfcrypt/src/port/af_alg/afalg_aes.c
@@ -513,7 +513,7 @@ int wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
     const word32 max_key_len = (AES_MAX_KEY_SIZE / 8);
 #endif
 
-    if (aes == NULL ||
+    if (aes == NULL || key == NULL ||
             !((len == 16) || (len == 24) || (len == 32))) {
         return BAD_FUNC_ARG;
     }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -17273,7 +17273,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t gmac_test(void)
 #endif
 
     byte tag[16];
-#if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM)
+#if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM) && \
+    !defined(WOLFSSL_KCAPI)
     #define BENCH_GMAC_LARGE 1024
 
     WOLFSSL_SMALL_STACK_STATIC const byte t4_lb[16][16] = {
@@ -17467,7 +17468,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t gmac_test(void)
 #endif /* !WC_NO_RNG && !HAVE_SELFTEST && !NO_AES_DECRYPT */
 #endif /* HAVE_FIPS */
 
-#if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM)
+#if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM) && !defined(WOLFSSL_KCAPI)
     for (i = 0; i < 16; i++) {
         XMEMSET(tag, 0, sizeof(tag));
         wc_GmacSetKey(gmac, k1, sizeof(k1));
@@ -17505,7 +17506,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t gmac_test(void)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     XFREE(gmac, HEAP_HINT, DYNAMIC_TYPE_AES);
 #endif
-#if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM) && !defined(WOLFSSL_NO_MALLOC)
+#if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM) && \
+    !defined(WOLFSSL_KCAPI) && !defined(WOLFSSL_NO_MALLOC)
     XFREE(large_input, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 


### PR DESCRIPTION
`wolfcrypt/src/aes.c`: define `GCM_GMULT_LEN()` when `WOLFSSL_ARMASM`, and fix gating on `wolfCrypt_FIPS_AES_sanity` (always gate in for FIPS v7+);

`wolfcrypt/src/port/af_alg/afalg_aes.c`: check for null key arg;

`configure.ac`: rename `BUILD_FIPS_CURRENT` to `BUILD_FIPS_V2_PLUS` (no functional change), and remove unused `ARMASM_DIST_SOURCES` set up code added in #9332;

`src/include.am`:
* set up `$(ARMASM_SHA256_C)`, and use it to properly include `wolfcrypt/src/sha256.c` alongside armasm when appropriate;
* fix gating on Curved25519 armasm (`BUILD_FIPS_V6_PLUS`, not `BUILD_FIPS_V6`);

`tests/api/test_aes.c` and `wolfcrypt/test/test.c`: gate out incompatible coverage for `WOLFSSL_AFALG` and `WOLFSSL_KCAPI` (`test_wc_AesCbcEncryptDecrypt_MultiBlocks()`, `test_wc_AesCtrSetKey*()`, `test_wc_AesCtrEncrypt*()`, `test_wc_AesGcmEncryptDecrypt_Sizes()`).

tested with
```
wolfssl-multi-test.sh ...
super-quick-check
all-afalg
defaults-afalg
fips-140-3-dev-optest-acvp-sp-asm-gcc-latest-no-sha-1
fips-140-3-dev-kcapi
lean-fips-dev-armv7-small-armasm-sanitizer
lean-fips-dev-aarch64-armasm-sanitizer
cross-aarch64-armasm-fips-140-3-ready-unittest-sanitizer
cross-aarch64-armasm-fips-140-3-dev-all-unittest-sanitizer
cross-armv7a-armasm-fips-140-3-dev-sp-all-testsuite-sanitizer
```
