### PR TITLE
Addressing a bug in the test logic

### DIFF
--- a/tests/api/test_random.c
+++ b/tests/api/test_random.c
@@ -114,7 +114,7 @@ int test_wc_RNG_GenerateBlock(void)
     ExpectIntEQ(wc_RNG_GenerateBlock(NULL, key , sizeof(key)),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
-    for (i = 0; i <= (int)sizeof(key); i++) {
+    for (i = 0; i < (int)sizeof(key); i++) {
         ExpectIntEQ(wc_RNG_GenerateBlock(&rng, key + i, sizeof(key) - i), 0);
     }
     DoExpectIntEQ(wc_FreeRng(&rng), 0);


### PR DESCRIPTION
# Description

While testing the FIPS release packages noticed what appeared to be stack overflow behavior, after a quick investigation it turned out it was in our TEST code and not the library proper. The for loop iterations resulted in a 1 byte overflow off the end of a local stack variable in a for loop within the `test_wc_RNG_GenerateBlock()` function in `tests/api/test_random.c` file.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
