### PR TITLE
Build errors in memtest config and sniffer

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -7349,8 +7349,8 @@ static int addSecretNode(unsigned char* clientRandom,
 
     XMEMCPY(node->clientRandom, clientRandom, CLIENT_RANDOM_LENGTH);
     XMEMCPY(node->secrets[type], secret, SECRET_LENGTH);
-    node->next = secretHashTable[index];
-    secretHashTable[index] = node;
+    node->next = secretHashTable[idx];
+    secretHashTable[idx] = node;
 
 unlockReturn:
 

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -1549,7 +1549,7 @@ void *xmalloc(size_t n, void* heap, int type, const char* func,
 #endif
 
     if (malloc_function) {
-#ifndef WOLFSSL_STATIC_MEMORY
+#if !defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFSSL_DEBUG_MEMORY)
         p32 = malloc_function(n + sizeof(word32) * 4);
 #else
         p32 = malloc_function(n + sizeof(word32) * 4, heap, type);
@@ -1592,7 +1592,7 @@ void *xrealloc(void *p, size_t n, void* heap, int type, const char* func,
     }
 
     if (realloc_function) {
-#ifndef WOLFSSL_STATIC_MEMORY
+#if !defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFSSL_DEBUG_MEMORY)
         p32 = realloc_function(oldp32, n + sizeof(word32) * 4);
 #else
         p32 = realloc_function(oldp32, n + sizeof(word32) * 4, heap, type);
@@ -1638,7 +1638,7 @@ void xfree(void *p, void* heap, int type, const char* func, const char* file,
                                                               func, file, line);
 
         if (free_function) {
-#ifndef WOLFSSL_STATIC_MEMORY
+#if !defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFSSL_DEBUG_MEMORY)
             free_function(p32);
 #else
             free_function(p32, heap, type);


### PR DESCRIPTION
# Description

I was able to reproduce the sniffer error with:
`./configure --enable-sniffer CPPFLAGS=-DWOLFSSL_SNIFFER_KEYLOGFILE`
Fixed by completing `index` to `idx` rename started in https://github.com/wolfSSL/wolfssl/pull/8759

I was able to reproduce the memtest error with:
`./configure --enable-memtest --enable-memorylog`
Fixed by adding macro check to conditional

Fixes #9347 

# Testing

Build tested

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
