### PR TITLE
Fix TLS 1.3 cipher suite when TLS 1.2 ciphers precede TLS 1.3 ciphers

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -37173,7 +37173,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     static WC_INLINE int IsTls13CipherSuite(byte first, byte second)
     {
         (void)second;  /* Suppress unused parameter warning */
-        
+
         /* TLS 1.3 cipher suites use TLS13_BYTE (0x13) as first byte */
         if (first == TLS13_BYTE)
             return 1;

--- a/src/internal.c
+++ b/src/internal.c
@@ -37172,6 +37172,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
      */
     static WC_INLINE int IsTls13CipherSuite(byte first, byte second)
     {
+        (void)second;  /* Suppress unused parameter warning */
+        
         /* TLS 1.3 cipher suites use TLS13_BYTE (0x13) as first byte */
         if (first == TLS13_BYTE)
             return 1;

--- a/src/internal.c
+++ b/src/internal.c
@@ -37176,15 +37176,20 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (first == TLS13_BYTE)
             return 1;
 
+#ifdef HAVE_NULL_CIPHER
         /* Special cases for integrity-only cipher suites */
         if (first == ECC_BYTE && (second == TLS_SHA256_SHA256 ||
                                   second == TLS_SHA384_SHA384))
             return 1;
+#endif
 
+#if (defined(WOLFSSL_SM4_GCM) || defined(WOLFSSL_SM4_CCM)) && \
+     defined(WOLFSSL_SM3)
         /* SM4 cipher suites for TLS 1.3 */
         if (first == CIPHER_BYTE && (second == TLS_SM4_GCM_SM3 ||
                                      second == TLS_SM4_CCM_SM3))
             return 1;
+#endif
 
         return 0;
     }


### PR DESCRIPTION
# Description

Fixes TLS 1.3 handshake failure when TLS 1.2 cipher suites are listed before TLS 1.3 cipher suites in the server's cipher list. Modified VerifyServerSuite() to filter out TLS 1.2 ciphers during TLS 1.3 negotiation.
Fixes #9030

# Testing

Tested with example server/client using mixed cipher list:
./examples/server/server -v 4 -l ECDHE-RSA-AES128-GCM-SHA256:TLS13-AES128-GCM-SHA256
./examples/client/client -v 4
TLS 1.3 connection now succeeds regardless of cipher order.
