### PR TITLE
wolfDTLS_accept_stateless: Fix handling for early data

### DIFF
--- a/doc/dox_comments/header_files/wolfio.h
+++ b/doc/dox_comments/header_files/wolfio.h
@@ -618,3 +618,51 @@ void wolfSSL_SSLDisableRead(WOLFSSL *ssl);
     \sa wolfSSL_SSLEnableRead
  */
 void wolfSSL_SSLEnableRead(WOLFSSL *ssl);
+
+/*!
+    \brief Set a custom DTLS recvfrom callback for a WOLFSSL session.
+
+    This function allows you to specify a custom callback function for receiving
+    datagrams (DTLS) using the `recvfrom`-style interface. The callback must match
+    the WolfSSLRecvFrom function pointer type and is expected to behave like the
+    POSIX `recvfrom()` function, including its return values and error handling.
+
+    \param ssl      A pointer to a WOLFSSL structure, created using wolfSSL_new().
+    \param recvFrom The custom callback function to use for DTLS datagram receive.
+
+    _Example_
+    \code
+    wolfSSL_SetRecvFrom(ssl, my_recvfrom_cb);
+    \endcode
+
+    \sa WolfSSLRecvFrom
+    \sa wolfSSL_SetSendTo
+    \sa EmbedReceiveFrom
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_SSLSetIORecv
+*/
+WOLFSSL_API void wolfSSL_SetRecvFrom(WOLFSSL* ssl, WolfSSLRecvFrom recvFrom);
+
+/*!
+    \brief Set a custom DTLS sendto callback for a WOLFSSL session.
+
+    This function allows you to specify a custom callback function for sending
+    datagrams (DTLS) using the `sendto`-style interface. The callback must match
+    the WolfSSLSento function pointer type and is expected to behave like the
+    POSIX `sendto()` function, including its return values and error handling.
+
+    \param ssl    A pointer to a WOLFSSL structure, created using wolfSSL_new().
+    \param sendTo The custom callback function to use for DTLS datagram send.
+
+    _Example_
+    \code
+    wolfSSL_SetSendTo(ssl, my_sendto_cb);
+    \endcode
+
+    \sa WolfSSLSento
+    \sa wolfSSL_SetRecvFrom
+    \sa EmbedSendTo
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_SSLSetIOSend
+*/
+WOLFSSL_API void wolfSSL_SetSendTo(WOLFSSL* ssl, WolfSSLSento sendTo);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -14596,6 +14596,12 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
             FALL_THROUGH;
 
         case TLS13_ACCEPT_SECOND_REPLY_DONE :
+            if (ssl->options.returnOnGoodCh) {
+                /* Higher level in stack wants us to return. Simulate a
+                 * WANT_WRITE to accomplish this. */
+                ssl->error = WANT_WRITE;
+                return WOLFSSL_FATAL_ERROR;
+            }
 
             if ((ssl->error = SendTls13ServerHello(ssl, server_hello)) != 0) {
                 WOLFSSL_ERROR(ssl->error);

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -638,6 +638,18 @@ static int isDGramSock(int sfd)
     }
 }
 
+void wolfSSL_SetRecvFrom(WOLFSSL* ssl, WolfSSLRecvFrom recvFrom)
+{
+    if (ssl != NULL)
+        ssl->buffers.dtlsCtx.recvfrom = recvFrom;
+}
+
+void wolfSSL_SetSendTo(WOLFSSL* ssl, WolfSSLSento sendTo)
+{
+    if (ssl != NULL)
+        ssl->buffers.dtlsCtx.sendto = sendTo;
+}
+
 /* The receive embedded callback
  *  return : nb bytes read, or error
  */
@@ -686,10 +698,6 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
         /* Store the peer address. It is used to calculate the DTLS cookie. */
         newPeer = dtlsCtx->peer.sa == NULL || !ssl->options.dtlsStateful;
         peer = &lclPeer;
-        if (dtlsCtx->peer.sa != NULL) {
-            XMEMCPY(peer, (SOCKADDR_S*)dtlsCtx->peer.sa, MIN(sizeof(lclPeer),
-                    dtlsCtx->peer.sz));
-        }
         peerSz = sizeof(lclPeer);
     }
 
@@ -785,8 +793,16 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 
         {
             XSOCKLENT inPeerSz = peerSz;
-            recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, (size_t)sz,
-                 ssl->rflags, (SOCKADDR*)peer, peer != NULL ? &inPeerSz : NULL);
+            if (dtlsCtx->recvfrom == NULL) {
+                recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, (size_t)sz,
+                        ssl->rflags, (SOCKADDR*)peer,
+                        peer != NULL ? &inPeerSz : NULL);
+            }
+            else {
+                recvd = (int)dtlsCtx->recvfrom(sd, buf, (size_t) sz,
+                        ssl->rflags, (SOCKADDR*) peer,
+                        peer != NULL ? &inPeerSz : NULL);
+            }
             /* Truncate peerSz. From the RECV(2) man page
              * The returned address is truncated if the buffer provided is too
              * small; in this case, addrlen will return a value greater than was
@@ -914,8 +930,14 @@ int EmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 #endif
     }
 
-    sent = (int)DTLS_SENDTO_FUNCTION(sd, buf, (size_t)sz, ssl->wflags,
-            (const SOCKADDR*)peer, peerSz);
+    if (dtlsCtx->sendto == NULL) {
+        sent = (int)DTLS_SENDTO_FUNCTION(sd, buf, (size_t)sz, ssl->wflags,
+                (const SOCKADDR*)peer, peerSz);
+    }
+    else {
+        sent = (int)dtlsCtx->sendto(sd, buf, (size_t)sz, ssl->wflags,
+                (const SOCKADDR*)peer, peerSz);
+    }
 
     sent = TranslateIoReturnCode(sent, sd, SOCKET_SENDING);
 

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -872,6 +872,7 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
                 /* Store size of saved address. Locking handled internally. */
                 if (wolfSSL_dtls_set_peer(ssl, peer, peerSz) != WOLFSSL_SUCCESS)
                     return WOLFSSL_CBIO_ERR_GENERAL;
+                dtlsCtx->userSet = 0;
             }
 #ifndef WOLFSSL_PEER_ADDRESS_CHANGES
             else {

--- a/tests/api/test_dtls.h
+++ b/tests/api/test_dtls.h
@@ -45,6 +45,8 @@ int test_dtls_replay(void);
 int test_dtls_srtp(void);
 int test_dtls_timeout(void);
 int test_dtls_certreq_order(void);
+int test_dtls_memio_wolfio(void);
+int test_dtls_memio_wolfio_stateless(void);
 
 #define TEST_DTLS_DECLS                                                        \
         TEST_DECL_GROUP("dtls", test_dtls12_basic_connection_id),              \
@@ -69,5 +71,7 @@ int test_dtls_certreq_order(void);
         TEST_DECL_GROUP("dtls", test_dtls_replay),                             \
         TEST_DECL_GROUP("dtls", test_dtls_srtp),                               \
         TEST_DECL_GROUP("dtls", test_dtls_certreq_order),                      \
-        TEST_DECL_GROUP("dtls", test_dtls_timeout)
+        TEST_DECL_GROUP("dtls", test_dtls_timeout),                            \
+        TEST_DECL_GROUP("dtls", test_dtls_memio_wolfio),                       \
+        TEST_DECL_GROUP("dtls", test_dtls_memio_wolfio_stateless)
 #endif /* TESTS_API_DTLS_H */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5091,6 +5091,7 @@ struct Options {
 #endif
     word16            hrrSentKeyShare:1;  /* HRR sent with key share */
 #endif
+    word16            returnOnGoodCh:1;
     word16            disableRead:1;
 
 #ifdef WOLFSSL_EARLY_DATA

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -26,6 +26,7 @@
 
 #include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/ssl.h>
+#include <wolfssl/wolfio.h>
 #ifdef HAVE_CRL
     #include <wolfssl/crl.h>
 #endif
@@ -2730,6 +2731,7 @@ struct WOLFSSL_SOCKADDR {
     void*        sa; /* pointer to the sockaddr_in or sockaddr_in6 */
 };
 
+#ifdef WOLFSSL_DTLS
 typedef struct WOLFSSL_DTLS_CTX {
 #ifdef WOLFSSL_RW_THREADED
     /* Protect peer access after the handshake */
@@ -2743,6 +2745,8 @@ typedef struct WOLFSSL_DTLS_CTX {
 #endif
     int rfd;
     int wfd;
+    WolfSSLRecvFrom recvfrom;
+    WolfSSLSento sendto;
     byte userSet:1;
     byte connected:1; /* When set indicates rfd and wfd sockets are
                        * connected (connect() and bind() both called).
@@ -2752,6 +2756,7 @@ typedef struct WOLFSSL_DTLS_CTX {
     byte processingPendingRecord:1;
 #endif
 } WOLFSSL_DTLS_CTX;
+#endif
 
 
 typedef struct WOLFSSL_DTLS_PEERSEQ {

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -624,6 +624,15 @@ WOLFSSL_LOCAL int BioReceiveInternal(WOLFSSL_BIO* biord, WOLFSSL_BIO* biowr,
                                      char* buf, int sz);
 #endif
 WOLFSSL_LOCAL int SslBioReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+
+#ifdef WOLFSSL_DTLS
+    typedef ssize_t (*WolfSSLRecvFrom)(int sockfd, void* buf, size_t len, int flags,
+                            void* src_addr, void* addrlen);
+    typedef ssize_t (*WolfSSLSento)(int sockfd, const void* buf, size_t len, int flags,
+                          const void* dest_addr, word32 addrlen);
+    WOLFSSL_API void wolfSSL_SetRecvFrom(WOLFSSL* ssl, WolfSSLRecvFrom recvFrom);
+    WOLFSSL_API void wolfSSL_SetSendTo(WOLFSSL* ssl, WolfSSLSento sendTo);
+#endif
 #if defined(USE_WOLFSSL_IO)
     /* default IO callbacks */
 


### PR DESCRIPTION
- wolfDTLS_accept_stateless now returns before sending any flights. This allows the user to retrieve early data.
- wolfio.c: Clearing `userSet` allows our callback to change the address while in stateless parsing
