### PR TITLE
Reset Return to Success if fallback to software Copy Callbacks Sha

### DIFF
--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -1169,6 +1169,7 @@ int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
             return ret;
         /* fall-through when unavailable */
     }
+    ret = 0; /* Reset ret to 0 to avoid returning the callback error code */
 #endif /* WOLF_CRYPTO_CB && WOLF_CRYPTO_CB_COPY */
 
     XMEMCPY(dst, src, sizeof(wc_Sha));

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -2569,6 +2569,7 @@ int wc_Sha224_Grow(wc_Sha224* sha224, const byte* in, int inSz)
                 return ret;
             /* fall-through when unavailable */
         }
+        ret = 0; /* Reset ret to 0 to avoid returning the callback error code */
 #endif /* WOLF_CRYPTO_CB && WOLF_CRYPTO_CB_COPY */
 
         XMEMCPY(dst, src, sizeof(wc_Sha224));
@@ -2709,6 +2710,7 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
             return ret;
         /* fall-through when unavailable */
     }
+    ret = 0; /* Reset ret to 0 to avoid returning the callback error code */
 #endif /* WOLF_CRYPTO_CB && WOLF_CRYPTO_CB_COPY */
 
     XMEMCPY(dst, src, sizeof(wc_Sha256));

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -1230,6 +1230,7 @@ static int wc_Sha3Copy(wc_Sha3* src, wc_Sha3* dst)
             return ret;
         /* fall-through when unavailable */
     }
+    ret = 0; /* Reset ret to 0 to avoid returning the callback error code */
 #endif /* WOLF_CRYPTO_CB && WOLF_CRYPTO_CB_COPY */
 
     XMEMCPY(dst, src, sizeof(wc_Sha3));

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -2214,6 +2214,7 @@ int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst)
             return ret;
         /* fall-through when unavailable */
     }
+    ret = 0; /* Reset ret to 0 to avoid returning the callback error code */
 #endif /* WOLF_CRYPTO_CB && WOLF_CRYPTO_CB_COPY */
 
     XMEMCPY(dst, src, sizeof(wc_Sha512));
@@ -2642,6 +2643,7 @@ int wc_Sha384Copy(wc_Sha384* src, wc_Sha384* dst)
             return ret;
         /* fall-through when unavailable */
     }
+    ret = 0; /* Reset ret to 0 to avoid returning the callback error code */
 #endif /* WOLF_CRYPTO_CB && WOLF_CRYPTO_CB_COPY */
 
     XMEMCPY(dst, src, sizeof(wc_Sha384));


### PR DESCRIPTION
Reset return value to success when copy callback requests to use software function instead

