### PR TITLE
[ja] update docs - part 2

### DIFF
--- a/doc/dox_comments/header_files-ja/ssl.h
+++ b/doc/dox_comments/header_files-ja/ssl.h
@@ -1,7 +1,9 @@
 /*!
-    \brief この関数はDTLS v1.2 クライアントメソッドを初期化します。
-    \return 作成に成功した場合は、WOLFSSL_METHODポインタを返します。
-    \return メモリ割り当てエラーまたはメソッドの作成の失敗の場合はNULLを返します。
+    \brief この関数はDTLS v1.2クライアントメソッドを初期化します。
+
+    \return pointer この関数は新しいWOLFSSL_METHOD構造体へのポインタを返します。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -11,6 +13,7 @@
     WOLFSSL* ssl = wolfSSL_new(ctx);
     …
     \endcode
+
     \sa wolfSSL_Init
     \sa wolfSSL_CTX_new
 */
@@ -18,16 +21,21 @@ WOLFSSL_METHOD *wolfDTLSv1_2_client_method_ex(void* heap);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、wolfSSLv23_client_methodと同様にWOLFSSL_METHODを返します（サーバー/クライアント）。
-    \return 作成に成功した場合は、WOLFSSL_METHODポインタを返します。
-    \return メモリ割り当てエラーまたはメソッドの作成の失敗の場合はNULLを返します。
+
+    \brief この関数はwolfSSLv23_client_methodに似たWOLFSSL_METHODを返しますが、どちら側(サーバ/クライアント)であるかがまだ決定されていない点が異なります。
+
+    \return WOLFSSL_METHOD* 正常に作成された場合、WOLFSSL_METHODポインタを返します
+    \return NULL メモリ割り当てエラーまたはメソッド作成失敗の場合はNullを返します
+
+    \param none パラメータはありません。
 
     _Example_
     \code
     WOLFSSL* ctx;
     ctx  = wolfSSL_CTX_new(wolfSSLv23_method());
-    // check ret value
+    // ret値をチェック
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -35,10 +43,13 @@ WOLFSSL_METHOD *wolfSSLv23_method(void);
 
 /*!
     \ingroup Setup
-    \brief  wolfSSLv3_server_method()関数は、アプリケーションがサーバーであることを示すために使用され、SSL3.0プロトコルのみをサポートします。
-    この関数は、wolfSSL_CTX_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
+
+    \brief wolfSSLv3_server_method()関数は、アプリケーションがサーバであり、SSL 3.0プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のためのメモリを割り当てて初期化します。
+
+    \return ＊ 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -49,12 +60,13 @@ WOLFSSL_METHOD *wolfSSLv23_method(void);
 
     method = wolfSSLv3_server_method();
     if (method == NULL) {
-	    unable to get method
+	    メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfTLSv1_server_method
     \sa wolfTLSv1_1_server_method
     \sa wolfTLSv1_2_server_method
@@ -62,15 +74,19 @@ WOLFSSL_METHOD *wolfSSLv23_method(void);
     \sa wolfDTLSv1_server_method
     \sa wolfSSLv23_server_method
     \sa wolfSSL_CTX_new
+
 */
 WOLFSSL_METHOD *wolfSSLv3_server_method(void);
 
 /*!
     \ingroup Setup
-    \brief  wolfSSLv3_client_method()関数は、アプリケーションがクライアントであり、SSL 3.0プロトコルのみをサポートすることを示すために使用されます。
-    この関数は、wolfSSL_CTX_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
+
+    \brief wolfSSLv3_client_method()関数は、アプリケーションがクライアントであり、SSL 3.0プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のためのメモリを割り当てて初期化します。
+
+    \return ＊ 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -81,12 +97,13 @@ WOLFSSL_METHOD *wolfSSLv3_server_method(void);
 
     method = wolfSSLv3_client_method();
     if (method == NULL) {
-	    unable to get method
+	    メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfTLSv1_client_method
     \sa wolfTLSv1_1_client_method
     \sa wolfTLSv1_2_client_method
@@ -99,10 +116,13 @@ WOLFSSL_METHOD *wolfSSLv3_client_method(void);
 
 /*!
     \ingroup Setup
-    \brief  wolfTLSv1_server_method()関数は、アプリケーションがサーバーであることを示すために使用され、TLS 1.0プロトコルのみをサポートします。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
+
+    \brief wolfTLSv1_server_method()関数は、アプリケーションがサーバであり、TLS 1.0プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のためのメモリを割り当てて初期化します。
+
+    \return ＊ 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -113,12 +133,13 @@ WOLFSSL_METHOD *wolfSSLv3_client_method(void);
 
     method = wolfTLSv1_server_method();
     if (method == NULL) {
-	    unable to get method
+	    メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_server_method
     \sa wolfTLSv1_1_server_method
     \sa wolfTLSv1_2_server_method
@@ -131,10 +152,13 @@ WOLFSSL_METHOD *wolfTLSv1_server_method(void);
 
 /*!
     \ingroup Setup
-    \brief  wolftlsv1_client_method()関数は、アプリケーションがクライアントであり、TLS 1.0プロトコルのみをサポートすることを示すために使用されます。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
+
+    \brief wolfTLSv1_client_method()関数は、アプリケーションがクライアントであり、TLS 1.0プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のためのメモリを割り当てて初期化します。
+
+    \return ＊ 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -145,12 +169,13 @@ WOLFSSL_METHOD *wolfTLSv1_server_method(void);
 
     method = wolfTLSv1_client_method();
     if (method == NULL) {
-	    unable to get method
+	    メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_client_method
     \sa wolfTLSv1_1_client_method
     \sa wolfTLSv1_2_client_method
@@ -163,10 +188,13 @@ WOLFSSL_METHOD *wolfTLSv1_client_method(void);
 
 /*!
     \ingroup Setup
-    \brief  wolfTLSv1_1_server_method()関数は、アプリケーションがサーバーであることを示すために使用され、TLS 1.1プロトコルのみをサポートします。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
+
+    \brief wolfTLSv1_1_server_method()関数は、アプリケーションがサーバであり、TLS 1.1プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のためのメモリを割り当てて初期化します。
+
+    \return ＊ 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -177,12 +205,13 @@ WOLFSSL_METHOD *wolfTLSv1_client_method(void);
 
     method = wolfTLSv1_1_server_method();
     if (method == NULL) {
-        // unable to get method
+        // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_server_method
     \sa wolfTLSv1_server_method
     \sa wolfTLSv1_2_server_method
@@ -195,10 +224,13 @@ WOLFSSL_METHOD *wolfTLSv1_1_server_method(void);
 
 /*!
     \ingroup Setup
-    \brief  wolfTLSv1_1_client_method()関数は、アプリケーションがクライアントであり、TLS 1.0プロトコルのみをサポートすることを示すために使用されます。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
+
+    \brief wolfTLSv1_1_client_method()関数は、アプリケーションがクライアントであり、TLS 1.0プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のためのメモリを割り当てて初期化します。
+
+    \return ＊ 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -209,12 +241,13 @@ WOLFSSL_METHOD *wolfTLSv1_1_server_method(void);
 
     method = wolfTLSv1_1_client_method();
     if (method == NULL) {
-        // unable to get method
+        // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_client_method
     \sa wolfTLSv1_client_method
     \sa wolfTLSv1_2_client_method
@@ -227,10 +260,13 @@ WOLFSSL_METHOD *wolfTLSv1_1_client_method(void);
 
 /*!
     \ingroup Setup
-    \brief  wolfTLSv1_2_server_method()関数は、アプリケーションがサーバーであることを示すために使用され、TLS 1.2プロトコルのみをサポートします。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
+
+    \brief wolfTLSv1_2_server_method()関数は、アプリケーションがサーバであり、TLS 1.2プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のためのメモリを割り当てて初期化します。
+
+    \return ＊ 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -241,12 +277,13 @@ WOLFSSL_METHOD *wolfTLSv1_1_client_method(void);
 
     method = wolfTLSv1_2_server_method();
     if (method == NULL) {
-	    // unable to get method
+	    // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_server_method
     \sa wolfTLSv1_server_method
     \sa wolfTLSv1_1_server_method
@@ -259,10 +296,13 @@ WOLFSSL_METHOD *wolfTLSv1_2_server_method(void);
 
 /*!
     \ingroup Setup
-    \brief  wolfTLSv1_2_client_method()関数は、アプリケーションがクライアントであり、TLS 1.2プロトコルのみをサポートすることを示すために使用されます。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
+
+    \brief wolfTLSv1_2_client_method()関数は、アプリケーションがクライアントであり、TLS 1.2プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のためのメモリを割り当てて初期化します。
+
+    \return ＊ 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -273,12 +313,13 @@ WOLFSSL_METHOD *wolfTLSv1_2_server_method(void);
 
     method = wolfTLSv1_2_client_method();
     if (method == NULL) {
-	    // unable to get method
+	    // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_client_method
     \sa wolfTLSv1_client_method
     \sa wolfTLSv1_1_client_method
@@ -291,11 +332,11 @@ WOLFSSL_METHOD *wolfTLSv1_2_client_method(void);
 
 /*!
     \ingroup Setup
-    \brief  wolfdtlsv1_client_method()関数は、アプリケーションがクライアントであり、DTLS 1.0プロトコルのみをサポートすることを示すために使用されます。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    この関数は、WolfSSLがDTLSサポート（--enable-dtls、またはWOLFSSL_DTLSを定義することによって）ビルドされている場合にのみ使用できます。
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
+    \brief wolfDTLSv1_client_method()関数は、アプリケーションがクライアントであり、DTLS 1.0プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のメモリを割り当て、初期化します。この関数は、wolfSSLがDTLSサポート付きでコンパイルされている場合(--enable-dtls、またはwolfSSL_DTLSを定義することによって)にのみ利用可能です。
+    \return ＊ 成功した場合、この呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます（通常はNULLで、errnoがENOMEMに設定されます）。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -304,12 +345,13 @@ WOLFSSL_METHOD *wolfTLSv1_2_client_method(void);
 
     method = wolfDTLSv1_client_method();
     if (method == NULL) {
-	    // unable to get method
+	    // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_client_method
     \sa wolfTLSv1_client_method
     \sa wolfTLSv1_1_client_method
@@ -322,11 +364,13 @@ WOLFSSL_METHOD *wolfDTLSv1_client_method(void);
 
 /*!
     \ingroup Setup
-    \brief  wolfDTLSv1_server_method()関数は、アプリケーションがサーバーであることを示すために使用され、DTLS 1.0プロトコルのみをサポートします。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    この関数は、WolfSSLがDTLSサポート（--enable-dtls、またはWOLFSSL_DTLSマクロを定義することによって）ビルドされている場合にのみ使用できます。
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
+
+    \brief wolfDTLSv1_server_method()関数は、アプリケーションがサーバーであり、DTLS 1.0プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のメモリを割り当て、初期化します。この関数は、wolfSSLがDTLSサポートを有効にしてコンパイルされている場合にのみ使用可能です（--enable-dtls、またはwolfSSL_DTLSを定義することによって）。
+
+    \return ＊ 成功した場合、この呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます（通常はNULLで、errnoがENOMEMに設定されます）。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -335,12 +379,13 @@ WOLFSSL_METHOD *wolfDTLSv1_client_method(void);
 
     method = wolfDTLSv1_server_method();
     if (method == NULL) {
-	    // unable to get method
+	    // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_server_method
     \sa wolfTLSv1_server_method
     \sa wolfTLSv1_1_server_method
@@ -350,31 +395,15 @@ WOLFSSL_METHOD *wolfDTLSv1_client_method(void);
     \sa wolfSSL_CTX_new
 */
 WOLFSSL_METHOD *wolfDTLSv1_server_method(void);
-
-/*!
-    \brief  wolfDTLSv1_2_server_method()関数はサーバ側用にWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-
-    _Example_
-    \code
-    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(wolfDTLSv1_2_server_method());
-    WOLFSSL* ssl = WOLFSSL_new(ctx);
-    …
-    \endcode
-    \sa wolfSSL_CTX_new
-*/
-WOLFSSL_METHOD *wolfDTLSv1_2_server_method(void);
-
 /*!
     \ingroup Setup
 
-    \brief wolfDTLSv1_3_server_method()関数はアプリケーションがサーバーであることを示すために使用され、DTLS 1.3プロトコルのみをサポートします。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    この関数は、WolfSSLがDTLSサポート（--enable-dtls13、またはWOLFSSL_DTLS13を定義することによって）ビルドされている場合にのみ使用できます。
+    \brief wolfDTLSv1_3_server_method()関数は、アプリケーションがサーバーであり、DTLS 1.3プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のメモリを割り当て、初期化します。この関数は、wolfSSLがDTLSv1.3サポートを有効にしてコンパイルされている場合にのみ使用可能です（--enable-dtls13、またはwolfSSL_DTLS13を定義することによって）。
 
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
-    \param なし
+    \return ＊ 成功した場合、この呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます（通常はNULLで、errnoがENOMEMに設定されます）。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -383,7 +412,7 @@ WOLFSSL_METHOD *wolfDTLSv1_2_server_method(void);
 
     method = wolfDTLSv1_3_server_method();
     if (method == NULL) {
-	    // unable to get method
+	    // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
@@ -395,18 +424,15 @@ WOLFSSL_METHOD *wolfDTLSv1_2_server_method(void);
 */
 
 WOLFSSL_METHOD *wolfDTLSv1_3_server_method(void);
-
 /*!
     \ingroup Setup
 
-    \brief wolfDTLSv1_3_client_method()関数はアプリケーションがクライアントであることを示すために使用され、DTLS 1.3プロトコルのみをサポートします。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    この関数は、WolfSSLがDTLSサポート（--enable-dtls13、またはWOLFSSL_DTLS13を定義することによって）ビルドされている場合にのみ使用できます。
+    \brief wolfDTLSv1_3_client_method()関数は、アプリケーションがクライアントであり、DTLS 1.3プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のメモリを割り当て、初期化します。この関数は、wolfSSLがDTLSv1.3サポートを有効にしてコンパイルされている場合にのみ使用可能です（--enable-dtls13、またはwolfSSL_DTLS13を定義することによって）。
 
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
-    \param なし
+    \return ＊ 成功した場合、この呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます（通常はNULLで、errnoがENOMEMに設定されます）。
 
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -415,7 +441,7 @@ WOLFSSL_METHOD *wolfDTLSv1_3_server_method(void);
 
     method = wolfDTLSv1_3_client_method();
     if (method == NULL) {
-	    // unable to get method
+	    // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
@@ -426,21 +452,15 @@ WOLFSSL_METHOD *wolfDTLSv1_3_server_method(void);
     \sa wolfDTLSv1_3_server_method
 */
 WOLFSSL_METHOD* wolfDTLSv1_3_client_method(void);
-
 /*!
     \ingroup Setup
 
-    \brief wolfDTLS_server_method()関数はアプリケーションがサーバーであることを示すために使用され、
-    可能な限り高いバージョン最小バージョンのDTLSプロトコルをサポートします。
-    デフォルトの最小バージョンはWOLFSSL_MIN_DTLS_DOWNGRADEマクロでの指定をもとにしていて、
-    実行時にwolfSSL_SetMinVersion()で変更することができます。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    この関数は、WolfSSLがDTLSサポート（--enable-dtls、またはWOLFSSL_DTLSを定義することによって）ビルドされている場合にのみ使用できます。
+    \brief wolfDTLS_server_method()関数は、アプリケーションがサーバーであり、利用可能な最新バージョンのDTLSおよび許可される最小バージョンまでのすべてのバージョンをサポートすることを示すために使用されます。デフォルトの許可される最小バージョンは、WOLFSSL_MIN_DTLS_DOWNGRADEの定義に基づいており、wolfSSL_SetMinVersion()を使用して実行時に変更できます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のメモリを割り当て、初期化します。この関数は、wolfSSLがDTLSサポートを有効にしてコンパイルされている場合にのみ使用可能です（--enable-dtls、またはwolfSSL_DTLSを定義することによって）。
 
+    \return ＊ 成功した場合、この呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます（通常はNULLで、errnoがENOMEMに設定されます）。
 
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
-    \param なし
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -449,7 +469,7 @@ WOLFSSL_METHOD* wolfDTLSv1_3_client_method(void);
 
     method = wolfDTLS_server_method();
     if (method == NULL) {
-	    // unable to get method
+	    // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
@@ -461,22 +481,15 @@ WOLFSSL_METHOD* wolfDTLSv1_3_client_method(void);
     \sa wolfSSL_SetMinVersion
 */
 WOLFSSL_METHOD *wolfDTLS_server_method(void);
-
 /*!
     \ingroup Setup
 
-    \brief wolfDTLS_client_method()関数は アプリケーションがクライアントであることを示すために使用され、
-    可能な限り高いバージョン最小バージョンのDTLSプロトコルをサポートします。
-    デフォルトの最小バージョンはWOLFSSL_MIN_DTLS_DOWNGRADEマクロでの指定をもとにしていて、
-    実行時にwolfSSL_SetMinVersion()で変更することができます。
-    この関数は、wolfSSL_ctx_new()を使用してSSL/TLSコンテキストを作成するときに使用される新しいWOLFSSL_METHOD構造体のメモリを割り当てて初期化します。
-    この関数は、wolfSSLがDTLSサポート（--enable-dtls、またはWOLFSSL_DTLSを定義することによって）ビルドされている場合にのみ使用できます。
+    \brief wolfDTLS_client_method()関数は、アプリケーションがクライアントであり、利用可能な最新バージョンのDTLSおよび許可される最小バージョンまでのすべてのバージョンをサポートすることを示すために使用されます。デフォルトの許可される最小バージョンは、WOLFSSL_MIN_DTLS_DOWNGRADEの定義に基づいており、wolfSSL_SetMinVersion()を使用して実行時に変更できます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のメモリを割り当て、初期化します。この関数は、wolfSSLがDTLSサポートを有効にしてコンパイルされている場合にのみ使用可能です（--enable-dtls、またはwolfSSL_DTLSを定義することによって）。
 
+    \return ＊ 成功した場合、この呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます（通常はNULLで、errnoがENOMEMに設定されます）。
 
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
-    \return XMALLOCを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
-    \param なし
-
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -485,7 +498,7 @@ WOLFSSL_METHOD *wolfDTLS_server_method(void);
 
     method = wolfDTLS_client_method();
     if (method == NULL) {
-	    // unable to get method
+	    // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
@@ -497,13 +510,12 @@ WOLFSSL_METHOD *wolfDTLS_server_method(void);
     \sa wolfSSL_SetMinVersion
 */
 WOLFSSL_METHOD *wolfDTLS_client_method(void);
-
 /*!
-    \brief この関数はサーバー側用にWOLFSSL_METHOD構造体を生成して初期化します。
+    \brief この関数は、サーバー側用のWOLFSSL_METHODを作成し、初期化します。
 
-    \return 成功した場合、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return この関数はWOLFSSL_METHODポインタを返します。
 
-    \param なし
+    \param none パラメータはありません。
 
     _Example_
     \code
@@ -516,14 +528,15 @@ WOLFSSL_METHOD *wolfDTLS_client_method(void);
 */
 WOLFSSL_METHOD *wolfDTLSv1_2_server_method(void);
 
-
 /*!
     \ingroup Setup
-    \brief  Chacha-Poly Aead Constructionの最初のリリースと新しいバージョンの間にいくつかの違いがあるため、
-    古いバージョンを使用してサーバー/クライアントと通信するオプションを追加しました。
-    デフォルトでは、wolfSSLは新しいバージョンを使用します。
-    \return 0  成功の場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成したWOLFSSL構造体へのポインタ。
+
+    \brief chacha-poly AEAD構築の最初のリリースと新しいバージョンの間にはいくつかの違いがあるため、古いバージョンを使用するサーバー/クライアントと通信するためのオプションを追加しました。デフォルトでは、wolfSSLは新しいバージョンを使用します。
+
+    \return 0 成功時
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param value poly1305の情報を設定する際に古いバージョンを使用するかどうか。フラグ値1を渡すと古いpoly AEADを使用することを示し、新しいバージョンの使用に戻すにはフラグ値0を渡します。
 
     _Example_
     \code
@@ -533,23 +546,24 @@ WOLFSSL_METHOD *wolfDTLSv1_2_server_method(void);
 
     ret = wolfSSL_use_old_poly(ssl, 1);
     if (ret != 0) {
-        // failed to set poly1305 AEAD version
+        // poly1305 AEADバージョンの設定に失敗しました
     }
     \endcode
+
     \sa none
 */
 int wolfSSL_use_old_poly(WOLFSSL* ssl, int value);
 
 /*!
-    \brief  wolfSSL_dtls_import()関数はシリアライズされたセッション状態を解析するために使われます。
-    これにより、ハンドシェイクが完了した後に接続をピックアップすることができます。
-    \return  成功した場合、読み取ったバッファの量が返されます。
-    \return  すべての失敗した戻り値は0未満になります。
-    \return VERSION_ERROR  バージョンの不一致が見つかった場合、(すなわち、DTLS v1とCTXがDTLS v1.2に設定された場合)、Version_Errorが返されます。
+    \brief wolfSSL_dtls_import()関数は、シリアル化されたセッション状態を解析するために使用されます。これにより、ハンドシェイクが完了した後に接続を再開できます。
 
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param buf  インポートするシリアル化されたセッション情報を格納するバッファへのポインタ。
-    \param sz バッファのサイズ
+    \return Success 成功した場合、読み取られたバッファの量が返されます。
+    \return Failure すべての失敗した戻り値は0未満になります。
+    \return VERSION_ERROR バージョンの不一致が見つかった場合、つまりDTLS v1でctxがDTLS v1.2用に設定されている場合、VERSION_ERRORが返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param buf インポートするシリアル化されたセッション。
+    \param sz シリアル化されたセッションバッファのサイズ。
 
     _Example_
     \code
@@ -558,17 +572,18 @@ int wolfSSL_use_old_poly(WOLFSSL* ssl, int value);
     unsigned char buf[MAX];
     bufSz = MAX;
     ...
-    //get information sent from wc_dtls_export function and place it in buf
+    // wc_dtls_export関数から送信された情報を取得し、bufに配置します
     fread(buf, 1, bufSz, input);
     ret = wolfSSL_dtls_import(ssl, buf, bufSz);
     if (ret < 0) {
-    // handle error case
+        // エラーケースを処理します
     }
-    // no wolfSSL_accept needed since handshake was already done
+    // ハンドシェイクが既に完了しているため、wolfSSL_acceptは不要です
     ...
-    ret = wolfSSL_write(ssl) and wolfSSL_read(ssl);
+    ret = wolfSSL_write(ssl) および wolfSSL_read(ssl);
     ...
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_dtls_set_export
@@ -578,13 +593,13 @@ int wolfSSL_dtls_import(WOLFSSL* ssl, unsigned char* buf,
 
 
 /*!
-    \brief  シリアライズされたTLSセッションをインポートします。
-    警告：bufには、状態に関する機密情報が含まれており、保存されている場合は保存する前に暗号化されるのが最善です。
-    追加のデバッグ情報をマクロWOLFSSL_SESSION_EXPORT_DEBUGを定義して表示できます。
-    \return バッファ'buf'から読み込まれたバイト数を返します。
-    \param ssl  セッションをインポートするためのWOLFSSL構造体へのポインタ
-    \param buf  シリアル化されたセッションを含むバッファへのポインタ
-    \param sz  バッファのサイズ
+    \brief シリアル化されたTLSセッションをインポートするために使用されます。この関数は、接続の状態をインポートするためのものです。警告：bufには状態に関する機密情報が含まれており、保存する場合は暗号化してから保存するのが最善です。マクロWOLFSSL_SESSION_EXPORT_DEBUGを定義することで、追加のデバッグ情報を表示できます。
+
+    \return バッファ'buf'から読み取られたバイト数
+
+    \param ssl セッションをインポートするWOLFSSL構造体
+    \param buf シリアル化されたセッション
+    \param sz  バッファ'buf'のサイズ
 
     \sa wolfSSL_dtls_import
     \sa wolfSSL_tls_export
@@ -593,62 +608,63 @@ int wolfSSL_tls_import(WOLFSSL* ssl, const unsigned char* buf,
         unsigned int sz);
 
 /*!
-    \brief  wolfSSL_CTX_dtls_set_export()関数はセッションをエクスポートするためのコールバック関数を設定します。
-    以前に格納されているエクスポート機能をクリアするためにパラメータfuncにNULLを渡すことが許されます。
-    サーバー側で使用され、ハンドシェイクが完了した直後に設定したコールバック関数が呼び出されます。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  NULLまたは予想されない引数が渡された場合に返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param func セッションをエクスポートする際に呼び出す関数ポインタ
+    \brief wolfSSL_CTX_dtls_set_export()関数は、セッションをエクスポートするためのコールバック関数を設定するために使用されます。以前に保存されたエクスポート関数をクリアするために、パラメータfuncとしてNULLを渡すことができます。サーバー側で使用され、ハンドシェイクが完了した直後に呼び出されます。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG nullまたは期待されない引数が渡された場合
+
+    \param ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param func セッションをエクスポートする際に使用するwc_dtls_export関数。
 
     _Example_
     \code
     int send_session(WOLFSSL* ssl, byte* buf, word32 sz, void* userCtx);
-    // body of send session (wc_dtls_export) that passes
-    // buf (serialized session) to destination
+    // buf（シリアル化されたセッション）を宛先に渡すsend session（wc_dtls_export）の本体
     WOLFSSL_CTX* ctx;
     int ret;
     ...
     ret = wolfSSL_CTX_dtls_set_export(ctx, send_session);
     if (ret != SSL_SUCCESS) {
-        // handle error case
+        // エラーケースを処理します
     }
     ...
     ret = wolfSSL_accept(ssl);
     ...
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_CTX_new
     \sa wolfSSL_dtls_set_export
     \sa Static buffer use
 */
-int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx, wc_dtls_export func);
+int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx,
+                                                           wc_dtls_export func);
 
 /*!
-    \brief  wolfSSL_dtls_set_export()関数はセッションをエクスポートする際に呼び出すコールバック関数を登録します。
-    以前に登録されているエクスポート関数をクリアするために使うこともできます。
-    サーバー側で使用され、ハンドシェイクが完了した直後に設定したコールバック関数が呼び出されます。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  NULLまたは予想されない引数が渡された場合に返されます。
-    \param ssl  wolfssl_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param func セッションをエクスポートする際に呼び出す関数ポインタ
+    \brief wolfSSL_dtls_set_export()関数は、セッションをエクスポートするためのコールバック関数を設定するために使用されます。以前に保存されたエクスポート関数をクリアするために、パラメータfuncとしてNULLを渡すことができます。サーバー側で使用され、ハンドシェイクが完了した直後に呼び出されます。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG nullまたは期待されない引数が渡された場合
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param func セッションをエクスポートする際に使用するwc_dtls_export関数。
 
     _Example_
-    \code
-    int send_session(WOLFSSL* ssl, byte* buf, word32 sz, void* userCtx);
-    // body of send session (wc_dtls_export) that passes
-    // buf (serialized session) to destination
+    \code    int send_session(WOLFSSL* ssl, byte* buf, word32 sz, void* userCtx);
+    // send sessionの本体(wc_dtls_export)
+    // buf(シリアライズされたセッション)を宛先に渡す
     WOLFSSL* ssl;
     int ret;
     ...
     ret = wolfSSL_dtls_set_export(ssl, send_session);
     if (ret != SSL_SUCCESS) {
-        // handle error case
+        // エラーケースの処理
     }
     ...
     ret = wolfSSL_accept(ssl);
     ...
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_dtls_set_export
@@ -656,14 +672,14 @@ int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx, wc_dtls_export func);
 int wolfSSL_dtls_set_export(WOLFSSL* ssl, wc_dtls_export func);
 
 /*!
-    \brief  wolfSSL_dtls_export()関数は提供されたバッファへセッションをシリアル化します。
-    セッションをエクスポートするための関数コールバックを使用するよりもメモリオーバーヘッドを減らすことができます。
-    関数に渡された引数bufがNULLの場合、szにはWolfSSLセッションのシリアライズに必要なバッファのサイズが設定されます。
-    \return 成功した場合、使用されるバッファサイズが返されます。
-    \return すべての失敗した戻り値は0未満になります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param buf  シリアライズしたセッションを保持するためのバッファ。
-    \param sz バッファのサイズ
+    \brief wolfSSL_dtls_export()関数は、WOLFSSLセッションを提供されたバッファにシリアライズするために使用されます。セッションを送信するための関数コールバックを使用するよりもメモリオーバーヘッドが少なく、セッションをシリアライズするタイミングを選択できます。関数に渡されたときにbufferがNULLの場合、szはWOLFSSLセッションをシリアライズするために必要なバッファのサイズに設定されます。
+
+    \return Success 成功した場合、使用されたバッファの量が返されます。
+    \return Failure すべての失敗時の戻り値は0未満になります。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param buf シリアライズされたセッションを保持するバッファ。
+    \param sz バッファのサイズ。
 
     _Example_
     \code
@@ -674,10 +690,11 @@ int wolfSSL_dtls_set_export(WOLFSSL* ssl, wc_dtls_export func);
     ...
     ret = wolfSSL_dtls_export(ssl, buf, bufSz);
     if (ret < 0) {
-        // handle error case
+        // エラーケースの処理
     }
     ...
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_dtls_set_export
@@ -687,14 +704,16 @@ int wolfSSL_dtls_export(WOLFSSL* ssl, unsigned char* buf,
                                                               unsigned int* sz);
 
 /*!
-    \brief  シリアライズされたTLSセッションをエクスポートします。
-    ほとんどの場合、wolfSSL_tls_exportの代わりにwolfssl_get1_sessionを使用する必要があります。
-    追加のデバッグ情報をマクロWOLFSSL_SESSION_EXPORT_DEBUGを定義して表示できます。
-    警告：bufには、状態に関する機密情報が含まれており、保存する場合は保存する前に暗号化されるのが最善です。
+    \brief シリアライズされたTLSセッションをエクスポートするために使用されます。この関数は接続のシリアライズされた状態をエクスポートするためのものです。
+    ほとんどの場合、wolfSSL_tls_exportの代わりにwolfSSL_get1_sessionを使用する必要があります。
+    追加のデバッグ情報は、マクロWOLFSSL_SESSION_EXPORT_DEBUGが定義されている場合に表示できます。
+    警告: bufには状態に関する機密情報が含まれているため、保存する場合は暗号化してから保存することが最善です。
+
     \return バッファ'buf'に書き込まれたバイト数
-    \param ssl  セッションをエクスポートするためのWOLFSSL構造体へのポインタ
-    \param buf シリアライズされたセッションの出力先バッファへのポインタ
-    \param sz 出力先バッファのサイズ
+
+    \param ssl セッションをエクスポートするWOLFSSL構造体
+    \param buf シリアライズされたセッションの出力
+    \param sz  'buf'に設定されたバイト単位のサイズ
 
     \sa wolfSSL_dtls_import
     \sa wolfSSL_tls_import
@@ -703,27 +722,17 @@ int wolfSSL_tls_export(WOLFSSL* ssl, unsigned char* buf,
         unsigned int* sz);
 
 /*!
-    \brief  この関数はCTX用に静的メモリ領域を設定する目的に使用されます。
-    設定された静的メモリ領域はCTXの有効期間およびCTXから作成された全てのSSLオブジェクトに使用されます。
-    引数ctxにNULLを渡し、wolfSSL_method_func関数を渡すことによって、CTX自体の作成も静的メモリを使用します。
-    wolfssl_method_funcは次のシグネチャとなっています:wolfssl_method *（* wolfssl_method_func)(void *heap)。
-    引数maxに0を渡すと、設定されていないものとして動作し、最大の同時使用制限が適用されません。
-    引数flagに渡した値によって、メモリの使用方法と動作が決まります。
-    利用可能なフラグ値は次のとおりです：
-    0 - デフォルトの一般メモリ、
-    WOLFMEM_IO_POOL - メッセージの受送信の際の入出力バッファとして使用され渡されたバッファ内のすべてのメモリがIOに使用されます、
-    WOLFMEM_IO_FIXED  -  WOLFMEM_IO_POOLと同じですが、各SSLは2つのバッファを自分のライフタイムの間保持して使用します。
-    WOLFMEM_TRACK_STATS  - 各SSLは実行中にメモリ使用統計を追跡します。
+    \brief この関数は、CTX用の静的メモリを確保するために使用されます。確保されたメモリは、CTXのライフタイム中およびCTXから作成されたSSLオブジェクトに使用されます。NULLのctxポインタとwolfSSL_method_func関数を渡すことで、CTX自体の作成も静的メモリを使用します。wolfSSL_method_funcは、WOLFSSL_METHOD* (*wolfSSL_method_func)(void* heap);という関数シグネチャを持ちます。maxに0を渡すと、設定されていないかのように動作し、最大同時使用制限は適用されません。渡されたflag値は、メモリの使用方法と動作中の挙動を決定します。利用可能なフラグは次のとおりです: 0 - デフォルトの一般メモリ、WOLFMEM_IO_POOL - メッセージの送受信時の入出力バッファに使用され、一般メモリをオーバーライドするため、渡されたバッファ内のすべてのメモリがIOに使用されます、WOLFMEM_IO_FIXED - WOLFMEM_IO_POOLと同じですが、各SSLがライフタイム中に2つのバッファを保持します、WOLFMEM_TRACK_STATS - 各SSLが実行中にメモリ統計を追跡します。
 
-    \return SSL_SUCCESS  成功した場合に返されます。に返されます。
-    \return SSL_FAILURE  失敗した場合に返されます。
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FAILURE 失敗時。
 
-    \param ctx  WOLFSSL_CTX構造体へのポインタのポインタ
-    \param method  メソッド関数（例えば、wolfSSLv23_server_method_ex）でctxがNULLでない場合はNULLにする必要があります。
-    \param buf  すべての操作に使用するメモリバッファへのポインタ。
-    \param sz  渡されているメモリバッファのサイズ。
-    \param flag  メモリの使用タイプ
-    \param max 同時使用の最大値
+    \param ctx WOLFSSL_CTX構造体へのポインタのアドレス。
+    \param method プロトコルを作成する関数。(ctxもNULLでない場合はNULLであるべきです)
+    \param buf すべての操作に使用するメモリ。
+    \param sz 渡されるメモリバッファのサイズ。
+    \param flag メモリのタイプ。
+    \param max 最大同時操作数。
 
     _Example_
     \code
@@ -736,21 +745,22 @@ int wolfSSL_tls_export(WOLFSSL* ssl, unsigned char* buf,
     int IOSz = MAX;
     int flag = WOLFMEM_IO_FIXED | WOLFMEM_TRACK_STATS;
     ...
-    // create ctx also using static memory, start with general memory to use
+    // 静的メモリを使用してctxも作成、使用する一般メモリから開始
     ctx = NULL:
     ret = wolfSSL_CTX_load_static_memory(&ctx, wolfSSLv23_server_method_ex,
     memory, memorySz, 0,    MAX_CONCURRENT_HANDSHAKES);
     if (ret != SSL_SUCCESS) {
-    // handle error case
+        // エラーケースの処理
     }
-    // load in memory for use with IO
+    // IOで使用するメモリをロード
     ret = wolfSSL_CTX_load_static_memory(&ctx, NULL, IO, IOSz, flag,
     MAX_CONCURRENT_IO);
     if (ret != SSL_SUCCESS) {
-    // handle error case
+        // エラーケースの処理
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_is_static_memory
     \sa wolfSSL_is_static_memory
@@ -761,14 +771,13 @@ int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx,
                                             int flag, int max);
 
 /*!
-    \brief  この関数は現時点の接続に関する振る舞いの変更は行いません。
-    静的メモリ使用量に関する情報を収集するためにのみ使用されます。
-    \return 1  CTXの静的メモリを使用している場合に返されます。
-    \return 0  静的メモリを使用していない場合に返されます。
+    \brief この関数は接続の動作を変更せず、静的メモリの使用状況に関する情報を収集するためにのみ使用されます。
 
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param mem_stats 静的メモリの使用量に関する情報を保持するWOLFSSL_MEM_STATS構造体へのポインタ
+    \return 1 CTXが静的メモリを使用している場合にtrueとして返されます。
+    \return 0 静的メモリを使用していない場合に返されます。
 
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param mem_stats 静的メモリの使用状況に関する情報を保持する構造体。
 
     _Example_
     \code
@@ -776,17 +785,18 @@ int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx,
     int ret;
     WOLFSSL_MEM_STATS mem_stats;
     ...
-    //get information about static memory with CTX
+    //CTXによる静的メモリに関する情報を取得
     ret = wolfSSL_CTX_is_static_memory(ctx, &mem_stats);
     if (ret == 1) {
-        // handle case of is using static memory
-        // print out or inspect elements of mem_stats
+        // 静的メモリを使用しているケースの処理
+        // mem_statsの要素を出力または検査
     }
     if (ret == 0) {
-        //handle case of ctx not using static memory
+        //ctxが静的メモリを使用していないケースの処理
     }
     …
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_load_static_memory
     \sa wolfSSL_is_static_memory
@@ -795,15 +805,13 @@ int wolfSSL_CTX_is_static_memory(WOLFSSL_CTX* ctx,
                                                  WOLFSSL_MEM_STATS* mem_stats);
 
 /*!
-    \brief  wolfSSL_is_static_memory関数はSSLの静的メモリ使用量に関する情報を集めます。
-    戻り値は、静的メモリが使用されているかどうかを示します。
-    引数sslの上位のWOLFSSL_CTXに静的メモリを使用するように指定してあり、WOLFMEM_TRACK_STATSが定義されている場合に
-    引数mem_statsに情報がセットされます。
-    \return 1  静的メモリを使用している場合に返されます。
-    \return 0  静的メモリを使用していない場合に返されます。
+    \brief wolfSSL_is_static_memoryは、SSLの静的メモリ使用状況に関する情報を収集するために使用されます。戻り値は静的メモリが使用されているかどうかを示し、WOLFSSL_MEM_CONN_STATSは、静的メモリをロードする際に親CTXにWOLFMEM_TRACK_STATSフラグが渡された場合にのみ入力されます。
 
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param mem_stats 静的メモリの使用量に関する情報を保持するWOLFSSL_MEM_STATS構造体へのポインタ
+    \return 1 CTXが静的メモリを使用している場合にtrueとして返されます。
+    \return 0 静的メモリを使用していない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param mem_stats 静的メモリの使用状況を含む構造体。
 
     _Example_
     \code
@@ -813,11 +821,12 @@ int wolfSSL_CTX_is_static_memory(WOLFSSL_CTX* ctx,
     ...
     ret = wolfSSL_is_static_memory(ssl, mem_stats);
     if (ret == 1) {
-        // handle case when is static memory
-        // investigate elements in mem_stats if WOLFMEM_TRACK_STATS flag
+        // 静的メモリの場合のケースを処理
+        // WOLFMEM_TRACK_STATSフラグがある場合、mem_stats内の要素を調査
     }
     ...
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_CTX_is_static_memory
 */
@@ -826,33 +835,29 @@ int wolfSSL_is_static_memory(WOLFSSL* ssl,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は証明書ファイルをSSLコンテキスト(WOLFSSL_CTX)にロードします。
-    ファイルは引数fileによって提供されます。
-    引数formatは、ファイルのフォーマットタイプ（SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM）を指定します。
-    適切な使用法の例をご覧ください。
 
-    \return SSL_SUCCESS  成功した場合に返されます。に返されます。
-    \return SSL_FAILURE  失敗時に返されます。失敗した場合の可能な原因としては、
-    ファイルが誤った形式の場合、または引数formatを使用して誤ったフォーマットが指定されている、
-    あるいはファイルが存在しない、あるいは読み取ることができない、または破損している、
-    メモリ不足が発生、Base16のデコードに失敗しているなどの原因が考えられます。
+    \brief この関数は、証明書ファイルをSSLコンテキスト(WOLFSSL_CTX)にロードします。ファイルはfile引数によって提供されます。format引数はファイルのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMのいずれかです。適切な使用方法については、exampleを参照してください。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FAILURE 関数呼び出しが失敗した場合、考えられる原因には、ファイルが間違ったフォーマットである、または"format"引数を使用して間違ったフォーマットが指定されている、ファイルが存在しない、読み取れない、または破損している、メモリ不足の状態が発生している、ファイルのBase16デコードが失敗したことなどが含まれます。
 
     \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ
-    \param file ロードする証明書を含むファイルパス文字列。
-    \param format ロードする証明書のフォーマット：SSL_FILETYPE_ASN1 あるいは SSL_FILETYPE_PEM
+    \param file wolfSSL SSLコンテキストにロードされる証明書を含むファイルの名前へのポインタ。
+    \param format - fileが指す証明書のフォーマット。可能なオプションはSSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL_CTX* ctx;
     ...
-    ret = wolfSSL_CTX_use_certificate_file(ctx, “./client-cert.pem”,
+    ret = wolfSSL_CTX_use_certificate_file(ctx, "./client-cert.pem",
                                      SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-	    // error loading cert file
+	    // 証明書ファイルのロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_use_certificate_buffer
     \sa wolfSSL_use_certificate_file
     \sa wolfSSL_use_certificate_buffer
@@ -863,36 +868,28 @@ int wolfSSL_CTX_use_certificate_file(WOLFSSL_CTX* ctx, const char* file,
 /*!
     \ingroup CertsKeys
 
-    \brief  この関数は、秘密鍵ファイルをSSLコンテキスト(WOLFSSL_CTX)にロードします。
-    ファイルは引数fileによって提供されます。
-    引数formatは、次のファイルのフォーマットタイプを指定します：SSL_FILETYPE_ASN1　あるいは SSL_FILETYPE_PEM。
-    適切な使用法の例をご覧ください。
-    外部キーストアを使用し、秘密鍵を持っていない場合は、
-    代わりに公開鍵を入力してcryptoコールバックを登録して署名を処理することができます。
-    このためには、cryptoコールバックまたはPKコールバックを使用したコンフィギュレーションでビルドします。
-    cryptoコールバックを有効にするには、--enable-cryptocbまたはWOLF_CRYPTO_CBマクロを使用し、
-    wc_CryptoCb_RegisterDeviceを使用して暗号コールバックを登録し、
-    wolfSSL_CTX_SetDevIdを使用して関連するdevidを設定します。
+    \brief この関数は、秘密鍵ファイルをSSLコンテキスト(WOLFSSL_CTX)にロードします。ファイルはfile引数によって提供されます。format引数はファイルのフォーマットタイプを指定します - SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。適切な使用方法については、exampleを参照してください。
 
-    \return SSL_SUCCESS  成功した場合に返されます。に返されます。
-    \return SSL_FAILURE  関数呼び出しが失敗した場合の可能な原因としては、
-    ファイルが誤った形式の場合、または引数formatを使用して誤ったフォーマットが指定されている、
-    あるいはファイルが存在しない、あるいは読み取ることができない、または破損している、
-    メモリ不足が発生、Base16のデコードに失敗しているなどの原因が考えられます
-    \param なし
+    外部キーストアを使用していて秘密鍵を持っていない場合、代わりに公開鍵を提供し、署名を処理するための暗号コールバックを登録できます。これには、暗号コールバックまたはPKコールバックのいずれかでビルドできます。暗号コールバックを有効にするには、--enable-cryptocbまたはWOLF_CRYPTO_CBでビルドし、wc_CryptoCb_RegisterDeviceを使用して暗号コールバックを登録し、wolfSSL_CTX_SetDevIdを使用して関連するdevIdを設定します。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FAILURE ファイルが間違ったフォーマットである、または"format"引数を使用して間違ったフォーマットが指定されている。ファイルが存在しない、読み取れない、または破損している。メモリ不足の状態が発生している。ファイルのBase16デコードが失敗した。キーファイルが暗号化されているが、パスワードが提供されていない。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL_CTX* ctx;
     ...
-    ret = wolfSSL_CTX_use_PrivateKey_file(ctx, “./server-key.pem”,
+    ret = wolfSSL_CTX_use_PrivateKey_file(ctx, "./server-key.pem",
                                     SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-	    // error loading key file
+	    // 鍵ファイルのロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_use_PrivateKey_buffer
     \sa wolfSSL_use_PrivateKey_file
     \sa wolfSSL_use_PrivateKey_buffer
@@ -903,43 +900,37 @@ int wolfSSL_CTX_use_PrivateKey_file(WOLFSSL_CTX* ctx, const char* file, int form
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、PEM形式のCA証明書ファイルをSSLコンテキスト(WOLFSSL_CTX)にロードします。
-    これらの証明書は、信頼できるルート証明書として扱われ、SSLハンドシェイク中にピアから受信した証明書を検証するために使用されます。
-    引数fileによって提供されるルート証明書ファイルは、単一の証明書または複数の証明書を含むファイルでの場合があります。
-    複数のCA証明書が同じファイルに含まれている場合、wolfSSLはファイルに表示されているのと同じ順序でそれらをロードします。
-    引数pathは、信頼できるルートCAの証明書を含むディレクトリの名前へのポインタです。
-    引数fileがNULLではない場合、パスが必要でない場合はNULLとして指定できます。
-    引数pathが指定されていてかつNO_WOLFSSL_DIRが定義されていない場合には、
-    wolfSSLライブラリは指定されたディレクトリに存在するすべてのCA証明書をロードします。
-    この関数はディレクトリ内のすべてのファイルをロードしようとします。
-    この関数は、ヘッダーに "-----BEGIN CERTIFICATE-----"を持つPEMフォーマットされたCERT_TYPEファイルを期待しています。
 
-    \return SSL_SUCCESS  成功した場合に返されます。に返されます。
-    \return SSL_FAILURE  CTXがNULLの場合、またはファイルとパスの両方がNULLの場合に返されます。
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合、読み込めない場合、または破損している場合に返されます。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return ASN_BEFORE_DATE_E  現在の日付が使用開始日より前の場合に返されます。
-    \return ASN_AFTER_DATE_E  現在の日付が使用期限後より後の場合に返されます。
-    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
-    \return BAD_PATH_ERROR  opendir()がパスを開こうとして失敗した場合に返されます。
+    \brief この関数は、PEM形式のCA証明書ファイルをSSLコンテキスト(WOLFSSL_CTX)にロードします。これらの証明書は信頼されたルート証明書として扱われ、SSLハンドシェイク中にピアから受信した証明書を検証するために使用されます。file引数によって提供されるルート証明書ファイルは、単一の証明書または複数の証明書を含むファイルである場合があります。
+    同じファイルに複数のCA証明書が含まれている場合、wolfSSLはファイル内に提示された順序でそれらをロードします。path引数は、信頼されたルートCAの証明書を含むディレクトリの名前へのポインタです。fileの値がNULLでない場合、必要でなければpathをNULLとして指定できます。pathが指定され、ライブラリのビルド時にNO_WOLFSSL_DIRが定義されていない場合、wolfSSLは指定されたディレクトリにあるすべてのCA証明書をロードします。この関数はディレクトリ内のすべてのファイルをロードしようとします。この関数は、ヘッダー"-----BEGIN CERTIFICATE-----"を持つPEM形式のCERT_TYPEファイルを想定しています。
 
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FAILURE ctxがNULLの場合、またはfileとpathの両方がNULLの場合に返されます。
+    \return SSL_BAD_FILETYPE ファイルが間違ったフォーマットの場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足の状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードが失敗した場合に返されます。
+    \return ASN_BEFORE_DATE_E 現在の日付がbefore dateより前の場合に返されます。
+    \return ASN_AFTER_DATE_E 現在の日付がafter dateより後の場合に返されます。
+    \return BUFFER_E チェーンバッファが受信バッファより大きい場合に返されます。
+    \return BAD_PATH_ERROR pathを開こうとしたときにopendir()が失敗した場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
     \param file PEM形式のCA証明書を含むファイルの名前へのポインタ。
-    \param path CA証明書を含んでいるディレクトリのディレクトリの名前へのポインタ。
+    \param path PEM形式の証明書をロードするディレクトリの名前へのポインタ。
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL_CTX* ctx;
     ...
-    ret = wolfSSL_CTX_load_verify_locations(ctx, “./ca-cert.pem”, NULL);
+    ret = wolfSSL_CTX_load_verify_locations(ctx, "./ca-cert.pem", NULL);
     if (ret != WOLFSSL_SUCCESS) {
-    	// error loading CA certs
+    	// CA証明書のロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_load_verify_locations_ex
     \sa wolfSSL_CTX_load_verify_buffer
     \sa wolfSSL_CTX_use_certificate_file
@@ -953,46 +944,37 @@ int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
                                                 const char* path);
 
 /*!
-    \brief  この関数は、PEM形式のCA証明書ファイルをSSLコンテキスト(WOLFSSL_CTX)にロードします。
-    これらの証明書は、信頼できるルート証明書として扱われ、SSLハンドシェイク中にピアから受信した証明書を検証するために使用されます。
-    引数fileによって提供されるルート証明書ファイルは、単一の証明書または複数の証明書を含むファイルでの場合があります。
-    複数のCA証明書が同じファイルに含まれている場合、wolfSSLはファイルに表示されているのと同じ順序でそれらをロードします。
-    引数pathは、信頼できるルートCAの証明書を含むディレクトリの名前へのポインタです。
-    引数fileがNULLではない場合、パスが必要でない場合はNULLとして指定できます。
-    引数pathが指定されていてかつNO_WOLFSSL_DIRが定義されていない場合には、
-    wolfSSLライブラリは指定されたディレクトリに存在するすべてのCA証明書をロードします。
-    この関数は引数flagsに基づいてディレクトリ内のすべてのファイルをロードしようとします。
-    この関数は、ヘッダーに "-----BEGIN CERTIFICATE-----"を持つPEMフォーマットされたCERT_TYPEファイルを期待しています。
+    \ingroup CertsKeys
 
-    \return SSL_SUCCESS  成功した場合に返されます。に返されます。
-    \return SSL_FAILURE  CTXがNULLの場合、またはファイルとパスの両方がNULLの場合に返されます。
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合、読み込めない場合、または破損している場合に返されます。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return ASN_BEFORE_DATE_E  現在の日付が使用開始日より前の場合に返されます。
-    \return ASN_AFTER_DATE_E  現在の日付が使用期限後より後の場合に返されます。
-    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
-    \return BAD_PATH_ERROR  opendir()がパスを開こうとして失敗した場合に返されます。
+    \brief この関数は、PEM形式のCA証明書ファイルをSSLコンテキスト(WOLFSSL_CTX)にロードします。これらの証明書は信頼されたルート証明書として扱われ、SSLハンドシェイク中にピアから受信した証明書を検証するために使用されます。file引数によって提供されるルート証明書ファイルは、単一の証明書または複数の証明書を含むファイルである場合があります。
+    同じファイルに複数のCA証明書が含まれている場合、wolfSSLはファイル内に提示された順序でそれらをロードします。path引数は、信頼されたルートCAの証明書を含むディレクトリの名前へのポインタです。fileの値がNULLでない場合、必要でなければpathをNULLとして指定できます。pathが指定され、ライブラリのビルド時にNO_WOLFSSL_DIRが定義されていない場合、wolfSSLは指定されたディレクトリにあるすべてのCA証明書をロードします。この関数は、指定されたフラグに基づいてディレクトリ内のすべてのファイルをロードしようとします。この関数は、ヘッダー"-----BEGIN CERTIFICATE-----"を持つPEM形式のCERT_TYPEファイルを想定しています。
 
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param file PEM形式のCA証明書を含むファイルの名前へのポインタ。
-    \param path CA証明書を含んでいるディレクトリのフォルダーパス
-    \param flags 指定可能なマスク値: WOLFSSL_LOAD_FLAG_IGNORE_ERR,
-    WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY, WOLFSSL_LOAD_FLAG_PEM_CA_ONLY
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FAILURE ctxがNULLの場合、またはfileとpathの両方がNULLの場合に返されます。少なくとも1つの証明書が正常にロードされたが、1つ以上が失敗した場合もこれが返されます。理由についてはエラースタックを確認してください。
+    \return SSL_BAD_FILETYPE ファイルが間違ったフォーマットの場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足の状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードが失敗した場合に返されます。
+    \return BUFFER_E チェーンバッファが受信バッファより大きい場合に返されます。
+    \return BAD_PATH_ERROR pathを開こうとしたときにopendir()が失敗した場合に返されます。    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param file PEM形式のCA証明書を含むファイル名へのポインタ。
+    \param path PEM形式の証明書を読み込むディレクトリ名へのポインタ。
+    \param flags 指定可能なマスク値: WOLFSSL_LOAD_FLAG_IGNORE_ERR、
+    WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY、WOLFSSL_LOAD_FLAG_PEM_CA_ONLY
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL_CTX* ctx;
     ...
-    ret = wolfSSL_CTX_load_verify_locations_ex(ctx, NULL, “./certs/external",
+    ret = wolfSSL_CTX_load_verify_locations_ex(ctx, NULL, "./certs/external",
         WOLFSSL_LOAD_FLAG_PEM_CA_ONLY);
     if (ret != WOLFSSL_SUCCESS) {
-        // error loading CA certs
+        // CA証明書の読み込みエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_load_verify_locations
     \sa wolfSSL_CTX_load_verify_buffer
     \sa wolfSSL_CTX_use_certificate_file
@@ -1008,13 +990,12 @@ int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX* ctx, const char* file,
 /*!
     \ingroup CertsKeys
 
-    \brief この関数は、wolfSSL_CTX_load_system_CA_certs が呼び出されたときに、
-    wolfSSLがシステムCA証明書を検索するディレクトリを表す文字列の配列へのポインタを返します。
+    \brief この関数は、wolfSSL_CTX_load_system_CA_certsが呼び出されたときにwolfSSLがシステムCA証明書を検索するディレクトリを表す文字列の配列へのポインタを返します。証明書をアクセス可能なシステムディレクトリに保存しないシステム(Appleプラットフォームなど)では、この関数は常にNULLを返します。
 
-    \return 成功時には文字列配列へのポインタを返します。
-    \return NULL 失敗時に返します。
+    \return 成功時は有効なポインタ。
+    \return 失敗時はNULLポインタ。
 
-    \param num word32型変数へのポインタ。文字列配列の長さを格納します。
+    \param num 文字列配列の長さが格納されるword32へのポインタ。
 
     _Example_
     \code
@@ -1038,16 +1019,18 @@ const char** wolfSSL_get_system_CA_dirs(word32* num);
 /*!
     \ingroup CertsKeys
 
-    \brief この関数は、CA証明書をOS依存のCA証明書ストアからWOLFSSL_CTXにロードしようとします。
-    ロードされた証明書は信頼されます。
-    サポートおよびテストされているプラットフォームは、Linux(Debian、Ubuntu、Gentoo、Fedora、RHEL)、
-    Windows 10/11、Android、Apple OS X、iOSです。
+    \brief ほとんどのプラットフォーム(LinuxおよびWindowsを含む)において、この関数はOS依存のCA証明書ストアからWOLFSSL_CTXへCA証明書を読み込もうと試みます。読み込まれた証明書は信頼されます。
 
-    \return WOLFSSL_SUCCESS 成功時に返されます。
-    \return WOLFSSL_BAD_PATH システムCA証明書がロードできなかった場合に返されます。
-    \return WOLFSSL_FAILURE そのほかのエラー発生時（Windows証明書ストアが正常にクローズされない等）
+    Appleプラットフォーム(macOSを除く)では、証明書をシステムから取得できないため、wolfSSL証明書マネージャに読み込むことができません。これらのプラットフォームでは、この関数は、WOLFSSL_CTXにバインドされたTLS接続において、ユーザーによって読み込まれた証明書に対してピア証明書の信頼性を最初に認証できない場合に、ネイティブシステムの信頼APIを使用してピア証明書チェーンの信頼性を検証できるようにします。
 
-    \param ctx wolfSSL_CTX_new()で生成されたWOLFSSL_CTX構造体へのポインタ。
+    サポートおよびテストされているプラットフォームは、Linux(Debian、Ubuntu、
+    Gentoo、Fedora、RHEL)、Windows 10/11、Android、macOS、およびiOSです。
+
+    \return 成功時はWOLFSSL_SUCCESS。
+    \return システムCA証明書が読み込まれなかった場合はWOLFSSL_BAD_PATH。
+    \return その他の失敗タイプの場合はWOLFSSL_FAILURE(例: Windows証明書ストアが適切に閉じられなかった場合)。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
 
     _Example_
     \code
@@ -1056,7 +1039,7 @@ const char** wolfSSL_get_system_CA_dirs(word32* num);
     ...
     ret = wolfSSL_CTX_load_system_CA_certs(ctx,);
     if (ret != WOLFSSL_SUCCESS) {
-        // error loading system CA certs
+        // システムCA証明書の読み込みエラー
     }
     ...
     \endcode
@@ -1067,23 +1050,22 @@ const char** wolfSSL_get_system_CA_dirs(word32* num);
 */
 int wolfSSL_CTX_load_system_CA_certs(WOLFSSL_CTX* ctx);
 
-
 /*!
     \ingroup Setup
-    \brief  この関数は、TLS/SSLハンドシェイクを実行するときにピアを検証するために使用する証明書をロードします。
-    ハンドシェイク中に送信されたピア証明書は、この関数で指定された証明書のSKIDと署名を比較することによって検証されます。
-    これら2つのことが一致しない場合は、ピア証明書の検証にはロードされたCA証明書が使用されます。
-    この機能はWOLFSSL_TRUST_PEER_CERTマクロを定義することで機能を有効にできます。
-    適切な使用法は例をご覧ください。
 
-    \return SSL_SUCCES  成功時に返されます。
-    \return SSL_FAILURE  CTXがNULLの場合、または両方のファイルと種類が無効な場合に返されます。
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \param ctx  wolfSSL_CTX_new()で生成されたWOLFSSL_CTX構造体へのポインタ。
-    \param file  証明書を含むファイルの名前へのポインタ
+    \brief この関数は、TLS/SSLハンドシェイクを実行する際にピアを検証するために使用する証明書を読み込みます。ハンドシェイク中に送信されるピア証明書は、利用可能な場合はSKIDを使用し、署名を使用して比較されます。これら2つが一致しない場合は、読み込まれたCAが使用されます。この機能はマクロWOLFSSL_TRUST_PEER_CERTを定義することで有効になります。適切な使用方法については、examplesを参照してください。
+
+    \return 成功時はSSL_SUCCES。
+    \return ctxがNULLの場合、またはfileとtypeの両方が無効な場合はSSL_FAILUREが返されます。
+    \return ファイルの形式が間違っている場合はSSL_BAD_FILETYPEが返されます。
+    \return ファイルが存在しない、読み取れない、または破損している場合はSSL_BAD_FILEが返されます。
+    \return メモリ不足状態が発生した場合はMEMORY_Eが返されます。
+    \return ファイルに対するBase16デコードが失敗した場合はASN_INPUT_Eが返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param file 証明書を含むファイル名へのポインタ。
+    \param type 読み込まれる証明書のタイプ、すなわちSSL_FILETYPE_ASN1
+    またはSSL_FILETYPE_PEM。
 
     _Example_
     \code
@@ -1091,13 +1073,14 @@ int wolfSSL_CTX_load_system_CA_certs(WOLFSSL_CTX* ctx);
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
     ...
 
-    ret = wolfSSL_CTX_trust_peer_cert(ctx, “./peer-cert.pem”,
+    ret = wolfSSL_CTX_trust_peer_cert(ctx, "./peer-cert.pem",
     SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-        // error loading trusted peer cert
+        // 信頼されたピア証明書の読み込みエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_load_verify_buffer
     \sa wolfSSL_CTX_use_certificate_file
     \sa wolfSSL_CTX_use_PrivateKey_file
@@ -1112,28 +1095,27 @@ int wolfSSL_CTX_trust_peer_cert(WOLFSSL_CTX* ctx, const char* file, int type);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、証明書チェーンをSSLコンテキスト(WOLFSSL_CTX)にロードします。
-    証明書チェーンを含むファイルは引数fileによって提供され、PEM形式の証明書を含める必要があります。
-    この関数は、最大MAX_CHAIN_DEPTH（既定で9、internal.hで定義されている）数の証明書を処理します。
-    この数にはサブジェクト証明書を含みます。
 
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  関数呼び出しが失敗した場合、可能な原因としては：誤った形式である場合、
-    または「format」引数を使用して誤ったフォーマットが指定されている場合、
-    ファイルが存在しない、読み取れない、または破損している、メモリ枯渇などが考えられます。
-    \param ctx  wolfSSL_CTX_new()で生成されたWOLFSSL_CTX構造体へのポインタ。
+    \brief この関数は、証明書チェーンをSSLコンテキスト(WOLFSSL_CTX)に読み込みます。証明書チェーンを含むファイルはfile引数によって提供され、PEM形式の証明書を含む必要があります。この関数は、MAX_CHAIN_DEPTH(デフォルト = 9、internal.hで定義)個までの証明書と、サブジェクト証明書を処理します。
+
+    \return 成功時はSSL_SUCCESS。
+    \return 関数呼び出しが失敗した場合はSSL_FAILURE。考えられる原因には、ファイルの形式が間違っている、または「format」引数を使用して間違った形式が指定されている、ファイルが存在しない、読み取れない、または破損している、メモリ不足状態が発生した、などがあります。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param file wolfSSL SSLコンテキストに読み込まれる証明書チェーンを含むファイルの名前へのポインタ。証明書はPEM形式である必要があります。
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL_CTX* ctx;
     ...
-    ret = wolfSSL_CTX_use_certificate_chain_file(ctx, “./cert-chain.pem”);
+    ret = wolfSSL_CTX_use_certificate_chain_file(ctx, "./cert-chain.pem");
     if (ret != SSL_SUCCESS) {
-	    // error loading cert file
+	    // 証明書ファイルの読み込みエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_use_certificate_file
     \sa wolfSSL_CTX_use_certificate_buffer
     \sa wolfSSL_use_certificate_file
@@ -1144,32 +1126,29 @@ int wolfSSL_CTX_use_certificate_chain_file(WOLFSSL_CTX *ctx,
 
 /*!
     \ingroup openSSL
-    \brief  この関数は、SSL接続で使用されているRSA秘密鍵をSSLコンテキスト(WOLFSSL_CTX)にロードします。
-    この関数は、wolfSSLがOpenSSL互換APIが有効（--enable-openSSLExtra、#define OPENSSL_EXTRA）でコンパイルされている場合にのみ利用可能で、
-    より一般的に使用されているwolfSSL_CTX_use_PrivateKey_file()関数と同じです。
-    ファイル引数には、RSA秘密鍵ファイルへのポインタが、引数formatで指定された形式で含まれています。
 
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  関数呼び出しが失敗した場合に返されます。
-    失敗の原因には次が考えられます：入力鍵ファイルが誤った形式である、
-    または引数formatを使用して誤った形式が与えられている場合、
-    ファイルが存在しない、読み込めない、または破損してる、メモリ不足状態が発生。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ
-    \param file  フォーマットで指定された形式で、WolfSSL SSLコンテキストにロードされるRSA秘密鍵を含むファイルの名前へのポインタ。
-    \param format RSA秘密鍵のエンコード形式を指定します。指定可能なフォーマット値は：SSL_FILETYPE_PEM と SSL_FILETYPE_ASN1
+    \brief この関数は、SSL接続で使用されるプライベートRSA鍵をSSLコンテキスト(WOLFSSL_CTX)に読み込みます。この関数は、wolfSSLがOpenSSL互換レイヤーを有効にしてコンパイルされた場合(--enable-opensslExtra、#define OPENSSL_EXTRA)にのみ利用可能であり、より一般的に使用されるwolfSSL_CTX_use_PrivateKey_file()関数と同一です。file引数には、format引数で指定された形式のRSAプライベート鍵ファイルへのポインタが含まれます。
+
+    \return 成功時はSSL_SUCCESS。
+    \return 関数呼び出しが失敗した場合はSSL_FAILURE。考えられる原因には、入力鍵ファイルの形式が間違っている、または「format」引数を使用して間違った形式が指定されている、ファイルが存在しない、読み取れない、または破損している、メモリ不足状態が発生した、などがあります。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param file wolfSSL SSLコンテキストに読み込まれるRSAプライベート鍵を含むファイルの名前へのポインタ。形式はformat引数で指定されます。
+    \param format file引数で指定されたRSAプライベート鍵のエンコーディングタイプ。指定可能な値には、SSL_FILETYPE_PEMおよびSSL_FILETYPE_ASN1が含まれます。
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL_CTX* ctx;
     ...
-    ret = wolfSSL_CTX_use_RSAPrivateKey_file(ctx, “./server-key.pem”,
+    ret = wolfSSL_CTX_use_RSAPrivateKey_file(ctx, "./server-key.pem",
                                        SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-	    // error loading private key file
+	    // プライベート鍵ファイルの読み込みエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_use_PrivateKey_buffer
     \sa wolfSSL_CTX_use_PrivateKey_file
     \sa wolfSSL_use_RSAPrivateKey_file
@@ -1180,9 +1159,13 @@ int wolfSSL_CTX_use_RSAPrivateKey_file(WOLFSSL_CTX* ctx, const char* file, int f
 
 /*!
     \ingroup IO
-    \brief  この関数は、有効なセッション（NULL以外の引数ssl）が指定された場合に、デフォルトで9の最大チェーン深度を返します。
-    \return MAX_CHAIN_DEPTH  WOLFSSL構造体がNULLではない場合に返されます。デフォルトでは値は9です。
-    \return BAD_FUNC_ARG  WOLFSSL構造体がNULLの場合に返されます。
+
+    \brief この関数は、有効なセッション(つまり、非NULLのセッションオブジェクト(ssl)が存在する場合)に対して許可される最大チェーン深度を返します。デフォルトは9です。
+
+    \return WOLFSSL構造体がNULLでない場合はMAX_CHAIN_DEPTHが返されます。デフォルトでは値は9です。
+    \return WOLFSSL構造体がNULLの場合はBAD_FUNC_ARGが返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -1192,34 +1175,40 @@ int wolfSSL_CTX_use_RSAPrivateKey_file(WOLFSSL_CTX* ctx, const char* file, int f
     long sslDep = wolfSSL_get_verify_depth(ssl);
 
     if(sslDep > EXPECTED){
-    	// The verified depth is greater than what was expected
+    	// 検証された深度は期待値よりも大きい
     } else {
-    	// The verified depth is smaller or equal to the expected value
+    	// 検証された深度は期待値以下
     }
     \endcode
+
     \sa wolfSSL_CTX_get_verify_depth
 */
 long wolfSSL_get_verify_depth(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、WOLFSSL_CTX構造体構造を使用して証明書チェーン深度を取得します。
-    \return MAX_CHAIN_DEPTH  WOLFSSL_CTX構造体がNULLではない場合に返されます。最大証明書チェーンピア深度の定数表現。
-    \return BAD_FUNC_ARG  WOLFSSL_CTX構造体がNULLの場合に返されます。
+
+    \brief この関数は、CTX構造体を使用して証明書チェーンの深度を取得します。
+
+    \return CTX構造体がNULLでない場合はMAX_CHAIN_DEPTHが返されます。最大証明書チェーンピア深度の定数表現です。
+    \return CTX構造体がNULLの場合はBAD_FUNC_ARGが返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
 
     _Example_
     \code
-    WOLFSSL_METHOD method; // protocol method
+    WOLFSSL_METHOD method; // プロトコルメソッド
     WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(method);
     …
     long ret = wolfSSL_CTX_get_verify_depth(ctx);
 
     if(ret == EXPECTED){
-    	//  You have the expected value
+    	//  期待値を取得しました
     } else {
-    	//  Handle an unexpected depth
+    	//  予期しない深度を処理
     }
     \endcode
+
     \sa wolfSSL_CTX_use_certificate_chain_file
     \sa wolfSSL_get_verify_depth
 */
@@ -1227,30 +1216,29 @@ long wolfSSL_CTX_get_verify_depth(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup openSSL
-    \brief  この関数は証明書ファイルをSSLセッション（WOLFSSL構造体）にロードします。
-    証明書ファイルはファイル引数によって提供されます。
-    引数formatは、ファイルのフォーマットタイプ（SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM）を指定します。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  関数呼び出しが失敗した場合に返されます。
-    可能な原因には次のようなものがあります。
-    ファイルが誤った形式、または引数formatを使用して誤った形式が与えられた、
-    メモリ不足状態が発生した、ファイルでBase16のデコードが失敗した
-    \param ssl  wolfSSL_new()で作成されたWOLFSSL構造体へのポインタ。
-    \param file  WOLFSSL構造体にロードされる証明書を含むファイルの名前へのポインタ
-    \param format 証明書ファイルのエンコード形式を指定します。指定可能なフォーマット値は：SSL_FILETYPE_PEM と SSL_FILETYPE_ASN1
+
+    \brief この関数は、証明書ファイルをSSLセッション(WOLFSSL構造体)に読み込みます。証明書ファイルはfile引数によって提供されます。format引数は、ファイルの形式タイプ(SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM)を指定します。
+
+    \return 成功時はSSL_SUCCESS。
+    \return 関数呼び出しが失敗した場合はSSL_FAILURE。考えられる原因には、ファイルの形式が間違っている、または「format」引数を使用して間違った形式が指定されている、ファイルが存在しない、読み取れない、または破損している、メモリ不足状態が発生した、ファイルに対するBase16デコードが失敗した、などがあります。
+
+    \param ssl wolfSSL_new()で作成されたWOLFSSL構造体へのポインタ。
+    \param file wolfSSL SSLセッションに読み込まれる証明書を含むファイルの名前へのポインタ。形式はformat引数で指定されます。
+    \param format file引数で指定された証明書のエンコーディングタイプ。指定可能な値には、SSL_FILETYPE_PEMおよびSSL_FILETYPE_ASN1が含まれます。
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL* ssl;
     ...
-    ret = wolfSSL_use_certificate_file(ssl, “./client-cert.pem”,
+    ret = wolfSSL_use_certificate_file(ssl, "./client-cert.pem",
                                  SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-    	// error loading cert file
+    	// 証明書ファイルの読み込みエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_use_certificate_buffer
     \sa wolfSSL_CTX_use_certificate_file
     \sa wolfSSL_use_certificate_buffer
@@ -1259,36 +1247,31 @@ int wolfSSL_use_certificate_file(WOLFSSL* ssl, const char* file, int format);
 
 /*!
     \ingroup openSSL
-    \brief  この関数は、秘密鍵ファイルをSSLセッション（WOLFSSL構造体）にロードします。
-    鍵ファイルは引数fileによって提供されます。
-    引数formatは、ファイルのタイプ（SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMが指定可）を指定します。
-    外部キーストアを使用し、秘密鍵を持っていない場合は、代わりに公開鍵を入力してCryProコールバックを登録して署名を処理することができます。
-    このためには、CryptoコールバックまたはPKコールバックを使用したコンフィグレーションでビルドします。
-    Cryptoコールバックを有効にするには、--enable-cryptocbまたはWOLF_CRYPTO_CBマクロを使用してビルドし、
-    wc_CryptoCb_RegisterDeviceを使用して暗号コールバックを登録し、
-    wolfSSL_SetDevIdを使用して関連するdevIdを設定します。
 
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  関数呼び出しが失敗した場合に返されます。
-    可能な原因には次のようなものがあります。
-    ファイルが誤った形式、または引数formatを使用して誤った形式が与えられた、
-    メモリ不足状態が発生した、ファイルでBase16のデコードが失敗した
-    \param ssl  wolfSSL_new()で作成されたWOLFSSL構造体へのポインタ。
-    \param file  WOLFSSL構造体にロードされる証明書を含むファイルの名前へのポインタ
-    \param format 秘密鍵ファイルのエンコード形式を指定します。指定可能なフォーマット値は：SSL_FILETYPE_PEM と SSL_FILETYPE_ASN1
+    \brief この関数は、プライベート鍵ファイルをSSLセッション(WOLFSSL構造体)に読み込みます。鍵ファイルはfile引数によって提供されます。format引数は、ファイルの形式タイプ(SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM)を指定します。
+
+    外部鍵ストアを使用していてプライベート鍵を持っていない場合は、代わりに公開鍵を提供し、署名を処理するための暗号コールバックを登録することができます。これには、暗号コールバックまたはPKコールバックのいずれかを有効にしてビルドします。暗号コールバックを有効にするには、--enable-cryptocbまたはWOLF_CRYPTO_CBを使用し、wc_CryptoCb_RegisterDeviceを使用して暗号コールバックを登録し、wolfSSL_SetDevIdを使用して関連するdevIdを設定します。
+
+    \return 成功時はSSL_SUCCESS。
+    \return 関数呼び出しが失敗した場合はSSL_FAILURE。考えられる原因には、ファイルの形式が間違っている、または「format」引数を使用して間違った形式が指定されている、ファイルが存在しない、読み取れない、または破損している、メモリ不足状態が発生した、ファイルに対するBase16デコードが失敗した、鍵ファイルが暗号化されているがパスワードが提供されていない、などがあります。
+
+    \param ssl wolfSSL_new()で作成されたWOLFSSL構造体へのポインタ。
+    \param file wolfSSL SSLセッションに読み込まれる鍵ファイルを含むファイルの名前へのポインタ。形式はformat引数で指定されます。
+    \param format file引数で指定された鍵のエンコーディングタイプ。指定可能な値には、SSL_FILETYPE_PEMおよびSSL_FILETYPE_ASN1が含まれます。
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL* ssl;
     ...
-    ret = wolfSSL_use_PrivateKey_file(ssl, “./server-key.pem”,
+    ret = wolfSSL_use_PrivateKey_file(ssl, "./server-key.pem",
                                 SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-	    // error loading key file
+	    // 鍵ファイルの読み込みエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_use_PrivateKey_buffer
     \sa wolfSSL_CTX_use_PrivateKey_file
     \sa wolfSSL_use_PrivateKey_buffer
@@ -1299,29 +1282,26 @@ int wolfSSL_use_PrivateKey_file(WOLFSSL* ssl, const char* file, int format);
 
 /*!
     \ingroup openSSL
-    \brief  この関数は、証明書チェーンをSSLセッションWOLFSSL構造体）にロードします。
-    証明書チェーンを含むファイルは引数fileによって提供され、PEM形式の証明書を含める必要があります。
-    この関数は、MAX_CHAIN_DEPTH（既定で9、internal.hで定義されている）証明書に加えて、サブジェクト証明書を処理します。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  関数呼び出しが失敗した場合に返されます。
-    可能な原因には次のようなものがあります：
-    ファイルが誤った形式、または引数formatを使用して誤った形式が与えられた、
-    メモリ不足状態が発生した、ファイルでbase16のデコードが失敗した
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param file  WOLFSSL構造体にロードされる証明書を含むファイルの名前へのポインタ。
-    証明書はPEM形式でなければなりません。
+    \brief この関数は、証明書のチェーンをSSLセッション(WOLFSSL構造体)にロードします。証明書チェーンを含むファイルはfile引数で指定され、PEM形式の証明書を含んでいる必要があります。この関数は、MAX_CHAIN_DEPTH(デフォルト = 9、internal.hで定義)個までの証明書と、サブジェクト証明書を処理します。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FAILURE 関数呼び出しが失敗した場合、考えられる原因は次のとおりです:ファイルの形式が間違っている、または"format"引数で与えられた形式が間違っている、ファイルが存在しない、読み取れない、または破損している、メモリ不足の状態が発生した
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \param file wolfSSL SSLセッションにロードする証明書のチェーンを含むファイルの名前へのポインタ。証明書はPEM形式でなければなりません。
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL* ctx;
     ...
-    ret = wolfSSL_use_certificate_chain_file(ssl, “./cert-chain.pem”);
+    ret = wolfSSL_use_certificate_chain_file(ssl, "./cert-chain.pem");
     if (ret != SSL_SUCCESS) {
-    	// error loading cert file
+    	// 証明書ファイルのロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_use_certificate_chain_file
     \sa wolfSSL_CTX_use_certificate_chain_buffer
     \sa wolfSSL_use_certificate_chain_buffer
@@ -1330,29 +1310,29 @@ int wolfSSL_use_certificate_chain_file(WOLFSSL* ssl, const char *file);
 
 /*!
     \ingroup openSSL
-    \brief  この関数は、SSL接続で使用されているRSA秘密鍵をSSLセッション（WOLFSSL構造体）にロードします。
-    この関数は、wolfSSLがOpenSSL互換APIを有効（--enable-openSSlExtra、#define OPENSSL_EXTRA）でビルドされている場合にのみ利用可能で、
-    より一般的に使用されるwolfSSL_use_PrivateKey_file()関数と同じです。
-    引数fileには、RSA秘密鍵ファイルへのポインタが、フォーマットで指定された形式で含まれています。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  関数呼び出しが失敗した場合に返されます。
-    可能な原因には次のようなものがあります：
-    ファイルが誤った形式、または引数formatを使用して誤った形式が与えられた、
-    メモリ不足状態が発生した、ファイルでBase16のデコードが失敗した
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数は、SSL接続で使用されるプライベートRSA鍵をSSLセッション(WOLFSSL構造体)にロードします。この関数は、wolfSSLがOpenSSL互換レイヤーを有効にしてコンパイルされている場合(--enable-opensslExtra、#define OPENSSL_EXTRA)にのみ利用可能であり、より一般的に使用されるwolfSSL_use_PrivateKey_file()関数と同一です。file引数は、formatで指定された形式のRSAプライベート鍵ファイルへのポインタを含みます。
+
+    \return SSL_SUCCESS 成功時
+    \return SSL_FAILURE 関数呼び出しが失敗した場合、考えられる原因は次のとおりです:入力鍵ファイルの形式が間違っている、または"format"引数で与えられた形式が間違っている、ファイルが存在しない、読み取れない、または破損している、メモリ不足の状態が発生した
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \param file wolfSSL SSLセッションにロードするRSAプライベート鍵を含むファイルの名前へのポインタ、形式はformatで指定されます。
+    \param format fileで指定されたRSAプライベート鍵のエンコーディングタイプ。指定可能な値はSSL_FILETYPE_PEMとSSL_FILETYPE_ASN1です。
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL* ssl;
     ...
-    ret = wolfSSL_use_RSAPrivateKey_file(ssl, “./server-key.pem”,
+    ret = wolfSSL_use_RSAPrivateKey_file(ssl, "./server-key.pem",
                                    SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-	    // error loading private key file
+	    // プライベート鍵ファイルのロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_use_RSAPrivateKey_file
     \sa wolfSSL_CTX_use_PrivateKey_buffer
     \sa wolfSSL_CTX_use_PrivateKey_file
@@ -1363,32 +1343,29 @@ int wolfSSL_use_RSAPrivateKey_file(WOLFSSL* ssl, const char* file, int format);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はwolfSSL_CTX_load_verify_locationsと似ていますが、
-    DERフォーマットされたCAファイルをSSLコンテキスト（WOLFSSL_CTX）にロードすることを許可します。
-    それはまだPEM形式のCAファイルをロードするためにも使用されるかもしれません。
-    これらの証明書は、信頼できるルート証明書として扱われ、SSLハンドシェイク中にピアから受信した証明書を検証するために使用されます。
-    ファイル引数によって提供されるルート証明書ファイルは、単一の証明書または複数の証明書を含むファイルでも可能。
-    複数のCA証明書が同じファイルに含まれている場合、wolfSSLはファイルに表示されているのと同じ順序でそれらをロードします。
-    引数formatは、証明書がSSL_FILETYPE_PEMまたはSSL_FILETYPE_ASN1（DER）のいずれかにある形式を指定します。
-    wolfSSL_CTX_load_verify_locationsとは異なり、この関数は特定のディレクトリパスからのCA証明書のロードを許可しません。
-    この関数は、wolfSSLライブラリがWOLFSSL_DER_LOADマクロが定義された状態でビルドされたときにのみ利用可能です。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  失敗すると返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ
-    \param file  wolfssl SSLコンテキストにロードされるCA証明書を含むファイルの名前をフォーマットで指定された形式で指定します。
+
+    \brief この関数はwolfSSL_CTX_load_verify_locationsに似ていますが、DER形式のCAファイルをSSLコンテキスト(WOLFSSL_CTX)にロードできます。PEM形式のCAファイルをロードするためにも使用できます。これらの証明書は信頼されたルート証明書として扱われ、SSLハンドシェイク中にピアから受信した証明書を検証するために使用されます。file引数で指定されるルート証明書ファイルは、単一の証明書または複数の証明書を含むファイルである可能性があります。複数のCA証明書が同じファイルに含まれている場合、wolfSSLはファイル内で提示された順序でそれらをロードします。format引数は、証明書の形式がSSL_FILETYPE_PEMまたはSSL_FILETYPE_ASN1(DER)のいずれかであることを指定します。wolfSSL_CTX_load_verify_locationsとは異なり、この関数は指定されたディレクトリパスからのCA証明書のロードを許可しません。この関数は、wolfSSLライブラリがWOLFSSL_DER_LOADを定義してコンパイルされている場合にのみ利用可能です。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FAILURE 失敗時。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ
+    \param file wolfSSL SSLコンテキストにロードするCA証明書を含むファイルの名前へのポインタ、形式はformatで指定されます。
+    \param format fileで指定された証明書のエンコーディングタイプ。指定可能な値はSSL_FILETYPE_PEMとSSL_FILETYPE_ASN1です。
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL_CTX* ctx;
     ...
-    ret = wolfSSL_CTX_der_load_verify_locations(ctx, “./ca-cert.der”,
+    ret = wolfSSL_CTX_der_load_verify_locations(ctx, "./ca-cert.der",
                                           SSL_FILETYPE_ASN1);
     if (ret != SSL_SUCCESS) {
-	    // error loading CA certs
+	    // CA証明書のロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_load_verify_locations
     \sa wolfSSL_CTX_load_verify_buffer
 */
@@ -1397,9 +1374,13 @@ int wolfSSL_CTX_der_load_verify_locations(WOLFSSL_CTX* ctx,
 
 /*!
     \ingroup Setup
-    \brief  この関数は、所望のSSL/TLSプロトコル用メソッド構造体を引数に取って、新しいSSLコンテキストを作成します。
-    \return pointer  成功した場合、新しく作成されたWOLFSSL_CTX構造体へのポインタを返します。
-    \return NULL  失敗時に返されます。
+
+    \brief この関数は、入力として希望するSSL/TLSプロトコルメソッドを取り、新しいSSLコンテキストを作成します。
+
+    \return pointer 成功した場合、呼び出しは新しく作成されたWOLFSSL_CTXへのポインタを返します。
+    \return NULL 失敗時。
+
+    \param method SSLコンテキストに使用する希望のWOLFSSL_METHODへのポインタ。これは、SSL/TLS/DTLSプロトコルレベルを指定するためのwolfSSLvXX_XXXX_method()関数のいずれかを使用して作成されます。
 
     _Example_
     \code
@@ -1408,23 +1389,28 @@ int wolfSSL_CTX_der_load_verify_locations(WOLFSSL_CTX* ctx,
 
     method = wolfSSLv3_client_method();
     if (method == NULL) {
-    	// unable to get method
+    	// メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-    	// context creation failed
+    	// コンテキストの作成に失敗しました
     }
     \endcode
+
     \sa wolfSSL_new
 */
 WOLFSSL_CTX* wolfSSL_CTX_new(WOLFSSL_METHOD*);
 
 /*!
     \ingroup Setup
-    \brief  この関数はすでに作成されたSSLコンテキスト(WOLFSSL_CTX)を入力として、新しいSSLセッション(WOLFSSL)を作成します。
-    \return 成功した場合、新しく作成されたWOLFSSL構造体へのポインタを返します。
-    \return NULL  失敗時に返されます。
+
+    \brief この関数は、既に作成されたSSLコンテキストを入力として取り、新しいSSLセッションを作成します。
+
+    \return ＊ 成功した場合、呼び出しは新しく作成されたwolfSSL構造体へのポインタを返します。
+    \return NULL 失敗時。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
 
     _Example_
     \code
@@ -1435,25 +1421,29 @@ WOLFSSL_CTX* wolfSSL_CTX_new(WOLFSSL_METHOD*);
 
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-	    // context creation failed
+	    // コンテキストの作成に失敗しました
     }
 
     ssl = wolfSSL_new(ctx);
     if (ssl == NULL) {
-	    // SSL object creation failed
+	    // SSLオブジェクトの作成に失敗しました
     }
     \endcode
+
     \sa wolfSSL_CTX_new
 */
 WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、SSL接続の入出力機能としてファイル記述子(fd)を割り当てます。通常これはソケットファイル記述子になります。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  失敗時に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param fd SSL/TLS接続に使用するファイルディスクリプタ
+
+    \brief この関数は、ファイルディスクリプタ(fd)をSSL接続の入出力機能として割り当てます。通常、これはソケットファイルディスクリプタになります。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 失敗時。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param fd SSL/TLS接続で使用するファイルディスクリプタ。
 
     _Example_
     \code
@@ -1463,27 +1453,27 @@ WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
 
     ret = wolfSSL_set_fd(ssl, sockfd);
     if (ret != SSL_SUCCESS) {
-    	// failed to set SSL file descriptor
+    	// SSLファイルディスクリプタの設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_CTX_SetIORecv
     \sa wolfSSL_SetIOReadCtx
     \sa wolfSSL_SetIOWriteCtx
 */
-int  wolfSSL_set_fd (WOLFSSL* ssl, int fd);
+int  wolfSSL_set_fd(WOLFSSL* ssl, int fd);
 
 /*!
     \ingroup Setup
-    \brief この関数はファイルディスクリプタ(fd)をSSLコネクションの入出力手段として設定します。
-    通常はソケットファイルディスクリプタが指定されます。この関数はDTLS専用のAPIであり、ソケットは接続済みとマークされます。
-    したがって、与えられたfdに対するrecvfromとsendto呼び出しでのaddrとaddr_lenはNULLに設定されます。
 
-    \return SSL_SUCCESS 成功時に返されます。
-    \return BAD_FUNC_ARG 失敗時に返されます。
+    \brief この関数は、ファイルディスクリプタ(fd)をSSL接続の入出力機能として割り当てます。通常、これはソケットファイルディスクリプタになります。これは、ソケットが接続されていることをマークするため、DTLS固有のAPIです。このfdに対するrecvfromおよびsendto呼び出しは、addrおよびaddr_lenパラメータがNULLに設定されます。
 
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param fd SSL/TLSコネクションに使用するファイルディスクリプタ。
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 失敗時。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param fd SSL/TLS接続で使用するファイルディスクリプタ。
 
     _Example_
     \code
@@ -1491,14 +1481,15 @@ int  wolfSSL_set_fd (WOLFSSL* ssl, int fd);
     WOLFSSL* ssl = 0;
     ...
     if (connect(sockfd, peer_addr, peer_addr_len) != 0) {
-        // handle connect error
+        // 接続エラーを処理
     }
     ...
     ret = wolfSSL_set_dtls_fd_connected(ssl, sockfd);
     if (ret != SSL_SUCCESS) {
-        // failed to set SSL file descriptor
+        // SSLファイルディスクリプタの設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_CTX_SetIORecv
     \sa wolfSSL_SetIOReadCtx
@@ -1510,37 +1501,30 @@ int wolfSSL_set_dtls_fd_connected(WOLFSSL* ssl, int fd);
 /*!
     \ingroup Setup
 
-    \brief この関数はDTLS ClientHelloメッセージが正しく処理できた際に呼び出されるコールバック関数を設定します。
-            クッキー交換メカニズムを使用する場合(DTLS1.2のHelloVerifyRequest か
-            DTLS1.3のクッキー拡張を伴ったHelloRetryRequestのいずれかを使用する場合)には、
-            クッキー交換が成功した時点でこのコールバック関数が呼び出されます。
-            この機能はひとつのWOLFSSLオブジェクトを新たな接続を待ち受けるリスナーとして使い,
-            ClientHelloが検証されたWOLFSSLオブジェクトから絶縁させることができます。
-            この場合の検証はクッキー交換かClientHelloが正しいフォーマットになっているかのチェックによってなされます。
-
+    \brief 正しく処理および検証されたDTLSクライアントhelloに対するコールバックを設定できます。クッキー交換メカニズム(DTLS 1.2のHelloVerifyRequestまたはクッキー拡張を伴うDTLS 1.3のHelloRetryRequest)を使用する場合、このコールバックはクッキー交換が成功した後に呼び出されます。これは、1つのWOLFSSLオブジェクトを新しい接続のリスナーとして使用し、ClientHelloが検証された後(クッキー交換を通じて、またはClientHelloが正しい形式であるかをチェックするだけで)にWOLFSSLオブジェクトを分離できるようにするのに役立ちます。
            DTLS 1.2:
            https://datatracker.ietf.org/doc/html/rfc6347#section-4.2.1
            DTLS 1.3:
            https://www.rfc-editor.org/rfc/rfc8446#section-4.2.2
 
-    \return SSL_SUCCESS 成功時に返されます。
-    \return BAD_FUNC_ARG 失敗時に返されます。
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 失敗時。
 
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param fd SSL/TLSコネクションに使用するファイルディスクリプタ。
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param fd SSL/TLS接続で使用するファイルディスクリプタ。
 
     _Example_
     \code
 
-    // Called when we have verified a connection
+    // 接続を検証したときに呼び出されます
     static int chGoodCb(WOLFSSL* ssl, void* arg)
     {
-        // setup peer and file descriptors
+        // ピアとファイルディスクリプタを設定
 
     }
 
     if (wolfDTLS_SetChGoodCb(ssl, chGoodCb, NULL) != WOLFSSL_SUCCESS) {
-         // error setting callback
+         // コールバック設定エラー
     }
     \endcode
 
@@ -1551,12 +1535,12 @@ int wolfDTLS_SetChGoodCb(WOLFSSL* ssl, ClientHelloGoodCb cb, void* user_ctx);
 /*!
     \ingroup IO
 
-    \brief この関数は引数で渡された優先順位の暗号名(Cipher)文字列へのポインタを返します。
+    \brief 渡された優先度レベルでの暗号の名前を取得します。
 
-    \return 成功時には暗号名(Cipher)文字列へのポインタを返します。
-    \return 0 引数で渡された優先順位が範囲外かあるいは無効な値であった場合に返されます。
+    \return string 成功
+    \return 0 優先度が範囲外または無効です。
 
-    \param priority 整数値で指定する優先順位
+    \param priority 暗号の優先度レベルを表す整数。
 
     _Example_
     \code
@@ -1570,24 +1554,28 @@ char* wolfSSL_get_cipher_list(int priority);
 
 /*!
     \ingroup IO
-    \brief  この関数はwolfSSで有効化されている暗号名(Cipher)を取得します。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG  引数bufがNULLの場合、または引数lenがゼロ以下の場合に返されます。
-    \return BUFFER_E  バッファが十分に大きくなく、オーバーフローする可能性がある場合に返されます。
-    \param buf  文字列を格納するバッファへのポインタ。
-    \param len バッファのサイズ
+
+    \brief この関数は、wolfSSLで有効になっている暗号を取得します。
+
+    \return SSL_SUCCESS 関数がエラーなく実行された場合に返されます。
+    \return BAD_FUNC_ARG bufパラメータがNULLまたはlen引数がゼロ以下の場合に返されます。
+    \return BUFFER_E バッファが十分に大きくなくオーバーフローする場合に返されます。
+
+    \param buf バッファを表すcharポインタ。
+    \param len バッファの長さ。
 
     _Example_
     \code
     static void ShowCiphers(void){
-	char* ciphers;
-	int ret = wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
+        char* ciphers;
+        int ret = wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
 
-	if(ret == SSL_SUCCES){
-	    	printf(“%s\n”, ciphers);
+	    if(ret == SSL_SUCCESS){
+	    	printf("%s\n", ciphers);
 	    }
     }
     \endcode
+
     \sa GetCipherNames
     \sa wolfSSL_get_cipher_list
     \sa ShowCiphers
@@ -1596,25 +1584,29 @@ int  wolfSSL_get_ciphers(char* buf, int len);
 
 /*!
     \ingroup IO
-    \brief  この関数は、引数をwolfSSL_get_cipher_name_internalに渡すことによって、DHE-RSAの形式の暗号名を取得します。
-    \return 成功時には一致した暗号スイートの文字列表現を返します。
-    \return NULL  エラーまたは暗号が見つからない場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数は、引数をwolfSSL_get_cipher_name_internalに渡すことによって、DHE-RSA形式で暗号名を取得します。
+
+    \return string この関数は、マッチした暗号スイートの文字列表現を返します。
+    \return NULL エラーまたは暗号が見つかりません。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
     WOLFSSL* ssl = wolfSSL_new(ctx);
     …
-    char* cipherS = wolfSSL_get_cipher_name(ssl);
+    char* cipher = wolfSSL_get_cipher_name(ssl);
 
     if(cipher == NULL){
-	    // There was not a cipher suite matched
+	    // 暗号スイートがマッチしませんでした
     } else {
-	    // There was a cipher suite matched
-	    printf(“%s\n”, cipherS);
+	    // 暗号スイートがマッチしました
+	    printf("%s\n", cipherS);
     }
     \endcode
+
     \sa wolfSSL_CIPHER_get_name
     \sa wolfSSL_get_current_cipher
     \sa wolfSSL_get_cipher_name_internal
@@ -1623,8 +1615,11 @@ const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  この関数は、SSL接続の入出力機能として使用されるファイル記述子(fd)を返します。通常これはソケットファイル記述子になります。
-    \return fd  成功時にはSSLセッションに関連つけられているファイル記述子を返します。
+
+    \brief この関数は、SSL接続の入力機能として使用される読み取りファイル記述子(fd)を返します。通常、これはソケットファイル記述子になります。
+    \return fd 成功した場合、この関数はSSLセッションファイルディスクリプタを返します。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
 
     _Example_
     \code
@@ -1634,22 +1629,46 @@ const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);
     sockfd = wolfSSL_get_fd(ssl);
     ...
     \endcode
+
     \sa wolfSSL_set_fd
+    \sa wolfSSL_set_read_fd
+    \sa wolfSSL_set_write_fd
 */
 int  wolfSSL_get_fd(const WOLFSSL*);
 
 /*!
+    \ingroup IO
+
+    \brief この関数は、SSL接続の出力機能として使用される書き込みファイルディスクリプタ(fd)を返します。通常はソケットファイルディスクリプタになります。
+
+    \return fd 成功した場合、この関数はSSLセッションファイルディスクリプタを返します。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+
+    _Example_
+    \code
+    int sockfd;
+    WOLFSSL* ssl = 0;
+    ...
+    sockfd = wolfSSL_get_wfd(ssl);
+    ...
+    \endcode
+
+    \sa wolfSSL_set_fd
+    \sa wolfSSL_set_read_fd
+    \sa wolfSSL_set_write_fd
+*/
+int  wolfSSL_get_wfd(const WOLFSSL*);
+
+/*!
     \ingroup Setup
-    \brief  この関数は、WOLFSSLオブジェクトに基礎となるI/Oがノンブロックであることを通知します。
-    アプリケーションがWOLFSSLオブジェクトを作成した後、ブロッキング以外のソケットで使用する場合は、
-    wolfssl_set_using_nonblock()を呼び出します。
-    これにより、wolfsslオブジェクトは、EWOULDBLOCKを受信することを意味します。
 
-    \return なし
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param nonblock WOLFSSLオブジェクトにノンブロッキングI/Oを使用することを通知するフラグ。
-    １を指定することでノンブロッキングI/Oを使用することを指定する。
+    \brief この関数は、WOLFSSLオブジェクトに対して、下層のI/Oがノンブロッキングであることを通知します。アプリケーションがWOLFSSLオブジェクトを作成した後、それをノンブロッキングソケットと共に使用する場合は、wolfSSL_set_using_nonblock()を呼び出してください。これにより、WOLFSSLオブジェクトは、EWOULDBLOCKを受け取ることがタイムアウトではなく、recvfrom呼び出しがブロックすることを意味すると認識できます。
 
+    \return none 戻り値はありません。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param nonblock WOLFSSLオブジェクトのノンブロッキングフラグを設定するための値。ノンブロッキングを指定する場合は1を、そうでない場合は0を使用してください。
 
     _Example_
     \code
@@ -1657,6 +1676,7 @@ int  wolfSSL_get_fd(const WOLFSSL*);
     ...
     wolfSSL_set_using_nonblock(ssl, 1);
     \endcode
+
     \sa wolfSSL_get_using_nonblock
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls_get_current_timeout
@@ -1665,13 +1685,13 @@ void wolfSSL_set_using_nonblock(WOLFSSL* ssl, int nonblock);
 
 /*!
     \ingroup IO
-    \brief  この機能により、wolfSSLがノンブロッキングI/Oを使用しているかどうかをアプリケーションが判断できます。
-    wolfSSLがノンブロッキングI/Oを使用している場合、この関数は1を返します。
-    アプリケーションがWOLFSSLオブジェクトを生成した後にwolfSSL_set_using_nonblock()を呼び出してノンブロッキングソケットを使うとこの関数は１を返します。
-    これにより、WOLFSSLオブジェクトは、recevfromがタイムアウトせず代わりにEWOULDBLOCKを受信するようになります。
 
-    \return 0  基礎となるI/Oがブロックされています。
-    \return 1  基礎となるI/Oは非ブロッキングです。
+    \brief この関数により、アプリケーションはwolfSSLがノンブロッキングI/Oを使用しているかどうかを判定できます。wolfSSLがノンブロッキングI/Oを使用している場合、この関数は1を返し、それ以外の場合は0を返します。アプリケーションがWOLFSSLオブジェクトを作成した後、それをノンブロッキングソケットと共に使用する場合は、wolfSSL_set_using_nonblock()を呼び出してください。これにより、WOLFSSLオブジェクトは、EWOULDBLOCKを受け取ることがタイムアウトではなく、recvfrom呼び出しがブロックすることを意味すると認識できます。
+
+    \return 0 下層のI/Oがブロッキングです。
+    \return 1 下層のI/Oがノンブロッキングです。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
 
     _Example_
     \code
@@ -1680,35 +1700,32 @@ void wolfSSL_set_using_nonblock(WOLFSSL* ssl, int nonblock);
     ...
     ret = wolfSSL_get_using_nonblock(ssl);
     if (ret == 1) {
-    	// underlying I/O is non-blocking
+    	// 下層のI/Oはノンブロッキング
     }
     ...
     \endcode
+
     \sa wolfSSL_set_session
 */
 int  wolfSSL_get_using_nonblock(WOLFSSL*);
 
 /*!
     \ingroup IO
-    \brief  この関数は、バッファあるいはデータから、SSL接続に対して、szバイトを書き込みます。
-    必要に応じて、wolfSSL_write()の呼び出し時点ではまだwolfSSL_connect()またはwolfSSL_accept()がまだ呼び出されていない場合、SSL/TLSセッションをネゴシエートします。
-    wolfSSL_write()は、ブロックとノンブロッキングI/Oの両方で動作します。
-    基礎となる入出力がノンブロッキングに設定されている場合、wolfSSL_write()が要求を満たすことができなかったらwolfSSL_write()は関数呼び出しからすぐに戻ります。
-    この場合、wolfSSL_get_error()の呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを返します。
-    その結果、基礎となるI/Oが準備ができたら、呼び出し側プロセスはwolfssl_write()への呼び出しを繰り返す必要があります。
-    基礎となる入出力がブロックされている場合、WolfSSL_WRITE()は、サイズSZのバッファデータが完全に書かれたかエラーが発生したら、戻るだけです。
 
-    \return 成功時には書き込んだバイト数（1以上）を返します。
-    \return 0  失敗したときに返されます。特定のエラーコードについてwolfSSL_get_error()を呼び出します。
-    \return SSL_FATAL_ERROR  エラーが発生したとき、または非ブロッキングソケットを使用するときには、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが受信され、再度WOLFSSL_WRITE()を呼び出す必要がある場合は、障害が発生します。特定のエラーコードを取得するには、wolfSSL_get_error()を使用してください。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param data  ピアに送信されるデータを含んでいるバッファへのポインタ。
-    \param sz 送信データを含んでいるバッファのサイズ
+    \brief この関数は、バッファdataからszバイトをSSL接続sslに書き込みます。必要に応じて、wolfSSL_connect()またはwolfSSL_accept()によってハンドシェイクがまだ実行されていない場合、wolfSSL_write()はSSL/TLSセッションをネゴシエートします。(D)TLSv1.3を使用していてearly data機能がコンパイルされている場合、この関数はデータ送信が可能になるまでハンドシェイクを進めます。次のwolfSSL_Connect()、wolfSSL_Accept()、wolfSSL_read()の呼び出しでハンドシェイクが完了します。wolfSSL_write()は、ブロッキングとノンブロッキングの両方のI/Oで動作します。下層のI/Oがノンブロッキングの場合、wolfSSL_write()は、下層のI/OがwolfSSL_write()を継続するために必要な要求を満たせなくなった時点で返されます。この場合、wolfSSL_get_error()を呼び出すと、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかが返されます。呼び出し側プロセスは、下層のI/Oの準備ができたら、wolfSSL_write()の呼び出しを繰り返す必要があります。下層のI/Oがブロッキングの場合、wolfSSL_write()は、サイズszのバッファデータが完全に書き込まれるか、エラーが発生するまで返されません。
+
+    \return ＞0 成功時に書き込まれたバイト数。
+    \return 0 失敗時に返されます。具体的なエラーコードについては、wolfSSL_get_error()を呼び出してください。
+    \return SSL_FATAL_ERROR エラーが発生した場合、またはノンブロッキングソケットを使用している場合にSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーを受け取り、アプリケーションがwolfSSL_write()を再度呼び出す必要がある場合に返されます。具体的なエラーコードを取得するには、wolfSSL_get_error()を使用してください。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param data ピアに送信されるデータバッファ。
+    \param sz ピアに送信するデータ(data)のサイズ(バイト単位)。
 
     _Example_
     \code
     WOLFSSL* ssl = 0;
-    char msg[64] = “hello wolfssl!”;
+    char msg[64] = "hello wolfssl!";
     int msgSz = (int)strlen(msg);
     int flags;
     int ret;
@@ -1716,9 +1733,10 @@ int  wolfSSL_get_using_nonblock(WOLFSSL*);
 
     ret = wolfSSL_write(ssl, msg, msgSz);
     if (ret <= 0) {
-    	// wolfSSL_write() failed, call wolfSSL_get_error()
+    	// wolfSSL_write()が失敗、wolfSSL_get_error()を呼び出す
     }
     \endcode
+
     \sa wolfSSL_send
     \sa wolfSSL_read
     \sa wolfSSL_recv
@@ -1727,23 +1745,16 @@ int  wolfSSL_write(WOLFSSL* ssl, const void* data, int sz);
 
 /*!
     \ingroup IO
-    \brief  この関数は、SSLセッション(ssl)の内部読み取りバッファからszバイトをバッファデータに読み出します。
-    読み取られたバイトは内部受信バッファから削除されます。
-    必要に応じて、wolfSSL_read()の呼び出し時点ではまだwolfSSL_connect()またはwolfSSL_accept()がまだ呼び出されていない場合、SSL/TLSセッションをネゴシエートします。
-    SSL/TLSプロトコルは、最大サイズのSSLレコードを使用します（最大レコードサイズは<wolfssl_root> /wolfssl/internal.h）。
-    そのため、wolfSSLは、レコードを処理および復号することができる前に、SSLレコード全体を内部的に読み取る必要があります。
-    このため、wolfSSL_read()への呼び出しは、呼び出し時に復号された最大バッファサイズを返すことができます。
-    検索され、次回のwolfSSL_read()への呼び出しで復号される内部wolfSSL受信バッファで待機していない追加の復号データがあるかもしれません。
-    szが内部読み取りバッファ内のバイト数より大きい場合、wolfSSL_read()は内部読み取りバッファで使用可能なバイトを返します。
-    BYTESが内部読み取りバッファにバッファされていない場合は、wolfSSL_read()への呼び出しは次のレコードの処理をトリガーします。
 
-    \return 成功時には読み取られたバイト数（1以上）を返します。
-    \return 0  失敗したときに返されます。これは、クリーン（通知アラートを閉じる）シャットダウンまたはピアが接続を閉じただけであることによって発生する可能性があります。
-    特定のエラーコードについてwolfSSL_get_error()を呼び出します。
-    \return SSL_FATAL_ERROR  エラーが発生したとき、またはノンブロッキングソケットを使用するときに、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが受信され、再度wolfSSL_read()を呼び出す必要がある場合は、障害が発生します。特定のエラーコードを取得するには、wolfSSL_get_error()を使用してください。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param data  wolfSSL_read()が読み取るデータを格納するバッファへのポインタ。
-    \param sz バッファに読み取るデータのサイズ
+    \brief この関数は、SSLセッション(ssl)の内部読み取りバッファからszバイトをバッファdataに読み込みます。読み取られたバイトは内部受信バッファから削除されます。必要に応じて、wolfSSL_connect()またはwolfSSL_accept()によってハンドシェイクがまだ実行されていない場合、wolfSSL_read()はSSL/TLSセッションをネゴシエートします。SSL/TLSプロトコルは、最大サイズが16kBのSSLレコードを使用します(最大レコードサイズは、<wolfssl_root>/wolfssl/internal.h内のMAX_RECORD_SIZE定義で制御できます)。そのため、wolfSSLは、レコードを処理および復号できるようになる前に、SSLレコード全体を内部的に読み取る必要があります。このため、wolfSSL_read()の呼び出しは、呼び出し時に復号された最大バッファサイズのみを返すことができます。内部wolfSSL受信バッファには、まだ復号されていない追加データが待機している可能性があり、これは次のwolfSSL_read()呼び出しで取得および復号されます。szが内部読み取りバッファ内のバイト数よりも大きい場合、SSL_read()は内部読み取りバッファ内で利用可能なバイトを返します。内部読み取りバッファにまだバイトがバッファリングされていない場合、wolfSSL_read()の呼び出しは次のレコードの処理をトリガします。
+
+    \return ＞0 成功時に読み取られたバイト数。
+    \return 0 失敗時に返されます。これは、クリーンシャットダウン(close notifyアラート)またはピアが接続を閉じたことが原因である可能性があります。具体的なエラーコードについては、wolfSSL_get_error()を呼び出してください。
+    \return SSL_FATAL_ERROR エラーが発生した場合、またはノンブロッキングソケットを使用している場合にSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーを受け取り、アプリケーションがwolfSSL_read()を再度呼び出す必要がある場合に返されます。具体的なエラーコードを取得するには、wolfSSL_get_error()を使用してください。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param data wolfSSL_read()が読み取ったデータを格納するバッファ。
+    \param sz dataに読み込むバイト数。
 
     _Example_
     \code
@@ -1753,12 +1764,12 @@ int  wolfSSL_write(WOLFSSL* ssl, const void* data, int sz);
 
     input = wolfSSL_read(ssl, reply, sizeof(reply));
     if (input > 0) {
-    	// “input” number of bytes returned into buffer “reply”
+    	// バッファ"reply"に"input"バイトが返された
     }
 
-    See wolfSSL examples (client, server, echoclient, echoserver) for more
-    complete examples of wolfSSL_read().
+    wolfSSL_read()のより完全な例については、wolfSSLの例(client、server、echoclient、echoserver)を参照してください。
     \endcode
+
     \sa wolfSSL_recv
     \sa wolfSSL_write
     \sa wolfSSL_peek
@@ -1768,13 +1779,16 @@ int  wolfSSL_read(WOLFSSL* ssl, void* data, int sz);
 
 /*!
     \ingroup IO
-    \brief  この関数はSSLセッション（SSL）内部読み取りバッファからSZバイトをバッファデータにコピーします。この関数は、内部SSLセッション受信バッファ内のデータが削除されていないか変更されていないことを除いて、wolfssl_read()と同じです。必要に応じて、wolfssl_read()のように、wolfssl_peek()はまだwolfssl_connect()またはwolfssl_accept()によってまだ実行されていない場合、wolfssl_peek()はSSL / TLSセッションをネゴシエートします。 SSL/TLSプロトコルは、最大サイズのSSLレコードを使用します（最大レコードサイズは<wolfssl_root> /wolfssl/internal.h）。そのため、WolfSSLは、レコードを処理および復号化することができる前に、SSLレコード全体を内部的に読み取る必要があります。このため、wolfssl_peek()への呼び出しは、呼び出し時に復号化された最大バッファサイズを返すことができます。 wolfssl_peek()/ wolfssl_read()への次の呼び出しで検索および復号化される内部WolfSSL受信バッファ内で待機していない追加の復号化データがあるかもしれません。 SZが内部読み取りバッファ内のバイト数よりも大きい場合、SSL_PEEK()は内部読み取りバッファで使用可能なバイトを返します。バイトが内部読み取りバッファにバッファされていない場合、Wolfssl_peek()への呼び出しは次のレコードの処理をトリガーします。
-    \return 成功時には読み取られたバイト数（1以上）を返します。
-    \return 0  失敗したときに返されます。これは、クリーン（通知アラートを閉じる）シャットダウンまたはピアが接続を閉じただけであることによって発生する可能性があります。特定のエラーコードについてwolfSSL_get_error()を呼び出します。
-    \return SSL_FATAL_ERROR  エラーが発生したとき、またはノンブロッキングソケットを使用するときに、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが受信され、再度wolfSSL_peek()を呼び出す必要がある場合は、障害が発生します。特定のエラーコードを取得するには、wolfSSL_get_error()を使用してください。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param data  wolfSSL_peek()がデータを読み取るバッファー。
-    \param sz バッファに読み取るデータのサイズ
+
+    \brief この関数は、SSLセッション(ssl)の内部読み取りバッファからszバイトをバッファdataにコピーします。この関数は、内部SSLセッション受信バッファ内のデータが削除または変更されない点を除いて、wolfSSL_read()と同じです。wolfSSL_read()と同様に、必要に応じて、wolfSSL_connect()またはwolfSSL_accept()によってハンドシェイクがまだ実行されていない場合、wolfSSL_peek()はSSL/TLSセッションをネゴシエートします。SSL/TLSプロトコルは、最大サイズが16kBのSSLレコードを使用します(最大レコードサイズは、<wolfssl_root>/wolfssl/internal.h内のMAX_RECORD_SIZE定義で制御できます)。そのため、wolfSSLは、レコードを処理および復号できるようになる前に、SSLレコード全体を内部的に読み取る必要があります。このため、wolfSSL_peek()の呼び出しは、呼び出し時に復号された最大バッファサイズのみを返すことができます。内部wolfSSL受信バッファには、まだ復号されていない追加データが待機している可能性があり、これは次のwolfSSL_peek()またはwolfSSL_read()呼び出しで取得および復号されます。szが内部読み取りバッファ内のバイト数よりも大きい場合、SSL_peek()は内部読み取りバッファ内で利用可能なバイトを返します。内部読み取りバッファにまだバイトがバッファリングされていない場合、wolfSSL_peek()の呼び出しは次のレコードの処理をトリガします。
+
+    \return ＞0 成功時に読み取られたバイト数。
+    \return 0 失敗時に返されます。これは、クリーンシャットダウン(close notifyアラート)またはピアが接続を閉じたことが原因である可能性があります。具体的なエラーコードについては、wolfSSL_get_error()を呼び出してください。
+    \return SSL_FATAL_ERROR エラーが発生した場合、またはノンブロッキングソケットを使用している場合にSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーを受け取り、アプリケーションがwolfSSL_peek()を再度呼び出す必要がある場合に返されます。具体的なエラーコードを取得するには、wolfSSL_get_error()を使用してください。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param data wolfSSL_peek()が読み取ったデータを格納するバッファ。
+    \param sz dataに読み込むバイト数。
 
     _Example_
     \code
@@ -1784,26 +1798,23 @@ int  wolfSSL_read(WOLFSSL* ssl, void* data, int sz);
 
     input = wolfSSL_peek(ssl, reply, sizeof(reply));
     if (input > 0) {
-	    // “input” number of bytes returned into buffer “reply”
+	    // バッファ"reply"に"input"バイトが返された
     }
     \endcode
+
     \sa wolfSSL_read
 */
 int  wolfSSL_peek(WOLFSSL* ssl, void* data, int sz);
 
 /*!
     \ingroup IO
-    \brief  この関数はサーバー側で呼び出され、SSLクライアントがSSL/TLSハンドシェイクを開始するのを待ちます。
-    この関数が呼び出されると、基礎となる通信チャネルはすでに設定されています。
-    wolfSSL_accept()は、ブロックとノンブロッキングI/Oの両方で動作します。
-    基礎となる入出力がノンブロッキングである場合、wolfSSL_accept()は、基礎となるI/OがwolfSSL_acceptの要求を満たすことができなかったときに戻ります。
-    この場合、wolfSSL_get_error()への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。
-    呼び出しプロセスは、読み取り可能なデータが使用可能であり、wolfSSLが停止した場所を拾うときに、wolfSSL_acceptの呼び出しを繰り返す必要があります。
-    ノンブロッキングソケットを使用する場合は、何も実行する必要がありますが、select()を使用して必要な条件を確認できます。
-    基礎となるI/Oがブロックされている場合、wolfSSL_accept()はハンドシェイクが終了したら、またはエラーが発生したら戻ります。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FATAL_ERROR  エラーが発生した場合に返されます。より詳細なエラーコードを取得するには、wolfSSL_get_error()を呼び出します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数はサーバ側で呼び出され、SSLクライアントがSSL/TLSハンドシェイクを開始するのを待機します。この関数が呼び出されるとき、下層の通信チャネルはすでに設定されています。wolfSSL_accept()は、ブロッキングとノンブロッキングの両方のI/Oで動作します。下層のI/Oがノンブロッキングの場合、wolfSSL_accept()は、下層のI/OがwolfSSL_acceptがハンドシェイクを継続するために必要な要求を満たせなくなった時点で返されます。この場合、wolfSSL_get_error()を呼び出すと、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかが返されます。呼び出し側プロセスは、データの読み取りが可能になったらwolfSSL_accept()の呼び出しを繰り返す必要があり、wolfSSLは中断した箇所から再開します。ノンブロッキングソケットを使用する場合、何もする必要はありませんが、select()を使用して必要な条件を確認できます。下層のI/Oがブロッキングの場合、wolfSSL_accept()は、ハンドシェイクが完了するか、エラーが発生するまで返されません。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FATAL_ERROR エラーが発生した場合に返されます。より詳細なエラーコードを取得するには、wolfSSL_get_error()を呼び出してください。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -1816,20 +1827,58 @@ int  wolfSSL_peek(WOLFSSL* ssl, void* data, int sz);
     ret = wolfSSL_accept(ssl);
     if (ret != SSL_SUCCESS) {
         err = wolfSSL_get_error(ssl, ret);
-        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
     }
     \endcode
+
     \sa wolfSSL_get_error
     \sa wolfSSL_connect
 */
 int  wolfSSL_accept(WOLFSSL*);
 
 /*!
+    \ingroup IO
+
+    \brief この関数はサーバ側で呼び出され、SSLクライアントがDTLSハンドシェイクを開始するのをステートレスに待機します。
+
+    \return WOLFSSL_SUCCESS 有効なクッキーを含むClientHelloが受信されました。wolfSSL_accept()で接続を続行できます。
+    \return WOLFSSL_FAILURE I/O層がWANT_READを返しました。これは、読み取るデータがなくノンブロッキングソケットを使用しているか、クッキーリクエストを送信して応答を待っているためです。ユーザは、I/O層でデータが利用可能になった後、wolfDTLS_accept_statelessを再度呼び出す必要があります。
+    \return WOLFSSL_FATAL_ERROR 致命的なエラーが発生しました。sslオブジェクトを解放して再割り当てしてから続行する必要があります。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
+    _Example_
+    \code
+    int ret = 0;
+    int err = 0;
+    WOLFSSL* ssl;
+    ...
+    do {
+        ret = wolfDTLS_accept_stateless(ssl);
+        if (ret == WOLFSSL_FATAL_ERROR)
+            // wolfSSL_free()とwolfSSL_new()でsslオブジェクトを再割り当て
+    } while (ret != WOLFSSL_SUCCESS);
+    ret = wolfSSL_accept(ssl);
+    if (ret != SSL_SUCCESS) {
+        err = wolfSSL_get_error(ssl, ret);
+        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
+    }
+    \endcode
+
+    \sa wolfSSL_accept
+    \sa wolfSSL_get_error
+    \sa wolfSSL_connect
+*/
+int  wolfDTLS_accept_stateless(WOLFSSL* ssl);
+
+/*!
     \ingroup Setup
-    \brief  この関数は、割り当てられたWOLFSSL_CTXオブジェクトを解放します。
-    この関数はCTX参照数を減らし、参照カウントが0に達したときにのみコンテキストを解放します。
-    \return なし
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ
+
+    \brief この関数は、割り当てられたWOLFSSL_CTXオブジェクトを解放します。この関数はCTX参照カウントをデクリメントし、参照カウントが0になった場合にのみコンテキストを解放します。
+
+    \return none 戻り値はありません。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
 
     _Example_
     \code
@@ -1837,6 +1886,7 @@ int  wolfSSL_accept(WOLFSSL*);
     ...
     wolfSSL_CTX_free(ctx);
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_new
     \sa wolfSSL_free
@@ -1845,9 +1895,12 @@ void wolfSSL_CTX_free(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
-    \brief  この関数は割り当てられたWOLFSSLオブジェクトを解放します。
-    \return なし
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数は、割り当てられたwolfSSLオブジェクトを解放します。
+
+    \return none 戻り値はありません。
+
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
 
     _Example_
     \code
@@ -1857,6 +1910,7 @@ void wolfSSL_CTX_free(WOLFSSL_CTX*);
     ...
     wolfSSL_free(ssl);
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_new
     \sa wolfSSL_CTX_free
@@ -1865,19 +1919,14 @@ void wolfSSL_free(WOLFSSL*);
 
 /*!
     \ingroup TLS
-    \brief  この関数は、引数sslのSSLセッションに対してアクティブなSSL/TLS接続をシャットダウンします。
-    この関数は、ピアに"Close Notify"アラートを送信しようとします。
-    呼び出し側アプリケーションは、Peerがその"Close Notify"アラートを応答として送信してくるのを待つか、
-    またはwolfSSL_shutdownから呼び出しが戻った時点で（リソースを保存するために）下層の接続を切断するのを待つことができます。
-    どちらのオプションもTLS仕様で許されています。シャットダウンした後に下層の接続を再び別のセッションで使用する予定ならば、ピア間で同期を保つために完全な2方向のシャットダウン手順を実行する必要があります。
-    wolfSSL_shutdown()は、ブロックとノンブロッキングI/Oの両方で動作します。
-    下層のI/Oがノンブロッキングの場合、wolfSSL_shutdown()が要求を満たすことができなかった場合、wolfSSL_shutdown()はエラーを返します。
-    この場合、wolfSSL_get_error()への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。
-    その結果、下層のI/Oが準備ができたら、呼び出し側プロセスはwolfSSL_shutdown()への呼び出しを繰り返す必要があります。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_SHUTDOWN_NOT_DONE  シャットダウンが終了していない場合に返され、関数を再度呼び出す必要があります。
-    \return SSL_FATAL_ERROR  失敗したときに返されます。より具体的なエラーコードはwolfSSL_get_error()を呼び出します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数は、SSLセッションsslを使用してアクティブなSSL/TLS接続をシャットダウンします。この関数は、ピアに「close notify」アラートを送信しようと試みます。呼び出し側のアプリケーションは、ピアからの応答として「close notify」アラートが送信されるのを待つか、wolfSSL_shutdown()を直接呼び出した後に基盤となる接続をシャットダウンするか(リソースを節約するため)を選択できます。TLS仕様では、どちらのオプションも許可されています。基盤となる接続を将来再び使用する場合は、ピア間の同期を維持するために、完全な双方向シャットダウン手順を実行する必要があります。wolfSSL_shutdown()は、ブロッキングI/OとノンブロッキングI/Oの両方で動作します。基盤となるI/Oがノンブロッキングの場合、基盤となるI/OがwolfSSL_shutdown()の継続に必要な要求を満たせなかった場合、wolfSSL_shutdown()はエラーを返します。この場合、wolfSSL_get_error()を呼び出すと、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかが返されます。呼び出し側プロセスは、基盤となるI/Oの準備ができたときに、wolfSSL_shutdown()の呼び出しを繰り返す必要があります。
+
+    \return SSL_SUCCESSが成功時に返されます。
+    \return SSL_SHUTDOWN_NOT_DONEは、シャットダウンが完了していない場合に返され、関数を再度呼び出す必要があります。
+    \return SSL_FATAL_ERRORは、失敗時に返されます。より具体的なエラーコードについては、wolfSSL_get_error()を呼び出してください。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
 
     _Example_
     \code
@@ -1888,9 +1937,10 @@ void wolfSSL_free(WOLFSSL*);
     ...
     ret = wolfSSL_shutdown(ssl);
     if (ret != 0) {
-	    // failed to shut down SSL connection
+	    // SSL接続のシャットダウンに失敗しました
     }
     \endcode
+
     \sa wolfSSL_free
     \sa wolfSSL_CTX_free
 */
@@ -1898,36 +1948,32 @@ int  wolfSSL_shutdown(WOLFSSL*);
 
 /*!
     \ingroup IO
-    \brief  この関数は、書き込み操作のために指定されたフラグを使用してバッファあるいはデータから、SSL接続に対して、szバイトを書き込みます。
-    必要に応じて、wolfSSL_send()の呼び出し時点ではまだwolfSSL_connect()またはwolfSSL_accept()がまだ呼び出されていない場合、SSL/TLSセッションをネゴシエートします。
-    wolfSSL_send()は、ブロックとノンブロッキングI/Oの両方で動作します。
-    基礎となる入出力がノンブロッキングに設定されている場合、wolfSSL_send()が要求を満たすことができなかったらwolfSSL_send()は関数呼び出しからすぐに戻ります。
-    この場合、wolfSSL_get_error()の呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを返します。
-    その結果、基礎となるI/Oが準備ができたら、呼び出し側プロセスはwolfSSL_send()への呼び出しを繰り返す必要があります。
-    基礎となる入出力がブロックされている場合、wolfSSL_send()は、サイズSZのバッファデータが完全に書かれたかエラーが発生したら、戻るだけです。
 
-    \return 成功時には書き込んだバイト数（1以上）を返します。
-    \return 0  失敗したときに返されます。特定のエラーコードについてwolfSSL_get_error()を呼び出します。
-    \return SSL_FATAL_ERROR  エラーが発生したとき、または非ブロッキングソケットを使用するときには、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが受信され、再度WOLFSSL_WRITE()を呼び出す必要がある場合は、障害が発生します。特定のエラーコードを取得するには、wolfSSL_get_error()を使用してください。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param data  ピアに送信されるデータを含んでいるバッファへのポインタ。
-    \param sz 送信データを含んでいるバッファのサイズ
-    \param flags 下層のI/Oのsendに対して指定するフラグ
+    \brief この関数は、指定されたフラグを使用して、バッファdataからszバイトをSSL接続sslに書き込みます。必要に応じて、wolfSSL_connect()またはwolfSSL_accept()によってハンドシェイクがまだ実行されていない場合、wolfSSL_send()はSSL/TLSセッションをネゴシエートします。wolfSSL_send()は、ブロッキングI/OとノンブロッキングI/Oの両方で動作します。基盤となるI/Oがノンブロッキングの場合、基盤となるI/OがwolfSSL_sendの継続に必要な要求を満たせなかった場合、wolfSSL_send()は戻ります。この場合、wolfSSL_get_error()を呼び出すと、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかが返されます。呼び出し側プロセスは、基盤となるI/Oの準備ができたときに、wolfSSL_send()の呼び出しを繰り返す必要があります。基盤となるI/Oがブロッキングの場合、wolfSSL_send()は、サイズszのバッファdataが完全に書き込まれるか、エラーが発生するまで戻りません。
 
+    \return ＞0は、成功時に書き込まれたバイト数です。
+    \return 0は、失敗時に返されます。具体的なエラーコードについては、wolfSSL_get_error()を呼び出してください。
+    \return SSL_FATAL_ERRORは、エラーが発生した場合、またはノンブロッキングソケットを使用している場合にSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが発生し、アプリケーションがwolfSSL_send()を再度呼び出す必要がある場合に返されます。具体的なエラーコードを取得するには、wolfSSL_get_error()を使用してください。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param data ピアに送信するデータバッファ。
+    \param sz ピアに送信するデータのサイズ(バイト単位)。
+    \param flags 基盤となる送信操作に使用する送信フラグ。
 
     _Example_
     \code
     WOLFSSL* ssl = 0;
-    char msg[64] = “hello wolfssl!”;
+    char msg[64] = "hello wolfssl!";
     int msgSz = (int)strlen(msg);
     int flags = ... ;
     ...
 
     input = wolfSSL_send(ssl, msg, msgSz, flags);
     if (input != msgSz) {
-    	// wolfSSL_send() failed
+    	// wolfSSL_send()が失敗しました
     }
     \endcode
+
     \sa wolfSSL_write
     \sa wolfSSL_read
     \sa wolfSSL_recv
@@ -1936,23 +1982,17 @@ int  wolfSSL_send(WOLFSSL* ssl, const void* data, int sz, int flags);
 
 /*!
     \ingroup IO
-    \brief  この関数は、基礎となるRECV動作のために指定されたフラグを使用して、SSLセッション（ssl）内部読み取りバッファからszバイトをバッファデータに読み出します。
-    読み取られたバイトは内部受信バッファから削除されます。
-    この関数はwolfssl_read()と同じです。
-    ただし、アプリケーションが基礎となる読み取り操作のRECVフラグを設定できることを許可します。
-    必要に応じてwolfssl_recv()がwolfssl_connect()またはwolfssl_accept()によってハンドシェイクがまだ実行されていない場合は、SSL/TLSセッションをネゴシエートします。
-    SSL/TLSプロトコルは、最大サイズのSSLレコードを使用します（最大レコードサイズは<wolfssl_root> /wolfssl/internal.h）。
-    そのため、wolfSSLは、レコードを処理および復号することができる前に、SSLレコード全体を内部的に読み取る必要があります。
-    このため、wolfSSL_recv()への呼び出しは、呼び出し時に復号された最大バッファサイズを返すことができるだけです。
-    wolfSSL_recv()への次の呼び出しで検索および復号される内部wolfSSL受信バッファで待機していない追加の復号化されたデータがあるかもしれません。
-    引数szが内部読み取りバッファ内のバイト数よりも大きい場合、wolfSSL_recv()は内部読み取りバッファで使用可能なバイトを返します。
-    バイトが内部読み取りバッファにバッファされていない場合は、wolfSSL_recv()への呼び出しは次のレコードの処理をトリガーします。
-    \return 成功時には読み取られたバイト数(1以上)を返します。
-    \return 0  失敗したときに返されます。これは、クリーン（通知アラートを閉じる）シャットダウンまたはピアが接続を閉じただけであることによって発生する可能性があります。特定のエラーコードについてwolfSSL_get_error()を呼び出します。
-    \return SSL_FATAL_ERROR  エラーが発生した場合、または非ブロッキングソケットを使用するときには、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが発生し、アプリケーションが再びWOLFSSL_RECV()を呼び出す必要があります。特定のエラーコードを取得するには、wolfSSL_get_error()を使用してください。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param data  wolfSSL_recv()がデータを読み取るバッファー。
-    \param sz  データを読み込むためのバイト数。
+
+    \brief この関数は、指定されたフラグを使用して、SSLセッション(ssl)の内部読み取りバッファからszバイトをバッファdataに読み込みます。読み取られたバイトは、内部受信バッファから削除されます。この関数は、基盤となる読み取り操作のrecvフラグをアプリケーションが設定できる点を除いて、wolfSSL_read()と同じです。必要に応じて、wolfSSL_connect()またはwolfSSL_accept()によってハンドシェイクがまだ実行されていない場合、wolfSSL_recv()はSSL/TLSセッションをネゴシエートします。SSL/TLSプロトコルは、最大サイズ16kBのSSLレコードを使用します(最大レコードサイズは、<wolfssl_root>/wolfssl/internal.hのMAX_RECORD_SIZE定義で制御できます)。そのため、wolfSSLは、レコードを処理および復号する前に、内部でSSLレコード全体を読み取る必要があります。このため、wolfSSL_recv()の呼び出しは、呼び出し時に復号された最大バッファサイズのみを返すことができます。まだ復号されていない追加データが内部wolfSSL受信バッファで待機している可能性があり、次回のwolfSSL_recv()呼び出しで取得および復号されます。szが内部読み取りバッファのバイト数より大きい場合、SSL_recv()は内部読み取りバッファで利用可能なバイトを返します。内部読み取りバッファにまだバッファリングされているバイトがない場合、wolfSSL_recv()の呼び出しは次のレコードの処理をトリガーします。
+
+    \return ＞0は、成功時に読み取られたバイト数です。
+    \return 0は、失敗時に返されます。これは、クリーンな(close notifyアラート)シャットダウンによって引き起こされる場合もあれば、単にピアが接続を閉じた場合もあります。具体的なエラーコードについては、wolfSSL_get_error()を呼び出してください。
+    \return SSL_FATAL_ERRORは、エラーが発生した場合、またはノンブロッキングソケットを使用している場合にSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが発生し、アプリケーションがwolfSSL_recv()を再度呼び出す必要がある場合に返されます。具体的なエラーコードを取得するには、wolfSSL_get_error()を使用してください。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param data wolfSSL_recv()が読み取ったデータを配置するバッファ。
+    \param sz dataに読み込むバイト数。
+    \param flags 基盤となる受信操作に使用する受信フラグ。
 
     _Example_
     \code
@@ -1963,9 +2003,10 @@ int  wolfSSL_send(WOLFSSL* ssl, const void* data, int sz, int flags);
 
     input = wolfSSL_recv(ssl, reply, sizeof(reply), flags);
     if (input > 0) {
-    	// “input” number of bytes returned into buffer “reply”
+    	// バッファ"reply"に"input"バイトが返されました
     }
     \endcode
+
     \sa wolfSSL_read
     \sa wolfSSL_write
     \sa wolfSSL_peek
@@ -1975,18 +2016,14 @@ int  wolfSSL_recv(WOLFSSL* ssl, void* data, int sz, int flags);
 
 /*!
     \ingroup Debug
-    \brief  この関数は、直前のAPI関数呼び出し（wolfssl_connect、wolfssl_accept、wolfssl_read、wolfssl_writeなど）がエラーコード（SSL_FAILURE）を呼び出した理由を表す一意のエラーコードを返します。
-    直前の関数の戻り値は、retを介してwolfSSL_get_errorに渡されます。wolfSSL_get_errorは一意のエラーコードを返します。
-    wolfSSL_err_error_string()を呼び出して人間が読めるエラー文字列を取得することができます。
-    詳細については、wolfSSL_err_error_string()を参照してください。
 
-    \return 呼び出し成功時、この関数は、直前の関数が失敗した理由を説明する固有のエラーコードを返します。
-    \return SSL_ERROR_NONE  引数retが0より大きい場合に返されます。retが0以下の場合、直前のAPIがエラーコードを返すが実際に発生しなかった場合にこの値を返す場合があります。
-    例としては、引数szに0を渡してwolfSSL_read()を呼び出す場合に発生します。
-    wolfssl_read()が0を戻した場合は通常エラーを示しますが、この場合はエラーは発生していません。
-    従って、wolfSSL_get_error()がその後呼び出された場合、ssl_error_noneが返されます。
+    \brief この関数は、前回のAPI関数呼び出し(wolfSSL_connect、wolfSSL_accept、wolfSSL_read、wolfSSL_write等)がエラーリターンコード(SSL_FAILURE)になった理由を説明する一意のエラーコードを返します。前回の関数の戻り値は、retを通じてwolfSSL_get_errorに渡されます。wolfSSL_get_errorが呼び出されて一意のエラーコードを返した後、wolfSSL_ERR_error_string()を呼び出して、人間が読めるエラー文字列を取得できます。詳細については、wolfSSL_ERR_error_string()を参照してください。
 
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \return 正常に完了した場合、この関数は前回のAPI関数が失敗した理由を説明する一意のエラーコードを返します。
+    \return SSL_ERROR_NONEは、ret > 0の場合に返されます。ret <= 0の場合、前回のAPIがエラーコードを返したように見えても実際にはエラーが発生していなかった場合に、この値が返されることがあります。例えば、szパラメータがゼロのwolfSSL_read()を呼び出した場合です。wolfSSL_read()からの0の戻り値は通常エラーを示しますが、この場合はエラーは発生していません。その後wolfSSL_get_error()を呼び出すと、SSL_ERROR_NONEが返されます。
+
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+    \param ret エラーリターンコードになった前回の関数の戻り値。
 
     _Example_
     \code
@@ -1996,8 +2033,9 @@ int  wolfSSL_recv(WOLFSSL* ssl, void* data, int sz, int flags);
     ...
     err = wolfSSL_get_error(ssl, 0);
     wolfSSL_ERR_error_string(err, buffer);
-    printf(“err = %d, %s\n”, err, buffer);
+    printf("err = %d, %s\n", err, buffer);
     \endcode
+
     \sa wolfSSL_ERR_error_string
     \sa wolfSSL_ERR_error_string_n
     \sa wolfSSL_ERR_print_errors_fp
@@ -2007,10 +2045,13 @@ int  wolfSSL_get_error(WOLFSSL* ssl, int ret);
 
 /*!
     \ingroup IO
-    \brief  この関数はアラート履歴を取得します。
-    \return SSL_SUCCESS  関数が正常に完了したときに返されます。警告履歴があったか、またはいずれにも、戻り値はSSL_SUCCESSです。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param h WOLFSSL構造体の"alert_history member" の値が格納される、WOLFSSL_ALERT_HISTORY構造体へのポインタ。
+
+    \brief この関数はアラート履歴を取得します。
+
+    \return SSL_SUCCESSは、関数が正常に完了したときに返されます。アラート履歴があってもなくても、いずれの場合も戻り値はSSL_SUCCESSです。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param h WOLFSSL構造体のalert_historyメンバーの値を保持するWOLFSSL_ALERT_HISTORY構造体へのポインタ。
 
     _Example_
     \code
@@ -2019,26 +2060,25 @@ int  wolfSSL_get_error(WOLFSSL* ssl, int ret);
     WOLFSSL_ALERT_HISTORY* h;
     ...
     wolfSSL_get_alert_history(ssl, h);
-    // h now has a copy of the ssl->alert_history  contents
+    // hにssl->alert_historyの内容のコピーが格納されました
     \endcode
+
     \sa wolfSSL_get_error
 */
 int  wolfSSL_get_alert_history(WOLFSSL* ssl, WOLFSSL_ALERT_HISTORY *h);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、SSLオブジェクトSSLがSSL/TLS接続を確立する目的で使用するセッションを設定します。
-    セッション再開を行う場合、wolfSSL_shutdown()を呼び出す前にwolfSSL_get1_session()を呼び出してセッションオブジェクトを取得し、セッションIDを保存しておく必要があります。
-    後で、アプリケーションは新しいWOLFSSLオブジェクトを作成し、保存したセッションをwolfSSL_set_session()に渡す必要があります。
-    その後アプリケーションはwolfSSL_connect()を呼び出し、wolfSSLはセッション再開を試みます。
-    wolfSSLサーバーコードでは、デフォルトでセッション再開を許可します。
-    wolfSSL_get1_session()によって返されたオブジェクトは、アプリケーションが使用後に解放する必要があります。
 
-    \return SSL_SUCCESS  セッションを正常に設定すると返されます。
-    \return SSL_FAILURE  失敗した場合に返されます。これはセッションキャッシュが無効になっている、またはセッションがタイムアウトした場合によって発生する可能性があります。
-    \return OPENSSL_EXTRAとWOLFSSL_ERROR_CODE_OPENSSLが定義されている場合には、セッションがタイムアウトしていてもSSL_SUCCESSが返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param session WOLFSSL_SESSION構造体へのポインタ。
+    \brief この関数は、SSLオブジェクトsslがSSL/TLS接続を確立するために使用されるときに使用されるセッションを設定します。セッション再開の場合、セッションオブジェクトでwolfSSL_shutdown()を呼び出す前に、アプリケーションはwolfSSL_get1_session()を呼び出してオブジェクトからセッションIDを保存する必要があります。これはセッションへのポインタを返します。後で、アプリケーションは新しいWOLFSSLオブジェクトを作成し、wolfSSL_set_session()を使用して保存されたセッションを割り当てる必要があります。この時点で、アプリケーションはwolfSSL_connect()を呼び出すことができ、wolfSSLはセッションの再開を試みます。wolfSSLサーバーコードは、デフォルトでセッション再開を許可します。wolfSSL_get1_session()によって返されたオブジェクトは、アプリケーションが使用を終えた後、wolfSSL_SESSION_free()を呼び出して解放する必要があります。
+
+    \return SSL_SUCCESSは、セッションの設定に成功した場合に返されます。
+    \return SSL_FAILUREは、失敗時に返されます。これは、セッションキャッシュが無効になっている場合、またはセッションがタイムアウトした場合に発生する可能性があります。
+
+    \return OPENSSL_EXTRAとWOLFSSL_ERROR_CODE_OPENSSLが定義されている場合、セッションがタイムアウトしてもSSL_SUCCESSが返されます。
+
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+    \param session sslのセッションを設定するために使用されるWOLFSSL_SESSIONへのポインタ。
 
     _Example_
     \code
@@ -2048,33 +2088,30 @@ int  wolfSSL_get_alert_history(WOLFSSL* ssl, WOLFSSL_ALERT_HISTORY *h);
     ...
     session = wolfSSL_get1_session(ssl);
     if (session == NULL) {
-        // failed to get session object from ssl object
+        // sslオブジェクトからセッションオブジェクトの取得に失敗しました
     }
     ...
     ret = wolfSSL_set_session(ssl, session);
     if (ret != SSL_SUCCESS) {
-    	// failed to set the SSL session
+    	// SSLセッションの設定に失敗しました
     }
     wolfSSL_SESSION_free(session);
     ...
     \endcode
+
     \sa wolfSSL_get1_session
 */
 int        wolfSSL_set_session(WOLFSSL* ssl, WOLFSSL_SESSION* session);
 
 /*!
     \ingroup IO
-    \brief  NO_SESSION_CACHE_REFが定義されている場合、この関数はSSLで使用されている現在のセッション（WOLFSSL_SESSION）へのポインタを返します。
-    この関数は、WOLFSSL_SESSIONオブジェクトへの永続的なポインタを返します。
-    返されるポインタは、wolfSSL_freeが呼び出されたときに解放されます。
-    この呼び出しは、現在のセッションを検査または変更するためにのみ使用されます。
-    セッション再開に使用する場合は、wolfSSL_get1_session()を使用することをお勧めします。
-    NO_SESSION_CACHE_REFが定義されていない場合の後方互換性のために、この関数はローカルキャッシュに格納されている永続セッションオブジェクトポインタを返します。
-    キャッシュサイズは有限であり、アプリケーションがwolfSSL_set_session()を呼び出す時までにセッションオブジェクトが別のSSL接続によって上書きされる危険性があります。
-    アプリケーションにNO_SESSION_CACHE_REFを定義し、セッション再開にwolfSSL_get1_session()を使用することをお勧めします。
 
-    \return 現在のSSLセッションオブジェクトへのポインタを返します。
-    \return NULL  sslがNULLの場合、SSLセッションキャッシュが無効になっている場合、wolfSSLはセッションIDを使用できない、またはミューテックス関数が失敗した場合に返されます。
+    \brief NO_SESSION_CACHE_REFが定義されている場合、この関数はsslで使用されている現在のセッション(WOLFSSL_SESSION)へのポインタを返します。この関数は、WOLFSSL_SESSIONオブジェクトへの非永続的なポインタを返します。返されたポインタは、wolfSSL_freeが呼び出されたときに解放されます。この呼び出しは、現在のセッションを検査または変更するためにのみ使用する必要があります。セッション再開には、wolfSSL_get1_session()を使用することをお勧めします。後方互換性のため、NO_SESSION_CACHE_REFが定義されていない場合、この関数はローカルキャッシュに格納されている永続的なセッションオブジェクトポインタを返します。キャッシュサイズは有限であり、アプリケーションがwolfSSL_set_session()を呼び出すまでに、別のssl接続によってセッションオブジェクトが上書きされるリスクがあります。アプリケーションでNO_SESSION_CACHE_REFを定義し、セッション再開にwolfSSL_get1_session()を使用することをお勧めします。
+
+    \return pointer 呼び出しが成功した場合、現在のSSLセッションオブジェクトへのポインタを返します。
+    \return NULLは、sslがNULLの場合、SSLセッションキャッシュが無効になっている場合、wolfSSLがセッションIDを利用できない場合、またはミューテックス関数が失敗した場合に返されます。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
 
     _Example_
     \code
@@ -2083,10 +2120,11 @@ int        wolfSSL_set_session(WOLFSSL* ssl, WOLFSSL_SESSION* session);
     ...
     session = wolfSSL_get_session(ssl);
     if (session == NULL) {
-	    // failed to get session pointer
+	    // セッションポインタの取得に失敗しました
     }
     ...
     \endcode
+
     \sa wolfSSL_get1_session
     \sa wolfSSL_set_session
 */
@@ -2094,15 +2132,13 @@ WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  この機能は、期限切れになったセッションキャッシュからセッションをフラッシュします。
-    時間比較には引数tmが使用されます。
-    wolfSSLは現在セッションに静的テーブルを使用しているため、フラッシングは不要です。
-    そのため、この機能は現在スタブとして存在しています。
-    この関数は、wolfsslがOpenSSL互換層でコンパイルされているときのOpenSSL互換性（ssl_flush_sessions）を提供します。
 
-    \return なし
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param tm セッションの有効期限の比較で使用される時間
+    \brief この関数は、期限切れのセッションをセッションキャッシュからフラッシュします。時刻tmは、時刻比較に使用されます。wolfSSLは現在セッションに静的テーブルを使用しているため、フラッシュは不要です。そのため、この関数は現在スタブにすぎません。この関数は、wolfSSLがOpenSSL互換レイヤーでコンパイルされている場合、OpenSSL互換性(SSL_flush_sessions)を提供します。
+
+    \return none 戻り値はありません。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param tm セッション有効期限比較に使用される時刻。
 
     _Example_
     \code
@@ -2110,6 +2146,7 @@ WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL* ssl);
     ...
     wolfSSL_flush_sessions(ctx, time(0));
     \endcode
+
     \sa wolfSSL_get1_session
     \sa wolfSSL_set_session
 */
@@ -2117,29 +2154,32 @@ void       wolfSSL_flush_sessions(WOLFSSL_CTX* ctx, long tm);
 
 /*!
     \ingroup TLS
-    \brief  この関数はクライアントセッションをサーバーIDと関連付けます。引数newSessionがオンの場合、既存のセッションは再利用されません。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG  引数sslまたは引数idがNULLの場合、または引数lenがゼロ以下の場合に返されます。
 
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param id  WOLFSSL_SESSION構造体のServerIDメンバーにコピーされるサーバーIDデータへのポインタ。
-    \param len  サーバーIDデータのサイズ
-    \param newSession セッションを再利用するか否かを指定するフラグ。オンの場合、既存のセッションは再利用されません。
+    \brief この関数は、クライアントセッションをサーバーIDに関連付けます。newSessionフラグがオンの場合、既存のセッションは再利用されません。
+
+    \return SSL_SUCCESSは、関数がエラーなく実行された場合に返されます。
+    \return BAD_FUNC_ARGは、WOLFSSL構造体またはidパラメータがNULLの場合、またはlenが0より大きくない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param id WOLFSSL_SESSION構造体のserverIDメンバーにコピーされる定数バイトポインタ。
+    \param len セッションidパラメータの長さを表すint型。
+    \param newSession セッションを再利用するかどうかを示すフラグを表すint型。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol );
     WOLFSSL* ssl = WOLFSSL_new(ctx);
-    const byte id[MAX_SIZE];  // or dynamically create space
-    int len = 0; // initialize length
-    int newSession = 0; // flag to allow
+    const byte id[MAX_SIZE];  // または動的にスペースを作成
+    int len = 0; // 長さを初期化
+    int newSession = 0; // 許可するフラグ
     …
     int ret = wolfSSL_SetServerID(ssl, id, len, newSession);
 
     if (ret == WOLFSSL_SUCCESS) {
-	    // The Id was successfully set
+	    // IDが正常に設定されました
     }
     \endcode
+
     \sa wolfSSL_set_session
 */
 int        wolfSSL_SetServerID(WOLFSSL* ssl, const unsigned char* id,
@@ -2147,9 +2187,11 @@ int        wolfSSL_SetServerID(WOLFSSL* ssl, const unsigned char* id,
 
 /*!
     \ingroup IO
-    \brief  この関数は、WOLFSSL構造体の指定セッションインデックス値を取得します。
-    \return この関数は、WOLFSSL構造体内のSessionIndexを表すint型の値を返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
+    \brief この関数は、WOLFSSL構造体のセッションインデックスを取得します。
+
+    \return int この関数は、WOLFSSL構造体内のsessionIndexを表すint型を返します。
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -2159,32 +2201,36 @@ int        wolfSSL_SetServerID(WOLFSSL* ssl, const unsigned char* id,
     int sesIdx = wolfSSL_GetSessionIndex(ssl);
 
     if(sesIdx < 0 || sesIdx > sizeof(ssl->sessionIndex)/sizeof(int)){
-    	// You have an out of bounds index number and something is not right.
+    	// インデックス番号が範囲外であり、何かが正しくありません。
     }
     \endcode
+
     \sa wolfSSL_GetSessionAtIndex
 */
 int wolfSSL_GetSessionIndex(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  この関数はセッションキャッシュの指定されたインデックスのセッションを取得し、それをメモリにコピーします。
-    WOLFSSL_SESSION構造体はセッション情報を保持します。
-    \return SSL_SUCCESS  関数が正常に実行され、エラーがスローされなかった場合に返されます。
-    \return BAD_MUTEX_E  アンロックまたはロックミューテックスエラーが発生した場合に返されます。
-    \return SSL_FAILURE  関数が正常に実行されなかった場合に返されます。
-    \param idx  セッションインデックス値
-    \param session WOLFSSL_SESSION構造体へのポインタ
+
+    \brief この関数はセッションキャッシュの指定されたインデックスにあるセッションを取得し、メモリにコピーします。WOLFSSL_SESSION構造体はセッション情報を保持します。
+
+    \return SSL_SUCCESS 関数が正常に実行され、エラーが発生しなかった場合に返されます。
+    \return BAD_MUTEX_E mutexのアンロックまたはロックエラーがあった場合に返されます。
+    \return SSL_FAILURE 関数が正常に実行されなかった場合に返されます。
+
+    \param idx セッションインデックスを表すint型。
+    \param session WOLFSSL_SESSION構造体へのポインタ。
 
     _Example_
     \code
-    int idx; // The index to locate the session.
-    WOLFSSL_SESSION* session;  // Buffer to copy to.
+    int idx; // セッションを特定するインデックス。
+    WOLFSSL_SESSION* session;  // コピー先のバッファ。
     ...
     if(wolfSSL_GetSessionAtIndex(idx, session) != SSL_SUCCESS){
-    	// Failure case.
+    	// 失敗ケース。
     }
     \endcode
+
     \sa UnLockMutex
     \sa LockMutex
     \sa wolfSSL_GetSessionIndex
@@ -2193,8 +2239,12 @@ int wolfSSL_GetSessionAtIndex(int idx, WOLFSSL_SESSION* session);
 
 /*!
     \ingroup IO
-    \brief  WOLFSSL_SESSION構造体からピア証明書チェーンを返します。
-    \param session WOLFSSL_SESSION構造体へのポインタ
+
+    \brief WOLFSSL_SESSION構造体からピア証明書チェーンを返します。
+
+    \return pointer ピア証明書チェーンを含むWOLFSSL_X509_CHAIN構造体へのポインタ。
+
+    \param session WOLFSSL_SESSION構造体へのポインタ。
 
     _Example_
     \code
@@ -2203,9 +2253,10 @@ int wolfSSL_GetSessionAtIndex(int idx, WOLFSSL_SESSION* session);
     ...
     chain = wolfSSL_SESSION_get_peer_chain(session);
     if(!chain){
-    	// There was no chain. Failure case.
+    	// チェーンがありませんでした。失敗ケース。
     }
     \endcode
+
     \sa wolfSSL_GetSessionAtIndex
     \sa wolfSSL_GetSessionIndex
     \sa AddSession
@@ -2215,29 +2266,14 @@ int wolfSSL_GetSessionAtIndex(int idx, WOLFSSL_SESSION* session);
 
 /*!
     \ingroup Setup
-    \brief  この関数はリモートピアの検証方法を設定し、また証明書検証コールバック関数をSSLコンテキストに登録することもできます。
-    検証コールバックは、検証障害が発生した場合にのみ呼び出されます。
-    検証コールバックが必要な場合は、NULLポインタをverify_callbackに使用できます。
-    ピア証明書の検証モードは、論理的またはフラグのリストです。
-    可能なフラグ値は次のとおりです:<br>
-    SSL_VERIFY_NONE<br>
-     -クライアントモード：クライアントはサーバーから受信した証明書を検証せず、ハンドシェイクは通常どおり続きます。<br>
-     -サーバーモード：サーバーはクライアントに証明書要求を送信しません。そのため、クライアント検証は有効になりません。<br>
-    SSL_VERIFY_PEER<br>
-     -クライアントモード：クライアントはハンドシェイク中にサーバーから受信した証明書を検証します。これはwolfSSLではデフォルトでオンにされます。したがって、このオプションを使用すると効果がありません。<br>
-     -サーバーモード：サーバーは証明書要求をクライアントに送信し、受信したクライアント証明書を確認します。<br>
-    SSL_VERIFY_FAIL_IF_NO_PEER_CERT<br>
-     -クライアントモード：クライアント側で使用されていない場合は効果がありません。<br>
-     -サーバーモード：要求されたときにクライアントが証明書の送信に失敗した場合は、サーバー側で検証が失敗します（SSLサーバーのSSL_VERIFY_PEERを使用する場合）。<br>
-    SSL_VERIFY_FAIL_EXCEPT_PSK<br>
-     -クライアントモード：クライアント側で使用されていない場合は効果がありません。<br>
-     -サーバーモード：PSK接続の場合を除き、検証はSSL_VERIFY_FAIL_IF_NO_PEER_CERTと同じです。 PSK接続が行われている場合、接続はピア証明書なしで通過します。<br>
 
-    \return なし
+    \brief この関数はリモートピアの検証方法を設定し、また検証コールバックをSSLコンテキストに登録できるようにします。検証コールバックは検証失敗が発生した場合にのみ呼び出されます。検証コールバックが不要な場合は、verify_callbackにNULLポインタを使用できます。ピア証明書の検証モードは論理OR演算されたフラグのリストです。可能なフラグ値は以下の通りです。SSL_VERIFY_NONE クライアントモード：クライアントはサーバーから受信した証明書を検証せず、ハンドシェイクは通常通り続行されます。サーバーモード：サーバーはクライアントに証明書要求を送信しません。したがって、クライアント検証は有効になりません。SSL_VERIFY_PEER クライアントモード：クライアントはハンドシェイク中にサーバーから受信した証明書を検証します。これはwolfSSLではデフォルトで有効になっているため、このオプションを使用しても効果はありません。サーバーモード：サーバーはクライアントに証明書要求を送信し、受信したクライアント証明書を検証します。SSL_VERIFY_FAIL_IF_NO_PEER_CERT クライアントモード：クライアント側で使用しても効果はありません。サーバーモード：クライアントが要求されたときに証明書の送信に失敗した場合（SSLサーバーでSSL_VERIFY_PEERを使用している場合）、サーバー側で検証が失敗します。SSL_VERIFY_FAIL_EXCEPT_PSK クライアントモード：クライアント側で使用しても効果はありません。サーバーモード：検証はSSL_VERIFY_FAIL_IF_NO_PEER_CERTと同じですが、PSK接続の場合を除きます。PSK接続が行われている場合、接続はピア証明書なしで続行されます。
 
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param mode ピアの証明書をどのように検証するかを示すフラグ値
-    \param verify_callback 証明書検証が失敗した際に呼び出されるコールバック関数。必要がないならNULLを指定すること。
+    \return none 返り値はありません。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param mode ピアの証明書の検証モードを示すフラグ。
+    \param verify_callback 検証が失敗したときに呼び出されるコールバック。コールバックが不要な場合は、verify_callbackにNULLポインタを使用できます。
 
     _Example_
     \code
@@ -2246,6 +2282,7 @@ int wolfSSL_GetSessionAtIndex(int idx, WOLFSSL_SESSION* session);
     wolfSSL_CTX_set_verify(ctx, (WOLFSSL_VERIFY_PEER |
                            WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT), NULL);
     \endcode
+
     \sa wolfSSL_set_verify
 */
 void wolfSSL_CTX_set_verify(WOLFSSL_CTX* ctx, int mode,
@@ -2253,29 +2290,14 @@ void wolfSSL_CTX_set_verify(WOLFSSL_CTX* ctx, int mode,
 
 /*!
     \ingroup Setup
-    \brief  この関数はリモートピアの検証方法を設定し、また証明書検証コールバック関数をWOLFSSLオブジェクトに登録することもできます。
-    検証コールバックは、検証障害が発生した場合にのみ呼び出されます。
-    検証コールバックが必要な場合は、NULLポインタをverify_callbackに使用できます。
-    ピア証明書の検証モードは、論理的またはフラグのリストです。
-    可能なフラグ値は次のとおりです:<br>
-    SSL_VERIFY_NONE<br>
-     -クライアントモード：クライアントはサーバーから受信した証明書を検証せず、ハンドシェイクは通常どおり続きます。<br>
-     -サーバーモード：サーバーはクライアントに証明書要求を送信しません。そのため、クライアント検証は有効になりません。<br>
-    SSL_VERIFY_PEER<br>
-     -クライアントモード：クライアントはハンドシェイク中にサーバーから受信した証明書を検証します。これはwolfSSLではデフォルトでオンにされます。したがって、このオプションを使用すると効果がありません。<br>
-     -サーバーモード：サーバーは証明書要求をクライアントに送信し、受信したクライアント証明書を確認します。<br>
-    SSL_VERIFY_FAIL_IF_NO_PEER_CERT<br>
-     -クライアントモード：クライアント側で使用されていない場合は効果がありません。<br>
-     -サーバーモード：要求されたときにクライアントが証明書の送信に失敗した場合は、サーバー側で検証が失敗します（SSLサーバーのSSL_VERIFY_PEERを使用する場合）。<br>
-    SSL_VERIFY_FAIL_EXCEPT_PSK<br>
-     -クライアントモード：クライアント側で使用されていない場合は効果がありません。<br>
-     -サーバーモード：PSK接続の場合を除き、検証はSSL_VERIFY_FAIL_IF_NO_PEER_CERTと同じです。 PSK接続が行われている場合、接続はピア証明書なしで通過します。<br>
 
-    \return なし
+    \brief この関数はリモートピアの検証方法を設定し、また検証コールバックをSSLセッションに登録できるようにします。検証コールバックは検証失敗が発生した場合にのみ呼び出されます。検証コールバックが不要な場合は、verify_callbackにNULLポインタを使用できます。ピア証明書の検証モードは論理OR演算されたフラグのリストです。可能なフラグ値は以下の通りです。SSL_VERIFY_NONE クライアントモード：クライアントはサーバーから受信した証明書を検証せず、ハンドシェイクは通常通り続行されます。サーバーモード：サーバーはクライアントに証明書要求を送信しません。したがって、クライアント検証は有効になりません。SSL_VERIFY_PEER クライアントモード：クライアントはハンドシェイク中にサーバーから受信した証明書を検証します。これはwolfSSLではデフォルトで有効になっているため、このオプションを使用しても効果はありません。サーバーモード：サーバーはクライアントに証明書要求を送信し、受信したクライアント証明書を検証します。SSL_VERIFY_FAIL_IF_NO_PEER_CERT クライアントモード：クライアント側で使用しても効果はありません。サーバーモード：クライアントが要求されたときに証明書の送信に失敗した場合（SSLサーバーでSSL_VERIFY_PEERを使用している場合）、サーバー側で検証が失敗します。SSL_VERIFY_FAIL_EXCEPT_PSK クライアントモード：クライアント側で使用しても効果はありません。サーバーモード：検証はSSL_VERIFY_FAIL_IF_NO_PEER_CERTと同じですが、PSK接続の場合を除きます。PSK接続が行われている場合、接続はピア証明書なしで続行されます。
 
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param mode ピアの証明書をどのように検証するかを示すフラグ値
-    \param verify_callback 証明書検証が失敗した際に呼び出されるコールバック関数。必要がないならNULLを指定すること。
+    \return none 返り値はありません。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param mode ピアの証明書の検証モードを示すフラグ。
+    \param verify_callback 検証が失敗したときに呼び出されるコールバック。コールバックが不要な場合は、verify_callbackにNULLポインタを使用できます。
 
     _Example_
     \code
@@ -2283,17 +2305,20 @@ void wolfSSL_CTX_set_verify(WOLFSSL_CTX* ctx, int mode,
     ...
     wolfSSL_set_verify(ssl, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
     \endcode
+
     \sa wolfSSL_CTX_set_verify
 */
 void wolfSSL_set_verify(WOLFSSL* ssl, int mode, VerifyCallback verify_callback);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、検証コールバックのためのユーザーCTXオブジェクト情報を格納します。
-    \return なし
 
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param ctx ボイドポインタ。WOLFSSL構造体のverifyCbCtx メンバーにセットされます。
+    \brief この関数は検証コールバック用のユーザーCTXオブジェクト情報を格納します。
+
+    \return none 返り値はありません。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param ctx WOLFSSL構造体のverifyCbCtxメンバの値に設定されるvoidポインタ。
 
     _Example_
     \code
@@ -2302,11 +2327,12 @@ void wolfSSL_set_verify(WOLFSSL* ssl, int mode, VerifyCallback verify_callback);
     (void*)ctx;
     ...
     if(ssl != NULL){
-    wolfSSL_SetCertCbCtx(ssl, ctx);
+        wolfSSL_SetCertCbCtx(ssl, ctx);
     } else {
-	    // Error case, the SSL is not initialized properly.
+	    // エラーケース、SSLが適切に初期化されていません。
     }
     \endcode
+
     \sa wolfSSL_CTX_save_cert_cache
     \sa wolfSSL_CTX_restore_cert_cache
     \sa wolfSSL_CTX_set_verify
@@ -2315,22 +2341,26 @@ void wolfSSL_SetCertCbCtx(WOLFSSL* ssl, void* ctx);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、検証コールバックのためのユーザーCTXオブジェクト情報を格納します。
-    \return なし
-    \param ctx  WOLFSSL_CTX構造体へのポインタ。
-    \param ctx ボイドポインタ。WOLFSSL_CTX構造体のverifyCbCtx メンバーにセットされます。
+
+    \brief この関数は検証コールバック用のユーザーCTXオブジェクト情報を格納します。
+
+    \return none 返り値はありません。
+
+    \param ctx WOLFSSL_CTX構造体へのポインタ。
+    \param userCtx WOLFSSL_CTX構造体のverifyCbCtxメンバの値を設定するために使用されるvoidポインタ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
-    void* userCtx = NULL; // Assign some user defined context
+    void* userCtx = NULL; // ユーザー定義のコンテキストを割り当て
     ...
     if(ctx != NULL){
         wolfSSL_SetCertCbCtx(ctx, userCtx);
     } else {
-        // Error case, the SSL is not initialized properly.
+        // エラーケース、SSLが適切に初期化されていません。
     }
     \endcode
+
     \sa wolfSSL_CTX_save_cert_cache
     \sa wolfSSL_CTX_restore_cert_cache
     \sa wolfSSL_CTX_set_verify
@@ -2339,9 +2369,12 @@ void wolfSSL_CTX_SetCertCbCtx(WOLFSSL_CTX* ctx, void* userCtx);
 
 /*!
     \ingroup IO
-    \brief  この関数は、wolfSSL_read()によって読み取られるWOLFSSLオブジェクトでバッファされているバイト数を返します。
-    \return この関数は、保留中のバイト数を返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数はSSLオブジェクト内でバッファリングされ、wolfSSL_read()によって読み取り可能な利用可能なバイト数を返します。
+
+    \return int この関数は保留中のバイト数を返します。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
 
     _Example_
     \code
@@ -2350,8 +2383,9 @@ void wolfSSL_CTX_SetCertCbCtx(WOLFSSL_CTX* ctx, void* userCtx);
     ...
 
     pending = wolfSSL_pending(ssl);
-    printf(“There are %d bytes buffered and available for reading”, pending);
+    printf("バッファリングされ読み取り可能な%dバイトがあります", pending);
     \endcode
+
     \sa wolfSSL_recv
     \sa wolfSSL_read
     \sa wolfSSL_peek
@@ -2360,14 +2394,18 @@ int  wolfSSL_pending(WOLFSSL*);
 
 /*!
     \ingroup Debug
-    \brief  この機能はOpenSSL API（SSL_load_error_string）との互換性の目的みで提供してあり処理は行いません。
-    \return なし
-    \param なし
+
+    \brief この関数はOpenSSL互換性（SSL_load_error_string）のためのものであり、何も動作を行いません。
+
+    \return none 返り値はありません。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
     wolfSSL_load_error_strings();
     \endcode
+
     \sa wolfSSL_get_error
     \sa wolfSSL_ERR_error_string
     \sa wolfSSL_ERR_error_string_n
@@ -2378,33 +2416,37 @@ void wolfSSL_load_error_strings(void);
 
 /*!
     \ingroup TLS
-    \brief  この関数はwolfSSL_CTX_new()内で内部的に呼び出されます。
-    この関数はwolfSSL_Init()のラッパーで、wolfSSLがOpenSSL互換層でコンパイルされたときのOpenSSL　API（ssl_library_init）との互換性の為に存在します。
-    wolfSSL_init()は、より一般的に使用されているwolfSSL初期化機能です。
 
-    \return SSL_SUCCESS  成功した場合に返されます。に返されます。
-    \return SSL_FATAL_ERROR  失敗したときに返されます。
+    \brief この関数はwolfSSL_CTX_new()内で内部的に呼び出されます。この関数はwolfSSL_Init()のラッパーであり、wolfSSLがOpenSSL互換性レイヤーでコンパイルされた場合のOpenSSL互換性（SSL_library_init）のために存在します。wolfSSL_Init()は、より一般的に使用されるwolfSSL初期化関数です。
+
+    \return SSL_SUCCESS 呼び出しが成功した場合に返されます。
+    \return SSL_FATAL_ERROR 失敗時に返されます。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
     int ret = 0;
     ret = wolfSSL_library_init();
     if (ret != SSL_SUCCESS) {
-	    failed to initialize wolfSSL
+	    // wolfSSLの初期化に失敗しました
     }
     ...
     \endcode
+
     \sa wolfSSL_Init
     \sa wolfSSL_Cleanup
 */
 int  wolfSSL_library_init(void);
 
 /*!
-    \brief この関数はWOLFSSLオブジェクトレベルでDevice Idをセットします。
-    \return WOLFSSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  sslがNULLの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param devId ハードウエアと共に使用する際に指定するID
+    \brief この関数はWOLFSSLセッションレベルでDevice Idを設定します。
+
+    \return WOLFSSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG sslがNULLの場合。
+
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+    \param devId 暗号コールバックまたは非同期ハードウェアで使用するID。使用しない場合はINVALID_DEVID（-2）に設定します。
 
     _Example_
     \code
@@ -2414,19 +2456,20 @@ int  wolfSSL_library_init(void);
     wolfSSL_SetDevId(ssl, devId);
 
     \endcode
+
     \sa wolfSSL_CTX_SetDevId
     \sa wolfSSL_CTX_GetDevId
 */
 int wolfSSL_SetDevId(WOLFSSL* ssl, int devId);
 
 /*!
-    \brief この関数はWOLFSSL_CTXレベルでDevice Idをセットします。
+    \brief この関数はWOLFSSL_CTXコンテキストレベルでDevice Idを設定します。
 
-    \return WOLFSSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  sslがNULLの場合に返されます。
+    \return WOLFSSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG sslがNULLの場合。
 
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param devId ハードウエアと共に使用する際に指定するID
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param devId 暗号コールバックまたは非同期ハードウェアで使用するID。使用しない場合はINVALID_DEVID（-2）に設定します。
 
     _Example_
     \code
@@ -2436,17 +2479,20 @@ int wolfSSL_SetDevId(WOLFSSL* ssl, int devId);
     wolfSSL_CTX_SetDevId(ctx, devId);
 
     \endcode
+
     \sa wolfSSL_SetDevId
     \sa wolfSSL_CTX_GetDevId
 */
 int wolfSSL_CTX_SetDevId(WOLFSSL_CTX* ctx, int devId);
 
 /*!
-    \brief この関数はWOLFSSL_CTXレベルでDevice Idを取得します。
-    \return devId  成功時に返されます。
-    \return INVALID_DEVID  SSLとCTXの両方がNULLの場合に返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief この関数はDevice Idを取得します。
+
+    \return devId 成功時。
+    \return INVALID_DEVID sslとctxの両方がNULLの場合。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
 
     _Example_
     \code
@@ -2455,22 +2501,22 @@ int wolfSSL_CTX_SetDevId(WOLFSSL_CTX* ctx, int devId);
     wolfSSL_CTX_GetDevId(ctx, ssl);
 
     \endcode
+
     \sa wolfSSL_SetDevId
     \sa wolfSSL_CTX_SetDevId
+
 */
 int wolfSSL_CTX_GetDevId(WOLFSSL_CTX* ctx, WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数はSSLセッションキャッシュ機能を有効または無効にします。
-    動作はモードに使用される値によって異なります。
-    モードの値は次のとおりです：
-    SSL_SESS_CACHE_OFF  - セッションキャッシングを無効にします。デフォルトでセッションキャッシングがオンになっています。
-    SSL_SESS_CACHE_NO_AUTO_CLEAR  - セッションキャッシュのオートフラッシュを無効にします。デフォルトで自動フラッシングはオンになっています。
 
-    \return SSL_SUCCESS  成功に戻ります。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param mode セッションキャッシュの振る舞いを変更する為に使用します。
+    \brief この関数はSSLセッションキャッシングを有効または無効にします。動作はmodeに使用される値に依存します。modeに使用できる値は以下の通りです。SSL_SESS_CACHE_OFF - セッションキャッシングを無効にします。セッションキャッシングはデフォルトで有効になっています。SSL_SESS_CACHE_NO_AUTO_CLEAR - セッションキャッシュの自動フラッシュを無効にします。自動フラッシュはデフォルトで有効になっています。
+
+    \return SSL_SUCCESS 成功時に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param mode セッションキャッシュの動作を変更するために使用される修飾子。
 
     _Example_
     \code
@@ -2478,9 +2524,10 @@ int wolfSSL_CTX_GetDevId(WOLFSSL_CTX* ctx, WOLFSSL* ssl);
     ...
     ret = wolfSSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
     if (ret != SSL_SUCCESS) {
-    	// failed to turn SSL session caching off
+        // SSLセッションキャッシングをオフにすることができませんでした。
     }
     \endcode
+
     \sa wolfSSL_flush_sessions
     \sa wolfSSL_get1_session
     \sa wolfSSL_set_session
@@ -2490,48 +2537,53 @@ int wolfSSL_CTX_GetDevId(WOLFSSL_CTX* ctx, WOLFSSL* ssl);
 long wolfSSL_CTX_set_session_cache_mode(WOLFSSL_CTX* ctx, long mode);
 
 /*!
-    \brief  この関数はセッションシークレットコールバック関数をセットします。
-    SessionSecretCbタイプは次のシグネチャとなっています：int（* sessioneCretcb）（wolfssl * ssl、void * secret、int * secretsz、void * ctx）。
-    WOLFSSL構造体のsessionSecretCbメンバーは引数cbに設定されます。
-    \return SSL_SUCCESS  関数の実行がエラーを返されなかった場合に返されます。
-    \return SSL_FATAL_ERROR  WOLFSSL構造がNULLの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param cb セッションシークレットコールバック関数ポインタ。
-    \param ctx セッションシークレットコールバック関数に渡されるユーザーコンテキスト。
+    \brief この関数は、セッションシークレットコールバック関数を設定します。SessionSecretCb型は次のシグネチャを持ちます:int (*SessionSecretCb)(WOLFSSL* ssl, void* secret, int* secretSz, void* ctx)。WOLFSSL構造体のsessionSecretCbメンバが、パラメータcbに設定されます。
+
+    \return SSL_SUCCESS 関数の実行がエラーを返さなかった場合に返されます。
+    \return SSL_FATAL_ERROR WOLFSSL構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param cb 上記のシグネチャを持つ関数ポインタであるSessionSecretCb型。
+    \param ctx 保存されるユーザコンテキストへのポインタ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
     WOLFSSL* ssl = wolfSSL_new(ctx);
-    // Signature of SessionSecretCb
+    // SessionSecretCbのシグネチャ
     int SessionSecretCB (WOLFSSL* ssl, void* secret, int* secretSz,
     void* ctx) = SessionSecretCb;
     …
     int wolfSSL_set_session_secret_cb(ssl, SessionSecretCB, (void*)ssl->ctx){
-	    // Function body.
+	    // 関数本体。
     }
     \endcode
+
     \sa SessionSecretCb
 */
 int  wolfSSL_set_session_secret_cb(WOLFSSL* ssl, SessionSecretCb cb, void* ctx);
 
 /*!
     \ingroup IO
-    \brief  この関数はセッションキャッシュをファイルに持続します。追加のメモリ使用のため、memsaveは使用されません。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。セッションキャッシュはファイルに書き込まれました。
-    \return SSL_BAD_FILE  FNAMEを開くことができないか、それ以外の場合は破損した場合に返されます。
-    \return FWRITE_ERROR  XfWriteがファイルへの書き込みに失敗した場合に返されます。
-    \return BAD_MUTEX_E  ミューテックスロック障害が発生した場合に返されます。
-    \param fname 書き込み対象ファイル名へのポインタ。
+
+    \brief この関数は、セッションキャッシュをファイルに永続化します。追加のメモリ使用量のため、memsaveは使用しません。
+
+    \return SSL_SUCCESS 関数がエラーなく実行された場合に返されます。セッションキャッシュがファイルに書き込まれました。
+    \return SSL_BAD_FILE fnameを開くことができないか、またはそれ以外の理由で破損している場合に返されます。
+    \return FWRITE_ERROR XFWRITEがファイルへの書き込みに失敗した場合に返されます。
+    \return BAD_MUTEX_E mutexロックの失敗があった場合に返されます。
+
+    \param fname 書き込み用ファイルを指す定数char型ポインタ。
 
     _Example_
     \code
     const char* fname;
     ...
     if(wolfSSL_save_session_cache(fname) != SSL_SUCCESS){
-    	// Fail to write to file.
+    	// ファイルへの書き込みに失敗しました。
     }
     \endcode
+
     \sa XFWRITE
     \sa wolfSSL_restore_session_cache
     \sa wolfSSL_memrestore_session_cache
@@ -2540,23 +2592,26 @@ int  wolfSSL_save_session_cache(const char* fname);
 
 /*!
     \ingroup IO
-    \brief  この関数はファイルから永続セッションキャッシュを復元します。追加のメモリ使用のため、memstoreは使用しません。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
-    \return SSL_BAD_FILE  関数に渡されたファイルが破損していてXFOPENによって開くことができなかった場合に返されます。
-    \return FREAD_ERROR  ファイルにXFREADから読み取りエラーが発生した場合に返されます。
-    \return CACHE_MATCH_ERROR  セッションキャッシュヘッダの一致が失敗した場合に返されます。
-    \return BAD_MUTEX_E  ミューテックスロック障害が発生した場合に返されます。
-    \param fname キャシュを読み取るためのファイル名へのポインタ。
 
+    \brief この関数は、永続的なセッションキャッシュをファイルから復元します。追加のメモリ使用量のため、memstoreは使用しません。
+
+    \return SSL_SUCCESS 関数がエラーなく実行された場合に返されます。
+    \return SSL_BAD_FILE 関数に渡されたファイルが破損しており、XFOPENで開くことができなかった場合に返されます。
+    \return FREAD_ERROR ファイルがXFREADからの読み取りエラーを持っていた場合に返されます。
+    \return CACHE_MATCH_ERROR セッションキャッシュヘッダのマッチングに失敗した場合に返されます。
+    \return BAD_MUTEX_E mutexロックの失敗があった場合に返されます。
+
+    \param fname 読み取られる定数char型ポインタファイル入力。
 
     _Example_
     \code
     const char *fname;
     ...
     if(wolfSSL_restore_session_cache(fname) != SSL_SUCCESS){
-        // Failure case. The function did not return SSL_SUCCESS.
+        // 失敗ケースです。関数はSSL_SUCCESSを返しませんでした。
     }
     \endcode
+
     \sa XFREAD
     \sa XFOPEN
 */
@@ -2564,22 +2619,26 @@ int  wolfSSL_restore_session_cache(const char* fname);
 
 /*!
     \ingroup IO
-    \brief  この関数はセッションキャッシュをメモリに保持します。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。セッションキャッシュはメモリに正常に永続化されました。
-    \return BAD_MUTEX_E  ミューテックスロックエラーが発生した場合に返されます。
-    \return BUFFER_E  バッファサイズが小さすぎると返されます。
-    \param mem  セッションキャッシュのコピー先バッファへのポインタ
-    \param sz コピー先バッファのサイズ
+
+    \brief この関数は、セッションキャッシュをメモリに永続化します。
+
+    \return SSL_SUCCESS 関数がエラーなく実行された場合に返されます。セッションキャッシュがメモリに正常に永続化されました。
+    \return BAD_MUTEX_E mutexロックエラーがあった場合に返されます。
+    \return BUFFER_E バッファサイズが小さすぎた場合に返されます。
+
+    \param mem メモリコピーXMEMCPY()の宛先を表すvoid型ポインタ。
+    \param sz memのサイズを表すint型。
 
     _Example_
     \code
     void* mem;
-    int sz; // Max size of the memory buffer.
+    int sz; // メモリバッファの最大サイズ。
     …
     if(wolfSSL_memsave_session_cache(mem, sz) != SSL_SUCCESS){
-    	// Failure case, you did not persist the session cache to memory
+    	// 失敗ケースです。セッションキャッシュをメモリに永続化できませんでした。
     }
     \endcode
+
     \sa XMEMCPY
     \sa wolfSSL_get_session_cache_memsize
 */
@@ -2587,13 +2646,16 @@ int  wolfSSL_memsave_session_cache(void* mem, int sz);
 
 /*!
     \ingroup IO
-    \brief  この関数はメモリから永続セッションキャッシュを復元します。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
-    \return BUFFER_E  メモリバッファが小さすぎると返されます。
-    \return BAD_MUTEX_E  セッションキャッシュミューテックスロックが失敗した場合に返されます。
-    \return CACHE_MATCH_ERROR  セッションキャッシュヘッダの一致が失敗した場合に返されます。
-    \param mem  セッションキャッシュを保持しているバッファへのポインタ。
-    \param sz バッファのサイズ
+
+    \brief この関数は、永続的なセッションキャッシュをメモリから復元します。
+
+    \return SSL_SUCCESS 関数がエラーなく実行された場合に返されます。
+    \return BUFFER_E メモリバッファが小さすぎる場合に返されます。
+    \return BAD_MUTEX_E セッションキャッシュのmutexロックに失敗した場合に返されます。
+    \return CACHE_MATCH_ERROR セッションキャッシュヘッダのマッチングに失敗した場合に返されます。
+
+    \param mem 復元のソースを含む定数void型ポインタ。
+    \param sz メモリバッファのサイズを表す整数。
 
     _Example_
     \code
@@ -2601,41 +2663,50 @@ int  wolfSSL_memsave_session_cache(void* mem, int sz);
     int szMf;
     ...
     if(wolfSSL_memrestore_session_cache(memoryFile, szMf) != SSL_SUCCESS){
-    	// Failure case. SSL_SUCCESS was not returned.
+    	// 失敗ケースです。SSL_SUCCESSが返されませんでした。
     }
     \endcode
+
     \sa wolfSSL_save_session_cache
 */
 int  wolfSSL_memrestore_session_cache(const void* mem, int sz);
 
 /*!
     \ingroup IO
-    \brief  この関数は、セッションキャッシュ保存バッファをどのように大きくするかを返します。
-    \return この関数は、セッションキャッシュ保存バッファのサイズを表す整数を返します。
+
+    \brief この関数は、セッションキャッシュの保存バッファがどのくらい大きくあるべきかを返します。
+
+    \return int この関数は、セッションキャッシュの保存バッファのサイズを表す整数を返します。
+
+    \param none パラメータなし。
 
     _Example_
     \code
-    int sz = // Minimum size for error checking;
+    int sz = // エラーチェックのための最小サイズ;
     ...
     if(sz < wolfSSL_get_session_cache_memsize()){
-        // Memory buffer is too small
+        // メモリバッファが小さすぎます。
     }
     \endcode
+
     \sa wolfSSL_memrestore_session_cache
 */
 int  wolfSSL_get_session_cache_memsize(void);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はCertキャッシュをメモリからファイルに書き込みます。
-    \return SSL_SUCCESS  CM_SaveCertCacheが正常に終了した場合。
-    \return BAD_FUNC_ARG  引数のいずれかの引数がNULLの場合に返されます。
-    \return SSL_BAD_FILE  証明書キャッシュ保存ファイルを開くことができなかった場合。
-    \return BAD_MUTEX_E  ロックミューテックスが失敗した場合
-    \return MEMORY_E  メモリの割り当てに失敗しました。
-    \return FWRITE_ERROR  証明書キャッシュファイルの書き込みに失敗しました。
-    \param ctx  WOLFSSL_CTX構造体へのポインタ、証明書情報を保持します。
-    \param fname  出力先ファイル名へのポインタ
+
+    \brief この関数は、証明書キャッシュをメモリからファイルに書き込みます。
+
+    \return SSL_SUCCESS CM_SaveCertCacheが正常に終了した場合に返されます。
+    \return BAD_FUNC_ARG いずれかの引数がNULLの場合に返されます。
+    \return SSL_BAD_FILE 証明書キャッシュ保存ファイルを開くことができなかった場合に返されます。
+    \return BAD_MUTEX_E ロックmutexが失敗した場合に返されます。
+    \return MEMORY_E メモリの割り当てに失敗した場合に返されます。
+    \return FWRITE_ERROR 証明書キャッシュファイルの書き込みに失敗しました。
+
+    \param ctx 証明書情報を保持するWOLFSSL_CTX構造体へのポインタ。
+    \param fname 書き込み用ファイルを指す定数char型ポインタ。
 
     _Example_
     \code
@@ -2643,9 +2714,10 @@ int  wolfSSL_get_session_cache_memsize(void);
     const char* fname;
     ...
     if(wolfSSL_CTX_save_cert_cache(ctx, fname)){
-	    // file was written.
+	    // ファイルが書き込まれました。
     }
     \endcode
+
     \sa CM_SaveCertCache
     \sa DoMemSaveCertCache
 */
@@ -2653,24 +2725,28 @@ int  wolfSSL_CTX_save_cert_cache(WOLFSSL_CTX* ctx, const char* fname);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はファイルから証明書キャッシュを担当します。
-    \return SSL_SUCCESS 正常に実行された場合に返されます。
-    \return SSL_BAD_FILE  XFOPENがXBADFILEを返すと返されます。ファイルが破損しています。
-    \return MEMORY_E  TEMPバッファの割り当てられたメモリが失敗した場合に返されます。
-    \return BAD_FUNC_ARG  引数fnameまたは引数ctxがNULLである場合に返されます。
-    \param ctx  WOLFSSL_CTX構造体へのポインタ、証明書情報を保持します。
-    \param fname 証明書キャッシュを読み取るファイル名へのポインタ。
+
+    \brief この関数は、証明書キャッシュをファイルから永続化します。
+
+    \return SSL_SUCCESS 関数CM_RestoreCertCacheが正常に実行された場合に返されます。
+    \return SSL_BAD_FILE XFOPENがXBADFILEを返した場合に返されます。ファイルが破損しています。
+    \return MEMORY_E 一時バッファに割り当てられたメモリが失敗した場合に返されます。
+    \return BAD_FUNC_ARG fnameまたはctxがNULL値を持つ場合に返されます。
+
+    \param ctx 証明書情報を保持するWOLFSSL_CTX構造体へのポインタ。
+    \param fname 読み取り用ファイルを指す定数char型ポインタ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
     WOLFSSL* ssl = wolfSSL_new(ctx);
-    const char* fname = "path to file";
+    const char* fname = "ファイルへのパス";
     ...
     if(wolfSSL_CTX_restore_cert_cache(ctx, fname)){
-    	// check to see if the execution was successful
+    	// 実行が成功したかどうかを確認します。
     }
     \endcode
+
     \sa CM_RestoreCertCache
     \sa XFOPEN
 */
@@ -2678,15 +2754,18 @@ int  wolfSSL_CTX_restore_cert_cache(WOLFSSL_CTX* ctx, const char* fname);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は証明書キャッシュをメモリに持続します。
-    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。エラーが投げられていません。
-    \return BAD_MUTEX_E  WOLFSSL_CERT_MANAGER構造体のcaLockメンバー0（ゼロ）ではなかった。
-    \return BAD_FUNC_ARG  引数ctx、memがNULLの場合、またはszが0以下の場合に返されます。
-    \return BUFFER_E  出力バッファMEMが小さすぎました。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param mem  宛先へのvoidポインタ（出力バッファ）。
-    \param sz  出力バッファのサイズ。
-    \param used 証明書キャッシュヘッダーのサイズを格納する変数へのポインタ。
+
+    \brief この関数は、証明書キャッシュをメモリに永続化します。
+
+    \return SSL_SUCCESS 関数の実行が成功し、エラーが発生しなかった場合に返されます。
+    \return BAD_MUTEX_E WOLFSSL_CERT_MANAGERメンバcaLockが0(ゼロ)でなかったmutexエラー。
+    \return BAD_FUNC_ARG ctx、mem、またはusedがNULLの場合、またはszが0(ゼロ)以下の場合に返されます。
+    \return BUFFER_E 出力バッファmemが小さすぎました。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param mem 宛先(出力バッファ)へのvoid型ポインタ。
+    \param sz 出力バッファのサイズ。
+    \param used 証明書キャッシュヘッダのサイズへのポインタ。
 
     _Example_
     \code
@@ -2696,9 +2775,10 @@ int  wolfSSL_CTX_restore_cert_cache(WOLFSSL_CTX* ctx, const char* fname);
     int* used;
     ...
     if(wolfSSL_CTX_memsave_cert_cache(ctx, mem, sz, used) != SSL_SUCCESS){
-	    // The function returned with an error
+	    // 関数がエラーを返しました。
     }
     \endcode
+
     \sa DoMemSaveCertCache
     \sa GetCertCacheMemSize
     \sa CM_MemRestoreCertCache
@@ -2708,15 +2788,18 @@ int  wolfSSL_CTX_memsave_cert_cache(WOLFSSL_CTX* ctx, void* mem, int sz, int* us
 
 /*!
     \ingroup Setup
-    \brief  この関数は証明書キャッシュをメモリから復元します。
-    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG  CTXまたはMEMパラメータがNULLまたはSZパラメータがゼロ以下の場合に返されます。
-    \return BUFFER_E  CERTキャッシュメモリバッファが小さすぎると戻ります。
-    \return CACHE_MATCH_ERROR  CERTキャッシュヘッダーの不一致があった場合に返されます。
-    \return BAD_MUTEX_E  ロックミューテックスが失敗した場合に返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param mem  証明書キャッシュに復元される値を保持しているバッファへのポインタ。
-    \param sz バッファのサイズ
+
+    \brief この関数は、証明書キャッシュをメモリから復元します。
+
+    \return SSL_SUCCESS 関数とサブルーチンがエラーなく実行された場合に返されます。
+    \return BAD_FUNC_ARG ctxまたはmemパラメータがNULLの場合、またはszパラメータが0以下の場合に返されます。
+    \return BUFFER_E 証明書キャッシュのメモリバッファが小さすぎる場合に返されます。
+    \return CACHE_MATCH_ERROR 証明書キャッシュヘッダの不一致があった場合に返されます。
+    \return BAD_MUTEX_E ロックmutexが失敗した場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param mem 証明書キャッシュに復元される値を持つvoid型ポインタ。
+    \param sz memパラメータのサイズを表すint型。
 
     _Example_
     \code
@@ -2726,21 +2809,24 @@ int  wolfSSL_CTX_memsave_cert_cache(WOLFSSL_CTX* ctx, void* mem, int sz, int* us
     int sz = (*int) sizeof(mem);
     …
     if(wolfSSL_CTX_memrestore_cert_cache(ssl->ctx, mem, sz)){
-    	// The success case
+    	// 成功ケース
     }
     \endcode
+
     \sa CM_MemRestoreCertCache
 */
 int  wolfSSL_CTX_memrestore_cert_cache(WOLFSSL_CTX* ctx, const void* mem, int sz);
 
 /*!
     \ingroup CertsKeys
-    \brief  Certificate Cache Saveバッファが必要なサイズを返します。
-    \return メモリサイズを返します。
-    \return BAD_FUNC_ARG  WOLFSSL_CTX構造体がNULLの場合に返されます。
-    \return BAD_MUTEX_E ミューテックスロックエラーが発生した場合に返されます。
 
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \brief 証明書キャッシュの保存バッファに必要なサイズを返します。
+
+    \return int 成功時にメモリサイズを表す整数値が返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULLの場合に返されます。
+    \return BAD_MUTEX_E mutexロックエラーがあった場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたwolfSSL_CTX構造体へのポインタ。
 
     _Example_
     \code
@@ -2749,40 +2835,36 @@ int  wolfSSL_CTX_memrestore_cert_cache(WOLFSSL_CTX* ctx, const void* mem, int sz
     int certCacheSize = wolfSSL_CTX_get_cert_cache_memsize(ctx);
 
     if(certCacheSize != BAD_FUNC_ARG || certCacheSize != BAD_MUTEX_E){
-	// Successfully retrieved the memory size.
+	// メモリサイズの取得に成功しました。
     }
     \endcode
+
     \sa CM_GetCertCacheMemSize
 */
 int  wolfSSL_CTX_get_cert_cache_memsize(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、与えられたWOLFSSL_CTXに暗号スイートリストを設定します。
-    この暗号スイートリストは、このコンテキストを使用して作成された新しいSSLセッション（WolfSSL）のデフォルトリストになります。
-    リスト内の暗号は、優先度の高いものの順に順にソートされるべきです。
-    wolfSSL_CTX_set_cipher_list()が呼び出される都度、特定のSSLコンテキストの暗号スイートリストを提供されたリストにリセットします。
-    暗号スイートリストはヌル終端されたコロン区切りリストです。
-    たとえば、リストの値が「DHE-RSA-AES256-SHA256：DHE-RSA-AES128-SHA256：AES256-SHA256」有効な暗号値は、src/internal.cのcipher_names []配列のフルネーム値です。
-    （有効な暗号化値の明確なリストの場合はsrc/internal.cをチェックしてください）
 
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  失敗した場合に返されます。
+    \brief この関数は、指定されたWOLFSSL_CTXに対する暗号スイートリストを設定します。この暗号スイートリストは、このコンテキストを使用して作成された新しいSSLセッション(WOLFSSL)のデフォルトリストになります。リスト内の暗号は、優先度の高い順から低い順に並べる必要があります。wolfSSL_CTX_set_cipher_list()を呼び出すたびに、関数が呼び出されるたびに、特定のSSLコンテキストの暗号スイートリストが提供されたリストにリセットされます。暗号スイートリストであるlistは、nullで終端されたテキスト文字列であり、コロン区切りのリストです。例えば、listの1つの値は「DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:AES256-SHA256」となる可能性があります。有効な暗号値は、src/internal.cのcipher_names[]配列からの完全な名前値です(有効な暗号値の明確なリストについては、src/internal.cを確認してください)。
 
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param list ヌル終端されたコロン区切りの暗号スイートリスト文字列へのポインタ。
+    \return SSL_SUCCESS 関数の実行が成功した場合に返されます。
+    \return SSL_FAILURE 失敗した場合に返されます。
 
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param list 指定されたSSLコンテキストで使用する暗号スイートのnullで終端されたテキスト文字列およびコロン区切りリスト。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = 0;
     ...
     ret = wolfSSL_CTX_set_cipher_list(ctx,
-    “DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:AES256-SHA256”);
+    "DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:AES256-SHA256");
     if (ret != SSL_SUCCESS) {
-    	// failed to set cipher suite list
+    	// 暗号スイートリストの設定に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_set_cipher_list
     \sa wolfSSL_CTX_new
 */
@@ -2790,19 +2872,13 @@ int  wolfSSL_CTX_set_cipher_list(WOLFSSL_CTX* ctx, const char* list);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、特定のWolfSSLオブジェクト（SSLセッション）の暗号スイートリストを設定します。
-    この暗号スイートリストは、このコンテキストを使用して作成された新しいSSLセッション（WolfSSL）のデフォルトリストになります。
-    リスト内の暗号は、優先度の高いものの順に順にソートされるべきです。
-    wolfSSL_CTX_set_cipher_list()が呼び出される都度、特定のSSLコンテキストの暗号スイートリストを提供されたリストにリセットします。
-    暗号スイートリストはヌル終端されたコロン区切りリストです。
-    たとえば、リストの値が「DHE-RSA-AES256-SHA256：DHE-RSA-AES128-SHA256：AES256-SHA256」有効な暗号値は、src/internal.cのcipher_names []配列のフルネーム値です。
-    （有効な暗号化値の明確なリストの場合はsrc/internal.cをチェックしてください）
 
-    \return SSL_SUCCESS  機能完了に成功したときに返されます。
-    \return SSL_FAILURE  失敗した場合に返されます。
+    \brief この関数は、指定されたWOLFSSLオブジェクト(SSLセッション)に対する暗号スイートリストを設定します。リスト内の暗号は、優先度の高い順から低い順に並べる必要があります。wolfSSL_set_cipher_list()を呼び出すたびに、関数が呼び出されるたびに、特定のSSLセッションの暗号スイートリストが提供されたリストにリセットされます。暗号スイートリストであるlistは、nullで終端されたテキスト文字列であり、コロン区切りのリストです。例えば、listの1つの値は「DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:AES256-SHA256」となる可能性があります。有効な暗号値は、src/internal.cのcipher_names[]配列からの完全な名前値です(有効な暗号値の明確なリストについては、src/internal.cを確認してください)。
+    \return SSL_SUCCESS 関数が正常に完了すると返されます。
+    \return SSL_FAILURE 失敗時に返されます。
 
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param list ヌル終端されたコロン区切りの暗号スイートリスト文字列へのポインタ。
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param list null終端テキスト文字列であり、指定されたSSLセッションで使用する暗号スイートのコロン区切りリスト。
 
     _Example_
     \code
@@ -2810,24 +2886,24 @@ int  wolfSSL_CTX_set_cipher_list(WOLFSSL_CTX* ctx, const char* list);
     WOLFSSL* ssl = 0;
     ...
     ret = wolfSSL_set_cipher_list(ssl,
-    “DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:AES256-SHA256”);
+    "DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:AES256-SHA256");
     if (ret != SSL_SUCCESS) {
-    	// failed to set cipher suite list
+    	// 暗号スイートリストの設定に失敗
     }
     \endcode
+
     \sa wolfSSL_CTX_set_cipher_list
     \sa wolfSSL_new
 */
 int  wolfSSL_set_cipher_list(WOLFSSL* ssl, const char* list);
 
 /*!
-    \brief  この関数はWOLFSSL DTLSオブジェクトに下層のUDP I/Oはノンブロッキングであることを通知します。
-    アプリケーションがWOLFSSLオブジェクトを作成した後、ノンブロッキングUDPソケットを使用する場合は、wolfSSL_dtls_set_using_nonblock()を呼び出します。
-    これにより、WOLFSSLオブジェクトは、recvfrom呼び出しがタイムアウトせずにEWOULDBLOCKを受信することを意味します。
-    \return なし
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param nonblock WOLFSSL構造体にノンブロッキングI/Oを使用していることを指定するフラグ。ノンブロッキングを使用している場合には１を指定、それ以外は0を指定してください。
+    \brief この関数は、WOLFSSL DTLSオブジェクトに対して、下層のUDP I/Oがノンブロッキングであることを通知します。アプリケーションがWOLFSSLオブジェクトを作成した後、それをノンブロッキングUDPソケットと共に使用する場合は、wolfSSL_dtls_set_using_nonblock()を呼び出してください。これにより、WOLFSSLオブジェクトは、EWOULDBLOCKを受け取ることがタイムアウトではなく、recvfrom呼び出しがブロックすることを意味すると認識できます。
 
+    \return none 戻り値はありません。
+
+    \param ssl wolfSSL_new()で作成されたDTLSセッションへのポインタ。
+    \param nonblock WOLFSSLオブジェクトのノンブロッキングフラグを設定するための値。ノンブロッキングを指定する場合は1を、そうでない場合は0を使用してください。
 
     _Example_
     \code
@@ -2835,19 +2911,19 @@ int  wolfSSL_set_cipher_list(WOLFSSL* ssl, const char* list);
     ...
     wolfSSL_dtls_set_using_nonblock(ssl, 1);
     \endcode
+
     \sa wolfSSL_dtls_get_using_nonblock
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls_get_current_timeout
 */
 void wolfSSL_dtls_set_using_nonblock(WOLFSSL* ssl, int nonblock);
 /*!
-    \brief  この関数はWOLFSSL DTLSオブジェクトが下層にUDPノンブロッキングI/Oを使用しているか否かを取得します。
-    WOLFSSLオブジェクトがノンブロッキングI/Oを使用している場合、この関数は1を返します。
-    これにより、WOLFSSLオブジェクトは、EWOULDBLOCKを受信することを意味します。
-    この機能はDTLSセッションにとってのみ意味があります。
-    \return 0  基礎となるI/Oがブロックされています。
-    \return 1  基礎となるI/Oはノンブロッキングです。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief この関数により、アプリケーションはwolfSSLがUDPでノンブロッキングI/Oを使用しているかどうかを判定できます。wolfSSLがノンブロッキングI/Oを使用している場合、この関数は1を返し、それ以外の場合は0を返します。アプリケーションがWOLFSSLオブジェクトを作成した後、それをノンブロッキングUDPソケットと共に使用する場合は、wolfSSL_dtls_set_using_nonblock()を呼び出してください。これにより、WOLFSSLオブジェクトは、EWOULDBLOCKを受け取ることがタイムアウトではなく、recvfrom呼び出しがブロックすることを意味すると認識できます。この関数はDTLSセッションにのみ意味があります。
+
+    \return 0 下層のI/Oがブロッキングです。
+    \return 1 下層のI/Oがノンブロッキングです。
+
+    \param ssl wolfSSL_new()で作成されたDTLSセッションへのポインタ。
 
     _Example_
     \code
@@ -2856,22 +2932,23 @@ void wolfSSL_dtls_set_using_nonblock(WOLFSSL* ssl, int nonblock);
     ...
     ret = wolfSSL_dtls_get_using_nonblock(ssl);
     if (ret == 1) {
-    	// underlying I/O is non-blocking
+    	// 下層のI/Oはノンブロッキング
     }
     ...
     \endcode
+
     \sa wolfSSL_dtls_set_using_nonblock
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls_set_using_nonblock
 */
 int  wolfSSL_dtls_get_using_nonblock(WOLFSSL* ssl);
 /*!
-    \brief  この関数は現在のタイムアウト値を秒単位で返します。
-    ノンブロッキングソケットを使用する場合、ユーザーコードでは、利用可能なrecvVデータの到着をチェックするタイミングや待つべき時間を知る必要があります。
-    この関数によって返される値は、アプリケーションがどのくらい待機するかを示します。
-    \return seconds  現在のDTLSタイムアウト値（秒）
-    \return NOT_COMPILED_IN  wolfSSLがDTLSサポートで構築されていない場合。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief この関数は、WOLFSSLオブジェクトの現在のタイムアウト値を秒単位で返します。ノンブロッキングソケットを使用する場合、ユーザコード内の何かが、利用可能な受信データをいつチェックするか、およびどのくらい待機しているかを決定する必要があります。この関数が返す値は、アプリケーションがどのくらい待機すべきかを示します。
+
+    \return seconds 現在のDTLSタイムアウト値(秒単位)。
+    \return NOT_COMPILED_IN wolfSSLがDTLSサポート付きでビルドされていない場合。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -2879,26 +2956,21 @@ int  wolfSSL_dtls_get_using_nonblock(WOLFSSL* ssl);
     WOLFSSL* ssl;
     ...
     timeout = wolfSSL_get_dtls_current_timeout(ssl);
-    printf(“DTLS timeout (sec) = %d\n”, timeout);
+    printf("DTLS timeout (sec) = %d\n", timeout);
     \endcode
+
     \sa wolfSSL_dtls
     \sa wolfSSL_dtls_get_peer
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls_set_peer
 */
 int  wolfSSL_dtls_get_current_timeout(WOLFSSL* ssl);
-
 /*!
-    \brief この関数はアプリケーションがより早いタイムアウト時間を設定する必要がある場合にtrueを返します。
-    ノンブロッキングソケットを使用する場合でユーザーコードで受信データが到着しているか何時チェックするか、
-    あるいはどのくらいの時間待てばよいのかを決める必要があります。
-    この関数が true を返した場合、ライブラリはすでに通信の中断を検出しましたが、
-    他のピアからのメッセージがまだ送信中の場合に備えて、もう少し待機する必要があることを意味します。
-    このタイマーの値を微調整するのはアプリケーション次第ですが、dtls_get_current_timeout()/4が最適です。
+    \brief この関数は、アプリケーションがより短いタイムアウトを設定すべき場合にtrueを返します。ノンブロッキングソケットを使用する場合、ユーザコード内の何かが、利用可能なデータをいつチェックするか、およびどのくらい待機する必要があるかを決定する必要があります。この関数がtrueを返す場合、ライブラリはすでに通信の中断を検出していますが、他のピアからのメッセージがまだ転送中である可能性に備えて、もう少し待機したいことを意味します。このタイマーの値を微調整するのはアプリケーション次第であり、適切な値はdtls_get_current_timeout() / 4かもしれません。
 
-    \return true アプリケーションがより早いタイムアウトを設定する必要がある場合に返されます。
+    \return true アプリケーションコードがより短いタイムアウトを設定すべき場合。
 
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     \sa wolfSSL_dtls
     \sa wolfSSL_dtls_get_peer
@@ -2910,14 +2982,10 @@ int  wolfSSL_dtls13_use_quick_timeout(WOLFSSL *ssl);
 /*!
   \ingroup Setup
 
-    \brief この関数は、ライブラリが中断を検出したときにすぐに他のピアにACKを送信するかどうかを設定します。
-    ACKをすぐに送信すると、遅延は最小限に抑えられますが、必要以上に多くの帯域幅が消費される可能性があります。
-    アプリケーションが独自にタイマーを管理しており、このオプションが0に設定されている場合、
-    アプリケーションコードはwolfSSL_dtls13_use_quick_timeout()を使用して、
-    遅延したACKを送信するためにより速いタイムアウトを設定する必要があるかどうかを判断できます。
+    \brief この関数は、中断を検出したときにライブラリがACKを他のピアに即座に送信すべきかどうかを設定します。ACKを即座に送信すると最小のレイテンシが保証されますが、必要以上に帯域幅を消費する可能性があります。アプリケーションが自分でタイマーを管理し、このオプションが0に設定されている場合、アプリケーションコードはwolfSSL_dtls13_use_quick_timeout()を使用して、これらの遅延ACKを送信するためにより短いタイムアウトを設定すべきかどうかを判定できます。
 
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param value 設定を行う場合には１を行わない場合には0を設定します。
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param value オプションを設定する場合は1、オプションを無効にする場合は0。
 
     \sa wolfSSL_dtls
     \sa wolfSSL_dtls_get_peer
@@ -2929,11 +2997,14 @@ void  wolfSSL_dtls13_set_send_more_acks(WOLFSSL *ssl, int value);
 
 /*!
     \ingroup Setup
-    \brief  この関数はDTLSタイムアウトを設定します。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。SSLのDTLS_TIMEOUT_INITとDTLS_TIMEOUTメンバーが設定されています。
-    \return BAD_FUNC_ARG  引数sslがNULLの場合、またはタイムアウトが0以下の場合に返されます。タイムアウト引数が許可されている最大値を超えている場合にも返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param value タイムアウトオプションを有効にする場合には1を指定し、無効にする場合には0を指定します。
+
+    \brief この関数はdtlsタイムアウトを設定します。
+
+    \return SSL_SUCCESS 関数がエラーなく実行された場合に返されます。SSLのdtls_timeout_initおよびdtls_timeoutメンバが設定されています。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLであるか、またはタイムアウトが0より大きくない場合に返されます。また、timeout引数が許容される最大値を超える場合にも返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param timeout WOLFSSL構造体のdtls_timeout_initメンバに設定されるint型の値。
 
     _Example_
     \code
@@ -2942,22 +3013,25 @@ void  wolfSSL_dtls13_set_send_more_acks(WOLFSSL *ssl, int value);
     int timeout = TIMEOUT;
     ...
     if(wolfSSL_dtls_set_timeout_init(ssl, timeout)){
-    	// the dtls timeout was set
+    	// dtlsタイムアウトが設定された
     } else {
-    	// Failed to set DTLS timeout.
+    	// DTLSタイムアウトの設定に失敗
     }
     \endcode
+
     \sa wolfSSL_dtls_set_timeout_max
     \sa wolfSSL_dtls_got_timeout
 */
 int  wolfSSL_dtls_set_timeout_init(WOLFSSL* ssl, int);
 
 /*!
-    \brief
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG  wolfssl構造体がNULLの場合、またはTIMEOUT引数がゼロ以下である場合、またはWolfSSL構造体のDTLS_TIMEOUT_INITメンバーよりも小さい場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param timeout 最大タイムアウト時間
+    \brief この関数は最大dtlsタイムアウトを設定します。
+
+    \return SSL_SUCCESS 関数がエラーなく実行された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLであるか、timeout引数が0より大きくないか、またはWOLFSSL構造体のdtls_timeout_initメンバより小さい場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param timeout dtls最大タイムアウトを表すint型の値。
 
     _Example_
     \code
@@ -2967,28 +3041,31 @@ int  wolfSSL_dtls_set_timeout_init(WOLFSSL* ssl, int);
     ...
     int ret = wolfSSL_dtls_set_timeout_max(ssl);
     if(!ret){
-    	// Failed to set the max timeout
+    	// 最大タイムアウトの設定に失敗
     }
     \endcode
+
     \sa wolfSSL_dtls_set_timeout_init
     \sa wolfSSL_dtls_got_timeout
 */
 int  wolfSSL_dtls_set_timeout_max(WOLFSSL* ssl, int);
 
 /*!
-    \brief  DTLSでノンブロッキングソケットを使用する場合、この関数は送信がタイムアウトしたと考えられる場合に呼び出される必要があります。
-    タイムアウト値の調整など、最後の送信を再試行するために必要なアクションを実行します。 時間がかかりすぎると、失敗が返されます。
+    \brief DTLSでノンブロッキングソケットを使用する場合、制御コードが送信がタイムアウトしたと判断したときに、この関数をWOLFSSLオブジェクトに対して呼び出す必要があります。この関数は、タイムアウト値の調整を含め、最後の送信を再試行するために必要なアクションを実行します。時間が経過しすぎた場合、失敗が返されます。
 
-    \return SSL_SUCCESS  成功時に戻ります
-    \return SSL_FATAL_ERROR  ピアからの応答を得ることなく、再送信/タイムアウトが多すぎる場合に返されます。
-    \return NOT_COMPILED_IN wolfSSLがDTLSサポートでコンパイルされていない場合に返されます。
+    \return SSL_SUCCESS 成功時に返されます。
+    \return SSL_FATAL_ERROR ピアからの応答なしで再送信またはタイムアウトが多すぎた場合に返されます。
+    \return NOT_COMPILED_IN wolfSSLがDTLSサポート付きでコンパイルされていない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
-    See the following files for usage examples:
+    使用例については以下のファイルを参照してください:
     <wolfssl_root>/examples/client/client.c
     <wolfssl_root>/examples/server/server.c
     \endcode
+
     \sa wolfSSL_dtls_get_current_timeout
     \sa wolfSSL_dtls_get_peer
     \sa wolfSSL_dtls_set_peer
@@ -2997,12 +3074,12 @@ int  wolfSSL_dtls_set_timeout_max(WOLFSSL* ssl, int);
 int  wolfSSL_dtls_got_timeout(WOLFSSL* ssl);
 
 /*!
-    \brief DTLSでノンブロッキングソケットを使用する場合、この関数は予想されるタイムアウト値と再送信回数を無視して最後のハンドシェイクフライトを再送信します。
-    これは、DTLSを使用しており、タイムアウトや再試行回数も管理する必要があるアプリケーションに役立ちます。
+    \brief DTLSでノンブロッキングソケットを使用する場合、この関数は予想されるタイムアウト値と再送信カウントを無視して、最後のハンドシェイクフライトを再送信します。これは、DTLSを使用していて、タイムアウトと再試行回数さえも管理する必要があるアプリケーションに役立ちます。
 
-    \return SSL_SUCCESS 成功時に戻ります
-    \return SSL_FATAL_ERROR ピアからの応答が得られないまま再送信/タイムアウトが多すぎる場合に返されます。
-    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \return SSL_SUCCESS 成功時に返されます。
+    \return SSL_FATAL_ERROR ピアからの応答なしで再送信またはタイムアウトが多すぎた場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -3019,9 +3096,12 @@ int  wolfSSL_dtls_got_timeout(WOLFSSL* ssl);
 int wolfSSL_dtls_retransmit(WOLFSSL* ssl);
 
 /*!
-    \brief  DTLSを使用するように構成されているかどうかを取得します。
-    \return 1  SSLセッション（SSL）がDTLSを使用するように設定されている場合、この関数は1を返します。
-    \return 0  そうでない場合に返されます。
+    \brief この関数は、SSLセッションがDTLSを使用するように設定されているかどうかを判定するために使用されます。
+
+    \return 1 SSLセッション(ssl)がDTLSを使用するように設定されている場合、この関数は1を返します。
+    \return 0 それ以外の場合。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -3030,9 +3110,10 @@ int wolfSSL_dtls_retransmit(WOLFSSL* ssl);
     ...
     ret = wolfSSL_dtls(ssl);
     if (ret) {
-    	// SSL session has been configured to use DTLS
+    	// SSLセッションはDTLSを使用するように設定されている
     }
     \endcode
+
     \sa wolfSSL_dtls_get_current_timeout
     \sa wolfSSL_dtls_get_peer
     \sa wolfSSL_dtls_got_timeout
@@ -3041,13 +3122,15 @@ int wolfSSL_dtls_retransmit(WOLFSSL* ssl);
 int  wolfSSL_dtls(WOLFSSL* ssl);
 
 /*!
-    \brief  この関数は引数peerで与えられるアドレスをDTLSのピアとしてセットします。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  失敗時に返されます。
-    \return SSL_NOT_IMPLEMENTED  wolfSSLがDTLSをサポートするようにコンパイルされていない場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param peer  ピアのアドレスを含むsockaddr_in構造体へのポインタ。
-    \param peerSz sockaddr_in構造体のサイズ。0が指定された場合にはsslに設定されているピアの情報をクリアします。
+    \brief この関数は、DTLSピアpeer(sockaddr_in)をサイズpeerSzで設定します。
+
+    \return SSL_SUCCESS 成功時に返されます。
+    \return SSL_FAILURE 失敗時に返されます。
+    \return SSL_NOT_IMPLEMENTED wolfSSLがDTLSサポート付きでコンパイルされていない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param peer ピアのsockaddr_in構造体へのポインタ。NULLの場合、ssl内のピア情報がクリアされます。
+    \param peerSz peerが指すsockaddr_in構造体のサイズ。0の場合、ssl内のピア情報がクリアされます。
 
     _Example_
     \code
@@ -3057,10 +3140,12 @@ int  wolfSSL_dtls(WOLFSSL* ssl);
     ...
     ret = wolfSSL_dtls_set_peer(ssl, &addr, sizeof(addr));
     if (ret != SSL_SUCCESS) {
-	    // failed to set DTLS peer
+	    // DTLSピアの設定に失敗
     }
     \endcode
+
     \sa wolfSSL_dtls_get_current_timeout
+    \sa wolfSSL_dtls_set_pending_peer
     \sa wolfSSL_dtls_get_peer
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls
@@ -3068,15 +3153,15 @@ int  wolfSSL_dtls(WOLFSSL* ssl);
 int  wolfSSL_dtls_set_peer(WOLFSSL* ssl, void* peer, unsigned int peerSz);
 
 /*!
-    \brief  この関数は、現在のDTLSピアのsockaddr_in(サイズpeerSz)を取得します。
-    この関数は、peerSzをSSLセッションに保存されている実際のDTLSピアサイズと比較します。
-    ピアアドレスがpeerに収まる場合は、peerSzがピアのサイズに設定されて、ピアのsockaddr_inがpeerにコピーされます。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  失敗時に返されます。
-    \return SSL_NOT_IMPLEMENTED  wolfSSLがDTLSをサポートするようにコンパイルされていない場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param peer  ピアのsockaddr_in構造体を保存するためのバッファへのポインタ。
-    \param peerSz サイズを格納する変数。入力時には引数peerで示されるバッファのサイズを指定してください。出力時には実際のsockaddr_in構造体のサイズを返します。
+    \brief この関数は、保留中のDTLSピアpeer(sockaddr_in)をサイズpeerSzで設定します。これにより、次のレコードの保護を正常に解除したときに通常のピアにアップグレードされる保留中のピアが設定されます。これは、ピアのアドレスが変更される可能性があるシナリオで、オフパス攻撃者がピアアドレスを変更するのを防ぐのに役立ちます。これは、新しいピアアドレスへのシームレスで安全な移行を可能にするために、Connection IDと共に使用する必要があります。
+
+    \return SSL_SUCCESS 成功時に返されます。
+    \return SSL_FAILURE 失敗時に返されます。
+    \return SSL_NOT_IMPLEMENTED wolfSSLがDTLSサポート付きでコンパイルされていない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param peer ピアのsockaddr_in構造体へのポインタ。NULLの場合、ssl内のピア情報がクリアされます。
+    \param peerSz peerが指すsockaddr_in構造体のサイズ。0の場合、ssl内のピア情報がクリアされます。
 
     _Example_
     \code
@@ -3084,11 +3169,43 @@ int  wolfSSL_dtls_set_peer(WOLFSSL* ssl, void* peer, unsigned int peerSz);
     WOLFSSL* ssl;
     sockaddr_in addr;
     ...
-    ret = wolfSSL_dtls_get_peer(ssl, &addr, sizeof(addr));
+    ret = wolfSSL_dtls_set_pending_peer(ssl, &addr, sizeof(addr));
     if (ret != SSL_SUCCESS) {
-	    // failed to get DTLS peer
+	    // DTLSピアの設定に失敗
     }
     \endcode
+
+    \sa wolfSSL_dtls_get_current_timeout
+    \sa wolfSSL_dtls_set_peer
+    \sa wolfSSL_dtls_get_peer
+    \sa wolfSSL_dtls_got_timeout
+    \sa wolfSSL_dtls
+*/
+int  wolfSSL_dtls_set_pending_peer(WOLFSSL* ssl, void* peer,
+                                   unsigned int peerSz);
+
+/*!
+    \brief この関数は、現在のDTLSピアのsockaddr_in(サイズpeerSz)を取得します。この関数はpeerSzを、SSLセッションに格納されている実際のDTLSピアサイズと比較します。ピアがpeerに収まる場合、ピアのsockaddr_inがpeerにコピーされ、peerSzがpeerのサイズに設定されます。
+
+    \return SSL_SUCCESS 成功時に返されます。
+    \return SSL_FAILURE 失敗時に返されます。
+    \return SSL_NOT_IMPLEMENTED wolfSSLがDTLSサポート付きでコンパイルされていない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param peer ピアのsockaddr_in構造体を格納するメモリ位置へのポインタ。
+    \param peerSz 入出力サイズ。入力として、peerが指す割り当てられたメモリのサイズ。出力として、peerが指す実際のsockaddr_in構造体のサイズ。
+
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl;
+    sockaddr_in addr;
+    ...    ret = wolfSSL_dtls_get_peer(ssl, &addr, sizeof(addr));
+    if (ret != SSL_SUCCESS) {
+	    // DTLSピアの取得に失敗しました
+    }
+    \endcode
+
     \sa wolfSSL_dtls_get_current_timeout
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls_set_peer
@@ -3097,15 +3214,47 @@ int  wolfSSL_dtls_set_peer(WOLFSSL* ssl, void* peer, unsigned int peerSz);
 int  wolfSSL_dtls_get_peer(WOLFSSL* ssl, void* peer, unsigned int* peerSz);
 
 /*!
+    \brief この関数は現在のDTLSピアのsockaddr_in（サイズpeerSz）を取得します。これはwolfSSL_dtls_get_peer()のゼロコピー代替です。
+
+    \return SSL_SUCCESS 成功時に返されます。
+    \return SSL_FAILURE 失敗時に返されます。
+    \return SSL_NOT_IMPLEMENTED wolfSSLがDTLSサポートでコンパイルされていない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param peer ピアアドレスを保持する内部バッファを返すためのポインタ。
+    \param peerSz peerが指す実際のsockaddr_in構造体のサイズを出力します。
+
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl;
+    sockaddr_in* addr;
+    unsigned int addrSz;
+    ...
+    ret = wolfSSL_dtls_get_peer(ssl, &addr, &addrSz);
+    if (ret != SSL_SUCCESS) {
+	    // DTLSピアの取得に失敗しました
+    }
+    \endcode
+
+    \sa wolfSSL_dtls_get_current_timeout
+    \sa wolfSSL_dtls_got_timeout
+    \sa wolfSSL_dtls_set_peer
+    \sa wolfSSL_dtls
+*/
+int  wolfSSL_dtls_get0_peer(WOLFSSL* ssl, const void** peer,
+                            unsigned int* peerSz);
+
+/*!
     \ingroup Debug
-    \brief  この関数は、wolfSSL_get_error()によって返されたエラーコードをより人間が読めるエラー文字列に変換します。
-    引数errNumberは、wolfSSL_get_error()によって返され、引数dataはエラー文字列が配置されるバッファへのポインタです。
-    MAX_ERROR_SZで定義されているように、データの最大長はデフォルトで80文字です。
-    これはwolfssl/wolfcrypt/error.hで定義されています。
-    \return success  正常に完了すると、この関数はdataに返されるのと同じ文字列を返します。
-    \return failure  失敗すると、この関数は適切な障害理由、MSGを持つ文字列を返します。
-    \param errNumber  wolfSSL_get_error()によって返されたエラーコード。
-    \param data 人間が読めるエラー文字列を格納したバッファへのポインタ
+
+    \brief この関数はwolfSSL_get_error()によって返されたエラーコードを、より人間が読みやすいエラー文字列に変換します。errNumberはwolfSSL_get_error()によって返されたエラーコードであり、dataはエラー文字列が配置される格納バッファです。dataの最大長はデフォルトで80文字であり、wolfssl/wolfcrypt/error.hのMAX_ERROR_SZで定義されています。
+
+    \return success 正常に完了した場合、この関数はdataで返されるのと同じ文字列を返します。
+    \return failure 失敗時には、この関数は適切な失敗理由msgを含む文字列を返します。
+
+    \param errNumber wolfSSL_get_error()によって返されたエラーコード。
+    \param data errNumberに一致する人間が読みやすいエラー文字列を含む出力バッファ。
 
     _Example_
     \code
@@ -3115,8 +3264,9 @@ int  wolfSSL_dtls_get_peer(WOLFSSL* ssl, void* peer, unsigned int* peerSz);
     ...
     err = wolfSSL_get_error(ssl, 0);
     wolfSSL_ERR_error_string(err, buffer);
-    printf(“err = %d, %s\n”, err, buffer);
+    printf("err = %d, %s\n", err, buffer);
     \endcode
+
     \sa wolfSSL_get_error
     \sa wolfSSL_ERR_error_string_n
     \sa wolfSSL_ERR_print_errors_fp
@@ -3126,15 +3276,14 @@ char* wolfSSL_ERR_error_string(unsigned long errNumber, char* data);
 
 /*!
     \ingroup Debug
-    \brief  この関数は、wolfssl_err_error_string()のバッファのサイズを指定するバージョンです。
-    ここで、引数lenは引数bufに書き込まれ得る最大文字数を指定します。
-    wolfSSL_err_error_string()と同様に、この関数はwolfSSL_get_error()から返されたエラーコードをより人間が読めるエラー文字列に変換します。
-    人間が読める文字列はbufに置かれます。
-    \return なし
-    \param e  wolfSSL_get_error()によって返されたエラーコード。
-    \param buff  eと一致する人間が読めるエラー文字列を含む出力バッファ。
-    \param len 出力バッファのサイズ
 
+    \brief この関数はwolfSSL_ERR_error_string()のバージョンであり、lenはbufに書き込まれる最大文字数を指定します。wolfSSL_ERR_error_string()と同様に、この関数はwolfSSL_get_error()から返されたエラーコードをより人間が読みやすいエラー文字列に変換します。人間が読みやすい文字列はbufに配置されます。
+
+    \return none 返り値はありません。
+
+    \param e wolfSSL_get_error()によって返されたエラーコード。
+    \param buff eに一致する人間が読みやすいエラー文字列を含む出力バッファ。
+    \param len bufに書き込まれる最大文字数。
 
     _Example_
     \code
@@ -3144,60 +3293,68 @@ char* wolfSSL_ERR_error_string(unsigned long errNumber, char* data);
     ...
     err = wolfSSL_get_error(ssl, 0);
     wolfSSL_ERR_error_string_n(err, buffer, 80);
-    printf(“err = %d, %s\n”, err, buffer);
+    printf("err = %d, %s\n", err, buffer);
     \endcode
+
     \sa wolfSSL_get_error
     \sa wolfSSL_ERR_error_string
     \sa wolfSSL_ERR_print_errors_fp
     \sa wolfSSL_load_error_strings
 */
 void  wolfSSL_ERR_error_string_n(unsigned long e, char* buf,
-                                           unsigned long sz);
+                                           unsigned long len);
 
 /*!
     \ingroup TLS
-    \brief  この関数は、Options構造体のcloseNotifyまたはconnResetまたはsentNotifyメンバーのシャットダウン条件をチェックします。
-    Options構造体はWOLFSSL構造体内にあります。
-    \return 1  SSL_SENT_SHUTDOWNが返されます。
-    \return 2  SSL_RECEIVED_SHUTDOWNが返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数はOptions構造体のcloseNotify、connReset、またはsentNotifyメンバのシャットダウン条件をチェックします。Options構造体はWOLFSSL構造体内にあります。
+
+    \return 1 SSL_SENT_SHUTDOWNが返されます。
+    \return 2 SSL_RECEIVED_SHUTDOWNが返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体への定数ポインタ。
 
     _Example_
     \code
     #include <wolfssl/ssl.h>
 
-    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new( protocol method );
     WOLFSSL* ssl = WOLFSSL_new(ctx);
     …
     int ret;
     ret = wolfSSL_get_shutdown(ssl);
 
     if(ret == 1){
-	    SSL_SENT_SHUTDOWN
+	    // SSL_SENT_SHUTDOWN
     } else if(ret == 2){
-	    SSL_RECEIVED_SHUTDOWN
+	    // SSL_RECEIVED_SHUTDOWN
     } else {
-	    Fatal error.
+	    // 致命的エラー。
     }
     \endcode
+
     \sa wolfSSL_SESSION_free
 */
 int  wolfSSL_get_shutdown(const WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  この関数は、オプション構造体の再開メンバを返します。フラグはセッションを再利用するかどうかを示します。そうでなければ、新しいセッションを確立する必要があります。
-    \return This  関数セッションの再利用のフラグを表すオプション構造に保持されているint型を返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数はoptions構造体のresumingメンバを返します。このフラグはセッションを再利用するかどうかを示します。再利用しない場合、新しいセッションを確立する必要があります。
+
+    \return この関数はセッション再利用のフラグを表すOptions構造体に保持されたint型を返します。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
     WOLFSSL* ssl = wolfSSL_new(ctx);
     …
     if(!wolfSSL_session_reused(sslResume)){
-	    // No session reuse allowed.
+	    // セッション再利用は許可されていません。
     }
     \endcode
+
     \sa wolfSSL_SESSION_free
     \sa wolfSSL_GetSessionIndex
     \sa wolfSSL_memsave_session_cache
@@ -3206,12 +3363,15 @@ int  wolfSSL_session_reused(WOLFSSL* ssl);
 
 /*!
     \ingroup TLS
-    \brief  この関数は、接続が確立されているかどうかを確認します。
-    \return 0  接続が確立されていない場合、すなわちWolfSSL構造体がNULLまたはハンドシェイクが行われていない場合に返されます。
-    \return 1  接続が確立されていない場合は返されます.WolfSSL構造体はNULLまたはハンドシェイクが行われていません。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
 
-    _Example_
+    \brief この関数は接続が確立されているかどうかをチェックします。
+
+    \return 0 接続が確立されていない場合に返されます、つまりWOLFSSL構造体がNULLまたはハンドシェイクが完了していない場合。
+    \return 1 接続が確立されている場合に返されます、つまりWOLFSSLハンドシェイクが完了している場合。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
+    _EXAMPLE_
     \code
     #include <wolfssl/ssl.h>
 
@@ -3219,9 +3379,10 @@ int  wolfSSL_session_reused(WOLFSSL* ssl);
     WOLFSSL* ssl = wolfSSL_new(ctx);
     ...
     if(wolfSSL_is_init_finished(ssl)){
-	    Handshake is done and connection is established
+	    // ハンドシェイクが完了し、接続が確立されています
     }
     \endcode
+
     \sa wolfSSL_set_accept_state
     \sa wolfSSL_get_keys
     \sa wolfSSL_set_shutdown
@@ -3230,52 +3391,60 @@ int  wolfSSL_is_init_finished(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  文字列として使用されているSSLバージョンを返します。
-    \return "SSLv3"  SSLv3を使う
-    \return "TLSv1"  TLSV1を使用する
-    \return "TLSv1.1"  TLSV1.1を使用する
-    \return "TLSv1.2"  TLSV1.2を使用する
-    \return "TLSv1.3"  TLSV1.3を使用する
-    \return "DTLS":  DTLSを使う
-    \return "DTLSv1.2"  DTLSV1.2を使用する
-    \return "unknown"  どのバージョンのTLSが使用されているかを判断するという問題がありました。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief 使用されているSSLバージョンを文字列として返します。
+
+    \return "SSLv3" SSLv3を使用しています
+    \return "TLSv1" TLSv1を使用しています
+    \return "TLSv1.1" TLSv1.1を使用しています
+    \return "TLSv1.2" TLSv1.2を使用しています
+    \return "TLSv1.3" TLSv1.3を使用しています
+    \return "DTLS" DTLSを使用しています
+    \return "DTLSv1.2" DTLSv1.2を使用しています
+    \return "unknown" 使用されているTLSのバージョンを判定する際に問題が発生しました。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
     wolfSSL_Init();
     WOLFSSL_CTX* ctx;
     WOLFSSL* ssl;
-    WOLFSSL_METHOD method = // Some wolfSSL method
+    WOLFSSL_METHOD method = // 何らかのwolfSSLメソッド
     ctx = wolfSSL_CTX_new(method);
     ssl = wolfSSL_new(ctx);
     printf(wolfSSL_get_version("Using version: %s", ssl));
     \endcode
+
     \sa wolfSSL_lib_version
 */
 const char*  wolfSSL_get_version(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  SSLセッションで現在の暗号スイートを返します。
-    \return ssl->options.cipherSuite  現在の暗号スイートを表す整数。
-    \return 0  提供されているSSLセッションはNULLです。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief sslセッションが使用している現在の暗号スイートを返します。
+
+    \return ssl->options.cipherSuite 現在の暗号スイートを表す整数。
+    \return 0 提供されたsslセッションがnullです。
+
+    \param ssl チェックするSSLセッション。
 
     _Example_
     \code
     wolfSSL_Init();
     WOLFSSL_CTX* ctx;
     WOLFSSL* ssl;
-    WOLFSSL_METHOD method = // Some wolfSSL method
+    WOLFSSL_METHOD method = // 何らかのwolfSSLメソッド
     ctx = wolfSSL_CTX_new(method);
     ssl = wolfSSL_new(ctx);
 
     if(wolfSSL_get_current_cipher_suite(ssl) == 0)
     {
-        // Error getting cipher suite
+        // 暗号スイートの取得エラー
     }
     \endcode
+
     \sa wolfSSL_CIPHER_get_name
     \sa wolfSSL_get_current_cipher
     \sa wolfSSL_get_cipher_list
@@ -3284,10 +3453,13 @@ int  wolfSSL_get_current_cipher_suite(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  この関数は、SSLセッションの現在の暗号へのポインタを返します。
-    \return The  関数WolfSSL構造体の暗号メンバーのアドレスを返します。これはwolfssl_icipher構造へのポインタです。
-    \return NULL  WolfSSL構造がNULLの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数はsslセッション内の現在の暗号へのポインタを返します。
+
+    \return この関数はWOLFSSL構造体のcipherメンバのアドレスを返します。これはWOLFSSL_CIPHER構造体へのポインタです。
+    \return NULL WOLFSSL構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -3297,11 +3469,12 @@ int  wolfSSL_get_current_cipher_suite(WOLFSSL* ssl);
     WOLFSSL_CIPHER* cipherCurr = wolfSSL_get_current_cipher;
 
     if(!cipherCurr){
-    	// Failure case.
+    	// 失敗ケース。
     } else {
-    	// The cipher was returned to cipherCurr
+    	// 暗号がcipherCurrに返されました
     }
     \endcode
+
     \sa wolfSSL_get_cipher
     \sa wolfSSL_get_cipher_name_internal
     \sa wolfSSL_get_cipher_name
@@ -3310,14 +3483,17 @@ WOLFSSL_CIPHER*  wolfSSL_get_current_cipher(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  この関数は、SSLオブジェクト内のCipher Suiteと使用可能なスイートと一致し、文字列表現を返します。
-    \return string  この関数は、一致した暗号スイートの文字列表現を返します。
-    \return none  スイートが一致していない場合は「なし」を返します。
-    \param cipher WOLFSSL_CIPHER構造体へのポインタ
+
+    \brief この関数はSSLオブジェクト内の暗号スイートを利用可能なスイートと照合し、文字列表現を返します。
+
+    \return string この関数は一致した暗号スイートの文字列表現を返します。
+    \return none 一致するスイートがない場合は"None"を返します。
+
+    \param cipher WOLFSSL_CIPHER構造体への定数ポインタ。
 
     _Example_
     \code
-    // gets cipher name in the format DHE_RSA ...
+    // DHE_RSA ...の形式で暗号名を取得します
     const char* wolfSSL_get_cipher_name_internal(WOLFSSL* ssl){
 	WOLFSSL_CIPHER* cipher;
 	const char* fullName;
@@ -3326,9 +3502,10 @@ WOLFSSL_CIPHER*  wolfSSL_get_current_cipher(WOLFSSL* ssl);
 	fullName = wolfSSL_CIPHER_get_name(cipher);
 
 	if(fullName){
-		// sanity check on returned cipher
+		// 返された暗号の健全性チェック
 	}
     \endcode
+
     \sa wolfSSL_get_cipher
     \sa wolfSSL_get_current_cipher
     \sa wolfSSL_get_cipher_name_internal
@@ -3338,55 +3515,54 @@ const char*  wolfSSL_CIPHER_get_name(const WOLFSSL_CIPHER* cipher);
 
 /*!
     \ingroup IO
-    \brief  この関数は、SSLオブジェクト内の暗号スイートと使用可能なスイートと一致します。
-    \return This  関数Suiteが一致させたString値を返します。スイートが一致していない場合は「なし」を返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数はSSLオブジェクト内の暗号スイートを利用可能なスイートと照合します。
+
+    \return この関数は一致したスイートの文字列値を返します。一致するスイートがない場合は"None"を返します。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
     #ifdef WOLFSSL_DTLS
     …
-    // make sure a valid suite is used
+    // 有効なスイートが使用されていることを確認
     if(wolfSSL_get_cipher(ssl) == NULL){
-	    WOLFSSL_MSG(“Can not match cipher suite imported”);
+	    WOLFSSL_MSG("インポートされた暗号スイートと一致しません");
 	    return MATCH_SUITE_ERROR;
     }
     …
     #endif // WOLFSSL_DTLS
     \endcode
+
     \sa wolfSSL_CIPHER_get_name
     \sa wolfSSL_get_current_cipher
 */
-const char*  wolfSSL_get_cipher(WOLFSSL* ssl);
+const char*  wolfSSL_get_cipher(WOLFSSL*);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、WOLFSSL構造体からWOLFSSL_SESSIONを参照型として返します。
-    これには、wolfSSL_SESSION_freeを呼び出してセッション参照を解除する必要があります。
-    WOLFSSL_SESSIONは、セッションの再開を実行するために必要なすべての必要な情報を含み、新しいハンドシェイクなしで接続を再確立します。
-    セッションの再開の場合、wolfSSL_shutdown()をセッションオブジェクトに呼び出す前に、アプリケーションはオブジェクトからwolfssl_get1_session()を呼び出して保存する必要があります。
-    これはセッションへのポインタを返します。
-    その後、アプリケーションは新しいWOLFSSLオブジェクトを作成し、保存したセッションをwolfssl_set_session()に割り当てる必要があります。
-    この時点で、アプリケーションはwolfssl_connect()を呼び出し、WolfSSLはセッションを再開しようとします。
-    WolfSSLサーバーコードでは、デフォルトでセッションの再開を許可します。
-    wolfssl_get1_session()によって返されたオブジェクトは、アプリケーションが使用後は解放される必要があります。
-    \return WOLFSSL_SESSION  成功の場合はセッションポインタを返します。
-    \return NULL  sslがNULLの場合、SSLセッションキャッシュが無効になっている場合、WolfSSLはセッションIDを使用できない、またはミューテックス関数が失敗します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数はWOLFSSL構造体からWOLFSSL_SESSIONを参照型として返します。これにはwolfSSL_SESSION_freeを呼び出してセッション参照を解放する必要があります。指されるWOLFSSL_SESSIONには、セッション再開を実行し、新しいハンドシェイクなしで接続を再確立するために必要なすべての情報が含まれています。セッション再開のために、セッションオブジェクトでwolfSSL_shutdown()を呼び出す前に、アプリケーションはwolfSSL_get1_session()の呼び出しでオブジェクトからセッションIDを保存する必要があります、これはセッションへのポインタを返します。後で、アプリケーションは新しいWOLFSSLオブジェクトを作成し、wolfSSL_set_session()で保存されたセッションを割り当てる必要があります。この時点で、アプリケーションはwolfSSL_connect()を呼び出すことができ、wolfSSLはセッションの再開を試みます。wolfSSLサーバーコードはデフォルトでセッション再開を許可します。wolfSSL_get1_session()によって返されたオブジェクトは、アプリケーションが使用を終えた後、wolfSSL_SESSION_free()を呼び出すことによって解放する必要があります。
+
+    \return WOLFSSL_SESSION 成功時にセッションポインタを返します。
+    \return NULL sslがNULL、SSLセッションキャッシュが無効、wolfSSLがセッションIDを利用できない、またはmutex関数が失敗した場合に返されます。
+
+    \param ssl セッションを取得するWOLFSSL構造体。
 
     _Example_
     \code
     WOLFSSL* ssl;
-    WOLFSSL_SESSION* ses;
-    // attempt/complete handshake
+    WOLFSSL_SESSION* ses;    // ハンドシェイクを試行/完了
     wolfSSL_connect(ssl);
     ses  = wolfSSL_get1_session(ssl);
-    // check ses information
-    // disconnect / setup new SSL instance
+    // ses情報を確認
+    // 切断/新しいSSLインスタンスをセットアップ
     wolfSSL_set_session(ssl, ses);
-    // attempt/resume handshake
+    // ハンドシェイクを試行/再開
     wolfSSL_SESSION_free(ses);
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
     \sa wolfSSL_SESSION_free
@@ -3395,9 +3571,13 @@ WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  wolfsslv23_client_method()関数は、アプリケーションがクライアントであることを示すために使用され、SSL 3.0~TLS 1.3の間でサーバーでサポートされている最高のプロトコルバージョンをサポートします。この関数は、wolfSSL_CTX_new()を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。WolfSSLクライアントとサーバーの両方が堅牢なバージョンのダウングレード機能を持っています。特定のプロトコルバージョンメソッドがどちらの側で使用されている場合は、そのバージョンのみがネゴシエートされたり、エラーが返されます。たとえば、TLSV1を使用し、SSLv3のみに接続しようとするクライアントは、TLSV1.1に接続しても失敗します。この問題を解決するために、wolfsslv23_client_method()関数を使用するクライアントは、サーバーでサポートされている最高のプロトコルバージョンを使用し、必要に応じてSSLv3にダウングレードします。この場合、クライアントはSSLv3  -  TLSv1.3を実行しているサーバーに接続できるようになります。
-    \return pointer  成功すると、wolfssl_methodへのポインタが返されます。
-    \return Failure  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがENOMEMに設定されます）。
+
+    \brief wolfSSLv23_client_method()関数は、アプリケーションがクライアントであり、SSL 3.0からTLS 1.3までの間でサーバがサポートする最も高いプロトコルバージョンをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいWOLFSSL_METHOD構造体のためのメモリを割り当て、初期化します。wolfSSLのクライアントとサーバの両方は、堅牢なバージョンダウングレード機能を持っています。どちらか一方で特定のプロトコルバージョンメソッドが使用された場合、そのバージョンのみがネゴシエートされるか、エラーが返されます。例えば、TLSv1を使用するクライアントがSSLv3のみのサーバに接続しようとすると失敗し、同様にTLSv1.1への接続も失敗します。この問題を解決するために、wolfSSLv23_client_method()関数を使用するクライアントは、サーバがサポートする最も高いプロトコルバージョンを使用し、必要に応じてSSLv3までダウングレードします。この場合、クライアントはSSLv3からTLSv1.3までを実行しているサーバに接続できます。
+
+    \return pointer 成功時、WOLFSSL_METHODへのポインタ。
+    \return Failure XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
+
+    \param none パラメータなし。
 
     _Example_
     \code
@@ -3405,12 +3585,13 @@ WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
     WOLFSSL_CTX* ctx;
     method = wolfSSLv23_client_method();
     if (method == NULL) {
-	// unable to get method
+	    // メソッドを取得できませんでした
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_client_method
     \sa wolfTLSv1_client_method
     \sa wolfTLSv1_1_client_method
@@ -3423,11 +3604,14 @@ WOLFSSL_METHOD* wolfSSLv23_client_method(void);
 
 /*!
     \ingroup IO
-    \brief  この関数は、内部メモリバッファの先頭へのバイトポインタを設定するために使用されます。
-    \return size  成功すると、バッファのサイズが返されます
-    \return SSL_FATAL_ERROR  エラーケースに遭遇した場合
-    \param bio  のメモリバッファを取得するためのWOLFSSL_BIO構造体。
-    \param p メモリバッファへのポインタ。
+
+    \brief これは、内部メモリバッファの先頭にバイトポインタを設定するために使用されます。
+
+    \return size 成功時、バッファのサイズが返されます。
+    \return SSL_FATAL_ERROR エラーケースが発生した場合。
+
+    \param bio メモリバッファを取得するWOLFSSL_BIO構造体。
+    \param p メモリバッファに設定するバイトポインタ。
 
     _Example_
     \code
@@ -3436,8 +3620,9 @@ WOLFSSL_METHOD* wolfSSLv23_client_method(void);
     int ret;
     bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
     ret  = wolfSSL_BIO_get_mem_data(bio, &p);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_mem
     \sa wolfSSL_BIO_set_fp
@@ -3447,19 +3632,23 @@ int wolfSSL_BIO_get_mem_data(WOLFSSL_BIO* bio,void* p);
 
 /*!
     \ingroup IO
-    \brief  使用するBIOのファイル記述子を設定します。
-    \return SSL_SUCCESS(1)  成功時に返されます。
-    \param bio  FDを設定するためのWOLFSSL_BIO構造。
-    \param fd  使用するファイル記述子。
-    \param closeF fdをクローズする際のふるまいを指定するフラグ
+
+    \brief bioが使用するファイルディスクリプタを設定します。
+
+    \return SSL_SUCCESS(1) 成功時。
+
+    \param bio fdを設定するWOLFSSL_BIO構造体。
+    \param fd 使用するファイルディスクリプタ。
+    \param closeF fdをクローズする際の動作フラグ。
 
     _Example_
     \code
     WOLFSSL_BIO* bio;
     int fd;
-    // setup bio
+    // bioをセットアップ
     wolfSSL_BIO_set_fd(bio, fd, BIO_NOCLOSE);
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_free
 */
@@ -3467,17 +3656,21 @@ long wolfSSL_BIO_set_fd(WOLFSSL_BIO* b, int fd, int flag);
 
 /*!
     \ingroup IO
-    \brief  BIOが解放されたときにI/Oストリームを閉じる必要があることを示すために使用されるクローズフラグを設定します。
-    \return SSL_SUCCESS(1)  成功時に返されます。
-    \param bio  WOLFSSL_BIO構造体。
-    \param flag I/Oストリームを閉じる必要があることを示すために使用されるクローズフラグ
+
+    \brief クローズフラグを設定します。これは、BIOが解放される際にI/Oストリームをクローズすべきかを示すために使用されます。
+
+    \return SSL_SUCCESS(1) 成功時。
+
+    \param bio WOLFSSL_BIO構造体。
+    \param flag I/Oストリームをクローズする際の動作フラグ。
 
     _Example_
     \code
     WOLFSSL_BIO* bio;
-    // setup bio
+    // bioをセットアップ
     wolfSSL_BIO_set_close(bio, BIO_NOCLOSE);
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_free
 */
@@ -3485,14 +3678,19 @@ int wolfSSL_BIO_set_close(WOLFSSL_BIO *b, long flag);
 
 /*!
     \ingroup IO
-    \brief  この関数はBIO_SOCKETタイプのWOLFSSL_BIO_METHODを取得するために使用されます。
-    \return WOLFSSL_BIO_METHOD  ソケットタイプであるWOLFSSL_BIO_METHOD構造体へのポインタ
+
+    \brief これは、BIO_SOCKETタイプのWOLFSSL_BIO_METHODを取得するために使用されます。
+
+    \return WOLFSSL_BIO_METHOD ソケットタイプであるWOLFSSL_BIO_METHOD構造体へのポインタ。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     WOLFSSL_BIO* bio;
     bio = wolfSSL_BIO_new(wolfSSL_BIO_s_socket);
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_mem
 */
@@ -3500,13 +3698,14 @@ WOLFSSL_BIO_METHOD *wolfSSL_BIO_s_socket(void);
 
 /*!
     \ingroup IO
-    \brief  この関数は、WOLFSSL_BIOのライトバッファのサイズを設定するために使用されます。
-    書き込みバッファが以前に設定されている場合、この関数はサイズをリセットするときに解放されます。
-    読み書きインデックスを0にリセットするという点で、wolfSSL_BIO_resetに似ています。
-    \return SSL_SUCCESS  書き込みバッファの設定に成功しました。
-    \return SSL_FAILURE  エラーケースに遭遇した場合
-    \param bio  FDを設定するためのWOLFSSL_BIO構造。
-    \param size バッファサイズ
+
+    \brief これは、WOLFSSL_BIOの書き込みバッファのサイズを設定するために使用されます。書き込みバッファが以前に設定されていた場合、この関数はサイズをリセットする際にそれを解放します。これは、読み取りと書き込みのインデックスを0にリセットする点でwolfSSL_BIO_resetに似ています。
+
+    \return SSL_SUCCESS 書き込みバッファの設定に成功した場合。
+    \return SSL_FAILURE エラーケースが発生した場合。
+
+    \param bio fdを設定するWOLFSSL_BIO構造体。
+    \param size 割り当てるバッファのサイズ。
 
     _Example_
     \code
@@ -3514,8 +3713,9 @@ WOLFSSL_BIO_METHOD *wolfSSL_BIO_s_socket(void);
     int ret;
     bio = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
     ret = wolfSSL_BIO_set_write_buf_size(bio, 15000);
-    // check return value
+    // 戻り値を確認
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_mem
     \sa wolfSSL_BIO_free
@@ -3524,11 +3724,14 @@ int  wolfSSL_BIO_set_write_buf_size(WOLFSSL_BIO *b, long size);
 
 /*!
     \ingroup IO
-    \brief  これは2つのBIOSを一緒にペアリングするために使用されます。一対のBIOSは、2つの方法パイプと同様に、他方で読み取られることができ、その逆も同様である。BIOSの両方が同じスレッド内にあることが予想されます。この機能はスレッドセーフではありません。2つのBIOSのうちの1つを解放すると、両方ともペアになっています。書き込みバッファサイズが以前に設定されていない場合、それはペアになる前に17000（wolfssl_bio_size）のデフォルトサイズに設定されます。
-    \return SSL_SUCCESS  2つのBIOSをうまくペアリングします。
-    \return SSL_FAILURE  エラーケースに遭遇した場合
-    \param b1  ペアを設定するための第一のWOLFSSL_BIO構造体へのポインタ。
-    \param b2 第二ののWOLFSSL_BIO構造体へのポインタ。
+
+    \brief これは、2つのbioをペアにするために使用されます。ペアになったbioは双方向パイプのように動作し、一方への書き込みはもう一方から読み取ることができ、その逆も同様です。両方のbioが同じスレッドにあることが期待されます。この関数はスレッドセーフではありません。2つのbioのうちの1つを解放すると、両方のペアが解除されます。いずれかのbioに書き込みバッファサイズが以前に設定されていなかった場合、ペアになる前にデフォルトサイズの17000(WOLFSSL_BIO_SIZE)に設定されます。
+
+    \return SSL_SUCCESS 2つのbioのペア化に成功した場合。
+    \return SSL_FAILURE エラーケースが発生した場合。
+
+    \param b1 ペアを設定するWOLFSSL_BIO構造体。
+    \param b2 ペアを完成させる2番目のWOLFSSL_BIO構造体。
 
     _Example_
     \code
@@ -3538,8 +3741,9 @@ int  wolfSSL_BIO_set_write_buf_size(WOLFSSL_BIO *b, long size);
     bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_bio());
     bio2 = wolfSSL_BIO_new(wolfSSL_BIO_s_bio());
     ret = wolfSSL_BIO_make_bio_pair(bio, bio2);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_mem
     \sa wolfSSL_BIO_free
@@ -3548,10 +3752,13 @@ int  wolfSSL_BIO_make_bio_pair(WOLFSSL_BIO *b1, WOLFSSL_BIO *b2);
 
 /*!
     \ingroup IO
-    \brief  この関数は、読み取り要求フラグを0に戻すために使用されます。
-    \return SSL_SUCCESS  値を正常に設定します。
-    \return SSL_FAILURE  エラーケースに遭遇した場合
-    \param bio WOLFSSL_BIO構造体へのポインタ。
+
+    \brief これは、読み取り要求フラグを0に戻すために使用されます。
+
+    \return SSL_SUCCESS 値の設定に成功した場合。
+    \return SSL_FAILURE エラーケースが発生した場合。
+
+    \param bio 読み取り要求フラグを設定するWOLFSSL_BIO構造体。
 
     _Example_
     \code
@@ -3559,32 +3766,35 @@ int  wolfSSL_BIO_make_bio_pair(WOLFSSL_BIO *b1, WOLFSSL_BIO *b2);
     int ret;
     ...
     ret = wolfSSL_BIO_ctrl_reset_read_request(bio);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_BIO_new, wolfSSL_BIO_s_mem
     \sa wolfSSL_BIO_new, wolfSSL_BIO_free
 */
-int  wolfSSL_BIO_ctrl_reset_read_request(WOLFSSL_BIO * bio);
+int  wolfSSL_BIO_ctrl_reset_read_request(WOLFSSL_BIO *bio);
 
 /*!
     \ingroup IO
-    \bri f  この関数は、読み取り用のバッファポインタを取得するために使用されます。
-    wolfSSL_BIO_nreadとは異なり、内部読み取りインデックスは関数呼び出しから返されたサイズ分進みません。
-    返される値を超えて読み取ると、アレイの境界から読み出される可能性があります。
-    \return >=0  成功すると、読み取るバイト数を返します
-    \param bio  WOLFSSL_BIO構造体へのポインタ。
-    \param buf 読み取り用バッファへのポインタのポインタ
+
+    \brief これは、読み取り用のバッファポインタを取得するために使用されます。wolfSSL_BIO_nreadとは異なり、内部読み取りインデックスは関数呼び出しから返される数だけ進められません。返される値を超えて読み取ると、配列の境界外を読み取る結果になる可能性があります。
+
+    \return ＞=0 成功時、読み取るバイト数を返します。
+
+    \param bio 読み取るWOLFSSL_BIO構造体。
+    \param buf 読み取り配列の先頭に設定するポインタ。
 
     _Example_
     \code
     WOLFSSL_BIO* bio;
     char* bufPt;
     int ret;
-    // set up bio
-    ret = wolfSSL_BIO_nread0(bio, &bufPt); // read as many bytes as possible
-    // handle negative ret check
-    // read ret bytes from bufPt
+    // bioをセットアップ
+    ret = wolfSSL_BIO_nread0(bio, &bufPt); // 可能な限り多くのバイトを読み取り
+    // 負のret値を確認
+    // bufPtからretバイトを読み取り
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_nwrite0
 */
@@ -3592,15 +3802,15 @@ int  wolfSSL_BIO_nread0(WOLFSSL_BIO *bio, char **buf);
 
 /*!
     \ingroup IO
-    \biieれは、この関数は、読み取り用のバッファポインタを取得するために使用されます。
-    内部読み取りインデックスは、読み取り元のバッファの先頭に指されているBUFを使用して、関数呼び出しから返されるサイズ分進みます。
-    数numで要求された値よりもバイトが少ない場合、より少ない値が返されます。
-    返される値を超えて読み取ると、アレイの境界から読み出される可能性があります。
-    \return >=0  成功すると、読み取るバイト数を返します
-    \return WOLFSSL_BIO_ERROR(-1)  Return -1を読むものではないエラーケースについて
-    \param bio  WOLFSSL_BIO構造体へのポインタ。
-    \param buf  読み取り配列の先頭に設定するポインタ。
-    \param num 読み取りサイズ
+
+    \brief これは、読み取り用のバッファポインタを取得するために使用されます。内部読み取りインデックスは、関数呼び出しから返される数だけ進められ、bufは読み取るバッファの先頭を指します。読み取りバッファ内のバイト数がnumで要求された値より少ない場合、より小さい値が返されます。返される値を超えて読み取ると、配列の境界外を読み取る結果になる可能性があります。
+
+    \return ＞=0 成功時、読み取るバイト数を返します。
+    \return WOLFSSL_BIO_ERROR(-1) 読み取るものがない場合のエラーケースで-1を返します。
+
+    \param bio 読み取るWOLFSSL_BIO構造体。
+    \param buf 読み取り配列の先頭に設定するポインタ。
+    \param num 読み取りを試みるバイト数。
 
     _Example_
     \code
@@ -3608,11 +3818,12 @@ int  wolfSSL_BIO_nread0(WOLFSSL_BIO *bio, char **buf);
     char* bufPt;
     int ret;
 
-    // set up bio
-    ret = wolfSSL_BIO_nread(bio, &bufPt, 10); // try to read 10 bytes
-    // handle negative ret check
-    // read ret bytes from bufPt
+    // bioをセットアップ
+    ret = wolfSSL_BIO_nread(bio, &bufPt, 10); // 10バイトの読み取りを試行
+    // 負のret値を確認
+    // bufPtからretバイトを読み取り
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_nwrite
 */
@@ -3620,25 +3831,28 @@ int  wolfSSL_BIO_nread(WOLFSSL_BIO *bio, char **buf, int num);
 
 /*!
     \ingroup IO
-    \brief  関数によって返される数のバイトを書き込むためにバッファーへのポインタを取得します。
-    返されるポインタに追加のバイトを書き込んだ場合、返された値は範囲外の書き込みにつながる可能性があります。
-    \return int  返されたバッファポインタに書き込むことができるバイト数を返します。
-    \return WOLFSSL_BIO_UNSET(-2)  バイオペアの一部ではない場合
-    \return WOLFSSL_BIO_ERROR(-1)  に書くべき部屋がこれ以上ない場合
-    \param bio  WOLFSSL_BIO構造に書き込む構造。
-    \param buf  書き込むためのバッファへのポインタ。
-    \param num 書き込みたいサイズ
+
+    \brief 関数が返す数だけのバイトを書き込むためのバッファへのポインタを取得します。返される値よりも多くのバイトを返されたポインタに書き込むと、境界外への書き込みになる可能性があります。
+
+    \return int バッファポインタに書き込むことができるバイト数を返します。
+    \return WOLFSSL_BIO_UNSET(-2) bioペアの一部ではない場合。
+    \return WOLFSSL_BIO_ERROR(-1) 書き込むスペースがこれ以上ない場合。
+
+    \param bio 書き込むWOLFSSL_BIO構造体。
+    \param buf 書き込むバッファへのポインタ。
+    \param num 書き込みたいバイト数。
 
     _Example_
     \code
     WOLFSSL_BIO* bio;
     char* bufPt;
     int ret;
-    // set up bio
-    ret = wolfSSL_BIO_nwrite(bio, &bufPt, 10); // try to write 10 bytes
-    // handle negative ret check
-    // write ret bytes to bufPt
+    // bioをセットアップ
+    ret = wolfSSL_BIO_nwrite(bio, &bufPt, 10); // 10バイトの書き込みを試行
+    // 負のret値を確認
+    // bufPtにretバイトを書き込み
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_free
     \sa wolfSSL_BIO_nread
@@ -3647,18 +3861,22 @@ int  wolfSSL_BIO_nwrite(WOLFSSL_BIO *bio, char **buf, int num);
 
 /*!
     \ingroup IO
-    \brief  バイオを初期状態にリセットします。タイプBIO_BIOの例として、これは読み書きインデックスをリセットします。
-    \return 0  バイオのリセットに成功しました。
-    \return WOLFSSL_BIO_ERROR(-1)  不良入力または失敗したリセットで返されます。
-    \param bio WOLFSSL_BIO構造体へのポインタ。
+
+    \brief bioを初期状態にリセットします。例えば、BIO_BIOタイプの場合、これは読み取りと書き込みのインデックスをリセットします。
+
+    \return 0 bioのリセットに成功した場合。
+    \return WOLFSSL_BIO_ERROR(-1) 不正な入力またはリセットに失敗した場合に返されます。
+
+    \param bio リセットするWOLFSSL_BIO構造体。
 
     _Example_
     \code
     WOLFSSL_BIO* bio;
-    // setup bio
+    // bioをセットアップ
     wolfSSL_BIO_reset(bio);
-    //use pt
+    //ptを使用
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_free
 */
@@ -3666,11 +3884,14 @@ int  wolfSSL_BIO_reset(WOLFSSL_BIO *bio);
 
 /*!
     \ingroup IO
-    \brief  この関数は、指定されたオフセットへファイルポインタを調整します。これはファイルの先頭からのオフセットです。
-    \return 0  正常に探しています。
-    \return -1  エラーケースに遭遇した場合
-    \param bio  設定するWOLFSSL_BIO構造体へのポインタ。
-    \param ofs ファイルの先頭からのオフセット
+
+    \brief この関数は、ファイルポインタを指定されたオフセットに調整します。これはファイルの先頭からのオフセットです。
+
+    \return 0 シークに成功した場合。
+    \return -1 エラーケースが発生した場合。
+
+    \param bio 設定するWOLFSSL_BIO構造体。
+    \param ofs ファイルへのオフセット。
 
     _Example_
     \code
@@ -3679,33 +3900,36 @@ int  wolfSSL_BIO_reset(WOLFSSL_BIO *bio);
     int ret;
     bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
     ret  = wolfSSL_BIO_set_fp(bio, &fp);
-    // check ret value
+    // ret値を確認
     ret  = wolfSSL_BIO_seek(bio, 3);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_mem
     \sa wolfSSL_BIO_set_fp
     \sa wolfSSL_BIO_free
 */
-int  wolfSSL_BIO_seek(WOLFSSL_BIO *bio, int ofs);
-
-/*!
+int  wolfSSL_BIO_seek(WOLFSSL_BIO *bio, int ofs);/*!
     \ingroup IO
-    \brief  これはファイルに設定および書き込むために使用されます。現在ファイル内のデータを上書きし、BIOが解放されたときにファイルを閉じるように設定されます。
-    \return SSL_SUCCESS  ファイルの開きと設定に成功しました。
-    \return SSL_FAILURE  エラーケースに遭遇した場合
-    \param bio  ファイルを設定するWOLFSSL_BIO構造体体。
-    \param name 書き込み先ファイル名へのポインタ
+
+    \brief ファイルを設定し、書き込むために使用されます。ファイル内の既存データを上書きし、bioが解放される際にファイルを閉じるよう設定されます。
+
+    \return SSL_SUCCESS ファイルのオープンと設定が成功した場合。
+    \return SSL_FAILURE エラーが発生した場合。
+
+    \param bio ファイルを設定するWOLFSSL_BIO構造体。
+    \param name 書き込み先のファイル名。
 
     _Example_
     \code
     WOLFSSL_BIO* bio;
     int ret;
     bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
-    ret  = wolfSSL_BIO_write_filename(bio, “test.txt”);
-    // check ret value
+    ret  = wolfSSL_BIO_write_filename(bio, "test.txt");
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_file
     \sa wolfSSL_BIO_set_fp
@@ -3715,10 +3939,13 @@ int  wolfSSL_BIO_write_filename(WOLFSSL_BIO *bio, char *name);
 
 /*!
     \ingroup IO
-    \brief  これはファイル値の終わりを設定するために使用されます。一般的な値は予想される正の値と混同されないように-1です。
-    \return 0  完了に戻りました
-    \param bio  ファイル値の終わりを設定するためのWOLFSSL_BIO構造体体。
-    \param v bioにセットする値。
+
+    \brief ファイル終端値を設定するために使用されます。一般的な値は-1で、期待される正の値と混同しないようにします。
+
+    \return 0 完了時に返されます。
+
+    \param bio ファイル終端値を設定するWOLFSSL_BIO構造体。
+    \param v bioに設定する値。
 
     _Example_
     \code
@@ -3726,8 +3953,9 @@ int  wolfSSL_BIO_write_filename(WOLFSSL_BIO *bio, char *name);
     int ret;
     bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
     ret  = wolfSSL_BIO_set_mem_eof_return(bio, -1);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_mem
     \sa wolfSSL_BIO_set_fp
@@ -3737,20 +3965,24 @@ long wolfSSL_BIO_set_mem_eof_return(WOLFSSL_BIO *bio, int v);
 
 /*!
     \ingroup IO
-    \brief  これはWolfSSL_BIOメモリポインタのゲッター関数です。
-    \return SSL_SUCCESS  ポインタSSL_SUCCESSを返す正常に（現在1の値）。
-    \return SSL_FAILURE  null引数が渡された場合（現在0の値）に渡された場合に返されます。
-    \param bio  メモリポインタを取得するためのWOLFSSL_BIO構造体へのポインタ。
-    \param ptr WOLFSSL_BUF_MEM構造体へのポインタ（現在はchar*となっている）
+
+    \brief WOLFSSL_BIOメモリポインタのgetter関数です。
+
+    \return SSL_SUCCESS ポインタの取得に成功した場合、SSL_SUCCESSが返されます(現在の値は1)。
+    \return SSL_FAILURE NULL引数が渡された場合に返されます(現在の値は0)。
+
+    \param bio メモリポインタを取得するためのWOLFSSL_BIO構造体へのポインタ。
+    \param ptr 現在char*である構造体。bioのメモリを指すように設定されます。
 
     _Example_
     \code
     WOLFSSL_BIO* bio;
     WOLFSSL_BUF_MEM* pt;
-    // setup bio
+    // bioをセットアップ
     wolfSSL_BIO_get_mem_ptr(bio, &pt);
-    //use pt
+    // ptを使用
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_mem
 */
@@ -3758,11 +3990,14 @@ long wolfSSL_BIO_get_mem_ptr(WOLFSSL_BIO *bio, WOLFSSL_BUF_MEM **m);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はX509の名前をバッファにコピーします。
-    \return A  WOLFSSL_X509_NAME構造名メンバーのデータが正常に実行された場合、nameメンバーのデータが返されます。
-    \param name  wolfssl_x509構造へのポインタ。
-    \param in  WOLFSSL_X509_NAME構造体からコピーされた名前を保持するためのバッファ。
-    \param sz バッファの最大サイズ
+
+    \brief この関数はx509の名前をバッファにコピーします。
+
+    \return 関数が正常に実行された場合、WOLFSSL_X509_NAME構造体のnameメンバーのデータを持つバッファへのcharポインタが返されます。
+
+    \param name WOLFSSL_X509構造体へのポインタ。
+    \param in WOLFSSL_X509_NAME構造体からコピーされた名前を保持するバッファ。
+    \param sz バッファの最大サイズ。
 
     _Example_
     \code
@@ -3772,9 +4007,10 @@ long wolfSSL_BIO_get_mem_ptr(WOLFSSL_BIO *bio, WOLFSSL_BUF_MEM **m);
     name = wolfSSL_X509_NAME_oneline(wolfSSL_X509_get_issuer_name(x509), 0, 0);
 
     if(name <= 0){
-    	// There’s nothing in the buffer.
+    	// バッファに何もありません
     }
     \endcode
+
     \sa wolfSSL_X509_get_subject_name
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_isCA
@@ -3785,10 +4021,13 @@ char*       wolfSSL_X509_NAME_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は証明書発行者の名前を返します。
-    \return point  WOLFSSL_X509構造体の発行者メンバーへのポインタが返されます。
-    \return NULL  渡された証明書がNULLの場合
-    \param cert WOLFSSL_X509構造体へのポインタ
+
+    \brief この関数は証明書の発行者名を返します。
+
+    \return point 渡されたcertがNULLでない場合、WOLFSSL_X509構造体のissuerメンバーへのポインタが返されます。
+    \return NULL 渡されたcertがNULLの場合。
+
+    \param cert WOLFSSL_X509構造体へのポインタ。
 
     _Example_
     \code
@@ -3798,11 +4037,12 @@ char*       wolfSSL_X509_NAME_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
     issuer = wolfSSL_X509_NAME_oneline(wolfSSL_X509_get_issuer_name(x509), 0, 0);
 
     if(!issuer){
-    	// NULL was returned
+    	// NULLが返されました
     } else {
-    	// issuer hods the name of the certificate issuer.
+    	// issuerは証明書の発行者名を保持しています
     }
     \endcode
+
     \sa wolfSSL_X509_get_subject_name
     \sa wolfSSL_X509_get_isCA
     \sa wolfSSL_get_peer_certificate
@@ -3812,9 +4052,12 @@ WOLFSSL_X509_NAME*  wolfSSL_X509_get_issuer_name(WOLFSSL_X509* cert);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、wolfssl_x509構造の件名メンバーを返します。
-    \return pointer  wolfssl_x509_name構造へのポインタ。WOLFSSL_X509構造体がNULLの場合、または構造体の件名メンバーがNULLの場合、ポインタはNULLになることがあります。
-    \param cert WOLFSSL_X509構造体へのポインタ
+
+    \brief この関数はWOLFSSL_X509構造体のsubjectメンバーを返します。
+
+    \return pointer WOLFSSL_X509_NAME構造体へのポインタ。WOLFSSL_X509構造体がNULLの場合、または構造体のsubjectメンバーがNULLの場合、ポインタはNULLになる可能性があります。
+
+    \param cert WOLFSSL_X509構造体へのポインタ。
 
     _Example_
     \code
@@ -3823,9 +4066,10 @@ WOLFSSL_X509_NAME*  wolfSSL_X509_get_issuer_name(WOLFSSL_X509* cert);
     …
     name = wolfSSL_X509_get_subject_name(cert);
     if(name == NULL){
-	    // Deal with the NULL cacse
+	    // NULLケースを処理
     }
     \endcode
+
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_isCA
     \sa wolfSSL_get_peer_certificate
@@ -3834,10 +4078,13 @@ WOLFSSL_X509_NAME*  wolfSSL_X509_get_subject_name(WOLFSSL_X509* cert);
 
 /*!
     \ingroup CertsKeys
-    \brief  WOLFSSL_X509構造体のisCaメンバーをチェックして値を返します。
-    \return isCA  WOLFSSL_X509構造体のisCaメンバーの値を返します。
-    \return 0  有効なWOLFSSL_X509構造体が渡されない場合に返されます。
-    \param cert WOLFSSL_X509構造体へのポインタ
+
+    \brief WOLFSSL_X509構造体のisCaメンバーをチェックし、その値を返します。
+
+    \return isCA WOLFSSL_X509構造体のisCaメンバーの値が返されます。
+    \return 0 有効なx509構造体が渡されなかった場合に返されます。
+
+    \param cert WOLFSSL_X509構造体へのポインタ。
 
     _Example_
     \code
@@ -3847,11 +4094,12 @@ WOLFSSL_X509_NAME*  wolfSSL_X509_get_subject_name(WOLFSSL_X509* cert);
     WOLFSSL* ssl = wolfSSL_new(ctx);
     ...
     if(wolfSSL_X509_get_isCA(ssl)){
-    	// This is the CA
+    	// これはCAです
     }else {
-    	// Failure case
+    	// 失敗ケース
     }
     \endcode
+
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_isCA
 */
@@ -3859,12 +4107,15 @@ int  wolfSSL_X509_get_isCA(WOLFSSL_X509* cert);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、渡されたNID値に関連するテキストを取得します。
-    \return int  テキストバッファのサイズを返します。
-    \param name  wolfssl_x509_nameテキストを検索する。
-    \param nid  検索するNID。
-    \param buf  見つかったときにテキストを保持するためのバッファー。
-    \param len バッファのサイズ
+
+    \brief この関数は渡されたNID値に関連するテキストを取得します。
+
+    \return int テキストバッファのサイズを返します。
+
+    \param name テキストを検索するWOLFSSL_X509_NAME。
+    \param nid 検索するNID。
+    \param buf 見つかったテキストを保持するバッファ。
+    \param len バッファの長さ。
 
     _Example_
     \code
@@ -3872,12 +4123,13 @@ int  wolfSSL_X509_get_isCA(WOLFSSL_X509* cert);
     char buffer[100];
     int bufferSz;
     int ret;
-    // get WOLFSSL_X509_NAME
+    // WOLFSSL_X509_NAMEを取得
     ret = wolfSSL_X509_NAME_get_text_by_NID(name, NID_commonName,
     buffer, bufferSz);
 
-    //check ret value
+    // ret値を確認
     \endcode
+
     \sa none
 */
 int wolfSSL_X509_NAME_get_text_by_NID(WOLFSSL_X509_NAME* name, int nid,
@@ -3885,10 +4137,13 @@ int wolfSSL_X509_NAME_get_text_by_NID(WOLFSSL_X509_NAME* name, int nid,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、WOLFSSL_X509構造体のsigOIDメンバーに格納されている値を返します。
-    \return 0  WOLFSSL_X509構造体がNULLの場合に返されます。
-    \return int  x509オブジェクトから取得された整数値が返されます。
-    \param cert WOLFSSL_X509構造体へのポインタ
+
+    \brief この関数はWOLFSSL_X509構造体のsigOIDメンバーに格納されている値を返します。
+
+    \return 0 WOLFSSL_X509構造体がNULLの場合に返されます。
+    \return int x509オブジェクトから取得された整数値が返されます。
+
+    \param cert WOLFSSL_X509構造体へのポインタ。
 
     _Example_
     \code
@@ -3898,9 +4153,10 @@ int wolfSSL_X509_NAME_get_text_by_NID(WOLFSSL_X509_NAME* name, int nid,
     int x509SigType = wolfSSL_X509_get_signature_type(x509);
 
     if(x509SigType != EXPECTED){
-	// Deal with an unexpected value
+	    // 予期しない値を処理
     }
     \endcode
+
     \sa wolfSSL_X509_get_signature
     \sa wolfSSL_X509_version
     \sa wolfSSL_X509_get_der
@@ -3913,8 +4169,8 @@ int wolfSSL_X509_get_signature_type(WOLFSSL_X509* cert);
 
 /*!
     \brief この関数はWOLFSSL_X509構造体を解放します。
-    \return なし
-    \param x509 WOLFSSL_X509構造体へのポインタ
+
+    \param x509 WOLFSSL_X509構造体へのポインタ。
 
     _Example_
     \code
@@ -3924,37 +4180,43 @@ int wolfSSL_X509_get_signature_type(WOLFSSL_X509* cert);
     wolfSSL_X509_free(x509);
 
     \endcode
+
     \sa wolfSSL_X509_get_signature
     \sa wolfSSL_X509_version
     \sa wolfSSL_X509_get_der
     \sa wolfSSL_X509_get_serial_number
     \sa wolfSSL_X509_notBefore
     \sa wolfSSL_X509_notAfter
+
 */
 void wolfSSL_X509_free(WOLFSSL_X509* x509);
 
 /*!
     \ingroup CertsKeys
-    \brief  x509署名を取得し、それをバッファに保存します。
-    \return SSL_SUCCESS  関数が正常に実行された場合に返されます。署名がバッファにロードされます。
-    \return SSL_FATAL_ERRROR  X509構造体またはBUFSZメンバーがNULLの場合に返します。SIG構造の長さメンバのチェックもある（SIGはX509のメンバーである）。
-    \param x509  wolfssl_x509構造へのポインタ。
-    \param buf  バッファへの文字ポインタ。
-    \param bufSz バッファサイズを格納するint型変数へのポインタ
+
+    \brief X509署名を取得し、バッファに格納します。
+
+    \return SSL_SUCCESS 関数が正常に実行された場合に返されます。署名はバッファに読み込まれます。
+    \return SSL_FATAL_ERRROR x509構造体またはbufSzメンバーがNULLの場合に返されます。sig構造体のlengthメンバー(sigはx509のメンバー)のチェックもあります。
+
+    \param x509 WOLFSSL_X509構造体へのポインタ。
+    \param buf バッファへのcharポインタ。
+    \param bufSz バッファのサイズへの整数ポインタ。
 
     _Example_
     \code
     WOLFSSL_X509* x509 = (WOLFSSL_X509)XMALOC(sizeof(WOLFSSL_X509), NULL,
     DYNAMIC_TYPE_X509);
-    unsigned char* buf; // Initialize
+    unsigned char* buf; // 初期化
     int* bufSz = sizeof(buf)/sizeof(unsigned char);
     ...
     if(wolfSSL_X509_get_signature(x509, buf, bufSz) != SSL_SUCCESS){
-	    // The function did not execute successfully.
+	    // 関数は正常に実行されませんでした
     } else{
-	    // The buffer was written to correctly.
+	    // バッファは正しく書き込まれました
     }
     \endcode
+
     \sa wolfSSL_X509_get_serial_number
     \sa wolfSSL_X509_get_signature_type
     \sa wolfSSL_X509_get_device_type
@@ -3963,11 +4225,14 @@ int wolfSSL_X509_get_signature(WOLFSSL_X509* x509, unsigned char* buf, int* bufS
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、WOLFSSL_X509_STRE構造体に証明書を追加します。
-    \return SSL_SUCCESS  証明書が正常に追加された場合。
-    \return SSL_FATAL_ERROR:  証明書が正常に追加されない場合
-    \param str  証明書を追加する証明書ストア。
-    \param x509 追加するWOLFSSL_X509構造体へのポインタ
+
+    \brief この関数はWOLFSSL_X509_STORE構造体に証明書を追加します。
+
+    \return SSL_SUCCESS 証明書が正常に追加された場合。
+    \return SSL_FATAL_ERROR 証明書が正常に追加されなかった場合。
+
+    \param str 証明書を追加する証明書ストア。
+    \param x509 追加する証明書。
 
     _Example_
     \code
@@ -3975,26 +4240,31 @@ int wolfSSL_X509_get_signature(WOLFSSL_X509* x509, unsigned char* buf, int* bufS
     WOLFSSL_X509* x509;
     int ret;
     ret = wolfSSL_X509_STORE_add_cert(str, x509);
-    //check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_X509_free
 */
 int wolfSSL_X509_STORE_add_cert(WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、WOLFSSL_X509_STORE_CTX構造体のチェーン変数のgetter関数です。現在チェーンは取り込まれていません。
-    \return pointer  成功した場合WOLFSSL_STACK（STACK_OF(WOLFSSL_X509)）ポインタと同じ
-    \return Null  失敗した場合に返されます。
-    \param ctx WOLFSSL_X509_STORE_CTX構造体へのポインタ
+
+    \brief この関数はWOLFSSL_X509_STORE_CTX構造体のchain変数のgetter関数です。現在、chainは入力されていません。
+
+    \return pointer 成功した場合、WOLFSSL_STACK(STACK_OF(WOLFSSL_X509)と同じ)ポインタを返します。
+    \return Null 失敗時。
+
+    \param ctx 解析チェーンを取得する証明書ストアコンテキスト。
 
     _Example_
     \code
     WOLFSSL_STACK* sk;
     WOLFSSL_X509_STORE_CTX* ctx;
     sk = wolfSSL_X509_STORE_CTX_get_chain(ctx);
-    //check sk for NULL and then use it. sk needs freed after done.
+    // skがNULLでないか確認してから使用。使用後はskを解放する必要があります
     \endcode
+
     \sa wolfSSL_sk_X509_free
 */
 WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(
@@ -4002,22 +4272,26 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、渡されたWOLFSSL_X509_STORE構造体の動作を変更するためのフラグを取ります。使用されるフラグの例はWOLFSSL_CRL_CHECKです。
-    \return SSL_SUCCESS  フラグを設定するときにエラーが発生しなかった場合。
-    \return <0  障害の際に負の値が返されます。
-    \param str  フラグを設定する証明書ストア。
-    \param flag フラグ
+
+    \brief この関数は渡されたWOLFSSL_X509_STORE構造体の動作を変更するためのフラグを受け取ります。使用されるフラグの例としてWOLFSSL_CRL_CHECKがあります。
+
+    \return SSL_SUCCESS フラグの設定時にエラーが発生しなかった場合。
+    \return <0 失敗時に負の値が返されます。
+
+    \param str フラグを設定する証明書ストア。
+    \param flag 動作のためのフラグ。
 
     _Example_
     \code
     WOLFSSL_X509_STORE* str;
     int ret;
-    // create and set up str
+    // strを作成して設定
     ret = wolfSSL_X509_STORE_set_flags(str, WOLFSSL_CRL_CHECKALL);
-    If (ret != SSL_SUCCESS) {
-    	//check ret value and handle error case
+    if (ret != SSL_SUCCESS) {
+    	//ret値を確認してエラーケースを処理する
     }
     \endcode
+
     \sa wolfSSL_X509_STORE_new
     \sa wolfSSL_X509_STORE_free
 */
@@ -4026,9 +4300,12 @@ int wolfSSL_X509_STORE_set_flags(WOLFSSL_X509_STORE* store,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はBYTEアレイとして符号化された"not before"要素を返します。
-    \return NULL  WOLFSSL_X509構造体がNULLの場合に返されます。
-    \return byte  NetBeforEdataを含むバッファへのポインタが返されます。
+
+    \brief この関数は、バイト配列としてエンコードされた証明書の「not before」有効期限を返します。
+
+    \return NULL WOLFSSL_X509構造体がNULLの場合に返されます。
+    \return byte notBeforeDataを含むバイトが返されます。
+
     \param x509 WOLFSSL_X509構造体へのポインタ。
 
     _Example_
@@ -4040,6 +4317,7 @@ int wolfSSL_X509_STORE_set_flags(WOLFSSL_X509_STORE* store,
 
 
     \endcode
+
     \sa wolfSSL_X509_get_signature
     \sa wolfSSL_X509_version
     \sa wolfSSL_X509_get_der
@@ -4051,9 +4329,12 @@ const byte* wolfSSL_X509_notBefore(WOLFSSL_X509* x509);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、BYTE配列として符号化された"not after"要素を返します。
-    \return NULL  WOLFSSL_X509構造体がNULLの場合に返されます。
-    \return byte  notAfterDataを含むバッファへのポインタが返されます。
+
+    \brief この関数は、バイト配列としてエンコードされた証明書の「not after」有効期限を返します。
+
+    \return NULL WOLFSSL_X509構造体がNULLの場合に返されます。
+    \return byte notAfterDataを含むバイトが返されます。
+
     \param x509 WOLFSSL_X509構造体へのポインタ。
 
     _Example_
@@ -4065,6 +4346,7 @@ const byte* wolfSSL_X509_notBefore(WOLFSSL_X509* x509);
 
 
     \endcode
+
     \sa wolfSSL_X509_get_signature
     \sa wolfSSL_X509_version
     \sa wolfSSL_X509_get_der
@@ -4076,25 +4358,27 @@ const byte* wolfSSL_X509_notAfter(WOLFSSL_X509* x509);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、WOLFSSL_ASN1_INTEGER値をWOLFSSL_BIGNUM構造体にコピーするために使用されます。
-    \return pointer  WOLFSSL_ASN1_INTEGER値を正常にコピーすると、WOLFSSL_BIGNUMポインタが返されます。
-    \return Null  失敗時に返されます。
-    \param ai WOLFSSL_ASN1_INTEGER構造体へのポインタ
-    \param bn もし、既存のWOLFSSL_BIGNUM構造体にコピーしたい場合そのポインタをこの引数で指定します。
-    NULLを指定すると新たにWOLFSSL_BIGNUM構造体が生成されて使用されます。
 
+    \brief この関数は、WOLFSSL_ASN1_INTEGER値をWOLFSSL_BIGNUM構造体にコピーするために使用されます。
+
+    \return pointer WOLFSSL_ASN1_INTEGER値のコピーに成功すると、WOLFSSL_BIGNUMポインタが返されます。
+    \return Null 失敗時にはNullが返されます。
+
+    \param ai コピー元のWOLFSSL_ASN1_INTEGER構造体。
+    \param bn 既存のWOLFSSL_BIGNUM構造体にコピーしたい場合は、そのポインタを渡します。オプションとして、これをNULLにすることで新しいWOLFSSL_BIGNUM構造体が作成されます。
 
     _Example_
     \code
     WOLFSSL_ASN1_INTEGER* ai;
     WOLFSSL_BIGNUM* bn;
-    // create ai
+    // aiを作成
     bn = wolfSSL_ASN1_INTEGER_to_BN(ai, NULL);
 
-    // or if having already created bn and wanting to reuse structure
+    // または既にbnを作成済みで構造体を再利用したい場合
     // wolfSSL_ASN1_INTEGER_to_BN(ai, bn);
-    // check bn is or return value is not NULL
+    // bnまたは戻り値がNULLでないことを確認
     \endcode
+
     \sa none
 */
 WOLFSSL_BIGNUM *wolfSSL_ASN1_INTEGER_to_BN(const WOLFSSL_ASN1_INTEGER *ai,
@@ -4102,21 +4386,25 @@ WOLFSSL_BIGNUM *wolfSSL_ASN1_INTEGER_to_BN(const WOLFSSL_ASN1_INTEGER *ai,
 
 /*!
     \ingroup Setup
-    \brief  この関数は、WOLFSSL_CTX構造で構築されている内部チェーンに証明書を追加します。
-    \return SSL_SUCCESS  証明書の追加に成功したら。
-    \return SSL_FAILURE  チェーンに証明書を追加することが失敗した場合。
-    \param ctx  証明書を追加するためのWOLFSSL_CTX構造。
-    \param x509 WOLFSSL_X509構造体へのポインタ。
+
+    \brief この関数は、WOLFSSL_CTX構造体内で構築中の内部チェーンに証明書を追加します。
+
+    \return SSL_SUCCESS 証明書の追加に成功した後に返されます。
+    \return SSL_FAILURE 証明書のチェーンへの追加に失敗した場合に返されます。
+
+    \param ctx 証明書を追加するWOLFSSL_CTX構造体。
+    \param x509 チェーンに追加する証明書。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx;
     WOLFSSL_X509* x509;
     int ret;
-    // create ctx
+    // ctxを作成
     ret = wolfSSL_CTX_add_extra_chain_cert(ctx, x509);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
@@ -4124,19 +4412,23 @@ long wolfSSL_CTX_add_extra_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、WOLFSSL_CTX構造からGet Read Hapeフラグを返します。
-    \return flag  成功すると、読み取り先のフラグを返します。
-    \return SSL_FAILURE  ctxがnullの場合、ssl_failureが返されます。
-    \param ctx WOLFSSL_CTX構造体へのポインタ
+
+    \brief この関数は、WOLFSSL_CTX構造体からリードアヘッドフラグを取得して返します。
+
+    \return flag 成功時にはリードアヘッドフラグが返されます。
+    \return SSL_FAILURE ctxがNULLの場合、SSL_FAILUREが返されます。
+
+    \param ctx リードアヘッドフラグを取得するWOLFSSL_CTX構造体。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx;
     int flag;
-    // setup ctx
+    // ctxをセットアップ
     flag = wolfSSL_CTX_get_read_ahead(ctx);
-    //check flag
+    //flagを確認
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
     \sa wolfSSL_CTX_set_read_ahead
@@ -4145,21 +4437,25 @@ int  wolfSSL_CTX_get_read_ahead(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、WOLFSSL_CTX構造内の読み出し先のフラグを設定します。
-    \return SSL_SUCCESS  ctxが先読みフラグを設定した場合。
-    \return SSL_FAILURE  ctxがNULLの場合に返されます。
-    \param ctx WOLFSSL_CTX構造体へのポインタ
-    \param v 先読みフラグ
+
+    \brief この関数は、WOLFSSL_CTX構造体内のリードアヘッドフラグを設定します。
+
+    \return SSL_SUCCESS ctxのリードアヘッドフラグが設定された場合。
+    \return SSL_FAILURE ctxがNULLの場合、SSL_FAILUREが返されます。
+
+    \param ctx リードアヘッドフラグを設定するWOLFSSL_CTX構造体。
+    \param v リードアヘッドフラグ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx;
     int flag;
     int ret;
-    // setup ctx
+    // ctxをセットアップ
     ret = wolfSSL_CTX_set_read_ahead(ctx, flag);
-    // check return value
+    // 戻り値を確認
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
     \sa wolfSSL_CTX_get_read_ahead
@@ -4168,44 +4464,270 @@ int  wolfSSL_CTX_set_read_ahead(WOLFSSL_CTX* ctx, int v);
 
 /*!
     \ingroup Setup
-    \brief  この関数はOCSPで使用するオプション引数を設定します。
-    \return SSL_FAILURE  CTXまたはITのCERT ManagerがNULLの場合。
-    \return SSL_SUCCESS  正常に設定されている場合。
-    \param ctx  WOLFSSL_CTX構造へのポインタ
-    \param arg ユーザー引数
+
+    \brief この関数は、OCSPで使用するオプション引数を設定します。
+
+    \return SSL_FAILURE ctxまたはその証明書マネージャがNULLの場合。
+    \return SSL_SUCCESS 正常に設定された場合。
+
+    \param ctx ユーザー引数を設定するWOLFSSL_CTX構造体。
+    \param arg ユーザー引数。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx;
     void* data;
     int ret;
-    // setup ctx
+    // ctxをセットアップ
     ret = wolfSSL_CTX_set_tlsext_status_arg(ctx, data);
 
-    //check ret value
+    //ret値を確認
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
 long wolfSSL_CTX_set_tlsext_status_arg(WOLFSSL_CTX* ctx, void* arg);
 
 /*!
+    \ingroup CertsKeys
+
+    \brief クライアント証明書と秘密鍵を選択するコールバックを設定します。
+
+    この関数は、ハンドシェイク中にクライアント証明書が要求されたときに呼び出されるコールバックをアプリケーションが登録できるようにします。コールバックは、使用する証明書と鍵を選択して提供できます。
+
+    \param ctx WOLFSSL_CTXオブジェクト。
+    \param cb クライアント証明書と鍵を選択するコールバック関数。
+
+    \return void
+
+    _Example_
+    \code
+    int my_client_cert_cb(WOLFSSL *ssl, WOLFSSL_X509 **x509, WOLFSSL_EVP_PKEY **pkey) { ... }
+    wolfSSL_CTX_set_client_cert_cb(ctx, my_client_cert_cb);
+    \endcode
+
+    \sa wolfSSL_CTX_set_cert_cb
+*/
+void wolfSSL_CTX_set_client_cert_cb(WOLFSSL_CTX *ctx, client_cert_cb cb);
+
+/*!
+    \ingroup CertsKeys
+
+    \brief 汎用証明書セットアップコールバックを設定します。
+
+    この関数は、証明書セットアップ中に呼び出されるコールバックをアプリケーションが登録できるようにします。コールバックは、カスタム証明書選択またはロードロジックを実行できます。
+
+    \param ctx WOLFSSL_CTXオブジェクト。
+    \param cb 証明書セットアップ用のコールバック関数。
+    \param arg コールバックに渡すユーザー引数。
+
+    \return void
+
+    _Example_
+    \code
+    int my_cert_setup_cb(WOLFSSL* ssl, void* arg) { ... }
+    wolfSSL_CTX_set_cert_cb(ctx, my_cert_setup_cb, NULL);
+    \endcode
+
+    \sa wolfSSL_CTX_set_client_cert_cb
+*/
+void wolfSSL_CTX_set_cert_cb(WOLFSSL_CTX* ctx, CertSetupCallback cb, void *arg);
+
+/*!
+    \ingroup OCSP
+
+    \brief OCSPステータス要求(OCSPステープリング)を処理するために使用されるコールバックを設定します。
+
+    この関数は、TLSハンドシェイク中にOCSPステータス要求を受信したときに呼び出されるコールバックをアプリケーションが登録できるようにします。コールバックは、ハンドシェイクにステープルされるOCSPレスポンスを提供できます。このAPIはサーバー側でのみ有用です。
+
+    \param ctx WOLFSSL_CTXオブジェクト。
+    \param cb OCSPステータス要求を処理するコールバック関数。
+
+    \return SSL_SUCCESS 成功時、それ以外の場合はSSL_FAILURE。
+
+    _Example_
+    \code
+    int my_ocsp_status_cb(WOLFSSL* ssl, void* arg) { ... }
+    wolfSSL_CTX_set_tlsext_status_cb(ctx, my_ocsp_status_cb);
+    \endcode
+
+    \sa wolfSSL_CTX_get_tlsext_status_cb
+    \sa wolfSSL_CTX_set_tlsext_status_arg
+*/
+int wolfSSL_CTX_set_tlsext_status_cb(WOLFSSL_CTX* ctx, tlsextStatusCb cb);
+
+/*!
+    \ingroup OCSP
+
+    \brief コンテキストに現在設定されているOCSPステータスコールバックを取得します。
+
+    \param ctx WOLFSSL_CTXオブジェクト。
+    \param cb コールバック関数を受け取るポインタ。
+
+    \return SSL_SUCCESS 成功時、それ以外の場合はSSL_FAILURE。
+
+    \sa wolfSSL_CTX_set_tlsext_status_cb
+*/
+int wolfSSL_CTX_get_tlsext_status_cb(WOLFSSL_CTX* ctx, tlsextStatusCb* cb);
+
+/*!
+    \ingroup OCSP
+
+    \brief OCSPステータスコールバックに渡される引数を設定します。
+
+    \param ctx WOLFSSL_CTXオブジェクト。
+    \param arg コールバックに渡すユーザー引数。
+
+    \return SSL_SUCCESS 成功時、それ以外の場合はSSL_FAILURE。
+
+    \sa wolfSSL_CTX_set_tlsext_status_cb
+*/
+long wolfSSL_CTX_set_tlsext_status_arg(WOLFSSL_CTX* ctx, void* arg);
+
+/*!
+    \ingroup OCSP
+
+    \brief ピアに送信(ステープル)されるOCSPレスポンスを取得します。
+
+    \param ssl WOLFSSLセッション。
+    \param resp レスポンスバッファを受け取るポインタ。
+
+    \return Length レスポンスの長さ、またはエラー時は負の値。
+
+    \sa wolfSSL_set_tlsext_status_ocsp_resp
+*/
+long wolfSSL_get_tlsext_status_ocsp_resp(WOLFSSL *ssl, unsigned char **resp);
+
+/*!
+    \ingroup OCSP
+
+    \brief ピアに送信(ステープル)されるOCSPレスポンスを設定します。
+
+    respのバッファはwolfSSLによって所有され、wolfSSLによって解放されます。アプリケーションは、この関数を呼び出した後、バッファを解放してはいけません。
+
+    \param ssl WOLFSSLセッション。
+    \param resp レスポンスバッファへのポインタ。
+    \param len レスポンスバッファの長さ。
+
+    \return SSL_SUCCESS 成功時、それ以外の場合はSSL_FAILURE。
+
+    \sa wolfSSL_get_tlsext_status_ocsp_resp
+*/
+long wolfSSL_set_tlsext_status_ocsp_resp(WOLFSSL *ssl, unsigned char *resp, int len);
+
+/*!
+    \ingroup OCSP
+
+    \brief TLSマルチ証明書チェーン用の複数のOCSPレスポンスを設定します。
+
+    respのバッファはwolfSSLによって所有され、wolfSSLによって解放されます。アプリケーションは、この関数を呼び出した後、バッファを解放してはいけません。
+
+    \param ssl WOLFSSLセッション。
+    \param resp レスポンスバッファへのポインタ。
+    \param len レスポンスバッファの長さ。
+    \param idx 証明書チェーンのインデックス。
+
+    \return SSL_SUCCESS 成功時、それ以外の場合はSSL_FAILURE。
+*/
+int wolfSSL_set_tlsext_status_ocsp_resp_multi(WOLFSSL* ssl, unsigned char *resp, int len, word32 idx);
+
+/*!
+    \ingroup OCSP
+
+    \brief OCSPステータスレスポンスを検証するコールバックを設定します。
+
+    OCSP検証中にピアの証明書チェーンにアクセスできるようにするため、SESSION_CERTSを有効にすることを推奨します。
+
+    \param ctx WOLFSSL_CTXオブジェクト。
+    \param cb コールバック関数。
+    \param cbArg コールバックに渡すユーザー引数。
+
+    \return void
+
+    _Example_
+    \code
+    void my_ocsp_verify_cb(WOLFSSL* ssl, int err, byte* resp, word32 respSz, word32 idx, void* arg)
+    {
+        (void)arg;
+        if (err == 0 && staple && stapleSz > 0) {
+            printf("Client: OCSP staple received, size=%u\n", stapleSz);
+            return 0;
+        }
+        // err != 0の場合、手動OCSPステープル検証
+        if (err != 0 && staple && stapleSz > 0) {
+            WOLFSSL_CERT_MANAGER* cm = NULL;
+            DecodedCert cert;
+            byte certInit = 0;
+            WOLFSSL_OCSP* ocsp = NULL;
+            WOLFSSL_X509_CHAIN* peerCerts;
+            int i;
+
+            cm = wolfSSL_CertManagerNew();
+            if (cm == NULL)
+                goto cleanup;
+            if (wolfSSL_CertManagerLoadCA(cm, CA_CERT, NULL) != WOLFSSL_SUCCESS)
+                goto cleanup;
+
+            peerCerts = wolfSSL_get_peer_chain(ssl);
+            if (peerCerts == NULL || wolfSSL_get_chain_count(peerCerts) <= (int)idx)
+                goto cleanup;
+
+            for (i = idx + 1; i < wolfSSL_get_chain_count(peerCerts); i++) {
+                if (wolfSSL_CertManagerLoadCABuffer(cm, wolfSSL_get_chain_cert(peerCerts, i),
+                        wolfSSL_get_chain_length(peerCerts, i), WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS)
+                    goto cleanup;
+            }
+
+            wc_InitDecodedCert(&cert, wolfSSL_get_chain_cert(peerCerts, idx), wolfSSL_get_chain_length(peerCerts, idx), NULL);
+            certInit = 1;
+            if (wc_ParseCert(&cert, CERT_TYPE, VERIFY, cm) != 0)
+                goto cleanup;
+            if ((ocsp = wc_NewOCSP(cm)) == NULL)
+                goto cleanup;
+            if (wc_CheckCertOcspResponse(ocsp, &cert, staple, stapleSz, NULL) != 0)
+                goto cleanup;
+
+            printf("Client: Manual OCSP staple verification succeeded for idx=%u\n", idx);
+            err = 0;
+    cleanup:
+            wc_FreeOCSP(ocsp);
+            if (certInit)
+                wc_FreeDecodedCert(&cert);
+            wolfSSL_CertManagerFree(cm);
+            if (err == 0)
+                return 0;
+            printf("Client: Manual OCSP staple verification failed for idx=%u\n", idx);
+        }
+        printf("Client: OCSP staple verify error=%d\n", err);
+        return err;
+    }
+    wolfSSL_CTX_set_ocsp_status_verify_cb(ctx, my_ocsp_verify_cb, NULL);
+    \endcode
+*/
+void wolfSSL_CTX_set_ocsp_status_verify_cb(WOLFSSL_CTX* ctx, ocspVerifyStatusCb cb, void* cbArg);
+
+/*!
     \ingroup Setup
-    \brief  この関数は、PRFコールバックに渡すオプションの引数を設定します。
-    \return SSL_FAILURE  CTXがNULLの場合
-    \return SSL_SUCCESS  正常に設定されている場合。
-    \param ctx  WOLFSSL_CTX構造へのポインタ
-    \param arg ユーザー引数
+
+    \brief この関数は、PRFコールバックに渡されるオプション引数を設定します。
+
+    \return SSL_FAILURE ctxがNULLの場合。
+    \return SSL_SUCCESS 正常に設定された場合。
+
+    \param ctx ユーザ引数を設定するWOLFSSL_CTX構造体。
+    \param arg ユーザ引数。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx;
     void* data;
     int ret;
-    // setup ctx
+    // ctxをセットアップ
     ret = wolfSSL_CTX_set_tlsext_opaques_prf_input_callback_arg(ctx, data);
-    //check ret value
+    //ret値を確認
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
@@ -4214,19 +4736,21 @@ long wolfSSL_CTX_set_tlsext_opaque_prf_input_callback_arg(
 
 /*!
     \ingroup Setup
-    \brief  この関数は、SSLのオプションマスクを設定します。
-    いくつかの有効なオプションは、ssl_op_all、ssl_op_cookie_exchange、ssl_op_no_sslv2、ssl_op_no_sslv3、ssl_op_no_tlsv1_1、ssl_op_no_tlsv1_2、ssl_op_no_compressionです。
-    \return val  SSLに格納されている更新されたオプションマスク値を返します。
-    \param s  オプションマスクを設定するためのWolfSSL構造。
-    \param op オプションマスク。以下の値が指定可能です：<br>
-    SSL_OP_ALL<br>
-    SSL_OP_COOKIE_EXCHANGE<br>
-    SSL_OP_NO_SSLv2<br>
-    SSL_OP_NO_SSLv3<br>
-    SSL_OP_NO_TLSv1<br>
-    SSL_OP_NO_TLSv1_1<br>
-    SSL_OP_NO_TLSv1_2<br>
-    SSL_OP_NO_COMPRESSION<br>
+
+    \brief この関数は、ssl内のオプションマスクを設定します。有効なオプションには、SSL_OP_ALL、SSL_OP_COOKIE_EXCHANGE、SSL_OP_NO_SSLv2、SSL_OP_NO_SSLv3、SSL_OP_NO_TLSv1、SSL_OP_NO_TLSv1_1、SSL_OP_NO_TLSv1_2、SSL_OP_NO_COMPRESSIONがあります。
+
+    \return val sslに格納されている更新されたオプションマスク値を返します。
+
+    \param s オプションマスクを設定するWOLFSSL構造体。
+    \param op この関数は、ssl内のオプションマスクを設定します。有効なオプションには以下が含まれます:
+    SSL_OP_ALL
+    SSL_OP_COOKIE_EXCHANGE
+    SSL_OP_NO_SSLv2
+    SSL_OP_NO_SSLv3
+    SSL_OP_NO_TLSv1
+    SSL_OP_NO_TLSv1_1
+    SSL_OP_NO_TLSv1_2
+    SSL_OP_NO_COMPRESSION
 
     _Example_
     \code
@@ -4234,8 +4758,9 @@ long wolfSSL_CTX_set_tlsext_opaque_prf_input_callback_arg(
     unsigned long mask;
     mask = SSL_OP_NO_TLSv1
     mask  = wolfSSL_set_options(ssl, mask);
-    // check mask
+    // maskを確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
     \sa wolfSSL_get_options
@@ -4244,17 +4769,21 @@ long wolfSSL_set_options(WOLFSSL *s, long op);
 
 /*!
     \ingroup Setup
-    \brief  この関数は現在のオプションマスクを返します。
-    \return val  SSLに格納されているマスク値を返します。
-    \param ssl WOLFSSL構造体へのポインタ
+
+    \brief この関数は、現在のオプションマスクを返します。
+
+    \return val sslに格納されているマスク値を返します。
+
+    \param ssl オプションマスクを取得するWOLFSSL構造体。
 
     _Example_
     \code
     WOLFSSL* ssl;
     unsigned long mask;
     mask  = wolfSSL_get_options(ssl);
-    // check mask
+    // maskを確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
     \sa wolfSSL_set_options
@@ -4263,21 +4792,25 @@ long wolfSSL_get_options(const WOLFSSL *ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、渡されたデバッグ引数を設定するために使用されます。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  NULL SSLが渡された場合。
-    \param ssl  引数を設定するためのWolfSSL構造。
-    \param arg デバッグ引数
+
+    \brief これは、渡されるデバッグ引数を設定するために使用されます。
+
+    \return SSL_SUCCESS 引数の設定に成功した場合。
+    \return SSL_FAILURE NULLのsslが渡された場合。
+
+    \param ssl 引数を設定するWOLFSSL構造体。
+    \param arg 使用する引数。
 
     _Example_
     \code
     WOLFSSL* ssl;
     void* args;
     int ret;
-    // create ssl object
+    // sslオブジェクトを作成
     ret  = wolfSSL_set_tlsext_debug_arg(ssl, args);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -4285,11 +4818,14 @@ long wolfSSL_set_tlsext_debug_arg(WOLFSSL *ssl, void *arg);
 
 /*!
     \ingroup openSSL
-    \brief  この関数は、サーバがOCSPステータス応答（OCSPステイプルとも呼ばれる）を送受信するクライアントアプリケーションが要求されたときに呼び出されます。
-    \return 1  成功時に返されます。
-    \return 0  エラー時に返されます。
-    \param s  ssl_new()関数によって作成されたWOLFSSL構造体へのポインタ
-    \param type ssl拡張タイプ。TLSEXT_STATUSTYPE_ocspのみ指定可。
+
+    \brief この関数は、クライアントアプリケーションがサーバにOCSPステータスレスポンス(OCSPステープリングとも呼ばれます)を返送するよう要求する際に呼び出されます。現在、サポートされている唯一のタイプはTLSEXT_STATUSTYPE_ocspです。
+
+    \return 1 成功時。
+    \return 0 エラー時。
+
+    \param s SSL_new()関数によって作成されたWOLFSSL構造体へのポインタ。
+    \param type TLSEXT_STATUSTYPE_ocspのみがサポートされているSSL拡張タイプ。
 
     _Example_
     \code
@@ -4302,6 +4838,7 @@ long wolfSSL_set_tlsext_debug_arg(WOLFSSL *ssl, void *arg);
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_CTX_new
     \sa wolfSSL_free
@@ -4311,19 +4848,23 @@ long wolfSSL_set_tlsext_status_type(WOLFSSL *s, int type);
 
 /*!
     \ingroup Setup
-    \bri f  この関数は、れは、ピアの証明書を確認しようとした後に結果を取得するために使用されます。
-    \return X509_V_OK  成功した検証について
-    \return SSL_FAILURE  NULL SSLが渡された場合。
-    \param ssl WOLFSSL 構造体へのポインタ
+
+    \brief これは、ピアの証明書の検証を試みた後の結果を取得するために使用されます。
+
+    \return X509_V_OK 検証が成功した場合。
+    \return SSL_FAILURE NULLのsslが渡された場合。
+
+    \param ssl 検証結果を取得するWOLFSSL構造体。
 
     _Example_
     \code
     WOLFSSL* ssl;
     long ret;
-    // attempt/complete handshake
+    // ハンドシェイクを試行/完了
     ret  = wolfSSL_get_verify_result(ssl);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -4331,10 +4872,13 @@ long wolfSSL_get_verify_result(const WOLFSSL *ssl);
 
 /*!
     \ingroup Debug
-    \brief  この関数は、wolfSSL_get_error()によって返されたエラーコードをより多くの人間が読めるエラー文字列に変換し、その文字列を出力ファイルに印刷します。ERRは、WOLFSSL_GET_ERROR()によって返され、FPがエラー文字列が配置されるファイルであるエラーコードです。
-    \return なし
-    \param fp  に書き込まれる人間が読めるエラー文字列の出力ファイル。
-    \param err wolfSSL_get_error()で返されるエラーコード。
+
+    \brief この関数は、wolfSSL_get_error()によって返されたエラーコードを、より人間が読みやすいエラー文字列に変換し、その文字列を出力ファイルfpに出力します。errはwolfSSL_get_error()によって返されたエラーコードであり、fpはエラー文字列が配置されるファイルです。
+
+    \return none 戻り値なし。
+
+    \param fp 人間が読みやすいエラー文字列が書き込まれる出力ファイル。
+    \param err wolfSSL_get_error()によって返されたエラーコード。
 
     _Example_
     \code
@@ -4345,6 +4889,7 @@ long wolfSSL_get_verify_result(const WOLFSSL *ssl);
     err = wolfSSL_get_error(ssl, 0);
     wolfSSL_ERR_print_errors_fp(fp, err);
     \endcode
+
     \sa wolfSSL_get_error
     \sa wolfSSL_ERR_error_string
     \sa wolfSSL_ERR_error_string_n
@@ -4354,10 +4899,13 @@ void  wolfSSL_ERR_print_errors_fp(XFILE fp, int err);
 
 /*!
     \ingroup Debug
-    \brief  この関数は提供されたコールバックを使用してエラー報告を処理します。コールバック関数はエラー回線ごとに実行されます。文字列、長さ、およびuserdataはコールバックパラメータに渡されます。
-    \return なし
-    \param cb  コールバック関数
-    \param u コールバック関数に渡されるuserdata
+
+    \brief この関数は、提供されたコールバックを使用してエラーレポートを処理します。コールバック関数は、各エラー行に対して実行されます。文字列、長さ、およびユーザデータがコールバックパラメータに渡されます。
+
+    \return none 戻り値なし。
+
+    \param cb コールバック関数。
+    \param u コールバック関数に渡すユーザデータ。
 
     _Example_
     \code
@@ -4367,6 +4915,7 @@ void  wolfSSL_ERR_print_errors_fp(XFILE fp, int err);
     FILE* fp = ...
     wolfSSL_ERR_print_errors_cb(error_cb, fp);
     \endcode
+
     \sa wolfSSL_get_error
     \sa wolfSSL_ERR_error_string
     \sa wolfSSL_ERR_error_string_n
@@ -4376,30 +4925,32 @@ void  wolfSSL_ERR_print_errors_cb (
         int (*cb)(const char *str, size_t len, void *u), void *u);
 
 /*!
-    \brief  この関数はWOLFSSL_CTX構造のclient_psk_cbメンバーをセットします。
-    \return なし
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param cb wc_psk_client_callback はコールバック関数ポインタでWOLFSSL_CTX構造体に格納されます。
-    戻り値は成功時には鍵長を返し、エラー時には０を返します。
+    \brief この関数は、WOLFSSL_CTX構造体のclient_psk_cbメンバを設定します。
+
+    \return none 戻り値なし。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param cb WOLFSSL_CTX構造体に格納される関数ポインタであるwc_psk_client_callback。戻り値は、成功時には鍵の長さ、エラー時にはゼロです。
     unsigned int (*wc_psk_client_callback)
-    PSK クライアントコールバック関数の引数：<br>
-    WOLFSSL* ssl - WOLFSSL構造体へのポインタ<br>
-    const char* hint - ユーザーに対して表示されるヒント文字列<br>
-    char* identity - ID<br>
-    unsigned int id_max_len - IDバッファのサイズ<br>
-    unsigned char* key - 格納される鍵<br>
-    unsigned int key_max_len - 鍵の最大サイズ<br>
+    PSKクライアントコールバックのパラメータ:
+    WOLFSSL* ssl - wolfSSL構造体へのポインタ
+    const char* hint - ユーザへのヒントを表示するために使用できる格納された文字列。
+    char* identity - IDがここに格納されます。
+    unsigned int id_max_len - IDバッファのサイズ。
+    unsigned char* key - 鍵がここに格納されます。
+    unsigned int key_max_len - 鍵の最大サイズ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = WOLFSSL_CTX_new( protocol def );
     …
     static WC_INLINE unsigned int my_psk_client_cb(WOLFSSL* ssl, const char* hint,
-    char* identity, unsigned int id_max_len, unsigned char* key,
-    Unsigned int key_max_len){
-    …
-    wolfSSL_CTX_set_psk_client_callback(ctx, my_psk_client_cb);
+        char* identity, unsigned int id_max_len, unsigned char* key,
+        Unsigned int key_max_len){
+        …
+        wolfSSL_CTX_set_psk_client_callback(ctx, my_psk_client_cb);
     \endcode
+
     \sa wolfSSL_set_psk_client_callback
     \sa wolfSSL_set_psk_server_callback
     \sa wolfSSL_CTX_set_psk_server_callback
@@ -4409,23 +4960,35 @@ void wolfSSL_CTX_set_psk_client_callback(WOLFSSL_CTX* ctx,
                                                     wc_psk_client_callback cb);
 
 /*!
-    \brief
-    \return none  いいえ返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造体へのポインタ
+    \brief PSKクライアント側コールバックを設定します。
+
+    \return none 戻り値なし。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param cb wc_psk_client_callback型への関数ポインタ。戻り値は、成功時には鍵の長さ、エラー時にはゼロです。
+    unsigned int (*wc_psk_client_callback)
+    PSKクライアントコールバックのパラメータ:
+    WOLFSSL* ssl - wolfSSL構造体へのポインタ
+    const char* hint - ユーザへのヒントを表示するために使用できる格納された文字列。
+    char* identity - IDがここに格納されます。
+    unsigned int id_max_len - IDバッファのサイズ。
+    unsigned char* key - 鍵がここに格納されます。
+    unsigned int key_max_len - 鍵の最大サイズ。
 
     _Example_
     \code
     WOLFSSL* ssl;
     static WC_INLINE unsigned int my_psk_client_cb(WOLFSSL* ssl, const char* hint,
-    char* identity, unsigned int id_max_len, unsigned char* key,
-    Unsigned int key_max_len){
-    …
-    if(ssl){
-    wolfSSL_set_psk_client_callback(ssl, my_psk_client_cb);
-    } else {
-    	// could not set callback
-    }
+        char* identity, unsigned int id_max_len, unsigned char* key,
+        Unsigned int key_max_len){
+        …
+        if(ssl){
+            wolfSSL_set_psk_client_callback(ssl, my_psk_client_cb);
+        } else {
+            // コールバックを設定できませんでした。
+        }
     \endcode
+
     \sa wolfSSL_CTX_set_psk_client_callback
     \sa wolfSSL_CTX_set_psk_server_callback
     \sa wolfSSL_set_psk_server_callback
@@ -4435,9 +4998,13 @@ void wolfSSL_set_psk_client_callback(WOLFSSL* ssl,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はPSKアイデンティティヒントを返します。
-    \return pointer  WolfSSL構造の配列メンバーに格納されている値へのconst charポインタが返されます。
-    \return NULL  WOLFSSLまたは配列構造がNULLの場合に返されます。
+
+    \brief この関数は、PSKアイデンティティヒントを返します。
+
+    \return pointer WOLFSSL構造体のarraysメンバに格納されていた値へのconst char型ポインタが返されます。
+    \return NULL WOLFSSLまたはArrays構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -4446,34 +5013,39 @@ void wolfSSL_set_psk_client_callback(WOLFSSL* ssl,
     ...
     idHint = wolfSSL_get_psk_identity_hint(ssl);
     if(idHint){
-    	// The hint was retrieved
+    	// ヒントが取得されました。
     	return idHint;
     } else {
-    	// Hint wasn’t successfully retrieved
+    	// ヒントの取得に成功しませんでした。
     }
     \endcode
+
     \sa wolfSSL_get_psk_identity
 */
 const char* wolfSSL_get_psk_identity_hint(const WOLFSSL*);
 
 /*!
     \ingroup CertsKeys
-    \brief  関数は、配列構造のClient_Identityメンバーへの定数ポインタを返します。
-    \return string  配列構造のclient_identityメンバの文字列値。
-    \return NULL  WOLFSSL構造がNULLの場合、またはWOLFSSL構造の配列メンバーがNULLの場合。
+
+    \brief この関数は、Arrays構造体のclient_identityメンバへの定数ポインタを返します。
+
+    \return string Arrays構造体のclient_identityメンバの文字列値。
+    \return NULL WOLFSSL構造体がNULL、またはWOLFSSL構造体のArraysメンバがNULLの場合。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
-    WOLFSSL* ssl = wolfSSL_new(ctx);
-    const char* pskID;
+    WOLFSSL* ssl = wolfSSL_new(ctx);    const char* pskID;
     ...
     pskID = wolfSSL_get_psk_identity(ssl);
 
     if(pskID == NULL){
-	    // There is not a value in pskID
+	    // pskIDに値がありません
     }
     \endcode
+
     \sa wolfSSL_get_psk_identity_hint
     \sa wolfSSL_use_psk_identity_hint
 */
@@ -4481,9 +5053,13 @@ const char* wolfSSL_get_psk_identity(const WOLFSSL*);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、WOLFSSL_CTX構造体のserver_hintメンバーにHINT引数を格納します。
-    \return SSL_SUCCESS  機能の実行が成功したために返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+
+    \brief この関数は、hint引数をWOLFSSL_CTX構造体のserver_hintメンバに格納します。
+
+    \return SSL_SUCCESS 関数の実行が成功した場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param hint WOLFSSL_CTX構造体にコピーされる定数charポインタ。
 
     _Example_
     \code
@@ -4493,22 +5069,27 @@ const char* wolfSSL_get_psk_identity(const WOLFSSL*);
     …
     ret = wolfSSL_CTX_use_psk_identity_hint(ctx, hint);
     if(ret == SSL_SUCCESS){
-    	// Function was successful.
+    	// 関数は成功しました
 	return ret;
     } else {
-    	// Failure case.
+    	// 失敗ケース
     }
     \endcode
+
     \sa wolfSSL_use_psk_identity_hint
 */
 int wolfSSL_CTX_use_psk_identity_hint(WOLFSSL_CTX* ctx, const char* hint);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、wolfssl構造内の配列構造のserver_hintメンバーにHINT引数を格納します。
-    \return SSL_SUCCESS  ヒントがWolfSSL構造に正常に保存された場合に返されます。
-    \return SSL_FAILURE  WOLFSSLまたは配列構造がNULLの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造体へのポインタ
+
+    \brief この関数は、hint引数をWOLFSSL構造体内のArrays構造体のserver_hintメンバに格納します。
+
+    \return SSL_SUCCESS hintがWOLFSSL構造体に正常に格納された場合に返されます。
+    \return SSL_FAILURE WOLFSSLまたはArrays構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param hint メモリに保存されるヒントを保持する定数文字ポインタ。
 
     _Example_
     \code
@@ -4516,17 +5097,27 @@ int wolfSSL_CTX_use_psk_identity_hint(WOLFSSL_CTX* ctx, const char* hint);
     const char* hint;
     ...
     if(wolfSSL_use_psk_identity_hint(ssl, hint) != SSL_SUCCESS){
-    	// Handle failure case.
+    	// 失敗ケースを処理
     }
     \endcode
+
     \sa wolfSSL_CTX_use_psk_identity_hint
 */
 int wolfSSL_use_psk_identity_hint(WOLFSSL* ssl, const char* hint);
 
 /*!
-    \brief  WOLFSSL_CTX構造体
-    \return none  いいえ返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造体へのポインタ
+    \brief この関数は、WOLFSSL_CTX構造体にサーバ側のpskコールバックを設定します。
+
+    \return none 戻り値なし。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param cb コールバック用の関数ポインタで、WOLFSSL_CTX構造体に格納されます。戻り値は成功時は鍵の長さ、エラー時は0です。
+    unsigned int (*wc_psk_server_callback)
+    PSKサーバコールバックのパラメータ
+    WOLFSSL* ssl - wolfSSL構造体へのポインタ
+    char* identity - IDがここに格納されます
+    unsigned char* key - 鍵がここに格納されます
+    unsigned int key_max_len - 鍵の最大サイズ
 
     _Example_
     \code
@@ -4536,15 +5127,16 @@ int wolfSSL_use_psk_identity_hint(WOLFSSL* ssl, const char* hint);
     static unsigned int my_psk_server_cb(WOLFSSL* ssl, const char* identity,
                            unsigned char* key, unsigned int key_max_len)
     {
-        // Function body.
+        // 関数本体
     }
     …
     if(ctx != NULL){
         wolfSSL_CTX_set_psk_server_callback(ctx, my_psk_server_cb);
     } else {
-    	// The CTX object was not properly initialized.
+    	// CTXオブジェクトが適切に初期化されませんでした
     }
     \endcode
+
     \sa wc_psk_server_callback
     \sa wolfSSL_set_psk_client_callback
     \sa wolfSSL_set_psk_server_callback
@@ -4554,9 +5146,19 @@ void wolfSSL_CTX_set_psk_server_callback(WOLFSSL_CTX* ctx,
                                                     wc_psk_server_callback cb);
 
 /*!
-    \brief  WolfSSL構造オプションメンバー。
-    \return none  いいえ返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造体へのポインタ
+    \brief WOLFSSL構造体のoptionsメンバを設定することにより、サーバ側のpskコールバックを設定します。
+
+    \return none 戻り値なし。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param cb コールバック用の関数ポインタで、WOLFSSL構造体に格納されます。戻り値は成功時は鍵の長さ、エラー時は0です。
+    unsigned int (*wc_psk_server_callback)
+    PSKサーバコールバックのパラメータ
+    WOLFSSL* ssl - wolfSSL構造体へのポインタ
+    char* identity - IDがここに格納されます
+    unsigned char* key - 鍵がここに格納されます
+    unsigned int key_max_len - 鍵の最大サイズ
+
 
     _Example_
     \code
@@ -4566,13 +5168,14 @@ void wolfSSL_CTX_set_psk_server_callback(WOLFSSL_CTX* ctx,
     static unsigned int my_psk_server_cb(WOLFSSL* ssl, const char* identity,
                            unsigned char* key, unsigned int key_max_len)
     {
-        // Function body.
+        // 関数本体
     }
     …
     if(ssl != NULL && cb != NULL){
         wolfSSL_set_psk_server_callback(ssl, my_psk_server_cb);
     }
     \endcode
+
     \sa wolfSSL_set_psk_client_callback
     \sa wolfSSL_CTX_set_psk_server_callback
     \sa wolfSSL_CTX_set_psk_client_callback
@@ -4585,9 +5188,12 @@ void wolfSSL_set_psk_server_callback(WOLFSSL* ssl,
 
 
 /*!
-    \brief
-    \return WOLFSSL_SUCCESS  またはwolfssl_failure.
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造体へのポインタ
+    \brief WOLFSSL構造体のoptionsメンバにPSKユーザコンテキストを設定します。
+
+    \return WOLFSSL_SUCCESSまたはWOLFSSL_FAILURE
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param psk_ctx ユーザPSKコンテキストへのvoidポインタ。
 
     \sa wolfSSL_get_psk_callback_ctx
     \sa wolfSSL_CTX_set_psk_callback_ctx
@@ -4596,9 +5202,13 @@ void wolfSSL_set_psk_server_callback(WOLFSSL* ssl,
 int wolfSSL_set_psk_callback_ctx(WOLFSSL* ssl, void* psk_ctx);
 
 /*!
-    \brief
-    \return WOLFSSL_SUCCESS  またはwolfssl_failure.
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \brief WOLFSSL_CTX構造体にPSKユーザコンテキストを設定します。
+
+    \return WOLFSSL_SUCCESSまたはWOLFSSL_FAILURE
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param psk_ctx ユーザPSKコンテキストへのvoidポインタ。
+
     \sa wolfSSL_set_psk_callback_ctx
     \sa wolfSSL_get_psk_callback_ctx
     \sa wolfSSL_CTX_get_psk_callback_ctx
@@ -4606,8 +5216,12 @@ int wolfSSL_set_psk_callback_ctx(WOLFSSL* ssl, void* psk_ctx);
 int wolfSSL_CTX_set_psk_callback_ctx(WOLFSSL_CTX* ctx, void* psk_ctx);
 
 /*!
-    \brief
-    \return void  ユーザーPSKコンテキストへのポインタ
+    \brief WOLFSSL構造体のoptionsメンバからPSKユーザコンテキストを取得します。
+
+    \return ユーザPSKコンテキストへのvoidポインタ。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
     \sa wolfSSL_set_psk_callback_ctx
     \sa wolfSSL_CTX_set_psk_callback_ctx
     \sa wolfSSL_CTX_get_psk_callback_ctx
@@ -4615,8 +5229,12 @@ int wolfSSL_CTX_set_psk_callback_ctx(WOLFSSL_CTX* ctx, void* psk_ctx);
 void* wolfSSL_get_psk_callback_ctx(WOLFSSL* ssl);
 
 /*!
-    \brief
-    \return void  ユーザーPSKコンテキストへのポインタ
+    \brief WOLFSSL_CTX構造体からPSKユーザコンテキストを取得します。
+
+    \return ユーザPSKコンテキストへのvoidポインタ。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+
     \sa wolfSSL_CTX_set_psk_callback_ctx
     \sa wolfSSL_set_psk_callback_ctx
     \sa wolfSSL_get_psk_callback_ctx
@@ -4625,9 +5243,13 @@ void* wolfSSL_CTX_get_psk_callback_ctx(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup Setup
-    \brief  この機能により、CTX構造のHAVAnonメンバーがコンパイル中に定義されている場合は、CTX構造のHABANONメンバーを有効にします。
-    \return SSL_SUCCESS  機能が正常に実行され、CTXのHaveannonメンバーが1に設定されている場合に返されます。
-    \return SSL_FAILURE  CTX構造がNULLの場合に返されます。
+
+    \brief この関数は、コンパイル時にHAVE_ANONが定義されている場合、CTX構造体のhavAnonメンバを有効にします。
+
+    \return SSL_SUCCESS 関数が正常に実行され、CTXのhaveAnnonメンバが1に設定された場合に返されます。
+    \return SSL_FAILURE CTX構造体がNULLの場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
 
     _Example_
     \code
@@ -4637,21 +5259,26 @@ void* wolfSSL_CTX_get_psk_callback_ctx(WOLFSSL_CTX* ctx);
     #ifdef HAVE_ANON
 	if(cipherList == NULL){
 	    wolfSSL_CTX_allow_anon_cipher(ctx);
-	    if(wolfSSL_CTX_set_cipher_list(ctx, “ADH_AES128_SHA”) != SSL_SUCCESS){
-		    // failure case
+	    if(wolfSSL_CTX_set_cipher_list(ctx, "ADH_AES128_SHA") != SSL_SUCCESS){
+		    // 失敗ケース
 	    }
     }
     #endif
     \endcode
+
     \sa none
 */
 int wolfSSL_CTX_allow_anon_cipher(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
-    \brief  wolfsslv23_server_method()関数は、アプリケーションがサーバーであることを示すために使用され、SSL 3.0  -  TLS 1.3からプロトコルバージョンと接続するクライアントをサポートします。この関数は、wolfSSL_CTX_new()を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
-    \return pointer  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
-    \return Failure  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc()実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+
+    \brief wolfSSLv23_server_method()関数は、アプリケーションがサーバであり、SSL 3.0からTLS 1.3までのプロトコルバージョンで接続するクライアントをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいWOLFSSL_METHOD構造体のためのメモリを割り当て、初期化します。
+
+    \return pointer 成功時、新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return Failure XMALLOCを呼び出す際にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
+
+    \param none パラメータなし。
 
     _Example_
     \code
@@ -4660,12 +5287,13 @@ int wolfSSL_CTX_allow_anon_cipher(WOLFSSL_CTX*);
 
     method = wolfSSLv23_server_method();
     if (method == NULL) {
-    	// unable to get method
+    	// メソッドを取得できませんでした
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_server_method
     \sa wolfTLSv1_server_method
     \sa wolfTLSv1_1_server_method
@@ -4678,18 +5306,23 @@ WOLFSSL_METHOD *wolfSSLv23_server_method(void);
 
 /*!
     \ingroup Setup
-    \bri f  この関数は、れは、WolfSSL構造体の内部エラー状態を取得するために使用されます。
-    \return wolfssl_error  SSLエラー状態、通常はマイナスを返します
-    \return BAD_FUNC_ARG  sslがNULLの場合
+
+    \brief これは、WOLFSSL構造体の内部エラー状態を取得するために使用されます。
+
+    \return wolfssl_error sslエラー状態を返します。通常は負の値です。
+    \return BAD_FUNC_ARG sslがNULLの場合。
+
+    \return ssl 状態を取得するWOLFSSL構造体。
 
     _Example_
     \code
     WOLFSSL* ssl;
     int ret;
-    // create ssl object
+    // sslオブジェクトを作成
     ret  = wolfSSL_state(ssl);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -4697,9 +5330,13 @@ int  wolfSSL_state(WOLFSSL* ssl);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はピアの証明書を取得します。
-    \return pointer  WOLFSSL_X509構造のPECRERTメンバーへのポインタが存在する場合は。
-    \return 0  ピア証明書発行者サイズが定義されていない場合に返されます。
+
+    \brief この関数は、ピアの証明書を取得します。
+
+    \return pointer 存在する場合、WOLFSSL_X509構造体のpeerCertメンバへのポインタ。
+    \return 0 ピア証明書発行者のサイズが定義されていない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -4709,9 +5346,10 @@ int  wolfSSL_state(WOLFSSL* ssl);
     WOLFSSL_X509* peerCert = wolfSSL_get_peer_certificate(ssl);
 
     if(peerCert){
-    	// You have a pointer peerCert to the peer certification
+    	// ピア証明書へのポインタpeerCertがあります
     }
     \endcode
+
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_subject_name
     \sa wolfSSL_X509_get_isCA
@@ -4720,9 +5358,13 @@ WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL* ssl);
 
 /*!
     \ingroup Debug
-    \brief  この関数は、wolfSSL_get_error()を呼び出してssl_error_want_readを取得するのと似ています。基礎となるエラー状態がSSL_ERROR_WANT_READの場合、この関数は1を返しますが、それ以外の場合は0です。
-    \return 1  WOLFSSL_GET_ERROR()はSSL_ERROR_WANT_READを返し、基礎となるI / Oには読み取り可能なデータがあります。
-    \return 0  SSL_ERROR_WANT_READエラー状態はありません。
+
+    \brief この関数は、wolfSSL_get_error()を呼び出してSSL_ERROR_WANT_READが返される場合と同様です。基礎となるエラー状態がSSL_ERROR_WANT_READの場合、この関数は1を返し、それ以外の場合は0を返します。
+
+    \return 1 wolfSSL_get_error()がSSL_ERROR_WANT_READを返す場合。基礎となるI/Oに読み取り可能なデータがあります。
+    \return 0 SSL_ERROR_WANT_READエラー状態がない場合。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
 
     _Example_
     \code
@@ -4732,9 +5374,10 @@ WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL* ssl);
 
     ret = wolfSSL_want_read(ssl);
     if (ret == 1) {
-    	// underlying I/O has data available for reading (SSL_ERROR_WANT_READ)
+    	// 基礎となるI/Oに読み取り可能なデータがあります(SSL_ERROR_WANT_READ)
     }
     \endcode
+
     \sa wolfSSL_want_write
     \sa wolfSSL_get_error
 */
@@ -4742,9 +5385,13 @@ int wolfSSL_want_read(WOLFSSL*);
 
 /*!
     \ingroup Debug
-    \brief  この関数は、wolfSSL_get_error()を呼び出し、RETURSのSSL_ERROR_WANT_WRITEを取得するのと同じです。基礎となるエラー状態がSSL_ERROR_WANT_WRITEの場合、この関数は1を返しますが、それ以外の場合は0です。
-    \return 1  WOLFSSL_GET_ERROR()はSSL_ERROR_WANT_WRITEを返します。基礎となるI / Oは、基礎となるSSL接続で進行状況を行うために書き込まれるデータを必要とします。
-    \return 0  ssl_error_want_writeエラー状態はありません。
+
+    \brief この関数は、wolfSSL_get_error()を呼び出してSSL_ERROR_WANT_WRITEが返される場合と同様です。基礎となるエラー状態がSSL_ERROR_WANT_WRITEの場合、この関数は1を返し、それ以外の場合は0を返します。
+
+    \return 1 wolfSSL_get_error()がSSL_ERROR_WANT_WRITEを返す場合。基礎となるSSL接続で進行するために、基礎となるI/Oにデータを書き込む必要があります。
+    \return 0 SSL_ERROR_WANT_WRITEエラー状態がない場合。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
 
     _Example_
     \code
@@ -4753,73 +5400,90 @@ int wolfSSL_want_read(WOLFSSL*);
     ...
     ret = wolfSSL_want_write(ssl);
     if (ret == 1) {
-    	// underlying I/O needs data to be written (SSL_ERROR_WANT_WRITE)
+    	// 基礎となるI/Oにデータを書き込む必要があります(SSL_ERROR_WANT_WRITE)
     }
     \endcode
+
     \sa wolfSSL_want_read
     \sa wolfSSL_get_error
-*/
-int wolfSSL_want_write(WOLFSSL*);
+*/int wolfSSL_want_write(WOLFSSL*);
 
 /*!
     \ingroup Setup
-    \brief  wolfsslデフォルトでは、有効な日付範囲と検証済みの署名のためにピア証明書をチェックします。wolfssl_connect()またはwolfssl_accept()の前にこの関数を呼び出すと、実行するチェックのリストにドメイン名チェックが追加されます。DN受信時にピア証明書を確認するためのドメイン名を保持します。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  メモリエラーが発生した場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造体へのポインタ
+
+    \brief wolfSSLはデフォルトでピア証明書の有効な日付範囲と検証済み署名をチェックします。wolfSSL_connect()またはwolfSSL_accept()の前にこの関数を呼び出すと、実行するチェックのリストにドメイン名チェックが追加されます。dnは、受信したピア証明書に対してチェックするドメイン名を保持します。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FAILURE メモリエラーが発生した場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param dn 受信したピア証明書に対してチェックするドメイン名。
 
     _Example_
     \code
     int ret = 0;
     WOLFSSL* ssl;
-    char* domain = (char*) “www.yassl.com”;
+    char* domain = (char*) "www.yassl.com";
     ...
 
     ret = wolfSSL_check_domain_name(ssl, domain);
     if (ret != SSL_SUCCESS) {
-       // failed to enable domain name check
+       // ドメイン名チェックの有効化に失敗しました
     }
     \endcode
+
     \sa none
 */
 int wolfSSL_check_domain_name(WOLFSSL* ssl, const char* dn);
 
 /*!
     \ingroup TLS
-    \brief  使用するためにWolfSSLライブラリを初期化します。アプリケーションごとに1回、その他のライブラリへの呼び出しの前に呼び出す必要があります。
-    \return SSL_SUCCESS  成功した場合に返されます。、通話が戻ります。
-    \return BAD_MUTEX_E  返される可能性があるエラーです。
+
+    \brief 使用するためにwolfSSLライブラリを初期化します。アプリケーションごとに1回、ライブラリへの他の呼び出しの前に呼び出す必要があります。
+
+    \return SSL_SUCCESS 成功した場合に返されます。
+    \return BAD_MUTEX_E 返される可能性のあるエラーです。
+    \return WC_INIT_E wolfCrypt初期化エラーが返されます。
 
     _Example_
     \code
     int ret = 0;
     ret = wolfSSL_Init();
     if (ret != SSL_SUCCESS) {
-	    failed to initialize wolfSSL library
+	    wolfSSLライブラリの初期化に失敗しました
     }
 
     \endcode
+
     \sa wolfSSL_Cleanup
 */
 int wolfSSL_Init(void);
 
 /*!
     \ingroup TLS
-    \brief  さらなる使用からWOLFSSLライブラリを初期化します。ライブラリによって使用されるリソースを解放しますが、呼び出される必要はありません。
-    \return SSL_SUCCESS  エラーを返しません。
+
+    \brief wolfSSLライブラリをこれ以上使用しないように初期化を解除します。呼び出す必要はありませんが、ライブラリが使用したリソースを解放します。
+
+    \return SSL_SUCCESS エラーなしで返されます。
+    \return BAD_MUTEX_E mutexエラーが返されます。
 
     _Example_
     \code
     wolfSSL_Cleanup();
     \endcode
+
     \sa wolfSSL_Init
 */
 int wolfSSL_Cleanup(void);
 
 /*!
     \ingroup IO
-    \brief  この関数は現在のライブラリーバージョンを返します。
-    \return LIBWOLFSSL_VERSION_STRING  バージョンを定義するconst charポインタ。
+
+    \brief この関数は現在のライブラリバージョンを返します。
+
+    \return LIBWOLFSSL_VERSION_STRING バージョンを定義するconst charポインタ。
+
+    \param none パラメータなし。
 
     _Example_
     \code
@@ -4827,17 +5491,22 @@ int wolfSSL_Cleanup(void);
     version = wolfSSL_KeepArrays();
     …
     if(version != ExpectedVersion){
-	    // Handle the mismatch case
+	    // 不一致ケースを処理
     }
     \endcode
+
     \sa word32_wolfSSL_lib_version_hex
 */
 const char* wolfSSL_lib_version(void);
 
 /*!
     \ingroup IO
-    \brief  この関数は、現在のライブラリーのバージョンを16進表記で返します。
-    \return LILBWOLFSSL_VERSION_HEX  wolfssl / version.hで定義されている16進数バージョンを返します。
+
+    \brief この関数は現在のライブラリバージョンを16進表記で返します。
+
+    \return LILBWOLFSSL_VERSION_HEX wolfssl/version.hで定義された16進バージョンを返します。
+
+    \param none パラメータなし。
 
     _Example_
     \code
@@ -4845,20 +5514,25 @@ const char* wolfSSL_lib_version(void);
     libV = wolfSSL_lib_version_hex();
 
     if(libV != EXPECTED_HEX){
-	    // How to handle an unexpected value
+	    // 予期しない値の処理方法
     } else {
-	    // The expected result for libV
+	    // libVの期待される結果
     }
     \endcode
+
     \sa wolfSSL_lib_version
 */
 word32 wolfSSL_lib_version_hex(void);
 
 /*!
     \ingroup IO
-    \brief  SSLメソッドの側面に基づいて、実際の接続または承認を実行します。クライアント側から呼び出された場合、サーバ側から呼び出された場合にwolfssl_accept()が実行されている間にwolfssl_connect()が行われる。
-    \return SSL_SUCCESS  成功した場合に返されます。に返却されます。（注意、古いバージョンは0を返します）
-    \return SSL_FATAL_ERROR  基礎となる呼び出しがエラーになった場合に返されます。特定のエラーコードを取得するには、wolfSSL_get_error()を使用してください。
+
+    \brief SSLメソッドの側面に基づいて実際の接続または受け入れを実行します。クライアント側から呼び出された場合はwolfSSL_connect()が実行され、サーバー側から呼び出された場合はwolfSSL_accept()が実行されます。
+
+    \return SSL_SUCCESS 成功した場合に返されます(注:古いバージョンでは0が返されます)。
+    \return SSL_FATAL_ERROR 基礎となる呼び出しがエラーになった場合に返されます。特定のエラーコードを取得するにはwolfSSL_get_error()を使用してください。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
 
     _Example_
     \code
@@ -4867,12 +5541,13 @@ word32 wolfSSL_lib_version_hex(void);
     ...
     ret = wolfSSL_negotiate(ssl);
     if (ret == SSL_FATAL_ERROR) {
-    	// SSL establishment failed
-	int error_code = wolfSSL_get_error(ssl);
-	...
+    	// SSL確立に失敗しました
+        int error_code = wolfSSL_get_error(ssl);
+        ...
     }
     ...
     \endcode
+
     \sa SSL_connect
     \sa SSL_accept
 */
@@ -4880,9 +5555,13 @@ int wolfSSL_negotiate(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  SSL接続に圧縮を使用する機能をオンにします。両側には圧縮がオンになっている必要があります。そうでなければ圧縮は使用されません。ZLIBライブラリは実際のデータ圧縮を実行します。ライブラリにコンパイルするには、システムの設定システムに--with-libzを使用し、そうでない場合はhand_libzを定義します。送受信されるメッセージの実際のサイズを減らす前にデータを圧縮している間に、圧縮によって保存されたデータの量は通常、ネットワークの遅いすべてのネットワークを除いたものよりも分析に時間がかかります。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return NOT_COMPILED_IN  圧縮サポートがライブラリに組み込まれていない場合に返されます。
+
+    \brief SSL接続で圧縮を使用する機能をオンにします。両側で圧縮をオンにする必要があります。そうでない場合、圧縮は使用されません。zlibライブラリが実際のデータ圧縮を実行します。ライブラリにコンパイルするには、configureシステムで--with-libzを使用し、HAVE_LIBZを定義してください。送信前にデータを圧縮すると送受信されるメッセージの実際のサイズは減少しますが、圧縮によって節約されるデータの量は、最も遅いネットワークを除いて、生データで送信するよりも解析に時間がかかることに注意してください。
+
+    \return SSL_SUCCESS 成功時。
+    \return NOT_COMPILED_IN 圧縮サポートがライブラリにビルドされていない場合に返されます。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
 
     _Example_
     \code
@@ -4891,19 +5570,24 @@ int wolfSSL_negotiate(WOLFSSL* ssl);
     ...
     ret = wolfSSL_set_compression(ssl);
     if (ret == SSL_SUCCESS) {
-    	// successfully enabled compression for SSL session
+    	// SSLセッションの圧縮を正常に有効化しました
     }
     \endcode
+
     \sa none
 */
 int wolfSSL_set_compression(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数はSSLセッションタイムアウト値を秒単位で設定します。
-    \return SSL_SUCCESS  セッションを正常に設定すると返されます。
-    \return BAD_FUNC_ARG  sslがNULLの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造体へのポインタ
+
+    \brief この関数はSSLセッションのタイムアウト値を秒単位で設定します。
+
+    \return SSL_SUCCESS セッションの設定に成功した場合に返されます。
+    \return BAD_FUNC_ARG sslがNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+    \param to SSLセッションタイムアウトの設定に使用される秒単位の値。
 
     _Example_
     \code
@@ -4913,10 +5597,11 @@ int wolfSSL_set_compression(WOLFSSL* ssl);
 
     ret = wolfSSL_set_timeout(ssl, 500);
     if (ret != SSL_SUCCESS) {
-    	// failed to set session timeout value
+    	// セッションタイムアウト値の設定に失敗しました
     }
     ...
     \endcode
+
     \sa wolfSSL_get1_session
     \sa wolfSSL_set_session
 */
@@ -4924,11 +5609,14 @@ int wolfSSL_set_timeout(WOLFSSL* ssl, unsigned int to);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、指定されたSSLコンテキストに対して、SSLセッションのタイムアウト値を秒単位で設定します。
-    \return the  wolfssl_error_code_opensslの場合、以前のタイムアウト値
-    \return defined  成功しています。定義されていない場合、SSL_SUCCESSは返されます。
-    \return BAD_FUNC_ARG  入力コンテキスト（CTX）がNULLのときに返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+
+    \brief この関数は、指定されたSSLコンテキストのSSLセッションのタイムアウト値を秒単位で設定します。
+
+    \return WOLFSSL_ERROR_CODE_OPENSSLが定義されている場合、成功時に以前のタイムアウト値が返されます。定義されていない場合、SSL_SUCCESSが返されます。
+    \return BAD_FUNC_ARG 入力コンテキスト(ctx)がnullの場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param to セッションタイムアウト値(秒単位)。
 
     _Example_
     \code
@@ -4936,9 +5624,10 @@ int wolfSSL_set_timeout(WOLFSSL* ssl, unsigned int to);
     ...
     ret = wolfSSL_CTX_set_timeout(ctx, 500);
     if (ret != SSL_SUCCESS) {
-	    // failed to set session timeout value
+	    // セッションタイムアウト値の設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_flush_sessions
     \sa wolfSSL_get1_session
     \sa wolfSSL_set_session
@@ -4949,14 +5638,19 @@ int wolfSSL_CTX_set_timeout(WOLFSSL_CTX* ctx, unsigned int to);
 
 /*!
     \ingroup openSSL
-    \brief  ピアの証明書チェーンを取得します。
-    \return chain  正常にコールがピアの証明書チェーンを返します。
-    \return 0  無効なWolfSSLポインタが関数に渡されると返されます。
+
+    \brief ピアの証明書チェーンを取得します。
+
+    \return chain 成功した場合、呼び出しはピアの証明書チェーンを返します。
+    \return 0 無効なWOLFSSLポインタが関数に渡された場合に返されます。
+
+    \param ssl 有効なWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_get_chain_count
     \sa wolfSSL_get_chain_length
     \sa wolfSSL_get_chain_cert
@@ -4966,14 +5660,19 @@ WOLFSSL_X509_CHAIN* wolfSSL_get_peer_chain(WOLFSSL* ssl);
 
 /*!
     \ingroup openSSL
-    \brief  ピアの証明書チェーン数を取得します。
-    \return Success  正常にコールがピアの証明書チェーン数を返します。
-    \return 0  無効なチェーンポインタが関数に渡されると返されます。
+
+    \brief ピアの証明書チェーン数を取得します。
+
+    \return Success 成功した場合、呼び出しはピアの証明書チェーン数を返します。
+    \return 0 無効なchainポインタが関数に渡された場合に返されます。
+
+    \param chain 有効なWOLFSSL_X509_CHAIN構造体へのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_get_peer_chain
     \sa wolfSSL_get_chain_length
     \sa wolfSSL_get_chain_cert
@@ -4983,15 +5682,20 @@ int  wolfSSL_get_chain_count(WOLFSSL_X509_CHAIN* chain);
 
 /*!
     \ingroup openSSL
-    \brief  Index（IDX）のピアのASN1.DER証明書長をバイト単位で取得します。
-    \return Success  正常にコールがインデックス別にピアの証明書長をバイト単位で返します。
-    \return 0  無効なチェーンポインタが関数に渡されると返されます。
-    \param chain  有効なwolfssl_x509_chain構造へのポインタ。
+
+    \brief インデックス(idx)におけるピアのASN1.DER証明書の長さをバイト単位で取得します。
+
+    \return Success 成功した場合、呼び出しはインデックスによるピアの証明書の長さをバイト単位で返します。
+    \return 0 無効なchainポインタが関数に渡された場合に返されます。
+
+    \param chain 有効なWOLFSSL_X509_CHAIN構造体へのポインタ。
+    \param idx チェーンの開始インデックス。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_get_peer_chain
     \sa wolfSSL_get_chain_count
     \sa wolfSSL_get_chain_cert
@@ -5001,15 +5705,20 @@ int  wolfSSL_get_chain_length(WOLFSSL_X509_CHAIN* chain, int idx);
 
 /*!
     \ingroup openSSL
-    \brief  インデックス（IDX）でピアのASN1.DER証明書を取得します。
-    \return Success  正常にコールがインデックスでピアの証明書を返します。
-    \return 0  無効なチェーンポインタが関数に渡されると返されます。
-    \param chain  有効なwolfssl_x509_chain構造へのポインタ。
+
+    \brief インデックス(idx)におけるピアのASN1.DER証明書を取得します。
+
+    \return Success 成功した場合、呼び出しはインデックスによるピアの証明書を返します。
+    \return 0 無効なchainポインタが関数に渡された場合に返されます。
+
+    \param chain 有効なWOLFSSL_X509_CHAIN構造体へのポインタ。
+    \param idx チェーンの開始インデックス。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_get_peer_chain
     \sa wolfSSL_get_chain_count
     \sa wolfSSL_get_chain_length
@@ -5019,27 +5728,32 @@ unsigned char* wolfSSL_get_chain_cert(WOLFSSL_X509_CHAIN* chain, int idx);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、証明書のチェーンからのピアのWOLFSSL_X509構造体をインデックス（IDX）で取得します。
-    \return pointer  WOLFSSL_X509構造体へのポインタを返します。
-    \param chain  動的メモリsession_cacheの場合に使用されるWOLFSSL_X509_CHAINへのポインタ。
 
-    注意：本関数から返された構造体をwolfSSL_FreeX509()を呼び出して解放するのはユーザーの責任です。
+    \brief この関数は証明書チェーンからインデックス(idx)にあるピアのwolfSSL_X509_certificateを取得します。
+
+    \return pointer WOLFSSL_X509構造体へのポインタを返します。
+
+    \param chain 動的メモリを使用しないSESSION_CACHEに使用されるWOLFSSL_X509_CHAINへのポインタ。
+    \param idx WOLFSSL_X509証明書のインデックス。
+
+    返されたメモリをwolfSSL_FreeX509()を呼び出して解放することはユーザーの責任です。
 
     _Example_
     \code
     WOLFSSL_X509_CHAIN* chain = &session->chain;
-    int idx = 999; // set idx
+    int idx = 999; // idxを設定
     ...
-    WOLFSSL_X509* ptr;
+    WOLFSSL_X509_CHAIN ptr;
     prt = wolfSSL_get_chain_X509(chain, idx);
 
     if(ptr != NULL){
-        //ptr contains the cert at the index specified
+        // ptrは指定されたインデックスの証明書を含みます
         wolfSSL_FreeX509(ptr);
     } else {
-	    // ptr is NULL
+        // ptrはNULLです
     }
     \endcode
+
     \sa InitDecodedCert
     \sa ParseCertRelative
     \sa CopyDecodedToX509
@@ -5048,15 +5762,19 @@ WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN* chain, int idx);
 
 /*!
     \ingroup openSSL
-    \brief  インデックス（IDX）でピアのPEM証明書を取得します。
-    \return Success  正常にコールがインデックスでピアの証明書を返します。
-    \return 0  無効なチェーンポインタが関数に渡されると返されます。
-    \param chain  有効なwolfssl_x509_chain構造へのポインタ。
+
+    \brief インデックス(idx)におけるピアのPEM証明書を取得します。
+
+    \return Success 成功した場合、呼び出しはインデックスによるピアの証明書を返します。
+    \return 0 無効なchainポインタが関数に渡された場合に返されます。
+
+    \param chain 有効なWOLFSSL_X509_CHAIN構造体へのポインタ。    \param idx チェーンの開始インデックス。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_get_peer_chain
     \sa wolfSSL_get_chain_count
     \sa wolfSSL_get_chain_length
@@ -5067,28 +5785,38 @@ int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN* chain, int idx,
 
 /*!
     \ingroup openSSL
-    \brief  セッションのIDを取得します。セッションIDは常に32バイトの長さです。
-    \return id  セッションID。
+
+    \brief セッションIDを取得します。セッションIDは常に32バイト長です。
+
+    \return id セッションID。
+
+    \param session 有効なwolfsslセッションへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa SSL_get_session
 */
 const unsigned char* wolfSSL_get_sessionID(const WOLFSSL_SESSION* s);
 
 /*!
     \ingroup openSSL
-    \brief  ピアの証明書のシリアル番号を取得します。シリアル番号バッファ（IN）は少なくとも32バイト以上であり、入力として* INOUTSZ引数として提供されます。関数を呼び出した後* INOUTSZはINバッファに書き込まれた実際の長さをバイト単位で保持します。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  関数の不良引数が見つかった場合に返されます。
-    \param in  シリアル番号バッファは少なくとも32バイトの長さであるべきです
+
+    \brief ピアの証明書シリアル番号を取得します。シリアル番号バッファ(in)は少なくとも32バイト長であり、入力として*inOutSz引数として提供される必要があります。関数を呼び出した後、*inOutSzにはinバッファに書き込まれた実際の長さ(バイト単位)が保持されます。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 不正な関数引数が検出された場合に返されます。
+
+    \param in シリアル番号バッファで、少なくとも32バイト長である必要があります。
+    \param inOutSz inバッファに書き込まれた実際の長さ(バイト単位)を保持します。
 
     _Example_
     \code
     none
     \endcode
+
     \sa SSL_get_peer_certificate
 */
 int  wolfSSL_X509_get_serial_number(WOLFSSL_X509* x509, unsigned char* in,
@@ -5096,9 +5824,13 @@ int  wolfSSL_X509_get_serial_number(WOLFSSL_X509* x509, unsigned char* in,
 
 /*!
     \ingroup CertsKeys
-    \brief  証明書から件名の共通名を返します。
-    \return NULL  X509構造がNULLの場合に返されます
-    \return string  サブジェクトの共通名の文字列表現は成功に返されます
+
+    \brief 証明書からサブジェクトのコモンネームを返します。
+
+    \return NULL x509構造体がnullの場合に返されます。
+    \return string 成功時にはサブジェクトのコモンネームの文字列表現が返されます。
+
+    \param x509 証明書情報を含むWOLFSSL_X509構造体へのポインタ。
 
     _Example_
     \code
@@ -5107,36 +5839,43 @@ int  wolfSSL_X509_get_serial_number(WOLFSSL_X509* x509, unsigned char* in,
     ...
     int x509Cn = wolfSSL_X509_get_subjectCN(x509);
     if(x509Cn == NULL){
-	    // Deal with NULL case
+	    // NULLケースを処理
     } else {
-	    // x509Cn contains the common name
+	    // x509Cnにはコモンネームが含まれる
     }
     \endcode
+
     \sa wolfSSL_X509_Name_get_entry
     \sa wolfSSL_X509_get_next_altname
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_subject_name
+
 */
 char*  wolfSSL_X509_get_subjectCN(WOLFSSL_X509*);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、wolfssl_x509構造体のDERエンコードされた証明書を取得します。
-    \return buffer  この関数はDerbuffer構造体のバッファメンバーを返します。これはバイト型です。
-    \return NULL  x509またはoutszパラメーターがnullの場合に返されます。
-    \param x509  証明書情報を含むWolfSSL_X509構造へのポインタ。
+
+    \brief この関数は、WOLFSSL_X509構造体内のDERエンコードされた証明書を取得します。
+
+    \return buffer この関数は、DerBuffer構造体のbufferメンバを返します。これはbyte型です。
+    \return NULL x509またはoutSzパラメータがNULLの場合に返されます。
+
+    \param x509 証明書情報を含むWOLFSSL_X509構造体へのポインタ。
+    \param outSz WOLFSSL_X509構造体のderBufferメンバの長さ。
 
     _Example_
     \code
     WOLFSSL_X509 x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
 							DYNAMIC_TYPE_X509);
-    int* outSz; // initialize
+    int* outSz; // 初期化
     ...
     byte* x509Der = wolfSSL_X509_get_der(x509, outSz);
     if(x509Der == NULL){
-	    // Failure case one of the parameters was NULL
+	    // 失敗ケース、パラメータの1つがNULLだった
     }
     \endcode
+
     \sa wolfSSL_X509_version
     \sa wolfSSL_X509_Name_get_entry
     \sa wolfSSL_X509_get_next_altname
@@ -5147,9 +5886,13 @@ const unsigned char* wolfSSL_X509_get_der(WOLFSSL_X509* x509, int* outSz);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、x509がnullのかどうかを確認し、そうでない場合は、x509構造体のノッカスメンバーを返します。
-    \return pointer  ASN1_TIMEを使用してX509構造体のノカフターメンバーに構造体を表明します。
-    \return NULL  X509オブジェクトがNULLの場合に返されます。
+
+    \brief この関数は、x509がNULLであるかどうかをチェックし、そうでない場合はx509構造体のnotAfterメンバを返します。
+
+    \return pointer x509構造体のnotAfterメンバへのASN1_TIMEを持つ構造体へのポインタ。
+    \return NULL x509オブジェクトがNULLの場合に返されます。
+
+    \param x509 WOLFSSL_X509構造体へのポインタ。
 
     _Example_
     \code
@@ -5158,18 +5901,23 @@ const unsigned char* wolfSSL_X509_get_der(WOLFSSL_X509* x509, int* outSz);
     ...
     const WOLFSSL_ASN1_TIME* notAfter = wolfSSL_X509_get_notAfter(x509);
     if(notAfter == NULL){
-        // Failure case, the x509 object is null.
+        // 失敗ケース、x509オブジェクトがnull
     }
     \endcode
+
     \sa wolfSSL_X509_get_notBefore
 */
 WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notAfter(WOLFSSL_X509*);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はX509証明書のバージョンを取得します。
-    \return 0  X509構造がNULLの場合に返されます。
-    \return version  X509構造に保存されているバージョンが返されます。
+
+    \brief この関数は、X509証明書のバージョンを取得します。
+
+    \return 0 x509構造体がNULLの場合に返されます。
+    \return version x509構造体に格納されているバージョンが返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -5178,9 +5926,10 @@ WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notAfter(WOLFSSL_X509*);
     ...
     version = wolfSSL_X509_version(x509);
     if(!version){
-	    // The function returned 0, failure case.
+	    // 関数は0を返した、失敗ケース
     }
     \endcode
+
     \sa wolfSSL_X509_get_subject_name
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_isCA
@@ -5190,23 +5939,28 @@ int wolfSSL_X509_version(WOLFSSL_X509*);
 
 /*!
     \ingroup CertsKeys
-    \brief  no_stdio_filesystemが定義されている場合、この関数はヒープメモリを割り当て、wolfssl_x509構造を初期化してそれにポインタを返します。
-    \return *WOLFSSL_X509  関数が正常に実行された場合、WolfSSL_X509構造ポインタが返されます。
-    \return NULL  Xftellマクロの呼び出しが負の値を返す場合。
-    \param x509  wolfssl_x509ポインタへのポインタ。
+
+    \brief NO_STDIO_FILESYSTEMが定義されている場合、この関数はヒープメモリを割り当て、WOLFSSL_X509構造体を初期化し、そのポインタを返します。
+
+    \return *WOLFSSL_X509 関数が正常に実行された場合、WOLFSSL_X509構造体ポインタが返されます。
+    \return NULL XFTELLマクロの呼び出しが負の値を返した場合。
+
+    \param x509 WOLFSSL_X509ポインタへのポインタ。
+    \param file FILEへのポインタである定義された型。
 
     _Example_
     \code
     WOLFSSL_X509* x509a = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
     DYNAMIC_TYPE_X509);
     WOLFSSL_X509** x509 = x509a;
-    XFILE file;  (mapped to struct fs_file*)
+    XFILE file;  // (struct fs_file*にマップされる)
     ...
     WOLFSSL_X509* newX509 = wolfSSL_X509_d2i_fp(x509, file);
     if(newX509 == NULL){
-	    // The function returned NULL
+	    // 関数はNULLを返した
     }
     \endcode
+
     \sa wolfSSL_X509_d2i
     \sa XFTELL
     \sa XREWIND
@@ -5217,20 +5971,25 @@ WOLFSSL_X509*
 
 /*!
     \ingroup CertsKeys
-    \brief  関数はX509証明書をメモリにロードします。
-    \return pointer  実行された実行は、wolfssl_x509構造へのポインタを返します。
-    \return NULL  証明書が書き込まれなかった場合に返されます。
-    \param fname  ロードする証明書ファイル。
+
+    \brief この関数は、x509証明書をメモリにロードします。
+
+    \return pointer 正常に実行されると、WOLFSSL_X509構造体へのポインタが返されます。
+    \return NULL 証明書を書き込むことができなかった場合に返されます。
+
+    \param fname ロードする証明書ファイル。
+    \param format 証明書のフォーマット。
 
     _Example_
     \code
-    #define cliCert    “certs/client-cert.pem”
+    #define cliCert    "certs/client-cert.pem"
     …
     X509* x509;
     …
     x509 = wolfSSL_X509_load_certificate_file(cliCert, SSL_FILETYPE_PEM);
     AssertNotNull(x509);
     \endcode
+
     \sa InitDecodedCert
     \sa PemToDer
     \sa wolfSSL_get_certificate
@@ -5241,11 +6000,15 @@ WOLFSSL_X509*
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、デバイスの種類をX509構造からバッファにコピーします。
-    \return pointer  X509構造からデバイスの種類を保持するバイトポインタを返します。
-    \return NULL  バッファサイズがNULLの場合に返されます。
-    \param x509  wolfssl_x509_new()で作成されたwolfssl_x509構造へのポインタ。
-    \param in  デバイスタイプ（バッファ）を保持するバイトタイプへのポインタ。
+
+    \brief この関数は、x509構造体からデバイスタイプをバッファにコピーします。
+
+    \return pointer x509構造体からデバイスタイプを保持するバイトポインタが返されます。
+    \return NULL バッファサイズがNULLの場合に返されます。
+
+    \param x509 WOLFSSL_X509_new()で作成されたWOLFSSL_X509構造体へのポインタ。
+    \param in デバイスタイプ(バッファ)を保持するバイト型へのポインタ。
+    \param inOutSz パラメータinOutSzまたはx509構造体のdeviceTypeSzメンバのいずれか小さい方。
 
     _Example_
     \code
@@ -5257,9 +6020,10 @@ WOLFSSL_X509*
     byte* deviceType = wolfSSL_X509_get_device_type(x509, in, inOutSz);
 
     if(!deviceType){
-	    // Failure case, NULL was returned.
+	    // 失敗ケース、NULLが返された
     }
     \endcode
+
     \sa wolfSSL_X509_get_hw_type
     \sa wolfSSL_X509_get_hw_serial_number
     \sa wolfSSL_X509_d2i
@@ -5270,24 +6034,29 @@ unsigned char*
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、wolfssl_x509構造のHWTypeメンバーをバッファにコピーします。
-    \return byte  この関数は、wolfssl_x509構造のHWTypeメンバーに以前に保持されているデータのバイトタイプを返します。
-    \return NULL  inoutszがnullの場合に返されます。
-    \param x509  証明書情報を含むWolfSSL_X509構造へのポインタ。
-    \param in  バッファを表すバイトを入力するポインタ。
+
+    \brief この関数は、WOLFSSL_X509構造体のhwTypeメンバをバッファにコピーします。
+
+    \return byte 関数は、以前にWOLFSSL_X509構造体のhwTypeメンバに保持されていたデータのバイト型を返します。
+    \return NULL inOutSzがNULLの場合に返されます。
+
+    \param x509 証明書情報を含むWOLFSSL_X509構造体へのポインタ。
+    \param in バッファを表すbyte型へのポインタ。
+    \param inOutSz バッファのサイズを表すint型へのポインタ。
 
     _Example_
     \code
-    WOLFSSL_X509* x509;  // X509 certificate
-    byte* in;  // initialize the buffer
-    int* inOutSz;  // holds the size of the buffer
+    WOLFSSL_X509* x509;  // X509証明書
+    byte* in;  // バッファを初期化
+    int* inOutSz;  // バッファのサイズを保持
     ...
     byte* hwType = wolfSSL_X509_get_hw_type(x509, in, inOutSz);
 
     if(hwType == NULL){
-	    // Failure case function returned NULL.
+	    // 失敗ケース、関数はNULLを返した
     }
     \endcode
+
     \sa wolfSSL_X509_get_hw_serial_number
     \sa wolfSSL_X509_get_device_type
 */
@@ -5297,10 +6066,14 @@ unsigned char*
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はX509オブジェクトのhwserialNumメンバを返します。
-    \return pointer  この関数は、X509オブジェクトからロードされたシリアル番号を含むINバッファへのバイトポインタを返します。
-    \param x509  証明書情報を含むWOLFSSL_X509構造へのポインタ。
-    \param in  コピーされるバッファへのポインタ。
+
+    \brief この関数は、x509オブジェクトのhwSerialNumメンバを返します。
+
+    \return pointer 関数は、x509オブジェクトからロードされたシリアル番号を含むinバッファへのバイトポインタを返します。
+
+    \param x509 証明書情報を含むWOLFSSL_X509構造体へのポインタ。
+    \param in コピー先のバッファへのポインタ。
+    \param inOutSz バッファのサイズへのポインタ。
 
     _Example_
     \code
@@ -5312,9 +6085,10 @@ unsigned char*
     serial = wolfSSL_X509_get_hw_serial_number(x509, in, inOutSz);
 
     if(serial == NULL || serial <= 0){
-    	// Failure case
+    	// 失敗ケース
     }
     \endcode
+
     \sa wolfSSL_X509_get_subject_name
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_isCA
@@ -5327,10 +6101,14 @@ unsigned char*
 
 /*!
     \ingroup IO
-    \brief  この関数はクライアント側で呼び出され、ピアの証明書チェーンを取得するのに十分な長さだけサーバーを持つSSL / TLSハンドシェイクを開始します。この関数が呼び出されると、基礎となる通信チャネルはすでに設定されています。 wolfssl_connect_cert()は、ブロックと非ブロックI / Oの両方で動作します。基礎となるI / Oがノンブロッキングである場合、wolfsl_connect_cert()は、wolfssl_connect_cert_cert()のニーズを満たすことができなかったときに戻ります。ハンドシェイクを続けます。この場合、wolfSSL_get_error()への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。通話プロセスは、基礎となるI / Oが準備ができて、wolfsslがオフになっているところを拾うときに、wolfssl_connect_cert()への呼び出しを繰り返す必要があります。ノンブロッキングソケットを使用する場合は、何も実行する必要がありますが、select()を使用して必要な条件を確認できます。基礎となる入出力がブロックされている場合、wolfssl_connect_cert()はピアの証明書チェーンが受信されたらのみ返されます。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FAILURE  SSLセッションパラメータがNULLの場合、返されます。
-    \return SSL_FATAL_ERROR  エラーが発生した場合に返されます。より詳細なエラーコードを取得するには、wolfSSL_get_error()を呼び出します。
+
+    \brief この関数はクライアント側で呼び出され、ピアの証明書チェーンを取得するのに十分な長さだけサーバーとのSSL/TLSハンドシェイクを開始します。この関数が呼び出されるとき、基礎となる通信チャネルはすでに設定されています。wolfSSL_connect_cert()は、ブロッキングI/Oと非ブロッキングI/Oの両方で動作します。基礎となるI/Oが非ブロッキングの場合、wolfSSL_connect_cert()は、基礎となるI/OがwolfSSL_connect_cert()がハンドシェイクを続行するために必要な処理を満たせないときに戻ります。この場合、wolfSSL_get_error()の呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。呼び出しプロセスは、基礎となるI/Oが準備できたときにwolfSSL_connect_cert()の呼び出しを繰り返す必要があり、wolfSSLは中断した場所から再開します。非ブロッキングソケットを使用する場合、何もする必要はありませんが、select()を使用して必要な条件をチェックできます。基礎となるI/OがブロッキングI/Oの場合、wolfSSL_connect_cert()はピアの証明書チェーンが受信されたときにのみ戻ります。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FAILURE SSLセッションパラメータがNULLの場合に返されます。
+    \return SSL_FATAL_ERROR エラーが発生した場合に返されます。より詳細なエラーコードを取得するには、wolfSSL_get_error()を呼び出してください。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -5342,21 +6120,25 @@ unsigned char*
     ret = wolfSSL_connect_cert(ssl);
     if (ret != SSL_SUCCESS) {
         err = wolfSSL_get_error(ssl, ret);
-        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
     }
     \endcode
+
     \sa wolfSSL_get_error
     \sa wolfSSL_connect
     \sa wolfSSL_accept
-*/
-int  wolfSSL_connect_cert(WOLFSSL* ssl);
+*/int  wolfSSL_connect_cert(WOLFSSL* ssl);
 
 /*!
     \ingroup openSSL
-    \brief  WOLFSSL_D2I_PKCS12_BIO（D2I_PKCS12_BIO）は、WOLFSSL_BIOから構造WC_PKCS12へのPKCS12情報にコピーされます。この情報は、オプションのMAC情報を保持するための構造とともにコンテンツに関する情報のリストとして構造内に分割されています。構造体WC_PKCS12で情報がチャンク（ただし復号化されていない）に分割された後、それはその後、呼び出しによって解析および復号化され得る。
-    \return WC_PKCS12  WC_PKCS12構造へのポインタ。
-    \return Failure  関数に失敗した場合はNULLを返します。
-    \param bio  PKCS12バッファを読み取るためのWOLFSSL_BIO構造。
+
+    \brief wolfSSL_d2i_PKCS12_bio(d2i_PKCS12_bio)は、WOLFSSL_BIOからWC_PKCS12構造体へPKCS12情報をコピーします。情報は、構造体内でコンテンツ情報のリストとして分割され、オプションのMAC情報を保持する構造体も含まれます。情報がWC_PKCS12構造体内でチャンク(ただし復号されていない)に分割された後、呼び出すことによって解析および復号できます。
+
+    \return WC_PKCS12 WC_PKCS12構造体へのポインタ。
+    \return Failure 関数が失敗した場合、NULLを返します。
+
+    \param bio PKCS12バッファを読み取るWOLFSSL_BIO構造体。
+    \param pkcs12 作成された新しいPKCS12構造体用のWC_PKCS12構造体ポインタ。NULLでも可。
 
     _Example_
     \code
@@ -5365,12 +6147,13 @@ int  wolfSSL_connect_cert(WOLFSSL* ssl);
     WOLFSSL_X509* cert;
     WOLFSSL_EVP_PKEY* pkey;
     STACK_OF(X509) certs;
-    //bio loads in PKCS12 file
+    //bioはPKCS12ファイルを読み込みます。
     wolfSSL_d2i_PKCS12_bio(bio, &pkcs);
-    wolfSSL_PKCS12_parse(pkcs, “a password”, &pkey, &cert, &certs)
+    wolfSSL_PKCS12_parse(pkcs, "a password", &pkey, &cert, &certs)
     wc_PKCS12_free(pkcs)
-    //use cert, pkey, and optionally certs stack
+    //cert、pkey、およびオプションでcertsスタックを使用します。
     \endcode
+
     \sa wolfSSL_PKCS12_parse
     \sa wc_PKCS12_free
 */
@@ -5379,10 +6162,14 @@ WC_PKCS12* wolfSSL_d2i_PKCS12_bio(WOLFSSL_BIO* bio,
 
 /*!
     \ingroup openSSL
-    \brief  WOLFSSL_I2D_PKCS12_BIO（I2D_PKCS12_BIO）は、構造WC_PKCS12からWOLFSSL_BIOへの証明書情報にコピーされます。
-    \return 1  成功のために。
-    \return Failure  0。
-    \param bio  PKCS12バッファを書き込むためのWOLFSSL_BIO構造。
+
+    \brief wolfSSL_i2d_PKCS12_bio(i2d_PKCS12_bio)は、WC_PKCS12構造体からWOLFSSL_BIOへ証明書情報をコピーします。
+
+    \return 1 成功時。
+    \return Failure 0。
+
+    \param bio PKCS12バッファを書き込むWOLFSSL_BIO構造体。
+    \param pkcs12 入力としてのPKCS12構造体用のWC_PKCS12構造体。
 
     _Example_
     \code
@@ -5396,14 +6183,15 @@ WC_PKCS12* wolfSSL_d2i_PKCS12_bio(WOLFSSL_BIO* bio,
     f = fopen(file, "rb");
     bytes = (int)fread(buffer, 1, sizeof(buffer), f);
     fclose(f);
-    //convert the DER file into an internal structure
+    //DERファイルを内部構造に変換します。
     wc_d2i_PKCS12(buffer, bytes, pkcs12);
     bio = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
-    //convert PKCS12 structure into bio
+    //PKCS12構造体をbioに変換します。
     wolfSSL_i2d_PKCS12_bio(bio, pkcs12);
     wc_PKCS12_free(pkcs)
-    //use bio
+    //bioを使用します。
     \endcode
+
     \sa wolfSSL_PKCS12_parse
     \sa wc_PKCS12_free
 */
@@ -5412,13 +6200,17 @@ WC_PKCS12* wolfSSL_i2d_PKCS12_bio(WOLFSSL_BIO* bio,
 
 /*!
     \ingroup openSSL
-    \brief  pkcs12は、configureコマンドへの-enable-openSSLAXTRAを追加することで有効にできます。それは復号化のためにトリプルDESとRC4を使うことができるので、OpenSSlextra（--enable-des3 -enable-arc4）を有効にするときにもこれらの機能を有効にすることをお勧めします。 wolfsslは現在RC2をサポートしていませんので、RC2での復号化は現在利用できません。これは、.p12ファイルを作成するためにOpenSSLコマンドラインで使用されるデフォルトの暗号化方式では注目すかもしれません。 WOLFSSL_PKCS12_PARSE（PKCS12_PARSE）。この関数が最初に行っているのは、存在する場合はMacが正しいチェックです。 MACが失敗した場合、関数は返され、保存されているコンテンツ情報のいずれかを復号化しようとしません。この関数は、バッグタイプを探している各コンテンツ情報を介して解析します。バッグタイプがわかっている場合は、必要に応じて復号化され、構築されている証明書のリストに格納されているか、見つかったキーとして保存されます。すべてのバッグを介して解析した後、見つかったキーは、一致するペアが見つかるまで証明書リストと比較されます。この一致するペアはキーと証明書として返され、オプションで見つかった証明書リストはstack_of証明書として返されます。瞬間、CRL、秘密または安全なバッグがスキップされ、解析されません。デバッグプリントアウトを見ることで、これらまたは他の「不明」バッグがスキップされているかどうかがわかります。フレンドリー名などの追加の属性は、PKCS12ファイルを解析するときにスキップされます。
-    \return SSL_SUCCESS  PKCS12の解析に成功しました。
-    \return SSL_FAILURE  エラーケースに遭遇した場合
-    \param pkcs12  wc_pkcs12解析する構造
-    \param paswd  PKCS12を復号化するためのパスワード。
-    \param pkey  PKCS12からデコードされた秘密鍵を保持するための構造。
-    \param cert  PKCS12から復号された証明書を保持する構造
+
+    \brief PKCS12は、configureコマンドに--enable-opensslextraを追加することで有効にできます。復号にトリプルDESとRC4を使用できるため、opensslextraを有効にする際にこれらの機能も有効にすることを推奨します(--enable-des3 --enable-arc4)。wolfSSLは現在RC2をサポートしていないため、RC2での復号は現在利用できません。これは、OpenSSLコマンドラインで.p12ファイルを作成する際に使用されるデフォルトの暗号化スキームで顕著になる可能性があります。wolfSSL_PKCS12_parse(PKCS12_parse)。この関数が最初に行うことは、存在する場合にMACが正しいかどうかを確認することです。MACが失敗した場合、関数は返され、保存されているコンテンツ情報の復号を試みません。この関数は、各コンテンツ情報を解析してバッグタイプを探し、バッグタイプが既知の場合、必要に応じて復号され、構築中の証明書リストまたは見つかった鍵として保存されます。すべてのバッグを解析した後、見つかった鍵は証明書リストと比較され、一致するペアが見つかります。この一致するペアは、鍵と証明書として返されます。オプションで、見つかった証明書リストはSTACK_OFの証明書として返されます。現時点では、CRL、Secret、またはSafeContentsバッグはスキップされ、解析されません。これらまたは他の「不明な」バッグがスキップされているかどうかは、デバッグ出力を表示することで確認できます。フレンドリ名などの追加属性は、PKCS12ファイルを解析する際にスキップされます。
+
+    \return SSL_SUCCESS PKCS12の解析が成功した場合。
+    \return SSL_FAILURE エラーケースに遭遇した場合。
+
+    \param pkcs12 解析するWC_PKCS12構造体。
+    \param paswd PKCS12を復号するためのパスワード。
+    \param pkey PKCS12から復号された秘密鍵を保持する構造体。
+    \param cert PKCS12から復号された証明書を保持する構造体。
+    \param stack 追加の証明書のオプションスタック。
 
     _Example_
     \code
@@ -5427,12 +6219,13 @@ WC_PKCS12* wolfSSL_i2d_PKCS12_bio(WOLFSSL_BIO* bio,
     WOLFSSL_X509* cert;
     WOLFSSL_EVP_PKEY* pkey;
     STACK_OF(X509) certs;
-    //bio loads in PKCS12 file
+    //bioはPKCS12ファイルを読み込みます。
     wolfSSL_d2i_PKCS12_bio(bio, &pkcs);
-    wolfSSL_PKCS12_parse(pkcs, “a password”, &pkey, &cert, &certs)
+    wolfSSL_PKCS12_parse(pkcs, "a password", &pkey, &cert, &certs)
     wc_PKCS12_free(pkcs)
-    //use cert, pkey, and optionally certs stack
+    //cert、pkey、およびオプションでcertsスタックを使用します。
     \endcode
+
     \sa wolfSSL_d2i_PKCS12_bio
     \sa wc_PKCS12_free
 */
@@ -5441,14 +6234,18 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
 
 /*!
     \ingroup CertsKeys
-    \brief  サーバーDIFFIE-HELLMANエフェメラルパラメータ設定。この関数は、サーバーがDHEを使用する暗号スイートをネゴシエートしている場合に使用するグループパラメータを設定します。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return MEMORY_ERROR  メモリエラーが発生した場合に返されます。
-    \return SIDE_ERROR  この関数がSSLサーバではなくSSLクライアントで呼び出されると返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param p  Diffie-Hellman素数パラメータ。
-    \param pSz  pのサイズ。
-    \param g  Diffie-Hellman "Generator"パラメータ。
+
+    \brief サーバDiffie-Hellmanエフェメラルパラメータの設定。この関数は、サーバがDHEを使用する暗号スイートをネゴシエートする場合に使用されるグループパラメータを設定します。
+
+    \return SSL_SUCCESS 成功時。
+    \return MEMORY_ERROR メモリエラーが発生した場合に返されます。
+    \return SIDE_ERROR この関数がSSLサーバではなくSSLクライアントで呼び出された場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param p Diffie-Hellman素数パラメータ。
+    \param pSz pのサイズ。
+    \param g Diffie-Hellman「生成元」パラメータ。
+    \param gSz gのサイズ。
 
     _Example_
     \code
@@ -5458,6 +6255,7 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
     ...
     wolfSSL_SetTmpDH(ssl, p, sizeof(p), g, sizeof(g));
     \endcode
+
     \sa SSL_accept
 */
 int  wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
@@ -5465,19 +6263,23 @@ int  wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
 
 /*!
     \ingroup CertsKeys
-    \brief  関数はwolfssl_settmph_buffer_wrapperを呼び出します。これはDiffie-Hellmanパラメータのラッパーです。
-    \return SSL_SUCCESS  実行に成功した場合。
-    \return SSL_BAD_FILETYPE  ファイルの種類がpemではなく、asn.1ではない場合WC_DHParamSLOADが正常に戻っていない場合は、も返されます。
-    \return SSL_NO_PEM_HEADER  PEMヘッダーがない場合はPemToderから返します。
-    \return SSL_BAD_FILE  PemToderにファイルエラーがある場合に返されます。
-    \return SSL_FATAL_ERROR  コピーエラーが発生した場合はPemToderから返されました。
-    \return MEMORY_E   - メモリ割り当てエラーが発生した場合
-    \return BAD_FUNC_ARG  wolfssl構造体がnullの場合、またはそうでない場合はサブルーチンに渡された場合に返されます。
-    \return DH_KEY_SIZE_E  wolfssl_settmph()またはWOLFSSL_CTX_settmph()の鍵サイズエラーがある場合に返されます。
-    \return SIDE_ERROR  wolfssl_settmphのサーバー側ではない場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param buf  wolfssl_settmph_file_wrapperから渡された割り当てバッファー。
-    \param sz  ファイルのサイズ（wolfssl_settmph_file_wrapper内のfname）を保持するロングint。
+
+    \brief この関数は、Diffie-HellmanパラメータのラッパーであるwolfSSL_SetTMpDH_buffer_wrapperを呼び出します。
+
+    \return SSL_SUCCESS 実行が成功した場合。
+    \return SSL_BAD_FILETYPE ファイルタイプがPEMでなく、ASN.1でもない場合。また、wc_DhParamsLoadが正常に返されなかった場合にも返されます。
+    \return SSL_NO_PEM_HEADER PEMヘッダが存在しない場合、PemToDerから返されます。
+    \return SSL_BAD_FILE PemToDerでファイルエラーがあった場合に返されます。
+    \return SSL_FATAL_ERROR コピーエラーがあった場合、PemToDerから返されます。
+    \return MEMORY_E メモリ割り当てエラーがあった場合。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合、またはサブルーチンにNULL引数が渡された場合に返されます。
+    \return DH_KEY_SIZE_E wolfSSL_SetTmpDH()またはwolfSSL_CTX_SetTmpDH()でキーサイズエラーがある場合に返されます。
+    \return SIDE_ERROR wolfSSL_SetTmpDHでサーバ側でない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param buf wolfSSL_SetTMpDH_file_wrapperから渡される割り当てられたバッファ。
+    \param sz ファイル(wolfSSL_SetTmpDH_file_wrapper内のfname)のサイズを保持するlong int型。
+    \param format wolfSSL_SetTmpDH_file_wrapper()から渡される証明書形式の表現である整数型。
 
     _Example_
     \code
@@ -5487,8 +6289,9 @@ int  wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
     byte* myBuffer = staticBuffer[FILE_BUFFER_SIZE];
     …
     if(ssl)
-    ret = wolfSSL_SetTmpDH_buffer(ssl, myBuffer, sz, format);
+        ret = wolfSSL_SetTmpDH_buffer(ssl, myBuffer, sz, format);
     \endcode
+
     \sa wolfSSL_SetTmpDH_buffer_wrapper
     \sa wc_DhParamsLoad
     \sa wolfSSL_SetTmpDH
@@ -5501,16 +6304,20 @@ int  wolfSSL_SetTmpDH_buffer(WOLFSSL* ssl, const unsigned char* b, long sz,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、wolfssl_settmph_file_wrapperを呼び出してサーバdiffie-hellmanパラメータを設定します。
-    \return SSL_SUCCESS  この機能の正常な完了とそのサブルーチンの完了に戻りました。
-    \return MEMORY_E  この関数またはサブルーチンにメモリ割り当てが失敗した場合に返されます。
-    \return SIDE_ERROR  WolfSSL構造体にあるオプション構造のサイドメンバーがサーバー側ではない場合。
-    \return SSL_BAD_FILETYPE  証明書が一連のチェックに失敗した場合は返します。
-    \return DH_KEY_SIZE_E  DHパラメーターの鍵サイズがWolfSSL構造体のMinkKeyszメンバーの値より小さい場合に返されます。
-    \return DH_KEY_SIZE_E  DHパラメータの鍵サイズがwolfssl構造体のMAXDHKEYSZメンバーの値よりも大きい場合に返されます。
-    \return BAD_FUNC_ARG  wolfssl構造など、引数値がnullの場合に返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param fname  証明書を保持している定数の文字ポインタ。
+
+    \brief この関数は、wolfSSL_SetTmpDH_file_wrapperを呼び出してサーバDiffie-Hellmanパラメータを設定します。
+
+    \return SSL_SUCCESS この関数とそのサブルーチンが正常に完了した場合に返されます。
+    \return MEMORY_E この関数またはサブルーチンでメモリ割り当てが失敗した場合に返されます。
+    \return SIDE_ERROR WOLFSSL構造体内のOptions構造体のsideメンバがサーバ側でない場合。
+    \return SSL_BAD_FILETYPE 証明書が一連のチェックに失敗した場合に返されます。
+    \return DH_KEY_SIZE_E DHパラメータの鍵サイズがWOLFSSL構造体のminDhKeySzメンバの値より小さい場合に返されます。
+    \return DH_KEY_SIZE_E DHパラメータの鍵サイズがWOLFSSL構造体のmaxDhKeySzメンバの値より大きい場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL構造体など、許可されていない引数値がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param fname 証明書を保持する定数char型ポインタ。
+    \param format 証明書の形式を保持する整数型。
 
     _Example_
     \code
@@ -5518,8 +6325,9 @@ int  wolfSSL_SetTmpDH_buffer(WOLFSSL* ssl, const unsigned char* b, long sz,
     const char* dhParam;
     …
     AssertIntNE(SSL_SUCCESS,
-    wolfSSL_SetTmpDH_file(ssl, dhParam, SSL_FILETYPE_PEM));
+        wolfSSL_SetTmpDH_file(ssl, dhParam, SSL_FILETYPE_PEM));
     \endcode
+
     \sa wolfSSL_CTX_SetTmpDH_file
     \sa wolfSSL_SetTmpDH_file_wrapper
     \sa wolfSSL_SetTmpDH_buffer
@@ -5532,20 +6340,24 @@ int  wolfSSL_SetTmpDH_file(WOLFSSL* ssl, const char* f, int format);
 
 /*!
     \ingroup CertsKeys
-    \brief  サーバーCTX Diffie-Hellmanのパラメータを設定します。
-    \return SSL_SUCCESS  関数とすべてのサブルーチンがエラーなしで戻った場合に返されます。
-    \return BAD_FUNC_ARG  CTX、P、またはGパラメーターがNULLの場合に返されます。
-    \return DH_KEY_SIZE_E  DHパラメータの鍵サイズがWOLFSSL_CTX構造体のMindHKEYSZメンバーの値より小さい場合に返されます。
-    \return DH_KEY_SIZE_E  DHパラメータの鍵サイズがWOLFSSL_CTX構造体のMaxDhkeySZメンバーの値よりも大きい場合に返されます。
-    \return MEMORY_E  この関数またはサブルーチンにメモリの割り当てが失敗した場合に返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param p  ServerDH_P構造体のバッファメンバーにロードされた定数の符号なし文字ポインタ。
-    \param pSz  pのサイズを表すint型は、max_dh_sizeに初期化されます。
-    \param g  ServerDh_g構造体のバッファメンバーにロードされた定数の符号なし文字ポインタ。
 
-    _Example_
+    \brief サーバCTX Diffie-Hellmanのパラメータを設定します。
+
+    \return SSL_SUCCESS 関数とすべてのサブルーチンがエラーなく返された場合に返されます。
+    \return BAD_FUNC_ARG CTX、pまたはgパラメータがNULLの場合に返されます。
+    \return DH_KEY_SIZE_E DHパラメータの鍵サイズがWOLFSSL_CTX構造体のminDhKeySzメンバの値より小さい場合に返されます。
+    \return DH_KEY_SIZE_E DHパラメータの鍵サイズがWOLFSSL_CTX構造体のmaxDhKeySzメンバの値より大きい場合に返されます。
+    \return MEMORY_E この関数またはサブルーチンでメモリ割り当てが失敗した場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param p serverDH_P構造体のbufferメンバに読み込まれる定数unsigned char型ポインタ。
+    \param pSz pのサイズを表すint型で、MAX_DH_SIZEに初期化されます。
+    \param g serverDH_G構造体のbufferメンバに読み込まれる定数unsigned char型ポインタ。
+    \param gSz gのサイズを表すint型で、MAX_DH_SIZEに初期化されます。
+
+    _Exmaple_
     \code
-    WOLFSSL_CTX* ctx =  wolfSSL_CTX_new( protocol );
+    WOLFSSL_CTX* ctx =  WOLFSSL_CTX_new( protocol );
     byte* p;
     byte* g;
     word32 pSz = (word32)sizeof(p)/sizeof(byte);
@@ -5554,9 +6366,10 @@ int  wolfSSL_SetTmpDH_file(WOLFSSL* ssl, const char* f, int format);
     int ret =  wolfSSL_CTX_SetTmpDH(ctx, p, pSz, g, gSz);
 
     if(ret != SSL_SUCCESS){
-    	// Failure case
+    	// 失敗ケース
     }
     \endcode
+
     \sa wolfSSL_SetTmpDH
     \sa wc_DhParamsLoad
 */
@@ -5565,21 +6378,25 @@ int  wolfSSL_CTX_SetTmpDH(WOLFSSL_CTX* ctx, const unsigned char* p,
 
 /*!
     \ingroup CertsKeys
-    \brief  wolfssl_settmph_buffer_wrapperを呼び出すラッパー関数
-    \return 0  実行が成功するために返されました。
-    \return BAD_FUNC_ARG  CTXパラメータまたはBUFパラメータがNULLの場合に返されます。
-    \return MEMORY_E  メモリ割り当てエラーがある場合
-    \return SSL_BAD_FILETYPE  フォーマットが正しくない場合に返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param buf  バッファとして割り当てられ、wolfssl_settmpdh_buffer_wrapperに渡された定数の符号なし文字型へのポインタ。
-    \param sz  wolfssl_settmph_file_wrapper()のFNAMEパラメータから派生した長い整数型。
+
+    \brief wolfSSL_SetTmpDH_buffer_wrapperを呼び出すラッパー関数です。
+
+    \return 0 実行が成功した場合に返されます。
+    \return BAD_FUNC_ARG ctxまたはbufパラメータがNULLの場合に返されます。
+    \return MEMORY_E メモリ割り当てエラーがある場合。
+    \return SSL_BAD_FILETYPE formatが正しくない場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param buf バッファとして割り当てられ、wolfSSL_SetTmpDH_buffer_wrapperに渡される定数unsigned char型へのポインタ。
+    \param sz wolfSSL_SetTmpDH_file_wrapper()のfnameパラメータから導出されるlong整数型。
+    \param format wolfSSL_SetTmpDH_file_wrapper()から渡される整数型。
 
     _Example_
     \code
     static int wolfSSL_SetTmpDH_file_wrapper(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
-    Const char* fname, int format);
+        Const char* fname, int format);
     #ifdef WOLFSSL_SMALL_STACK
-    byte staticBuffer[1]; // force heap usage
+    byte staticBuffer[1]; // ヒープ使用を強制
     #else
     byte* staticBuffer;
     long sz = 0;
@@ -5587,9 +6404,10 @@ int  wolfSSL_CTX_SetTmpDH(WOLFSSL_CTX* ctx, const unsigned char* p,
     if(ssl){
     	ret = wolfSSL_SetTmpDH_buffer(ssl, myBuffer, sz, format);
     } else {
-    ret = wolfSSL_CTX_SetTmpDH_buffer(ctx, myBuffer, sz, format);
+        ret = wolfSSL_CTX_SetTmpDH_buffer(ctx, myBuffer, sz, format);
     }
     \endcode
+
     \sa wolfSSL_SetTmpDH_buffer_wrapper
     \sa wolfSSL_SetTMpDH_buffer
     \sa wolfSSL_SetTmpDH_file_wrapper
@@ -5600,37 +6418,41 @@ int  wolfSSL_CTX_SetTmpDH_buffer(WOLFSSL_CTX* ctx, const unsigned char* b,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、wolfssl_settmph_file_wrapperを呼び出してサーバーDiffie-Hellmanパラメータを設定します。
-    \return SSL_SUCCESS  wolfssl_settmph_file_wrapperまたはそのサブルーチンのいずれかが正常に戻った場合に返されます。
-    \return MEMORY_E  動的メモリの割り当てがサブルーチンで失敗した場合に返されます。
-    \return BAD_FUNC_ARG  CTXまたはFNAMEパラメータがNULLまたはサブルーチンがNULL引数に渡された場合に返されます。
-    \return SSL_BAD_FILE  証明書ファイルが開くことができない場合、またはファイルの一連のチェックがwolfssl_settmpdh_file_wrapperから失敗した場合に返されます。
-    \return SSL_BAD_FILETYPE  フォーマットがwolfssl_settmph_buffer_wrapper()からPEMまたはASN.1ではない場合に返されます。
-    \return DH_KEY_SIZE_E  DHパラメータの鍵サイズがWOLFSSL_CTX構造体のMindHKEYSZメンバーの値より小さい場合に返されます。
-    \return DH_KEY_SIZE_E  DHパラメータの鍵サイズがWOLFSSL_CTX構造体のMaxDhkeySZメンバーの値よりも大きい場合に返されます。
-    \return SIDE_ERROR  wolfssl_settmph()で返されたサイドがサーバー終了ではない場合。
-    \return SSL_NO_PEM_HEADER  PEMヘッダーがない場合はPemToderから返されます。
-    \return SSL_FATAL_ERROR  メモリコピーの失敗がある場合はPemToderから返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param fname  証明書ファイルへの定数文字ポインタ。
+
+    \brief この関数は、wolfSSL_SetTmpDH_file_wrapperを呼び出してサーバDiffie-Hellmanパラメータを設定します。
+
+    \return SSL_SUCCESS wolfSSL_SetTmpDH_file_wrapperまたはそのサブルーチンのいずれかが正常に返された場合に返されます。
+    \return MEMORY_E サブルーチンで動的メモリの割り当てが失敗した場合に返されます。
+    \return BAD_FUNC_ARG ctxまたはfnameパラメータがNULLの場合、またはサブルーチンにNULL引数が渡された場合に返されます。
+    \return SSL_BAD_FILE 証明書ファイルを開けない場合、またはwolfSSL_SetTmpDH_file_wrapperからのファイルに対する一連のチェックが失敗した場合に返されます。
+    \return SSL_BAD_FILETYPE wolfSSL_SetTmpDH_buffer_wrapper()から、形式がPEMでもASN.1でもない場合に返されます。
+    \return DH_KEY_SIZE_E DHパラメータの鍵サイズがWOLFSSL_CTX構造体のminDhKeySzメンバの値より小さい場合に返されます。
+    \return DH_KEY_SIZE_E DHパラメータの鍵サイズがWOLFSSL_CTX構造体のmaxDhKeySzメンバの値より大きい場合に返されます。
+    \return SIDE_ERROR サーバ側でない場合、wolfSSL_SetTmpDH()で返されます。
+    \return SSL_NO_PEM_HEADER PEMヘッダがない場合、PemToDerから返されます。
+    \return SSL_FATAL_ERROR メモリコピーの失敗がある場合、PemToDerから返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param fname 証明書ファイルへの定数文字ポインタ。
+    \param format 証明書形式の表現である、wolfSSL_SetTmpDH_file_wrapper()から渡される整数型。
 
     _Example_
     \code
-    #define dhParam     “certs/dh2048.pem”
+    #define dhParam     "certs/dh2048.pem"
     #DEFINE aSSERTiNTne(x, y)     AssertInt(x, y, !=, ==)
     WOLFSSL_CTX* ctx;
     …
     AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()))
     …
     AssertIntNE(SSL_SUCCESS, wolfSSL_CTX_SetTmpDH_file(NULL, dhParam,
-    SSL_FILETYPE_PEM));
+        SSL_FILETYPE_PEM));
     \endcode
+
     \sa wolfSSL_SetTmpDH_buffer_wrapper
     \sa wolfSSL_SetTmpDH
     \sa wolfSSL_CTX_SetTmpDH
     \sa wolfSSL_SetTmpDH_buffer
-    \sa wolfSSL_CTX_SetTmpDH_buffer
-    \sa wolfSSL_SetTmpDH_file_wrapper
+    \sa wolfSSL_CTX_SetTmpDH_buffer    \sa wolfSSL_SetTmpDH_file_wrapper
     \sa AllocDer
     \sa PemToDer
 */
@@ -5639,17 +6461,22 @@ int  wolfSSL_CTX_SetTmpDH_file(WOLFSSL_CTX* ctx, const char* f,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、WOLFSSL_CTX構造体のminkkeyszメンバーにアクセスして、Diffie Hellman鍵サイズの最小サイズ（ビット単位）を設定します。
-    \return SSL_SUCCESS  関数が正常に完了した場合に返されます。
-    \return BAD_FUNC_ARG  WOLFSSL_CTX構造体がnullの場合、またはキーz_BITSが16,000を超えるか、または8によって割り切れない場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+
+    \brief この関数は、WOLFSSL_CTX構造体のminDhKeySzメンバにアクセスして、Diffie-Hellman鍵サイズの最小サイズ(ビット単位)を設定します。
+
+    \return SSL_SUCCESS 関数が正常に完了した場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULLの場合、またはkeySz_bitsが16,000より大きいか8で割り切れない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param keySz_bits 最小DH鍵サイズをビット単位で設定するために使用されるword16型。WOLFSSL_CTX構造体はこの情報をminDhKeySzメンバに保持します。
 
     _Example_
     \code
     public static int CTX_SetMinDhKey_Sz(IntPtr ctx, short minDhKey){
-    …
-    return wolfSSL_CTX_SetMinDhKey_Sz(local_ctx, minDhKeyBits);
+        …
+        return wolfSSL_CTX_SetMinDhKey_Sz(local_ctx, minDhKeyBits);
     \endcode
+
     \sa wolfSSL_SetMinDhKey_Sz
     \sa wolfSSL_CTX_SetMaxDhKey_Sz
     \sa wolfSSL_SetMaxDhKey_Sz
@@ -5660,10 +6487,14 @@ int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX* ctx, word16);
 
 /*!
     \ingroup CertsKeys
-    \brief  WolfSSL構造のDiffie-Hellman鍵の最小サイズ（ビット単位）を設定します。
-    \return SSL_SUCCESS  最小サイズは正常に設定されました。
-    \return BAD_FUNC_ARG  wolfssl構造はNULL、またはKeysz_BITSが16,000を超えるか、または8によって割り切れない場合
-    \param ssl  wolfssl_new()を使用して作成されたWolfSSL構造へのポインタ。
+
+    \brief WOLFSSL構造体内のDiffie-Hellman鍵の最小サイズ(ビット単位)を設定します。
+
+    \return SSL_SUCCESS 最小サイズが正常に設定されました。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合、またはkeySz_bitsが16,000より大きいか8で割り切れない場合。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param keySz_bits 最小DH鍵サイズをビット単位で設定するために使用されるword16型。WOLFSSL_CTX構造体はこの情報をminDhKeySzメンバに保持します。
 
     _Example_
     \code
@@ -5671,9 +6502,10 @@ int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX* ctx, word16);
     word16 keySz_bits;
     ...
     if(wolfSSL_SetMinDhKey_Sz(ssl, keySz_bits) != SSL_SUCCESS){
-	    // Failed to set.
+	    // 設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_CTX_SetMinDhKey_Sz
     \sa wolfSSL_GetDhKey_Sz
 */
@@ -5681,17 +6513,22 @@ int wolfSSL_SetMinDhKey_Sz(WOLFSSL* ssl, word16 keySz_bits);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、WOLFSSL_CTX構造体のmaxdhkeyszメンバーにアクセスして、Diffie Hellman鍵サイズの最大サイズ（ビット単位）を設定します。
-    \return SSL_SUCCESS  関数が正常に完了した場合に返されます。
-    \return BAD_FUNC_ARG  WOLFSSL_CTX構造体がnullの場合、またはキーz_BITSが16,000を超えるか、または8によって割り切れない場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数は、WOLFSSL_CTX構造体のmaxDhKeySzメンバにアクセスして、Diffie-Hellman鍵サイズの最大サイズ(ビット単位)を設定します。
+
+    \return SSL_SUCCESS 関数が正常に完了した場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULLの場合、またはkeySz_bitsが16,000より大きいか8で割り切れない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param keySz_bits 最大DH鍵サイズをビット単位で設定するために使用されるword16型。WOLFSSL_CTX構造体はこの情報をmaxDhKeySzメンバに保持します。
 
     _Example_
     \code
     public static int CTX_SetMaxDhKey_Sz(IntPtr ctx, short maxDhKey){
-    …
-    return wolfSSL_CTX_SetMaxDhKey_Sz(local_ctx, keySz_bits);
+        …
+        return wolfSSL_CTX_SetMaxDhKey_Sz(local_ctx, keySz_bits);
     \endcode
+
     \sa wolfSSL_SetMinDhKey_Sz
     \sa wolfSSL_CTX_SetMinDhKey_Sz
     \sa wolfSSL_SetMaxDhKey_Sz
@@ -5702,10 +6539,14 @@ int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX* ctx, word16 keySz_bits);
 
 /*!
     \ingroup CertsKeys
-    \brief  WolfSSL構造のDiffie-Hellman鍵の最大サイズ（ビット単位）を設定します。
-    \return SSL_SUCCESS  最大サイズは正常に設定されました。
-    \return BAD_FUNC_ARG  WOLFSSL構造はNULLまたはKEYSZパラメータは許容サイズより大きかったか、または8によって割り切れませんでした。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief WOLFSSL構造体内のDiffie-Hellman鍵の最大サイズ(ビット単位)を設定します。
+
+    \return SSL_SUCCESS 最大サイズが正常に設定されました。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合、またはkeySzパラメータが許容サイズより大きいか8で割り切れない場合。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param keySz 最大DH鍵のビットサイズを表すword16型。
 
     _Example_
     \code
@@ -5713,9 +6554,10 @@ int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX* ctx, word16 keySz_bits);
     word16 keySz;
     ...
     if(wolfSSL_SetMaxDhKey(ssl, keySz) != SSL_SUCCESS){
-	    // Failed to set.
+	    // 設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_CTX_SetMaxDhKey_Sz
     \sa wolfSSL_GetDhKey_Sz
 */
@@ -5723,9 +6565,13 @@ int wolfSSL_SetMaxDhKey_Sz(WOLFSSL* ssl, word16 keySz_bits);
 
 /*!
     \ingroup CertsKeys
-    \brief  オプション構造のメンバーであるDHKEYSZ（ビット内）の値を返します。この値は、Diffie-Hellman鍵サイズをバイト単位で表します。
-    \return dhKeySz  サイズを表す整数値であるssl-> options.dhkeyszで保持されている値を返します。
-    \return BAD_FUNC_ARG  wolfssl構造体がNULLの場合に返します。
+
+    \brief options構造体のメンバであるdhKeySzの値(ビット単位)を返します。この値は、Diffie-Hellman鍵サイズをバイト単位で表します。
+
+    \return dhKeySz ssl->options.dhKeySzに保持されている値を返します。これはビット単位のサイズを表す整数値です。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -5736,11 +6582,12 @@ int wolfSSL_SetMaxDhKey_Sz(WOLFSSL* ssl, word16 keySz_bits);
     dhKeySz = wolfSSL_GetDhKey_Sz(ssl);
 
     if(dhKeySz == BAD_FUNC_ARG || dhKeySz <= 0){
-    	// Failure case
+    	// 失敗ケース
     } else {
-    	// dhKeySz holds the size of the key.
+    	// dhKeySzは鍵のサイズを保持しています
     }
     \endcode
+
     \sa wolfSSL_SetMinDhKey_sz
     \sa wolfSSL_CTX_SetMinDhKey_Sz
     \sa wolfSSL_CTX_SetTmpDH
@@ -5751,10 +6598,14 @@ int wolfSSL_GetDhKey_Sz(WOLFSSL*);
 
 /*!
     \ingroup CertsKeys
-    \brief  WOLFSSL_CTX構造体とwolfssl_cert_manager構造の両方で最小RSA鍵サイズを設定します。
-    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。
-    \return BAD_FUNC_ARG  CTX構造がNULLの場合、またはKEYSZがゼロより小さいか、または8によって割り切れない場合に返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+
+    \brief WOLFSSL_CTX構造体とWOLFSSL_CERT_MANAGER構造体の両方で最小RSA鍵サイズを設定します。
+
+    \return SSL_SUCCESS 関数の実行が成功した場合に返されます。
+    \return BAD_FUNC_ARG ctx構造体がNULLの場合、またはkeySzがゼロ未満か8で割り切れない場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param keySz ctx構造体とcm構造体のminRsaKeySzに格納され、バイトに変換されるshort整数型。
 
     _Example_
     \code
@@ -5765,18 +6616,23 @@ int wolfSSL_GetDhKey_Sz(WOLFSSL*);
     minDhKeyBits = atoi(myoptarg);
     …
     if(wolfSSL_CTX_SetMinRsaKey_Sz(ctx, minRsaKeyBits) != SSL_SUCCESS){
-    …
+        …
     \endcode
+
     \sa wolfSSL_SetMinRsaKey_Sz
 */
 int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX* ctx, short keySz);
 
 /*!
     \ingroup CertsKeys
-    \brief  WolfSSL構造にあるRSAのためのビットで最小許容鍵サイズを設定します。
-    \return SSL_SUCCESS  最小値が正常に設定されました。
-    \return BAD_FUNC_ARG  SSL構造がNULLの場合、またはKSYSZがゼロより小さい場合、または8によって割り切れない場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief WOLFSSL構造体にあるRSAの最小許容鍵サイズをビット単位で設定します。
+
+    \return SSL_SUCCESS 最小値が正常に設定されました。
+    \return BAD_FUNC_ARG ssl構造体がNULLの場合、またはksySzがゼロ未満か8で割り切れない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param keySz 最小鍵をビット単位で表すshort整数値。
 
     _Example_
     \code
@@ -5786,49 +6642,60 @@ int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX* ctx, short keySz);
 
     int isSet =  wolfSSL_SetMinRsaKey_Sz(ssl, keySz);
     if(isSet != SSL_SUCCESS){
-	    Failed to set.
+	    設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_CTX_SetMinRsaKey_Sz
 */
 int wolfSSL_SetMinRsaKey_Sz(WOLFSSL* ssl, short keySz);
 
 /*!
     \ingroup CertsKeys
-    \brief  wolf_ctx構造体とwolfssl_cert_manager構造体のECC鍵の最小サイズをビット単位で設定します。
-    \return SSL_SUCCESS  実行が成功したために返され、MineCkeyszメンバーが設定されます。
-    \return BAD_FUNC_ARG  WOLFSSL_CTX構造体がnullの場合、または鍵が負の場合、または8によって割り切れない場合に返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+
+    \brief WOLF_CTX構造体とWOLFSSL_CERT_MANAGER構造体でECC鍵の最小サイズをビット単位で設定します。
+
+    \return SSL_SUCCESS 実行が成功し、minEccKeySzメンバが設定された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULLの場合、またはkeySzが負の値か8で割り切れない場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param keySz 最小ECC鍵サイズをビット単位で表すshort整数型。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
-    short keySz; // minimum key size
+    short keySz; // 最小鍵サイズ
     …
     if(wolfSSL_CTX_SetMinEccKey(ctx, keySz) != SSL_SUCCESS){
-	    // Failed to set min key size
+	    // 最小鍵サイズの設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_SetMinEccKey_Sz
 */
 int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX* ssl, short keySz);
 
 /*!
     \ingroup CertsKeys
-    \brief  オプション構造のMineCckeyszメンバーの値を設定します。オプション構造体は、WolfSSL構造のメンバーであり、SSLパラメータを介してアクセスされます。
-    \return SSL_SUCCESS  関数がオプション構造のMineCckeyszメンバーを正常に設定した場合。
-    \return BAD_FUNC_ARG  WOLFSSL_CTX構造体がnullの場合、または鍵サイズ（keysz）が0（ゼロ）未満の場合、または8で割り切れない場合。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief options構造体のminEccKeySzメンバの値を設定します。options構造体はWOLFSSL構造体のメンバであり、sslパラメータを通じてアクセスされます。
+
+    \return SSL_SUCCESS 関数がoptions構造体のminEccKeySzメンバを正常に設定した場合。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULLの場合、または鍵サイズ(keySz)が0未満か8で割り切れない場合。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param keySz 最小ECC鍵サイズを設定するために使用される値。options構造体に値を設定します。
 
     _Example_
     \code
-    WOLFSSL* ssl = wolfSSL_new(ctx); // New session
-    short keySz = 999; // should be set to min key size allowable
+    WOLFSSL* ssl = wolfSSL_new(ctx); // 新しいセッション
+    short keySz = 999; // 許容される最小鍵サイズに設定すべきです
     ...
     if(wolfSSL_SetMinEccKey_Sz(ssl, keySz) != SSL_SUCCESS){
-	    // Failure case.
+	    // 失敗ケース
     }
     \endcode
+
     \sa wolfSSL_CTX_SetMinEccKey_Sz
     \sa wolfSSL_CTX_SetMinRsaKey_Sz
     \sa wolfSSL_SetMinRsaKey_Sz
@@ -5837,22 +6704,27 @@ int wolfSSL_SetMinEccKey_Sz(WOLFSSL* ssl, short keySz);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、eap_tlsとeap-ttlsによって、マスターシークレットからキーイングマテリアルを導出します。
-    \return BUFFER_E  バッファの実際のサイズが許容最大サイズを超える場合に返されます。
-    \return MEMORY_E  メモリ割り当てにエラーがある場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param msk  p_hash関数の結果を保持するvoidポインタ変数。
-    \param len  MSK変数の長さを表す符号なし整数。
+
+    \brief この関数は、マスターシークレットから鍵材料を導出するためにEAP_TLSとEAP-TTLSによって使用されます。
+
+    \return BUFFER_E バッファの実際のサイズが許容される最大サイズを超えた場合に返されます。
+    \return MEMORY_E メモリ割り当てでエラーが発生した場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param key p_hash関数の結果を保持するvoidポインタ変数。
+    \param len key変数の長さを表すunsigned整数。
+    \param label wc_PRF()でコピーされる定数charポインタ。
 
     _Example_
     \code
     WOLFSSL* ssl = wolfSSL_new(ctx);;
-    void* msk;
+    void* key;
     unsigned int len;
     const char* label;
     …
-    return wolfSSL_make_eap_keys(ssl, msk, len, label);
+    return wolfSSL_make_eap_keys(ssl, key, len, label);
     \endcode
+
     \sa wc_PRF
     \sa wc_HmacFinal
     \sa wc_HmacUpdate
@@ -5862,19 +6734,23 @@ int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
 
 /*!
     \ingroup IO
-    \brief  Writev Semanticsをシミュレートしますが、SSL_Write()の動作のために実際にはブロックしないため、フロント追加が小さくなる可能性があるためWritevを使いやすいソフトウェアに移植する。
-    \return >0  成功時に書かれたバイト数。
-    \return 0  失敗したときに返されます。特定のエラーコードについてwolfSSL_get_error()を呼び出します。
-    \return MEMORY_ERROR  メモリエラーが発生した場合に返されます。
-    \return SSL_FATAL_ERROR  エラーが発生したとき、または非ブロッキングソケットを使用するときには、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが受信され、再度WOLFSSL_WRITE()を呼び出す必要がある場合は、障害が発生します。特定のエラーコードを取得するには、wolfSSL_get_error()を使用してください。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param iov  書き込みへのI / Oベクトルの配列
+
+    \brief writevのセマンティクスをシミュレートしますが、SSL_write()の動作とフロント追加が小さい場合があるため、実際には一度にブロック単位では行いません。writevを使用するソフトウェアへの移植を容易にします。
+
+    \return ＞0 成功時、書き込まれたバイト数。
+    \return 0 失敗時に返されます。wolfSSL_get_error()を呼び出して特定のエラーコードを取得してください。
+    \return MEMORY_ERROR メモリエラーが発生した場合に返されます。
+    \return SSL_FATAL_ERROR エラーが発生した場合、またはノンブロッキングソケットを使用しているときにSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーを受信し、アプリケーションがwolfSSL_write()を再度呼び出す必要がある場合に返されます。wolfSSL_get_error()を使用して特定のエラーコードを取得してください。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param iov 書き込むI/Oベクトルの配列。
+    \param iovcnt iov配列内のベクトル数。
 
     _Example_
     \code
     WOLFSSL* ssl = 0;
-    char *bufA = “hello\n”;
-    char *bufB = “hello world\n”;
+    char *bufA = "hello\n";
+    char *bufB = "hello world\n";
     int iovcnt;
     struct iovec iov[2];
 
@@ -5885,8 +6761,9 @@ int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
     iovcnt = 2;
     ...
     ret = wolfSSL_writev(ssl, iov, iovcnt);
-    // wrote “ret” bytes, or error if <= 0.
+    // "ret"バイトを書き込みました。または<=0の場合はエラー
     \endcode
+
     \sa wolfSSL_write
 */
 int wolfSSL_writev(WOLFSSL* ssl, const struct iovec* iov,
@@ -5894,34 +6771,69 @@ int wolfSSL_writev(WOLFSSL* ssl, const struct iovec* iov,
 
 /*!
     \ingroup Setup
-    \brief  この関数はCA署名者リストをアンロードし、署名者全体のテーブルを解放します。
-    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。
-    \return BAD_FUNC_ARG  WOLFSSL_CTX構造体がnullの場合、または他の方法では未解決の引数値がサブルーチンに渡された場合に返されます。
-    \return BAD_MUTEX_E  ミューテックスエラーが発生した場合に返されます。lockmutex()は0を返しませんでした。
+
+    \brief この関数は、CA署名者リストをアンロードし、署名者テーブル全体を解放します。
+
+    \return SSL_SUCCESS 関数の実行が成功した場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULLの場合、またはサブルーチンで許可されない引数値が渡された場合に返されます。
+    \return BAD_MUTEX_E mutexエラーが発生した場合に返されます。LockMutex()が0を返しませんでした。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
 
     _Example_
     \code
     WOLFSSL_METHOD method = wolfTLSv1_2_client_method();
-    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(method);
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(method);
     …
-    if(!wolfSSL_CTX_UnloadCAs(ctx)){
-    	// The function did not unload CAs
+    if(wolfSSL_CTX_UnloadCAs(ctx) != SSL_SUCCESS){
+    	// 関数はCAをアンロードしませんでした
     }
     \endcode
+
     \sa wolfSSL_CertManagerUnloadCAs
     \sa LockMutex
-    \sa FreeSignerTable
     \sa UnlockMutex
 */
 int wolfSSL_CTX_UnloadCAs(WOLFSSL_CTX*);
 
+
 /*!
     \ingroup Setup
-    \brief  この関数は、以前にロードされたすべての信頼できるピア証明書をアンロードするために使用されます。マクロwolfssl_trust_peer_certを定義することで機能が有効になっています。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  CTXがNULLの場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+
+    \brief この関数は、CA署名者リストに追加された中間証明書をアンロードし、解放します。
+
+    \return SSL_SUCCESS 関数の実行が成功した場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULLの場合、またはサブルーチンで許可されない引数値が渡された場合に返されます。
+    \return BAD_STATE_E WOLFSSL_CTXの参照カウントが1より大きい場合に返されます。    \return BAD_MUTEX_E mutexエラーが発生した場合に返されます。LockMutex()が0を返しませんでした。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+
+    _Example_
+    \code
+    WOLFSSL_METHOD method = wolfTLSv1_2_client_method();
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(method);
+    …
+    if(wolfSSL_CTX_UnloadIntermediateCerts(ctx) != NULL){
+        // 関数はCAをアンロードしませんでした
+    }
+    \endcode
+
+    \sa wolfSSL_CTX_UnloadCAs
+    \sa wolfSSL_CertManagerUnloadIntermediateCerts
+*/
+int wolfSSL_CTX_UnloadIntermediateCerts(WOLFSSL_CTX* ctx);
+
+/*!
+    \ingroup Setup
+
+    \brief この関数は以前にロードされたすべての信頼されたピア証明書をアンロードするために使用されます。この機能は、マクロWOLFSSL_TRUST_PEER_CERTを定義することで有効になります。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG ctxがNULLの場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足の状態が発生した場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
 
     _Example_
     \code
@@ -5930,10 +6842,11 @@ int wolfSSL_CTX_UnloadCAs(WOLFSSL_CTX*);
     ...
     ret = wolfSSL_CTX_Unload_trust_peers(ctx);
     if (ret != SSL_SUCCESS) {
-        // error unloading trusted peer certs
+        // 信頼されたピア証明書のアンロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_trust_peer_buffer
     \sa wolfSSL_CTX_trust_peer_cert
 */
@@ -5941,16 +6854,20 @@ int wolfSSL_CTX_Unload_trust_peers(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、TLS / SSLハンドシェイクを実行するときにピアを検証するために使用する証明書をロードします。ハンドシェイク中に送信されたピア証明書は、使用可能なときにスキッドを使用することによって比較されます。これら2つのことが一致しない場合は、ロードされたCASが使用されます。ファイルの代わりにバッファーの場合は、wolfssl_ctx_trust_peer_certと同じ機能です。特徴はマクロwolfssl_trust_peer_certを定義することによって有効になっています適切な使用法の例を参照してください。
-    \return SSL_SUCCESS  成功すると
-    \return SSL_FAILURE  CTXがNULLの場合、または両方のファイルと種類が無効な場合に返されます。
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param buffer  証明書を含むバッファへのポインタ。
-    \param sz  バッファ入力の長さ。
+
+    \brief この関数は、TLS/SSLハンドシェイクを実行する際にピアを検証するために使用する証明書をロードします。ハンドシェイク中に送信されるピア証明書は、利用可能な場合はSKIDと署名を使用して比較されます。これら2つが一致しない場合は、ロードされたCAが使用されます。ファイルではなくバッファからの入力である点を除いて、wolfSSL_CTX_trust_peer_certと同じ機能です。この機能は、マクロWOLFSSL_TRUST_PEER_CERTを定義することで有効になります。適切な使用方法については例を参照してください。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FAILURE ctxがNULL、またはfileとtypeの両方が無効な場合に返されます。
+    \return SSL_BAD_FILETYPE ファイルの形式が間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足の状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードが失敗した場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param buffer 証明書を含むバッファへのポインタ。
+    \param sz 入力バッファの長さ。
+    \param type ロードされる証明書のタイプ、すなわちSSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。
 
     _Example_
     \code
@@ -5961,10 +6878,11 @@ int wolfSSL_CTX_Unload_trust_peers(WOLFSSL_CTX*);
     ret = wolfSSL_CTX_trust_peer_buffer(ctx, bufferPtr, bufferSz,
     SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-    // error loading trusted peer cert
+        // 信頼されたピア証明書のロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_load_verify_buffer
     \sa wolfSSL_CTX_use_certificate_file
     \sa wolfSSL_CTX_use_PrivateKey_file
@@ -5980,32 +6898,36 @@ int wolfSSL_CTX_trust_peer_buffer(WOLFSSL_CTX* ctx, const unsigned char* in,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はCA証明書バッファをWolfSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。フォーマットがPEM内にある限り、バッファあたり複数のCA証明書をロードすることができます。適切な使用法の例をご覧ください。
-    \return SSL_SUCCESS  成功すると
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param in  CA証明書バッファへのポインタ。
-    \param sz  入力CA証明書バッファのサイズ、IN。
 
+    \brief この関数はCA証明書バッファをWOLFSSLコンテキストにロードします。バッファ非対応版と同様に動作しますが、ファイルの代わりにバッファを入力として呼び出せる点が異なります。バッファはサイズszのin引数によって提供されます。formatはバッファの形式タイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。形式がPEMであれば、1つのバッファに複数のCA証明書をロードできます。適切な使用方法については例を参照してください。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_BAD_FILETYPE ファイルの形式が間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足の状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードが失敗した場合に返されます。
+    \return BUFFER_E チェーンバッファが受信バッファより大きい場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param in CA証明書バッファへのポインタ。
+    \param sz 入力CA証明書バッファ(in)のサイズ。
+    \param format バッファ証明書の形式、SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。
 
     _Example_
     \code
     int ret = 0;
-    int sz = 0;
     WOLFSSL_CTX* ctx;
     byte certBuff[...];
+    long sz = sizeof(certBuff);
     ...
 
     ret = wolfSSL_CTX_load_verify_buffer(ctx, certBuff, sz, SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-    	// error loading CA certs from buffer
+    	// バッファからのCA証明書のロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_load_verify_locations
     \sa wolfSSL_CTX_use_certificate_buffer
     \sa wolfSSL_CTX_use_PrivateKey_buffer
@@ -6020,35 +6942,40 @@ int wolfSSL_CTX_load_verify_buffer(WOLFSSL_CTX* ctx, const unsigned char* in,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はCA証明書バッファをWolfSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。フォーマットがPEM内にある限り、バッファあたり複数のCA証明書をロードすることができます。_EXバージョンはPR 2413に追加され、UserChainとFlagsの追加の引数をサポートします。
-    \return SSL_SUCCESS  成功すると
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param in  CA証明書バッファへのポインタ。
-    \param sz  入力CA証明書バッファのサイズ、IN。
-    \param format  バッファ証明書の形式、SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。
-    \param userChain  フォーマットwolfssl_filetype_asn1を使用する場合、このセットはゼロ以外のセットを示しています.Derのチェーンが表示されています。
+
+    \brief この関数はCA証明書バッファをWOLFSSLコンテキストにロードします。バッファ非対応版と同様に動作しますが、ファイルの代わりにバッファを入力として呼び出せる点が異なります。バッファはサイズszのin引数によって提供されます。formatはバッファの形式タイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。形式がPEMであれば、1つのバッファに複数のCA証明書をロードできます。_ex版はPR 2413で追加され、userChainとflagsの追加引数をサポートします。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_BAD_FILETYPE ファイルの形式が間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足の状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードが失敗した場合に返されます。
+    \return BUFFER_E チェーンバッファが受信バッファより大きい場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param in CA証明書バッファへのポインタ。
+    \param sz 入力CA証明書バッファ(in)のサイズ。
+    \param format バッファ証明書の形式、SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。
+    \param userChain 形式WOLFSSL_FILETYPE_ASN1を使用している場合、これを非ゼロに設定すると、DERのチェーンが提示されていることを示します。
+    \param flags ssl.hのWOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS付近を参照してください。
 
     _Example_
     \code
     int ret = 0;
-    int sz = 0;
     WOLFSSL_CTX* ctx;
     byte certBuff[...];
+    long sz = sizeof(certBuff);
     ...
 
-    // Example for force loading an expired certificate
+    // 期限切れ証明書を強制的にロードする例
     ret = wolfSSL_CTX_load_verify_buffer_ex(ctx, certBuff, sz, SSL_FILETYPE_PEM,
         0, (WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY));
     if (ret != SSL_SUCCESS) {
-    	// error loading CA certs from buffer
+    	// バッファからのCA証明書のロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_load_verify_buffer
     \sa wolfSSL_CTX_load_verify_locations
     \sa wolfSSL_CTX_use_certificate_buffer
@@ -6064,32 +6991,37 @@ int wolfSSL_CTX_load_verify_buffer_ex(WOLFSSL_CTX* ctx,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、CA証明書チェーンバッファをWolfSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。フォーマットがPEM内にある限り、バッファあたり複数のCA証明書をロードすることができます。適切な使用法の例をご覧ください。
-    \return SSL_SUCCESS  成功すると
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param in  CA証明書バッファへのポインタ。
-    \param sz  入力CA証明書バッファのサイズ、IN。
+
+    \brief この関数はCA証明書チェーンバッファをWOLFSSLコンテキストにロードします。バッファ非対応版と同様に動作しますが、ファイルの代わりにバッファを入力として呼び出せる点が異なります。バッファはサイズszのin引数によって提供されます。formatはバッファの形式タイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。形式がPEMであれば、1つのバッファに複数のCA証明書をロードできます。適切な使用方法については例を参照してください。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_BAD_FILETYPE ファイルの形式が間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足の状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードが失敗した場合に返されます。
+    \return BUFFER_E チェーンバッファが受信バッファより大きい場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param in CA証明書バッファへのポインタ。
+    \param sz 入力CA証明書バッファ(in)のサイズ。
+    \param format バッファ証明書の形式、SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。
 
     _Example_
     \code
     int ret = 0;
-    int sz = 0;
     WOLFSSL_CTX* ctx;
     byte certBuff[...];
+    long sz = sizeof(certBuff);
     ...
 
     ret = wolfSSL_CTX_load_verify_chain_buffer_format(ctx,
                          certBuff, sz, WOLFSSL_FILETYPE_ASN1);
     if (ret != SSL_SUCCESS) {
-        // error loading CA certs from buffer
+        // バッファからのCA証明書のロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_load_verify_locations
     \sa wolfSSL_CTX_use_certificate_buffer
     \sa wolfSSL_CTX_use_PrivateKey_buffer
@@ -6104,29 +7036,34 @@ int wolfSSL_CTX_load_verify_chain_buffer_format(WOLFSSL_CTX* ctx,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は証明書バッファをWolfSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。適切な使用法の例をご覧ください。
-    \return SSL_SUCCESS  成功すると
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param in  ロードする証明書を含む入力バッファ。
-    \param sz  入力バッファのサイズ。
+
+    \brief この関数は証明書バッファをWOLFSSLコンテキストにロードします。バッファ非対応版と同様に動作しますが、ファイルの代わりにバッファを入力として呼び出せる点が異なります。バッファはサイズszのin引数によって提供されます。formatはバッファの形式タイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。適切な使用方法については例を参照してください。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_BAD_FILETYPE ファイルの形式が間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足の状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードが失敗した場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param in ロードする証明書を含む入力バッファ。
+    \param sz 入力バッファのサイズ。
+    \param format 入力バッファ(in)に格納されている証明書の形式。指定可能な値はSSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。
 
     _Example_
     \code
     int ret = 0;
-    int sz = 0;
     WOLFSSL_CTX* ctx;
     byte certBuff[...];
+    long sz = sizeof(certBuff);
     ...
     ret = wolfSSL_CTX_use_certificate_buffer(ctx, certBuff, sz, SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-	    // error loading certificate from buffer
+	    // バッファからの証明書のロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_load_verify_buffer
     \sa wolfSSL_CTX_use_PrivateKey_buffer
     \sa wolfSSL_CTX_use_certificate_chain_buffer
@@ -6140,30 +7077,35 @@ int wolfSSL_CTX_use_certificate_buffer(WOLFSSL_CTX* ctx,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、秘密鍵バッファをSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1OR SSL_FILETYPE_PEM。適切な使用法の例をご覧ください。
-    \return SSL_SUCCESS  成功すると
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return NO_PASSWORD  鍵ファイルが暗号化されているがパスワードが提供されていない場合に返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param in  ロードする秘密鍵を含む入力バッファ。
-    \param sz  入力バッファのサイズ。
+
+    \brief この関数は秘密鍵バッファをSSLコンテキストにロードします。バッファ非対応版と同様に動作しますが、ファイルの代わりにバッファを入力として呼び出せる点が異なります。バッファはサイズszのin引数によって提供されます。formatはバッファの形式タイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。適切な使用方法については例を参照してください。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_BAD_FILETYPE ファイルの形式が間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足の状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードが失敗した場合に返されます。
+    \return NO_PASSWORD 鍵ファイルが暗号化されているがパスワードが提供されていない場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param in ロードする秘密鍵を含む入力バッファ。
+    \param sz 入力バッファのサイズ。
+    \param format 入力バッファ(in)に格納されている秘密鍵の形式。指定可能な値はSSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。
 
     _Example_
     \code
     int ret = 0;
-    int sz = 0;
     WOLFSSL_CTX* ctx;
     byte keyBuff[...];
+    long sz = sizeof(certBuff);
     ...
     ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx, keyBuff, sz, SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-    	// error loading private key from buffer
+    	// バッファからの秘密鍵のロードエラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_load_verify_buffer
     \sa wolfSSL_CTX_use_certificate_buffer
     \sa wolfSSL_CTX_use_certificate_chain_buffer
@@ -6177,29 +7119,34 @@ int wolfSSL_CTX_use_PrivateKey_buffer(WOLFSSL_CTX* ctx,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、証明書チェーンバッファをWolfSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。バッファはPEM形式で、ルート証明書で終わる対象の証明書から始めてください。適切な使用法の例をご覧ください。
-    \return SSL_SUCCESS  成功すると
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param in  ロードされるPEM形式の証明書チェーンを含む入力バッファ。
+
+    \brief この関数は証明書チェーンバッファをWOLFSSLコンテキストにロードします。バッファ非対応版と同様に動作しますが、ファイルの代わりにバッファを入力として呼び出せる点が異なります。バッファはサイズszのin引数によって提供されます。バッファはPEM形式で、サブジェクトの証明書から始まり、ルート証明書で終わる必要があります。適切な使用方法については例を参照してください。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_BAD_FILETYPE ファイルの形式が間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足の状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードが失敗した場合に返されます。
+    \return BUFFER_E チェーンバッファが受信バッファより大きい場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param in ロードするPEM形式の証明書チェーンを含む入力バッファ。
+    \param sz 入力バッファのサイズ。
 
     _Example_
     \code
     int ret = 0;
-    int sz = 0;
     WOLFSSL_CTX* ctx;
     byte certChainBuff[...];
+    long sz = sizeof(certBuff);
     ...
     ret = wolfSSL_CTX_use_certificate_chain_buffer(ctx, certChainBuff, sz);
     if (ret != SSL_SUCCESS) {
-    	// error loading certificate chain from buffer
+    	// バッファから証明書チェーンの読み込みに失敗
     }
     ...
     \endcode
+
     \sa wolfSSL_CTX_load_verify_buffer
     \sa wolfSSL_CTX_use_certificate_buffer
     \sa wolfSSL_CTX_use_PrivateKey_buffer
@@ -6212,29 +7159,34 @@ int wolfSSL_CTX_use_certificate_chain_buffer(WOLFSSL_CTX* ctx,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、証明書バッファをWolfSSLオブジェクトにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。適切な使用法の例をご覧ください。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \param ssl  wolfSSL_new()で作成されたSSLセッションへのポインタ。
-    \param in  ロードする証明書を含むバッファ。
-    \param sz  バッファにある証明書のサイズ。
+
+    \brief この関数は、証明書バッファをWOLFSSLオブジェクトにロードします。バッファなしバージョンと同様に動作しますが、ファイルの代わりにバッファを入力として呼び出すことができる点が異なります。バッファはサイズszのin引数によって提供されます。formatはバッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。適切な使用方法については例を参照してください。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_BAD_FILETYPE ファイルのフォーマットが間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードに失敗した場合に返されます。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param in ロードする証明書を含むバッファ。
+    \param sz バッファ内の証明書のサイズ。
+    \param format ロードする証明書のフォーマット。指定可能な値はSSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。
 
     _Example_
     \code
-    int buffSz;
     int ret;
     byte certBuff[...];
     WOLFSSL* ssl = 0;
+    long buffSz = sizeof(certBuff);
     ...
 
     ret = wolfSSL_use_certificate_buffer(ssl, certBuff, buffSz, SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-    	// failed to load certificate from buffer
+    	// バッファから証明書の読み込みに失敗
     }
     \endcode
+
     \sa wolfSSL_CTX_load_verify_buffer
     \sa wolfSSL_CTX_use_certificate_buffer
     \sa wolfSSL_CTX_use_PrivateKey_buffer
@@ -6247,29 +7199,34 @@ int wolfSSL_use_certificate_buffer(WOLFSSL* ssl, const unsigned char* in,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、秘密鍵バッファをWolfSSLオブジェクトにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。適切な使用法の例をご覧ください。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return NO_PASSWORD  鍵ファイルが暗号化されているがパスワードが提供されていない場合に返されます。
-    \param ssl  wolfssl_new()で作成されたSSLセッションへのポインタ。
-    \param in  ロードする秘密鍵を含むバッファ。
-    \param sz  バッファにある秘密鍵のサイズ。
+
+    \brief この関数は、秘密鍵バッファをWOLFSSLオブジェクトにロードします。バッファなしバージョンと同様に動作しますが、ファイルの代わりにバッファを入力として呼び出すことができる点が異なります。バッファはサイズszのin引数によって提供されます。formatはバッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。適切な使用方法については例を参照してください。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_BAD_FILETYPE ファイルのフォーマットが間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードに失敗した場合に返されます。
+    \return NO_PASSWORD 鍵ファイルが暗号化されているがパスワードが提供されていない場合に返されます。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param in ロードする秘密鍵を含むバッファ。
+    \param sz バッファ内の秘密鍵のサイズ。
+    \param format ロードする秘密鍵のフォーマット。指定可能な値はSSL_FILETYPE_ASN1またはSSL_FILETYPE_PEMです。
 
     _Example_
     \code
-    int buffSz;
     int ret;
     byte keyBuff[...];
     WOLFSSL* ssl = 0;
+    long buffSz = sizeof(certBuff);
     ...
     ret = wolfSSL_use_PrivateKey_buffer(ssl, keyBuff, buffSz, SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-    	// failed to load private key from buffer
+    	// バッファから秘密鍵の読み込みに失敗
     }
     \endcode
+
     \sa wolfSSL_use_PrivateKey
     \sa wolfSSL_CTX_load_verify_buffer
     \sa wolfSSL_CTX_use_certificate_buffer
@@ -6283,28 +7240,33 @@ int wolfSSL_use_PrivateKey_buffer(WOLFSSL* ssl, const unsigned char* in,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、証明書チェーンバッファをWolfSSLオブジェクトにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。バッファはPEM形式で、ルート証明書で終わる対象の証明書から始めてください。適切な使用法の例をご覧ください。
-    \return SSL_SUCCES  成功時に返されます。
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param in  ロードする証明書を含むバッファ。
+
+    \brief この関数は、証明書チェーンバッファをWOLFSSLオブジェクトにロードします。バッファなしバージョンと同様に動作しますが、ファイルの代わりにバッファを入力として呼び出すことができる点が異なります。バッファはサイズszのin引数によって提供されます。バッファはPEMフォーマットである必要があり、サブジェクトの証明書から始まり、ルート証明書で終わる必要があります。適切な使用方法については例を参照してください。
+
+    \return SSL_SUCCES 成功時。
+    \return SSL_BAD_FILETYPE ファイルのフォーマットが間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードに失敗した場合に返されます。
+    \return BUFFER_E チェーンバッファが受信バッファより大きい場合に返されます。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
+    \param in ロードする証明書を含むバッファ。
+    \param sz バッファ内の証明書のサイズ。
 
     _Example_
     \code
-    int buffSz;
     int ret;
     byte certChainBuff[...];
     WOLFSSL* ssl = 0;
+    long buffSz = sizeof(certBuff);
     ...
     ret = wolfSSL_use_certificate_chain_buffer(ssl, certChainBuff, buffSz);
     if (ret != SSL_SUCCESS) {
-    	// failed to load certificate chain from buffer
+    	// バッファから証明書チェーンの読み込みに失敗
     }
     \endcode
+
     \sa wolfSSL_CTX_load_verify_buffer
     \sa wolfSSL_CTX_use_certificate_buffer
     \sa wolfSSL_CTX_use_PrivateKey_buffer
@@ -6317,9 +7279,13 @@ int wolfSSL_use_certificate_chain_buffer(WOLFSSL* ssl,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、SSLが所有する証明書または鍵をアンロードします。
-    \return SSL_SUCCESS   - 関数が正常に実行された場合に返されます。
-    \return BAD_FUNC_ARG   -  wolfsslオブジェクトがnullの場合に返されます。
+
+    \brief この関数は、SSLが所有する証明書または鍵をアンロードします。
+
+    \return SSL_SUCCESS 関数が正常に実行された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSLオブジェクトがNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -6327,18 +7293,23 @@ int wolfSSL_use_certificate_chain_buffer(WOLFSSL* ssl,
     ...
     int unloadKeys = wolfSSL_UnloadCertsKeys(ssl);
     if(unloadKeys != SSL_SUCCESS){
-	    // Failure case.
+	    // 失敗ケース
     }
     \endcode
+
     \sa wolfSSL_CTX_UnloadCAs
 */
 int wolfSSL_UnloadCertsKeys(WOLFSSL*);
 
 /*!
     \ingroup Setup
-    \brief  この機能は、可能な限りハンドシェイクメッセージのグループ化をオンにします。
-    \return SSL_SUCCESS  成功に戻ります。
-    \return BAD_FUNC_ARG  入力コンテキストがNULLの場合、返されます。
+
+    \brief この関数は、可能な場合にハンドシェイクメッセージのグループ化をオンにします。
+
+    \return SSL_SUCCESS 成功時に返されます。
+    \return BAD_FUNC_ARG 入力コンテキストがnullの場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
 
     _Example_
     \code
@@ -6346,9 +7317,10 @@ int wolfSSL_UnloadCertsKeys(WOLFSSL*);
     ...
     ret = wolfSSL_CTX_set_group_messages(ctx);
     if (ret != SSL_SUCCESS) {
-	    // failed to set handshake message grouping
+	    // ハンドシェイクメッセージのグループ化の設定に失敗
     }
     \endcode
+
     \sa wolfSSL_set_group_messages
     \sa wolfSSL_CTX_new
 */
@@ -6356,10 +7328,13 @@ int wolfSSL_CTX_set_group_messages(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
-    \brief  この機能は、可能な限りハンドシェイクメッセージのグループ化をオンにします。
-    \return SSL_SUCCESS  成功に戻ります。
-    \return BAD_FUNC_ARG  入力コンテキストがNULLの場合、返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数は、可能な場合にハンドシェイクメッセージのグループ化をオンにします。
+
+    \return SSL_SUCCESS 成功時に返されます。
+    \return BAD_FUNC_ARG 入力コンテキストがnullの場合に返されます。
+
+    \param ssl wolfSSL_new()で作成されたSSLセッションへのポインタ。
 
     _Example_
     \code
@@ -6367,20 +7342,23 @@ int wolfSSL_CTX_set_group_messages(WOLFSSL_CTX*);
     ...
     ret = wolfSSL_set_group_messages(ssl);
     if (ret != SSL_SUCCESS) {
-	// failed to set handshake message grouping
+	    // ハンドシェイクメッセージのグループ化の設定に失敗
     }
     \endcode
+
     \sa wolfSSL_CTX_set_group_messages
     \sa wolfSSL_new
 */
 int wolfSSL_set_group_messages(WOLFSSL*);
 
 /*!
-    \brief
-    \return none  いいえ返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param cbf  フォームの関数ポインタであるCallBackFozzerタイプ：int（* callbackfuzzer）（wolfssl * ssl、consigned char * buf、int sz、int型、void * fuzzctx）;
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief この関数はファザーコールバックを設定します。
+
+    \return none 戻り値はありません。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param cbf 次の形式の関数ポインタであるCallbackFuzzer型: int (*CallbackFuzzer)(WOLFSSL* ssl, const unsigned char* buf, int sz, int type, void* fuzzCtx);
+    \param fCtx WOLFSSL構造体のfuzzerCtxメンバに設定されるvoidポインタ型。
 
     _Example_
     \code
@@ -6390,37 +7368,42 @@ int wolfSSL_set_group_messages(WOLFSSL*);
 
     int callbackFuzzerCB(WOLFSSL* ssl, const unsigned char* buf, int sz,
 				int type, void* fuzzCtx){
-    // function definition
+        // 関数定義
     }
     …
     wolfSSL_SetFuzzerCb(ssl, callbackFuzzerCB, fCtx);
     \endcode
+
     \sa CallbackFuzzer
 */
 void wolfSSL_SetFuzzerCb(WOLFSSL* ssl, CallbackFuzzer cbf, void* fCtx);
 
 /*!
-    \brief
-    \return 0  関数がエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG  許容できない値で関数に渡された引数があった場合に返されます。
-    \return COOKIE_SECRET_SZ  秘密サイズが0の場合に返されます。
-    \return MEMORY_ERROR  新しいCookie Secretにメモリを割り当てる問題がある場合は返されました。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
-    \param secret  秘密バッファを表す定数バイトポインタ。
+    \brief この関数は新しいdtls cookieシークレットを設定します。
+
+    \return 0 関数がエラーなく実行された場合に返されます。
+    \return BAD_FUNC_ARG 関数に許容できない値を持つ引数が渡された場合に返されます。
+    \return COOKIE_SECRET_SZ シークレットサイズが0の場合に返されます。
+    \return MEMORY_ERROR 新しいcookieシークレット用のメモリ割り当てに問題があった場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param secret シークレットバッファを表す定数バイトポインタ。
+    \param secretSz バッファのサイズ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
     WOLFSSL* ssl = wolfSSL_new(ctx);
     const* byte secret;
-    word32 secretSz; // size of secret
+    word32 secretSz; // secretのサイズ
     …
     if(!wolfSSL_DTLS_SetCookieSecret(ssl, secret, secretSz)){
-    	// Code block for failure to set DTLS cookie secret
+    	// DTLSクッキーシークレットの設定失敗のコードブロック
     } else {
-    	// Success! Cookie secret is set.
+    	// 成功！クッキーシークレットが設定されました
     }
     \endcode
+
     \sa ForceZero
     \sa wc_RNG_GenerateBlock
 */
@@ -6429,9 +7412,13 @@ int   wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                                                unsigned int secretSz);
 
 /*!
-    \brief
-    \return rng  成功時に返されます。
-    \return NULL  sslがNULLの場合
+    \brief この関数は乱数を取得します。
+
+    \return rng 成功時。
+    \return NULL sslがNULLの場合。
+
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+
     _Example_
     \code
     WOLFSSL* ssl;
@@ -6439,99 +7426,127 @@ int   wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     wolfSSL_GetRNG(ssl);
 
     \endcode
+
     \sa  wolfSSL_CTX_new_rng
+
 */
 WC_RNG* wolfSSL_GetRNG(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、許可されている最小のダウングレードバージョンを設定します。接続が（wolfsslv23_client_methodまたはwolfsslv23_server_method）を使用して、接続がダウングレードできる場合にのみ適用されます。
-    \return SSL_SUCCESS  エラーなしで返された関数と最小バージョンが設定されている場合に返されます。
-    \return BAD_FUNC_ARG  WOLFSSL_CTX構造がNULLの場合、または最小バージョンがサポートされていない場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数は、許可される最小ダウングレードバージョンを設定します。ダウングレードを許可する接続(wolfSSLv23_client_methodまたはwolfSSLv23_server_method)を使用する場合にのみ適用されます。
+
+    \return SSL_SUCCESS 関数がエラーなく戻り、最小バージョンが設定された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULLの場合、または最小バージョンがサポートされていない場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param version 最小値として設定されるバージョンの整数表現: WOLFSSL_SSLV3 = 0、WOLFSSL_TLSV1 = 1、WOLFSSL_TLSV1_1 = 2、またはWOLFSSL_TLSV1_2 = 3。
 
     _Example_
     \code
-    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new( protocol method );
     WOLFSSL* ssl = WOLFSSL_new(ctx);
-    int version; // macrop representation
+    int version; // マクロ表現
     …
     if(wolfSSL_CTX_SetMinVersion(ssl->ctx, version) != SSL_SUCCESS){
-    	// Failed to set min version
+    	// 最小バージョンの設定に失敗
     }
     \endcode
+
     \sa SetMinVersionHelper
 */
 int wolfSSL_CTX_SetMinVersion(WOLFSSL_CTX* ctx, int version);
 
 /*!
     \ingroup TLS
-    \brief  この関数は、許可されている最小のダウングレードバージョンを設定します。接続が（wolfsslv23_client_methodまたはwolfsslv23_server_method）を使用して、接続がダウングレードできる場合にのみ適用されます。
-    \return SSL_SUCCESS  この関数とそのサブルーチンがエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG  SSLオブジェクトがNULLの場合に返されます。サブルーチンでは、良いバージョンが一致しない場合、このエラーはスローされます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief この関数は、許可される最小ダウングレードバージョンを設定します。ダウングレードを許可する接続(wolfSSLv23_client_methodまたはwolfSSLv23_server_method)を使用する場合にのみ適用されます。
+
+    \return SSL_SUCCESS この関数とそのサブルーチンがエラーなく実行された場合に返されます。
+    \return BAD_FUNC_ARG SSLオブジェクトがNULLの場合に返されます。サブルーチンでは、バージョンマッチが良好でない場合にこのエラーがスローされます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param version 最小値として設定されるバージョンの整数表現: WOLFSSL_SSLV3 = 0、WOLFSSL_TLSV1 = 1、WOLFSSL_TLSV1_1 = 2、またはWOLFSSL_TLSV1_2 = 3。
 
     _Example_
     \code
-    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(protocol method);
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(protocol method);
     WOLFSSL* ssl = WOLFSSL_new(ctx);
-    int version;  macro representation
+    int version;  // マクロ表現
     …
     if(wolfSSL_CTX_SetMinVersion(ssl->ctx, version) != SSL_SUCCESS){
-	    Failed to set min version
+	    // 最小バージョンの設定に失敗
     }
     \endcode
+
     \sa SetMinVersionHelper
 */
 int wolfSSL_SetMinVersion(WOLFSSL* ssl, int version);
 
 /*!
-    \brief  ビルドオプションと設定に依存します。WolfSSLを構築するときにshow_sizesが定義されている場合、この関数はWolfSSLオブジェクト（スイート、暗号など）内の個々のオブジェクトのサイズもstdoutに印刷されます。
-    \return size  この関数は、WolfSSLオブジェクトのサイズを返します。
+    \brief この関数はWOLFSSLオブジェクトのサイズを返し、ビルドオプションと設定に依存します。wolfSSLをビルドする際にSHOW_SIZESが定義されている場合、この関数はWOLFSSLオブジェクト内の個々のオブジェクト(Suites、Ciphersなど)のサイズもstdoutに出力します。
+
+    \return size この関数はWOLFSSLオブジェクトのサイズを返します。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
     int size = 0;
     size = wolfSSL_GetObjectSize();
-    printf(“sizeof(WOLFSSL) = %d\n”, size);
+    printf("sizeof(WOLFSSL) = %d\n", size);
     \endcode
+
     \sa wolfSSL_new
 */
-int wolfSSL_GetObjectSize(void);  /* object size based on build */
+int wolfSSL_GetObjectSize(void);  /* ビルドに基づくオブジェクトサイズ */
 /*!
-    \brief  アプリケーションがトランスポートレイヤ間で何バイトを送信したい場合は、指定された平文の入力サイズを指定してください。SSL / TLSハンドシェイクが完了した後に呼び出す必要があります。
-    \return size  成功すると、要求されたサイズが返されます
-    \return INPUT_SIZE_E  入力サイズが最大TLSフラグメントサイズより大きい場合は返されます（WOLFSSL_GETMAXOUTPUTSIZE()）。
-    \return BAD_FUNC_ARG  無効な関数引数に戻り、またはSSL / TLSハンドシェイクがまだ完了していない場合
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 平文入力のレコード層サイズを返します。これは、アプリケーションが指定された平文入力サイズに対して、トランスポート層を介して送信されるバイト数を知りたい場合に役立ちます。この関数は、SSL/TLSハンドシェイクが完了した後に呼び出す必要があります。
+
+    \return size 成功時には、要求されたサイズが返されます。
+    \return INPUT_SIZE_E 入力サイズが最大TLSフラグメントサイズより大きい場合に返されます(wolfSSL_GetMaxOutputSize()を参照)。
+    \return BAD_FUNC_ARG 無効な関数引数が渡された場合、またはSSL/TLSハンドシェイクがまだ完了していない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
+    \param inSz 平文データのサイズ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetMaxOutputSize
 */
 int wolfSSL_GetOutputSize(WOLFSSL* ssl, int inSz);
 
 /*!
-    \brief  プロトコル規格で指定されている最大SSL / TLSレコードサイズのいずれかに対応します。この関数は、アプリケーションがwolfssl_getOutputSize()と呼ばれ、input_size_eエラーを受信したときに役立ちます。SSL / TLSハンドシェイクが完了した後に呼び出す必要があります。
-    \return size  成功すると、最大出力サイズが返されます
-    \return BAD_FUNC_ARG  無効な関数引数のときに返されるか、SSL / TLSハンドシェイクがまだ完了していない場合。
+    \brief 平文データの最大レコード層サイズを返します。これは、プロトコル標準で指定されている最大SSL/TLSレコードサイズ、またはTLS最大フラグメント長拡張によって設定された最大TLSフラグメントサイズのいずれかに対応します。この関数は、アプリケーションがwolfSSL_GetOutputSize()を呼び出してINPUT_SIZE_Eエラーを受け取った場合に役立ちます。この関数は、SSL/TLSハンドシェイクが完了した後に呼び出す必要があります。
+
+    \return size 成功時には、最大出力サイズが返されます。
+    \return BAD_FUNC_ARG 無効な関数引数が渡された場合、またはSSL/TLSハンドシェイクがまだ完了していない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetOutputSize
 */
 int wolfSSL_GetMaxOutputSize(WOLFSSL*);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、バージョンで指定されたバージョンを使用して、指定されたSSLセッション（WolfSSLオブジェクト）のSSL/TLSプロトコルバージョンを設定します。これにより、SSLセッション（SSL）のプロトコル設定が最初に定義され、SSLコンテキスト（wolfSSL_CTX_new()）メソッドの種類によって上書きされます。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  入力SSLオブジェクトがNULLまたは誤ったプロトコルバージョンがバージョンで指定されている場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+
+    \brief この関数は、versionで指定されたバージョンを使用して、指定されたSSLセッション(WOLFSSLオブジェクト)のSSL/TLSプロトコルバージョンを設定します。これにより、SSLセッション(ssl)のプロトコル設定が上書きされます。これは元々SSLコンテキスト(wolfSSL_CTX_new())のメソッドタイプによって定義および設定されたものです。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 入力されたSSLオブジェクトがNULLの場合、またはversionに不正なプロトコルバージョンが指定された場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param version SSL/TLSプロトコルバージョン。指定可能な値には、WOLFSSL_SSLV3、WOLFSSL_TLSV1、WOLFSSL_TLSV1_1、WOLFSSL_TLSV1_2があります。
 
     _Example_
     \code
@@ -6541,63 +7556,78 @@ int wolfSSL_GetMaxOutputSize(WOLFSSL*);
 
     ret = wolfSSL_SetVersion(ssl, WOLFSSL_TLSV1);
     if (ret != SSL_SUCCESS) {
-        // failed to set SSL session protocol version
+        // SSLセッションのプロトコルバージョンの設定に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_CTX_new
 */
 int wolfSSL_SetVersion(WOLFSSL* ssl, int version);
 
 /*!
-    \brief  MAC /暗号化コールバック。コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。MacOutは、MACの結果を保存する必要がある出力バッファです。MacinはMac入力バッファーとMacinszのサイズを注意しています。MacContentとMacverifyは、Wolfssl_SettlShmacinner()に必要であり、そのまま通過します。Encoutは、暗号化の結果を格納する必要がある出力バッファです。ENCINはENCSZが入力のサイズである間は暗号化する入力バッファです。コールバックの例は、wolfssl / test.h mymacencryptcb()を見つけることができます。
-    \return none  返品不可。
+    \brief 呼び出し元がアトミックユーザレコード処理Mac/暗号化コールバックを設定できるようにします。コールバックは、成功時には0、エラー時には<0を返す必要があります。sslとctxポインタは、ユーザの利便性のために利用可能です。macOutは、macの結果を格納する出力バッファです。macInはmac入力バッファであり、macInSzはバッファのサイズを示します。macContentとmacVerifyは、wolfSSL_SetTlsHmacInner()に必要であり、そのまま渡す必要があります。encOutは、暗号化の結果を格納する出力バッファです。encInは暗号化する入力バッファであり、encSzは入力のサイズです。コールバックの例は、wolfssl/test.hのmyMacEncryptCb()にあります。
+
+    \return none 戻り値なし。
+
+    \param No パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_SetMacEncryptCtx
     \sa wolfSSL_GetMacEncryptCtx
 */
 void  wolfSSL_CTX_SetMacEncryptCb(WOLFSSL_CTX* ctx, CallbackMacEncrypti cb);
 
 /*!
-    \brief  CTXへのコールバックコンテキスト。
-    \return none  返品不可。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元がアトミックユーザレコード処理Mac/暗号化コールバックコンテキストをctxに設定できるようにします。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetMacEncryptCb
     \sa wolfSSL_GetMacEncryptCtx
 */
 void  wolfSSL_SetMacEncryptCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
-    \brief  Mac / Encryptコールバックコンテキストは、wolfssl_setmacencryptx()で保存されていました。
-    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
-    \return NULL  空白のコンテキストのために返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元が、wolfSSL_SetMacEncryptCtx()で以前に保存されたアトミックユーザレコード処理Mac/暗号化コールバックコンテキストを取得できるようにします。
+
+    \return pointer 成功した場合、呼び出しはコンテキストへの有効なポインタを返します。
+    \return NULL 空のコンテキストの場合に返されます。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetMacEncryptCb
     \sa wolfSSL_SetMacEncryptCtx
 */
 void* wolfSSL_GetMacEncryptCtx(WOLFSSL* ssl);
 
 /*!
-    \brief  コールバックを復号化/確認します。コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。DECOUTは、復号化の結果を格納する出力バッファです。DECINは暗号化された入力バッファーとDecinszのサイズを注意しています。コンテンツと検証は、WolfSSL_SettlShmacinner()に必要であり、そのまま通過します。PADSZは、パディングの合計値で設定する出力変数です。つまり、MACサイズとパディングバイトとパッドバイトを加えています。コールバックの例は、wolfssl / test.h mydecryptverifycb()を見つけることができます。
-    \return none  いいえ返します。
+    \brief 呼び出し元がアトミックユーザレコード処理復号/検証コールバックを設定できるようにします。コールバックは、成功時には0、エラー時には<0を返す必要があります。sslとctxポインタは、ユーザの利便性のために利用可能です。decOutは、復号の結果を格納する出力バッファです。decInは暗号化された入力バッファであり、decInSzはバッファのサイズを示します。contentとverifyは、wolfSSL_SetTlsHmacInner()に必要であり、そのまま渡す必要があります。padSzは、パディングの合計値を設定する必要がある出力変数です。つまり、macサイズに加えて、パディングとパディングバイトです。コールバックの例は、wolfssl/test.hのmyDecryptVerifyCb()にあります。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_SetMacEncryptCtx
     \sa wolfSSL_GetMacEncryptCtx
 */
@@ -6605,97 +7635,119 @@ void  wolfSSL_CTX_SetDecryptVerifyCb(WOLFSSL_CTX* ctx,
                                                CallbackDecryptVerify cb);
 
 /*!
-    \brief  コールバックコンテキストをCTXに復号化/検証します。
-    \return none  いいえ返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元がアトミックユーザレコード処理復号/検証コールバックコンテキストをctxに設定できるようにします。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetDecryptVerifyCb
     \sa wolfSSL_GetDecryptVerifyCtx
 */
 void  wolfSSL_SetDecryptVerifyCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
-    \brief  wolfssl_setdecryptverifyctx()で以前に保存されているコールバックコンテキストを復号化/検証します。
-    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
-    \return NULL  空白のコンテキストのために返されます。
+    \brief 呼び出し元が、wolfSSL_SetDecryptVerifyCtx()で以前に保存されたアトミックユーザレコード処理復号/検証コールバックコンテキストを取得できるようにします。
+
+    \return pointer 成功した場合、呼び出しはコンテキストへの有効なポインタを返します。
+    \return NULL 空のコンテキストの場合に返されます。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetDecryptVerifyCb
     \sa wolfSSL_SetDecryptVerifyCtx
 */
 void* wolfSSL_GetDecryptVerifyCtx(WOLFSSL* ssl);
 
 /*!
-    \brief  VERIFYパラメーターは、これがピア・メッセージの検証のためのものであるかどうかを指定します。
-    \return pointer  正常にコールが秘密に有効なポインタを返します。秘密のサイズは、Wolfssl_gethmacsize()から入手できます。
-    \return NULL  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief ハンドシェイクプロセスからHmac/Macシークレットの取得を可能にします。verifyパラメータは、これがピアメッセージの検証用であるかどうかを指定します。
+
+    \return pointer 成功した場合、呼び出しはシークレットへの有効なポインタを返します。シークレットのサイズは、wolfSSL_GetHmacSize()から取得できます。
+    \return NULL エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
+    \param verify これがピアメッセージの検証用であるかどうかを指定します。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetHmacSize
 */
 const unsigned char* wolfSSL_GetMacSecret(WOLFSSL* ssl, int verify);
 
 /*!
-    \brief
-    \return pointer  正常にコールがキーへの有効なポインタを返します。鍵のサイズは、wolfssl_getkeysize()から取得できます。
-    \return NULL  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief ハンドシェイクプロセスからクライアント書き込み鍵の取得を可能にします。
+
+    \return pointer 成功した場合、呼び出しは鍵への有効なポインタを返します。鍵のサイズは、wolfSSL_GetKeySize()から取得できます。
+    \return NULL エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetKeySize
     \sa wolfSSL_GetClientWriteIV
 */
 const unsigned char* wolfSSL_GetClientWriteKey(WOLFSSL*);
 
 /*!
-    \brief  ハンドシェイクプロセスから。
-    \return pointer  正常にコールがIVへの有効なポインタを返します。IVのサイズは、wolfssl_getCipherBlockSize()から取得できます。
-    \return NULL  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief ハンドシェイクプロセスからクライアント書き込みIV(初期化ベクトル)の取得を可能にします。
+
+    \return pointer 成功した場合、呼び出しはIVへの有効なポインタを返します。IVのサイズは、wolfSSL_GetCipherBlockSize()から取得できます。
+    \return NULL エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetCipherBlockSize()
     \sa wolfSSL_GetClientWriteKey()
 */
 const unsigned char* wolfSSL_GetClientWriteIV(WOLFSSL*);
 
 /*!
-    \brief
-    \return pointer  正常にコールが鍵への有効なポインタを返します。鍵のサイズは、wolfssl_getkeysize()から取得できます。
-    \return NULL  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief ハンドシェイクプロセスからサーバ書き込み鍵の取得を可能にします。
+
+    \return pointer 成功した場合、呼び出しは鍵への有効なポインタを返します。鍵のサイズは、wolfSSL_GetKeySize()から取得できます。
+    \return NULL エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetKeySize
     \sa wolfSSL_GetServerWriteIV
 */
 const unsigned char* wolfSSL_GetServerWriteKey(WOLFSSL*);
 
 /*!
-    \brief  ハンドシェイクプロセスから。
-    \return pointer  正常にコールがIVへの有効なポインタを返します。IVのサイズは、wolfssl_getCipherBlockSize()から取得できます。
-    \return NULL  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief ハンドシェイクプロセスからサーバ書き込みIV(初期化ベクトル)の取得を可能にします。
+
+    \return pointer 成功した場合、呼び出しはIVへの有効なポインタを返します。IVのサイズは、wolfSSL_GetCipherBlockSize()から取得できます。
+    \return NULL エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     \sa wolfSSL_GetCipherBlockSize
     \sa wolfSSL_GetClientWriteKey
@@ -6703,15 +7755,18 @@ const unsigned char* wolfSSL_GetServerWriteKey(WOLFSSL*);
 const unsigned char* wolfSSL_GetServerWriteIV(WOLFSSL*);
 
 /*!
-    \brief
-    \return size  正常にコールが鍵サイズをバイト単位で返します。
-    \return BAD_FUNC_ARG  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief ハンドシェイクプロセスから鍵サイズの取得を可能にします。
+
+    \return size 成功した場合、呼び出しは鍵サイズをバイト単位で返します。
+    \return BAD_FUNC_ARG エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetClientWriteKey
     \sa wolfSSL_GetServerWriteKey
 */
@@ -6719,10 +7774,13 @@ int                  wolfSSL_GetKeySize(WOLFSSL*);
 
 /*!
     \ingroup CertsKeys
-    \brief  WolfSSL構造体に保持されているSpecs構造体のIV_SIZEメンバーを返します。
-    \return iv_size  ssl-> specs.iv_sizeで保持されている値を返します。
-    \return BAD_FUNC_ARG  WolfSSL構造がNULLの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+
+    \brief WOLFSSL構造体に保持されているspecs構造体のiv_sizeメンバを返します。
+
+    \return iv_size ssl->specs.iv_sizeに保持されている値を返します。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -6733,9 +7791,10 @@ int                  wolfSSL_GetKeySize(WOLFSSL*);
     ivSize = wolfSSL_GetIVSize(ssl);
 
     if(ivSize > 0){
-    	// ivSize holds the specs.iv_size value.
+    	// ivSizeはspecs.iv_size値を保持しています。
     }
     \endcode
+
     \sa wolfSSL_GetKeySize
     \sa wolfSSL_GetClientWriteIV
     \sa wolfSSL_GetServerWriteIV
@@ -6743,135 +7802,164 @@ int                  wolfSSL_GetKeySize(WOLFSSL*);
 int                  wolfSSL_GetIVSize(WOLFSSL*);
 
 /*!
-    \brief
-    \return success  成功した場合、呼び出しがWolfSSLオブジェクトの側面に応じてwolfssl_server_endまたはwolfssl_client_endを返します。
-    \return BAD_FUNC_ARG  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief このWOLFSSL接続のサイド(側)の取得を可能にします。
+
+    \return success 成功した場合、呼び出しはWOLFSSLオブジェクトのサイドに応じて、WOLFSSL_SERVER_ENDまたはWOLFSSL_CLIENT_ENDのいずれかを返します。
+    \return BAD_FUNC_ARG エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetClientWriteKey
     \sa wolfSSL_GetServerWriteKey
 */
 int                  wolfSSL_GetSide(WOLFSSL*);
 
 /*!
-    \brief  少なくともTLSバージョン1.1以上です。
-    \return true/false  成功した場合、呼び出しがTRUEまたは0の場合は0を返します。
-    \return BAD_FUNC_ARG  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元が、ネゴシエートされたプロトコルバージョンが少なくともTLSバージョン1.1以上であるかどうかを判断できるようにします。
+
+    \return true/false 成功した場合、呼び出しは真の場合は1、偽の場合は0を返します。
+    \return BAD_FUNC_ARG エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetSide
 */
-int                  wolfSSL_IsTLSv1_1(WOLFSSL*);
+int                  wolfSSL_IsTLSv1_1(WOLFSSL*);/*!
+    \brief 呼び出し元がハンドシェイクからネゴシエートされたバルク暗号アルゴリズムを判定できるようにします。
 
-/*!
-    \brief  ハンドシェイクから。
-    \return If  コールが成功すると、wolfssl_cipher_null、wolfssl_des、wolfssl_triple_des、wolfssl_aes、wolfssl_aes_gcm、wolfssl_aes_ccm、wolfssl_camellia。
-    \return BAD_FUNC_ARG  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \return 成功時、以下のいずれかを返します。
+    wolfssl_cipher_null、wolfssl_des、wolfssl_triple_des、wolfssl_aes、
+    wolfssl_aes_gcm、wolfssl_aes_ccm、wolfssl_camellia。
+    \return BAD_FUNC_ARG エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetCipherBlockSize
     \sa wolfSSL_GetKeySize
 */
 int                  wolfSSL_GetBulkCipher(WOLFSSL*);
 
 /*!
-    \brief  ハンドシェイク。
-    \return size  正常にコールが暗号ブロックサイズのサイズをバイト単位で戻します。
-    \return BAD_FUNC_ARG  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元がハンドシェイクからネゴシエートされた暗号ブロックサイズを判定できるようにします。
+
+    \return size 成功時、暗号ブロックサイズのバイト数を返します。
+    \return BAD_FUNC_ARG エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetKeySize
 */
 int                  wolfSSL_GetCipherBlockSize(WOLFSSL*);
 
 /*!
-    \brief  ハンドシェーク。暗号タイプのwolfssl_aead_typeの場合。
-    \return size  正常にコールがEAD MACサイズのサイズをバイト単位で戻します。
-    \return BAD_FUNC_ARG  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元がハンドシェイクからネゴシエートされたaead macサイズを判定できるようにします。暗号タイプWOLFSSL_AEAD_TYPE用。
+
+    \return size 成功時、aead macサイズのバイト数を返します。
+    \return BAD_FUNC_ARG エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetKeySize
 */
 int                  wolfSSL_GetAeadMacSize(WOLFSSL*);
 
 /*!
-    \brief  ハンドシェーク。wolfssl_aead_type以外の暗号タイプの場合。
-    \return size  正常にコールが（H）MACサイズのサイズをバイト単位で戻します。
-    \return BAD_FUNC_ARG  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元がハンドシェイクからネゴシエートされた(h)macサイズを判定できるようにします。WOLFSSL_AEAD_TYPE以外の暗号タイプ用。
+
+    \return size 成功時、(h)macサイズのバイト数を返します。
+    \return BAD_FUNC_ARG エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetHmacType
 */
 int                  wolfSSL_GetHmacSize(WOLFSSL*);
 
 /*!
-    \brief  ハンドシェーク。wolfssl_aead_type以外の暗号タイプの場合。
-    \return If  コールが成功すると、次のいずれかが返されます.MD5、SHA、SHA256、SHA384。
-    \return BAD_FUNC_ARG  エラー状態に対して返される可能性があります。
-    \return SSL_FATAL_ERROR  エラー状態にも返される可能性があります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元がハンドシェイクからネゴシエートされた(h)macタイプを判定できるようにします。WOLFSSL_AEAD_TYPE以外の暗号タイプ用。
+
+    \return 成功時、以下のいずれかを返します。
+    MD5、SHA、SHA256、SHA384。
+    \return BAD_FUNC_ARG エラー状態の場合に返される可能性があります。
+    \return SSL_FATAL_ERROR エラー状態の場合に返される可能性があります。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetHmacSize
 */
 int                  wolfSSL_GetHmacType(WOLFSSL*);
 
 /*!
-    \brief  ハンドシェイクから。
-    \return If  正常にコールは次のいずれかを返します.WolfSSL_BLOCK_TYPE、WOLFSSL_STREAM_TYPE、WOLFSSL_AEAD_TYPE。
-    \return BAD_FUNC_ARG  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元がハンドシェイクからネゴシエートされた暗号タイプを判定できるようにします。
+
+    \return 成功時、以下のいずれかを返します。
+    WOLFSSL_BLOCK_TYPE、WOLFSSL_STREAM_TYPE、WOLFSSL_AEAD_TYPE。
+    \return BAD_FUNC_ARG エラー状態の場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetHmacType
 */
 int                  wolfSSL_GetCipherType(WOLFSSL*);
 
 /*!
-    \brief  送受信結果は、少なくともwolfssl_gethmacsize()バイトであるべきである内部に書き込まれます。メッセージのサイズはSZで指定され、内容はメッセージの種類であり、検証はこれがピアメッセージの検証であるかどうかを指定します。wolfssl_aead_typeを除く暗号タイプに有効です。
-    \return 1  成功時に返されます。
-    \return BAD_FUNC_ARG  エラー状態に戻ります。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元がメッセージの送受信のためにHmac Innerベクトルを設定できるようにします。結果はinnerに書き込まれ、少なくともwolfSSL_GetHmacSize()バイトである必要があります。メッセージのサイズはszで指定され、contentはメッセージのタイプ、verifyはこれがピアメッセージの検証であるかを指定します。WOLFSSL_AEAD_TYPEを除く暗号タイプで有効です。
+
+    \return 1 成功時。
+    \return BAD_FUNC_ARG エラー状態の場合に返されます。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetHmacType
 */
@@ -6879,318 +7967,398 @@ int wolfSSL_SetTlsHmacInner(WOLFSSL* ssl, byte* inner,
                             word32 sz, int content, int verify);
 
 /*!
-    \brief  コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。INSは入力バッファーが入力の長さを表します。OUTは、署名の結果を保存する必要がある出力バッファです。OUTSZは、呼び出し時に出力バッファのサイズを指定する入力/出力変数であり、署名の実際のサイズを戻す前に格納する必要があります。keyderはASN1フォーマットのECC秘密鍵であり、Keyszは鍵のキーの長さです。コールバックの例は、wolfssl / test.h myeccsign()を見つけることができます。
-    \return none  いいえ返します。
+    \brief 呼び出し元がECC署名用の公開鍵コールバックを設定できるようにします。コールバックは成功時に0、エラー時に0未満を返す必要があります。sslとctxポインタはユーザの便宜のために利用可能です。inは署名する入力バッファで、inSzは入力の長さを示します。outは署名の結果を格納する出力バッファです。outSzは入出力変数で、呼び出し時の出力バッファのサイズを指定し、返す前に署名の実際のサイズをそこに格納する必要があります。keyDerはASN1形式のECC秘密鍵で、keySzは鍵の長さをバイト単位で表します。コールバックの例はwolfssl/test.h myEccSign()にあります。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_SetEccSignCtx
     \sa wolfSSL_GetEccSignCtx
 */
 void  wolfSSL_CTX_SetEccSignCb(WOLFSSL_CTX* ctx, CallbackEccSign cb);
 
 /*!
-    \brief  CTXへのコンテキスト。
-    \return none  いいえ返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元が公開鍵ECC署名コールバックコンテキストをctxに設定できるようにします。
+
+    \return none 戻り値なし。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
+    \param ctx 格納するユーザコンテキストへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetEccSignCb
     \sa wolfSSL_GetEccSignCtx
 */
 void  wolfSSL_SetEccSignCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
-    \brief  以前にwolfssl_seteccsignctx()で保存されていたコンテキスト。
-    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
-    \return NULL  空白のコンテキストのために返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元が以前にwolfSSL_SetEccSignCtx()で格納された公開鍵ECC署名コールバックコンテキストを取得できるようにします。
+
+    \return pointer 成功時、コンテキストへの有効なポインタを返します。
+    \return NULL 空のコンテキストの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSLオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetEccSignCb
     \sa wolfSSL_SetEccSignCtx
 */
 void* wolfSSL_GetEccSignCtx(WOLFSSL* ssl);
 
 /*!
-    \brief  CTXへのコンテキスト。
-    \return none  いいえ返します。
-    \param ctx  wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+    \brief 呼び出し元が公開鍵ECC署名コールバックコンテキストをctxに設定できるようにします。
+
+    \return none 戻り値なし。
+
+    \param ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param ctx 格納するユーザコンテキストへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetEccSignCb
     \sa wolfSSL_CTX_GetEccSignCtx
 */
 void  wolfSSL_CTX_SetEccSignCtx(WOLFSSL_CTX* ctx, void *userCtx);
 
 /*!
-    \brief  以前にwolfssl_seteccsignctx()で保存されていたコンテキスト。
-    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
-    \return NULL  空白のコンテキストのために返されます。
+    \brief 呼び出し元が以前にwolfSSL_SetEccSignCtx()で格納された公開鍵ECC署名コールバックコンテキストを取得できるようにします。
+
+    \return pointer 成功時、コンテキストへの有効なポインタを返します。
+    \return NULL 空のコンテキストの場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetEccSignCb
     \sa wolfSSL_CTX_SetEccSignCtx
 */
 void* wolfSSL_CTX_GetEccSignCtx(WOLFSSL_CTX* ctx);
 
 /*!
-    \brief  コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。SIGは検証の署名であり、SIGSZは署名の長さを表します。ハッシュはメッセージのダイジェストを含む入力バッファであり、HASHSZはハッシュの長さを意味します。結果は、検証の結果を格納する出力変数、成功のために1、失敗のために0を記憶する必要があります。keyderはASN1フォーマットのECC秘密鍵であり、Keyszはキーのキーの長さです。コールバックの例は、wolfssl / test.h myeccverify()を見つけることができます。
-    \return none  いいえ返します。
+    \brief 呼び出し元がECC検証用の公開鍵コールバックを設定できるようにします。コールバックは成功時に0、エラー時に0未満を返す必要があります。sslとctxポインタはユーザの便宜のために利用可能です。sigは検証する署名で、sigSzは署名の長さを示します。hashはメッセージのダイジェストを含む入力バッファで、hashSzはハッシュの長さをバイト単位で示します。resultは検証の結果を格納する出力変数で、成功時は1、失敗時は0です。keyDerはASN1形式のECC秘密鍵で、keySzは鍵の長さをバイト単位で表します。コールバックの例はwolfssl/test.h myEccVerify()にあります。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_SetEccVerifyCtx
     \sa wolfSSL_GetEccVerifyCtx
 */
 void  wolfSSL_CTX_SetEccVerifyCb(WOLFSSL_CTX* ctx, CallbackEccVerify cb);
 
 /*!
-    \brief  CTXへのコンテキスト。
-    \return none  いいえ返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元が公開鍵ECC検証コールバックコンテキストをctxに設定できるようにします。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetEccVerifyCb
     \sa wolfSSL_GetEccVerifyCtx
 */
 void  wolfSSL_SetEccVerifyCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
-    \brief  以前にwolfssl_setecverifyctx()で保存されていたコンテキスト。
-    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
-    \return NULL  空白のコンテキストのために返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元が以前にwolfSSL_SetEccVerifyCtx()で格納された公開鍵ECC検証コールバックコンテキストを取得できるようにします。
+
+    \return pointer 成功時、コンテキストへの有効なポインタを返します。
+    \return NULL 空のコンテキストの場合に返されます。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetEccVerifyCb
     \sa wolfSSL_SetEccVerifyCtx
 */
 void* wolfSSL_GetEccVerifyCtx(WOLFSSL* ssl);
 
 /*!
-    \brief  コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。INSは入力バッファーが入力の長さを表します。OUTは、署名の結果を保存する必要がある出力バッファです。OUTSZは、呼び出し時に出力バッファのサイズを指定する入力/出力変数であり、署名の実際のサイズを戻す前に格納する必要があります。keyderはASN1フォーマットのRSA秘密鍵であり、Keyszはバイト数のキーの長さです。コールバックの例は、wolfssl / test.h myrsasign()を見つけることができます。
-    \return none  いいえ返します。
+    \brief 呼び出し元がRSA署名用の公開鍵コールバックを設定できるようにします。コールバックは成功時に0、エラー時に0未満を返す必要があります。sslとctxポインタはユーザの便宜のために利用可能です。inは署名する入力バッファで、inSzは入力の長さを示します。outは署名の結果を格納する出力バッファです。outSzは入出力変数で、呼び出し時の出力バッファのサイズを指定し、返す前に署名の実際のサイズをそこに格納する必要があります。keyDerはASN1形式のRSA秘密鍵で、keySzは鍵の長さをバイト単位で表します。コールバックの例はwolfssl/test.h myRsaSign()にあります。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_SetRsaSignCtx
     \sa wolfSSL_GetRsaSignCtx
 */
 void  wolfSSL_CTX_SetRsaSignCb(WOLFSSL_CTX* ctx, CallbackRsaSign cb);
 
 /*!
-    \brief  ctxに。
-    \return none  いいえ返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元が公開鍵RSA署名コールバックコンテキストをctxに設定できるようにします。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetRsaSignCb
     \sa wolfSSL_GetRsaSignCtx
 */
 void  wolfSSL_SetRsaSignCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
-    \brief  以前にwolfssl_setrsAsignctx()で保存されていたコンテキスト。
-    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
-    \return NULL  空白のコンテキストのために返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元が以前にwolfSSL_SetRsaSignCtx()で格納された公開鍵RSA署名コールバックコンテキストを取得できるようにします。
+
+    \return pointer 成功時、コンテキストへの有効なポインタを返します。
+    \return NULL 空のコンテキストの場合に返されます。
+
+    \param none パラメータなし。
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetRsaSignCb
     \sa wolfSSL_SetRsaSignCtx
 */
 void* wolfSSL_GetRsaSignCtx(WOLFSSL* ssl);
 
 /*!
-    \brief  コールバックは、成功のための平文バイト数または<0エラーの場合は<0を返すべきです。SSLとCTXポインタはユーザーの利便性に利用できます。SIGは検証の署名であり、SIGSZは署名の長さを表します。復号化プロセスとパディングの後に検証バッファの先頭に設定する必要があります。keyderはASN1形式のRSA公開鍵であり、Keyszはキーのキーの長さです。コールバックの例は、wolfssl / test.h myrsaverify()を見つけることができます。
-    \return none  いいえ返します。
+    \brief 呼び出し元がRSA検証用の公開鍵コールバックを設定できるようにします。コールバックは成功時に平文のバイト数、エラー時に0未満を返す必要があります。sslとctxポインタはユーザの便宜のために利用可能です。sigは検証する署名で、sigSzは署名の長さを示します。outは復号プロセスとパディングの後、検証バッファの先頭に設定する必要があります。keyDerはASN1形式のRSA公開鍵で、keySzは鍵の長さをバイト単位で表します。コールバックの例はwolfssl/test.h myRsaVerify()にあります。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
+
     \sa wolfSSL_SetRsaVerifyCtx
     \sa wolfSSL_GetRsaVerifyCtx
 */
-void  wolfSSL_CTX_SetRsaVerifyCb(WOLFSSL_CTX* ctx, CallbackRsaVerify cb);
+void  wolfSSL_CTX_SetRsaVerifyCb(WOLFSSL_CTX* ctx, CallbackRsaVerify cb);/*!
+    \brief 呼び出し元が公開鍵RSA検証コールバックコンテキストをctxに設定できるようにします。
 
-/*!
-    \brief  CTXへのコンテキスト。
-    \return none  いいえ返します。
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetRsaVerifyCb
     \sa wolfSSL_GetRsaVerifyCtx
 */
 void  wolfSSL_SetRsaVerifyCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
-    \brief  以前にwolfssl_setrsaverifyctx()で保存されていたコンテキスト。
-    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
-    \return NULL  空白のコンテキストのために返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元がwolfSSL_SetRsaVerifyCtx()で以前に保存された公開鍵RSA検証コールバックコンテキストを取得できるようにします。
+
+    \return pointer 成功した場合、呼び出しはコンテキストへの有効なポインタを返します。
+    \return NULL 空のコンテキストに対して返されます。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetRsaVerifyCb
     \sa wolfSSL_SetRsaVerifyCtx
 */
 void* wolfSSL_GetRsaVerifyCtx(WOLFSSL* ssl);
 
 /*!
-    \brief  暗号化します。コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。INは入力バッファですが、INSZは入力の長さを表します。暗号化の結果を保存する必要がある出力バッファです。OUTSZは、呼び出し時に出力バッファのサイズを指定する入力/出力変数であり、暗号化の実際のサイズは戻って前に格納されるべきです。keyderはASN1形式のRSA公開鍵であり、Keyszはキーのキーの長さです。例コールバックの例は、wolfssl / test.h myrsaenc()を見つけることができます。
-    \return none  いいえ返します。
+    \brief 呼び出し元がRSA公開暗号化のための公開鍵コールバックを設定できるようにします。コールバックは成功の場合は0を、エラーの場合は0未満を返す必要があります。sslとctxポインタはユーザーの利便性のために利用可能です。inは暗号化する入力バッファで、inSzは入力の長さを示します。outは暗号化の結果を格納する出力バッファです。outSzは入出力変数で、呼び出し時に出力バッファのサイズを指定し、戻る前に暗号化の実際のサイズを格納する必要があります。keyDerはASN1形式のRSA公開鍵で、keySzはバイト単位の鍵の長さです。コールバックの例はwolfssl/test.hのmyRsaEnc()にあります。
 
-    _Example_
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
+
+    _Examples_
     \code
     none
     \endcode
+
     \sa wolfSSL_SetRsaEncCtx
     \sa wolfSSL_GetRsaEncCtx
 */
 void  wolfSSL_CTX_SetRsaEncCb(WOLFSSL_CTX* ctx, CallbackRsaEnc cb);
 
 /*!
-    \brief  CTXへのコールバックコンテキスト。
-    \return none  いいえ返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元が公開鍵RSA公開暗号化コールバックコンテキストをctxに設定できるようにします。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetRsaEncCb
     \sa wolfSSL_GetRsaEncCtx
 */
 void  wolfSSL_SetRsaEncCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
-    \brief  コールバックコンテキストは、wolfssl_setrsaencctx()で以前に保存されていました。
-    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
-    \return NULL  空白のコンテキストのために返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元がwolfSSL_SetRsaEncCtx()で以前に保存された公開鍵RSA公開暗号化コールバックコンテキストを取得できるようにします。
+
+    \return pointer 成功した場合、呼び出しはコンテキストへの有効なポインタを返します。
+    \return NULL 空のコンテキストに対して返されます。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetRsaEncCb
     \sa wolfSSL_SetRsaEncCtx
 */
 void* wolfSSL_GetRsaEncCtx(WOLFSSL* ssl);
 
 /*!
-    \brief  復号化します。コールバックは、成功のための平文バイト数または<0エラーの場合は<0を返すべきです。SSLとCTXポインタはユーザーの利便性に利用できます。INは、復号化する入力バッファが入力の長さを表します。復号化プロセスおよび任意のパディングの後、復号化バッファの先頭に設定する必要があります。keyderはASN1フォーマットのRSA秘密鍵であり、Keyszはバイト数のキーの長さです。コールバックの例は、wolfssl / test.h myrsadec()を見つけることができます。
-    \return none  いいえ返します。
+    \brief 呼び出し元がRSA秘密復号のための公開鍵コールバックを設定できるようにします。コールバックは成功の場合は平文のバイト数を、エラーの場合は0未満を返す必要があります。sslとctxポインタはユーザーの利便性のために利用可能です。inは復号する入力バッファで、inSzは入力の長さを示します。outは復号処理とパディングの後、復号バッファの先頭に設定する必要があります。keyDerはASN1形式のRSA秘密鍵で、keySzはバイト単位の鍵の長さです。コールバックの例はwolfssl/test.hのmyRsaDec()にあります。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_SetRsaDecCtx
     \sa wolfSSL_GetRsaDecCtx
 */
 void  wolfSSL_CTX_SetRsaDecCb(WOLFSSL_CTX* ctx, CallbackRsaDec cb);
 
 /*!
-    \brief  CTXへのコールバックコンテキスト。
-    \return none  いいえ返します。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元が公開鍵RSA秘密復号コールバックコンテキストをctxに設定できるようにします。
+
+    \return none 戻り値なし。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetRsaDecCb
     \sa wolfSSL_GetRsaDecCtx
 */
 void  wolfSSL_SetRsaDecCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
-    \brief  コールバックコンテキストは、wolfssl_setrsadecctx()で以前に保存されていました。
-    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
-    \return NULL  空白のコンテキストのために返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ
+    \brief 呼び出し元がwolfSSL_SetRsaDecCtx()で以前に保存された公開鍵RSA秘密復号コールバックコンテキストを取得できるようにします。
+
+    \return pointer 成功した場合、呼び出しはコンテキストへの有効なポインタを返します。
+    \return NULL 空のコンテキストに対して返されます。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_SetRsaDecCb
     \sa wolfSSL_SetRsaDecCtx
 */
 void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl);
 
 /*!
-    \brief  新しいCA証明書がWolfSSLにロードされたときに呼び出される（WolfSSL_CTX）。コールバックには、符号化された証明書を持つバッファが与えられます。
-    \return none  返品不可。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \brief この関数は、新しいCA証明書がwolfSSLにロードされたときに呼び出されるコールバックをSSLコンテキスト(WOLFSSL_CTX)に登録します。コールバックにはDERエンコードされた証明書を含むバッファが渡されます。
+
+    \return none 戻り値なし。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param callback wolfSSLコンテキストctxのCAコールバックとして登録される関数。この関数のシグネチャは、上記の概要セクションに示されているものに従う必要があります。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = 0;
 
-    // CA callback prototype
+    // CAコールバックのプロトタイプ
     int MyCACallback(unsigned char *der, int sz, int type);
 
-    // Register the custom CA callback with the SSL context
+    // SSLコンテキストにカスタムCAコールバックを登録
     wolfSSL_CTX_SetCACb(ctx, MyCACallback);
 
     int MyCACallback(unsigned char* der, int sz, int type)
     {
-    	// custom CA callback function, DER-encoded cert
-        // located in “der” of size “sz” with type “type”
+    	// カスタムCAコールバック関数、DERエンコードされた証明書は
+        // サイズszの"der"に格納され、タイプは"type"
     }
     \endcode
+
     \sa wolfSSL_CTX_load_verify_locations
 */
 void wolfSSL_CTX_SetCACb(WOLFSSL_CTX* ctx, CallbackCACache cb);
 
 /*!
     \ingroup CertManager
-    \brief  新しい証明書マネージャコンテキストを割り当てて初期化します。このコンテキストは、SSLのニーズとは無関係に使用できます。証明書をロードしたり、証明書を確認したり、失効状況を確認したりするために使用することができます。
-    \return WOLFSSL_CERT_MANAGER  正常にコールが有効なwolfssl_cert_managerポインタを返します。
-    \return NULL  エラー状態に戻ります。
+    \brief 新しい証明書マネージャーコンテキストを割り当て、初期化します。このコンテキストはSSLの必要性とは独立して使用できます。証明書のロード、証明書の検証、失効ステータスのチェックに使用できます。
+
+    \return WOLFSSL_CERT_MANAGER 成功した場合、呼び出しは有効なWOLFSSL_CERT_MANAGERポインタを返します。
+    \return NULL エラー状態の場合に返されます。
+
+    \param none パラメータなし。
+
     \sa wolfSSL_CertManagerFree
 */
 WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew_ex(void* heap);
 
 /*!
     \ingroup CertManager
-    \brief  新しい証明書マネージャコンテキストを割り当てて初期化します。このコンテキストは、SSLのニーズとは無関係に使用できます。証明書をロードしたり、証明書を確認したり、失効状況を確認したりするために使用することができます。
-    \return WOLFSSL_CERT_MANAGER  正常にコールが有効なwolfssl_cert_managerポインタを返します。
-    \return NULL  エラー状態に戻ります。
+    \brief 新しい証明書マネージャーコンテキストを割り当て、初期化します。このコンテキストはSSLの必要性とは独立して使用できます。証明書のロード、証明書の検証、失効ステータスのチェックに使用できます。
+
+    \return WOLFSSL_CERT_MANAGER 成功した場合、呼び出しは有効なWOLFSSL_CERT_MANAGERポインタを返します。
+    \return NULL エラー状態の場合に返されます。
+
+    \param none パラメータなし。
 
     _Example_
     \code
@@ -7199,17 +8367,21 @@ WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew_ex(void* heap);
     WOLFSSL_CERT_MANAGER* cm;
     cm = wolfSSL_CertManagerNew();
     if (cm == NULL) {
-	// error creating new cert manager
+	    // 新しい証明書マネージャーの作成エラー
     }
     \endcode
+
     \sa wolfSSL_CertManagerFree
 */
 WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew(void);
 
 /*!
     \ingroup CertManager
-    \brief  証明書マネージャのコンテキストに関連付けられているすべてのリソースを解放します。証明書マネージャを使用する必要がなくなるときにこれを呼び出します。
-    \return none
+    \brief 証明書マネージャーコンテキストに関連するすべてのリソースを解放します。証明書マネージャーを使用する必要がなくなったときにこれを呼び出します。
+
+    \return none 戻り値なし。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
 
     _Example_
     \code
@@ -7219,22 +8391,26 @@ WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew(void);
     ...
     wolfSSL_CertManagerFree(cm);
     \endcode
+
     \sa wolfSSL_CertManagerNew
 */
 void wolfSSL_CertManagerFree(WOLFSSL_CERT_MANAGER*);
 
 /*!
     \ingroup CertManager
-    \brief  ManagerコンテキストへのCA証明書のロードの場所を指定します。PEM証明書カフェイルには、複数の信頼できるCA証明書が含まれている可能性があります。capathがnullでない場合、PEM形式のCA証明書を含むディレクトリを指定します。
-    \return SSL_SUCCESS  成功した場合に返されます。、通話が戻ります。
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return BAD_FUNC_ARG  ポインタが提供されていない場合に返されるエラーです。
-    \return SSL_FATAL_ERROR   - 失敗時に返されます。
-    \param cm  wolfssl_certmanagernew()を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
-    \param file  ロードするCA証明書を含むファイルの名前へのポインタ。
+    \brief マネージャーコンテキストへのCA証明書ロードの場所を指定します。PEM証明書CAfileには複数の信頼されたCA証明書を含めることができます。CApathがNULLでない場合、PEM形式のCA証明書を含むディレクトリを指定します。
+
+    \return SSL_SUCCESS 成功した場合に返されます。
+    \return SSL_BAD_FILETYPE ファイルの形式が間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足の状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードが失敗した場合に返されます。
+    \return BAD_FUNC_ARG ポインタが提供されていない場合に返されるエラーです。
+    \return SSL_FATAL_ERROR 失敗時に返されます。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param file ロードするCA証明書を含むファイル名へのポインタ。
+    \param path ロードするCA証明書を含むディレクトリパスの名前へのポインタ。証明書ディレクトリが不要な場合はNULLポインタを使用できます。
 
     _Example_
     \code
@@ -7243,11 +8419,12 @@ void wolfSSL_CertManagerFree(WOLFSSL_CERT_MANAGER*);
     int ret = 0;
     WOLFSSL_CERT_MANAGER* cm;
     ...
-    ret = wolfSSL_CertManagerLoadCA(cm, “path/to/cert-file.pem”, 0);
+    ret = wolfSSL_CertManagerLoadCA(cm, "path/to/cert-file.pem", 0);
     if (ret != SSL_SUCCESS) {
-	// error loading CA certs into cert manager
+	    // 証明書マネージャーへのCA証明書のロードエラー
     }
     \endcode
+
     \sa wolfSSL_CertManagerVerify
 */
 int wolfSSL_CertManagerLoadCA(WOLFSSL_CERT_MANAGER* cm, const char* f,
@@ -7255,12 +8432,15 @@ int wolfSSL_CertManagerLoadCA(WOLFSSL_CERT_MANAGER* cm, const char* f,
 
 /*!
     \ingroup CertManager
-    \brief  wolfssl_ctx_load_verify_bufferを呼び出して、関数に渡されたCM内の情報を失うことなく一時的なCMを使用してその結果を返すことによってCAバッファをロードします。
-    \return SSL_FATAL_ERROR  wolfssl_cert_manager構造体がNULLの場合、またはwolfSSL_CTX_new()がNULLを返す場合に返されます。
-    \return SSL_SUCCESS  実行が成功するために返されます。
-    \param cm  wolfssl_certmanagernew()を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
-    \param in  CERT情報用のバッファー。
-    \param sz  バッファの長さ。
+    \brief wolfSSL_CTX_load_verify_bufferを呼び出し、関数に渡されたcmの情報を失わないように一時的なcmを使用してその結果を返すことで、CAバッファをロードします。
+
+    \return SSL_FATAL_ERROR WOLFSSL_CERT_MANAGER構造体がNULL、またはwolfSSL_CTX_new()がNULLを返した場合に返されます。
+    \return SSL_SUCCESS 正常に実行された場合に返されます。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param in 証明書情報のバッファ。
+    \param sz バッファの長さ。
+    \param format 証明書の形式、PEMまたはDER。
 
     _Example_
     \code
@@ -7271,9 +8451,10 @@ int wolfSSL_CertManagerLoadCA(WOLFSSL_CERT_MANAGER* cm, const char* f,
     int format;
     …
     if(wolfSSL_CertManagerLoadCABuffer(vp, sz, format) != SSL_SUCCESS){
-	    Error returned. Failure case code block.
+	    // エラーが返されました。失敗ケースのコードブロック。
     }
     \endcode
+
     \sa wolfSSL_CTX_load_verify_buffer
     \sa ProcessChainBuffer
     \sa ProcessBuffer
@@ -7284,66 +8465,100 @@ int wolfSSL_CertManagerLoadCABuffer(WOLFSSL_CERT_MANAGER* cm,
 
 /*!
     \ingroup CertManager
-    \brief  この関数はCA署名者リストをアンロードします。
-    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。
-    \return BAD_FUNC_ARG  wolfssl_cert_managerがnullの場合に返されます。
-    \return BAD_MUTEX_E  ミューテックスエラーが発生した場合に返されます。
+    \brief この関数はCA署名者リストをアンロードします。
+
+    \return SSL_SUCCESS 関数の正常な実行時に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGERがNULLの場合に返されます。
+    \return BAD_MUTEX_E mutexエラーが発生した場合に返されます。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
 
     _Example_
     \code
     #include <wolfssl/ssl.h>
 
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new(protocol method);
-    WOLFSSL_CERT_MANAGER* cm = wolfSSL_CertManagerNew();
+    WOLFSSL_CERT_MANAGER* cm = wolfSSL_CTX_GetCertManager(ctx);
     ...
-    if(wolfSSL_CertManagerUnloadCAs(ctx->cm) != SSL_SUCCESS){
-    	Failure case.
+    if(wolfSSL_CertManagerUnloadCAs(cm) != SSL_SUCCESS){
+        // 失敗ケース。
     }
     \endcode
-    \sa FreeSignerTable
+
     \sa UnlockMutex
 */
 int wolfSSL_CertManagerUnloadCAs(WOLFSSL_CERT_MANAGER* cm);
 
 /*!
     \ingroup CertManager
-    \brief  関数は信頼できるピアリンクリストを解放し、信頼できるピアリストのロックを解除します。
-    \return SSL_SUCCESS  関数が正常に完了した場合
-    \return BAD_FUNC_ARG  wolfssl_cert_managerがnullの場合
-    \return BAD_MUTEX_E  ミューテックスエラーTPLOCKでは、WOLFSSL_CERT_MANAGER構造体のメンバーは0（ニル）です。
+    \brief この関数はCA署名者リストに追加された中間証明書をアンロードします。
+
+    \return SSL_SUCCESS 関数の正常な実行時に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGERがNULLの場合に返されます。
+    \return BAD_MUTEX_E mutexエラーが発生した場合に返されます。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
 
     _Example_
     \code
     #include <wolfssl/ssl.h>
 
-    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(Protocol define);
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(protocol method);
+    WOLFSSL_CERT_MANAGER* cm = wolfSSL_CTX_GetCertManager(ctx);
+    ...
+    if(wolfSSL_CertManagerUnloadIntermediateCerts(cm) != SSL_SUCCESS){
+    	// 失敗ケース。
+    }
+    \endcode
+
+    \sa UnlockMutex
+*/
+int wolfSSL_CertManagerUnloadIntermediateCerts(WOLFSSL_CERT_MANAGER* cm);/*!
+    \ingroup CertManager
+    \brief この関数は、Trusted Peerリンクリストを解放し、トラステッドピアリストのロックを解除します。
+
+    \return SSL_SUCCESS 関数が正常に完了した場合。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGERがNULLの場合。
+    \return BAD_MUTEX_E WOLFSSL_CERT_MANAGER構造体のメンバであるtpLockが0(null)の場合、mutexエラー。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
+
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(Protocol define);
     WOLFSSL_CERT_MANAGER* cm = wolfSSL_CertManagerNew();
     ...
     if(wolfSSL_CertManagerUnload_trust_peers(cm) != SSL_SUCCESS){
-	    The function did not execute successfully.
+	    // 関数は正常に実行されませんでした。
     }
     \endcode
+
     \sa UnLockMutex
 */
 int wolfSSL_CertManagerUnload_trust_peers(WOLFSSL_CERT_MANAGER* cm);
 
 /*!
     \ingroup CertManager
-    \brief  証明書マネージャのコンテキストで確認する証明書を指定します。フォーマットはSSL_FILETYPE_PEMまたはSSL_FILETYPE_ASN1にすることができます。
-    \return SSL_SUCCESS  成功した場合に返されます。
-    \return ASN_SIG_CONFIRM_E  署名が検証できなかった場合に返されます。
-    \return ASN_SIG_OID_E  署名の種類がサポートされていない場合に返されます。
-    \return CRL_CERT_REVOKED  この証明書が取り消された場合に返されるエラーです。
-    \return CRL_MISSING  現在の発行者CRLが利用できない場合に返されるエラーです。
-    \return ASN_BEFORE_DATE_E  現在の日付が前日の前にある場合に返されます。
-    \return ASN_AFTER_DATE_E  現在の日付が後の日付の後の場合に返されます。
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return BAD_FUNC_ARG  ポインタが提供されていない場合に返されるエラーです。
-    \param cm  wolfssl_certmanagernew()を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
-    \param fname  検証する証明書を含むファイルの名前へのポインタ。
+    \brief Certificate Managerコンテキストで検証する証明書を指定します。フォーマットはSSL_FILETYPE_PEMまたはSSL_FILETYPE_ASN1を指定できます。
+
+    \return SSL_SUCCESS 成功時。
+    \return ASN_SIG_CONFIRM_E 署名を検証できなかった場合に返されます。
+    \return ASN_SIG_OID_E 署名タイプがサポートされていない場合に返されます。
+    \return CRL_CERT_REVOKED この証明書が失効している場合に返されるエラー。
+    \return CRL_MISSING 現在の発行者CRLが利用できない場合に返されるエラー。
+    \return ASN_BEFORE_DATE_E 現在の日付がbefore dateより前の場合に返されます。
+    \return ASN_AFTER_DATE_E 現在の日付がafter dateより後の場合に返されます。
+    \return SSL_BAD_FILETYPE ファイルのフォーマットが間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードに失敗した場合に返されます。
+    \return BAD_FUNC_ARG ポインタが提供されていない場合に返されるエラー。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param fname 検証する証明書を含むファイルの名前へのポインタ。
+    \param format 検証する証明書のフォーマット - SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。
 
     _Example_
     \code
@@ -7351,12 +8566,13 @@ int wolfSSL_CertManagerUnload_trust_peers(WOLFSSL_CERT_MANAGER* cm);
     WOLFSSL_CERT_MANAGER* cm;
     ...
 
-    ret = wolfSSL_CertManagerVerify(cm, “path/to/cert-file.pem”,
+    ret = wolfSSL_CertManagerVerify(cm, "path/to/cert-file.pem",
     SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-	    error verifying certificate
+	    // 証明書の検証エラー
     }
     \endcode
+
     \sa wolfSSL_CertManagerLoadCA
     \sa wolfSSL_CertManagerVerifyBuffer
 */
@@ -7365,22 +8581,25 @@ int wolfSSL_CertManagerVerify(WOLFSSL_CERT_MANAGER* cm, const char* f,
 
 /*!
     \ingroup CertManager
-    \brief  証明書マネージャのコンテキストを使用して確認する証明書バッファを指定します。フォーマットはSSL_FILETYPE_PEMまたはSSL_FILETYPE_ASN1にすることができます。
-    \return SSL_SUCCESS  成功した場合に返されます。
-    \return ASN_SIG_CONFIRM_E  署名が検証できなかった場合に返されます。
-    \return ASN_SIG_OID_E  署名の種類がサポートされていない場合に返されます。
-    \return CRL_CERT_REVOKED  この証明書が取り消された場合に返されるエラーです。
-    \return CRL_MISSING  現在の発行者CRLが利用できない場合に返されるエラーです。
-    \return ASN_BEFORE_DATE_E  現在の日付が前日の前にある場合に返されます。
-    \return ASN_AFTER_DATE_E  現在の日付が後の日付の後の場合に返されます。
-    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合に返されます。
-    \return SSL_BAD_FILE  ファイルが存在しない場合に返されます。読み込め、または破損していません。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
-    \return BAD_FUNC_ARG  ポインタが提供されていない場合に返されるエラーです。
-    \param cm  wolfssl_certmanagernew()を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
-    \param buff  検証する証明書を含むバッファ。
-    \param sz  バッファのサイズ、BUF。
+    \brief Certificate Managerコンテキストで検証する証明書バッファを指定します。フォーマットはSSL_FILETYPE_PEMまたはSSL_FILETYPE_ASN1を指定できます。
+
+    \return SSL_SUCCESS 成功時。
+    \return ASN_SIG_CONFIRM_E 署名を検証できなかった場合に返されます。
+    \return ASN_SIG_OID_E 署名タイプがサポートされていない場合に返されます。
+    \return CRL_CERT_REVOKED この証明書が失効している場合に返されるエラー。
+    \return CRL_MISSING 現在の発行者CRLが利用できない場合に返されるエラー。
+    \return ASN_BEFORE_DATE_E 現在の日付がbefore dateより前の場合に返されます。
+    \return ASN_AFTER_DATE_E 現在の日付がafter dateより後の場合に返されます。
+    \return SSL_BAD_FILETYPE ファイルのフォーマットが間違っている場合に返されます。
+    \return SSL_BAD_FILE ファイルが存在しない、読み取れない、または破損している場合に返されます。
+    \return MEMORY_E メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E ファイルのBase16デコードに失敗した場合に返されます。
+    \return BAD_FUNC_ARG ポインタが提供されていない場合に返されるエラー。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param buff 検証する証明書を含むバッファ。
+    \param sz バッファbufのサイズ。
+    \param format buf内にある検証する証明書のフォーマット - SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。
 
     _Example_
     \code
@@ -7394,10 +8613,11 @@ int wolfSSL_CertManagerVerify(WOLFSSL_CERT_MANAGER* cm, const char* f,
 
     ret = wolfSSL_CertManagerVerifyBuffer(cm, certBuff, sz, SSL_FILETYPE_PEM);
     if (ret != SSL_SUCCESS) {
-    	error verifying certificate
+    	// 証明書の検証エラー
     }
 
     \endcode
+
     \sa wolfSSL_CertManagerLoadCA
     \sa wolfSSL_CertManagerVerify
 */
@@ -7406,46 +8626,54 @@ int wolfSSL_CertManagerVerifyBuffer(WOLFSSL_CERT_MANAGER* cm,
 
 /*!
     \ingroup CertManager
-    \brief  この関数は、証明書マネージャーのverifyCallback関数を設定します。存在する場合、それはロードされた各CERTに対して呼び出されます。検証エラーがある場合は、検証コールバックを使用してエラーを過度に乗り越えます。
-    \return none  返品不可。
-    \param cm  wolfssl_certmanagernew()を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    \brief この関数は、Certificate Manager内にverifyCallback関数を設定します。存在する場合、ロードされた各証明書に対して呼び出されます。検証エラーがある場合、verify callbackを使用してエラーをオーバーライドできます。
+
+    \return none 戻り値はありません。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param verify_callback コールバックルーチンへのVerifyCallback関数ポインタ。
 
     _Example_
     \code
     #include <wolfssl/ssl.h>
 
     int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
-    { // do custom verification of certificate }
+    { // 証明書のカスタム検証を実行 }
 
-    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(Protocol define);
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(Protocol define);
     WOLFSSL_CERT_MANAGER* cm = wolfSSL_CertManagerNew();
     ...
     wolfSSL_CertManagerSetVerify(cm, myVerify);
 
     \endcode
+
     \sa wolfSSL_CertManagerVerify
 */
 void wolfSSL_CertManagerSetVerify(WOLFSSL_CERT_MANAGER* cm,
-                                                             VerifyCallback vc);
+        VerifyCallback verify_callback);
 
 /*!
-    \brief  CRLリスト。
-    \return SSL_SUCCESS  関数が予想どおりに返された場合は返します。wolfssl_cert_manager構造体のCRLENABLEDメンバーがオンになっている場合。
-    \return MEMORY_E  割り当てられたメモリが失敗した場合は返します。
-    \return BAD_FUNC_ARG  wolfssl_cert_managerがnullの場合
-    \param cm  wolfssl_cert_manager構造体へのポインタ。
-    \param der  DERフォーマット証明書へのポインタ。
+    \brief オプションが有効な場合、CRLをチェックし、証明書をCRLリストと比較します。
+
+    \return SSL_SUCCESS 関数が期待どおりに戻った場合に返されます。WOLFSSL_CERT_MANAGER構造体のcrlEnabledメンバがオンになっている場合。
+    \return MEMORY_E 割り当てられたメモリが失敗した場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGERがNULLの場合。
+
+    \param cm WOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param der DERフォーマットの証明書へのポインタ。
+    \param sz 証明書のサイズ。
 
     _Example_
     \code
     WOLFSSL_CERT_MANAGER* cm;
     byte* der;
-    int sz; // size of der
+    int sz; // derのサイズ
     ...
     if(wolfSSL_CertManagerCheckCRL(cm, der, sz) != SSL_SUCCESS){
-    	// Error returned. Deal with failure case.
+    	// エラーが返されました。失敗ケースを処理。
     }
     \endcode
+
     \sa CheckCertCRL
     \sa ParseCertRelative
     \sa wolfSSL_CertManagerSetCRL_CB
@@ -7456,13 +8684,16 @@ int wolfSSL_CertManagerCheckCRL(WOLFSSL_CERT_MANAGER* cm,
 
 /*!
     \ingroup CertManager
-    \brief  証明書マネージャを使用して証明書を検証するときに証明書失効リストの確認をオンにします。デフォルトでは、CRLチェックはオフです。オプションには、wolfssl_crl_checkallが含まれます。これは、チェーン内の各証明書に対してCRL検査を実行します。これはデフォルトであるリーフ証明書のみです。
-    \return SSL_SUCCESS  成功した場合に返されます。、通話が戻ります。
-    \return NOT_COMPILED_IN  WolfSSLがCRLを有効にして構築されていない場合に返されます。
-    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
-    \return BAD_FUNC_ARG  ポインタが提供されていない場合に返されるエラーです。
-    \return SSL_FAILURE  CRLコンテキストを正しく初期化できない場合に返されます。
-    \param cm  wolfssl_certmanagernew()を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    \brief Certificate Managerで証明書を検証する際に、Certificate Revocation Listチェックをオンにします。デフォルトでは、CRLチェックはオフです。optionsには、リーフ証明書のみ(デフォルト)ではなくチェーン内の各証明書に対してCRLチェックを実行するWOLFSSL_CRL_CHECKALLが含まれます。
+
+    \return SSL_SUCCESS 成功した場合、呼び出しは戻ります。
+    \return NOT_COMPILED_IN wolfSSLがCRLを有効にしてビルドされていない場合に返されます。
+    \return MEMORY_E メモリ不足状態が発生した場合に返されます。
+    \return BAD_FUNC_ARG ポインタが提供されていない場合に返されるエラー。
+    \return SSL_FAILURE CRLコンテキストを適切に初期化できない場合に返されます。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param options Certification Manager(cm)を有効にする際に使用するオプション。
 
     _Example_
     \code
@@ -7474,11 +8705,12 @@ int wolfSSL_CertManagerCheckCRL(WOLFSSL_CERT_MANAGER* cm,
 
     ret = wolfSSL_CertManagerEnableCRL(cm, 0);
     if (ret != SSL_SUCCESS) {
-    	error enabling cert manager
+    	// cert managerの有効化エラー
     }
 
     ...
     \endcode
+
     \sa wolfSSL_CertManagerDisableCRL
 */
 int wolfSSL_CertManagerEnableCRL(WOLFSSL_CERT_MANAGER* cm,
@@ -7486,9 +8718,12 @@ int wolfSSL_CertManagerEnableCRL(WOLFSSL_CERT_MANAGER* cm,
 
 /*!
     \ingroup CertManager
-    \brief  証明書マネージャを使用して証明書を検証するときに証明書失効リストの確認をオフにします。デフォルトでは、CRLチェックはオフです。この関数を使用して、このCertificate Managerコンテキストを使用してCRL検査を一時的または恒久的に無効にして、以前はCRL検査が有効になっていました。
-    \return SSL_SUCCESS  成功した場合に返されます。、通話が戻ります。
-    \return BAD_FUNC_ARG  関数ポインタが提供されていない場合に返されるエラーです。
+    \brief Certificate Managerで証明書を検証する際に、Certificate Revocation Listチェックをオフにします。デフォルトでは、CRLチェックはオフです。この関数を使用して、以前にCRLチェックを有効にしていたこのCertificate Managerコンテキストに対して、CRLチェックを一時的または永続的に無効にできます。
+
+    \return SSL_SUCCESS 成功した場合、呼び出しは戻ります。
+    \return BAD_FUNC_ARG 関数ポインタが提供されていない場合に返されるエラー。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
 
     _Example_
     \code
@@ -7499,26 +8734,29 @@ int wolfSSL_CertManagerEnableCRL(WOLFSSL_CERT_MANAGER* cm,
     ...
     ret = wolfSSL_CertManagerDisableCRL(cm);
     if (ret != SSL_SUCCESS) {
-    	error disabling cert manager
+    	// cert managerの無効化エラー
     }
     ...
     \endcode
+
     \sa wolfSSL_CertManagerEnableCRL
 */
 int wolfSSL_CertManagerDisableCRL(WOLFSSL_CERT_MANAGER*);
 
 /*!
     \ingroup CertManager
-    \brief  証明書の失効確認のために証明書をCRLにロードする際にエラーチェックを行い、その後証明書をLoadCRL()へ渡します。
+    \brief エラーチェックを行い、LoadCRL()に渡して失効チェックのためにCRLに証明書をロードします。更新されたCRLをロードするには、まずwolfSSL_CertManagerFreeCRLを呼び出してから、新しいCRLをロードします。
 
-    \return SSL_SUCCESS  wolfSSL_CertManagerLoadCRLでエラーが発生せず、loadCRLが成功で戻る場合に返されます。
-    \return BAD_FUNC_ARG  WOLFSSL_CERT_MANAGER構造体がNULLの場合
-    \return SSL_FATAL_ERROR  wolfSSL_CertManagerEnableCRLがSSL_SUCCESS以外のを返す場合。
-    \return BAD_PATH_ERROR  pathがNULLの場合
-    \return MEMORY_E  LOADCRLがヒープメモリの割り当てに失敗した場合。
-    \param cm  wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
-    \param path  CRLへのパスを保持しているバッファーへのポインタ。
-    \param type  ロードする証明書の種類。
+    \return SSL_SUCCESS wolfSSL_CertManagerLoadCRLにエラーがなく、LoadCRLが正常に戻った場合。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGER構造体がNULLの場合。
+    \return SSL_FATAL_ERROR wolfSSL_CertManagerEnableCRLがSSL_SUCCESS以外を返した場合。
+    \return BAD_PATH_ERROR pathがNULLの場合。
+    \return MEMORY_E LoadCRLがヒープメモリの割り当てに失敗した場合。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param path CRLパスを保持する定数char型ポインタ。
+    \param type ロードする証明書のタイプ。
+    \param monitor LoadCRL()での監視を要求します。
 
     _Example_
     \code
@@ -7529,21 +8767,26 @@ int wolfSSL_CertManagerDisableCRL(WOLFSSL_CERT_MANAGER*);
     …
     wolfSSL_CertManagerLoadCRL(SSL_CM(ssl), path, type, monitor);
     \endcode
+
     \sa wolfSSL_CertManagerEnableCRL
     \sa wolfSSL_LoadCRL
+    \sa wolfSSL_CertManagerFreeCRL
 */
 int wolfSSL_CertManagerLoadCRL(WOLFSSL_CERT_MANAGER* cm,
                                const char* path, int type, int monitor);
 
 /*!
     \ingroup CertManager
-    \brief  この関数は、BufferLoadCRLを呼び出すことによってCRLファイルをロードします。
-    \return SSL_SUCCESS  関数がエラーなしで完了した場合に返されます。
-    \return BAD_FUNC_ARG  wolfssl_cert_managerがnullの場合に返されます。
-    \return SSL_FATAL_ERROR  wolfssl_cert_managerに関連付けられているエラーがある場合に返されます。
-    \param cm  wolfssl_cert_manager構造体へのポインタ。
-    \param buff  定数バイトタイプとバッファです。
-    \param sz  バッファのサイズを表す長いint。
+    \brief この関数は、BufferLoadCRLを呼び出してCRLファイルをロードします。
+
+    \return SSL_SUCCESS 関数がエラーなく完了した場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGERがNULLの場合に返されます。
+    \return SSL_FATAL_ERROR WOLFSSL_CERT_MANAGERに関連するエラーがある場合に返されます。
+
+    \param cm WOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param buff 定数byte型でバッファです。
+    \param sz バッファのサイズを表すlong int型。
+    \param type 証明書タイプを保持するlong integer型。
 
     _Example_
     \code
@@ -7551,16 +8794,17 @@ int wolfSSL_CertManagerLoadCRL(WOLFSSL_CERT_MANAGER* cm,
 
     WOLFSSL_CERT_MANAGER* cm;
     const unsigned char* buff;
-    long sz; size of buffer
-    int type;  cert type
+    long sz; バッファのサイズ
+    int type;  証明書タイプ
     ...
     int ret = wolfSSL_CertManagerLoadCRLBuffer(cm, buff, sz, type);
     if(ret == SSL_SUCCESS){
-	return ret;
+	    return ret;
     } else {
-    	Failure case.
+    	// 失敗ケース。
     }
     \endcode
+
     \sa BufferLoadCRL
     \sa wolfSSL_CertManagerEnableCRL
 */
@@ -7570,10 +8814,13 @@ int wolfSSL_CertManagerLoadCRLBuffer(WOLFSSL_CERT_MANAGER* cm,
 
 /*!
     \ingroup CertManager
-    \brief  この関数はCRL証明書マネージャコールバックを設定します。LABE_CRLが定義されていて一致するCRLレコードが見つからない場合、CBMissingCRLは呼び出されます（WolfSSL_CertManagerSetCRL_CBを介して設定）。これにより、CRLを外部に検索してロードすることができます。
-    \return SSL_SUCCESS  関数とサブルーチンの実行が成功したら返されます。
-    \return BAD_FUNC_ARG  wolfssl_cert_manager構造体がNULLの場合に返されます。
-    \param cm  証明書の情報を保持しているWOLFSSL_CERT_MANAGER構造。
+    \brief この関数は、CRL Certificate Managerコールバックを設定します。HAVE_CRLが定義されており、一致するCRLレコードが見つからない場合、cbMissingCRLが呼び出されます(wolfSSL_CertManagerSetCRL_Cbで設定)。これにより、外部からCRLを取得してロードできます。
+
+    \return SSL_SUCCESS 関数とサブルーチンの実行が成功した場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGER構造体がNULLの場合に返されます。
+
+    \param cm 証明書の情報を保持するWOLFSSL_CERT_MANAGER構造体。
+    \param cb WOLFSSL_CERT_MANAGERのcbMissingCRLメンバに設定される(*CbMissingCRL)への関数ポインタ。
 
     _Example_
     \code
@@ -7583,7 +8830,7 @@ int wolfSSL_CertManagerLoadCRLBuffer(WOLFSSL_CERT_MANAGER* cm,
     WOLFSSL* ssl = wolfSSL_new(ctx);
     …
     void cb(const char* url){
-	    Function body.
+	    // 関数本体。
     }
     …
     CbMissingCRL cb = CbMissingCRL;
@@ -7592,20 +8839,90 @@ int wolfSSL_CertManagerLoadCRLBuffer(WOLFSSL_CERT_MANAGER* cm,
         return wolfSSL_CertManagerSetCRL_Cb(SSL_CM(ssl), cb);
     }
     \endcode
+
     \sa CbMissingCRL
     \sa wolfSSL_SetCRL_Cb
 */
 int wolfSSL_CertManagerSetCRL_Cb(WOLFSSL_CERT_MANAGER* cm,
                                  CbMissingCRL cb);
+
 /*!
     \ingroup CertManager
-    \brief この関数は証明書マネジャーに保持されているCRLを解放します。
-    アプリケーションはCRLをwolfSSL_CertManagerFreeCRLを呼び出して解放した後に、新しいCRLをロードすることができます。
+    \brief この関数は、CRL更新コールバックを設定します。HAVE_CRLとHAVE_CRL_UPDATE_CBが定義されており、CRLが追加されるときに同じ発行者でより低いCRL番号を持つエントリが存在する場合、既存のエントリと、それを置き換える新しいエントリの詳細と共にCbUpdateCRLが呼び出されます。
 
-    \return SSL_SUCCESS 関数の実行に成功した場合に返されます。
-    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGER構造体へのポインターがNULLで渡された場合に返されます。
+    \return SSL_SUCCESS 関数とサブルーチンが正常に実行された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGER構造体がNULLの場合に返されます。
 
-    \param cm wolfSSL_CertManagerNew()で生成されたWOLFSSL_CERT_MANAGER構造体へのポインター。
+    \param cm 証明書の情報を保持するWOLFSSL_CERT_MANAGER構造体。
+    \param cb WOLFSSL_CERT_MANAGERのcbUpdateCRLメンバに設定される(*CbUpdateCRL)への関数ポインタ。
+    シグネチャ要件:
+	void (*CbUpdateCRL)(CrlInfo *old, CrlInfo *new);
+
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(protocol method);
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    void cb(CrlInfo *old, CrlInfo *new){
+	    // 関数本体。
+    }
+    …
+    CbUpdateCRL cb = CbUpdateCRL;
+    …
+    if(ctx){
+        return wolfSSL_CertManagerSetCRLUpdate_Cb(SSL_CM(ssl), cb);
+    }
+    \endcode
+
+    \sa CbUpdateCRL
+*/
+int wolfSSL_CertManagerSetCRLUpdate_Cb(WOLFSSL_CERT_MANAGER* cm,
+                                       CbUpdateCRL cb);
+
+/*!
+    \ingroup CertManager
+    \brief この関数は、エンコードされたCRLバッファから解析されたCRL情報を含む構造体を生成します。
+
+    \return SSL_SUCCESS 関数とサブルーチンが正常に実行された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGER構造体がNULLの場合に返されます。
+
+    \param cm   WOLFSSL_CERT_MANAGER構造体。
+    \param info CRL情報を受け取る呼び出し元管理のCrlInfo構造体へのポインタ。
+    \param buff エンコードされたCRLを含む入力バッファ。
+    \param sz   buff内の入力CRLデータの長さ(バイト単位)。
+    \param type WOLFSSL_FILETYPE_PEMまたはWOLFSSL_FILETYPE_DER
+
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    CrlInfo info;
+    WOLFSSL_CERT_MANAGER* cm = NULL;
+
+    cm = wolfSSL_CertManagerNew();
+
+    // ファイルからバッファへcrlデータを読み込む
+
+    wolfSSL_CertManagerGetCRLInfo(cm, &info, crlData, crlDataLen,
+                                  WOLFSSL_FILETYPE_PEM);
+    \endcode
+
+    \sa CbUpdateCRL
+    \sa wolfSSL_SetCRL_Cb
+*/
+int wolfSSL_CertManagerGetCRLInfo(WOLFSSL_CERT_MANAGER* cm, CrlInfo* info,
+    const byte* buff, long sz, int type)
+
+/*!
+    \ingroup CertManager
+    \brief この関数は、証明書マネージャに保存されているCRLを解放します。アプリケーションは、wolfSSL_CertManagerFreeCRLを呼び出してから新しいCRLを読み込むことで、CRLを更新できます。
+
+    \return SSL_SUCCESS 関数とサブルーチンが正常に実行された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGER構造体がNULLの場合に返されます。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
 
     _Example_
     \code
@@ -7626,12 +8943,15 @@ int wolfSSL_CertManagerFreeCRL(WOLFSSL_CERT_MANAGER* cm);
 
 /*!
     \ingroup CertManager
-    \brief  この機能により、OCSPENABLED OCSPENABLEDがOCSPチェックオプションが有効になっていることを意味します。
-    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。wolfssl_cert_managerのOCSPENABLEDメンバーが有効になっています。
-    \return BAD_FUNC_ARG  wolfssl_cert_manager構造体がnullの場合、または許可されていない引数値がサブルーチンに渡された場合に返されます。
-    \return MEMORY_E  この関数内にメモリを割り当てるエラーまたはサブルーチンがある場合に返されます。
-    \param cm  wolfssl_certmanagernew()を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
-    \param der  証明書へのバイトポインタ。
+    \brief この関数は、WOLFSSL_CERT_MANAGERのメンバであるocspEnabledを有効にして、OCSPチェックオプションが有効になっていることを示します。
+
+    \return SSL_SUCCESS 関数の実行が成功した場合に返されます。WOLFSSL_CERT_MANAGERのocspEnabledメンバが有効になります。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGER構造体がNULLの場合、またはサブルーチンに許可されていない引数値が渡された場合に返されます。
+    \return MEMORY_E この関数またはサブルーチン内でメモリの割り当てにエラーがある場合に返されます。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param der 証明書へのbyteポインタ。
+    \param sz DER証明書のサイズを表すint型。
 
     _Example_
     \code
@@ -7639,12 +8959,13 @@ int wolfSSL_CertManagerFreeCRL(WOLFSSL_CERT_MANAGER* cm);
 
     WOLFSSL* ssl = wolfSSL_new(ctx);
     byte* der;
-    int sz; size of der
+    int sz; // derのサイズ
     ...
     if(wolfSSL_CertManagerCheckOCSP(cm, der, sz) != SSL_SUCCESS){
-	 Failure case.
+	    // 失敗ケース。
     }
     \endcode
+
     \sa ParseCertRelative
     \sa CheckCertOCSP
 */
@@ -7653,13 +8974,16 @@ int wolfSSL_CertManagerCheckOCSP(WOLFSSL_CERT_MANAGER* cm,
 
 /*!
     \ingroup CertManager
-    \brief  OCSPがオフになっている場合はOCSPをオンにし、[設定]オプションを使用可能になっている場合。
-    \return SSL_SUCCESS  関数呼び出しが成功した場合に返されます。
-    \return BAD_FUNC_ARG  cm構造体がnullの場合
-    \return MEMORY_E  wolfssl_ocsp struct値がnullの場合
-    \return SSL_FAILURE  WOLFSSL_OCSP構造体の初期化は初期化に失敗します。
-    \return NOT_COMPILED_IN  正しい機能を有効にしてコンパイルされていないビルド。
-    \param cm  wolfssl_certmanagernew()を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    \brief OCSPがオフになっている場合にオンにし、設定オプションでコンパイルされている場合に有効にします。
+
+    \return SSL_SUCCESS 関数呼び出しが成功した場合に返されます。
+    \return BAD_FUNC_ARG cm構造体がNULLの場合。
+    \return MEMORY_E WOLFSSL_OCSP構造体の値がNULLの場合。
+    \return SSL_FAILURE WOLFSSL_OCSP構造体の初期化が失敗した場合。
+    \return NOT_COMPILED_IN 正しい機能を有効にしてコンパイルされていないビルド。
+
+    \param cm wolfSSL_CertManagerNew()を使用して作成されたWOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param options WOLFSSL_CERT_MANAGER構造体の値を設定するために使用されます。
 
     _Example_
     \code
@@ -7671,9 +8995,10 @@ int wolfSSL_CertManagerCheckOCSP(WOLFSSL_CERT_MANAGER* cm,
     int options;
     …
     if(wolfSSL_CertManagerEnableOCSP(SSL_CM(ssl), options) != SSL_SUCCESS){
-	    Failure case.
+	    // 失敗ケース。
     }
     \endcode
+
     \sa wolfSSL_CertManagerNew
 */
 int wolfSSL_CertManagerEnableOCSP(WOLFSSL_CERT_MANAGER* cm,
@@ -7681,9 +9006,12 @@ int wolfSSL_CertManagerEnableOCSP(WOLFSSL_CERT_MANAGER* cm,
 
 /*!
     \ingroup CertManager
-    \brief  OCSP証明書の失効を無効にします。
-    \return SSL_SUCCESS  WolfSSL_CertMangerDisableCRLは、WolfSSL_CERT_MANAGER構造体のCRLEnabledメンバを無効にしました。
-    \return BAD_FUNC_ARG  WOLFSSL構造はヌルでした。
+    \brief OCSP証明書失効を無効にします。
+
+    \return SSL_SUCCESS wolfSSL_CertMangerDisableCRLがWOLFSSL_CERT_MANAGER構造体のcrlEnabledメンバを正常に無効にしました。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLでした。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -7693,19 +9021,23 @@ int wolfSSL_CertManagerEnableOCSP(WOLFSSL_CERT_MANAGER* cm,
     WOLFSSL* ssl = wolfSSL_new(ctx);
     ...
     if(wolfSSL_CertManagerDisableOCSP(ssl) != SSL_SUCCESS){
-	    Fail case.
+	    // 失敗ケース。
     }
     \endcode
+
     \sa wolfSSL_DisableCRL
 */
 int wolfSSL_CertManagerDisableOCSP(WOLFSSL_CERT_MANAGER*);
 
 /*!
     \ingroup CertManager
-    \brief  この関数は、URLをwolfssl_cert_manager構造体のOCSpoverrideURLメンバーにコピーします。
-    \return SSL_SUCCESS  この機能は期待どおりに実行できました。
-    \return BAD_FUNC_ARG  wolfssl_cert_manager構造体はnullです。
-    \return MEMEORY_E  証明書マネージャのOCSPoverRideURLメンバーにメモリを割り当てることができませんでした。
+    \brief この関数は、URLをWOLFSSL_CERT_MANAGER構造体のocspOverrideURLメンバにコピーします。
+
+    \return SSL_SUCCESS 関数が期待通りに実行できた場合。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGER構造体がNULLの場合。
+    \return MEMEORY_E 証明書マネージャのocspOverrideURLメンバにメモリを割り当てることができなかった場合。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -7716,9 +9048,10 @@ int wolfSSL_CertManagerDisableOCSP(WOLFSSL_CERT_MANAGER*);
     int wolfSSL_SetOCSP_OverrideURL(WOLFSSL* ssl, const char* url)
     …
     if(wolfSSL_CertManagerSetOCSPOverrideURL(SSL_CM(ssl), url) != SSL_SUCCESS){
-	    Failure case.
+	    // 失敗ケース。
     }
     \endcode
+
     \sa ocspOverrideURL
     \sa wolfSSL_SetOCSP_OverrideURL
 */
@@ -7727,12 +9060,15 @@ int wolfSSL_CertManagerSetOCSPOverrideURL(WOLFSSL_CERT_MANAGER* cm,
 
 /*!
     \ingroup CertManager
-    \brief  この関数は、wolfssl_cert_managerのOCSPコールバックを設定します。
-    \return SSL_SUCCESS  実行に成功したことに戻ります。引数はwolfssl_cert_manager構造体に保存されます。
-    \return BAD_FUNC_ARG  wolfssl_cert_managerがnullの場合に返されます。
-    \param cm  wolfssl_cert_manager構造体へのポインタ。
-    \param ioCb  CBocSpio型の関数ポインタ。
-    \param respFreeCb   -  CBOCSPRESPFREAS型の関数ポインタ。
+    \brief この関数は、WOLFSSL_CERT_MANAGER内のOCSPコールバックを設定します。
+
+    \return SSL_SUCCESS 実行が成功した場合に返されます。引数はWOLFSSL_CERT_MANAGER構造体に保存されます。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGERがNULLの場合に返されます。
+
+    \param cm WOLFSSL_CERT_MANAGER構造体へのポインタ。
+    \param ioCb CbOCSPIO型の関数ポインタ。
+    \param respFreeCb CbOCSPRespFree型の関数ポインタ。
+    \param ioCbCtx I/Oコールバックユーザ登録コンテキストへのvoidポインタ変数。
 
     _Example_
     \code
@@ -7740,13 +9076,14 @@ int wolfSSL_CertManagerSetOCSPOverrideURL(WOLFSSL_CERT_MANAGER* cm,
 
     wolfSSL_SetOCSP_Cb(WOLFSSL* ssl, CbOCSPIO ioCb,
     CbOCSPRespFree respFreeCb, void* ioCbCtx){
-    …
-    return wolfSSL_CertManagerSetOCSP_Cb(SSL_CM(ssl), ioCb, respFreeCb, ioCbCtx);
+        …
+        return wolfSSL_CertManagerSetOCSP_Cb(SSL_CM(ssl), ioCb, respFreeCb, ioCbCtx);
     \endcode
+
     \sa wolfSSL_CertManagerSetOCSPOverrideURL
     \sa wolfSSL_CertManagerCheckOCSP
     \sa wolfSSL_CertManagerEnableOCSPStapling
-    \sa wolfSSL_ENableOCSP
+    \sa wolfSSL_EnableOCSP
     \sa wolfSSL_DisableOCSP
     \sa wolfSSL_SetOCSP_Cb
 */
@@ -7756,51 +9093,61 @@ int wolfSSL_CertManagerSetOCSP_Cb(WOLFSSL_CERT_MANAGER* cm,
 
 /*!
     \ingroup CertManager
-    \brief  この関数は、オプションをオンにしないとOCSPステープルをオンにします。オプションを設定します。
-    \return SSL_SUCCESS  エラーがなく、関数が正常に実行された場合に返されます。
-    \return BAD_FUNC_ARG  wolfssl_cert_manager構造体がNULLまたはそうでない場合は、サブルーチンに渡された未解決の引数値があった場合に返されます。
-    \return MEMORY_E  メモリ割り当てがある問題が発生した場合に返されます。
-    \return SSL_FAILURE  OCSP構造体の初期化が失敗した場合に返されます。
-    \return NOT_COMPILED_IN  wolfsslがhaber_certificate_status_requestオプションでコンパイルされていない場合に返されます。
+    \brief この関数は、OCSPステープリングがオンになっていない場合にオンにし、オプションを設定します。
+
+    \return SSL_SUCCESS エラーがなく、関数が正常に実行された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGER構造体がNULLの場合、またはサブルーチンに許可されていない引数値が渡された場合に返されます。
+    \return MEMORY_E メモリの割り当てに問題があった場合に返されます。
+    \return SSL_FAILURE OCSP構造体の初期化が失敗した場合に返されます。
+    \return NOT_COMPILED_IN wolfSSLがHAVE_CERTIFICATE_STATUS_REQUESTオプションでコンパイルされていない場合に返されます。
+
+    \param cm WOLFSSL_CTX構造体のメンバであるWOLFSSL_CERT_MANAGER構造体へのポインタ。
 
     _Example_
     \code
     int wolfSSL_CTX_EnableOCSPStapling(WOLFSSL_CTX* ctx){
-    …
-    return wolfSSL_CertManagerEnableOCSPStapling(ctx->cm);
+        …
+        return wolfSSL_CertManagerEnableOCSPStapling(ctx->cm);
     \endcode
+
     \sa wolfSSL_CTX_EnableOCSPStapling
 */
 int wolfSSL_CertManagerEnableOCSPStapling(
                                                       WOLFSSL_CERT_MANAGER* cm);
 
 /*!
-    \brief
-    \return SSL_SUCCESS  関数とサブルーチンはエラーなしで返されました。
-    \return BAD_FUNC_ARG  WolfSSL構造がNULLの場合に返されます。
-    \return MEMORY_E  メモリの割り当てが失敗した場合に返されます。
-    \return SSL_FAILURE  initcrl関数が正常に戻されない場合に返されます。
-    \return NOT_COMPILED_IN  have_crlはコンパイル中に有効になっていませんでした。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+    \brief CRL証明書失効を有効にします。
+
+    \return SSL_SUCCESS 関数とサブルーチンがエラーなく返された場合。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合に返されます。
+    \return MEMORY_E メモリの割り当てが失敗した場合に返されます。
+    \return SSL_FAILURE InitCRL関数が正常に返されなかった場合に返されます。
+    \return NOT_COMPILED_IN コンパイル時にHAVE_CRLが有効になっていませんでした。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param options WOLFSSL_CERT_MANAGER構造体のcrlCheckAllメンバの設定を決定するために使用される整数。
 
     _Example_
     \code
     WOLFSSL* ssl = wolfSSL_new(ctx);
     …
     if (wolfSSL_EnableCRL(ssl, WOLFSSL_CRL_CHECKALL) != SSL_SUCCESS){
-	    // Failure case. SSL_SUCCESS was not returned by this function or
-    a subroutine
+	    // 失敗ケース。この関数またはサブルーチンがSSL_SUCCESSを返しませんでした。
     }
     \endcode
+
     \sa wolfSSL_CertManagerEnableCRL
     \sa InitCRL
 */
 int wolfSSL_EnableCRL(WOLFSSL* ssl, int options);
 
 /*!
-    \brief
-    \return SSL_SUCCESS  WolfSSL_CertMangerDisableCRLは、WolfSSL_CERT_MANAGER構造体のCRLEnabledメンバを無効にしました。
-    \return BAD_FUNC_ARG  WOLFSSL構造はヌルでした。
+    \brief CRL証明書失効を無効にします。
+
+    \return SSL_SUCCESS wolfSSL_CertMangerDisableCRLがWOLFSSL_CERT_MANAGER構造体のcrlEnabledメンバを正常に無効にしました。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLでした。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -7808,22 +9155,26 @@ int wolfSSL_EnableCRL(WOLFSSL* ssl, int options);
     WOLFSSL* ssl = wolfSSL_new(ctx);
     ...
     if(wolfSSL_DisableCRL(ssl) != SSL_SUCCESS){
-    	// Failure case
+    	// 失敗ケース
     }
     \endcode
+
     \sa wolfSSL_CertManagerDisableCRL
     \sa wolfSSL_CertManagerDisableOCSP
 */
 int wolfSSL_DisableCRL(WOLFSSL* ssl);
 
 /*!
-    \brief  失効検査の証明書
-    \return WOLFSSL_SUCCESS  関数とすべてのサブルーチンがエラーなしで実行された場合に返されます。
-    \return SSL_FATAL_ERROR  サブルーチンの1つが正常に戻されない場合に返されます。
-    \return BAD_FUNC_ARG  wolfssl_cert_managerまたはwolfssl構造がnullの場合
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param path  CRLファイルへのパスを保持する定数文字ポインタ。
-    \param type  証明書の種類を表す整数。
+    \brief 失効チェックのための証明書を読み込むためにLoadCRLを最終的に呼び出すラッパー関数です。
+
+    \return WOLFSSL_SUCCESS 関数とすべてのサブルーチンがエラーなく実行された場合に返されます。
+    \return SSL_FATAL_ERROR サブルーチンの1つが正常に返されなかった場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CERT_MANAGERまたはWOLFSSL構造体がNULLの場合。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param path crlファイルへのパスを保持する定数文字ポインタ。
+    \param type 証明書のタイプを表す整数。
+    \param monitor 要求された場合にモニタパスを検証するために使用される整数変数。
 
     _Example_
     \code
@@ -7831,9 +9182,10 @@ int wolfSSL_DisableCRL(WOLFSSL* ssl);
     const char* crlPemDir;
     …
     if(wolfSSL_LoadCRL(ssl, crlPemDir, SSL_FILETYPE_PEM, 0) != SSL_SUCCESS){
-    	// Failure case. Did not return SSL_SUCCESS.
+    	// 失敗ケース。SSL_SUCCESSを返しませんでした。
     }
     \endcode
+
     \sa wolfSSL_CertManagerLoadCRL
     \sa wolfSSL_CertManagerEnableCRL
     \sa LoadCRL
@@ -7841,77 +9193,95 @@ int wolfSSL_DisableCRL(WOLFSSL* ssl);
 int wolfSSL_LoadCRL(WOLFSSL* ssl, const char* path, int type, int monitor);
 
 /*!
-    \brief
-    \return SSL_SUCCESS  関数またはサブルーチンがエラーなしで実行された場合に返されます。wolfssl_cert_managerのCBMissingCRLメンバーが設定されています。
-    \return BAD_FUNC_ARG  WOLFSSLまたはWOLFSSL_CERT_MANAGER構造体がNULLの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+    \brief WOLFSSL_CERT_MANAGER構造体内のCRLコールバックを設定します。
+
+    \return SSL_SUCCESS 関数またはサブルーチンがエラーなく実行された場合に返されます。WOLFSSL_CERT_MANAGERのcbMissingCRLメンバが設定されます。
+    \return BAD_FUNC_ARG WOLFSSLまたはWOLFSSL_CERT_MANAGER構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param cb CbMissingCRLへの関数ポインタ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
     WOLFSSL* ssl = wolfSSL_new(ctx);
     …
-    void cb(const char* url) // required signature
+    void cb(const char* url) // 必要なシグネチャ
     {
-    	// Function body
+        // 関数本体
     }
     …
     int crlCb = wolfSSL_SetCRL_Cb(ssl, cb);
     if(crlCb != SSL_SUCCESS){
-    	// The callback was not set properly
+    	// コールバックが正しく設定されませんでした
     }
     \endcode
+
     \sa CbMissingCRL
     \sa wolfSSL_CertManagerSetCRL_Cb
 */
 int wolfSSL_SetCRL_Cb(WOLFSSL* ssl, CbMissingCRL cb);
 
 /*!
-    \brief
-    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG  この関数またはサブルーチンの引数が無効な引数値を受信した場合に返されます。
-    \return MEMORY_E  構造体やその他の変数にメモリを割り当てるエラーが発生した場合に返されます。
-    \return NOT_COMPILED_IN  wolfsslがhane_ocspオプションでコンパイルされていない場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+    \brief この関数は、OCSP証明書検証を有効にします。optionsの値は、以下のオプションの1つ以上をOR演算することで形成されます。
+    WOLFSSL_OCSP_URL_OVERRIDE - 証明書内のURLの代わりにオーバーライドURLを使用します。オーバーライドURLはwolfSSL_CTX_SetOCSP_OverrideURL()関数を使用して指定されます。
+    WOLFSSL_OCSP_CHECKALL - すべてのOCSPチェックをオンに設定します。
+    WOLFSSL_OCSP_NO_NONCE - OCSP要求作成時のnonceオプションを設定します。
+
+    \return SSL_SUCCESS 関数とサブルーチンがエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG この関数またはサブルーチンの引数が無効な引数値を受け取った場合に返されます。
+    \return MEMORY_E 構造体または他の変数のメモリ割り当てでエラーが発生した場合に返されます。
+    \return NOT_COMPILED_IN wolfSSLがHAVE_OCSPオプション付きでコンパイルされていない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param options 設定チェックに使用されるwolfSSL_CertMangerENableOCSP()に渡される整数型。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
     WOLFSSL* ssl = wolfSSL_new(ctx);
-    int options; // initialize to option constant
+    int options; // オプション定数で初期化
     …
     int ret = wolfSSL_EnableOCSP(ssl, options);
     if(ret != SSL_SUCCESS){
-    	// OCSP is not enabled
+    	// OCSPが有効になっていません
     }
     \endcode
+
     \sa wolfSSL_CertManagerEnableOCSP
 */
 int wolfSSL_EnableOCSP(WOLFSSL* ssl, int options);
 
 /*!
-    \brief
-    \return SSL_SUCCESS  関数とそのサブルーチンがエラーなしで戻った場合に返されます。wolfssl_cert_manager構造体のOCSPENABLEDメンバーは正常に設定されました。
-    \return BAD_FUNC_ARG  WolfSSL構造がNULLの場合に返されます。
+    \brief OCSP証明書失効オプションを無効にします。
+
+    \return SSL_SUCCESS 関数とそのサブルーチンがエラーなしで返された場合に返されます。WOLFSSL_CERT_MANAGER構造体のocspEnabledメンバが正常に設定されました。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
     WOLFSSL* ssl = wolfSSL_new(ctx);
     …
     if(wolfSSL_DisableOCSP(ssl) != SSL_SUCCESS){
-	    // Returned with an error. Failure case in this block.
+	    // エラーで返されました。このブロック内が失敗ケースです
     }
     \endcode
+
     \sa wolfSSL_CertManagerDisableOCSP
 */
 int wolfSSL_DisableOCSP(WOLFSSL*);
 
 /*!
-    \brief  wolfssl_cert_manager構造体。
-    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。
-    \return BAD_FUNC_ARG  wolfssl構造体がnullの場合、または未解決の引数がサブルーチンに渡された場合に返されます。
-    \return MEMORY_E  サブルーチンにメモリを割り当てるエラーが発生した場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+    \brief この関数は、WOLFSSL_CERT_MANAGER構造体のocspOverrideURLメンバを設定します。
+
+    \return SSL_SUCCESS 関数の実行が成功した場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合、またはサブルーチンに許可されていない引数が渡された場合に返されます。
+    \return MEMORY_E サブルーチンでメモリ割り当てエラーが発生した場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param url WOLFSSL_CERT_MANAGER構造体のocspOverrideURLメンバに格納されるURLへの定数charポインタ。
 
     _Example_
     \code
@@ -7920,32 +9290,36 @@ int wolfSSL_DisableOCSP(WOLFSSL*);
     char url[URLSZ];
     ...
     if(wolfSSL_SetOCSP_OverrideURL(ssl, url)){
-    	// The override url is set to the new value
+    	// オーバーライドURLが新しい値に設定されました
     }
     \endcode
+
     \sa wolfSSL_CertManagerSetOCSPOverrideURL
 */
 int wolfSSL_SetOCSP_OverrideURL(WOLFSSL* ssl, const char* url);
 
 /*!
-    \brief  wolfssl_cert_manager構造体。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。CMのOCSPIOCB、OCSPRESPFREECB、およびOCSPIOCTXメンバーが設定されています。
-    \return BAD_FUNC_ARG  WOLFSSLまたはWOLFSSL_CERT_MANAGER構造がNULLの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param ioCb  CBocSpioを入力するための関数ポインタ。
-    \param respFreeCb  応答メモリを解放するための呼び出しであるCBocSpreSpFreeを入力するための関数ポインタ。
+    \brief この関数は、WOLFSSL_CERT_MANAGER構造体にOCSPコールバックを設定します。
+
+    \return SSL_SUCCESS 関数がエラーなしで実行された場合に返されます。CMのocspIOCb、ocspRespFreeCb、ocspIOCtxメンバが設定されます。
+    \return BAD_FUNC_ARG WOLFSSLまたはWOLFSSL_CERT_MANAGER構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param ioCb CbOCSPIO型への関数ポインタ。
+    \param respFreeCb CbOCSPRespFree型への関数ポインタで、レスポンスメモリを解放する呼び出しです。
+    \param ioCbCtx CMのocspIOCtxメンバに保持されるvoidポインタ。
 
     _Example_
     \code
     WOLFSSL* ssl = wolfSSL_new(ctx);
     …
     int OCSPIO_CB(void* , const char*, int , unsigned char* , int,
-    unsigned char**){  // must have this signature
-    // Function Body
+    unsigned char**){  // このシグネチャが必要です
+        // 関数本体
     }
     …
-    void OCSPRespFree_CB(void* , unsigned char* ){ // must have this signature
-    	// function body
+    void OCSPRespFree_CB(void* , unsigned char* ){ // このシグネチャが必要です
+    	// 関数本体
     }
     …
     void* ioCbCtx;
@@ -7953,9 +9327,10 @@ int wolfSSL_SetOCSP_OverrideURL(WOLFSSL* ssl, const char* url);
 
     if(wolfSSL_SetOCSP_Cb(ssl, OCSPIO_CB( pass args ), CB_OCSPRespFree,
 				ioCbCtx) != SSL_SUCCESS){
-	    // Callback not set
+	    // コールバックが設定されませんでした
     }
     \endcode
+
     \sa wolfSSL_CertManagerSetOCSP_Cb
     \sa CbOCSPIO
     \sa CbOCSPRespFree
@@ -7964,12 +9339,15 @@ int wolfSSL_SetOCSP_Cb(WOLFSSL* ssl, CbOCSPIO ioCb, CbOCSPRespFree respFreeCb,
                        void* ioCbCtx);
 
 /*!
-    \brief
-    \return SSL_SUCCESS  この関数とそれがサブルーチンの場合はエラーなしで実行されます。
-    \return BAD_FUNC_ARG  CTX構造体がNULLの場合、またはその他の点ではサブルーチンに無効な引数があった場合に返されます。
-    \return MEMORY_E  関数の実行中にメモリの割り当てエラーが発生した場合に返されます。
-    \return SSL_FAILURE  wolfssl_cert_managerのCRLメンバーが正しく初期化されなかった場合に返されます。
-    \return NOT_COMPILED_IN  wolfsslはhane_crlオプションでコンパイルされませんでした。
+    \brief CTXを通じてCRL証明書検証を有効にします。
+
+    \return SSL_SUCCESS この関数とそのサブルーチンがエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG CTX構造体がNULLの場合、またはサブルーチンで無効な引数が渡された場合に返されます。
+    \return MEMORY_E 関数の実行中にメモリ割り当てエラーが発生した場合に返されます。
+    \return SSL_FAILURE WOLFSSL_CERT_MANAGERのcrlメンバが正しく初期化できなかった場合に返されます。
+    \return NOT_COMPILED_IN wolfSSLがHAVE_CRLオプション付きでコンパイルされていません。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -7977,9 +9355,10 @@ int wolfSSL_SetOCSP_Cb(WOLFSSL* ssl, CbOCSPIO ioCb, CbOCSPRespFree respFreeCb,
     WOLFSSL* ssl = wolfSSL_new(ctx);
     ...
     if(wolfSSL_CTX_EnableCRL(ssl->ctx, options) != SSL_SUCCESS){
-    	// The function failed
+    	// 関数が失敗しました
     }
     \endcode
+
     \sa wolfSSL_CertManagerEnableCRL
     \sa InitCRL
     \sa wolfSSL_CTX_DisableCRL
@@ -7987,9 +9366,12 @@ int wolfSSL_SetOCSP_Cb(WOLFSSL* ssl, CbOCSPIO ioCb, CbOCSPRespFree respFreeCb,
 int wolfSSL_CTX_EnableCRL(WOLFSSL_CTX* ctx, int options);
 
 /*!
-    \brief
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。wolfssl_cert_manager構造体のCRLEnabledメンバーは0に設定されています。
-    \return BAD_FUNC_ARG  CTX構造体またはCM構造体にNULL値がある場合に返されます。
+    \brief この関数は、CTX構造体でCRL検証を無効にします。
+
+    \return SSL_SUCCESS 関数がエラーなしで実行された場合に返されます。WOLFSSL_CERT_MANAGER構造体のcrlEnabledメンバが0に設定されます。
+    \return BAD_FUNC_ARG CTX構造体またはCM構造体のいずれかがNULL値の場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
 
     _Example_
     \code
@@ -7997,22 +9379,26 @@ int wolfSSL_CTX_EnableCRL(WOLFSSL_CTX* ctx, int options);
     WOLFSSL* ssl = wolfSSL_new(ctx);
     ...
     if(wolfSSL_CTX_DisableCRL(ssl->ctx) != SSL_SUCCESS){
-    	// Failure case.
+    	// 失敗ケース
     }
     \endcode
+
     \sa wolfSSL_CertManagerDisableCRL
 */
 int wolfSSL_CTX_DisableCRL(WOLFSSL_CTX* ctx);
 
 /*!
-    \brief  wolfssl_certmanagerLoadcr()。
-    \return SSL_SUCCESS   - 関数とそのサブルーチンがエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG   - この関数またはサブルーチンがNULL構造に渡された場合に返されます。
-    \return BAD_PATH_ERROR   - パス変数がnullとして開くと戻ります。
-    \return MEMORY_E   - メモリの割り当てが失敗した場合に返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param path  証明書へのパス。
-    \param type  証明書の種類を保持する整数変数。
+    \brief この関数は、wolfSSL_CertManagerLoadCRL()を通じてCRLをWOLFSSL_CTX構造体にロードします。
+
+    \return SSL_SUCCESS - 関数とそのサブルーチンがエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG - この関数またはサブルーチンにNULL構造体が渡された場合に返されます。
+    \return BAD_PATH_ERROR - path変数がNULLとして開かれた場合に返されます。
+    \return MEMORY_E - メモリの割り当てが失敗した場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param path 証明書へのパス。
+    \param type 証明書のタイプを保持する整数変数。
+    \param monitor モニタパスが要求されているかを判定するために使用される整数変数。
 
     _Example_
     \code
@@ -8021,56 +9407,80 @@ int wolfSSL_CTX_DisableCRL(WOLFSSL_CTX* ctx);
     …
     return wolfSSL_CTX_LoadCRL(ctx, path, SSL_FILETYPE_PEM, 0);
     \endcode
+
     \sa wolfSSL_CertManagerLoadCRL
     \sa LoadCRL
 */
 int wolfSSL_CTX_LoadCRL(WOLFSSL_CTX* ctx, const char* path, int type, int monitor);
 
 /*!
-    \brief  wolfssl_certmanagersetCRL_CBを呼び出して、WolfSSL_CERT_MANAGER構造のメンバー。
-    \return SSL_SUCCESS  実行が成功するために返されました。WOLFSSL_CERT_MANAGER構造体のCBMSSINGCRLはCBに正常に設定されました。
-    \return BAD_FUNC_ARG  wolfssl_ctxまたはwolfssl_cert_managerがNULLの場合に返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+    \brief この関数は、wolfSSL_CertManagerSetCRL_Cbを呼び出すことにより、コールバック引数をWOLFSSL_CERT_MANAGER構造体のcbMissingCRLメンバに設定します。
+
+    \return SSL_SUCCESS 実行が成功した場合に返されます。WOLFSSL_CERT_MANAGER構造体のメンバcbMssingCRLがcbに正常に設定されました。
+    \return BAD_FUNC_ARG WOLFSSL_CTXまたはWOLFSSL_CERT_MANAGERがNULLの場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param cb CbMissingCRL型のコールバック関数へのポインタ。
+    シグネチャ要件:
+	void (*CbMissingCRL)(const char* url);
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
     …
-    void cb(const char* url) // Required signature
+    void cb(const char* url) // 必要なシグネチャ
     {
-    	// Function body
+    	// 関数本体
     }
     …
     if (wolfSSL_CTX_SetCRL_Cb(ctx, cb) != SSL_SUCCESS){
-    	// Failure case, cb was not set correctly.
+    	// 失敗ケース、cbが正しく設定されませんでした
     }
     \endcode
+
     \sa wolfSSL_CertManagerSetCRL_Cb
     \sa CbMissingCRL
 */
 int wolfSSL_CTX_SetCRL_Cb(WOLFSSL_CTX* ctx, CbMissingCRL cb);
 
 /*!
-    \brief  wolfsslの機能オプションの値が1つ以上のオプションで構成されている場合は、次のオプションを1つ以上にします.wolfssl_ocsp_enable  -  OCSPルックアップを有効にするwolfssl_ocsp_url_override  - 証明書のURLの代わりにURLをオーバーライドします。オーバーライドURLは、wolfssl_ctx_setocsp_overrideURL()関数を使用して指定されます。この関数は、wolfsslがOCSPサポート（--enable-ocsp、#define hane_ocsp）でコンパイルされたときにのみOCSPオプションを設定します。
-    \return SSL_SUCCESS  成功したときに返されます。
-    \return SSL_FAILURE  失敗したときに返されます。
-    \return NOT_COMPILED_IN  この関数が呼び出されたときに返されますが、wolfsslがコンパイルされたときにOCSPサポートは有効になっていませんでした。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \brief この関数は、wolfSSLのOCSP機能の動作を設定するオプションを設定します。optionsの値は、以下のオプションの1つ以上をOR演算することで形成されます。
+    WOLFSSL_OCSP_URL_OVERRIDE - 証明書内のURLの代わりにオーバーライドURLを使用します。オーバーライドURLはwolfSSL_CTX_SetOCSP_OverrideURL()関数を使用して指定されます。
+    WOLFSSL_OCSP_CHECKALL - すべてのOCSPチェックをオンに設定します。
+    WOLFSSL_OCSP_NO_NONCE - OCSP要求作成時のnonceオプションを設定します。
+
+    この関数は、wolfSSLがOCSPサポート付きでコンパイルされている場合(--enable-ocsp、#define HAVE_OCSP)にのみOCSPオプションを設定します。
+
+    \return SSL_SUCCESS 成功時に返されます。
+    \return SSL_FAILURE 失敗時に返されます。
+    \return NOT_COMPILED_IN この関数が呼び出されたが、wolfSSLのコンパイル時にOCSPサポートが有効になっていなかった場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param options OCSPオプションを設定するために使用される値。
 
     _Example_
     \code
-    WOLFSSL_CTX* ctx = 0;
-    ...
-    wolfSSL_CTX_OCSP_set_options(ctx, WOLFSSL_OCSP_ENABLE);
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    int options; // オプション定数で初期化
+    …
+    int ret = wolfSSL_CTX_EnableOCSP(ctx, options);
+    if(ret != SSL_SUCCESS){
+        // OCSPが有効になっていません
+    }
     \endcode
-    \sa wolfSSL_CTX_OCSP_set_override_url
+
+    \sa wolfSSL_CertManagerEnableOCSP
+    \sa wolfSSL_EnableOCSP
 */
 int wolfSSL_CTX_EnableOCSP(WOLFSSL_CTX* ctx, int options);
 
 /*!
-    \brief  wolfssl_cert_manager構造体のOCSPENABLEDメンバーに影響を与えます。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。CMのOCSPENABLEDメンバーは無効になっています。
-    \return BAD_FUNC_ARG  WOLFSSL_CTX構造がnullの場合に返されます。
+    \brief この関数は、WOLFSSL_CERT_MANAGER構造体のocspEnabledメンバに影響を与えることにより、OCSP証明書失効チェックを無効にします。
+
+    \return SSL_SUCCESS 関数がエラーなしで実行された場合に返されます。CMのocspEnabledメンバが無効にされました。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULLの場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
 
     _Example_
     \code
@@ -8078,38 +9488,46 @@ int wolfSSL_CTX_EnableOCSP(WOLFSSL_CTX* ctx, int options);
     WOLFSSL* ssl = wolfSSL_new(ctx);
     ...
     if(!wolfSSL_CTX_DisableOCSP(ssl->ctx)){
-    	// OCSP is not disabled
+    	// OCSPが無効になっていません
     }
     \endcode
+
     \sa wolfSSL_DisableOCSP
     \sa wolfSSL_CertManagerDisableOCSP
 */
 int wolfSSL_CTX_DisableOCSP(WOLFSSL_CTX*);
 
 /*!
-    \brief  wolfssl_csp_url_overrideオプションがwolfssl_ctx_enableocspを使用して設定されていない限り、OCSPは個々の証明書にあるURLを使用します。
-    \return SSL_SUCCESS  成功したときに返されます。
-    \return SSL_FAILURE  失敗したときに返されます。
-    \return NOT_COMPILED_IN  この関数が呼び出されたときに返されますが、wolfsslがコンパイルされたときにOCSPサポートは有効になっていませんでした。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \brief この関数は、OCSPが使用するURLを手動で設定します。デフォルトでは、wolfSSL_CTX_EnableOCSPを使用してWOLFSSL_OCSP_URL_OVERRIDEオプションが設定されていない限り、OCSPは個々の証明書で見つかったURLを使用します。
+
+    \return SSL_SUCCESS 成功時に返されます。
+    \return SSL_FAILURE 失敗時に返されます。
+    \return NOT_COMPILED_IN この関数が呼び出されたが、wolfSSLのコンパイル時にOCSPサポートが有効になっていなかった場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param url wolfSSLが使用するOCSP URLへのポインタ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = 0;
     ...
-    wolfSSL_CTX_OCSP_set_override_url(ctx, “custom-url-here”);
+    wolfSSL_CTX_OCSP_set_override_url(ctx, "custom-url-here");
     \endcode
+
     \sa wolfSSL_CTX_OCSP_set_options
 */
 int wolfSSL_CTX_SetOCSP_OverrideURL(WOLFSSL_CTX* ctx, const char* url);
 
 /*!
-    \brief
-    \return SSL_SUCCESS  関数が正常に実行された場合に返されます。CM内のOCSPIOCB、OCSPRESPFREECB、およびOCSPIOCTXメンバーは正常に設定されました。
-    \return BAD_FUNC_ARG  WOLFSSL_CTXまたはwolfssl_cert_manager構造体がnullの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param ioCb  関数ポインタであるCBocSpio型。
-    \param respFreeCb  関数ポインタであるCBocSprepSprepFree型。
+    \brief WOLFSSL_CTX構造体にOCSPのコールバックを設定します。
+
+    \return SSL_SUCCESS 関数が正常に実行された場合に返されます。CM内のocspIOCb、ocspRespFreeCb、ocspIOCtxメンバが正常に設定されました。
+    \return BAD_FUNC_ARG WOLFSSL_CTXまたはWOLFSSL_CERT_MANAGER構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param ioCb 関数ポインタであるCbOCSPIO型。
+    \param respFreeCb 関数ポインタであるCbOCSPRespFree型。
+    \param ioCbCtx WOLFSSL_CERT_MANAGERに保持されるvoidポインタ。
 
     _Example_
     \code
@@ -8124,9 +9542,10 @@ int wolfSSL_CTX_SetOCSP_OverrideURL(WOLFSSL_CTX* ctx, const char* url);
     ocspRespFreeCb, ioCbCtx);
 
     if(isSetOCSP != SSL_SUCCESS){
-    	// The function did not return successfully.
+    	// 関数が正常に返されませんでした
     }
     \endcode
+
     \sa wolfSSL_CertManagerSetOCSP_Cb
     \sa CbOCSPIO
     \sa CbOCSPRespFree
@@ -8136,22 +9555,25 @@ int wolfSSL_CTX_SetOCSP_Cb(WOLFSSL_CTX* ctx,
                            void* ioCbCtx);
 
 /*!
-    \brief  wolfssl_certmanagerEnableOcspStapling()。
-    \return SSL_SUCCESS  エラーがなく、関数が正常に実行された場合に返されます。
-    \return BAD_FUNC_ARG  WOLFSSL_CTX構造体がNULLまたはそうでない場合は、サブルーチンに渡された未解決の引数値があった場合に返されます。
-    \return MEMORY_E  メモリ割り当てがある問題が発生した場合に返されます。
-    \return SSL_FAILURE  OCSP構造体の初期化が失敗した場合に返されます。
-    \return NOT_COMPILED_IN  wolfsslがhaber_certificate_status_requestオプションでコンパイルされていない場合に返されます。
+    \brief この関数は、wolfSSL_CertManagerEnableOCSPStapling()を呼び出してOCSPステープリングを有効にします。
+    \return SSL_SUCCESS エラーがなく、関数が正常に実行された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULL、またはサブルーチンに許可されていない引数値が渡された場合に返されます。
+    \return MEMORY_E メモリの割り当てに問題があった場合に返されます。
+    \return SSL_FAILURE OCSP構造体の初期化が失敗した場合に返されます。
+    \return NOT_COMPILED_IN wolfSSLがHAVE_CERTIFICATE_STATUS_REQUESTオプション付きでコンパイルされていない場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
 
     _Example_
     \code
-    WOLFSSL* ssl = wolfSSL_new();
-    ssl->method.version; // set to desired protocol
+    WOLFSSL* ssl = WOLFSSL_new();
+    ssl->method.version; // 希望するプロトコルに設定
     ...
     if(!wolfSSL_CTX_EnableOCSPStapling(ssl->ctx)){
-    	// OCSP stapling is not enabled
+    	// OCSPステープリングが有効になっていません
     }
     \endcode
+
     \sa wolfSSL_CertManagerEnableOCSPStapling
     \sa InitOCSP
 */
@@ -8159,8 +9581,12 @@ int wolfSSL_CTX_EnableOCSPStapling(WOLFSSL_CTX*);
 
 /*!
     \ingroup CertsKeys
-    \brief  通常、SSLハンドシェイクの最後に、WolfSSLは一時的なアレイを解放します。ハンドシェイクが始まる前にこの関数を呼び出すと、WolfSSLは一時的な配列を解放するのを防ぎます。Wolfssl_get_keys()またはPSKのヒントなどのものには、一時的な配列が必要になる場合があります。ユーザが一時的な配列で行われると、wolfssl_freearray()のいずれかが即座にリソースを解放することができ、あるいは、関連するSSLオブジェクトが解放されたときにリソースが解放されるようになる可能性がある。
-    \return none  返品不可。
+
+    \brief 通常、SSLハンドシェイクの終了時に、wolfSSLは一時配列を解放します。ハンドシェイクが始まる前にこの関数を呼び出すと、wolfSSLは一時配列を解放しなくなります。一時配列はwolfSSL_get_keys()やPSKヒントなどに必要になる場合があります。ユーザーが一時配列を使い終わったら、wolfSSL_FreeArrays()を呼び出してリソースを即座に解放するか、あるいは関連するSSLオブジェクトが解放されるときにリソースが解放されます。
+
+    \return none 戻り値なし。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -8168,14 +9594,19 @@ int wolfSSL_CTX_EnableOCSPStapling(WOLFSSL_CTX*);
     ...
     wolfSSL_KeepArrays(ssl);
     \endcode
+
     \sa wolfSSL_FreeArrays
 */
 void wolfSSL_KeepArrays(WOLFSSL*);
 
 /*!
     \ingroup CertsKeys
-    \brief  通常、SSLハンドシェイクの最後に、WolfSSLは一時的なアレイを解放します。wolfssl_keeparrays()がハンドシェイクの前に呼び出された場合、WolfSSLは一時的な配列を解放しません。この関数は一時的な配列を明示的に解放し、ユーザーが一時的な配列で行われたときに呼び出されるべきであり、SSLオブジェクトがこれらのリソースを解放するのを待ったくない。
-    \return none  返品不可。
+
+    \brief 通常、SSLハンドシェイクの終了時に、wolfSSLは一時配列を解放します。ハンドシェイクの前にwolfSSL_KeepArrays()が呼び出されていた場合、wolfSSLは一時配列を解放しません。この関数は一時配列を明示的に解放し、ユーザーが一時配列を使い終わり、SSLオブジェクトが解放されるのを待たずにこれらのリソースを解放したい場合に呼び出す必要があります。
+
+    \return none 戻り値なし。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -8183,18 +9614,22 @@ void wolfSSL_KeepArrays(WOLFSSL*);
     ...
     wolfSSL_FreeArrays(ssl);
     \endcode
+
     \sa wolfSSL_KeepArrays
 */
 void wolfSSL_FreeArrays(WOLFSSL*);
 
 /*!
-    \brief  'ssl'パラメータに渡されたオブジェクト。これは、WolfSSLクライアントによってSNI拡張機能がClientHelloで送信され、WolfSSL ServerはServerHello + SNIまたはSNIミスマッチの場合は致命的なAlert Hello + SNIを応答します。
-    \return WOLFSSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  次のいずれかの場合で返されるエラーです.SSLはNULL、データはNULL、タイプは不明な値です。（下記参照）
-    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
-    \param ssl  wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
-    \param type  どの種類のサーバー名がデータに渡されたかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
-    \param data  サーバー名データへのポインタ。
+    \brief この関数は、'ssl'パラメータで渡されたSSLオブジェクトでServer Name Indicationの使用を有効にします。つまり、wolfSSLクライアントはClientHelloでSNI拡張を送信し、wolfSSLサーバーはSNI不一致の場合、ClientHello + SNIに対してServerHello + 空のSNIまたはfatalアラートで応答します。
+
+    \return WOLFSSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 次のいずれかの場合に返されるエラーです。sslがNULL、dataがNULL、typeが未知の値(以下を参照)。
+    \return MEMORY_E メモリが不足している場合に返されるエラーです。
+
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+    \param type dataで渡されるサーバー名のタイプを示します。既知のタイプは、enum { WOLFSSL_SNI_HOST_NAME = 0 }です。
+    \param data サーバー名データへのポインタ。
+    \param size サーバー名データのサイズ。
 
     _Example_
     \code
@@ -8203,18 +9638,19 @@ void wolfSSL_FreeArrays(WOLFSSL*);
     WOLFSSL* ssl = 0;
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-        // context creation failed
+        // コンテキスト作成失敗
     }
     ssl = wolfSSL_new(ctx);
     if (ssl == NULL) {
-        // ssl creation failed
+        // ssl作成失敗
     }
     ret = wolfSSL_UseSNI(ssl, WOLFSSL_SNI_HOST_NAME, "www.yassl.com",
         strlen("www.yassl.com"));
     if (ret != WOLFSSL_SUCCESS) {
-        // sni usage failed
+        // sni使用失敗
     }
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_CTX_UseSNI
 */
@@ -8222,13 +9658,16 @@ int wolfSSL_UseSNI(WOLFSSL* ssl, unsigned char type,
                                          const void* data, unsigned short size);
 
 /*!
-    \brief  SSLコンテキストから作成されたオブジェクトは 'ctx'パラメータに渡されました。これは、WolfSSLクライアントによってSNI拡張機能がClientHelloで送信され、WolfSSLサーバーはServerHello + SNIまたはSNIの不一致の場合には致命的なALERT Hello + SNIを応答します。
-    \return WOLFSSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  次のいずれかの場合で返されるエラーです.CTXはNULL、データはNULL、タイプは不明な値です。（下記参照）
-    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param type  どの種類のサーバー名がデータに渡されたかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
-    \param data  サーバー名データへのポインタ。
+    \brief この関数は、'ctx'パラメータで渡されたSSLコンテキストから作成されたSSLオブジェクトに対してServer Name Indicationの使用を有効にします。つまり、wolfSSLクライアントはClientHelloでSNI拡張を送信し、wolfSSLサーバーはSNI不一致の場合、ClientHello + SNIに対してServerHello + 空のSNIまたはfatalアラートで応答します。
+
+    \return WOLFSSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 次のいずれかの場合に返されるエラーです。ctxがNULL、dataがNULL、typeが未知の値(以下を参照)。
+    \return MEMORY_E メモリが不足している場合に返されるエラーです。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param type dataで渡されるサーバー名のタイプを示します。既知のタイプは、enum { WOLFSSL_SNI_HOST_NAME = 0 }です。
+    \param data サーバー名データへのポインタ。
+    \param size サーバー名データのサイズ。
 
     _Example_
     \code
@@ -8236,14 +9675,15 @@ int wolfSSL_UseSNI(WOLFSSL* ssl, unsigned char type,
     WOLFSSL_CTX* ctx = 0;
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-        // context creation failed
+        // コンテキスト作成失敗
     }
     ret = wolfSSL_CTX_UseSNI(ctx, WOLFSSL_SNI_HOST_NAME, "www.yassl.com",
         strlen("www.yassl.com"));
     if (ret != WOLFSSL_SUCCESS) {
-        // sni usage failed
+        // sni使用失敗
     }
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_UseSNI
 */
@@ -8251,12 +9691,15 @@ int wolfSSL_CTX_UseSNI(WOLFSSL_CTX* ctx, unsigned char type,
                                          const void* data, unsigned short size);
 
 /*!
-    \brief  'ssl'パラメータに渡されたSSLオブジェクト内のサーバー名表示を使用したSSLセッションの動作。オプションを以下に説明します。
-    \return none  いいえ返します。
-    \param ssl  wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
-    \param type  どの種類のサーバー名がデータに渡されたかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
-    \param options  選択されたオプションを持つビット単位のセマフォ。利用可能なオプションは次のとおりです。enum {wolfssl_sni_continue_on_mismatch = 0x01、wolfssl_sni_answer_on_mismatch = 0x02};通常、サーバーは、クライアントによって提供されたホスト名がサーバーと表示されているホスト名がサーバーで提供されている場合、サーバーはhandshakeを中止します。
-    \param WOLFSSL_SNI_CONTINUE_ON_MISMATCH  このオプションを設定すると、サーバーはセッションを中止する代わりにSNI応答を送信しません。
+    \brief この関数は、'ssl'パラメータで渡されたSSLオブジェクトでServer Name Indicationを使用するSSLセッションの動作を設定するために、サーバー側で呼び出されます。オプションについては以下で説明します。
+
+    \return none 戻り値なし。
+
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+    \param type dataで渡されるサーバー名のタイプを示します。既知のタイプは、enum { WOLFSSL_SNI_HOST_NAME = 0 }です。
+    \param options 選択されたオプションを含むビット単位のセマフォ。利用可能なオプションは、enum { WOLFSSL_SNI_CONTINUE_ON_MISMATCH = 0x01, WOLFSSL_SNI_ANSWER_ON_MISMATCH = 0x02 }です。通常、クライアントから提供されたホスト名がサーバーと一致しない場合、サーバーはfatalレベルのunrecognized_name(112)アラートを送信してハンドシェイクを中止します。
+    \param WOLFSSL_SNI_CONTINUE_ON_MISMATCH このオプションが設定されている場合、サーバーはセッションを中止する代わりにSNI応答を送信しません。
+    \param WOLFSSL_SNI_ANSWER_ON_MISMATCH このオプションが設定されている場合、サーバーはセッションを中止する代わりに、ホスト名が一致しているかのようにSNI応答を送信します。
 
     _Example_
     \code
@@ -8265,19 +9708,20 @@ int wolfSSL_CTX_UseSNI(WOLFSSL_CTX* ctx, unsigned char type,
     WOLFSSL* ssl = 0;
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-        // context creation failed
+        // コンテキスト作成失敗
     }
     ssl = wolfSSL_new(ctx);
     if (ssl == NULL) {
-        // ssl creation failed
+        // ssl作成失敗
     }
     ret = wolfSSL_UseSNI(ssl, 0, "www.yassl.com", strlen("www.yassl.com"));
     if (ret != WOLFSSL_SUCCESS) {
-        // sni usage failed
+        // sni使用失敗
     }
     wolfSSL_SNI_SetOptions(ssl, WOLFSSL_SNI_HOST_NAME,
         WOLFSSL_SNI_CONTINUE_ON_MISMATCH);
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_UseSNI
     \sa wolfSSL_CTX_SNI_SetOptions
@@ -8286,12 +9730,15 @@ void wolfSSL_SNI_SetOptions(WOLFSSL* ssl, unsigned char type,
                                                          unsigned char options);
 
 /*!
-    \brief  SSLセッションを使用したSSLオブジェクトのサーバ名指示を使用して、SSLコンテキストから作成されたSSLオブジェクトから作成されます。オプションを以下に説明します。
-    \return none  いいえ返します。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
-    \param type  どの種類のサーバー名がデータに渡されたかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
-    \param options  選択されたオプションを持つビット単位のセマフォ。利用可能なオプションは次のとおりです。enum {wolfssl_sni_continue_on_mismatch = 0x01、wolfssl_sni_answer_on_mismatch = 0x02};通常、サーバーは、クライアントによって提供されたホスト名がサーバーと表示されているホスト名がサーバーで提供されている場合、サーバーはhandshakeを中止します。
-    \param WOLFSSL_SNI_CONTINUE_ON_MISMATCH  このオプションを設定すると、サーバーはセッションを中止する代わりにSNI応答を送信しません。
+    \brief この関数は、'ctx'パラメータで渡されたSSLコンテキストから作成されたSSLオブジェクトに対してServer Name Indicationを使用するSSLセッションの動作を設定するために、サーバー側で呼び出されます。オプションについては以下で説明します。
+
+    \return none 戻り値なし。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param type dataで渡されるサーバー名のタイプを示します。既知のタイプは、enum { WOLFSSL_SNI_HOST_NAME = 0 }です。
+    \param options 選択されたオプションを含むビット単位のセマフォ。利用可能なオプションは、enum { WOLFSSL_SNI_CONTINUE_ON_MISMATCH = 0x01, WOLFSSL_SNI_ANSWER_ON_MISMATCH = 0x02 }です。通常、クライアントから提供されたホスト名がサーバーと一致しない場合、サーバーはfatalレベルのunrecognized_name(112)アラートを送信してハンドシェイクを中止します。
+    \param WOLFSSL_SNI_CONTINUE_ON_MISMATCH このオプションが設定されている場合、サーバーはセッションを中止する代わりにSNI応答を送信しません。
+    \param WOLFSSL_SNI_ANSWER_ON_MISMATCH このオプションが設定されている場合、サーバーはセッションを中止する代わりに、ホスト名が一致しているかのようにSNI応答を送信します。
 
     _Example_
     \code
@@ -8299,15 +9746,16 @@ void wolfSSL_SNI_SetOptions(WOLFSSL* ssl, unsigned char type,
     WOLFSSL_CTX* ctx = 0;
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-       // context creation failed
+       // コンテキスト作成失敗
     }
     ret = wolfSSL_CTX_UseSNI(ctx, 0, "www.yassl.com", strlen("www.yassl.com"));
     if (ret != WOLFSSL_SUCCESS) {
-        // sni usage failed
+        // sni使用失敗
     }
     wolfSSL_CTX_SNI_SetOptions(ctx, WOLFSSL_SNI_HOST_NAME,
     WOLFSSL_SNI_CONTINUE_ON_MISMATCH);
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_UseSNI
     \sa wolfSSL_SNI_SetOptions
@@ -8316,27 +9764,31 @@ void wolfSSL_CTX_SNI_SetOptions(WOLFSSL_CTX* ctx,
                                      unsigned char type, unsigned char options);
 
 /*!
-    \brief  クライアントによってクライアントから提供された名前表示クライアントによって送信されたメッセージセッションを開始する。SNIを取得するためのコンテキストまたはセッション設定が必要ありません。
-    \return WOLFSSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  このケースで返されるエラーは、次のいずれかの場合で返されます。バッファはNULL、BUFFERSZ <= 0、SNIはNULL、INOUTSZはNULLまたは<= 0です。
-    \return BUFFER_ERROR  不正なクライアントhelloメッセージがあるときにエラーが返されます。
-    \return INCOMPLETE_DATA  抽出を完了するのに十分なデータがない場合に返されるエラーです。
-    \param buffer  クライアントから提供されたデータへのポインタ（クライアントhello）。
-    \param bufferSz  クライアントhelloメッセージのサイズ。
-    \param type  どの種類のサーバー名がバッファーから取得されているかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
-    \param sni  出力が保存される場所へのポインタ。
+    \brief この関数は、クライアントがセッションを開始するために送信したClient Helloメッセージからクライアントによって提供されたServer Name Indicationを取得するために、サーバー側で呼び出されます。SNIを取得するためにコンテキストやセッションのセットアップは必要ありません。
+
+    \return WOLFSSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 次のいずれかの場合に返されるエラーです。bufferがNULL、bufferSz <= 0、sniがNULL、inOutSzがNULLまたは<= 0。
+    \return BUFFER_ERROR 不正な形式のClient Helloメッセージがある場合に返されるエラーです。
+    \return INCOMPLETE_DATA 抽出を完了するのに十分なデータがない場合に返されるエラーです。
+
+    \param buffer クライアントから提供されたデータ(Client Hello)へのポインタ。
+    \param bufferSz Client Helloメッセージのサイズ。
+    \param type bufferから取得されるサーバー名のタイプを示します。既知のタイプは、enum { WOLFSSL_SNI_HOST_NAME = 0 }です。
+    \param sni 出力が格納される場所へのポインタ。
+    \param inOutSz 出力サイズへのポインタ。この値はMIN("SNIの長さ", inOutSz)に更新されます。
 
     _Example_
     \code
     unsigned char buffer[1024] = {0};
     unsigned char result[32]   = {0};
     int           length       = 32;
-    // read Client Hello to buffer...
-    ret = wolfSSL_SNI_GetFromBuffer(buffer, sizeof(buffer), 0, result, &length));
+    // Client Helloをbufferに読み込み...
+    ret = wolfSSL_SNI_GetFromBuffer(buffer, sizeof(buffer), 0, result, &length);
     if (ret != WOLFSSL_SUCCESS) {
-        // sni retrieve failed
+        // sni取得失敗
     }
     \endcode
+
     \sa wolfSSL_UseSNI
     \sa wolfSSL_CTX_UseSNI
     \sa wolfSSL_SNI_GetRequest
@@ -8347,10 +9799,14 @@ int wolfSSL_SNI_GetFromBuffer(
 
 /*!
     \ingroup IO
-    \brief  この関数はSNIオブジェクトのステータスを取得します。
-    \return value  SNIがNULLでない場合、この関数はSNI構造体のステータスメンバーのバイト値を返します。
-    \return 0  SNIオブジェクトがNULLの場合
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+
+    \brief この関数はSNIオブジェクトのステータスを取得します。
+
+    \return value SNIがNULLでない場合、この関数はSNI構造体のstatusメンバーのバイト値を返します。
+    \return 0 SNIオブジェクトがNULLの場合。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param type SNIタイプ。
 
     _Example_
     \code
@@ -8364,6 +9820,7 @@ int wolfSSL_SNI_GetFromBuffer(
     AssertIntEQ(WOLFSSL_SNI_NO_MATCH, wolfSSL_SNI_Status(ssl, type));
     …
     \endcode
+
     \sa TLSX_SNI_Status
     \sa TLSX_SNI_find
     \sa TLSX_Find
@@ -8371,10 +9828,13 @@ int wolfSSL_SNI_GetFromBuffer(
 unsigned char wolfSSL_SNI_Status(WOLFSSL* ssl, unsigned char type);
 
 /*!
-    \brief  SSLセッションでクライアントによって提供されるサーバー名の表示。
-    \return size  提供されたSNIデータのサイズ。
-    \param ssl  wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
-    \param type  どの種類のサーバー名がデータ内で取得されているかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
+    \brief この関数は、SSLセッションでクライアントによって提供されたServer Name Indicationを取得するために、サーバー側で呼び出されます。
+
+    \return size 提供されたSNIデータのサイズ。
+
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+    \param type dataで取得されるサーバー名のタイプを示します。既知のタイプは、enum { WOLFSSL_SNI_HOST_NAME = 0 }です。
+    \param data クライアントから提供されたデータへのポインタ。
 
     _Example_
     \code
@@ -8383,21 +9843,22 @@ unsigned char wolfSSL_SNI_Status(WOLFSSL* ssl, unsigned char type);
     WOLFSSL* ssl = 0;
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-        // context creation failed
+        // コンテキスト作成失敗
     }
     ssl = wolfSSL_new(ctx);
     if (ssl == NULL) {
-        // ssl creation failed
+        // ssl作成失敗
     }
     ret = wolfSSL_UseSNI(ssl, 0, "www.yassl.com", strlen("www.yassl.com"));
     if (ret != WOLFSSL_SUCCESS) {
-        // sni usage failed
+        // sni使用失敗
     }
     if (wolfSSL_accept(ssl) == SSL_SUCCESS) {
         void *data = NULL;
         unsigned short size = wolfSSL_SNI_GetRequest(ssl, 0, &data);
     }
     \endcode
+
     \sa wolfSSL_UseSNI
     \sa wolfSSL_CTX_UseSNI
 */
@@ -8406,32 +9867,35 @@ unsigned short wolfSSL_SNI_GetRequest(WOLFSSL *ssl,
 
 /*!
     \ingroup Setup
-    \brief  wolfsslセッションにALPNを設定します。
-    \return WOLFSSL_SUCCESS:  成功時に返されます。
-    \return BAD_FUNC_ARG  SSLまたはPROTOCOL_NAME_LISTがNULLまたはPROTOCOL_NAME_LISTSZが大きすぎたり、オプションがサポートされていないものを含みます。
-    \return MEMORY_ERROR  プロトコルリストのメモリの割り当て中にエラーが発生しました。
-    \return SSL_FAILURE  失敗時に返されます。
-    \param ssl  使用するWolfSSLセッション。
-    \param protocol_name_list  使用するプロトコル名のリスト。カンマ区切り文字列が必要です。
-    \param protocol_name_listSz  プロトコル名のリストのサイズ。
+
+    \brief wolfSSLセッションでALPNの使用をセットアップします。
+
+    \return WOLFSSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG sslまたはprotocol_name_listがnull、またはprotocol_name_listSzが大きすぎる、またはoptionsがサポートされていない何かを含む場合に返されます。
+    \return MEMORY_ERROR プロトコルリストのメモリ割り当てエラー。
+    \return SSL_FAILURE 失敗時。
+
+    \param ssl 使用するwolfSSLセッション。
+    \param protocol_name_list 使用するプロトコル名のリスト。カンマ区切りの文字列が必要です。
+    \param protocol_name_listSz プロトコル名リストのサイズ。
+    \param options WOLFSSL_ALPN_CONTINUE_ON_MISMATCHまたはWOLFSSL_ALPN_FAILED_ON_MISMATCH。
 
     _Example_
     \code
     wolfSSL_Init();
     WOLFSSL_CTX* ctx;
     WOLFSSL* ssl;
-    WOLFSSL_METHOD method = // Some wolfSSL method
+    WOLFSSL_METHOD method = // 任意のwolfSSLメソッド
     ctx = wolfSSL_CTX_new(method);
     ssl = wolfSSL_new(ctx);
 
-    char alpn_list[] = {};
-
-    if (wolfSSL_UseALPN(ssl, alpn_list, sizeof(alpn_list),
+    char alpn_list[] = {};    if (wolfSSL_UseALPN(ssl, alpn_list, sizeof(alpn_list),
         WOLFSSL_APN_FAILED_ON_MISMATCH) != WOLFSSL_SUCCESS)
     {
-       // Error setting session ticket
+       // セッションチケット設定エラー
     }
     \endcode
+
     \sa TLSX_UseALPN
 */
 int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
@@ -8440,17 +9904,21 @@ int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
 
 /*!
     \ingroup TLS
-    \brief  この関数は、サーバーによって設定されたプロトコル名を取得します。
-    \return SSL_SUCCESS  エラーが投げられていない正常な実行に戻りました。
-    \return SSL_FATAL_ERROR  拡張子が見つからなかった場合、またはピアとプロトコルが一致しなかった場合に返されます。2つ以上のプロトコル名が受け入れられている場合は、スローされたエラーもあります。
-    \return SSL_ALPN_NOT_FOUND  ピアとプロトコルの一致が見つからなかったことを示す返されました。
-    \return BAD_FUNC_ARG  関数に渡されたnull引数があった場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param protocol_name  プロトコル名を表すCHARへのポインタは、ALPN構造に保持されます。
+
+    \brief この関数は、サーバーによって設定されたプロトコル名を取得します。
+
+    \return SSL_SUCCESS エラーがスローされずに正常に実行された場合に返されます。
+    \return SSL_FATAL_ERROR 拡張が見つからなかった場合、またはピアとのプロトコルマッチがなかった場合に返されます。また、受け入れられたプロトコル名が複数ある場合にもエラーがスローされます。
+    \return SSL_ALPN_NOT_FOUND ピアとのプロトコルマッチが見つからなかったことを示して返されます。
+    \return BAD_FUNC_ARG 関数にNULL引数が渡された場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param protocol_name プロトコル名を表し、ALPN構造体に保持されるcharへのポインタ。
+    \param size protocol_nameのサイズを表すword16型。
 
     _Example_
     \code
-    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new( protocol method );
     WOLFSSL* ssl = WOLFSSL_new(ctx);
     ...
     int err;
@@ -8459,9 +9927,10 @@ int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
     err = wolfSSL_ALPN_GetProtocol(ssl, &protocol_name, &protocol_nameSz);
 
     if(err == SSL_SUCCESS){
-	    // Sent ALPN protocol
+	    // ALPNプロトコルを送信
     }
     \endcode
+
     \sa TLSX_ALPN_GetRequest
     \sa TLSX_Find
 */
@@ -8470,13 +9939,17 @@ int wolfSSL_ALPN_GetProtocol(WOLFSSL* ssl, char **protocol_name,
 
 /*!
     \ingroup TLS
-    \brief  この関数は、alpn_client_listデータをSSLオブジェクトからバッファにコピーします。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。SSLオブジェクトのALPN_CLIENT_LISTメンバーがLISTパラメータにコピーされました。
-    \return BAD_FUNC_ARG  listまたはlistszパラメーターがnullの場合に返されます。
-    \return BUFFER_ERROR  リストバッファに問題がある場合は（NULLまたはサイズが0の場合）に問題がある場合に返されます。
-    \return MEMORY_ERROR  メモリを動的に割り当てる問題がある場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param list  バッファへのポインタ。SSLオブジェクトからのデータがコピーされます。
+
+    \brief この関数は、SSLオブジェクトからalpn_client_listデータをバッファにコピーします。
+
+    \return SSL_SUCCESS 関数がエラーなく実行された場合に返されます。SSLオブジェクトのalpn_client_listメンバがlistパラメータにコピーされました。
+    \return BAD_FUNC_ARG listまたはlistSzパラメータがNULLの場合に返されます。
+    \return BUFFER_ERROR listバッファに問題がある場合に返されます(NULLであるか、サイズが0の場合)。
+    \return MEMORY_ERROR メモリの動的割り当てに問題があった場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param list バッファへのポインタ。SSLオブジェクトからのデータがここにコピーされます。
+    \param listSz バッファサイズ。
 
     _Example_
     \code
@@ -8492,20 +9965,24 @@ int wolfSSL_ALPN_GetProtocol(WOLFSSL* ssl, char **protocol_name,
     err = wolfSSL_ALPN_GetPeerProtocol(ssl, &list, &listSz);
 
     if(err == SSL_SUCCESS){
-	    List of protocols names sent by client
+	    // クライアントが送信したプロトコル名のリスト
     }
     \endcode
+
     \sa wolfSSL_UseALPN
 */
 int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list,
                                              unsigned short *listSz);
 
 /*!
-    \brief  'ssl'パラメータに渡されたSSLオブジェクト内の最大フラグメント長。これは、最大フラグメント長拡張機能がWolfSSLクライアントによってClientHelloで送信されることを意味します。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.SSLはNULL、MFLは範囲外です。
-    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
-    \param ssl  wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+    \brief この関数は、'ssl'パラメータで渡されたSSLオブジェクトでMaximum Fragment Lengthの使用を有効にするために、クライアント側で呼び出されます。これは、wolfSSLクライアントによってClientHelloでMaximum Fragment Length拡張が送信されることを意味します。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 次のいずれかの場合に返されるエラー: sslがNULL、mflが範囲外。
+    \return MEMORY_E メモリが不足している場合に返されるエラー。
+
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+    \param mfl セッションに要求されるMaximum Fragment Lengthを示します。利用可能なオプションは: enum { WOLFSSL_MFL_2_9  = 1, 512バイト WOLFSSL_MFL_2_10 = 2, 1024バイト WOLFSSL_MFL_2_11 = 3, 2048バイト WOLFSSL_MFL_2_12 = 4, 4096バイト WOLFSSL_MFL_2_13 = 5, 8192バイト wolfSSL専用!!! };
 
     _Example_
     \code
@@ -8514,28 +9991,32 @@ int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list,
     WOLFSSL* ssl = 0;
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-        // context creation failed
+        // コンテキストの作成に失敗
     }
     ssl = wolfSSL_new(ctx);
     if (ssl == NULL) {
-        // ssl creation failed
+        // sslの作成に失敗
     }
     ret = wolfSSL_UseMaxFragment(ssl, WOLFSSL_MFL_2_11);
     if (ret != 0) {
-        // max fragment usage failed
+        // max fragmentの使用に失敗
     }
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_CTX_UseMaxFragment
 */
 int wolfSSL_UseMaxFragment(WOLFSSL* ssl, unsigned char mfl);
 
 /*!
-    \brief  SSLコンテキストから作成されたSSLオブジェクトの最大フラグメント長さ 'ctx'パラメータに渡されました。これは、最大フラグメント長拡張機能がWolfSSLクライアントによってClientHelloで送信されることを意味します。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.CTXはNULL、MFLは範囲外です。
-    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \brief この関数は、'ctx'パラメータで渡されたSSLコンテキストから作成されたSSLオブジェクトに対してMaximum Fragment Lengthの使用を有効にするために、クライアント側で呼び出されます。これは、wolfSSLクライアントによってClientHelloでMaximum Fragment Length拡張が送信されることを意味します。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 次のいずれかの場合に返されるエラー: ctxがNULL、mflが範囲外。
+    \return MEMORY_E メモリが不足している場合に返されるエラー。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param mfl セッションに要求されるMaximum Fragment Lengthを示します。利用可能なオプションは: enum { WOLFSSL_MFL_2_9  = 1 512バイト、WOLFSSL_MFL_2_10 = 2 1024バイト、WOLFSSL_MFL_2_11 = 3 2048バイト WOLFSSL_MFL_2_12 = 4 4096バイト、WOLFSSL_MFL_2_13 = 5 8192バイト wolfSSL専用!!!、WOLFSSL_MFL_2_13 = 6 256バイト wolfSSL専用!!! };
 
     _Example_
     \code
@@ -8543,23 +10024,27 @@ int wolfSSL_UseMaxFragment(WOLFSSL* ssl, unsigned char mfl);
     WOLFSSL_CTX* ctx = 0;
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-        // context creation failed
+        // コンテキストの作成に失敗
     }
     ret = wolfSSL_CTX_UseMaxFragment(ctx, WOLFSSL_MFL_2_11);
     if (ret != 0) {
-        // max fragment usage failed
+        // max fragmentの使用に失敗
     }
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_UseMaxFragment
 */
 int wolfSSL_CTX_UseMaxFragment(WOLFSSL_CTX* ctx, unsigned char mfl);
 
 /*!
-    \brief  'ssl'パラメータに渡されたSSLオブジェクト内のtruncated HMAC。これは、切り捨てられたHMAC拡張機能がWolfSSLクライアントによってClientHelloで送信されることを意味します。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.SSLはNULLです
-    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
+    \brief この関数は、'ssl'パラメータで渡されたSSLオブジェクトでTruncated HMACの使用を有効にするために、クライアント側で呼び出されます。これは、wolfSSLクライアントによってClientHelloでTruncated HMAC拡張が送信されることを意味します。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 次のいずれかの場合に返されるエラー: sslがNULL。
+    \return MEMORY_E メモリが不足している場合に返されるエラー。
+
+    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
 
     _Example_
     \code
@@ -8568,27 +10053,31 @@ int wolfSSL_CTX_UseMaxFragment(WOLFSSL_CTX* ctx, unsigned char mfl);
     WOLFSSL* ssl = 0;
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-        // context creation failed
+        // コンテキストの作成に失敗
     }
     ssl = wolfSSL_new(ctx);
     if (ssl == NULL) {
-        // ssl creation failed
+        // sslの作成に失敗
     }
     ret = wolfSSL_UseTruncatedHMAC(ssl);
     if (ret != 0) {
-        // truncated HMAC usage failed
+        // truncated HMACの使用に失敗
     }
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_CTX_UseMaxFragment
 */
 int wolfSSL_UseTruncatedHMAC(WOLFSSL* ssl);
 
 /*!
-    \brief  'ctx'パラメータに渡されたSSLコンテキストから作成されたSSLオブジェクトのためのTruncated HMAC。これは、切り捨てられたHMAC拡張機能がWolfSSLクライアントによってClientHelloで送信されることを意味します。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.CTXはNULL
-    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
+    \brief この関数は、'ctx'パラメータで渡されたSSLコンテキストから作成されたSSLオブジェクトに対してTruncated HMACの使用を有効にするために、クライアント側で呼び出されます。これは、wolfSSLクライアントによってClientHelloでTruncated HMAC拡張が送信されることを意味します。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 次のいずれかの場合に返されるエラー: ctxがNULL。
+    \return MEMORY_E メモリが不足している場合に返されるエラー。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
 
     _Example_
     \code
@@ -8596,35 +10085,40 @@ int wolfSSL_UseTruncatedHMAC(WOLFSSL* ssl);
     WOLFSSL_CTX* ctx = 0;
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-        // context creation failed
+        // コンテキストの作成に失敗
     }
     ret = wolfSSL_CTX_UseTruncatedHMAC(ctx);
     if (ret != 0) {
-        // truncated HMAC usage failed
+        // truncated HMACの使用に失敗
     }
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_UseMaxFragment
 */
 int wolfSSL_CTX_UseTruncatedHMAC(WOLFSSL_CTX* ctx);
 
 /*!
-    \brief  OCSPで提示された証明書失効チェックのコストを下げます。
-    \return SSL_SUCCESS  tlsx_usecertificateStatusRequestがエラーなしで実行された場合に返されます。
-    \return MEMORY_E  メモリの割り当てにエラーがある場合に返されます。
-    \return BAD_FUNC_ARG  NULLまたはその他の点では、関数に渡された値が渡される引数がある場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param status_type  tlsx_usecertificateSrequest()に渡され、CertificateStatusRequest構造体に格納されているバイトタイプ。
+    \brief ステープリングはCAに連絡する必要性を排除します。ステープリングは、OCSPで提示される証明書失効チェックのコストを削減します。
+
+    \return SSL_SUCCESS TLSX_UseCertificateStatusRequestがエラーなく実行された場合に返されます。
+    \return MEMORY_E メモリの割り当てにエラーがある場合に返されます。
+    \return BAD_FUNC_ARG 関数に渡された引数がNULLまたは許容できない値である場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param status_type TLSX_UseCertificateStatusRequest()に渡され、CertificateStatusRequest構造体に格納されるバイト型。
+    \param options TLSX_UseCertificateStatusRequest()に渡され、CertificateStatusRequest構造体に格納されるバイト型。
 
     _Example_
     \code
     WOLFSSL* ssl = wolfSSL_new(ctx);
     …
     if (wolfSSL_UseOCSPStapling(ssl, WOLFSSL_CSR2_OCSP,
-    WOLFSSL_CSR2_OCSP_USE_NONCE) != SSL_SUCCESS){
-	    // Failed case.
+        WOLFSSL_CSR2_OCSP_USE_NONCE) != SSL_SUCCESS){
+	    // 失敗ケース
     }
     \endcode
+
     \sa TLSX_UseCertificateStatusRequest
     \sa wolfSSL_CTX_UseOCSPStapling
 */
@@ -8632,28 +10126,32 @@ int wolfSSL_UseOCSPStapling(WOLFSSL* ssl,
                               unsigned char status_type, unsigned char options);
 
 /*!
-    \brief
-    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG  未解決の値がサブルーチンに渡された場合、WOLFSSL_CTX構造体がNULLまたはそうでない場合に返されます。
-    \return MEMORY_E  関数またはサブルーチンがメモリを正しく割り振ることができなかった場合に返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param status_type  tlsx_usecertificateSrequest()に渡され、CertificateStatusRequest構造体に格納されているバイトタイプ。
+    \brief この関数は、ハンドシェイク中に証明書ステータスを要求します。
+
+    \return SSL_SUCCESS 関数とサブルーチンがエラーなく実行された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULLの場合、またはサブルーチンに許可されていない値が渡された場合に返されます。
+    \return MEMORY_E 関数またはサブルーチンがメモリの適切な割り当てに失敗した場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param status_type TLSX_UseCertificateStatusRequest()に渡され、CertificateStatusRequest構造体に格納されるバイト型。
+    \param options TLSX_UseCertificateStatusRequest()に渡され、CertificateStatusRequest構造体に格納されるバイト型。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
     WOLFSSL* ssl = wolfSSL_new(ctx);
-    byte statusRequest = 0; // Initialize status request
+    byte statusRequest = 0; // ステータスリクエストを初期化
     …
     switch(statusRequest){
     	case WOLFSSL_CSR_OCSP:
     		if(wolfSSL_CTX_UseOCSPStapling(ssl->ctx, WOLFSSL_CSR_OCSP,
-    WOLF_CSR_OCSP_USE_NONCE) != SSL_SUCCESS){
-    // UseCertificateStatusRequest failed
+                WOLF_CSR_OCSP_USE_NONCE) != SSL_SUCCESS){
+                // UseCertificateStatusRequestが失敗
     }
-    // Continue switch cases
+    // switchケースを続ける
     \endcode
-    \sa wolfSSL_UseOCSPStaplingV2
+
+    \sa wolfSSL_UseOCSPStapingV2
     \sa wolfSSL_UseOCSPStapling
     \sa TLSX_UseCertificateStatusRequest
 */
@@ -8661,21 +10159,25 @@ int wolfSSL_CTX_UseOCSPStapling(WOLFSSL_CTX* ctx,
                               unsigned char status_type, unsigned char options);
 
 /*!
-    \brief
-    \return SSL_SUCCESS   - 関数とサブルーチンがエラーなしで実行された場合に返されます。
-    \return MEMORY_E   - メモリエラーの割り当てがあった場合に返されます。
-    \return BAD_FUNC_ARG   -  NULLまたはそれ以外の場合は解読されていない引数が関数またはサブルーチンに渡された場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param status_type  OCSPステータスタイプをロードするバイトタイプ。
+    \brief この関数は、OCSPのステータスタイプとオプションを設定します。
+
+    \return SSL_SUCCESS 関数とサブルーチンがエラーなく実行された場合に返されます。
+    \return MEMORY_E メモリ割り当てエラーがあった場合に返されます。
+    \return BAD_FUNC_ARG 関数またはサブルーチンにNULLまたは許容されない引数が渡された場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param status_type OCSPステータスタイプをロードするバイト型。
+    \param options wolfSSL_SNI_SetOptions()とwolfSSL_CTX_SNI_SetOptions()で設定されるOCSPオプションを保持するバイト型。
 
     _Example_
     \code
     WOLFSSL* ssl = wolfSSL_new(ctx);
     ...
     if (wolfSSL_UseOCSPStaplingV2(ssl, WOLFSSL_CSR2_OCSP_MULTI, 0) != SSL_SUCCESS){
-    	// Did not execute properly. Failure case code block.
+    	// 正しく実行されませんでした。失敗ケースのコードブロック
     }
     \endcode
+
     \sa TLSX_UseCertificatStatusRequestV2
     \sa wolfSSL_SNI_SetOptions
     \sa wolfSSL_CTX_SNI_SetOptions
@@ -8684,12 +10186,15 @@ int wolfSSL_UseOCSPStaplingV2(WOLFSSL* ssl,
                               unsigned char status_type, unsigned char options);
 
 /*!
-    \brief  OCSPステイプルのために。
-    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで実行された場合。
-    \return BAD_FUNC_ARG  WOLFSSL_CTX構造がnullの場合、または側数変数がクライアント側ではない場合に返されます。
-    \return MEMORY_E  メモリの割り当てが失敗した場合に返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param status_type  CertificatStatusRequest構造体にあるバイトタイプで、wolfssl_csr2_ocspまたはwolfssl_csr2_ocsp_multiでなければなりません。
+    \brief OCSPステープリング用の証明書ステータス要求を作成して初期化します。
+
+    \return SSL_SUCCESS 関数とサブルーチンがエラーなく実行された場合。
+    \return BAD_FUNC_ARG WOLFSSL_CTX構造体がNULL、またはside変数がクライアント側でない場合に返されます。
+    \return MEMORY_E メモリの割り当てに失敗した場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param status_type CertificatStatusRequest構造体にあるバイト型で、WOLFSSL_CSR2_OCSPまたはWOLFSSL_CSR2_OCSP_MULTIのいずれかである必要があります。
+    \param options CertificateStatusRequestItemV2構造体に保持されるバイト型。
 
     _Example_
     \code
@@ -8698,9 +10203,10 @@ int wolfSSL_UseOCSPStaplingV2(WOLFSSL* ssl,
     byte options;
     ...
     if(wolfSSL_CTX_UseOCSPStaplingV2(ctx, status_type, options); != SSL_SUCCESS){
-    	// Failure case.
+    	// 失敗ケース
     }
     \endcode
+
     \sa TLSX_UseCertificateStatusRequestV2
     \sa wc_RNG_GenerateBlock
     \sa TLSX_Push
@@ -8709,11 +10215,15 @@ int wolfSSL_CTX_UseOCSPStaplingV2(WOLFSSL_CTX* ctx,
                               unsigned char status_type, unsigned char options);
 
 /*!
-    \brief  サポートされている楕円曲線拡張子は、 'SSL'パラメータに渡されたSSLオブジェクトでサポートされています。これは、サポートされているカーブがWolfSSLクライアントによってClientHelloで送信されることを意味します。この機能は複数の曲線を有効にするために複数の時間と呼ぶことができます。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.SSLはNULLです。名前は未知の値です。（下記参照）
-    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
-    \param ssl  wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+    \brief この関数は、'ssl'パラメータで渡されたSSLオブジェクトでSupported Elliptic Curves拡張の使用を有効にするために、クライアント側で呼び出されます。これは、wolfSSLクライアントによってClientHelloで有効化されたサポートされる曲線が送信されることを意味します。この関数は、複数の曲線を有効にするために複数回呼び出すことができます。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 次のいずれかの場合に返されるエラー: sslがNULL、nameが不明な値(下記参照)。
+    \return MEMORY_E メモリが不足している場合に返されるエラー。    \param ssl wolfSSL_new()で作成されたSSLオブジェクトへのポインタ。
+    \param name セッションでサポートされる曲線を示します。利用可能なオプションは以下の通りです: enum { WOLFSSL_ECC_SECP160R1 = 0x10,
+    WOLFSSL_ECC_SECP192R1 = 0x13, WOLFSSL_ECC_SECP224R1 = 0x15,
+    WOLFSSL_ECC_SECP256R1 = 0x17, WOLFSSL_ECC_SECP384R1 = 0x18,
+    WOLFSSL_ECC_SECP521R1 = 0x19 };
 
     _Example_
     \code
@@ -8722,28 +10232,35 @@ int wolfSSL_CTX_UseOCSPStaplingV2(WOLFSSL_CTX* ctx,
     WOLFSSL* ssl = 0;
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-        // context creation failed
+        // コンテキストの作成に失敗しました。
     }
     ssl = wolfSSL_new(ctx);
     if (ssl == NULL) {
-        // ssl creation failed
+        // sslの作成に失敗しました。
     }
     ret = wolfSSL_UseSupportedCurve(ssl, WOLFSSL_ECC_SECP256R1);
     if (ret != 0) {
-        // Elliptic Curve Extension usage failed
+        // 楕円曲線拡張の使用に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_UseSupportedCurve
 */
 int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name);
 
 /*!
-    \brief  サポートされている楕円曲線は、 'ctx'パラメータに渡されたSSLコンテキストから作成されたSSLオブジェクトの拡張子です。これは、サポートされているカーブがWolfSSLクライアントによってClientHelloで送信されることを意味します。この機能は複数の曲線を有効にするために複数の時間と呼ぶことができます。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.CTXはNULL、名前は未知の値です。（下記参照）
-    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
-    \param ctx  wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \brief この関数は、ctxパラメータで渡されたSSLコンテキストから作成されたSSLオブジェクトに対して、サポートされる楕円曲線拡張の使用を有効にするためにクライアント側で呼び出されます。これは、有効にされたサポートされる曲線がwolfSSLクライアントによってClientHelloで送信されることを意味します。この関数は、複数の曲線を有効にするために複数回呼び出すことができます。
+
+    \return SSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG 次のいずれかの場合に返されるエラー: ctxがNULL、nameが不明な値(下記参照)。
+    \return MEMORY_E メモリが不足している場合に返されるエラー。
+
+    \param ctx wolfSSL_CTX_new()で作成されたSSLコンテキストへのポインタ。
+    \param name セッションでサポートされる曲線を示します。利用可能なオプションは以下の通りです: enum { WOLFSSL_ECC_SECP160R1 = 0x10,
+    WOLFSSL_ECC_SECP192R1 = 0x13, WOLFSSL_ECC_SECP224R1 = 0x15,
+    WOLFSSL_ECC_SECP256R1 = 0x17, WOLFSSL_ECC_SECP384R1 = 0x18,
+    WOLFSSL_ECC_SECP521R1 = 0x19 };
 
     _Example_
     \code
@@ -8751,13 +10268,14 @@ int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name);
     WOLFSSL_CTX* ctx = 0;
     ctx = wolfSSL_CTX_new(method);
     if (ctx == NULL) {
-        // context creation failed
+        // コンテキストの作成に失敗しました。
     }
     ret = wolfSSL_CTX_UseSupportedCurve(ctx, WOLFSSL_ECC_SECP256R1);
     if (ret != 0) {
-        // Elliptic Curve Extension usage failed
+        // 楕円曲線拡張の使用に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_UseSupportedCurve
 */
@@ -8766,25 +10284,30 @@ int wolfSSL_CTX_UseSupportedCurve(WOLFSSL_CTX* ctx,
 
 /*!
     \ingroup IO
-    \brief  この関数は、供給されたWOLFSSL構造の安全な再交渉を強制します。これはお勧めできません。
-    \return SSL_SUCCESS  安全な再ネゴシエーションを正常に設定します。
-    \return BAD_FUNC_ARG  sslがNULLの場合、エラーを返します。
-    \return MEMORY_E  安全な再交渉のためにメモリを割り当てることができない場合、エラーを返します。
+
+    \brief この関数は、提供されたWOLFSSL構造体に対して安全な再ネゴシエーションを強制します。これは推奨されません。
+
+    \return SSL_SUCCESS 安全な再ネゴシエーションの設定に成功しました。
+    \return BAD_FUNC_ARG sslがNULLの場合にエラーを返します。
+    \return MEMORY_E 安全な再ネゴシエーション用のメモリを割り当てできない場合にエラーを返します。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
     wolfSSL_Init();
     WOLFSSL_CTX* ctx;
     WOLFSSL* ssl;
-    WOLFSSL_METHOD method = // Some wolfSSL method
+    WOLFSSL_METHOD method = // 何らかのwolfSSLメソッド
     ctx = wolfSSL_CTX_new(method);
     ssl = wolfSSL_new(ctx);
 
     if(wolfSSL_UseSecureRenegotiation(ssl) != SSL_SUCCESS)
     {
-        // Error setting secure renegotiation
+        // 安全な再ネゴシエーションの設定エラー
     }
     \endcode
+
     \sa TLSX_Find
     \sa TLSX_UseSecureRenegotiation
 */
@@ -8792,20 +10315,25 @@ int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  この関数は安全な再交渉ハンドシェイクを実行します。これは、WolfSSLがこの機能を妨げるように強制されます。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG  wolfssl構造がnullまたはそうでなければ、許容できない引数がサブルーチンに渡された場合に返されます。
-    \return SECURE_RENEGOTIATION_E  ハンドシェイクを再ネゴシエーションすることにエラーが発生した場合に返されます。
-    \return SSL_FATAL_ERROR  サーバーまたはクライアント構成にエラーが発生した場合は、再ネゴシエーションが完了できなかった場合に返されます。wolfssl_negotiate()を参照してください。
+
+    \brief この関数は安全な再ネゴシエーションハンドシェイクを実行します。wolfSSLはこの機能を推奨していないため、これはユーザが強制するものです。
+
+    \return SSL_SUCCESS 関数がエラーなく実行された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合、またはサブルーチンで受け入れられない引数が渡された場合に返されます。
+    \return SECURE_RENEGOTIATION_E ハンドシェイクの再ネゴシエーションでエラーがあった場合に返されます。
+    \return SSL_FATAL_ERROR サーバまたはクライアント設定にエラーがあり、再ネゴシエーションを完了できなかった場合に返されます。wolfSSL_negotiate()を参照してください。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
     WOLFSSL* ssl = wolfSSL_new(ctx);
     ...
     if(wolfSSL_Rehandshake(ssl) != SSL_SUCCESS){
-	    // There was an error and the rehandshake is not successful.
+	    // エラーが発生し、再ハンドシェイクは成功しませんでした。
     }
     \endcode
+
     \sa wolfSSL_negotiate
     \sa wc_InitSha512
     \sa wc_InitSha384
@@ -8817,73 +10345,89 @@ int wolfSSL_Rehandshake(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  セッションチケットを使用するようにWolfSSL構造を強制します。定数hous_session_ticketを定義し、定数NO_WOLFSSL_CLIENTをこの関数を使用するように定義しないでください。
-    \return SSL_SUCCESS  セッションチケットを使用したセットに成功しました。
-    \return BAD_FUNC_ARG  sslがNULLの場合に返されます。
-    \return MEMORY_E  セッションチケットを設定するためのメモリの割り当て中にエラーが発生しました。
+
+    \brief 提供されたWOLFSSL構造体にセッションチケットを使用するよう強制します。定数HAVE_SESSION_TICKETが定義されており、定数NO_WOLFSSL_CLIENTが定義されていない必要があります。
+
+    \return SSL_SUCCESS セッションチケットの使用設定に成功しました。
+    \return BAD_FUNC_ARG sslがNULLの場合に返されます。
+    \return MEMORY_E セッションチケット設定のためのメモリ割り当てエラー。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
     wolfSSL_Init();
     WOLFSSL_CTX* ctx;
     WOLFSSL* ssl;
-    WOLFSSL_METHOD method = // Some wolfSSL method
+    WOLFSSL_METHOD method = // 何らかのwolfSSLメソッド
     ctx = wolfSSL_CTX_new(method);
     ssl = wolfSSL_new(ctx);
 
     if(wolfSSL_UseSessionTicket(ssl) != SSL_SUCCESS)
     {
-        // Error setting session ticket
+        // セッションチケットの設定エラー
     }
     \endcode
+
     \sa TLSX_UseSessionTicket
 */
 int wolfSSL_UseSessionTicket(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、セッションチケットを使用するようにWolfSSLコンテキストを設定します。
-    \return SSL_SUCCESS  関数は正常に実行されます。
-    \return BAD_FUNC_ARG  CTXがNULLの場合に返されます。
-    \return MEMORY_E  内部関数内のメモリの割り当て中にエラーが発生しました。
+
+    \brief この関数は、wolfSSLコンテキストにセッションチケットを使用するよう設定します。
+
+    \return SSL_SUCCESS 関数が正常に実行されました。
+    \return BAD_FUNC_ARG ctxがNULLの場合に返されます。
+    \return MEMORY_E 内部関数でメモリ割り当てエラー。
+
+    \param ctx 使用するWOLFSSL_CTX構造体。
 
     _Example_
     \code
     wolfSSL_Init();
     WOLFSSL_CTX* ctx;
-    WOLFSSL_METHOD method = // Some wolfSSL method ;
+    WOLFSSL_METHOD method = // 何らかのwolfSSLメソッド ;
     ctx = wolfSSL_CTX_new(method);
 
     if(wolfSSL_CTX_UseSessionTicket(ctx) != SSL_SUCCESS)
     {
-        // Error setting session ticket
+        // セッションチケットの設定エラー
     }
     \endcode
+
     \sa TLSX_UseSessionTicket
 */
 int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup IO
-    \brief  この機能は、セッション構造のチケットメンバーをバッファにコピーします。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG  引数の1つがNULLの場合、またはbufsz引数が0の場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param buf  メモリバッファを表すバイトポインタ。
+
+    \brief この関数は、Session構造体のticketメンバをバッファにコピーします。bufがNULLでbufSzが非NULLの場合、bufSzはチケット長に設定されます。
+
+    \return SSL_SUCCESS 関数がエラーなく実行された場合に返されます。
+    \return BAD_FUNC_ARG sslまたはbufSzがNULLの場合、またはbufSzが非NULLでbufがNULLの場合に返されます。
+
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param buf メモリバッファを表すbyteポインタ。
+    \param bufSz バッファサイズを表すword32ポインタ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
     WOLFSSL* ssl = wolfSSL_new(ctx);
     byte* buf;
-    word32 bufSz;  // Initialize with buf size
+    word32 bufSz;  // bufサイズで初期化
     …
     if(wolfSSL_get_SessionTicket(ssl, buf, bufSz) <= 0){
-	    // Nothing was written to the buffer
+	    // バッファに何も書き込まれませんでした。
     } else {
-	    // the buffer holds the content from ssl->session->ticket
+	    // バッファはssl->session->ticketの内容を保持しています。
     }
     \endcode
+
     \sa wolfSSL_UseSessionTicket
     \sa wolfSSL_set_SessionTicket
 */
@@ -8891,34 +10435,43 @@ int wolfSSL_get_SessionTicket(WOLFSSL* ssl, unsigned char* buf, word32* bufSz);
 
 /*!
     \ingroup IO
-    \brief  この関数は、WolfSSL構造体内のwolfssl_session構造体のチケットメンバーを設定します。関数に渡されたバッファはメモリにコピーされます。
-    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。関数はエラーなしで返されました。
-    \return BAD_FUNC_ARG  WolfSSL構造がNULLの場合に返されます。BUF引数がNULLの場合は、これはスローされますが、bufsz引数はゼロではありません。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param buf  セッション構造のチケットメンバーにロードされるバイトポインタ。
+
+    \brief この関数は、WOLFSSL構造体内のWOLFSSL_SESSION構造体のticketメンバを設定します。関数に渡されたバッファはメモリにコピーされます。
+
+    \return SSL_SUCCESS 関数の実行が成功した場合に返されます。関数はエラーなく返されました。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合に返されます。bufSz引数がゼロでないのにbuf引数がNULLの場合にも返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param buf セッション構造体のticketメンバに読み込まれるbyteポインタ。
+    \param bufSz バッファのサイズを表すword32型。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
     WOLFSSL* ssl = wolfSSL_new(ctx);
-    byte* buffer; // File to load
+    byte* buffer; // 読み込むファイル
     word32 bufSz;
     ...
     if(wolfSSL_KeepArrays(ssl, buffer, bufSz) != SSL_SUCCESS){
-    	// There was an error loading the buffer to memory.
+    	// バッファをメモリに読み込む際にエラーが発生しました。
     }
     \endcode
+
     \sa wolfSSL_set_SessionTicket_cb
 */
 int wolfSSL_set_SessionTicket(WOLFSSL* ssl, const unsigned char* buf,
                               word32 bufSz);
 
 /*!
-    \brief  CallbackSessionTicketは、int（* callbacksessionTicket）（wolfssl *、const unsigned char *、int、void *）の関数ポインタです。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
-    \return BAD_FUNC_ARG  WolfSSL構造がNULLの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param cb  Type CallbackSessionTicketへの関数ポインタ。
+    \brief この関数は、セッションチケットコールバックを設定します。CallbackSessionTicket型は、次のシグネチャを持つ関数ポインタです:
+    int (*CallbackSessionTicket)(WOLFSSL*, const unsigned char*, int, void*)
+
+    \return SSL_SUCCESS 関数がエラーなく実行された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param cb CallbackSessionTicket型への関数ポインタ。
+    \param ctx WOLFSSL構造体のsession_ticket_ctxメンバへのvoidポインタ。
 
     _Example_
     \code
@@ -8927,9 +10480,10 @@ int wolfSSL_set_SessionTicket(WOLFSSL* ssl, const unsigned char* buf,
     …
     int sessionTicketCB(WOLFSSL* ssl, const unsigned char* ticket, int ticketSz,
 				void* ctx){ … }
-    wolfSSL_set_SessionTicket_cb(ssl, sessionTicketCB, (void*)”initial session”);
+    wolfSSL_set_SessionTicket_cb(ssl, sessionTicketCB, (void*)"initial session");
     \endcode
-    \sa wolfSSL_set_SessionTicket
+
+    \sa wolfSSL_get_SessionTicket
     \sa CallbackSessionTicket
     \sa sessionTicketCB
 */
@@ -8937,15 +10491,15 @@ int wolfSSL_set_SessionTicket_cb(WOLFSSL* ssl,
                                  CallbackSessionTicket cb, void* ctx);
 
 /*!
-    \brief この関数はTLS1.3ハンドシェークが確立したあとでセッションチケットを送信します。
+    \brief この関数は、TLS v1.3ハンドシェイクが確立された後、クライアントにセッションチケットを送信します。
 
-    \return WOLFSSL_SUCCESS セッションチケットが送信された場合に返されます。
-    \return BAD_FUNC_ARG WOLFSSL構造体がNULL,あるいはTLS v1.3を使用しない場合に返されます。
-    \return SIDE_ERROR returned サーバー側でない場合に返されます。
-    \return NOT_READY_ERROR ハンドシェークが完了しない場合に返されます。
-    \return WOLFSSL_FATAL_ERROR メッセージの生成か送信に失敗した際に返されます。
+    \return WOLFSSL_SUCCESS 新しいセッションチケットが送信された場合に返されます。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULL、またはTLS v1.3を使用していない場合に返されます。
+    \return SIDE_ERROR サーバでない場合に返されます。
+    \return NOT_READY_ERROR ハンドシェイクが完了していない場合に返されます。
+    \return WOLFSSL_FATAL_ERROR メッセージの作成または送信に失敗した場合に返されます。
 
-    \param ssl wolfSSL_new()を使って生成されたWOLFSSL構造体へのポインタ。
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -8955,7 +10509,7 @@ int wolfSSL_set_SessionTicket_cb(WOLFSSL* ssl,
     …
     ret = wolfSSL_send_SessionTicket(ssl);
     if (ret != WOLFSSL_SUCCESS) {
-        // New session ticket not sent.
+        // 新しいセッションチケットが送信されませんでした。
     }
     \endcode
 
@@ -8966,25 +10520,29 @@ int wolfSSL_set_SessionTicket_cb(WOLFSSL* ssl,
 int wolfSSL_send_SessionTicket(WOLFSSL* ssl);
 
 /*!
-    \brief  RFC 5077で指定されているセッションチケットをサポートするためのサーバーが。
-    \return SSL_SUCCESS  セッションを正常に設定すると返されます。
-    \return BAD_FUNC_ARG  失敗した場合に返されます。これは、無効な引数を関数に渡すことによって発生します。
-    \param ctx  wolfSSL_CTX_new()で作成されたWOLFSSL_CTXオブジェクトへのポインタ。
-    \param cb  セッションチケットを暗号化/復号化するためのユーザーコールバック関数
-    \param ssl(Callback)  wolfSSL_new()で作成されたWolfSSLオブジェクトへのポインタ
-    \param key_name(Callback)  このチケットコンテキストの一意のキー名はランダムに生成されるべきです
-    \param iv(Callback)  ユニークなIVこのチケットの場合、最大128ビット、ランダムに生成されるべきです
-    \param mac(Callback)  このチケットの最大256ビットMAC
-    \param enc(Callback)  この暗号化パラメータがtrueの場合、ユーザーはキーコード、IV、Macを記入し、チケットを長さのインレルの範囲内に暗号化し、結果として生じる出力長を* outreenに設定する必要があります。 wolfssl_ticket_ret_okを返す暗号化が成功したことをWolfSSLに指示します。この暗号化パラメータがfalseの場合、key_name、iv、およびmacを使用して、リングインレーンの範囲内のチケットの復号化を実行する必要があります。結果の復号長は* outreenに設定する必要があります。 wolfssl_ticket_ret_okを返すと、復号化されたチケットの使用を続行するようにWolfSSLに指示します。 wolfssl_ticket_ret_createを返すと、復号化されたチケットを使用するだけでなく、クライアントに送信するための新しいものを生成するように指示し、最近ロールされている場合に役立つ、フルハンドシェイクを強制したくない。 wolfssl_ticket_ret_rejectを返すと、WolfSSLにこのチケットを拒否し、フルハンドシェイクを実行し、通常のセッション再開のための新しい標準セッションIDを作成します。 wolfssl_ticket_ret_fatalを返すと、致命的なエラーで接続の試みを終了するようにWolfSSLに指示します。
-    \param ticket(Callback)  暗号化チケットの入出力バッファ。ENCパラメータを参照してください
-    \param inLen(Callback)  チケットパラメータの入力長
-    \param outLen(Callback)  チケットパラメータの結果の出力長。コールバックoutlenを入力すると、チケットバッファで使用可能な最大サイズが表示されます。
+    \brief この関数は、RFC 5077で規定されているセッションチケットをサポートするサーバのセッションチケット鍵暗号化コールバック関数を設定します。
+
+    \return SSL_SUCCESS セッションの設定に成功した場合に返されます。
+    \return BAD_FUNC_ARG 失敗時に返されます。これは、関数に無効な引数が渡された場合に発生します。
+
+    \param ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTXオブジェクトへのポインタ。
+    \param cb セッションチケットを暗号化/復号するユーザコールバック関数
+    \param ssl(Callback) wolfSSL_new()で作成されたWOLFSSLオブジェクトへのポインタ
+    \param key_name(Callback) このチケットコンテキスト用の一意の鍵名、ランダムに生成されるべきです
+    \param iv(Callback) このチケット用の一意のIV、最大128ビット、ランダムに生成されるべきです
+    \param mac(Callback) このチケット用の最大256ビットのmac
+    \param enc(Callback) この暗号化パラメータがtrueの場合、ユーザはkey_name、iv、macを入力し、長さinLenのチケットをインプレースで暗号化し、結果の出力長を*outLenに設定する必要があります。WOLFSSL_TICKET_RET_OKを返すことで、wolfSSLに暗号化が成功したことを伝えます。この暗号化パラメータがfalseの場合、ユーザはkey_name、iv、macを使用して長さinLenのチケットのインプレース復号を実行する必要があります。結果の復号長は*outLenに設定する必要があります。WOLFSSL_TICKET_RET_OKを返すことで、wolfSSLに復号されたチケットを使用して続行するよう伝えます。WOLFSSL_TICKET_RET_CREATEを返すことで、wolfSSLに復号されたチケットを使用するが、クライアントに送信する新しいチケットも生成するよう伝えます。これは最近鍵をロールした場合に完全なハンドシェイクを強制したくない場合に役立ちます。WOLFSSL_TICKET_RET_REJECTを返すことで、wolfSSLにこのチケットを拒否し、完全なハンドシェイクを実行し、通常のセッション再開用の新しい標準セッションIDを作成するよう伝えます。WOLFSSL_TICKET_RET_FATALを返すことで、wolfSSLに致命的エラーで接続試行を終了するよう伝えます。
+    \param ticket(Callback) 暗号化されたチケットの入出力バッファ。encパラメータを参照してください。
+    \param inLen(Callback) ticketパラメータの入力長。
+    \param outLen(Callback) ticketパラメータの結果出力長。コールバックに入るとき、outLenはticketバッファで利用可能な最大サイズを示します。
+    \param userCtx(Callback) wolfSSL_CTX_set_TicketEncCtx()で設定されたユーザコンテキスト
 
     _Example_
     \code
-    See wolfssl/test.h myTicketEncCb() used by the example
-    server and example echoserver.
+    wolfssl/test.hのmyTicketEncCb()を参照してください。
+    サンプルサーバとサンプルechoserverで使用されています。
     \endcode
+
     \sa wolfSSL_CTX_set_TicketHint
     \sa wolfSSL_CTX_set_TicketEncCtx
 */
@@ -8992,52 +10550,66 @@ int wolfSSL_CTX_set_TicketEncCb(WOLFSSL_CTX* ctx,
                                             SessionTicketEncCb);
 
 /*!
-    \brief  サーバーサイドの使用のために。
-    \return SSL_SUCCESS  セッションを正常に設定すると返されます。
-    \return BAD_FUNC_ARG  失敗した場合に返されます。これは、無効な引数を関数に渡すことによって発生します。
-    \param ctx  wolfSSL_CTX_new()で作成されたWOLFSSL_CTXオブジェクトへのポインタ。
+    \brief この関数は、クライアントに中継されるセッションチケットヒントを設定します。サーバ側での使用。
+
+    \return SSL_SUCCESS セッションの設定に成功した場合に返されます。
+    \return BAD_FUNC_ARG 失敗時に返されます。これは、関数に無効な引数が渡された場合に発生します。
+
+    \param ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTXオブジェクトへのポインタ。
+    \param hint チケットが有効である可能性がある秒数。クライアントへのヒント。
 
     _Example_
     \code
     none
     \endcode
-    \sa wolfSSL_CTX_set_TicketEncCb
-*/
+
+    \sa wolfSSL_CTX_set_TicketEncCb*/
 int wolfSSL_CTX_set_TicketHint(WOLFSSL_CTX* ctx, int);
 
 /*!
-    \brief  折り返し電話。サーバーサイドの使用のために。
-    \return SSL_SUCCESS  セッションを正常に設定すると返されます。
-    \return BAD_FUNC_ARG  失敗した場合に返されます。これは、無効な引数を関数に渡すことによって発生します。
-    \param ctx  wolfSSL_CTX_new()で作成されたWOLFSSL_CTXオブジェクトへのポインタ。
+    \brief この関数は、コールバック用のセッションチケット暗号化ユーザコンテキストを設定します。サーバ側で使用します。
+
+    \return SSL_SUCCESS セッションの設定に成功した場合に返されます。
+    \return BAD_FUNC_ARG 失敗時に返されます。これは関数に無効な引数が渡されたことが原因です。
+
+    \param ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTXオブジェクトへのポインタ。
+    \param userCtx コールバック用のユーザコンテキスト。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_set_TicketEncCb
 */
 int wolfSSL_CTX_set_TicketEncCtx(WOLFSSL_CTX* ctx, void*);
 
 /*!
-    \brief  折り返し電話。サーバーサイドの使用のために。
-    \return userCtx  セッションを正常に取得すると返されます。
-    \return NULL  失敗した場合に返されます。これは、無効な引数を関数に渡すことによって、またはユーザーコンテキストが設定されていないときに発生します。
+    \brief この関数は、コールバック用のセッションチケット暗号化ユーザコンテキストを取得します。サーバ側で使用します。
+
+    \return userCtx セッションの取得に成功した場合に返されます。
+    \return NULL 失敗時に返されます。これは関数に無効な引数が渡された場合、またはユーザコンテキストが設定されていない場合に発生します。
+
+    \param ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTXオブジェクトへのポインタ。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_CTX_set_TicketEncCtx
 */
 void* wolfSSL_CTX_get_TicketEncCtx(WOLFSSL_CTX* ctx);
 
 /*!
-    \brief  この機能には、WolfSSL構造のHSDonectxメンバーが設定されています。
-    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。WolfSSL構造体のHSDONECBとHSDonectxメンバーが設定されています。
-    \return BAD_FUNC_ARG  wolfssl構造体がNULLの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
-    \param cb  int（* HandshakedOneCB）（wolfssl *、void *）の署名を持つタイプHandshakedOneCBの関数ポインタ。
+    \brief この関数は、ハンドシェイク完了コールバックを設定します。WOLFSSL構造体のhsDoneCbとhsDoneCtxメンバがこの関数で設定されます。
+
+    \return SSL_SUCCESS 関数がエラーなしで実行された場合に返されます。WOLFSSL構造体のhsDoneCbとhsDoneCtxメンバが設定されます。
+    \return BAD_FUNC_ARG WOLFSSL構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param cb HandShakeDoneCb型の関数ポインタで、次の形式のシグネチャを持ちます: int (*HandShakeDoneCb)(WOLFSSL*, void*);
+    \param user_ctx ユーザ登録コンテキストへのvoidポインタ。
 
     _Example_
     \code
@@ -9045,53 +10617,64 @@ void* wolfSSL_CTX_get_TicketEncCtx(WOLFSSL_CTX* ctx);
     WOLFSSL* ssl = wolfSSL_new(ctx);
     …
     int myHsDoneCb(WOLFSSL* ssl, void* user_ctx){
-        // callback function
+        // コールバック関数
     }
     …
     wolfSSL_SetHsDoneCb(ssl, myHsDoneCb, NULL);
     \endcode
+
     \sa HandShakeDoneCb
 */
 int wolfSSL_SetHsDoneCb(WOLFSSL* ssl, HandShakeDoneCb cb, void* user_ctx);
 
 /*!
     \ingroup IO
-    \brief  この関数はセッションから統計を印刷します。
-    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで戻った場合に返されます。セッション統計は正常に取得され印刷されました。
-    \return BAD_FUNC_ARG  サブルーチンwolfssl_get_session_stats()が許容できない引数に渡された場合に返されます。
-    \return BAD_MUTEX_E  サブルーチンにミューテックスエラーがあった場合に返されます。
+
+    \brief この関数は、セッションの統計情報を出力します。
+
+    \return SSL_SUCCESS 関数とサブルーチンがエラーなしで返された場合に返されます。セッション統計が正常に取得され、出力されました。
+    \return BAD_FUNC_ARG サブルーチンwolfSSL_get_session_stats()に許容できない引数が渡された場合に返されます。
+    \return BAD_MUTEX_E サブルーチンでmutexエラーが発生した場合に返されます。
+
+    \param none パラメータなし。
 
     _Example_
     \code
-    // You will need to have a session object to retrieve stats from.
-    if(wolfSSL_PrintSessionStats(void) != SSL_SUCCESS	){
-        // Did not print session stats
+    // 統計を取得するためのセッションオブジェクトが必要です
+    if(wolfSSL_PrintSessionStats(void) != SSL_SUCCESS){
+        // セッション統計を出力しませんでした
     }
 
     \endcode
+
     \sa wolfSSL_get_session_stats
 */
 int wolfSSL_PrintSessionStats(void);
 
 /*!
     \ingroup IO
-    \brief  この関数はセッションの統計を取得します。
-    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで戻った場合に返されます。セッション統計は正常に取得され印刷されました。
-    \return BAD_FUNC_ARG  サブルーチンwolfssl_get_session_stats()が許容できない引数に渡された場合に返されます。
-    \return BAD_MUTEX_E  サブルーチンにミューテックスエラーがあった場合に返されます。
-    \param active  現在のセッションの合計を表すWord32ポインタ。
-    \param total  総セッションを表すWord32ポインタ。
-    \param peak  ピークセッションを表すWord32ポインタ。
+
+    \brief この関数は、セッションの統計情報を取得します。
+
+    \return SSL_SUCCESS 関数とサブルーチンがエラーなしで返された場合に返されます。セッション統計が正常に取得され、出力されました。
+    \return BAD_FUNC_ARG サブルーチンwolfSSL_get_session_stats()に許容できない引数が渡された場合に返されます。
+    \return BAD_MUTEX_E サブルーチンでmutexエラーが発生した場合に返されます。
+
+    \param active 総現在セッション数を表すword32ポインタ。
+    \param total 総セッション数を表すword32ポインタ。
+    \param peak ピークセッション数を表すword32ポインタ。
+    \param maxSessions 最大セッション数を表すword32ポインタ。
 
     _Example_
     \code
     int wolfSSL_PrintSessionStats(void){
     …
     ret = wolfSSL_get_session_stats(&totalSessionsNow,
-    &totalSessionsSeen, &peak, &maxSessions);
+        &totalSessionsSeen, &peak, &maxSessions);
     …
     return ret;
     \endcode
+
     \sa wolfSSL_PrintSessionStats
 */
 int wolfSSL_get_session_stats(unsigned int* active,
@@ -9101,36 +10684,39 @@ int wolfSSL_get_session_stats(unsigned int* active,
 
 /*!
     \ingroup TLS
-    \brief  この関数はCRとSRの値をコピーしてからWC_PRF（疑似ランダム関数）に渡し、その値を返します。
-    \return 0  成功した
-    \return BUFFER_E  バッファのサイズにエラーが発生した場合に返されます。
-    \return MEMORY_E  サブルーチンが動的メモリを割り当てることができなかった場合に返されます。
-    \param ms  マスターシークレットはアレイ構造に保持されています。
-    \param msLen  マスターシークレットの長さ。
-    \param pms  マスター前の秘密はアレイ構造に保持されています。
-    \param pmsLen  マスタープレマスターシークレットの長さ。
-    \param cr  クライアントのランダム
-    \param sr  サーバーのランダムです。
-    \param tls1_2  バージョンが少なくともTLSバージョン1.2であることを意味します。
+
+    \brief この関数は、crとsrの値をコピーし、wc_PRF(疑似乱数関数)に渡し、その値を返します。
+
+    \return 0 成功時。
+    \return BUFFER_E バッファのサイズでエラーが発生する場合に返されます。
+    \return MEMORY_E サブルーチンが動的メモリの割り当てに失敗した場合に返されます。
+
+    \param ms Arrays構造体に保持されているマスターシークレット。
+    \param msLen マスターシークレットの長さ。
+    \param pms Arrays構造体に保持されているプリマスターシークレット。
+    \param pmsLen プリマスターシークレットの長さ。
+    \param cr クライアントランダム。
+    \param sr サーバランダム。
+    \param tls1_2 バージョンが少なくともTLSバージョン1.2であることを示します。
+    \param hash_type ハッシュタイプを示します。
 
     _Example_
     \code
     WOLFSSL* ssl;
 
-    called in MakeTlsMasterSecret and retrieves the necessary
-    information as follows:
+    MakeTlsMasterSecretで呼び出され、以下のように必要な情報を取得します:
 
     int MakeTlsMasterSecret(WOLFSSL* ssl){
-	int ret;
-	ret = wolfSSL_makeTlsMasterSecret(ssl->arrays->masterSecret, SECRET_LEN,
-    ssl->arrays->preMasterSecret, ssl->arrays->preMasterSz,
-    ssl->arrays->clientRandom, ssl->arrays->serverRandom,
-    IsAtLeastTLSv1_2(ssl), ssl->specs.mac_algorithm);
-    …
-    return ret;
-
+        int ret;
+        ret = wolfSSL_makeTlsMasterSecret(ssl->arrays->masterSecret, SECRET_LEN,
+            ssl->arrays->preMasterSecret, ssl->arrays->preMasterSz,
+            ssl->arrays->clientRandom, ssl->arrays->serverRandom,
+            IsAtLeastTLSv1_2(ssl), ssl->specs.mac_algorithm);
+        …
+        return ret;
     }
     \endcode
+
     \sa wc_PRF
     \sa MakeTlsMasterSecret
 */
@@ -9142,29 +10728,34 @@ int wolfSSL_MakeTlsMasterSecret(unsigned char* ms, word32 msLen,
 
 /*!
     \ingroup CertsKeys
-    \brief  TLSキーを導き出すための外部のラッパー。
-    \return 0  成功に戻りました。
-    \return BUFFER_E  LABLENとSEADLENの合計（合計サイズを計算）が最大サイズを超えると返されます。
-    \return MEMORY_E  メモリの割り当てが失敗した場合に返されます。
-    \param key_data  DeriveTlSkeysに割り当てられ、最終ハッシュを保持するためにWC_PRFに渡されたバイトポインタ。
-    \param keyLen  WOLFSSL構造体のスペックメンバーからのDerivetlskeysで派生したWord32タイプ。
-    \param ms  WolfSSL構造内でアレイ構造に保持されているマスターシークレットを保持する定数ポインタ型。
-    \param msLen  列挙された定義で、マスターシークレットの長さを保持するWord32タイプ。
-    \param sr  WOLFSSL構造内の配列構造のServerRandomメンバーへの定数バイトポインタ。
-    \param cr  WolfSSL構造内の配列構造のClientRandomメンバーへの定数バイトポインタ。
-    \param tls1_2  ISATLEASTLSV1_2()から返された整数型。
+
+    \brief TLS鍵を導出するための外部向けラッパー。
+
+    \return 0 成功時に返されます。
+    \return BUFFER_E labLenとseedLenの合計(合計サイズを計算)が最大サイズを超えた場合に返されます。
+    \return MEMORY_E メモリの割り当てに失敗した場合に返されます。
+
+    \param key_data DeriveTlsKeysで割り当てられ、最終ハッシュを保持するためにwc_PRFに渡されるバイトポインタ。
+    \param keyLen DeriveTlsKeysでWOLFSSL構造体のspecsメンバから導出されるword32型。
+    \param ms WOLFSSL構造体内のarrays構造体に保持されているマスターシークレットを保持する定数ポインタ型。
+    \param msLen 列挙定義SECRET_LENでマスターシークレットの長さを保持するword32型。
+    \param sr WOLFSSL構造体内のarrays構造体のserverRandomメンバへの定数バイトポインタ。
+    \param cr WOLFSSL構造体内のarrays構造体のclientRandomメンバへの定数バイトポインタ。
+    \param tls1_2 IsAtLeastTLSv1_2()から返される整数型。
+    \param hash_type WOLFSSL構造体に保持されている整数型。
 
     _Example_
     \code
     int DeriveTlsKeys(WOLFSSL* ssl){
-    int ret;
-    …
-    ret = wolfSSL_DeriveTlsKeys(key_data, length, ssl->arrays->masterSecret,
-    SECRET_LEN, ssl->arrays->clientRandom,
-    IsAtLeastTLSv1_2(ssl), ssl->specs.mac_algorithm);
-    …
+        int ret;
+        …
+        ret = wolfSSL_DeriveTlsKeys(key_data, length, ssl->arrays->masterSecret,
+            SECRET_LEN, ssl->arrays->clientRandom,
+            IsAtLeastTLSv1_2(ssl), ssl->specs.mac_algorithm);
+        …
     }
     \endcode
+
     \sa wc_PRF
     \sa DeriveTlsKeys
     \sa IsAtLeastTLSv1_2
@@ -9176,34 +10767,42 @@ int wolfSSL_DeriveTlsKeys(unsigned char* key_data, word32 keyLen,
                                int tls1_2, int hash_type);
 
 /*!
-    \brief  ハンドシェイクコールバックが設定されます。これは、デバッガが利用できず、スニッフィングが実用的ではない場合に、サポートをデバッグするための組み込みシステムで役立ちます。ハンドシェイクエラーが発生したか否かが呼び出されます。SSLパケットの最大数が既知であるため、動的メモリは使用されません。パケット名をPacketNames []でアクセスできます。接続拡張機能は、タイムアウト値とともにタイムアウトコールバックを設定することもできます。これは、ユーザーがTCPスタックをタイムアウトするのを待ったくない場合に便利です。この拡張子は、コールバックのどちらか、またはどちらのコールバックも呼び出されません。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return GETTIME_ERROR  gettimeofday()がエラーを検出した場合、返されます。
-    \return SETITIMER_ERROR  setItimer()がエラーを検出した場合、返されます。
-    \return SIGACT_ERROR  sigAction()がエラーを検出した場合、返されます。
-    \return SSL_FATAL_ERROR  基になるssl_connect()呼び出しがエラーを検出した場合に返されます。
+    \brief wolfSSL_connect_ex()は、HandShakeコールバックを設定できる拡張です。これは、デバッガが利用できず、スニッフィングが実用的でない場合に、組み込みシステムのデバッグサポートに役立ちます。HandShakeコールバックは、ハンドシェイクエラーが発生したかどうかに関わらず呼び出されます。SSLパケットの最大数が既知であるため、動的メモリは使用されません。パケット名はpacketNames[]を通じてアクセスできます。接続拡張はまた、タイムアウト値と共にTimeoutコールバックを設定できます。これは、ユーザがTCPスタックのタイムアウトを待ちたくない場合に便利です。この拡張は、いずれか、両方、またはどちらのコールバックもなしで呼び出すことができます。
+
+    \return SSL_SUCCESS 成功時。
+    \return GETTIME_ERROR gettimeofday()がエラーに遭遇した場合に返されます。
+    \return SETITIMER_ERROR setitimer()がエラーに遭遇した場合に返されます。
+    \return SIGACT_ERROR sigaction()がエラーに遭遇した場合に返されます。
+    \return SSL_FATAL_ERROR 基礎となるSSL_connect()呼び出しがエラーに遭遇した場合に返されます。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_accept_ex
 */
 int wolfSSL_connect_ex(WOLFSSL* ssl, HandShakeCallBack hsCb,
                        TimeoutCallBack toCb, WOLFSSL_TIMEVAL timeout);
 
 /*!
-    \brief  設定する。これは、デバッガが利用できず、スニッフィングが実用的ではない場合に、サポートをデバッグするための組み込みシステムで役立ちます。ハンドシェイクエラーが発生したか否かが呼び出されます。SSLパケットの最大数が既知であるため、動的メモリは使用されません。パケット名をPacketNames []でアクセスできます。接続拡張機能は、タイムアウト値とともにタイムアウトコールバックを設定することもできます。これは、ユーザーがTCPスタックをタイムアウトするのを待ったくない場合に便利です。この拡張子は、コールバックのどちらか、またはどちらのコールバックも呼び出されません。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return GETTIME_ERROR  gettimeofday()がエラーを検出した場合、返されます。
-    \return SETITIMER_ERROR  setItimer()がエラーを検出した場合、返されます。
-    \return SIGACT_ERROR  sigAction()がエラーを検出した場合、返されます。
-    \return SSL_FATAL_ERROR  基礎となるssl_accept()呼び出しがエラーを検出した場合に返されます。
+    \brief wolfSSL_accept_ex()は、HandShakeコールバックを設定できる拡張です。これは、デバッガが利用できず、スニッフィングが実用的でない場合に、組み込みシステムのデバッグサポートに役立ちます。HandShakeコールバックは、ハンドシェイクエラーが発生したかどうかに関わらず呼び出されます。SSLパケットの最大数が既知であるため、動的メモリは使用されません。パケット名はpacketNames[]を通じてアクセスできます。接続拡張はまた、タイムアウト値と共にTimeoutコールバックを設定できます。これは、ユーザがTCPスタックのタイムアウトを待ちたくない場合に便利です。この拡張は、いずれか、両方、またはどちらのコールバックもなしで呼び出すことができます。
+
+    \return SSL_SUCCESS 成功時。
+    \return GETTIME_ERROR gettimeofday()がエラーに遭遇した場合に返されます。
+    \return SETITIMER_ERROR setitimer()がエラーに遭遇した場合に返されます。
+    \return SIGACT_ERROR sigaction()がエラーに遭遇した場合に返されます。
+    \return SSL_FATAL_ERROR 基礎となるSSL_accept()呼び出しがエラーに遭遇した場合に返されます。
+
+    \param none パラメータなし。
 
     _Example_
     \code
     none
     \endcode
+
     \sa wolfSSL_connect_ex
 */
 int wolfSSL_accept_ex(WOLFSSL* ssl, HandShakeCallBacki hsCb,
@@ -9211,11 +10810,15 @@ int wolfSSL_accept_ex(WOLFSSL* ssl, HandShakeCallBacki hsCb,
 
 /*!
     \ingroup IO
-    \brief  これはBIOの内部ファイルポインタを設定するために使用されます。
-    \return SSL_SUCCESS  ファイルポインタを正常に設定します。
-    \return SSL_FAILURE  エラーケースに遭遇した場合
-    \param bio  ペアを設定するためのWOLFSSL_BIO構造体。
-    \param fp  バイオで設定するファイルポインタ。
+
+    \brief これは、BIOの内部ファイルポインタを設定するために使用されます。
+
+    \return SSL_SUCCESS ファイルポインタの設定に成功した場合。
+    \return SSL_FAILURE エラーケースが発生した場合。
+
+    \param bio ペアを設定するWOLFSSL_BIO構造体。
+    \param fp bioに設定するファイルポインタ。
+    \param c ファイルクローズ動作フラグ。
 
     _Example_
     \code
@@ -9224,8 +10827,9 @@ int wolfSSL_accept_ex(WOLFSSL* ssl, HandShakeCallBacki hsCb,
     int ret;
     bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
     ret  = wolfSSL_BIO_set_fp(bio, fp, BIO_CLOSE);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_mem
     \sa wolfSSL_BIO_get_fp
@@ -9235,10 +10839,14 @@ long wolfSSL_BIO_set_fp(WOLFSSL_BIO *bio, XFILE fp, int c);
 
 /*!
     \ingroup IO
-\brief  この関数は、    \brief  これは、BIOの内部ファイルポインタを取得するために使用されます。
-    \return SSL_SUCCESS  ファイルポインタを正常に取得します。
-    \return SSL_FAILURE  エラーケースに遭遇した場合
-    \param bio  ペアを設定するためのWOLFSSL_BIO構造体。
+
+    \brief これは、BIOの内部ファイルポインタを取得するために使用されます。
+
+    \return SSL_SUCCESS ファイルポインタの取得に成功した場合。
+    \return SSL_FAILURE エラーケースが発生した場合。
+
+    \param bio ペアを設定するWOLFSSL_BIO構造体。
+    \param fp bioに設定するファイルポインタ。
 
     _Example_
     \code
@@ -9247,8 +10855,9 @@ long wolfSSL_BIO_set_fp(WOLFSSL_BIO *bio, XFILE fp, int c);
     int ret;
     bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
     ret  = wolfSSL_BIO_get_fp(bio, &fp);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_mem
     \sa wolfSSL_BIO_set_fp
@@ -9258,19 +10867,24 @@ long wolfSSL_BIO_get_fp(WOLFSSL_BIO *bio, XFILE* fp);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、秘密鍵が使用されている証明書との一致であることを確認します。
-    \return SSL_SUCCESS  うまく一致します。
-    \return SSL_FAILURE  エラーケースに遭遇した場合
-    \return <0  ssl_failure以外のすべてのエラーケースは負の値です。
+
+    \brief この関数は、秘密鍵が使用されている証明書と一致していることを確認します。
+
+    \return SSL_SUCCESS 一致に成功した場合。
+    \return SSL_FAILURE エラーケースが発生した場合。
+    \return <0 SSL_FAILURE以外のすべてのエラーケースは負の値です。
+
+    \param ssl 確認するWOLFSSL構造体。
 
     _Example_
     \code
     WOLFSSL* ssl;
     int ret;
-    // create and set up ssl
+    // sslを作成してセットアップ
     ret  = wolfSSL_check_private_key(ssl);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -9278,11 +10892,16 @@ int wolfSSL_check_private_key(const WOLFSSL* ssl);
 
 /*!
     \ingroup CertsKeys
-    \brief  この機能は、渡されたNID値に一致する拡張索引を探して返します。
-    \return >=  0拡張インデックスが成功した場合に返されます。
-    \return -1  拡張が見つからないかエラーが発生した場合
-    \param x509  拡張のために解析する証明書。
-    \param nid  見つかる拡張OID。
+
+    \brief この関数は、渡されたNID値に一致する拡張インデックスを検索して返します。
+
+    \return ＞= 0 成功時、拡張インデックスが返されます。
+    \return -1 拡張が見つからない場合、またはエラーが発生した場合。
+
+    \param x509 拡張を検索するために解析する証明書。
+    \param nid 見つける拡張OID。
+    \param lastPos lastPos以降の拡張から検索を開始します。
+                   最初は-1に設定します。
 
     _Example_
     \code
@@ -9291,19 +10910,22 @@ int wolfSSL_check_private_key(const WOLFSSL* ssl);
     int idx;
 
     idx = wolfSSL_X509_get_ext_by_NID(x509, NID_basic_constraints, lastPos);
-    \endcode
-*/
+    \endcode*/
 int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509,
                                              int nid, int lastPos);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、渡されたNID値に合った拡張子を探して返します。
-    \return pointer  STACK_OF（wolfssl_asn1_object）ポインタが成功した場合に返されます。
-    \return NULL  拡張が見つからないかエラーが発生した場合
-    \param x509  拡張のために解析する証明書。
-    \param nid  見つかる拡張OID。
-    \param c  not nullが複数の拡張子に-2に設定されていない場合は-1が見つかりませんでした。
+
+    \brief この関数は渡されたNID値に一致する拡張を検索して返します。
+
+    \return pointer 成功した場合、STACK_OF(WOLFSSL_ASN1_OBJECT)ポインタが返されます。
+    \return NULL 拡張が見つからない、またはエラーが発生した場合。
+
+    \param x509 拡張を解析する証明書。
+    \param nid 検索する拡張OID。
+    \param c NULLでない場合、複数の拡張が見つかった場合は-2、見つからなかった場合は-1、見つかってクリティカルでない場合は0、見つかってクリティカルな場合は1に設定されます。
+    \param idx NULLの場合は最初に一致した拡張を返します。それ以外の場合、x509に格納されていなければidxから開始します。
 
     _Example_
     \code
@@ -9313,8 +10935,9 @@ int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509,
     STACK_OF(WOLFSSL_ASN1_OBJECT)* sk;
 
     sk = wolfSSL_X509_get_ext_d2i(x509, NID_basic_constraints, &c, &idx);
-    //check sk for NULL and then use it. sk needs freed after done.
+    // skがNULLでないか確認してから使用。使用後はskを解放する必要があります
     \endcode
+
     \sa wolfSSL_sk_ASN1_OBJECT_free
 */
 void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509,
@@ -9322,12 +10945,16 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はDER証明書のハッシュを返します。
-    \return SSL_SUCCESS  ハッシュの作成に成功しました。
-    \return SSL_FAILURE  不良入力または失敗したハッシュに戻りました。
-    \param x509  ハッシュを得るための証明書。
-    \param digest  使用するハッシュアルゴリズム
-    \param buf  ハッシュを保持するためのバッファ。
+
+    \brief この関数はDER証明書のハッシュを返します。
+
+    \return SSL_SUCCESS ハッシュの作成に成功した場合。
+    \return SSL_FAILURE 不正な入力またはハッシュ失敗時に返されます。
+
+    \param x509 ハッシュを取得する証明書。
+    \param digest 使用するハッシュアルゴリズム。
+    \param buf ハッシュを保持するバッファ。
+    \param len バッファの長さ。
 
     _Example_
     \code
@@ -9337,8 +10964,9 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509,
     int ret;
 
     ret = wolfSSL_X509_digest(x509, wolfSSL_EVP_sha256(), buffer, &bufferSz);
-    //check ret value
+    // ret値を確認
     \endcode
+
     \sa none
 */
 int wolfSSL_X509_digest(const WOLFSSL_X509* x509,
@@ -9346,19 +10974,24 @@ int wolfSSL_X509_digest(const WOLFSSL_X509* x509,
 
 /*!
     \ingroup Setup
-    \brief  ハンドシェイク中に使用するために、WolfSSL構造の証明書を設定するために使用されます。
-    \return SSL_SUCCESS  設定の成功した引数について。
-    \return SSL_FAILURE  NULL引数が渡された場合。
-    \param ssl  証明書を設定するためのWolfSSL構造。
+
+    \brief ハンドシェイク中に使用するWOLFSSL構造体の証明書を設定するために使用されます。
+
+    \return SSL_SUCCESS 引数の設定に成功した場合。
+    \return SSL_FAILURE NULL引数が渡された場合。
+
+    \param ssl 証明書を設定するWOLFSSL構造体。
+    \param x509 使用する証明書。
 
     _Example_
     \code WOLFSSL* ssl;
     WOLFSSL_X509* x509
     int ret;
-    // create ssl object and x509
+    // sslオブジェクトとx509を作成
     ret  = wolfSSL_use_certificate(ssl, x509);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -9366,11 +10999,15 @@ int wolfSSL_use_certificate(WOLFSSL* ssl, WOLFSSL_X509* x509);
 
 /*!
     \ingroup Setup
-    \biiこfは、この関数は、handshakeの間に使用するためにWolfSSL構造の証明書を設定するために使用されます。DERフォーマットバッファが予想されます。
-    \return SSL_SUCCESS  設定の成功した引数について。
-    \return SSL_FAILURE  NULL引数が渡された場合。
-    \param ssl  証明書を設定するためのWolfSSL構造。
-    \param der  使用する証明書。
+
+    \brief ハンドシェイク中に使用するWOLFSSL構造体の証明書を設定するために使用されます。DER形式のバッファが必要です。
+
+    \return SSL_SUCCESS 引数の設定に成功した場合。
+    \return SSL_FAILURE NULL引数が渡された場合。
+
+    \param ssl 証明書を設定するWOLFSSL構造体。
+    \param der 使用するDER証明書。
+    \param derSz 渡されたDERバッファのサイズ。
 
     _Example_
     \code
@@ -9378,10 +11015,11 @@ int wolfSSL_use_certificate(WOLFSSL* ssl, WOLFSSL_X509* x509);
     unsigned char* der;
     int derSz;
     int ret;
-    // create ssl object and set DER variables
+    // sslオブジェクトを作成してDER変数を設定
     ret  = wolfSSL_use_certificate_ASN1(ssl, der, derSz);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -9390,20 +11028,25 @@ int wolfSSL_use_certificate_ASN1(WOLFSSL* ssl, unsigned char* der,
 
 /*!
     \ingroup CertsKeys
-    \brief  これはWolfSSL構造の秘密鍵を設定するために使用されます。
-    \return SSL_SUCCESS  設定の成功した引数について。
-    \return SSL_FAILURE  NULL SSLが渡された場合。すべてのエラーケースは負の値になります。
-    \param ssl  引数を設定するためのWolfSSL構造。
+
+    \brief WOLFSSL構造体の秘密鍵を設定するために使用されます。
+
+    \return SSL_SUCCESS 引数の設定に成功した場合。
+    \return SSL_FAILURE NULLのsslが渡された場合。すべてのエラーケースは負の値になります。
+
+    \param ssl 引数を設定するWOLFSSL構造体。
+    \param pkey 使用する秘密鍵。
 
     _Example_
     \code
     WOLFSSL* ssl;
     WOLFSSL_EVP_PKEY* pkey;
     int ret;
-    // create ssl object and set up private key
+    // sslオブジェクトを作成して秘密鍵をセットアップ
     ret  = wolfSSL_use_PrivateKey(ssl, pkey);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -9411,12 +11054,16 @@ int wolfSSL_use_PrivateKey(WOLFSSL* ssl, WOLFSSL_EVP_PKEY* pkey);
 
 /*!
     \ingroup CertsKeys
-    \brief  これはWolfSSL構造の秘密鍵を設定するために使用されます。DERフォーマットのキーバッファが予想されます。
-    \return SSL_SUCCESS  秘密鍵の構文解析と設定に成功した場合。
-    \return SSL_FAILURE  NULL SSLが渡された場合。すべてのエラーケースは負の値になります。
-    \param pri  秘密鍵の種類。
-    \param ssl  引数を設定するためのWolfSSL構造。
-    \param der  バッファー保持DERキー。
+
+    \brief WOLFSSL構造体の秘密鍵を設定するために使用されます。DER形式の鍵バッファが必要です。
+
+    \return SSL_SUCCESS 秘密鍵の解析と設定に成功した場合。
+    \return SSL_FAILURE NULLのsslが渡された場合。すべてのエラーケースは負の値になります。
+
+    \param pri 秘密鍵のタイプ。
+    \param ssl 引数を設定するWOLFSSL構造体。
+    \param der DER鍵を保持するバッファ。
+    \param derSz derバッファのサイズ。
 
     _Example_
     \code
@@ -9424,10 +11071,11 @@ int wolfSSL_use_PrivateKey(WOLFSSL* ssl, WOLFSSL_EVP_PKEY* pkey);
     unsigned char* pkey;
     long pkeySz;
     int ret;
-    // create ssl object and set up private key
+    // sslオブジェクトを作成して秘密鍵をセットアップ
     ret  = wolfSSL_use_PrivateKey_ASN1(1, ssl, pkey, pkeySz);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
     \sa wolfSSL_use_PrivateKey
@@ -9437,11 +11085,15 @@ int wolfSSL_use_PrivateKey_ASN1(int pri, WOLFSSL* ssl,
 
 /*!
     \ingroup CertsKeys
-    \brief  これはWolfSSL構造の秘密鍵を設定するために使用されます。DERフォーマットのRSAキーバッファが予想されます。
-    \return SSL_SUCCESS  秘密鍵の構文解析と設定に成功した場合。
-    \return SSL_FAILURE  NULL SSLが渡された場合。すべてのエラーケースは負の値になります。
-    \param ssl  引数を設定するためのWolfSSL構造。
-    \param der  バッファー保持DERキー。
+
+    \brief WOLFSSL構造体の秘密鍵を設定するために使用されます。DER形式のRSA鍵バッファが必要です。
+
+    \return SSL_SUCCESS 秘密鍵の解析と設定に成功した場合。
+    \return SSL_FAILURE NULLのsslが渡された場合。すべてのエラーケースは負の値になります。
+
+    \param ssl 引数を設定するWOLFSSL構造体。
+    \param der DER鍵を保持するバッファ。
+    \param derSz derバッファのサイズ。
 
     _Example_
     \code
@@ -9449,10 +11101,11 @@ int wolfSSL_use_PrivateKey_ASN1(int pri, WOLFSSL* ssl,
     unsigned char* pkey;
     long pkeySz;
     int ret;
-    // create ssl object and set up RSA private key
+    // sslオブジェクトを作成してRSA秘密鍵をセットアップ
     ret  = wolfSSL_use_RSAPrivateKey_ASN1(ssl, pkey, pkeySz);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
     \sa wolfSSL_use_PrivateKey
@@ -9462,31 +11115,40 @@ int wolfSSL_use_RSAPrivateKey_ASN1(WOLFSSL* ssl, unsigned char* der,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、DSAのパラメータを新しく作成されたWOLFSSL_DH構造体に重複しています。
-    \return WOLFSSL_DH  重複した場合はWolfSSL_DH構造体を返す場合
-    \return NULL  失敗すると
+
+    \brief この関数はdsaのパラメータを新しく作成されたWOLFSSL_DH構造体に複製します。
+
+    \return WOLFSSL_DH 複製に成功した場合、WOLFSSL_DH構造体を返します。
+    \return NULL 失敗時。
+
+    \param dsa 複製するWOLFSSL_DSA構造体。
 
     _Example_
     \code
     WOLFSSL_DH* dh;
     WOLFSSL_DSA* dsa;
-    // set up dsa
+    // dsaをセットアップ
     dh = wolfSSL_DSA_dup_DH(dsa);
 
-    // check dh is not null
+    // dhがnullでないか確認
     \endcode
+
     \sa none
 */
 WOLFSSL_DH *wolfSSL_DSA_dup_DH(const WOLFSSL_DSA *r);
 
 /*!
     \ingroup Setup
-    \brief  これはハンドシェイクを完了した後にマスターキーを取得するために使用されます。
-    \return >0  データの取得に成功した場合、0より大きい値を返します。
-    \return 0  ランダムなデータバッファまたはエラー状態が返されない場合は0
-    \return max  渡されたOUTSZが0の場合、必要な最大バッファサイズが返されます。
-    \param ses  マスターシークレットバッファを取得するためのWolfSSL_SESSION構造。
-    \param out  データを保持するためのバッファ。
+
+    \brief ハンドシェイク完了後にマスターキーを取得するために使用されます。
+
+    \return ＞0 データの取得に成功した場合、0より大きい値を返します。
+    \return 0 ランダムデータバッファがない、またはエラー状態の場合は0を返します。
+    \return max 渡されたoutSzが0の場合、必要な最大バッファサイズが返されます。
+
+    \param ses マスターシークレットバッファを取得するWOLFSSL_SESSION構造体。
+    \param out データを保持するバッファ。
+    \param outSz 渡されたoutバッファのサイズ(0の場合、関数は必要な最大バッファサイズを返します)。
 
     _Example_
     \code
@@ -9494,12 +11156,13 @@ WOLFSSL_DH *wolfSSL_DSA_dup_DH(const WOLFSSL_DSA *r);
     unsigned char* buffer;
     size_t bufferSz;
     size_t ret;
-    // complete handshake and get session structure
+    // ハンドシェイクを完了してセッション構造体を取得
     bufferSz  = wolfSSL_SESSION_get_master_secret(ses, NULL, 0);
     buffer = malloc(bufferSz);
     ret  = wolfSSL_SESSION_get_master_secret(ses, buffer, bufferSz);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -9508,8 +11171,12 @@ int wolfSSL_SESSION_get_master_key(const WOLFSSL_SESSION* ses,
 
 /*!
     \ingroup Setup
-    \brief  これはマスター秘密鍵の長さを取得するために使用されます。
-    \return size  マスターシークレットキーサイズを返します。
+
+    \brief マスターシークレットキーの長さを取得するために使用されます。
+
+    \return size マスターシークレットキーのサイズを返します。
+
+    \param ses マスターシークレットバッファを取得するWOLFSSL_SESSION構造体。
 
     _Example_
     \code
@@ -9517,11 +11184,12 @@ int wolfSSL_SESSION_get_master_key(const WOLFSSL_SESSION* ses,
     unsigned char* buffer;
     size_t bufferSz;
     size_t ret;
-    // complete handshake and get session structure
+    // ハンドシェイクを完了してセッション構造体を取得
     bufferSz  = wolfSSL_SESSION_get_master_secret_length(ses);
     buffer = malloc(bufferSz);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -9529,18 +11197,23 @@ int wolfSSL_SESSION_get_master_key_length(const WOLFSSL_SESSION* ses);
 
 /*!
     \ingroup Setup
-    \bri f  この関数は、れは、CTXのWOLFSSL_X509_STORE構造の設定機能です。
-    \return none  返品不可。
-    \param ctx  Cert Storeポインタを設定するためのWolfSSL_CTX構造体へのポインタ。
+
+    \brief ctxのWOLFSSL_X509_STORE構造体のsetter関数です。
+
+    \return none 戻り値なし。
+
+    \param ctx 証明書ストアポインタを設定するWOLFSSL_CTX構造体へのポインタ。
+    \param str ctxに設定するWOLFSSL_X509_STOREへのポインタ。
 
     _Example_
     \code
     WOLFSSL_CTX ctx;
     WOLFSSL_X509_STORE* st;
-    // setup ctx and st
+    // ctxとstをセットアップ
     st = wolfSSL_CTX_set_cert_store(ctx, st);
-    //use st
+    // stを使用
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
@@ -9549,39 +11222,49 @@ void wolfSSL_CTX_set_cert_store(WOLFSSL_CTX* ctx,
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はBIOからDERバッファを取得し、それをWolfSSL_X509構造に変換します。
-    \return pointer  成功したwolfssl_x509構造ポインタを返します。
-    \return Null  失敗時にNULLを返します
-    \param bio  DER証明書バッファを持つWOLFSSL_BIO構造体体へのポインタ。
+
+    \brief この関数はbioからDERバッファを取得し、それをWOLFSSL_X509構造体に変換します。
+
+    \return pointer 成功時にWOLFSSL_X509構造体ポインタを返します。
+    \return Null 失敗時にNULLを返します。
+
+    \param bio DER証明書バッファを持つWOLFSSL_BIO構造体へのポインタ。
+    \param x509 作成された新しいWOLFSSL_X509構造体に設定されるポインタ。
 
     _Example_
     \code
     WOLFSSL_BIO* bio;
     WOLFSSL_X509* x509;
-    // load DER into bio
+    // DERをbioにロード
     x509 = wolfSSL_d2i_X509_bio(bio, NULL);
-    Or
+    // または
     wolfSSL_d2i_X509_bio(bio, &x509);
-    // use x509 returned (check for NULL)
+    // 返されたx509を使用(NULLをチェック)
     \endcode
+
     \sa none
 */
 WOLFSSL_X509* wolfSSL_d2i_X509_bio(WOLFSSL_BIO* bio, WOLFSSL_X509** x509);
 
 /*!
     \ingroup Setup
-    \bri f  この関数は、れは、CTXのWOLFSSL_X509_STORE構造のゲッター関数です。
-    \return WOLFSSL_X509_STORE*  ポインタを正常に入手します。
-    \return NULL  NULL引数が渡された場合に返されます。
+
+    \brief ctxのWOLFSSL_X509_STORE構造体のgetter関数です。
+
+    \return WOLFSSL_X509_STORE* ポインタの取得に成功した場合。
+    \return NULL NULL引数が渡された場合に返されます。
+
+    \param ctx 証明書ストアポインタを取得するWOLFSSL_CTX構造体へのポインタ。
 
     _Example_
     \code
     WOLFSSL_CTX ctx;
     WOLFSSL_X509_STORE* st;
-    // setup ctx
+    // ctxをセットアップ
     st = wolfSSL_CTX_get_cert_store(ctx);
-    //use st
+    // stを使用
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
     \sa wolfSSL_CTX_set_cert_store
@@ -9590,17 +11273,21 @@ WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup IO
-    \brief  保留中のバイト数を読み取る数を取得します。BIOタイプがBIO_BIOの場合、ペアから読み取る番号です。BIOにSSLオブジェクトが含まれている場合は、SSLオブジェクトからのデータを保留中です（WolfSSL_Pending（SSL））。bio_memoryタイプがある場合は、メモリバッファのサイズを返します。
-    \return >=0  保留中のバイト数。
+
+    \brief 読み取り保留中のバイト数を取得します。BIOタイプがBIO_BIOの場合、ペアから読み取るバイト数です。BIOがSSLオブジェクトを含む場合、SSLオブジェクトからの保留中のデータです(wolfSSL_pending(ssl))。BIO_MEMORYタイプの場合、メモリバッファのサイズを返します。
+
+    \return ＞=0 保留中のバイト数。
+
+    \param bio すでに作成されているWOLFSSL_BIO構造体へのポインタ。
 
     _Example_
     \code
-    WOLFSSL_BIO* bio;
-    int pending;
+    WOLFSSL_BIO* bio;    int pending;
     bio = wolfSSL_BIO_new();
     …
     pending = wolfSSL_BIO_ctrl_pending(bio);
     \endcode
+
     \sa wolfSSL_BIO_make_bio_pair
     \sa wolfSSL_BIO_new
 */
@@ -9608,12 +11295,16 @@ size_t wolfSSL_BIO_ctrl_pending(WOLFSSL_BIO *b);
 
 /*!
     \ingroup Setup
-    \biiefは、この関数は、ハンドシェイク中にサーバーによって送信されたランダムなデータを取得するために使用されます。
-    \return >0  データの取得に成功した場合、0より大きい値を返します。
-    \return 0  ランダムなデータバッファまたはエラー状態が返されない場合は0
-    \return max  渡されたOUTSZが0の場合、必要な最大バッファサイズが返されます。
-    \param ssl  クライアントのランダムデータバッファを取得するためのWolfSSL構造。
-    \param out  ランダムデータを保持するためのバッファ。
+
+    \brief ハンドシェイク中にサーバーから送信されたランダムデータを取得するために使用されます。
+
+    \return ＞0 データの取得に成功した場合、0より大きい値を返します。
+    \return 0 ランダムデータバッファがない場合、またはエラー状態の場合、0を返します。
+    \return max 渡されたoutSzが0の場合、必要な最大バッファサイズを返します。
+
+    \param ssl クライアントのランダムデータバッファを取得するWOLFSSL構造体。
+    \param out ランダムデータを保持するバッファ。
+    \param outSz 渡されたoutバッファのサイズ(0の場合、関数は必要な最大バッファサイズを返します)。
 
     _Example_
     \code
@@ -9624,8 +11315,9 @@ size_t wolfSSL_BIO_ctrl_pending(WOLFSSL_BIO *b);
     bufferSz  = wolfSSL_get_server_random(ssl, NULL, 0);
     buffer = malloc(bufferSz);
     ret  = wolfSSL_get_server_random(ssl, buffer, bufferSz);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -9634,12 +11326,16 @@ size_t wolfSSL_get_server_random(const WOLFSSL *ssl,
 
 /*!
     \ingroup Setup
-    \biiefは、この関数は、ハンドシェイク中にクライアントによって送信されたランダムなデータを取得するために使用されます。
-    \return >0  データの取得に成功した場合、0より大きい値を返します。
-    \return 0  ランダムなデータバッファまたはエラー状態が返されない場合は0
-    \return max  渡されたOUTSZが0の場合、必要な最大バッファサイズが返されます。
-    \param ssl  クライアントのランダムデータバッファを取得するためのWolfSSL構造。
-    \param out  ランダムデータを保持するためのバッファ。
+
+    \brief ハンドシェイク中にクライアントから送信されたランダムデータを取得するために使用されます。
+
+    \return ＞0 データの取得に成功した場合、0より大きい値を返します。
+    \return 0 ランダムデータバッファがない場合、またはエラー状態の場合、0を返します。
+    \return max 渡されたoutSzが0の場合、必要な最大バッファサイズを返します。
+
+    \param ssl クライアントのランダムデータバッファを取得するWOLFSSL構造体。
+    \param out ランダムデータを保持するバッファ。
+    \param outSz 渡されたoutバッファのサイズ(0の場合、関数は必要な最大バッファサイズを返します)。
 
     _Example_
     \code
@@ -9650,8 +11346,9 @@ size_t wolfSSL_get_server_random(const WOLFSSL *ssl,
     bufferSz  = wolfSSL_get_client_random(ssl, NULL, 0);
     buffer = malloc(bufferSz);
     ret  = wolfSSL_get_client_random(ssl, buffer, bufferSz);
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -9660,18 +11357,23 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl,
 
 /*!
     \ingroup Setup
-    \brief  これはCTXで設定されたパスワードコールバックのゲッター関数です。
-    \return func  成功すると、コールバック関数を返します。
-    \return NULL  CTXがNULLの場合、NULLが返されます。
+
+    \brief ctx内に設定されたパスワードコールバックのgetter関数です。
+
+    \return func 成功時にはコールバック関数を返します。
+    \return NULL ctxがNULLの場合、NULLを返します。
+
+    \param ctx コールバックを取得するWOLFSSL_CTX構造体。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx;
     wc_pem_password_cb cb;
-    // setup ctx
+    // ctxをセットアップ
     cb = wolfSSL_CTX_get_default_passwd_cb(ctx);
-    //use cb
+    //cbを使用
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
@@ -9680,18 +11382,23 @@ wc_pem_password_cb* wolfSSL_CTX_get_default_passwd_cb(WOLFSSL_CTX*
 
 /*!
     \ingroup Setup
-    \bri f  この関数は、れは、CTXで設定されているパスワードコールバックユーザーデータの取得機能です。
-    \return pointer  成功すると、ユーザーデータポインタを返します。
-    \return NULL  CTXがNULLの場合、NULLが返されます。
+
+    \brief ctx内に設定されたパスワードコールバックユーザーデータのgetter関数です。
+
+    \return pointer 成功時にはユーザーデータポインタを返します。
+    \return NULL ctxがNULLの場合、NULLを返します。
+
+    \param ctx ユーザーデータを取得するWOLFSSL_CTX構造体。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx;
     void* data;
-    // setup ctx
+    // ctxをセットアップ
     data = wolfSSL_CTX_get_default_passwd_cb(ctx);
-    //use data
+    //dataを使用
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
@@ -9699,21 +11406,26 @@ void *wolfSSL_CTX_get_default_passwd_cb_userdata(WOLFSSL_CTX *ctx);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はwolfssl_pem_read_bio_x509と同じように動作します。AUXは、信頼できる/拒否されたユースケースや人間の読みやすさのためのフレンドリーな名前などの追加情報を含むことを意味します。
-    \return WOLFSSL_X509  PEMバッファの解析に成功した場合、wolfssl_x509構造が返されます。
-    \return Null  PEMバッファの解析に失敗した場合。
-    \param bp  WOLFSSL_BIO構造体体からPEMバッファを取得します。
-    \param x  wolfssl_x509を機能副作用で設定する場合
-    \param cb  パスワードコールバック
+
+    \brief この関数はwolfSSL_PEM_read_bio_X509と同じように動作します。AUXは、信頼された/拒否されたユースケースや人間が読みやすいフレンドリ名などの追加情報を含むことを意味します。
+
+    \return WOLFSSL_X509 PEMバッファの解析に成功した場合、WOLFSSL_X509構造体が返されます。
+    \return Null PEMバッファの解析に失敗した場合。
+
+    \param bp PEMバッファを取得するWOLFSSL_BIO構造体。
+    \param x 関数の副作用によってWOLFSSL_X509を設定する場合。
+    \param cb パスワードコールバック。
+    \param u NULL終端のユーザーパスワード。
 
     _Example_
     \code
     WOLFSSL_BIO* bio;
     WOLFSSL_X509* x509;
-    // setup bio
+    // bioをセットアップ
     X509 = wolfSSL_PEM_read_bio_X509_AUX(bio, NULL, NULL, NULL);
-    //check x509 is not null and then use it
+    //x509がnullでないことを確認してから使用
     \endcode
+
     \sa wolfSSL_PEM_read_bio_X509
 */
 WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
@@ -9721,12 +11433,16 @@ WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
 
 /*!
     \ingroup CertsKeys
-    \brief  WOLFSSL_CTX構造体のDHメンバーをdiffie-hellmanパラメータで初期化します。
-    \return SSL_SUCCESS  関数が正常に実行された場合に返されます。
-    \return BAD_FUNC_ARG  CTXまたはDH構造体がNULLの場合に返されます。
-    \return SSL_FATAL_ERROR  構造値を設定するエラーが発生した場合に返されます。
-    \return MEMORY_E  メモリを割り当てることができなかった場合に返されます。
-    \param ctx  wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+
+    \brief WOLFSSL_CTX構造体のdhメンバをDiffie-Hellmanパラメータで初期化します。
+
+    \return SSL_SUCCESS 関数が正常に実行された場合に返されます。
+    \return BAD_FUNC_ARG ctxまたはdh構造体がNULLの場合に返されます。
+    \return SSL_FATAL_ERROR 構造体の値の設定にエラーがあった場合に返されます。
+    \return MEMORY_E メモリの割り当てに失敗した場合に返されます。
+
+    \param ctx wolfSSL_CTX_new()を使用して作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param dh WOLFSSL_DH構造体へのポインタ。
 
     _Example_
     \code
@@ -9735,28 +11451,34 @@ WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
     …
     return wolfSSL_CTX_set_tmp_dh(ctx, dh);
     \endcode
+
     \sa wolfSSL_BN_bn2bin
 */
 long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、BIOのPEMバッファからDSAパラメータを取得します。
-    \return WOLFSSL_DSA  PEMバッファの解析に成功した場合、WolfSSL_DSA構造が作成され、返されます。
-    \return Null  PEMバッファの解析に失敗した場合。
-    \param bio  PEMメモリポインタを取得するためのWOLFSSL_BIO構造体体へのポインタ。
-    \param x  新しいWolfSSL_DSA構造に設定するポインタ。
-    \param cb  パスワードコールバック関数
+
+    \brief この関数は、bio内のPEMバッファからDSAパラメータを取得します。
+
+    \return WOLFSSL_DSA PEMバッファの解析に成功した場合、WOLFSSL_DSA構造体が作成されて返されます。
+    \return Null PEMバッファの解析に失敗した場合。
+
+    \param bio PEMメモリポインタを取得するためのWOLFSSL_BIO構造体へのポインタ。
+    \param x 新しいWOLFSSL_DSA構造体に設定されるポインタ。
+    \param cb パスワードコールバック関数。
+    \param u null終端のパスワード文字列。
 
     _Example_
     \code
     WOLFSSL_BIO* bio;
     WOLFSSL_DSA* dsa;
-    // setup bio
+    // bioをセットアップ
     dsa = wolfSSL_PEM_read_bio_DSAparams(bio, NULL, NULL, NULL);
 
-    // check dsa is not NULL and then use dsa
+    // dsaがNULLでないことを確認してからdsaを使用
     \endcode
+
     \sa none
 */
 WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSAparams(WOLFSSL_BIO *bp,
@@ -9764,25 +11486,34 @@ WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSAparams(WOLFSSL_BIO *bp,
 
 /*!
     \ingroup Debug
-    \brief  この関数は、wolfssl_Errorに遭遇した最後のエラーの絶対値を返します。
-    \return error  最後のエラーの絶対値を返します。
+
+    \brief この関数は、WOLFSSL_ERRORから発生した最後のエラーの絶対値を返します。
+
+    \return error 最後のエラーの絶対値を返します。
+
+    \param none パラメータはありません。
 
     _Example_
     \code
     unsigned long err;
     ...
     err = wolfSSL_ERR_peek_last_error();
-    // inspect err value
+    // err値を検査
     \endcode
+
     \sa wolfSSL_ERR_print_errors_fp
 */
 unsigned long wolfSSL_ERR_peek_last_error(void);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数はピアの証明書チェーンを取得します。
-    \return pointer  ピアの証明書スタックへのポインタを返します。
-    \return NULL  ピア証明書がない場合に返されます。
+
+    \brief この関数は、ピアの証明書チェーンを取得します。
+
+    \return pointer ピアのCertificateスタックへのポインタを返します。
+    \return NULL ピア証明書がない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -9791,10 +11522,11 @@ unsigned long wolfSSL_ERR_peek_last_error(void);
     ...
     wolfSSL_connect(ssl);
     STACK_OF(WOLFSSL_X509)* chain = wolfSSL_get_peer_cert_chain(ssl);
-    ifchain){
-	    // You have a pointer to the peer certificate chain
+    if(chain){
+	    // ピア証明書チェーンへのポインタがあります
     }
     \endcode
+
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_subject_name
     \sa wolfSSL_X509_get_isCA
@@ -9803,8 +11535,12 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_get_peer_cert_chain(const WOLFSSL*);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、WOLFSSL_CTXオブジェクトのオプションビットをリセットします。
-    \return option  新しいオプションビット
+
+    \brief この関数は、WOLFSSL_CTXオブジェクトのオプションビットをリセットします。
+
+    \return option 新しいオプションビット。
+
+    \param ctx SSLコンテキストへのポインタ。
 
     _Example_
     \code
@@ -9812,6 +11548,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_get_peer_cert_chain(const WOLFSSL*);
     ...
     wolfSSL_CTX_clear_options(ctx, SSL_OP_NO_TLSv1);
     \endcode
+
     \sa wolfSSL_CTX_new
     \sa wolfSSL_new
     \sa wolfSSL_free
@@ -9820,31 +11557,39 @@ long wolfSSL_CTX_clear_options(WOLFSSL_CTX* ctx, long opt);
 
 /*!
     \ingroup IO
-    \brief  この関数は、WolfSSL構造のjobjectrefメンバーを設定します。
-    \return SSL_SUCCESS  jobjectrefがobjptrに正しく設定されている場合に返されます。
-    \return SSL_FAILURE  関数が正しく実行されず、jobjectrefが設定されていない場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+
+    \brief この関数は、WOLFSSL構造体のjObjectRefメンバを設定します。
+
+    \return SSL_SUCCESS jObjectRefがobjPtrに適切に設定された場合に返されます。
+    \return SSL_FAILURE 関数が適切に実行されず、jObjectRefが設定されていない場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param objPtr jObjectRefに設定されるvoidポインタ。
 
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
-    WOLFSSL* ssl = wolfSSL_new();
+    WOLFSSL* ssl = WOLFSSL_new();
     void* objPtr = &obj;
     ...
     if(wolfSSL_set_jobject(ssl, objPtr)){
-    	// The success case
+    	// 成功ケース
     }
     \endcode
+
     \sa wolfSSL_get_jobject
 */
 int wolfSSL_set_jobject(WOLFSSL* ssl, void* objPtr);
 
 /*!
     \ingroup IO
-    \brief  この関数は、wolfssl構造のjobjectrefメンバーを返します。
-    \return value  wolfssl構造体がnullでない場合、関数はjobjectref値を返します。
-    \return NULL  wolfssl構造体がNULLの場合に返されます。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+
+    \brief この関数は、WOLFSSL構造体のjObjectRefメンバを返します。
+
+    \return value WOLFSSL構造体がNULLでない場合、関数はjObjectRef値を返します。
+    \return NULL WOLFSSL構造体がNULLの場合に返されます。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -9854,19 +11599,23 @@ int wolfSSL_set_jobject(WOLFSSL* ssl, void* objPtr);
     void* jobject = wolfSSL_get_jobject(ssl);
 
     if(jobject != NULL){
-    	// Success case
+    	// 成功ケース
     }
     \endcode
+
     \sa wolfSSL_set_jobject
 */
 void* wolfSSL_get_jobject(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数はSSL内のコールバックを設定します。コールバックはハンドシェイクメッセージを観察することです。CBのNULL値はコールバックをリセットします。
-    \return SSL_SUCCESS  成功しています。
-    \return SSL_FAILURE  NULL SSLが渡された場合。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+
+    \brief この関数は、ssl内にコールバックを設定します。コールバックはハンドシェイクメッセージを監視するためのものです。cbのNULL値はコールバックをリセットします。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FAILURE NULLのsslが渡された場合。
+
+    \param ssl コールバック引数を設定するWOLFSSL構造体。
 
     _Example_
     \code
@@ -9875,17 +11624,21 @@ void* wolfSSL_get_jobject(WOLFSSL* ssl);
     …
     WOLFSSL* ssl;
     ret  = wolfSSL_set_msg_callback(ssl, cb);
-    // check ret
+    // retを確認
     \endcode
+
     \sa wolfSSL_set_msg_callback_arg
 */
 int wolfSSL_set_msg_callback(WOLFSSL *ssl, SSL_Msg_Cb cb);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、SSL内の関連コールバックコンテキスト値を設定します。値はコールバック引数に渡されます。
-    \return none  返品不可。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+
+    \brief この関数は、ssl内に関連するコールバックコンテキスト値を設定します。値はコールバック引数に渡されます。
+
+    \return none 戻り値はありません。
+
+    \param ssl コールバック引数を設定するWOLFSSL構造体。
 
     _Example_
     \code
@@ -9894,18 +11647,23 @@ int wolfSSL_set_msg_callback(WOLFSSL *ssl, SSL_Msg_Cb cb);
     …
     WOLFSSL* ssl;
     ret  = wolfSSL_set_msg_callback(ssl, cb);
-    // check ret
+    // retを確認
     wolfSSL_set_msg_callback(ssl, arg);
     \endcode
+
     \sa wolfSSL_set_msg_callback
 */
 int wolfSSL_set_msg_callback_arg(WOLFSSL *ssl, void* arg);
 
 /*!
     \ingroup CertsKeys
-    \brief  この関数は、存在する場合は、ピア証明書からaltnameを返します。
-    \return NULL  次のAltNameがない場合。
-    \return cert->altNamesNext->name  wolfssl_x509から、AltNameリストからの文字列値である構造が存在する場合に返されます。
+
+    \brief この関数は、ピア証明書から次の代替名(もしあれば)を返します。
+
+    \return NULL 次の代替名がない場合。
+    \return cert->altNamesNext->name WOLFSSL_X509構造体から返されます。    altNameリストからの文字列値が存在する場合に返されます。
+
+    \param cert wolfSSL_X509構造体へのポインタ。
 
     _Example_
     \code
@@ -9914,20 +11672,24 @@ int wolfSSL_set_msg_callback_arg(WOLFSSL *ssl, void* arg);
     …
     int x509NextAltName = wolfSSL_X509_get_next_altname(x509);
     if(x509NextAltName == NULL){
-            //There isn’t another alt name
+        //別のalt nameはありません。
     }
     \endcode
+
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_subject_name
 */
-char* wolfSSL_X509_get_next_altname(WOLFSSL_X509* x509);
+char* wolfSSL_X509_get_next_altname(WOLFSSL_X509*);
 
 /*!
     \ingroup CertsKeys
-    \brief  関数は、x509がnullのかどうかを確認し、そうでない場合は、WOLFSSL_X509構造体のNotBeforeメンバーを返します。
-    \return pointer  WOLFSSL_ASN1_TIMEへのポインタ（WOLFSSL_X509構造体のNotBeforeメンバーへのポインタ）を返します。
-    \return NULL  WOLFSSL_X509構造体がNULLの場合に返されます。
-    \param x509 WOLFSSL_X509構造体へのポインタ
+
+    \brief この関数は、x509がNULLかどうかを確認し、NULLでない場合はx509構造体のnotBeforeメンバを返します。
+
+    \return pointer x509構造体のnotBeforeメンバへのASN1_TIMEを持つ構造体へのポインタ。
+    \return NULL x509構造体がNULLの場合、関数はNULLを返します。
+
+    \param x509 WOLFSSL_X509構造体へのポインタ。
 
     _Example_
     \code
@@ -9936,31 +11698,23 @@ char* wolfSSL_X509_get_next_altname(WOLFSSL_X509* x509);
     …
     const WOLFSSL_ASN1_TIME* notAfter = wolfSSL_X509_get_notBefore(x509);
     if(notAfter == NULL){
-            //The x509 object was NULL
+        //x509オブジェクトがNULLでした。
     }
     \endcode
+
     \sa wolfSSL_X509_get_notAfter
 */
-WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notBefore(WOLFSSL_X509* x509);
+WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notBefore(WOLFSSL_X509*);
 
 /*!
     \ingroup IO
-    \brief  この関数はクライアント側で呼び出され、サーバーとのSSL/TLSハンドシェイクを開始します。
-    この関数が呼び出されるまでに下層の通信チャネルはすでに設定されている必要があります。
-    wolfSSL_connect()は、ブロッキングとノンブロッキングI/Oの両方で動作します。
-    下層のI/Oがノンブロッキングの場合、wolfSSL_connect()は、下層のI/OがwolfSSL_connectの要求（送信データ、受信データ）を満たすことができなかったときには即戻ります。
-    この場合、wolfSSL_get_error()の呼び出しでSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかが返されます。
-    呼び出したプロセスは、下層のI/OががREADYになった時点で、WOLFSSLが停止したときから再開できるようにwolfSSL_connect()への呼び出しを繰り返す必要があります。
-    これにはselect()を使用して必要な条件が整ったかどうかを確認できます。
-    ブロッキングI/Oを使用する場合は、ハンドシェークが終了するかエラーが発生するまで戻ってきません。
-    wolfSSLはOpenSSLと比べて証明書検証に異なるアプローチを取ります。クライアントのデフォルトポリシーはサーバーを認証することです。
-    これは、CA証明書を読み込まない場合、サーバーを確認することができず”-155”のエラーコードが返されます。
-    OpenSSLと同じ振る舞い（つまり、CA証明書のロードなしでサーバー認証を成功させる）を取らせたい場合には、セキュリティ面でお勧めはしませんが、
-    SSL_CTX_SET_VERIFY（ctx、SSL_VERIFY_NONE、0)を呼び出すことで可能となります。
 
-    \return SSL_SUCCESS  成功した場合に返されます。
-    \return SSL_FATAL_ERROR  エラーが発生した場合に返されます。より詳細なエラーコードを取得するには、wolfSSL_get_error()を呼び出します。
-    \param ssl  wolfSSL_new()を使用して作成されたWolfSSL構造へのポインタ。
+    \brief この関数はクライアント側で呼び出され、サーバとのSSL/TLSハンドシェイクを開始します。この関数が呼び出されるとき、基礎となる通信チャネルはすでに設定されています。wolfSSL_connect()は、ブロッキングI/Oと非ブロッキングI/Oの両方で動作します。基礎となるI/Oが非ブロッキングの場合、wolfSSL_connect()は、基礎となるI/OがwolfSSL_connect()がハンドシェイクを続行するために必要とするものを満たすことができないときに返されます。この場合、wolfSSL_get_error()の呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEを返します。呼び出しプロセスは、基礎となるI/Oの準備ができたときにwolfSSL_connect()の呼び出しを繰り返す必要があり、wolfSSLは中断したところから再開します。非ブロッキングソケットを使用する場合、何もする必要はありませんが、select()を使用して必要な条件を確認できます。基礎となるI/Oがブロッキングの場合、wolfSSL_connect()はハンドシェイクが完了するかエラーが発生するまで返されません。wolfSSLは、OpenSSLとは異なるアプローチで証明書検証を行います。クライアントのデフォルトポリシーはサーバを検証することです。つまり、サーバを検証するためのCAを読み込まない場合、接続エラー、検証不可(-155)が発生します。サーバの検証が失敗してもSSL_connectが成功し、セキュリティを低下させるOpenSSLの動作を模倣したい場合は、SSL_new()を呼び出す前にSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0);を呼び出すことでこれを実現できます。ただし、推奨されません。
+
+    \return SSL_SUCCESS 成功した場合。
+    \return SSL_FATAL_ERROR エラーが発生した場合に返されます。より詳細なエラーコードを取得するには、wolfSSL_get_error()を呼び出してください。
+
+    \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
     \code
@@ -9971,10 +11725,11 @@ WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notBefore(WOLFSSL_X509* x509);
     ...
     ret = wolfSSL_connect(ssl);
     if (ret != SSL_SUCCESS) {
-    err = wolfSSL_get_error(ssl, ret);
-    printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+        err = wolfSSL_get_error(ssl, ret);
+        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
     }
     \endcode
+
     \sa wolfSSL_get_error
     \sa wolfSSL_accept
 */
@@ -9982,14 +11737,18 @@ int  wolfSSL_connect(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数はサーバー側で呼び出されて、HellORetryRequestメッセージにCookieを含める必要があることを示します。Cookieは現在のトランスクリプトのハッシュを保持しているので、別のサーバープロセスは応答でClientHelloを処理できます。秘密はCookieデータの整合性チェックをGenertingするときに使用されます。
-    \param [in,out]    ssl l wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param [in]  秘密を保持しているバッファへのポインタを秘密にします。渡すNULLは、新しいランダムシークレットを生成することを示します。
-    \param [in]  シークスのサイズをバイト単位でサイズ。0を渡すと、デフォルトのサイズを使用することを示します.WC_SHA256_DIGEST_SIZE（またはSHA-256が使用できない場合はWC_SHA_DIGEST_SIZE）。
-    \return BAD_FUNC_ARG  sslがNULLの場合、またはTLS v1.3を使用していない場合。
-    \return SIDE_ERROR  クライアントで呼び出された場合。
-    \return WOLFSSL_SUCCESS  成功した場合に返されます。
-    \return MEMORY_ERROR  秘密を保存するために動的メモリを割り当てる場合に失敗しました。
+
+    \brief この関数は、HelloRetryRequestメッセージにCookieを含める必要があることを示すために、サーバ側で呼び出されます。また、プロトコルDTLS v1.3を使用する場合、ハンドシェイクには常にCookie交換が含まれることを示します。プロトコルDTLS v1.3を使用する場合、Cookie交換はデフォルトで有効になっていることに注意してください。Cookieは現在のトランスクリプトのハッシュを保持しており、別のサーバプロセスが応答のClientHelloを処理できるようにします。secretは、Cookieデータの完全性チェックを生成する際に使用されます。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param [in] secret secretを保持するバッファへのポインタ。NULLを渡すと、新しいランダムなsecretを生成することを示します。
+    \param [in] secretSz secretのサイズ(バイト単位)。0を渡すと、デフォルトサイズを使用することを示します:WC_SHA256_DIGEST_SIZE(SHA-256が利用できない場合はWC_SHA_DIGEST_SIZE)。
+
+    \return BAD_FUNC_ARG sslがNULLまたはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR クライアントで呼び出された場合。
+    \return WOLFSSL_SUCCESS 成功した場合。
+    \return MEMORY_ERROR secretを保存するための動的メモリの割り当てに失敗した場合。
+    \return Another 内部エラーの場合は他の負の値。
 
     _Example_
     \code
@@ -9999,10 +11758,12 @@ int  wolfSSL_connect(WOLFSSL* ssl);
     ...
     ret = wolfSSL__send_hrr_cookie(ssl, secret, sizeof(secret));
     if (ret != WOLFSSL_SUCCESS) {
-        // failed to set use of Cookie and secret
+        // Cookieとsecretの使用設定に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_new
+    \sa wolfSSL_disable_hrr_cookie
 */
 int  wolfSSL_send_hrr_cookie(WOLFSSL* ssl,
     const unsigned char* secret, unsigned int secretSz);
@@ -10011,27 +11772,28 @@ int  wolfSSL_send_hrr_cookie(WOLFSSL* ssl,
 
     \ingroup Setup
 
-    \brief この関数はサーバー側で呼び出され、HelloRetryRequestメッセージがクッキーを含んではならないこと、
-    DTLSv1.3が使用されている場合にはクッキーの交換がハンドシェークに含まれないことを表明します。
-    DTLSv1.3ではクッキー交換を行わないとサーバーがDoS/Amplification攻撃を受けやすくなる可能性があることに留意してください。
+    \brief この関数は、HelloRetryRequestメッセージにCookieを含めてはならないこと、およびプロトコルDTLS v1.3を使用している場合、ハンドシェイクにCookie交換を含めないことを示すために、サーバ側で呼び出されます。プロトコルDTLS v1.3を使用する際にCookie交換を行わないと、サーバがDoS/増幅攻撃に対して脆弱になる可能性があることに注意してください。
 
     \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
-    \return WOLFSSL_SUCCESS 成功時に返されます。
-    \return BAD_FUNC_ARG sslがNULLあるいはTLS v1.3を使用していない場合に返されます。
-    \return SIDE_ERROR クライアント側でこの関数が呼び出された場合に返されます。
+    \return WOLFSSL_SUCCESS 成功した場合。
+    \return BAD_FUNC_ARG sslがNULLまたはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR クライアントで呼び出された場合。
 
     \sa wolfSSL_send_hrr_cookie
 */
 int wolfSSL_disable_hrr_cookie(WOLFSSL* ssl);
 
-
 /*!
     \ingroup Setup
-    \brief  この関数はサーバー上で呼び出され、ハンドシェイク完了時にセッション再開のためのセッションチケットの送信を行わないようにします。
-    \param [in,out]  ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
-    \return BAD_FUNC_ARG  CTXがNULLの場合、またはTLS v1.3を使用していない場合。
-    \return SIDE_ERROR  クライアントで呼び出された場合。
+
+    \brief この関数は、ハンドシェイクが完了した後、再開セッションチケットの送信を停止するために、サーバで呼び出されます。
+
+    \param [in,out] ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+
+    \return BAD_FUNC_ARG ctxがNULLまたはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR クライアントで呼び出された場合。
+    \return 0 成功した場合。
 
     _Example_
     \code
@@ -10040,19 +11802,24 @@ int wolfSSL_disable_hrr_cookie(WOLFSSL* ssl);
     ...
     ret = wolfSSL_CTX_no_ticket_TLSv13(ctx);
     if (ret != 0) {
-        // failed to set no ticket
+        // no ticketの設定に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_no_ticket_TLSv13
 */
 int  wolfSSL_CTX_no_ticket_TLSv13(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup Setup
-    \brief  ハンドシェイクが完了すると、この関数はサーバー上で再開セッションチケットの送信を停止するように呼び出されます。
-    \param [in,out]    ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \return BAD_FUNC_ARG  sslがNULLの場合、またはTLS v1.3を使用していない場合。
-    \return SIDE_ERROR  クライアントで呼び出された場合。
+
+    \brief この関数は、ハンドシェイクが完了した後、再開セッションチケットの送信を停止するために、サーバで呼び出されます。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
+    \return BAD_FUNC_ARG sslがNULLまたはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR クライアントで呼び出された場合。
+    \return 0 成功した場合。
 
     _Example_
     \code
@@ -10061,18 +11828,23 @@ int  wolfSSL_CTX_no_ticket_TLSv13(WOLFSSL_CTX* ctx);
     ...
     ret = wolfSSL_no_ticket_TLSv13(ssl);
     if (ret != 0) {
-        // failed to set no ticket
+        // no ticketの設定に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_CTX_no_ticket_TLSv13
 */
 int  wolfSSL_no_ticket_TLSv13(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、Authenticationにプリシェアキーを使用している場合、DIFFIE-HELLMAN（DH）スタイルのキー交換を許可するTLS V1.3 WolfSSLコンテキストで呼び出されます。
-    \param [in,out]  ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
-    \return BAD_FUNC_ARG  CTXがNULLの場合、またはTLS v1.3を使用していない場合。
+
+    \brief この関数は、事前共有鍵を認証に使用するハンドシェイクの際に、Diffie-Hellman(DH)スタイルの鍵交換を禁止するために、TLS v1.3 wolfSSLコンテキストで呼び出されます。
+
+    \param [in,out] ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+
+    \return BAD_FUNC_ARG ctxがNULLまたはTLS v1.3を使用していない場合。
+    \return 0 成功した場合。
 
     _Example_
     \code
@@ -10081,18 +11853,23 @@ int  wolfSSL_no_ticket_TLSv13(WOLFSSL* ssl);
     ...
     ret = wolfSSL_CTX_no_dhe_psk(ctx);
     if (ret != 0) {
-        // failed to set no DHE for PSK handshakes
+        // PSKハンドシェイクのDHE無効化の設定に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_no_dhe_psk
 */
 int  wolfSSL_CTX_no_dhe_psk(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、事前共有鍵を使用しているTLS V1.3クライアントまたはサーバーで、にDiffie-Hellman（DH）スタイルの鍵交換を許可しないように設定します。
-    \param [in,out]    ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \return BAD_FUNC_ARG  sslがNULLの場合、またはTLS v1.3を使用していない場合。
+
+    \brief この関数は、事前共有鍵を認証に使用するハンドシェイクの際に、Diffie-Hellman(DH)スタイルの鍵交換を禁止するために、TLS v1.3クライアントまたはサーバwolfSSLで呼び出されます。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
+    \return BAD_FUNC_ARG sslがNULLまたはTLS v1.3を使用していない場合。
+    \return 0 成功した場合。
 
     _Example_
     \code
@@ -10101,19 +11878,24 @@ int  wolfSSL_CTX_no_dhe_psk(WOLFSSL_CTX* ctx);
     ...
     ret = wolfSSL_no_dhe_psk(ssl);
     if (ret != 0) {
-        // failed to set no DHE for PSK handshakes
+        // PSKハンドシェイクのDHE無効化の設定に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_CTX_no_dhe_psk
 */
 int  wolfSSL_no_dhe_psk(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  この関数は、TLS v1.3クライアントまたはサーバーのwolfsslで呼び出されて、キーのロールオーバーを強制します。KeyUpdateメッセージがピアに送信され、新しいキーが暗号化のために計算されます。ピアはKeyUpdateメッセージを送り、新しい復号化キーWILを計算します。この機能は、ハンドシェイクが完了した後にのみ呼び出すことができます。
-    \param [in,out]    ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \return BAD_FUNC_ARG  sslがNULLの場合、またはTLS v1.3を使用していない場合。
-    \return WANT_WRITE  書き込みが準備ができていない場合
+
+    \brief この関数は、鍵のロールオーバーを強制するために、TLS v1.3クライアントまたはサーバwolfSSLで呼び出されます。KeyUpdateメッセージがピアに送信され、暗号化用の新しい鍵が計算されます。ピアはKeyUpdateメッセージを送り返し、その後新しい復号鍵が計算されます。この関数は、ハンドシェイクが完了した後にのみ呼び出すことができます。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
+    \return BAD_FUNC_ARG sslがNULLまたはTLS v1.3を使用していない場合。
+    \return WANT_WRITE 書き込みの準備ができていない場合。
+    \return WOLFSSL_SUCCESS 成功した場合。
 
     _Example_
     \code
@@ -10122,22 +11904,27 @@ int  wolfSSL_no_dhe_psk(WOLFSSL* ssl);
     ...
     ret = wolfSSL_update_keys(ssl);
     if (ret == WANT_WRITE) {
-        // need to call again when I/O ready
+        // I/Oの準備ができたら再度呼び出す必要があります。
     }
     else if (ret != WOLFSSL_SUCCESS) {
-        // failed to send key update
+        // 鍵更新の送信に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_write
 */
 int  wolfSSL_update_keys(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
-    \brief  この関数は、TLS v1.3クライアントまたはサーバーのwolfsslで呼び出され、キーのロールオーバーが進行中かどうかを判断します。wolfssl_update_keys()が呼び出されると、KeyUpdateメッセージが送信され、暗号化キーが更新されます。復号化キーは、応答が受信されたときに更新されます。
-    \param [in]  ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param [out]  キー更新応答が必要ない場合は必須0。1キー更新応答が必要ない場合。
-    \return 0  成功した。
+
+    \brief この関数は、鍵のロールオーバーが進行中かどうかを判断するために、TLS v1.3クライアントまたはサーバwolfSSLで呼び出されます。wolfSSL_update_keys()が呼び出されると、KeyUpdateメッセージが送信され、暗号化鍵が更新されます。復号鍵は、応答を受信したときに更新されます。
+
+    \param [in] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param [out] required 鍵更新応答が不要な場合は0。鍵更新応答が必要な場合は1。
+
+    \return 0 成功した場合。
+    \return BAD_FUNC_ARG sslがNULLまたはTLS v1.3を使用していない場合。
 
     _Example_
     \code
@@ -10147,22 +11934,27 @@ int  wolfSSL_update_keys(WOLFSSL* ssl);
     ...
     ret = wolfSSL_key_update_response(ssl, &required);
     if (ret != 0) {
-        // bad parameters
+        // 不正なパラメータ
     }
     if (required) {
-        // encrypt Key updated, awaiting response to change decrypt key
+        // 暗号化鍵が更新され、復号鍵を変更するための応答を待っています。
     }
     \endcode
+
     \sa wolfSSL_update_keys
 */
 int  wolfSSL_key_update_response(WOLFSSL* ssl, int* required);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、TLS v1.3クライアントのWolfSSLコンテキストで呼び出され、クライアントはサーバーからの要求に応じてPost Handshakeを送信できるようにします。これは、クライアント認証などを必要としないページを持つWebサーバーに接続するときに役立ちます。
-    \param [in,out]  ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
-    \return BAD_FUNC_ARG  CTXがNULLの場合、またはTLS v1.3を使用していない場合。
-    \return SIDE_ERROR  サーバーで呼び出された場合。
+
+    \brief この関数は、サーバからの要求に応じてクライアント証明書をハンドシェイク後に送信できるようにするために、TLS v1.3クライアントwolfSSLコンテキストで呼び出されます。これは、クライアント認証が必要なページとそうでないページを持つWebサーバに接続する際に便利です。
+
+    \param [in,out] ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+
+    \return BAD_FUNC_ARG ctxがNULLまたはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR サーバで呼び出された場合。
+    \return 0 成功した場合。
 
     _Example_
     \code
@@ -10171,9 +11963,10 @@ int  wolfSSL_key_update_response(WOLFSSL* ssl, int* required);
     ...
     ret = wolfSSL_allow_post_handshake_auth(ctx);
     if (ret != 0) {
-        // failed to allow post handshake authentication
+        // ハンドシェイク後認証の許可に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_allow_post_handshake_auth
     \sa wolfSSL_request_certificate
 */
@@ -10181,10 +11974,14 @@ int  wolfSSL_CTX_allow_post_handshake_auth(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、TLS V1.3クライアントWolfSSLで呼び出され、クライアントはサーバーからの要求に応じてハンドシェイクを送ります。handshakeクライアント認証拡張機能はClientHelloで送信されます。これは、クライアント認証などを必要としないページを持つWebサーバーに接続するときに役立ちます。
-    \param [in,out]  ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \return BAD_FUNC_ARG  sslがNULLの場合、またはTLS v1.3を使用していない場合。
-    \return SIDE_ERROR  サーバーで呼び出された場合。
+
+    \brief この関数は、サーバからの要求に応じてクライアント証明書をハンドシェイク後に送信できるようにするために、TLS v1.3クライアントwolfSSLで呼び出されます。Post-Handshake Client Authentication拡張がClientHelloで送信されます。これは、クライアント認証が必要なページとそうでないページを持つWebサーバに接続する際に便利です。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
+    \return BAD_FUNC_ARG sslがNULLまたはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR サーバで呼び出された場合。
+    \return 0 成功した場合。
 
     _Example_
     \code
@@ -10193,24 +11990,28 @@ int  wolfSSL_CTX_allow_post_handshake_auth(WOLFSSL_CTX* ctx);
     ...
     ret = wolfSSL_allow_post_handshake_auth(ssl);
     if (ret != 0) {
-        // failed to allow post handshake authentication
+        // ハンドシェイク後認証の許可に失敗しました。
     }
     \endcode
+
     \sa wolfSSL_CTX_allow_post_handshake_auth
     \sa wolfSSL_request_certificate
 */
 int  wolfSSL_allow_post_handshake_auth(WOLFSSL* ssl);
 
-/*!
-    \ingroup IO
-    \brief  この関数は、TLS v1.3クライアントからクライアント証明書を要求します。これは、Webサーバーがクライアント認証やその他のものを必要とするページにサービスを提供している場合に役立ちます。接続で最大256の要求を送信できます。
-    \param [in,out]    ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \return BAD_FUNC_ARG  sslがNULLの場合、またはTLS v1.3を使用していない場合。
-    \return WANT_WRITE  書き込みが準備ができていない場合
-    \return SIDE_ERROR  クライアントで呼び出された場合。
-    \return NOT_READY_ERROR  ハンドシェイクが終了していないときに呼び出された場合。
-    \return POST_HAND_AUTH_ERROR  送付後認証が許可されていない場合。
-    \return MEMORY_E  動的メモリ割り当てが失敗した場合
+/*!    \ingroup IO
+
+    \brief この関数は、TLS v1.3クライアントからクライアント証明書を要求します。これは、Webサーバがクライアント認証を必要とするページと必要としないページの両方を提供している場合に便利です。接続上で最大256回の要求を送信できます。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
+    \return BAD_FUNC_ARG sslがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return WANT_WRITE 書き込みの準備ができていない場合。
+    \return SIDE_ERROR クライアントで呼び出された場合。
+    \return NOT_READY_ERROR ハンドシェイクが完了していないときに呼び出された場合。
+    \return POST_HAND_AUTH_ERROR ポストハンドシェイク認証が許可されていない場合。
+    \return MEMORY_E 動的メモリ割り当てが失敗した場合。
+    \return WOLFSSL_SUCCESS 成功時。
 
     _Example_
     \code
@@ -10219,12 +12020,13 @@ int  wolfSSL_allow_post_handshake_auth(WOLFSSL* ssl);
     ...
     ret = wolfSSL_request_certificate(ssl);
     if (ret == WANT_WRITE) {
-        // need to call again when I/O ready
+        // I/Oの準備ができたら再度呼び出す必要があります
     }
     else if (ret != WOLFSSL_SUCCESS) {
-        // failed to request a client certificate
+        // クライアント証明書の要求に失敗しました
     }
     \endcode
+
     \sa wolfSSL_allow_post_handshake_auth
     \sa wolfSSL_write
 */
@@ -10232,10 +12034,14 @@ int  wolfSSL_request_certificate(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数は楕円曲線グループのリストを設定して、WolfSSLコンテキストを希望の順に設定します。リストはヌル終了したテキスト文字列、およびコロン区切りリストです。この関数を呼び出して、TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定します。
-    \param [in,out]  ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param [in] list 楕円曲線グループのコロン区切りリストである文字列をリストします。
-    \return WOLFSSL_FAILURE  ポインタパラメータがNULLの場合、wolfssl_max_group_countグループが多い場合は、グループ名が認識されないか、TLS v1.3を使用していません。
+
+    \brief この関数は、wolfSSLコンテキストで優先順位に従って許可する楕円曲線グループのリストを設定します。リストはnull終端のテキスト文字列で、コロン区切りのリストです。TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定するには、この関数を呼び出してください。
+
+    \param [in,out] ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param [in] list 楕円曲線グループのコロン区切りリストである文字列。
+
+    \return WOLFSSL_FAILURE ポインタパラメータがNULLの場合、グループがWOLFSSL_MAX_GROUP_COUNTを超える場合、グループ名が認識されない場合、またはTLS v1.3を使用していない場合。
+    \return WOLFSSL_SUCCESS 成功時。
 
     _Example_
     \code
@@ -10245,9 +12051,10 @@ int  wolfSSL_request_certificate(WOLFSSL* ssl);
     ...
     ret = wolfSSL_CTX_set1_groups_list(ctx, list);
     if (ret != WOLFSSL_SUCCESS) {
-        // failed to set group list
+        // グループリストの設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_set1_groups_list
     \sa wolfSSL_CTX_set_groups
     \sa wolfSSL_set_groups
@@ -10258,10 +12065,14 @@ int  wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, char *list);
 
 /*!
     \ingroup Setup
-    \brief  この関数は楕円曲線グループのリストを設定して、WolfSSLを希望の順に設定します。リストはヌル終了したテキスト文字列、およびコロン区切りリストです。この関数を呼び出して、TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定します。
-    \param [in,out]  ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param [in] list 鍵交換グループのコロン区切りリストである文字列をリストします。
-    \return WOLFSSL_FAILURE  ポインタパラメータがNULLの場合、wolfssl_max_group_countグループが多い場合は、グループ名が認識されないか、TLS v1.3を使用していません。
+
+    \brief この関数は、wolfSSLで優先順位に従って許可する楕円曲線グループのリストを設定します。リストはnull終端のテキスト文字列で、コロン区切りのリストです。TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定するには、この関数を呼び出してください。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param [in] list 鍵交換グループのコロン区切りリストである文字列。
+
+    \return WOLFSSL_FAILURE ポインタパラメータがNULLの場合、グループがWOLFSSL_MAX_GROUP_COUNTを超える場合、グループ名が認識されない場合、またはTLS v1.3を使用していない場合。
+    \return WOLFSSL_SUCCESS 成功時。
 
     _Example_
     \code
@@ -10271,9 +12082,10 @@ int  wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, char *list);
     ...
     ret = wolfSSL_CTX_set1_groups_list(ssl, list);
     if (ret != WOLFSSL_SUCCESS) {
-        // failed to set group list
+        // グループリストの設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_CTX_set1_groups_list
     \sa wolfSSL_CTX_set_groups
     \sa wolfSSL_set_groups
@@ -10284,11 +12096,15 @@ int  wolfSSL_set1_groups_list(WOLFSSL *ssl, char *list);
 
 /*!
     \ingroup TLS
-    \brief  この関数は、クライアントがTLS v1.3ハンドシェイクで使用することを好む鍵交換グループを返します。この情報を完了した後にこの機能を呼び出して、サーバーがどのグループが予想されるようにこの情報が将来の接続で使用できるようになるかを決定するために、この情報が将来の接続で鍵交換のための鍵ペアを事前生成することができます。
-    \param [in,out]    ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \return BAD_FUNC_ARG  sslがNULLの場合、またはTLS v1.3を使用していない場合。
-    \return SIDE_ERROR  サーバーで呼び出された場合。
-    \return NOT_READY_ERROR  ハンドシェイクが完了する前に呼び出された場合。
+
+    \brief この関数は、TLS v1.3ハンドシェイクでクライアントが優先的に使用したい鍵交換グループを返します。ハンドシェイク完了後にこの関数を呼び出して、サーバが優先するグループを判定し、この情報を将来の接続で使用して鍵交換用の鍵ペアを事前生成できます。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
+    \return BAD_FUNC_ARG sslがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR サーバで呼び出された場合。
+    \return NOT_READY_ERROR ハンドシェイク完了前に呼び出された場合。
+    \return Group identifier 成功時、グループ識別子。
 
     _Example_
     \code
@@ -10298,10 +12114,11 @@ int  wolfSSL_set1_groups_list(WOLFSSL *ssl, char *list);
     ...
     ret = wolfSSL_CTX_set1_groups_list(ssl)
     if (ret < 0) {
-        // failed to get group
+        // グループの取得に失敗しました
     }
     group = ret;
     \endcode
+
     \sa wolfSSL_UseKeyShare
     \sa wolfSSL_CTX_set_groups
     \sa wolfSSL_set_groups
@@ -10312,11 +12129,15 @@ int  wolfSSL_preferred_group(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数は楕円曲線グループのリストを設定して、WolfSSLコンテキストを希望の順に設定します。リストは、Countで指定された識別子の数を持つグループ識別子の配列です。この関数を呼び出して、TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定します。
-    \param [in,out]  ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param [in] groups 識別子によって鍵交換グループのリストをグループ化します。
-    \param [in] count グループ内の鍵交換グループの数を数えます。
-    \return BAD_FUNC_ARG  ポインタパラメータがNULLの場合、グループ数はwolfssl_max_group_countを超えているか、TLS v1.3を使用していません。
+
+    \brief この関数は、wolfSSLコンテキストで優先順位に従って許可する楕円曲線グループのリストを設定します。リストはグループ識別子の配列で、識別子の数はcountで指定されます。TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定するには、この関数を呼び出してください。
+
+    \param [in,out] ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param [in] groups 識別子による鍵交換グループのリスト。
+    \param [in] count groups内の鍵交換グループの数。
+
+    \return BAD_FUNC_ARG ポインタパラメータがnullの場合、グループ数がWOLFSSL_MAX_GROUP_COUNTを超える場合、またはTLS v1.3を使用していない場合。
+    \return WOLFSSL_SUCCESS 成功時。
 
     _Example_
     \code
@@ -10327,9 +12148,10 @@ int  wolfSSL_preferred_group(WOLFSSL* ssl);
     ...
     ret = wolfSSL_CTX_set1_groups_list(ctx, groups, count);
     if (ret != WOLFSSL_SUCCESS) {
-        // failed to set group list
+        // グループリストの設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_set_groups
     \sa wolfSSL_UseKeyShare
     \sa wolfSSL_CTX_set_groups
@@ -10343,11 +12165,15 @@ int  wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups,
 
 /*!
     \ingroup Setup
-    \brief  この関数は、wolfsslを許すために楕円曲線グループのリストを設定します。リストは、Countで指定された識別子の数を持つグループ識別子の配列です。この関数を呼び出して、TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定します。
-    \param [in,out]  ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param [in]  groups 識別子によって鍵交換グループのリストをグループ化します。
-    \param [in]  count グループ内の鍵交換グループの数を数えます。
-    \return BAD_FUNC_ARG  ポインタパラメータがNULLの場合、グループ数がWolfSSL_MAX_GROUP_COUNTを超えている場合、任意の識別子は認識されないか、TLS v1.3を使用していません。
+
+    \brief この関数は、wolfSSLで許可する楕円曲線グループのリストを設定します。リストはグループ識別子の配列で、識別子の数はcountで指定されます。TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定するには、この関数を呼び出してください。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param [in] groups 識別子による鍵交換グループのリスト。
+    \param [in] count groups内の鍵交換グループの数。
+
+    \return BAD_FUNC_ARG ポインタパラメータがnullの場合、グループ数がWOLFSSL_MAX_GROUP_COUNTを超える場合、識別子のいずれかが認識されない場合、またはTLS v1.3を使用していない場合。
+    \return WOLFSSL_SUCCESS 成功時。
 
     _Example_
     \code
@@ -10358,9 +12184,10 @@ int  wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups,
     ...
     ret = wolfSSL_set_groups(ssl, groups, count);
     if (ret != WOLFSSL_SUCCESS) {
-        // failed to set group list
+        // グループリストの設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_CTX_set_groups
     \sa wolfSSL_UseKeyShare
     \sa wolfSSL_CTX_set_groups
@@ -10373,22 +12200,12 @@ int  wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count);
 
 /*!
     \ingroup IO
-    \brief  この関数はクライアント側で呼び出され、サーバーとのTLS v1.3ハンドシェイクを開始します。
-    この関数が呼び出されると、下層の通信チャネルはすでに設定されています。
-     wolfSSL_connect()は、ブロックとノンブロックI/Oの両方で動作します。
-     下層I/Oがノンブロッキングの場合、wolfSSL_connect()は、下層I/Oがwolfssl_connectの要求を満たすことができなかったときに戻ります。
-     この場合、wolfSSL_get_error()への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。
-     通話プロセスは、下層I/OがREADYおよびWOLFSSLが停止したときにwolfssl_connect()への呼び出しを繰り返す必要があります。
-     ノンブロッキングソケットを使用する場合は、何も実行する必要がありますが、select()を使用して必要な条件を確認できます。
-     基礎となる入出力がブロックされている場合、wolfssl_connect()はハンドシェイクが終了したら、またはエラーが発生したらのみ戻ります。
-     WolfSSLはOpenSSLよりも証明書検証に異なるアプローチを取ります。
-     クライアントのデフォルトポリシーはサーバーを確認することです。
-     これは、CASを読み込まない場合、サーバーを確認することができ、確認できません（-155）。
-     SSL_CONNECTを持つことのOpenSSLの動作が成功した場合は、サーバーを検証してセキュリティを抑えることができます。
-     SSL_CTX_SET_VERIFY（CTX、SSL_VERIFY_NONE、0）。
-     ssl_new()を呼び出す前に。お勧めできませんが。
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FATAL_ERROR  エラーが発生した場合に返されます。より詳細なエラーコードを取得するには、wolfSSL_get_error()を呼び出します。
+
+    \brief この関数はクライアント側で呼び出され、サーバとのTLS v1.3ハンドシェイクを開始します。この関数が呼び出されるとき、基礎となる通信チャネルはすでに設定されています。wolfSSL_connect()はブロッキングI/Oと非ブロッキングI/Oの両方で動作します。基礎となるI/Oが非ブロッキングの場合、基礎となるI/OがwolfSSL_connect()がハンドシェイクを続行するために必要なものを満たせない場合、wolfSSL_connect()は返されます。この場合、wolfSSL_get_error()を呼び出すとSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかが返されます。呼び出し側プロセスは、基礎となるI/Oの準備ができたときにwolfSSL_connect()の呼び出しを繰り返す必要があり、wolfSSLは中断したところから再開します。非ブロッキングソケットを使用する場合、何もする必要はありませんが、select()を使用して必要な条件を確認できます。基礎となるI/OがブロッキングI/Oの場合、wolfSSL_connect()はハンドシェイクが完了するかエラーが発生するまで返されません。wolfSSLは証明書検証にOpenSSLとは異なるアプローチを取ります。クライアントのデフォルトポリシーはサーバを検証することです。つまり、サーバを検証するためのCAをロードしない場合、接続エラー「検証できません(-155)」が発生します。サーバの検証が失敗してもSSL_connectが成功するというOpenSSLの動作を模倣し、セキュリティを低下させたい場合は、SSL_new()を呼び出す前にSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0)を呼び出すことでこれを行うことができます。ただし、これは推奨されません。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FATAL_ERROR エラーが発生した場合に返されます。より詳細なエラーコードを取得するには、wolfSSL_get_error()を呼び出してください。
+
     \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
@@ -10402,30 +12219,25 @@ int  wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count);
     ret = wolfSSL_connect_TLSv13(ssl);
     if (ret != SSL_SUCCESS) {
         err = wolfSSL_get_error(ssl, ret);
-        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
     }
     \endcode
+
     \sa wolfSSL_get_error
     \sa wolfSSL_connect
     \sa wolfSSL_accept_TLSv13
     \sa wolfSSL_accept
 */
-int  wolfSSL_connect_TLSv13(WOLFSSL* ssl);
+int  wolfSSL_connect_TLSv13(WOLFSSL*);
 
 /*!
     \ingroup IO
-    \brief  この関数はサーバー側で呼び出され、SSL/TLSクライアントがSSL/TLSハンドシェイクを開始するのを待ちうけます。
-    この関数が呼び出されると、下層の通信チャネルはすでに設定されています。
-    wolfSSL_accept()は、ブロックとノンブロッキングI/Oの両方で動作します。
-    下層の入出力がノンブロッキングである場合、wolfSSL_accept()は、下層のI/OがwolfSSL_acceptの要求を満たすことができなかったときに戻ります。
-    この場合、wolfSSL_get_error()への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。
-    通話プロセスは、読み取り可能なデータが使用可能であり、wolfsslが停止した場所を拾うときに、wolfssl_acceptの呼び出しを繰り返す必要があります。
-    ノンブロッキングソケットを使用する場合は、何も実行する必要がありますが、select()を使用して必要な条件を確認できます。
-    下層のI/Oがブロックされている場合、wolfssl_accept()はハンドシェイクが終了したら、またはエラーが発生したら戻ります。
-    古いバージョンのClientHelloメッセージがサポートされていますが、TLS v1.3接続を期待するときにこの関数を呼び出します。
 
-    \return SSL_SUCCESS  成功時に返されます。
-    \return SSL_FATAL_ERROR  エラーが発生した場合に返されます。より詳細なエラーコードを取得するには、wolfSSL_get_error()を呼び出します。
+    \brief この関数はサーバ側で呼び出され、SSL/TLSクライアントがSSL/TLSハンドシェイクを開始するのを待ちます。この関数が呼び出されるとき、基礎となる通信チャネルはすでに設定されています。wolfSSL_accept()はブロッキングI/Oと非ブロッキングI/Oの両方で動作します。基礎となるI/Oが非ブロッキングの場合、基礎となるI/OがwolfSSL_accept()がハンドシェイクを続行するために必要なものを満たせない場合、wolfSSL_accept()は返されます。この場合、wolfSSL_get_error()を呼び出すとSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかが返されます。呼び出し側プロセスは、データが読み取り可能になったときにwolfSSL_acceptの呼び出しを繰り返す必要があり、wolfSSLは中断したところから再開します。非ブロッキングソケットを使用する場合、何もする必要はありませんが、select()を使用して必要な条件を確認できます。基礎となるI/OがブロッキングI/Oの場合、wolfSSL_accept()はハンドシェイクが完了するかエラーが発生するまで返されません。TLS v1.3接続を期待する場合にこの関数を呼び出してください。ただし、古いバージョンのClientHelloメッセージもサポートされています。
+
+    \return SSL_SUCCESS 成功時。
+    \return SSL_FATAL_ERROR エラーが発生した場合に返されます。より詳細なエラーコードを取得するには、wolfSSL_get_error()を呼び出してください。
+
     \param ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
 
     _Example_
@@ -10439,9 +12251,10 @@ int  wolfSSL_connect_TLSv13(WOLFSSL* ssl);
     ret = wolfSSL_accept_TLSv13(ssl);
     if (ret != SSL_SUCCESS) {
         err = wolfSSL_get_error(ssl, ret);
-        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
     }
     \endcode
+
     \sa wolfSSL_get_error
     \sa wolfSSL_connect_TLSv13
     \sa wolfSSL_connect
@@ -10452,16 +12265,14 @@ wolfSSL_accept_TLSv13(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、WolfSSLコンテキストを使用してTLS V1.3サーバーによって受け入れられるアーリーデータの最大量を設定します。
-    この関数を呼び出して、再生攻撃を軽減するためのプロセスへのアーリーデータの量を制限します。
-    初期のデータは、セッションチケットが送信されたこと、したがってセッションチケットが再開されるたびに同じ接続の鍵から派生した鍵によって保護されます。
-    値は再開のためにセッションチケットに含まれています。
-    ゼロの値は、セッションチケットを使用してクライアントによってアーリーデータを送信することを示します。
-    アーリーデータバイト数をアプリケーションで実際には可能な限り低く保つことをお勧めします。
-    \param [in,out]  ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
-    \param [in]  sz バイト単位で受け入れるアーリーデータのサイズ。
-    \return BAD_FUNC_ARG  CTXがNULLの場合、またはTLS v1.3を使用していない場合。
-    \return SIDE_ERROR  クライアントで呼び出された場合。
+
+    \brief この関数は、TLS v1.3クライアントまたはサーバがwolfSSLコンテキストを使用して交換する意思のある早期データの最大量を設定します。リプレイ攻撃を軽減するために処理する早期データの量を制限するには、この関数を呼び出してください。早期データは、セッションチケットが送信された接続の鍵から派生した鍵によって保護されるため、セッションチケットが再開に使用されるたびに同じになります。この値は再開用のセッションチケットに含まれます。サーバの値がゼロの場合、セッションチケットを使用してクライアントが早期データを送信しないことを示します。クライアントの値がゼロの場合、クライアントが早期データを送信しないことを示します。早期データのバイト数は、アプリケーションで実用的に可能な限り低く保つことをお勧めします。
+
+    \param [in,out] ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param [in] sz 受け入れる早期データの量(バイト単位)。
+
+    \return BAD_FUNC_ARG ctxがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return 0 成功時。
 
     _Example_
     \code
@@ -10470,9 +12281,10 @@ wolfSSL_accept_TLSv13(WOLFSSL* ssl);
     ...
     ret = wolfSSL_CTX_set_max_early_data(ctx, 128);
     if (ret != WOLFSSL_SUCCESS) {
-        // failed to set group list
+        // グループリストの設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_set_max_early_data
     \sa wolfSSL_write_early_data
     \sa wolfSSL_read_early_data
@@ -10482,27 +12294,24 @@ int  wolfSSL_CTX_set_max_early_data(WOLFSSL_CTX* ctx,
 
 /*!
     \ingroup Setup
-    \brief  この関数は、WolfSSLコンテキストを使用してTLS V1.3サーバーによって受け入れられるアーリーデータの最大量を設定します。
-    この関数を呼び出して、再生攻撃を軽減するためプロセスへのアーリーデータの量を制限します。
-    初期のデータは、セッションチケットが送信されたこと、したがってセッションチケットが再開されるたびに同じ接続の鍵から派生した鍵によって保護されます。
-    値は再開のためにセッションチケットに含まれています。
-    ゼロの値は、セッションチケットを使用してクライアントによってアーリーデータを送信することを示します。
-    アーリーデータバイト数をアプリケーションで実際には可能な限り低く保つことをお勧めします。
-    \param [in,out]   ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param [in]  SZクライアントからバイト単位で受け入れるアーリーデータのサイズ。
-    \return BAD_FUNC_ARG  sslがNULLの場合、またはTLS v1.3を使用していない場合。
-    \return SIDE_ERROR  クライアントで呼び出された場合。
 
-    _Example_
+    \brief この関数は、TLS v1.3クライアントまたはサーバが交換する意思のある早期データの最大量を設定します。リプレイ攻撃を軽減するために処理する早期データの量を制限するには、この関数を呼び出してください。早期データは、セッションチケットが送信された接続の鍵から派生した鍵によって保護されるため、セッションチケットが再開に使用されるたびに同じになります。この値は再開用のセッションチケットに含まれます。サーバの値がゼロの場合、セッションチケットを使用してクライアントが早期データを送信しないことを示します。クライアントの値がゼロの場合、クライアントが早期データを送信しないことを示します。早期データのバイト数は、アプリケーションで実用的に可能な限り低く保つことをお勧めします。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param [in] sz クライアントから受け入れる早期データの量(バイト単位)。
+
+    \return BAD_FUNC_ARG sslがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return 0 成功時。    _Example_
     \code
     int ret;
     WOLFSSL* ssl;
     ...
     ret = wolfSSL_set_max_early_data(ssl, 128);
     if (ret != WOLFSSL_SUCCESS) {
-        // failed to set group list
+        // グループリストの設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_CTX_set_max_early_data
     \sa wolfSSL_write_early_data
     \sa wolfSSL_read_early_data
@@ -10511,17 +12320,18 @@ int  wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz);
 
 /*!
     \ingroup IO
-    \brief  この関数は、セッション再開時にサーバーにアーリーデータを書き込みます。
-    wolfSSL_connect()またはwolfSSL_connect_tlsv13()の代わりにこの関数を呼び出して、サーバーに接続してハンドシェイクにデータを送ります。
-    この機能はクライアントでのみ使用されます。
-    \return BAD_FUNC_ARG  ポインタパラメータがNULLの場合に返されます。szは0未満またはTLSV1.3を使用しない場合にも返されます。
-    \return SIDE_ERROR  サーバーで呼び出された場合に返されます。
-    \return WOLFSSL_FATAL_ERROR  接続が行われていない場合に返されます。
 
-    \param [in,out]  ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param [in]  data アーリーデータを保持しているバッファへのポインタ。
-    \param [in]  sz 書き込むアーリーデータのサイズ
-    \param [out]  outSz 書き込んだアーリーデータのサイズ
+    \brief この関数は再開時にサーバーにアーリーデータを書き込みます。サーバーに接続してハンドシェイクでデータを送信するには、wolfSSL_connect()またはwolfSSL_connect_TLSv13()の代わりにこの関数を呼び出します。この関数はクライアントでのみ使用されます。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param [in] data サーバーに書き込むアーリーデータを保持するバッファ。
+    \param [in] sz 書き込むアーリーデータの量(バイト単位)。
+    \param [out] outSz 書き込まれたアーリーデータの量(バイト単位)。
+
+    \return BAD_FUNC_ARG ポインタパラメータがNULL、szが0未満、またはTLSv1.3を使用していない場合。
+    \return SIDE_ERROR サーバーで呼び出された場合。
+    \return WOLFSSL_FATAL_ERROR 接続が確立されなかった場合。
+    \return WOLFSSL_SUCCESS 成功した場合。
 
     _Example_
     \code
@@ -10536,18 +12346,19 @@ int  wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz);
     ret = wolfSSL_write_early_data(ssl, earlyData, sizeof(earlyData), &outSz);
     if (ret != WOLFSSL_SUCCESS) {
         err = wolfSSL_get_error(ssl, ret);
-        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
         goto err_label;
     }
     if (outSz < sizeof(earlyData)) {
-        // not all early data was sent
+        // すべてのアーリーデータが送信されませんでした
     }
     ret = wolfSSL_connect_TLSv13(ssl);
     if (ret != SSL_SUCCESS) {
         err = wolfSSL_get_error(ssl, ret);
-        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
     }
     \endcode
+
     \sa wolfSSL_read_early_data
     \sa wolfSSL_connect
     \sa wolfSSL_connect_TLSv13
@@ -10557,14 +12368,18 @@ int  wolfSSL_write_early_data(WOLFSSL* ssl, const void* data,
 
 /*!
     \ingroup IO
-    \brief  この関数は、再開時にクライアントからの早期データを読み取ります。wolfssl_accept()またはwolfssl_accept_tlsv13()の代わりにこの関数を呼び出して、クライアントを受け入れ、ハンドシェイク内の早期データを読み取ります。ハンドシェイクよりも早期データがない場合は、通常として処理されます。この機能はサーバーでのみ使用されます。
-    \param [in,out]    ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param [out]  データはクライアントから読み込まれた早期データを保持するためのバッファ。
-    \param [in]  バッファのSZサイズバイト数。
-    \param [out]  OUTSZ初期データのバイト数。
-    \return BAD_FUNC_ARG  ポインタパラメータがNULLの場合、SZは0未満またはTLSV1.3を使用しない。
-    \return SIDE_ERROR  クライアントで呼び出された場合。
-    \return WOLFSSL_FATAL_ERROR  接続を受け入れると失敗した場合
+
+    \brief この関数は再開時にクライアントからのアーリーデータを読み取ります。クライアントを受け入れ、ハンドシェイクでアーリーデータを読み取るには、wolfSSL_accept()またはwolfSSL_accept_TLSv13()の代わりにこの関数を呼び出します。wolfSSL_is_init_finished()がtrueを返すまで関数を呼び出す必要があります。アーリーデータは複数のメッセージでクライアントから送信される場合があります。アーリーデータがない場合、ハンドシェイクは通常通り処理されます。この関数はサーバーでのみ使用されます。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param [out] data クライアントから読み取ったアーリーデータを保持するバッファ。
+    \param [in] sz バッファのサイズ(バイト単位)。
+    \param [out] outSz 読み取ったアーリーデータのバイト数。
+
+    \return BAD_FUNC_ARG ポインタパラメータがNULL、szが0未満、またはTLSv1.3を使用していない場合。
+    \return SIDE_ERROR クライアントで呼び出された場合。
+    \return WOLFSSL_FATAL_ERROR 接続の受け入れが失敗した場合。
+    \return 読み取ったアーリーデータのバイト数(ゼロの場合もあります)。
 
     _Example_
     \code
@@ -10576,20 +12391,18 @@ int  wolfSSL_write_early_data(WOLFSSL* ssl, const void* data,
     char buffer[80];
     ...
 
-    ret = wolfSSL_read_early_data(ssl, earlyData, sizeof(earlyData), &outSz);
-    if (ret != SSL_SUCCESS) {
-        err = wolfSSL_get_error(ssl, ret);
-        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
-    }
-    if (outSz > 0) {
-        // early data available
-    }
-    ret = wolfSSL_accept_TLSv13(ssl);
-    if (ret != SSL_SUCCESS) {
-        err = wolfSSL_get_error(ssl, ret);
-        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
-    }
+    do {
+        ret = wolfSSL_read_early_data(ssl, earlyData, sizeof(earlyData), &outSz);
+        if (ret < 0) {
+            err = wolfSSL_get_error(ssl, ret);
+            printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
+        }
+        if (outSz > 0) {
+            // アーリーデータが利用可能
+        }
+    } while (!wolfSSL_is_init_finished(ssl));
     \endcode
+
     \sa wolfSSL_write_early_data
     \sa wolfSSL_accept
     \sa wolfSSL_accept_TLSv13
@@ -10598,9 +12411,41 @@ int  wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz,
     int* outSz);
 
 /*!
+    \ingroup IO
+
+    \brief この関数はWOLFSSLオブジェクトにデータを注入するために呼び出されます。これは、データを単一の場所から読み取り、複数の接続に分割する必要がある場合に便利です。呼び出し元はwolfSSL_read()を呼び出してWOLFSSLオブジェクトから平文データを抽出する必要があります。
+
+    \param [in] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param [in] data sslオブジェクトに注入するデータ。
+    \param [in] sz 注入するデータのバイト数。
+
+    \return BAD_FUNC_ARG いずれかのポインタパラメータがNULLまたはsz <= 0の場合。
+    \return APP_DATA_READY 読み取るべきアプリケーションデータが残っている場合。
+    \return MEMORY_E 割り当てが失敗した場合。
+    \return WOLFSSL_SUCCESS 成功時。
+
+    _Example_
+    \code
+    byte buf[2000]
+    sz = recv(fd, buf, sizeof(buf), 0);
+    if (sz <= 0)
+        // エラー
+    if (wolfSSL_inject(ssl, buf, sz) != WOLFSSL_SUCCESS)
+        // エラー
+    sz = wolfSSL_read(ssl, buf, sizeof(buf);
+    \endcode
+
+    \sa wolfSSL_read
+*/
+int wolfSSL_inject(WOLFSSL* ssl, const void* data, int sz);
+
+/*!
     \ingroup Setup
-    \brief  この関数は、TLS v1.3接続のプレシェア鍵（PSK）クライアント側コールバックを設定します。コールバックはPSKアイデンティティを見つけ、そのキーと、ハンドシェイクに使用する暗号の名前を返します。この関数は、WOLFSSL_CTX構造体のclient_psk_tls13_cbメンバーを設定します。
-    \param [in,out]  ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+
+    \brief この関数はTLS v1.3接続のための事前共有鍵(PSK)クライアント側コールバックを設定します。コールバックはPSKアイデンティティを検索し、その鍵とハンドシェイクで使用する暗号の名前を返すために使用されます。この関数はWOLFSSL_CTX構造体のclient_psk_tls13_cbメンバーを設定します。
+
+    \param [in,out] ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param [in] cb TLS 1.3クライアント用の事前共有鍵(PSK)コールバック。
 
     _Example_
     \code
@@ -10608,6 +12453,7 @@ int  wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz,
     ...
     wolfSSL_CTX_set_psk_client_tls13_callback(ctx, my_psk_client_tls13_cb);
     \endcode
+
     \sa wolfSSL_set_psk_client_tls13_callback
     \sa wolfSSL_CTX_set_psk_server_tls13_callback
     \sa wolfSSL_set_psk_server_tls13_callback
@@ -10617,8 +12463,11 @@ void wolfSSL_CTX_set_psk_client_tls13_callback(WOLFSSL_CTX* ctx,
 
 /*!
     \ingroup Setup
-    \brief  この関数は、TLS v1.3接続のプレシェアキー（PSK）クライアント側コールバックを設定します。コールバックはPSKアイデンティティを見つけ、そのキーと、ハンドシェイクに使用する暗号の名前を返します。この関数は、wolfssl構造体のOptionsフィールドのclient_psk_tls13_cbメンバーを設定します。
-    \param [in,out]    ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
+    \brief この関数はTLS v1.3接続のための事前共有鍵(PSK)クライアント側コールバックを設定します。コールバックはPSKアイデンティティを検索し、その鍵とハンドシェイクで使用する暗号の名前を返すために使用されます。この関数はWOLFSSL構造体のoptionsフィールドのclient_psk_tls13_cbメンバーを設定します。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param [in] cb TLS 1.3クライアント用の事前共有鍵(PSK)コールバック。
 
     _Example_
     \code
@@ -10626,6 +12475,7 @@ void wolfSSL_CTX_set_psk_client_tls13_callback(WOLFSSL_CTX* ctx,
     ...
     wolfSSL_set_psk_client_tls13_callback(ssl, my_psk_client_tls13_cb);
     \endcode
+
     \sa wolfSSL_CTX_set_psk_client_tls13_callback
     \sa wolfSSL_CTX_set_psk_server_tls13_callback
     \sa wolfSSL_set_psk_server_tls13_callback
@@ -10635,8 +12485,11 @@ void wolfSSL_set_psk_client_tls13_callback(WOLFSSL* ssl,
 
 /*!
     \ingroup Setup
-    \brief  この関数は、TLS v1.3接続用の事前共有鍵（PSK）サーバ側コールバックを設定します。コールバックはPSKアイデンティティを見つけ、そのキーと、ハンドシェイクに使用する暗号の名前を返します。この関数は、wolfssl_ctx構造体のserver_psk_tls13_cbメンバーを設定します。
-    \param [in,out]  ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+
+    \brief この関数はTLS v1.3接続のための事前共有鍵(PSK)サーバー側コールバックを設定します。コールバックはPSKアイデンティティを検索し、その鍵とハンドシェイクで使用する暗号の名前を返すために使用されます。この関数はWOLFSSL_CTX構造体のserver_psk_tls13_cbメンバーを設定します。
+
+    \param [in,out] ctx wolfSSL_CTX_new()で作成されたWOLFSSL_CTX構造体へのポインタ。
+    \param [in] cb TLS 1.3サーバー用の事前共有鍵(PSK)コールバック。
 
     _Example_
     \code
@@ -10644,6 +12497,7 @@ void wolfSSL_set_psk_client_tls13_callback(WOLFSSL* ssl,
     ...
     wolfSSL_CTX_set_psk_server_tls13_callback(ctx, my_psk_client_tls13_cb);
     \endcode
+
     \sa wolfSSL_CTX_set_psk_client_tls13_callback
     \sa wolfSSL_set_psk_client_tls13_callback
     \sa wolfSSL_set_psk_server_tls13_callback
@@ -10653,8 +12507,11 @@ void wolfSSL_CTX_set_psk_server_tls13_callback(WOLFSSL_CTX* ctx,
 
 /*!
     \ingroup Setup
-    \brief  この関数は、TLS v1.3接続用の事前共有鍵（PSK）サーバ側コールバックを設定します。コールバックはPSKアイデンティティを見つけ、そのキーと、ハンドシェイクに使用する暗号の名前を返します。この関数は、wolfssl構造体のオプションフィールドのserver_psk_tls13_cbメンバーを設定します。
-    \param [in,out]    ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+
+    \brief この関数はTLS v1.3接続のための事前共有鍵(PSK)サーバー側コールバックを設定します。コールバックはPSKアイデンティティを検索し、その鍵とハンドシェイクで使用する暗号の名前を返すために使用されます。この関数はWOLFSSL構造体のoptionsフィールドのserver_psk_tls13_cbメンバーを設定します。
+
+    \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
+    \param [in] cb TLS 1.3サーバー用の事前共有鍵(PSK)コールバック。
 
     _Example_
     \code
@@ -10662,6 +12519,7 @@ void wolfSSL_CTX_set_psk_server_tls13_callback(WOLFSSL_CTX* ctx,
     ...
     wolfSSL_set_psk_server_tls13_callback(ssl, my_psk_server_tls13_cb);
     \endcode
+
     \sa wolfSSL_CTX_set_psk_client_tls13_callback
     \sa wolfSSL_set_psk_client_tls13_callback
     \sa wolfSSL_CTX_set_psk_server_tls13_callback
@@ -10671,11 +12529,15 @@ void wolfSSL_set_psk_server_tls13_callback(WOLFSSL* ssl,
 
 /*!
     \ingroup Setup
-    \brief  この関数は、キーペアの生成を含むグループからキーシェアエントリを作成します。Keyshareエクステンションには、鍵交換のための生成されたすべての公開鍵が含まれています。この関数が呼び出されると、指定されたグループのみが含まれます。優先グループがサーバーに対して以前に確立されているときにこの関数を呼び出します。
+
+    \brief この関数は鍵ペアの生成を含む、グループから鍵共有エントリを作成します。KeyShare拡張には鍵交換用に生成されたすべての公開鍵が含まれます。この関数が呼び出されると、指定されたグループのみが含まれます。サーバーに対して優先グループが以前に確立されている場合に、この関数を呼び出します。
+
     \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \param [in]  キー交換グループ識別子をグループ化します。
-    \return BAD_FUNC_ARG  sslがNULLの場合に返されます。
-    \return MEMORY_E  動的メモリ割り当てに失敗すると返されます。
+    \param [in] group 鍵交換グループ識別子。
+
+    \return BAD_FUNC_ARG sslがNULLの場合。
+    \return MEMORY_E 動的メモリ割り当てが失敗した場合。
+    \return WOLFSSL_SUCCESS 成功した場合。
 
     _Example_
     \code
@@ -10684,9 +12546,10 @@ void wolfSSL_set_psk_server_tls13_callback(WOLFSSL* ssl,
     ...
     ret = wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_X25519);
     if (ret != WOLFSSL_SUCCESS) {
-        // failed to set key share
+        // 鍵共有の設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_preferred_group
     \sa wolfSSL_CTX_set1_groups_list
     \sa wolfSSL_set1_groups_list
@@ -10698,10 +12561,14 @@ int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、ClientHelloで鍵共有が送信されないように呼び出されます。これにより、ハンドシェイクに鍵交換が必要な場合は、サーバーがHelloretryRequestで応答するように強制します。予想される鍵交換グループが知られておらず、キーの生成を不必要に回避するときにこの機能を呼び出します。鍵交換が必要なときにハンドシェイクを完了するために追加の往復が必要になることに注意してください。
+
+    \brief この関数はClientHelloで鍵共有が送信されないようにするために呼び出されます。これにより、ハンドシェイクで鍵交換が必要な場合、サーバーはHelloRetryRequestで応答することになります。期待される鍵交換グループが不明で、不要な鍵の生成を避けたい場合にこの関数を呼び出します。鍵交換が必要な場合、ハンドシェイクを完了するために追加のラウンドトリップが必要になることに注意してください。
+
     \param [in,out] ssl wolfSSL_new()を使用して作成されたWOLFSSL構造体へのポインタ。
-    \return BAD_FUNC_ARG  sslがNULLの場合に返されます。
-    \return SIDE_ERROR  サーバーで呼び出された場合。
+
+    \return BAD_FUNC_ARG sslがNULLの場合。
+    \return SIDE_ERROR サーバーで呼び出された場合。
+    \return WOLFSSL_SUCCESS 成功した場合。
 
     _Example_
     \code
@@ -10710,18 +12577,23 @@ int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group);
     ...
     ret = wolfSSL_NoKeyShares(ssl);
     if (ret != WOLFSSL_SUCCESS) {
-        // failed to set no key shares
+        // 鍵共有なしの設定に失敗しました
     }
     \endcode
+
     \sa wolfSSL_UseKeyShare
 */
 int wolfSSL_NoKeyShares(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、アプリケーションがサーバーであることを示すために使用され、TLS 1.3プロトコルのみをサポートします。この関数は、wolfSSL_CTX_new()を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
-    \param [in]  ヒープ静的メモリ割り当て中に静的メモリ割り当て器が使用するバッファへのポインタを使用します。
-    \return 新しく作成されたwWOLFSSL_METHOS構造体へのポインタを返します。
+
+    \brief この関数はアプリケーションがサーバーであり、TLS 1.3プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のメモリを割り当て、初期化します。
+
+    \param [in] heap 静的メモリアロケータが動的メモリ割り当て時に使用するバッファへのポインタ。
+
+    \return 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCの呼び出し時にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
 
     _Example_
     \code
@@ -10732,12 +12604,13 @@ int wolfSSL_NoKeyShares(WOLFSSL* ssl);
 
     method = wolfTLSv1_3_server_method_ex(NULL);
     if (method == NULL) {
-        // unable to get method
+        // メソッドの取得ができません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_server_method
     \sa wolfTLSv1_server_method
     \sa wolfTLSv1_1_server_method
@@ -10751,25 +12624,28 @@ WOLFSSL_METHOD *wolfTLSv1_3_server_method_ex(void* heap);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、アプリケーションがクライアントであることを示すために使用され、TLS 1.3プロトコルのみをサポートします。この関数は、wolfSSL_CTX_new()を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
-    \param [in]  ヒープ静的メモリ割り当て中に静的メモリ割り当て器が使用するバッファへのポインタを使用します。
-    \return 新しく作成されたwWOLFSSL_METHOS構造体へのポインタを返します。
+
+    \brief この関数はアプリケーションがクライアントであり、TLS 1.3プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体のメモリを割り当て、初期化します。
+
+    \param [in] heap 静的メモリアロケータが動的メモリ割り当て時に使用するバッファへのポインタ。
+
+    \return 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOCの呼び出し時にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常はNULLで、errnoがENOMEMに設定されます)。
 
     _Example_
     \code
     #include <wolfssl/ssl.h>
 
     WOLFSSL_METHOD* method;
-    WOLFSSL_CTX* ctx;
-
-    method = wolfTLSv1_3_client_method_ex(NULL);
+    WOLFSSL_CTX* ctx;    method = wolfTLSv1_3_client_method_ex(NULL);
     if (method == NULL) {
-        // unable to get method
+        // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_client_method
     \sa wolfTLSv1_client_method
     \sa wolfTLSv1_1_client_method
@@ -10783,8 +12659,11 @@ WOLFSSL_METHOD *wolfTLSv1_3_client_method_ex(void* heap);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、アプリケーションがサーバーであることを示すために使用され、TLS 1.3プロトコルのみをサポートします。この関数は、wolfSSL_CTX_new()を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
-    \return 新しく作成されたwWOLFSSL_METHOS構造体へのポインタを返します。
+
+    \brief この関数は、アプリケーションがサーバーであり、TLS 1.3プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体用のメモリを割り当て、初期化します。
+
+    \return 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOC呼び出し時にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常、errnoがENOMEMに設定されたNULL)。
 
     _Example_
     \code
@@ -10795,12 +12674,13 @@ WOLFSSL_METHOD *wolfTLSv1_3_client_method_ex(void* heap);
 
     method = wolfTLSv1_3_server_method();
     if (method == NULL) {
-        // unable to get method
+        // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_server_method
     \sa wolfTLSv1_server_method
     \sa wolfTLSv1_1_server_method
@@ -10814,8 +12694,11 @@ WOLFSSL_METHOD *wolfTLSv1_3_server_method(void);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、アプリケーションがクライアントであることを示すために使用され、TLS 1.3プロトコルのみをサポートします。この関数は、wolfSSL_CTX_new()を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
-    \return 新しく作成されたwWOLFSSL_METHOS構造体へのポインタを返します。
+
+    \brief この関数は、アプリケーションがクライアントであり、TLS 1.3プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfSSL_CTX_new()でSSL/TLSコンテキストを作成する際に使用される新しいwolfSSL_METHOD構造体用のメモリを割り当て、初期化します。
+
+    \return 成功した場合、呼び出しは新しく作成されたWOLFSSL_METHOD構造体へのポインタを返します。
+    \return FAIL XMALLOC呼び出し時にメモリ割り当てが失敗した場合、基礎となるmalloc()実装の失敗値が返されます(通常、errnoがENOMEMに設定されたNULL)。
 
     _Example_
     \code
@@ -10826,12 +12709,13 @@ WOLFSSL_METHOD *wolfTLSv1_3_server_method(void);
 
     method = wolfTLSv1_3_client_method();
     if (method == NULL) {
-        // unable to get method
+        // メソッドを取得できません
     }
 
     ctx = wolfSSL_CTX_new(method);
     ...
     \endcode
+
     \sa wolfSSLv3_client_method
     \sa wolfTLSv1_client_method
     \sa wolfTLSv1_1_client_method
@@ -10845,16 +12729,21 @@ WOLFSSL_METHOD *wolfTLSv1_3_client_method(void);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、まだどちらの側（サーバ/クライアント）を決定していないことを除いて、Wolftlsv1_3_client_methodと同様のwolfssl_methodを返します。
-    \param [in]  ヒープ静的メモリ割り当て中に静的メモリ割り当て器が使用するバッファへのポインタを使用します。
-    \return WOLFSSL_METHOD  成功した作成では、wolfssl_methodポインタを返します
+
+    \brief この関数は、どちら側(サーバー/クライアント)であるかがまだ決定されていないことを除いて、wolfTLSv1_3_client_methodと同様のWOLFSSL_METHODを返します。
+
+    \param [in] heap 静的メモリアロケータが動的メモリ割り当て中に使用するバッファへのポインタ。
+
+    \return WOLFSSL_METHOD 正常に作成された場合、WOLFSSL_METHODポインタを返します。
+    \return NULL メモリ割り当てエラーまたはメソッドの作成に失敗した場合はNull。
 
     _Example_
     \code
     WOLFSSL* ctx;
     ctx  = wolfSSL_CTX_new(wolfTLSv1_3_method_ex(NULL));
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
@@ -10862,44 +12751,149 @@ WOLFSSL_METHOD *wolfTLSv1_3_method_ex(void* heap);
 
 /*!
     \ingroup Setup
-    \brief  この関数は、まだどちらの側（サーバ/クライアント）を決定していないことを除いて、Wolftlsv1_3_client_methodと同様のwolfssl_methodを返します。
-    \return WOLFSSL_METHOD  成功した作成では、wolfssl_methodポインタを返します
+
+    \brief この関数は、どちら側(サーバー/クライアント)であるかがまだ決定されていないことを除いて、wolfTLSv1_3_client_methodと同様のWOLFSSL_METHODを返します。
+
+    \return WOLFSSL_METHOD 正常に作成された場合、WOLFSSL_METHODポインタを返します。
+    \return NULL メモリ割り当てエラーまたはメソッドの作成に失敗した場合はNull。
 
     _Example_
     \code
     WOLFSSL* ctx;
     ctx  = wolfSSL_CTX_new(wolfTLSv1_3_method());
-    // check ret value
+    // ret値を確認
     \endcode
+
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
 WOLFSSL_METHOD *wolfTLSv1_3_method(void);
 
 /*!
- \ingroup Setup
- \brief  この関数はクライアント側で呼び出される場合には、サーバー側にCertificateメッセージで送信できる証明書タイプを設定します。
- サーバー側で呼び出される場合には、受入れ可能なクライアント証明書タイプを設定します。
- Raw Public Key 証明書を送受信したい場合にはこの関数を使って証明書タイプを設定しなければなりません。
- 設定する証明書タイプは優先度順に格納したバイト配列として渡します。
- 設定するバッファアドレスにNULLを渡すか、あるいはバッファサイズに0を渡すと規定値にもどすことができます。
- 規定値はX509証明書（WOLFSSL_CERT_TYPE_X509）のみを扱う設定となっています。
+ \ingroup SSL
+ \brief この関数は、テスト専用の固定/静的エフェメラル鍵を設定します。
+ \return 0 鍵が正常にロードされました。
+ \param ctx WOLFSSL_CTXコンテキストポインタ。
+ \param keyAlgo WC_PK_TYPE_DHやWC_PK_TYPE_ECDHなどのenum wc_PkType。
+ \param key 鍵ファイルパス(keySz == 0の場合)または実際の鍵バッファ(PEMまたはASN.1)。
+ \param keySz 鍵サイズ("key"引数がファイルパスの場合は0である必要があります)。
+ \param format WOLFSSL_FILETYPE_ASN1またはWOLFSSL_FILETYPE_PEM。
+ \sa wolfSSL_CTX_get_ephemeral_key
+ */
+int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, const char* key, unsigned int keySz, int format);
 
- \return WOLFSSL_SUCCESS 成功
- \return BAD_FUNC_ARG ctxとしてNULLを渡した、あるいは不正な証明書タイプを指定した、
- あるいはMAX_CLIENT_CERT_TYPE_CNT以上のバッファサイズを指定した、あるいは指定の証明書タイプに重複がある
- \param ctx  wolfssl_ctxコンテキストポインタ
- \param ctype  証明書タイプを格納したバッファへのポインタ
- \param len  証明書タイプを格納したバッファのサイズ（バイト数）
+/*!
+ \ingroup SSL
+ \brief この関数は、テスト専用の固定/静的エフェメラル鍵を設定します。
+ \return 0 鍵が正常にロードされました。
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param keyAlgo WC_PK_TYPE_DHやWC_PK_TYPE_ECDHなどのenum wc_PkType。
+ \param key 鍵ファイルパス(keySz == 0の場合)または実際の鍵バッファ(PEMまたはASN.1)。
+ \param keySz 鍵サイズ("key"引数がファイルパスの場合は0である必要があります)。
+ \param format WOLFSSL_FILETYPE_ASN1またはWOLFSSL_FILETYPE_PEM。
+ \sa wolfSSL_get_ephemeral_key
+ */
+int wolfSSL_set_ephemeral_key(WOLFSSL* ssl, int keyAlgo, const char* key, unsigned int keySz, int format);
+
+/*!
+ \ingroup SSL
+ \brief この関数は、ASN.1/DERとしてロードされた鍵へのポインタを返します。
+ \return 0 鍵が正常に返されました。
+ \param ctx WOLFSSL_CTXコンテキストポインタ。
+ \param keyAlgo WC_PK_TYPE_DHやWC_PK_TYPE_ECDHなどのenum wc_PkType。
+ \param key 鍵バッファポインタ。
+ \param keySz 鍵サイズポインタ。
+ \sa wolfSSL_CTX_set_ephemeral_key
+ */
+int wolfSSL_CTX_get_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo,
+    const unsigned char** key, unsigned int* keySz);
+
+/*!
+ \ingroup SSL
+ \brief この関数は、ASN.1/DERとしてロードされた鍵へのポインタを返します。
+ \return 0 鍵が正常に返されました。
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param keyAlgo WC_PK_TYPE_DHやWC_PK_TYPE_ECDHなどのenum wc_PkType。
+ \param key 鍵バッファポインタ。
+ \param keySz 鍵サイズポインタ。
+ \sa wolfSSL_set_ephemeral_key
+ */
+int wolfSSL_get_ephemeral_key(WOLFSSL* ssl, int keyAlgo,
+    const unsigned char** key, unsigned int* keySz);
+
+/*!
+ \ingroup SSL
+ \brief 選択したメッセージダイジェスト、パディング、およびRSA鍵でメッセージに署名します。
+ \return WOLFSSL_SUCCESS 成功時、エラー時はc。
+ \param type ハッシュNID。
+ \param m 署名するメッセージ。おそらくこれは署名するメッセージのダイジェストになります。
+ \param mLen 署名するメッセージの長さ。
+ \param sigRet 出力バッファ。
+ \param sigLen 入力時: sigRetバッファの長さ、出力時: sigRetに書き込まれたデータの長さ。
+ \param rsa 入力の署名に使用されるRSA鍵。
+ \param flag 1: 署名を出力、0: パディングされていない署名と比較すべき値を出力。注意: RSA_PKCS1_PSS_PADDINGの場合、*Verify*関数の出力をチェックするためにwc_RsaPSS_CheckPadding_ex関数を使用する必要があります。
+ \param padding 使用するパディング。現在、署名にはRSA_PKCS1_PSS_PADDINGとRSA_PKCS1_PADDINGのみがサポートされています。
+ */
+int wolfSSL_RSA_sign_generic_padding(int type, const unsigned char* m,
+                               unsigned int mLen, unsigned char* sigRet,
+                               unsigned int* sigLen, WOLFSSL_RSA* rsa,
+                               int flag, int padding);
+/*!
+
+\brief DTLSv1.3スタックが送信したが、まだ他のピアから確認応答されていないメッセージがあるかどうかをチェックします。
+
+ \return 1 保留中のメッセージがある場合、それ以外は0。
+ \param ssl WOLFSSLオブジェクトポインタ。
+*/
+int wolfSSL_dtls13_has_pending_msg(WOLFSSL *ssl);
+
+/*!
+    \ingroup SSL
+    \brief セッションからEarly Dataの最大サイズを取得します。
+
+    \param [in] s WOLFSSL_SESSIONインスタンス。
+
+    \return セッションが派生したWOLFSSL*で設定されたmax_early_dataの値。
+
+    \sa wolfSSL_set_max_early_data
+    \sa wolfSSL_write_early_data
+    \sa wolfSSL_read_early_data
+ */
+unsigned int wolfSSL_SESSION_get_max_early_data(const WOLFSSL_SESSION *s);
+
+/*!
+    \ingroup SSL
+    \brief 外部データ用の新しいインデックスを取得します。このエントリは以下のAPIにも適用されます:
+           - wolfSSL_CTX_get_ex_new_index
+           - wolfSSL_get_ex_new_index
+           - wolfSSL_SESSION_get_ex_new_index
+           - wolfSSL_X509_get_ex_new_index
+
+    \param [in] すべての入力パラメータは無視されます。コールバック関数はwolfSSLではサポートされていません。
+
+    \return このオブジェクトクラスの外部データAPIで使用される新しいインデックス値。
+ */
+int wolfSSL_CRYPTO_get_ex_new_index(int, void*, void*, void*, void*);
+
+/*!
+ \ingroup Setup
+ \brief この関数がクライアント側で呼び出された場合、ピアに送信できる証明書タイプを設定します。サーバー側で呼び出された場合、ピアから受け入れ可能な証明書タイプを設定します。優先順位の高い順にバッファに証明書タイプを格納します。設定をデフォルトにリセットするには、bufにNULLを渡すか、lenに0を渡します。デフォルトでは、証明書タイプはX509のみです。両側が"Raw public key"証明書を送信または受け入れることを意図している場合、WOLFSSL_CERT_TYPE_RPKをバッファに含めて設定する必要があります。
+
+ \return WOLFSSL_SUCCESS 証明書タイプが正常に設定された場合。
+ \return BAD_FUNC_ARG ctxにNULLが渡された場合、証明書タイプとして不正な値が指定された場合、bufサイズがMAX_CLIENT_CERT_TYPE_CNTを超えた場合、またはbuf内に重複する値が見つかった場合。
+
+ \param ctx WOLFSSL_CTXオブジェクトポインタ。
+ \param buf 証明書タイプが格納されるバッファ。
+ \param len bufサイズ(バイト単位)(含まれる証明書タイプの数と同じ)。
     _Example_
  \code
   int ret;
   WOLFSSL_CTX* ctx;
-  char ctype[] = {WOLFSSL_CERT_TYPE_RPK, WOLFSSL_CERT_TYPE_X509};
-  int len = sizeof(ctype)/sizeof(byte);
-　...
+  char buf[] = {WOLFSSL_CERT_TYPE_RPK, WOLFSSL_CERT_TYPE_X509};
+  int len = sizeof(buf)/sizeof(char);
+  ...
 
-  ret = wolfSSL_CTX_set_client_cert_type(ctx, ctype, len);
+  ret = wolfSSL_CTX_set_client_cert_type(ctx, buf, len);
  \endcode
  \sa wolfSSL_set_client_cert_type
  \sa wolfSSL_CTX_set_server_cert_type
@@ -10911,29 +12905,23 @@ int wolfSSL_CTX_set_client_cert_type(WOLFSSL_CTX* ctx, const char* buf, int len)
 
 /*!
  \ingroup Setup
- \brief  この関数はサーバー側で呼び出される場合には、クライアント側にCertificateメッセージで送信できる証明書タイプを設定します。
- クライアント側で呼び出される場合には、受入れ可能なサーバー証明書タイプを設定します。
- Raw Public Key 証明書を送受信したい場合にはこの関数を使って証明書タイプを設定しなければなりません。
- 設定する証明書タイプは優先度順に格納したバイト配列として渡します。
- 設定するバッファアドレスにNULLを渡すか、あるいはバッファサイズに0を渡すと規定値にもどすことができます。
- 規定値はX509証明書（WOLFSSL_CERT_TYPE_X509）のみを扱う設定となっています。
+ \brief この関数がサーバー側で呼び出された場合、ピアに送信できる証明書タイプを設定します。クライアント側で呼び出された場合、ピアから受け入れ可能な証明書タイプを設定します。優先順位の高い順にバッファに証明書タイプを格納します。設定をデフォルトにリセットするには、bufにNULLを渡すか、lenに0を渡します。デフォルトでは、証明書タイプはX509のみです。両側が"Raw public key"証明書を送信または受け入れることを意図している場合、WOLFSSL_CERT_TYPE_RPKをバッファに含めて設定する必要があります。
 
- \return WOLFSSL_SUCCESS 成功
- \return BAD_FUNC_ARG ctxとしてNULLを渡した、あるいは不正な証明書タイプを指定した、
- あるいはMAX_SERVER_CERT_TYPE_CNT以上のバッファサイズを指定した、あるいは指定の証明書タイプに重複がある
+ \return WOLFSSL_SUCCESS 証明書タイプが正常に設定された場合。
+ \return BAD_FUNC_ARG ctxにNULLが渡された場合、証明書タイプとして不正な値が指定された場合、bufサイズがMAX_SERVER_CERT_TYPE_CNTを超えた場合、またはbuf内に重複する値が見つかった場合。
 
- \param ctx  wolfssl_ctxコンテキストポインタ
- \param ctype  証明書タイプを格納したバッファへのポインタ
- \param len  証明書タイプを格納したバッファのサイズ（バイト数）
+ \param ctx WOLFSSL_CTXオブジェクトポインタ。
+ \param buf 証明書タイプが格納されるバッファ。
+ \param len bufサイズ(バイト単位)(含まれる証明書タイプの数と同じ)。
     _Example_
  \code
   int ret;
   WOLFSSL_CTX* ctx;
-  char ctype[] = {WOLFSSL_CERT_TYPE_RPK, WOLFSSL_CERT_TYPE_X509};
-  int len = sizeof(ctype)/sizeof(byte);
-　...
+  char buf[] = {WOLFSSL_CERT_TYPE_RPK, WOLFSSL_CERT_TYPE_X509};
+  int len = sizeof(buf)/sizeof(char);
+  ...
 
-  ret = wolfSSL_CTX_set_server_cert_type(ctx, ctype, len);
+  ret = wolfSSL_CTX_set_server_cert_type(ctx, buf, len);
  \endcode
  \sa wolfSSL_set_client_cert_type
  \sa wolfSSL_CTX_set_client_cert_type
@@ -10945,29 +12933,23 @@ int wolfSSL_CTX_set_server_cert_type(WOLFSSL_CTX* ctx, const char* buf, int len)
 
 /*!
  \ingroup Setup
- \brief  この関数はクライアント側で呼び出される場合には、サーバー側にCertificateメッセージで送信できる証明書タイプを設定します。
- サーバー側で呼び出される場合には、受入れ可能なクライアント証明書タイプを設定します。
- Raw Public Key 証明書を送受信したい場合にはこの関数を使って証明書タイプを設定しなければなりません。
- 設定する証明書タイプは優先度順に格納したバイト配列として渡します。
- 設定するバッファアドレスにNULLを渡すか、あるいはバッファサイズに0を渡すと規定値にもどすことができます。
- 規定値はX509証明書（WOLFSSL_CERT_TYPE_X509）のみを扱う設定となっています。
+ \brief この関数がクライアント側で呼び出された場合、ピアに送信できる証明書タイプを設定します。サーバー側で呼び出された場合、ピアから受け入れ可能な証明書タイプを設定します。優先順位の高い順にバッファに証明書タイプを格納します。設定をデフォルトにリセットするには、bufにNULLを渡すか、lenに0を渡します。デフォルトでは、証明書タイプはX509のみです。両側が"Raw public key"証明書を送信または受け入れることを意図している場合、WOLFSSL_CERT_TYPE_RPKをバッファに含めて設定する必要があります。
 
- \return WOLFSSL_SUCCESS 成功
- \return BAD_FUNC_ARG sslとしてNULLを渡した、あるいは不正な証明書タイプを指定した、
- あるいはMAX_CLIENT_CERT_TYPE_CNT以上のバッファサイズを指定した、あるいは指定の証明書タイプに重複がある
+ \return WOLFSSL_SUCCESS 証明書タイプが正常に設定された場合。
+ \return BAD_FUNC_ARG ctxにNULLが渡された場合、証明書タイプとして不正な値が指定された場合、bufサイズがMAX_CLIENT_CERT_TYPE_CNTを超えた場合、またはbuf内に重複する値が見つかった場合。
 
- \param ssl  WOLFSSL構造体へのポインタ
- \param ctype  証明書タイプを格納したバッファへのポインタ
- \param len  証明書タイプを格納したバッファのサイズ（バイト数）
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param buf 証明書タイプが格納されるバッファ。
+ \param len bufサイズ(バイト単位)(含まれる証明書タイプの数と同じ)。
     _Example_
  \code
   int ret;
   WOLFSSL* ssl;
-  char ctype[] = {WOLFSSL_CERT_TYPE_RPK, WOLFSSL_CERT_TYPE_X509};
-  int len = sizeof(ctype)/sizeof(byte);
-　...
+  char buf[] = {WOLFSSL_CERT_TYPE_RPK, WOLFSSL_CERT_TYPE_X509};
+  int len = sizeof(buf)/sizeof(char);
+  ...
 
-  ret = wolfSSL_set_client_cert_type(ssl, ctype, len);
+  ret = wolfSSL_set_client_cert_type(ssl, buf, len);
  \endcode
  \sa wolfSSL_CTX_set_client_cert_type
  \sa wolfSSL_CTX_set_server_cert_type
@@ -10979,29 +12961,22 @@ int wolfSSL_set_client_cert_type(WOLFSSL* ssl, const char* buf, int len);
 
 /*!
  \ingroup Setup
- \brief  この関数はサーバー側で呼び出される場合には、クライアント側にCertificateメッセージで送信できる証明書タイプを設定します。
- クライアント側で呼び出される場合には、受入れ可能なサーバー証明書タイプを設定します。
- Raw Public Key 証明書を送受信したい場合にはこの関数を使って証明書タイプを設定しなければなりません。
- 設定する証明書タイプは優先度順に格納したバイト配列として渡します。
- 設定するバッファアドレスにNULLを渡すか、あるいはバッファサイズに0を渡すと規定値にもどすことができます。
- 規定値はX509証明書（WOLFSSL_CERT_TYPE_X509）のみを扱う設定となっています。
+ \brief この関数がサーバー側で呼び出された場合、ピアに送信できる証明書タイプを設定します。クライアント側で呼び出された場合、ピアから受け入れ可能な証明書タイプを設定します。優先順位の高い順にバッファに証明書タイプを格納します。設定をデフォルトにリセットするには、bufにNULLを渡すか、lenに0を渡します。デフォルトでは、証明書タイプはX509のみです。両側が"Raw public key"証明書を送信または受け入れることを意図している場合、WOLFSSL_CERT_TYPE_RPKをバッファに含めて設定する必要があります。
 
- \return WOLFSSL_SUCCESS 成功
- \return BAD_FUNC_ARG ctxとしてNULLを渡した、あるいは不正な証明書タイプを指定した、
- あるいはMAX_SERVER_CERT_TYPE_CNT以上のバッファサイズを指定した、あるいは指定の証明書タイプに重複がある
+ \return WOLFSSL_SUCCESS 証明書タイプが正常に設定された場合。
+ \return BAD_FUNC_ARG ctxにNULLが渡された場合、証明書タイプとして不正な値が指定された場合、bufサイズがMAX_SERVER_CERT_TYPE_CNTを超えた場合、またはbuf内に重複する値が見つかった場合。
 
- \param ssl  WOLFSSL構造体へのポインタ
- \param ctype  証明書タイプを格納したバッファへのポインタ
- \param len  証明書タイプを格納したバッファのサイズ（バイト数）
+ \param ctx WOLFSSL_CTXオブジェクトポインタ。
+ \param buf 証明書タイプが格納されるバッファ。
+ \param len bufサイズ(バイト単位)(含まれる証明書タイプの数と同じ)。
     _Example_
  \code
-  int ret;
-  WOLFSSL* ssl;
-  char ctype[] = {WOLFSSL_CERT_TYPE_RPK, WOLFSSL_CERT_TYPE_X509};
-  int len = sizeof(ctype)/sizeof(byte);
-　...
+  int ret;  WOLFSSL* ssl;
+  char buf[] = {WOLFSSL_CERT_TYPE_RPK, WOLFSSL_CERT_TYPE_X509};
+  int len = sizeof(buf)/sizeof(char);
+  ...
 
-  ret = wolfSSL_set_server_cert_type(ssl, ctype, len);
+  ret = wolfSSL_set_server_cert_type(ssl, buf, len);
  \endcode
  \sa wolfSSL_set_client_cert_type
  \sa wolfSSL_CTX_set_server_cert_type
@@ -11012,22 +12987,116 @@ int wolfSSL_set_client_cert_type(WOLFSSL* ssl, const char* buf, int len);
 int wolfSSL_set_server_cert_type(WOLFSSL* ssl, const char* buf, int len);
 
 /*!
- \ingroup SSL
- \brief  この関数はハンドシェーク終了後に呼び出し、相手とのネゴシエーションの結果得られたクライアント証明書のタイプを返します。
- ネゴシエーションが発生しない場合には戻り値としてWOLFSSL_SUCCESSが返されますが、
- 証明書タイプとしてはWOLFSSL_CERT_TYPE_UNKNOWNが返されます。
+    \ingroup Setup
 
- \return WOLFSSL_SUCCESS 成功時にかえります。tpに返された証明書タイプはWOLFSSL_CERT_TYPE_X509,
-  WOLFSSL_CERT_TYPE_RPK あるいはWOLFSSL_CERT_TYPE_UNKNOWNのいずれかとなります。
- \return BAD_FUNC_ARG sslとしてNULLを渡した、あるいはtpとしてNULLを渡した
- \param ssl  WOLFSSL構造体へのポインタ
- \param tp  証明書タイプが返されるバッファへのポインタ
+    \brief 指定されたWOLFSSL_CTXコンテキストに対してハンドシェイクメッセージグループ化を有効にします。
+
+    この関数は、指定されたコンテキストから作成されたすべてのSSLオブジェクトに対してハンドシェイクメッセージグループ化をオンにします。
+
+    \return WOLFSSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG ctxがNULLの場合。
+
+    \param ctx WOLFSSL_CTX構造体へのポインタ。
+
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
+    wolfSSL_CTX_set_group_messages(ctx);
+    \endcode
+
+    \sa wolfSSL_CTX_clear_group_messages
+    \sa wolfSSL_set_group_messages
+    \sa wolfSSL_clear_group_messages
+*/
+int wolfSSL_CTX_set_group_messages(WOLFSSL_CTX* ctx);
+
+/*!
+    \ingroup Setup
+
+    \brief 指定されたWOLFSSL_CTXコンテキストに対してハンドシェイクメッセージグループ化を無効にします。
+
+    この関数は、指定されたコンテキストから作成されたすべてのSSLオブジェクトに対してハンドシェイクメッセージグループ化をオフにします。
+
+    \return WOLFSSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG ctxがNULLの場合。
+
+    \param ctx WOLFSSL_CTX構造体へのポインタ。
+
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
+    wolfSSL_CTX_clear_group_messages(ctx);
+    \endcode
+
+    \sa wolfSSL_CTX_set_group_messages
+    \sa wolfSSL_set_group_messages
+    \sa wolfSSL_clear_group_messages
+*/
+int wolfSSL_CTX_clear_group_messages(WOLFSSL_CTX* ctx);
+
+/*!
+    \ingroup Setup
+
+    \brief 指定されたWOLFSSLオブジェクトに対してハンドシェイクメッセージグループ化を有効にします。
+
+    この関数は、指定されたSSLオブジェクトに対してハンドシェイクメッセージグループ化をオンにします。
+
+    \return WOLFSSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG sslがNULLの場合。
+
+    \param ssl WOLFSSL構造体へのポインタ。
+
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    wolfSSL_set_group_messages(ssl);
+    \endcode
+
+    \sa wolfSSL_clear_group_messages
+    \sa wolfSSL_CTX_set_group_messages
+    \sa wolfSSL_CTX_clear_group_messages
+*/
+int wolfSSL_set_group_messages(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup
+
+    \brief 指定されたWOLFSSLオブジェクトに対してハンドシェイクメッセージグループ化を無効にします。
+
+    この関数は、指定されたSSLオブジェクトに対してハンドシェイクメッセージグループ化をオフにします。
+
+    \return WOLFSSL_SUCCESS 成功時。
+    \return BAD_FUNC_ARG sslがNULLの場合。
+
+    \param ssl WOLFSSL構造体へのポインタ。
+
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    wolfSSL_clear_group_messages(ssl);
+    \endcode
+
+    \sa wolfSSL_set_group_messages
+    \sa wolfSSL_CTX_set_group_messages
+    \sa wolfSSL_CTX_clear_group_messages
+*/
+int wolfSSL_clear_group_messages(WOLFSSL* ssl);
+
+/*!
+ \ingroup SSL
+ \brief この関数は、ClientHelloとServerHelloで行われたクライアント証明書タイプネゴシエーションの結果を返します。ネゴシエーションが発生しなかった場合、戻り値としてWOLFSSL_SUCCESSが返され、証明書タイプとしてWOLFSSL_CERT_TYPE_UNKNOWNが返されます。
+
+ \return WOLFSSL_SUCCESS ネゴシエートされた証明書タイプを取得できた場合。
+ \return BAD_FUNC_ARG ctxまたはtpにNULLが渡された場合。
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param tp 証明書タイプが返されるバッファ。次の3つの証明書タイプのいずれかが返されます:WOLFSSL_CERT_TYPE_RPK、WOLFSSL_CERT_TYPE_X509、またはWOLFSSL_CERT_TYPE_UNKNOWN。
+
     _Example_
  \code
   int ret;
   WOLFSSL* ssl;
   int tp;
-　...
+  ...
 
   ret = wolfSSL_get_negotiated_client_cert_type(ssl, &tp);
  \endcode
@@ -11041,13 +13110,12 @@ int wolfSSL_get_negotiated_client_cert_type(WOLFSSL* ssl, int* tp);
 
 /*!
  \ingroup SSL
- \brief  この関数はハンドシェーク終了後に呼び出し、相手とのネゴシエーションの結果得られたサーバー証明書のタイプを返します。
- ネゴシエーションが発生しない場合には戻り値としてWOLFSSL_SUCCESSが返されますが、証明書タイプとしてはWOLFSSL_CERT_TYPE_UNKNOWNが返されます。
- \return WOLFSSL_SUCCESS 成功時にかえります。tpに返された証明書タイプはWOLFSSL_CERT_TYPE_X509,
-  WOLFSSL_CERT_TYPE_RPK あるいはWOLFSSL_CERT_TYPE_UNKNOWNのいずれかとなります。
- \return BAD_FUNC_ARG sslとしてNULLを渡した、あるいはtpとしてNULLを渡した
- \param ssl  WOLFSSL構造体へのポインタ
- \param tp  証明書タイプが返されるバッファへのポインタ
+ \brief この関数は、ClientHelloとServerHelloで行われたサーバ証明書タイプネゴシエーションの結果を返します。ネゴシエーションが発生しなかった場合、戻り値としてWOLFSSL_SUCCESSが返され、証明書タイプとしてWOLFSSL_CERT_TYPE_UNKNOWNが返されます。
+
+ \return WOLFSSL_SUCCESS ネゴシエートされた証明書タイプを取得できた場合。
+ \return BAD_FUNC_ARG ctxまたはtpにNULLが渡された場合。
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param tp 証明書タイプが返されるバッファ。次の3つの証明書タイプのいずれかが返されます:WOLFSSL_CERT_TYPE_RPK、WOLFSSL_CERT_TYPE_X509、またはWOLFSSL_CERT_TYPE_UNKNOWN。
     _Example_
  \code
   int ret;
@@ -11066,121 +13134,12 @@ int wolfSSL_get_negotiated_client_cert_type(WOLFSSL* ssl, int* tp);
 int wolfSSL_get_negotiated_server_cert_type(WOLFSSL* ssl, int* tp);
 
 /*!
- \ingroup SSL
- \brief  この関数はテストのための固定/静的なエフェラルキーを設定します。
- \return 0  成功時に返されます。
- \param ctx  WOLFSSL_CTXコンテキストポインタ
- \param keyAlgo  WC_PK_TYPE_DHおよびWC_PK_TYPE_ECDHのようなenum wc_pktype
- \param key  キーファイルパス（Keysz == 0）または実際のキーバッファ（PEMまたはASN.1）
- \param keySz  キーサイズ（「キー」argはファイルパスの場合は0になります）
- \sa wolfSSL_CTX_get_ephemeral_key
- */
-int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, const char* key, unsigned int keySz, int format);
 
-/*!
- \ingroup SSL
- \brief  この関数はテストのための固定/静的なエフェラルキーを設定します。
- \return 0  成功時に返されます。
- \param ssl  WOLFSSL構造体へのポインタ
- \param keyAlgo  WC_PK_TYPE_DHおよびWC_PK_TYPE_ECDHのようなenum wc_pktype
- \param key  キーファイルパス（Keysz == 0）または実際のキーバッファ（PEMまたはASN.1）
- \param keySz  キーサイズ（「キー」argはファイルパスの場合は0になります）
- \sa wolfSSL_get_ephemeral_key
- */
-int wolfSSL_set_ephemeral_key(WOLFSSL* ssl, int keyAlgo, const char* key, unsigned int keySz, int format);
+\brief SSLオブジェクトに対してConnectionID拡張の使用を有効にします。RFC 9146およびRFC 9147を参照してください。
 
-/*!
- \ingroup SSL
- \brief  この関数は ASN.1/DERとしてロードされたキーへのポインタを返します
- \return 0  成功時に返されます。
- \param ctx  wolfssl_ctxコンテキストポインタ
- \param keyAlgo  WC_PK_TYPE_DHおよびWC_PK_TYPE_ECDHのようなenum wc_pktype
- \param key  キーバッファポインタ
- \sa wolfSSL_CTX_set_ephemeral_key
- */
-int wolfSSL_CTX_get_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo,
-    const unsigned char** key, unsigned int* keySz);
+ \return WOLFSSL_SUCCESS 成功時、それ以外の場合はエラーコード。
 
-/*!
- \ingroup SSL
- \brief  この関数は ASN.1/DERとしてロードされた鍵へのポインタを返します
- \return 0  成功時に返されます。
- \param ssl  WOLFSSL構造体へのポインタ
- \param keyAlgo  WC_PK_TYPE_DHおよびWC_PK_TYPE_ECDHのようなenum wc_pktype
- \param key  キーバッファポインタ
- \sa wolfSSL_set_ephemeral_key
- */
-int wolfSSL_get_ephemeral_key(WOLFSSL* ssl, int keyAlgo,
-    const unsigned char** key, unsigned int* keySz);
-
-/*!
- \ingroup SSL
- \brief  選択したメッセージダイジェスト、パディング、およびRSAキーを使用してメッセージに署名します。
- \return WOLFSSL_SUCCESS  成功時に返されます。
- \return WOLFSSL_FAILURE  エラー発生時に返されます。
-
- \param type  ハッシュNID
- \param m  署名するメッセージ。これは署名するメッセージのダイジェスト
- \param mLen  署名するメッセージの長さ
- \param sigRet  出力バッファへのポインタ
- \param sigLen 入力時にはsigRetの長さを指定します。出力時にはsigRetに書き込まれたデータの長さを格納します。
- \param rsa  入力に署名するために使用されるRSA鍵
- \param flag  1：シグニチャ0：未パワード署名を比較する値を出力します。注：RSA_PKCS1_PSS_PADDINGの場合は、wc_rsapss_checkpadding_ex関数を使用して* VERIFY *関数の出力を確認する必要があります。
- \param padding パディング
- */
-int wolfSSL_RSA_sign_generic_padding(int type, const unsigned char* m,
-                               unsigned int mLen, unsigned char* sigRet,
-                               unsigned int* sigLen, WOLFSSL_RSA* rsa,
-                               int flag, int padding);
-
-/*!
-　\ingroup SSL
-　\brief DTLSv1.3 送信済みだがまだ相手からアクノリッジを受けとっていないメッセージがあるか調べます。
-
- \return 1 ペンディングのメッセージがある場合に返されます。それ以外は0が返されます。
- \param ssl WOLFSSL構造体へのポインタ。
-*/
-int wolfSSL_dtls13_has_pending_msg(WOLFSSL *ssl);
-
-/*!
-    \ingroup SSL
-    \brief アーリーデータの最大サイズを取得します。
-
-    \param [in] s  WOLFSSL_SESSION構造体へのポインタ
-
-    \return アーリーデータの最大サイズ（max_early_data）
-    \param s WOLFSSL_SESSION構造体へのポインタ
-
-    \sa wolfSSL_set_max_early_data
-    \sa wolfSSL_write_early_data
-    \sa wolfSSL_read_early_data
- */
-unsigned int wolfSSL_SESSION_get_max_early_data(const WOLFSSL_SESSION *s);
-
-/*!
-    \ingroup SSL
-    \brief Get a new index for external data. This entry applies also for the
-           following API:
-           - wolfSSL_CTX_get_ex_new_index
-           - wolfSSL_get_ex_new_index
-           - wolfSSL_SESSION_get_ex_new_index
-           - wolfSSL_X509_get_ex_new_index
-
-    \param [in] All input parameters are ignored. The callback functions are not
-                supported with wolfSSL.
-
-    \return The new index value to be used with the external data API for this
-            object class.
- */
-int wolfSSL_CRYPTO_get_ex_new_index(int, void*, void*, void*, void*);
-
-/*!
-
- \brief コネクションID拡張を有効にします。RFC9146とRFC9147を参照してください。
-
- \return WOLFSSL_SUCCESS 成功時に返されます。それ以外はエラーコードが返されます。
-
- \param ssl WOLFSSL構造体へのポインタ。
+ \param ssl WOLFSSLオブジェクトポインタ。
 
  \sa wolfSSL_dtls_cid_is_enabled
  \sa wolfSSL_dtls_cid_set
@@ -11193,12 +13152,11 @@ int wolfSSL_dtls_cid_use(WOLFSSL* ssl);
 
 /*!
 
- \brief この関数はハンドシェークが完了した後に呼び出されると、コネクションIDがネゴシエートされたかどうか確認することができます。
- RFC9146とRFC9147を参照してください。
+\brief ハンドシェイク完了後に呼び出された場合、SSLオブジェクトに対してConnectionIDが正常にネゴシエートされたかどうかを確認します。RFC 9146およびRFC 9147を参照してください。
 
- \return 1 コネクションIDがネゴシエートされた場合に返されます。それ以外は0が返されます。
+ \return 1 ConnectionIDが正しくネゴシエートされた場合、それ以外は0。
 
- \param ssl WOLFSSL構造体へのポインタ。
+ \param ssl WOLFSSLオブジェクトポインタ。
 
  \sa wolfSSL_dtls_cid_use
  \sa wolfSSL_dtls_cid_set
@@ -11211,16 +13169,13 @@ int wolfSSL_dtls_cid_is_enabled(WOLFSSL* ssl);
 
 /*!
 
- \brief このコネクションで他のピアに対してレコードを送信するためのコネクションIDをセットします。
- RFC9146とRFC9147を参照してください。コネクションIDは最大値がDTLS_CID_MAX_SIZEでなければなりません。
- DTLS_CID_MAX_SIZEはビルド時に値を指定が可能ですが255バイトをこえることはできません。
+\brief この接続でレコードを送信する際に相手ピアが使用するConnectionIDを設定します。RFC 9146およびRFC 9147を参照してください。ConnectionIDは最大DTLS_CID_MAX_SIZE(調整可能なコンパイル時定義)である必要があり、255バイトを超えることはできません。
 
+ \return WOLFSSL_SUCCESS ConnectionIDが正しく設定された場合、それ以外の場合はエラーコード。
 
- \return WOLFSSL_SUCCESS コネクションIDがセットできた場合に返されます。それ以外はエラーコードが返されます。
-
- \param ssl WOLFSSL構造体へのポインタ。
- \param cid コネクションID
- \param size コネクションIDのサイズ
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param cid 使用するConnectionID。
+ \param size 提供されたConnectionIDのサイズ。
 
  \sa wolfSSL_dtls_cid_use
  \sa wolfSSL_dtls_cid_is_enabled
@@ -11234,12 +13189,12 @@ int wolfSSL_dtls_cid_set(WOLFSSL* ssl, unsigned char* cid,
 
 /*!
 
- \brief コネクションIDのサイズを取得します。RFC9146とRFC9147を参照してください。
+\brief この接続でレコードを送信する際に相手ピアが使用するConnectionIDのサイズを取得します。RFC 9146およびRFC 9147を参照してください。サイズはパラメータsizeに格納されます。
 
- \return WOLFSSL_SUCCESS コネクションIDが取得できた場合に返されます。それ以外はエラーコードが返されます。
+ \return WOLFSSL_SUCCESS ConnectionIDが正しくネゴシエートされた場合、それ以外の場合はエラーコード。
 
- \param ssl WOLFSSL構造体へのポインタ。
- \param size コネクションIDのサイズを格納するint型変数へのポインタ。
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param size サイズが格納される符号なしint型へのポインタ。
 
  \sa wolfSSL_dtls_cid_use
  \sa wolfSSL_dtls_cid_is_enabled
@@ -11253,16 +13208,15 @@ int wolfSSL_dtls_cid_get_rx_size(WOLFSSL* ssl,
 
 /*!
 
- \brief コネクションIDを引数bufferで指定されたバッファにコピーします。
- RFC9146とRFC9147を参照してください。
- バッファのサイズは引数bufferSzで指定してください。
+\brief この接続でレコードを送信する際に相手ピアが使用するConnectionIDを、パラメータbufferが指すバッファにコピーします。RFC 9146およびRFC 9147を参照してください。bufferSzでバッファ内の利用可能なスペースを提供する必要があります。
 
- \return WOLFSSL_SUCCESS コネクションIDが取得できた場合に返されます。それ以外はエラーコードが返されます。
+ \return WOLFSSL_SUCCESS ConnectionIDが正しくコピーされた場合、それ以外の場合はエラーコード。
 
- \param ssl WOLFSSL構造体へのポインタ。
- \param buffer コネクションIDがコピーされる先のバッファへのポインタ。
- \param bufferSz バッファのサイズ
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param buffer ConnectionIDがコピーされるバッファ。
+ \param bufferSz buffer内の利用可能なスペース。
 
+ \sa wolfSSL_dtls_cid_get0_rx
  \sa wolfSSL_dtls_cid_use
  \sa wolfSSL_dtls_cid_is_enabled
  \sa wolfSSL_dtls_cid_set
@@ -11275,13 +13229,31 @@ int wolfSSL_dtls_cid_get_rx(WOLFSSL* ssl, unsigned char* buffer,
 
 /*!
 
- \brief コネクションIDのサイズを取得します。ｃ
- サイズは引数size変数に格納されます。
+\brief 相手ピアが使用するConnectionIDを取得します。RFC 9146およびRFC 9147を参照してください。
 
- \return WOLFSSL_SUCCESS コネクションIDのサイズが取得できた場合に返されます。それ以外はエラーコードが返されます。
+ \return WOLFSSL_SUCCESS ConnectionIDがcidに正しく設定された場合。
 
- \param ssl WOLFSSL構造体へのポインタ。
- \param size コネクションIDのサイズを格納するint型変数へのポインタ。
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param cid CIDを保持する内部メモリに設定されるポインタ。
+
+ \sa wolfSSL_dtls_cid_get_rx
+ \sa wolfSSL_dtls_cid_use
+ \sa wolfSSL_dtls_cid_is_enabled
+ \sa wolfSSL_dtls_cid_set
+ \sa wolfSSL_dtls_cid_get_rx_size
+ \sa wolfSSL_dtls_cid_get_tx_size
+ \sa wolfSSL_dtls_cid_get_tx
+*/
+int wolfSSL_dtls_cid_get0_rx(WOLFSSL* ssl, unsigned char** cid);
+
+/*!
+
+\brief この接続でレコードを送信する際に使用するConnectionIDのサイズを取得します。RFC 9146およびRFC 9147を参照してください。サイズはパラメータsizeに格納されます。
+
+ \return WOLFSSL_SUCCESS ConnectionIDサイズが正しく格納された場合、それ以外の場合はエラーコード。
+
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param size サイズが格納される符号なしint型へのポインタ。
 
  \sa wolfSSL_dtls_cid_use
  \sa wolfSSL_dtls_cid_is_enabled
@@ -11294,15 +13266,15 @@ int wolfSSL_dtls_cid_get_tx_size(WOLFSSL* ssl, unsigned int* size);
 
 /*!
 
- \brief コネクションIDを引き数bufferで指定されるバッファにコピーします。RFC9146とRFC9147を参照してください。
- バッファのサイズは引き数bufferSzで指定します。
+\brief この接続でレコードを送信する際に使用するConnectionIDを、パラメータbufferが指すバッファにコピーします。RFC 9146およびRFC 9147を参照してください。bufferSzで利用可能なサイズを提供する必要があります。
 
- \return WOLFSSL_SUCCESS ConnectionIDが正常にコピーされた際に返されます。それ以外はエラーコードが返されます。
+ \return WOLFSSL_SUCCESS ConnectionIDが正しくコピーされた場合、それ以外の場合はエラーコード。
 
- \param ssl WOLFSSL構造体へのポインタ。
- \param buffer ConnectionIDがコピーされるバッファへのポインタ。
- \param bufferSz バッファのサイズ
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param buffer ConnectionIDがコピーされるバッファ。
+ \param bufferSz buffer内の利用可能なスペース。
 
+ \sa wolfSSL_dtls_cid_get0_tx
  \sa wolfSSL_dtls_cid_use
  \sa wolfSSL_dtls_cid_is_enabled
  \sa wolfSSL_dtls_cid_set
@@ -11312,3 +13284,342 @@ int wolfSSL_dtls_cid_get_tx_size(WOLFSSL* ssl, unsigned int* size);
 */
 int wolfSSL_dtls_cid_get_tx(WOLFSSL* ssl, unsigned char* buffer,
     unsigned int bufferSz);
+
+/*!
+
+\brief この接続でレコードを送信する際に使用するConnectionIDを取得します。RFC 9146およびRFC 9147を参照してください。
+
+ \return WOLFSSL_SUCCESS ConnectionIDが正しく取得された場合、それ以外の場合はエラーコード。
+
+ \param ssl WOLFSSLオブジェクトポインタ。
+ \param cid CIDを保持する内部メモリに設定されるポインタ。
+
+ \sa wolfSSL_dtls_cid_get_tx
+ \sa wolfSSL_dtls_cid_use
+ \sa wolfSSL_dtls_cid_is_enabled
+ \sa wolfSSL_dtls_cid_set
+ \sa wolfSSL_dtls_cid_get_rx_size
+ \sa wolfSSL_dtls_cid_get_rx
+ \sa wolfSSL_dtls_cid_get_tx_size
+*/
+int wolfSSL_dtls_cid_get0_tx(WOLFSSL* ssl, unsigned char** cid);
+
+/*!
+
+\brief レコードデータグラム/メッセージからConnectionIDを抽出します。RFC 9146およびRFC 9147を参照してください。
+
+ \param msg ネットワークから読み取られたデータグラムを保持するバッファ。
+ \param msgSz msgのサイズ(バイト単位)。
+ \param cid msgバッファ内のCIDの開始位置へのポインタ。
+ \param cidSz 期待されるCIDのサイズ。レコード層にはCIDサイズフィールドがないため、CIDのサイズを事前に知っている必要があります。すべての接続に定数CIDを使用することを推奨します。
+
+ \sa wolfSSL_dtls_cid_get_tx
+ \sa wolfSSL_dtls_cid_use
+ \sa wolfSSL_dtls_cid_is_enabled
+ \sa wolfSSL_dtls_cid_set
+ \sa wolfSSL_dtls_cid_get_rx_size
+ \sa wolfSSL_dtls_cid_get_rx
+ \sa wolfSSL_dtls_cid_get_tx_size
+*/
+const unsigned char* wolfSSL_dtls_cid_parse(const unsigned char* msg,
+        unsigned int msgSz, unsigned int cidSz);
+
+/*!
+    \ingroup TLS
+    \brief サーバ側では、この関数は証明書要求でクライアントに送信されるCA名のリストを設定します。これは、サーバがサポートするCAのヒントとして機能します。
+
+    クライアント側では、この関数は効果がありません。
+
+    \param [in] ctx wolfSSLコンテキストへのポインタ。
+    \param [in] names 設定される名前のリスト。
+
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+void wolfSSL_CTX_set_client_CA_list(WOLFSSL_CTX* ctx,
+                                    WOLF_STACK_OF(WOLFSSL_X509_NAME)* names);
+
+/*!
+    \ingroup TLS
+    \brief これは、wolfSSL_CTX_set_client_CA_listを介して以前に設定されたリストを取得します。リストが設定されていない場合はNULLを返します。
+
+    \param [in] ctx wolfSSLコンテキストへのポインタ。
+    \return CA名を含むWOLFSSL_X509_NAMEのスタック。
+
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+WOLFSSL_STACK *wolfSSL_CTX_get_client_CA_list(
+        const WOLFSSL_CTX *ctx);
+
+/*!
+    \ingroup TLS
+    \brief wolfSSL_CTX_set_client_CA_listと同じですが、セッション固有です。CAリストがコンテキストとセッションの両方に設定されている場合、セッション上のリストが使用されます。
+
+    \param [in] ssl WOLFSSLオブジェクトへのポインタ。
+    \param [in] names 設定する名前のリスト。
+
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+void wolfSSL_set_client_CA_list(WOLFSSL* ssl,
+                                    WOLF_STACK_OF(WOLFSSL_X509_NAME)* names);
+
+/*!
+    \ingroup TLS
+    \brief サーバ側では、wolfSSL_set_client_CA_listを介して以前に設定されたリストを取得します。何も設定されていない場合は、wolfSSL_CTX_set_client_CA_listを介して以前に設定されたリストを返します。リストが全く設定されていない場合は、NULLを返します。
+
+    クライアント側では、サーバから受信したリストを取得します。何も受信していない場合はNULLを返します。wolfSSL_CTX_set_cert_cbを使用して、サーバから証明書要求を受信したときに証明書を動的にロードするコールバックを登録できます。
+
+    \param [in] ssl WOLFSSLオブジェクトへのポインタ。
+    \return CA名を含むWOLFSSL_X509_NAMEのスタック。
+
+    \sa wolfSSL_CTX_set_cert_cb
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+WOLFSSL_STACK* wolfSSL_get_client_CA_list(
+            const WOLFSSL* ssl);
+
+/*!
+    \ingroup TLS
+    \brief この関数は、ピアの認証でサポートされているCAのヒントとしてピアに送信されるCA名のリストを設定します。
+
+    TLS >= 1.3では、これはクライアントとサーバ間の両方向でサポートされています。サーバ側では、CA名はCertificateRequestの一部として送信されるため、この関数は*_set_client_CA_listと同等です。クライアント側では、これらはClientHelloの一部として送信されます。
+
+    TLS < 1.3では、クライアントからサーバへのCA名の送信はサポートされていないため、この関数はwolfSSL_CTX_set_client_CA_listと同等です。
+
+    *_set_client_CA_listと*_set0_CA_listを介して設定されたリストは内部的に別々であることに注意してください。つまり、*_get_client_CA_listを呼び出しても*_set0_CA_listを介して設定されたリストは取得されず、その逆も同様です。両方が設定されている場合、サーバはクライアントにCA名を送信する際に*_set0_CA_listを無視します。
+
+    \param [in] ctx wolfSSLコンテキストへのポインタ。
+    \param [in] names 設定する名前のリスト。
+
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+void wolfSSL_CTX_set0_CA_list(WOLFSSL_CTX *ctx,
+        WOLF_STACK_OF(WOLFSSL_X509_NAME)* names);
+
+/*!
+    \ingroup TLS
+    \brief これは、wolfSSL_CTX_set0_CA_listを介して以前に設定されたリストを取得します。リストが設定されていない場合はNULLを返します。
+
+    \param [in] ctx wolfSSLコンテキストへのポインタ。
+    \return CA名を含むWOLFSSL_X509_NAMEのスタック。
+
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+WOLFSSL_STACK *wolfSSL_CTX_get0_CA_list(
+        const WOLFSSL_CTX *ctx);
+
+/*!
+    \ingroup TLS
+    \brief wolfSSL_CTX_set0_CA_listと同じですが、セッション固有です。CAリストがコンテキストとセッションの両方に設定されている場合、セッション上のリストが使用されます。
+
+    \param [in] ssl WOLFSSLオブジェクトへのポインタ。
+    \param [in] names 設定する名前のリスト。
+
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+void wolfSSL_set0_CA_list(WOLFSSL *ssl,
+        WOLF_STACK_OF(WOLFSSL_X509_NAME) *names);
+
+/*!
+    \ingroup TLS
+    \brief これは、wolfSSL_set0_CA_listを介して以前に設定されたリストを取得します。何も設定されていない場合は、wolfSSL_CTX_set0_CA_listを介して以前に設定されたリストを返します。リストが全く設定されていない場合は、NULLを返します。
+
+    \param [in] ssl WOLFSSLオブジェクトへのポインタ。
+    \return CA名を含むWOLFSSL_X509_NAMEのスタック。
+
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_peer_CA_list
+*/
+WOLFSSL_STACK *wolfSSL_get0_CA_list(
+        const WOLFSSL *ssl);
+
+/*!
+    \ingroup TLS
+    \brief これは、ピアから受信したCAリストを返します。
+
+    クライアント側では、これはサーバがCertificateRequestで送信したリストであり、この関数はwolfSSL_get_client_CA_listと同等です。
+
+    サーバ側では、これはTLS >= 1.3でクライアントがClientHelloメッセージで送信したリストです。TLS < 1.3では、この関数はサーバ側で常にNULLを返します。
+
+    wolfSSL_CTX_set_cert_cbを使用して、ピアからCAリストを受信したときに証明書を動的にロードするコールバックを登録できます。
+
+    \param [in] ssl WOLFSSLオブジェクトへのポインタ。
+    \return CA名を含むWOLFSSL_X509_NAMEのスタック。
+
+    \sa wolfSSL_CTX_set_cert_cb
+    \sa wolfSSL_CTX_set_client_CA_list
+    \sa wolfSSL_set_client_CA_list
+    \sa wolfSSL_CTX_get_client_CA_list
+    \sa wolfSSL_get_client_CA_list
+    \sa wolfSSL_CTX_set0_CA_list
+    \sa wolfSSL_set0_CA_list
+    \sa wolfSSL_CTX_get0_CA_list
+    \sa wolfSSL_get0_CA_list
+*/
+WOLFSSL_STACK *wolfSSL_get0_peer_CA_list(const WOLFSSL *ssl);
+
+/*!
+    \ingroup TLS
+    \brief この関数は、証明書が使用される直前に呼び出されるコールバックを設定し、アプリケーションが証明書を検査、設定、またはクリアできるようにします。例えば、ピアから送信されたCAリストに反応することができます。
+
+    \param [in] ctx wolfSSLコンテキストへのポインタ。
+    \param [in] cb コールバックへの関数ポインタ。
+    \param [in] arg コールバックに渡されるポインタ。
+
+    \sa wolfSSL_get0_peer_CA_list
+    \sa wolfSSL_get_client_CA_list
+*/
+void wolfSSL_CTX_set_cert_cb(WOLFSSL_CTX* ctx,
+    int (*cb)(WOLFSSL *, void *), void *arg);
+
+/*!
+    \ingroup TLS
+
+    \brief この関数は、クライアントが提供する暗号スイートと署名アルゴリズムの生のリストを返します。リストは、wolfSSL_CTX_set_cert_cb()で設定されたコールバック内でのみ保存され、返されます。これは、利用可能な暗号スイートと署名アルゴリズムに基づいて証明書と鍵を動的にロードできるようにするのに便利です。
+
+    \param [in] ssl リストを抽出するWOLFSSLオブジェクト。
+    \param [out] optional suites クライアント暗号スイートの生の未フィルタリストリスト。
+    \param [out] optional suiteSz suitesのサイズ(バイト単位)。
+    \param [out] optional hashSigAlgo クライアント署名アルゴリズムの生の未フィルタリストリスト。
+    \param [out] optional hashSigAlgoSz hashSigAlgoのサイズ(バイト単位)。
+    \return WOLFSSL_SUCCESS スイートが利用可能な場合。
+    \return WOLFSSL_FAILURE スイートが利用できない場合。
+
+    _Example_
+    \code
+    int certCB(WOLFSSL* ssl, void* arg)
+    {
+        const byte* suites = NULL;
+        word16 suiteSz = 0;
+        const byte* hashSigAlgo = NULL;
+        word16 hashSigAlgoSz = 0;
+
+        wolfSSL_get_client_suites_sigalgs(ssl, &suites, &suiteSz, &hashSigAlgo,
+                &hashSigAlgoSz);
+
+        // 暗号スイートとsigalgsに基づいてロードする証明書を選択
+    }
+
+    WOLFSSL* ctx;
+    ctx  = wolfSSL_CTX_new(wolfTLSv1_3_method_ex(NULL));
+    wolfSSL_CTX_set_cert_cb(ctx, certCB, NULL);
+    \endcode
+
+    \sa wolfSSL_get_ciphersuite_info
+    \sa wolfSSL_get_sigalg_info
+*/
+int wolfSSL_get_client_suites_sigalgs(const WOLFSSL* ssl,
+        const byte** suites, word16* suiteSz,
+        const byte** hashSigAlgo, word16* hashSigAlgoSz);
+
+/*!
+    \ingroup TLS
+
+    \brief これは、生の暗号スイートバイトから直接暗号スイートに関する情報を返します。
+
+    \param [in] first 暗号スイートの最初のバイト。
+    \param [in] second 暗号スイートの2番目のバイト。
+
+    \return WOLFSSL_CIPHERSUITE_INFO 暗号スイートで使用される認証のタイプに関する情報を含む構造体。
+
+    _Example_
+    \code
+    WOLFSSL_CIPHERSUITE_INFO info =
+            wolfSSL_get_ciphersuite_info(suites[0], suites[1]);
+    if (info.rsaAuth)
+        haveRSA = 1;
+    else if (info.eccAuth)
+        haveECC = 1;
+    \endcode
+
+    \sa wolfSSL_get_client_suites_sigalgs
+    \sa wolfSSL_get_sigalg_info
+*/
+WOLFSSL_CIPHERSUITE_INFO wolfSSL_get_ciphersuite_info(byte first,
+        byte second);
+
+/*!
+    \ingroup TLS
+
+    \brief これは、生の暗号スイートバイトから直接ハッシュおよび署名アルゴリズムに関する情報を返します。
+
+    \param [in] first ハッシュおよび署名アルゴリズムの最初のバイト。
+    \param [in] second ハッシュおよび署名アルゴリズムの2番目のバイト。
+    \param [out] hashAlgo MACアルゴリズムのenum wc_HashType。
+    \param [out] sigAlgo 認証アルゴリズムのenum Key_Sum。
+
+    \return 0            情報が正しく設定された場合。
+    \return BAD_FUNC_ARG 入力パラメータのいずれかがNULLの場合、またはバイトが認識されるsigalgスイートでない場合。
+
+    _Example_
+    \code
+    enum wc_HashType hashAlgo;
+    enum Key_Sum sigAlgo;
+
+    wolfSSL_get_sigalg_info(hashSigAlgo[idx+0], hashSigAlgo[idx+1],
+            &hashAlgo, &sigAlgo);
+
+    if (sigAlgo == RSAk || sigAlgo == RSAPSSk)
+        haveRSA = 1;
+    else if (sigAlgo == ECDSAk)
+        haveECC = 1;
+    \endcode
+
+    \sa wolfSSL_get_client_suites_sigalgs
+    \sa wolfSSL_get_ciphersuite_info
+*/
+int wolfSSL_get_sigalg_info(byte first, byte second,
+        int* hashAlgo, int* sigAlgo);


### PR DESCRIPTION
# Description

Sync `doc/dox_comments/header_files-ja/` with the English version.
Other files are provided by https://github.com/wolfSSL/wolfssl/pull/9371 .

>[!NOTE]
>This ended up being a huge commit and PR, but it had already been discussed with the reviewer in advance.

# Testing

The pdf/html build results using `wolfssl/documentation` have been manually checked.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [x] Updated manual and documentation
