### PR TITLE
Use portable mktemp syntax in ocsp-stapling_tls13multi.test

### DIFF
--- a/scripts/ocsp-stapling_tls13multi.test
+++ b/scripts/ocsp-stapling_tls13multi.test
@@ -77,7 +77,8 @@ PARENTDIR="$PWD"
 #WORKSPACE="${PARENTDIR}/workspace.pid$$"
 #mkdir "${WORKSPACE}" || exit $?
 
-WORKSPACE="$(mktemp -d -p ${PARENTDIR})"
+# Use portable mktemp syntax that works on both Linux and macOS
+WORKSPACE="$(mktemp -d ${PARENTDIR}/wolfssl-ocsp-test.XXXXXX)"
 
 cp -pR ${SCRIPT_DIR}/../certs "${WORKSPACE}"/ || exit $?
 cd "$WORKSPACE" || exit $?


### PR DESCRIPTION
# Description

`scripts/ocsp-stapling_tls13multi.test` was failing on macOS with:

```
mktemp: illegal option -- p
usage: mktemp [-d] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-q] [-u] -t prefix
```

Changing here to use hopefully more portable template syntax.

# Testing

Tested on Intel Core i9, macOS Ventura 13.3.1. mktemp from `/usr/bin/mktemp`. wolfSSL had been configured with `./configure --enable-all`.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
