### PR TITLE
Fixed issue with AES ECB offloading to hardware to use full size

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -13036,6 +13036,9 @@ int wc_AesGetKeySize(Aes* aes, word32* keySize)
 #elif defined(WOLFSSL_RISCV_ASM)
     /* implemented in wolfcrypt/src/port/riscv/riscv-64-aes.c */
 
+#elif defined(WOLFSSL_SILABS_SE_ACCEL)
+    /* implemented in wolfcrypt/src/port/silabs/silabs_aes.c */
+
 #elif defined(MAX3266X_AES)
 
 int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)

--- a/wolfcrypt/src/port/silabs/silabs_aes.c
+++ b/wolfcrypt/src/port/silabs/silabs_aes.c
@@ -89,6 +89,48 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
     return ret;
 }
 
+#ifdef HAVE_AES_ECB
+int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    sl_status_t status;
+    if ((in == NULL) || (out == NULL) || (aes == NULL)) {
+        return BAD_FUNC_ARG;
+    }
+    if ((sz % WC_AES_BLOCK_SIZE) != 0) {
+        return BAD_LENGTH_E;
+    }
+
+    status = sl_se_aes_crypt_ecb(
+        &(aes->ctx.cmd_ctx),
+        &(aes->ctx.key),
+        SL_SE_ENCRYPT,
+        sz,
+        in,
+        out);
+    return (status != SL_STATUS_OK) ? WC_HW_E : 0;
+}
+
+int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    sl_status_t status;
+    if ((in == NULL) || (out == NULL) || (aes == NULL)) {
+        return BAD_FUNC_ARG;
+    }
+    if ((sz % WC_AES_BLOCK_SIZE) != 0) {
+        return BAD_LENGTH_E;
+    }
+
+    status = sl_se_aes_crypt_ecb(
+        &(aes->ctx.cmd_ctx),
+        &(aes->ctx.key),
+        SL_SE_DECRYPT,
+        sz,
+        in,
+        out);
+    return (status != SL_STATUS_OK) ? WC_HW_E : 0;
+}
+#endif /* HAVE_AES_ECB */
+
 #ifdef WOLFSSL_AES_DIRECT
 int wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 {


### PR DESCRIPTION
# Description

Fixed issue with AES ECB offloading to hardware to use full size, not just block

Fixes ZD 20695

# Testing

On Silicon Labs ERF32 G25 with AES ECB and direct.

The benchmarks went from:

```
AES-128-ECB-enc             55 KiB took 1.146 seconds,   47.993 KiB/s
AES-128-ECB-dec             55 KiB took 1.164 seconds,   47.251 KiB/s
AES-192-ECB-enc             55 KiB took 1.178 seconds,   46.689 KiB/s
AES-192-ECB-dec             55 KiB took 1.182 seconds,   46.531 KiB/s
AES-256-ECB-enc             55 KiB took 1.182 seconds,   46.531 KiB/s
AES-256-ECB-dec             55 KiB took 1.174 seconds,   46.848 KiB/s
```

To:

```
AES-128-ECB-enc              3 MiB took 1.001 seconds,    2.779 MiB/s
AES-128-ECB-dec              3 MiB took 1.003 seconds,    2.774 MiB/s
AES-192-ECB-enc              3 MiB took 1.000 seconds,    2.739 MiB/s
AES-192-ECB-dec              3 MiB took 1.001 seconds,    2.737 MiB/s
AES-256-ECB-enc              3 MiB took 1.002 seconds,    2.712 MiB/s
AES-256-ECB-dec              3 MiB took 1.001 seconds,    2.704 MiB/s
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
