### PR TITLE
fix(linuxkm): Fix shell syntax error on RHEL8/9

### DIFF
--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -142,7 +142,7 @@ endif
 
 .PHONY: libwolfssl.ko
 libwolfssl.ko:
-	@function resolved_link_is_equal() { [[ -L "$$1" && ("$$(readlink -f "$$1")" == "$$(readlink -f "$$2")") ]] }
+	@function resolved_link_is_equal() { [[ -L "$$1" && ("$$(readlink -f "$$1")" == "$$(readlink -f "$$2")") ]]; }
 	@if test -z '$(KERNEL_ROOT)'; then echo '$$KERNEL_ROOT is unset' >&2; exit 1; fi
 	@if test -z '$(AM_CFLAGS)$(CFLAGS)'; then echo '$$AM_CFLAGS and $$CFLAGS are both unset.' >&2; exit 1; fi
 	@if test -z '$(src_libwolfssl_la_OBJECTS)'; then echo '$$src_libwolfssl_la_OBJECTS is unset.' >&2; exit 1; fi


### PR DESCRIPTION
# Description

The change fixes Bash syntax error manifesting itself on RHEL8/9 (Rocky Linux 8/9, to be precise):

	...
	make -C linuxkm libwolfssl.ko
	make[1]: Entering directory '/wolfssl/linuxkm'
	bash: -c: line 1: syntax error near unexpected token `}'
	bash: -c: line 1: `function resolved_link_is_equal() { [[ -L "$1" && ("$(readlink -f "$1")" == "$(readlink -f "$2")") ]] }'
	make[1]: *** [Makefile:145: libwolfssl.ko] Error 2
	...

Best reproduced with `rockylinux/rockylinux:8` and `rockylinux/rockylinux:9` Docker images (Bash versions 4.4.x and 5.1.x, respectively) - the `configure` options don't seem to matter, since the function in question doesn't use any configuration-dependent logic
Please describe the scope of the fix or feature addition.

Fixes zd# N/A

# Testing

Local Docker-based environment (`rockylinux/rockylinux:8` and `rockylinux/rockylinux:9`)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
