### PR TITLE
Silence dubious ownership from git for hostap; Add clone retry

### DIFF
--- a/.github/workflows/hostap-vm.yml
+++ b/.github/workflows/hostap-vm.yml
@@ -80,7 +80,36 @@ jobs:
 
       - name: Checkout hostap
         if: steps.cache.outputs.cache-hit != 'true'
-        run: git clone git://w1.fi/hostap.git hostap
+        run: |
+            # Fetch the host AP source
+            set -Eeuo pipefail
+
+            cloned=0
+            REMOTE1="https://w1.fi/cgit/hostap"   # try HTTPS first
+            REMOTE2="git://w1.fi/hostap.git"      # fallback (9418 often blocked)
+
+            for remote in "$REMOTE1" "$REMOTE2"; do
+              echo "Trying $remote"
+              for i in 1 2 3 4 5; do
+                rm -rf hostap
+                if git clone --filter=blob:none "$remote" hostap; then
+                  echo "Cloned from $remote"
+                  cloned=1
+                  break 2          # success, break both loops, DO NOT exit the step
+                fi
+                sleep_secs=$(( i * 30 ))
+                echo "Clone failed (attempt $i). Sleeping ${sleep_secs}s..."
+                sleep "$sleep_secs"
+              done
+            done
+
+            if [ "$cloned" -ne 1 ]; then
+              echo "::warning:: hostap clone failed after retries; abort"
+              exit 1
+            fi
+
+            # Silence Git "dubious ownership" on the host (runner):
+            git config --global --add safe.directory "$GITHUB_WORKSPACE/hostap" || true
 
   build_uml_linux:
     name: Build UML (UserMode Linux)
@@ -226,7 +255,43 @@ jobs:
 
       - name: Checkout correct ref
         working-directory: hostap
-        run: git checkout ${{ matrix.config.hostap_ref }}
+        run: |
+            # Ensure a clean hostap before each checkout in matrix
+            git config --global --add safe.directory "$GITHUB_WORKSPACE/hostap" || true
+            git reset --hard
+            git clean -fdx
+            git -c advice.detachedHead=false checkout ${{ matrix.config.hostap_ref }}
+
+            # see "inside.sh"
+            # https://git.w1.fi/cgit/hostap/tree/tests/hwsim/vm/inside.sh
+            # And make every UML guest do the same at boot:
+            # (inside.sh runs inside each VM before tests)
+            target="tests/hwsim/vm/inside.sh"
+
+            # Just in case the inside.sh is moved, we won't fail here.
+            if [ ! -f "$target" ]; then
+              echo "::Warning:: $target not found at this ref, skipping Git safe.directory step"
+              ls -la tests/hwsim/vm || true
+              exit 0
+            fi
+
+            # PREPEND the lines so they run before anything else inside the guest
+            echo "marking safe.directory during inside.sh"
+            tmp="$(mktemp)"
+            {
+              printf '#!/bin/sh\n'
+              printf '# Added by CI to silence Git safe.directory warnings\n'
+              printf 'git config --global --add safe.directory "*"\n'
+              printf 'git config --global --add safe.directory "/home/runner/work/wolfssl/wolfssl/hostap"\n'
+              cat "$target"
+            } > "$tmp"
+            mv "$tmp" "$target"
+
+            # Ensure it stays executable
+            chmod +x $target || true
+
+            # peek at inside.sh
+            cat $target || true
 
       - name: Update certs
         working-directory: hostap/tests/hwsim/auth_serv
@@ -316,7 +381,7 @@ jobs:
             KERNELDIR=$GITHUB_WORKSPACE/linux
             KVMARGS="-cpu host"
           EOF
-          git config --global --add safe.directory $GITHUB_WORKSPACE/hostap
+
           # Run tests in increments of 200 to not stall out the parallel-vm script
           while mapfile -t -n 200 ary && ((${#ary[@]})); do
             TESTS=$(printf '%s\n' "${ary[@]}" | tr '\n' ' ')


### PR DESCRIPTION
# Description

This PR attempts to fix the occasional and unpredictable "_fatal: detected dubious ownership in repository_" that passed during pull request time, but then [failed during merge test time](https://github.com/wolfSSL/wolfssl/actions/runs/19238743188/job/54996044974):

```
VM 0 - unexpected stdout output:
fatal: detected dubious ownership in repository at '/home/runner/work/wolfssl/wolfssl/hostap'
To add an exception for this directory, call:
	git config --global --add safe.directory /home/runner/work/wolfssl/wolfssl/hostap
```

Note the failure happened _inside_ the VM, so the fix in this PR _also_ updates the script file in the hostap script:

```
hostap/tests/hwsim/vm/inside.sh
```

While working on this, I also encountered a [connection refused](https://github.com/gojimmypi/wolfssl/actions/runs/19246601543/job/55022590168)

```
  env:
    LINUX_REF: v6.12
Cloning into 'hostap'...
fatal: unable to connect to w1.fi:
w1.fi[0: 212.71.239.96]: errno=Connection refused
```

Thus I also added a new git clone retry with two different URL ports (http & git).

While editing the `inside.sh` files, there was of course a complaint in the next matrix about changes that needed to be committed. So I added a git reset & clean, only to be reminded with this error:

```
If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at cff80b4f7 Preparations for v2.10 release
```

I added the `advice.detachedHead` as recommended.

## Additional Concern

Unrelated to the dubious ownership in this PR, is [this](https://github.com/gojimmypi/wolfssl/actions/runs/19248472177/job/55028235540) failure:

```
Failed test cases:
owe_invalid_assoc_resp 2025-11-10 22:48:50,252 INFO Failed: owe_invalid_assoc_resp

Failed even on retry:
owe_invalid_assoc_resp 2025-11-10 22:48:50,252 INFO Failed on retry: owe_invalid_assoc_resp

TOTAL=201 PASS=152 FAIL=2 SKIP=47
2025-11-10 22:48:50,252 INFO TOTAL=201 PASS=152 FAIL=2 SKIP=47
Logs: /tmp/hwsim-test-logs/1762814889
2025-11-10 22:48:50,252 INFO Logs: /tmp/hwsim-test-logs/1762814889
Other skip reasons: ['Driver does not support random GAS TA', 'No pyrad modules available', 'macsec supported (wpa_supplicant CONFIG_MACSEC, CONFIG_DRIVER_MACSEC_LINUX; kernel CONFIG_MACSEC)']
```

It may be this one is more of a resource / concurrency issue? Upon retry it was successful, and I only saw it once.

I can address in a separate PR if it is problematic upstream.





Fixes zd# n/a

# Testing

How did you test?

See:

- my test https://github.com/gojimmypi/wolfssl/actions/runs/19248472177
- my re-test https://github.com/gojimmypi/wolfssl/actions/runs/19248916944
- the result here at wolfssl: https://github.com/wolfSSL/wolfssl/actions/runs/19249034732


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
