### PR TITLE
TLS 1.3 duplicate KeyShare entry fix

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -9830,7 +9830,7 @@ static int TLSX_KeyShareEntry_Parse(const WOLFSSL* ssl, const byte* input,
         return BUFFER_ERROR;
 
     if (seenGroups != NULL) {
-        if (*seenGroupsCnt == MAX_KEYSHARE_NAMED_GROUPS) {
+        if (*seenGroupsCnt >= MAX_KEYSHARE_NAMED_GROUPS) {
             return BAD_KEY_SHARE_DATA;
         }
         for (i = 0; i < *seenGroupsCnt; i++) {


### PR DESCRIPTION
# Description

Fix comparison to be greater than or equal in case count is incremented after maxing out.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
