### PR TITLE
Improve TLS 1.3 early data handling.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -22842,8 +22842,8 @@ default:
                                    exit */
                                 ssl->earlyData = no_early_data;
                                 ssl->options.processReply = doProcessInit;
-
-                                return ZERO_RETURN;
+                                if (ssl->options.clientInEarlyData)
+                                    return APP_DATA_READY;
                             }
 #endif /* WOLFSSL_EARLY_DATA */
                             if (ret == 0 ||
@@ -22889,7 +22889,8 @@ default:
                                 ssl->options.handShakeState == HANDSHAKE_DONE) {
                             ssl->earlyData = no_early_data;
                             ssl->options.processReply = doProcessInit;
-                            return ZERO_RETURN;
+                            if (ssl->options.clientInEarlyData)
+                                return APP_DATA_READY;
                         }
     #endif
 #else

--- a/src/quic.c
+++ b/src/quic.c
@@ -608,11 +608,6 @@ int wolfSSL_quic_do_handshake(WOLFSSL* ssl)
             else {
                 ret = wolfSSL_read_early_data(ssl, tmpbuffer,
                                               sizeof(tmpbuffer), &len);
-                if (ret < 0 && ssl->error == WC_NO_ERR_TRACE(ZERO_RETURN)) {
-                    /* this is expected, since QUIC handles the actual early
-                     * data separately. */
-                    ret = WOLFSSL_SUCCESS;
-                }
             }
             if (ret < 0) {
                 goto cleanup;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -15092,10 +15092,13 @@ int wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz, int* outSz)
             return WOLFSSL_FATAL_ERROR;
     }
     if (ssl->options.handShakeState == SERVER_FINISHED_COMPLETE) {
+        ssl->options.clientInEarlyData = 1;
         ret = ReceiveData(ssl, (byte*)data, (size_t)sz, FALSE);
+        ssl->options.clientInEarlyData = 0;
         if (ret > 0)
             *outSz = ret;
-        if (ssl->error == WC_NO_ERR_TRACE(ZERO_RETURN)) {
+        if (ssl->error == WC_NO_ERR_TRACE(APP_DATA_READY)) {
+            ret = 0;
             ssl->error = WOLFSSL_ERROR_NONE;
 #ifdef WOLFSSL_DTLS13
             if (ssl->options.dtls) {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5083,6 +5083,10 @@ struct Options {
     word16            hrrSentKeyShare:1;  /* HRR sent with key share */
 #endif
     word16            disableRead:1;
+
+#ifdef WOLFSSL_EARLY_DATA
+    word16            clientInEarlyData:1; /* Client is in wolfSSL_read_early_data */
+#endif
 #ifdef WOLFSSL_DTLS
     byte              haveMcast;          /* using multicast ? */
 #endif


### PR DESCRIPTION
Introduce `clientInEarlyData` to only return when in `wolfSSL_read_early_data`. This makes sure that other API don't return `ZERO_RETURN` when not in `wolfSSL_read_early_data`. Chose `APP_DATA_READY` as it won't result in a false positive return from `wolfSSL_read_early_data`.
