### PR TITLE
fixed oss-fuzz warnings

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -23523,7 +23523,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
 
         wc_Md5Free(&md5);
     }
-    else {
+    else if (ssl->specs.mac_algorithm == sha_mac) {
         ret =  wc_InitSha_ex(&sha, ssl->heap, ssl->devId);
         if (ret != 0)
             return ret;
@@ -23572,6 +23572,10 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
 
         wc_ShaFree(&sha);
+    }
+    else {
+        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
+        return VERIFY_MAC_ERROR;
     }
     return 0;
 }


### PR DESCRIPTION
# Description

There are two distinct errors being thrown by this oss-fuzz issue: one for hmac, and another for aes.

The hmac issue is in SSL_hmac and occurs because it tries to use a sha256 digest size instead of a sha1 digest size. This happened because the server hello allowed a ciphersuite containing sha256 to be used.

The aes issue was not encountered after fixing the hmac problem. Since the issue seems to be related to SSLv3 it's currently less of a priority to debug.

Fixes oss-fuzz issue [442261624](https://issues.oss-fuzz.com/issues/442261624).

# Testing

Using the oss-fuzz reproduction steps.

Ran a `make check` in wolfssl with the default configuration.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
