### PR TITLE
Update and pin Watcom to 2025-11-03-Build release

### DIFF
--- a/.github/workflows/watcomc.yml
+++ b/.github/workflows/watcomc.yml
@@ -62,9 +62,10 @@ jobs:
         uses: open-watcom/setup-watcom@v0
         with:
           version: ${{ matrix.platform.owimage }}
-          tag: 2025-09-01-Build
-          # Currently fixed to this build because of latest compiler error:
-          # file clbrdll.lib(fltuse80): undefined symbol _SetLD80bit_
+          # Currently fixed to a monthly build because of historical instability with daily releases.
+          # See https://github.com/wolfSSL/wolfssl/pull/9167
+          # Pin to monthly release as needed:
+          tag: 2025-11-03-Build
 
       - name: Checkout wolfSSL
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Bumps Open Watcom to [2025-11-03-Build](https://github.com/open-watcom/open-watcom-v2/releases/tag/2025-11-03-Build)  after problems encountered in daily latest releases. See https://github.com/wolfSSL/wolfssl/pull/9167

All Watcom V2 releases: https://github.com/open-watcom/open-watcom-v2/releases

GitHub CI/CD: https://github.com/open-watcom/setup-watcom

## Prior Failing GitHub CI/CD Workflow

Bumped Open Watcom to [2025-11-01-Build](https://github.com/open-watcom/open-watcom-v2/releases/tag/2025-11-01-Build)  

The required `ow-snapshot.tar.xz` was missing from the 2025-11-01 Build, causing [404 failure](https://github.com/wolfSSL/wolfssl/actions/runs/19013957238/job/54299045787?pr=9370): 

https://github.com/open-watcom/open-watcom-v2/releases/tag/2025-11-01-Build  (now deleted)

Prior recent release where  `ow-snapshot.tar.xz`  was found:

https://github.com/open-watcom/open-watcom-v2/releases/tag/2025-09-01-Build

See [Discord thread](https://discord.com/channels/922934435744206908/922947071613497424/1434562148637347840)

## Note

Not all monthly releases occur on the 1st. For example the October releases was instead on 2025-10-02

There should be 17 files in the release asset bundle, in particular  `ow-snapshot.tar.xz` 

-----

Fixes zd# n/a

# Testing

How did you test?

Untested locally. 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
