### PR TITLE
20251025-fix-clang-tidy-all-crypto-no-sha-1

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -40834,6 +40834,8 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                 else {
                     SendAlert(ssl, alert_fatal, illegal_parameter);
                 }
+            #else
+                (void)ret;
             #endif
                 return ECC_PEERKEY_ERROR;
             }
@@ -40891,6 +40893,8 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                 else {
                     SendAlert(ssl, alert_fatal, illegal_parameter);
                 }
+            #else
+                (void)ret;
             #endif
                 return ECC_PEERKEY_ERROR;
             }


### PR DESCRIPTION
`src/internal.c`: suppress `clang-analyzer-deadcode.DeadStores` in `ImportPeerECCKey()` introduced by 4964a1760a.

tested with `wolfssl-multi-test.sh ... check-source-text clang-tidy-all-crypto-no-sha-1`
