### PR TITLE
20251029-NullPointerArithm-fixes

### DIFF
--- a/examples/pem/pem.c
+++ b/examples/pem/pem.c
@@ -977,7 +977,7 @@ int main(int argc, char* argv[])
             out_len = der->length;
         }
     }
-    else {
+    else if (ret == 0) {
 #ifdef WOLFSSL_DER_TO_PEM
     #if defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_PWDBASED)
         if (enc_der) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -10470,7 +10470,7 @@ int HashOutput(WOLFSSL* ssl, const byte* output, int sz, int ivSz)
 {
     const byte* adj;
 
-    if (ssl->hsHashes == NULL)
+    if ((ssl->hsHashes == NULL) || (output == NULL))
         return BAD_FUNC_ARG;
 
     adj = output + RECORD_HEADER_SZ + ivSz;


### PR DESCRIPTION
`src/internal.c`: in `HashOutput()`, check for null output pointer;

`examples/pem/pem.c`: in `main()`, add missing check that `ret == 0` in `_DER_TO_PEM` code path.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
clang-tidy-Customer-CFG-7
clang-tidy-defaults
clang-tidy-intmath
clang-tidy-fips-140-3-defaults
clang-tidy-fips-140-3-pilot-defaults
clang-tidy-fips-140-3-dev-defaults
clang-tidy-fips-140-3-dev-defaults-no-sha-1
clang-tidy-fips-140-3-v6-defaults
clang-tidy-all-crypto-no-sha-1
```
