### PR TITLE
ECC sign hash: only allow up to max digest size

### DIFF
--- a/tests/api/test_ecc.c
+++ b/tests/api/test_ecc.c
@@ -429,6 +429,10 @@ int test_wc_ecc_signVerify_hash(void)
         WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
     ExpectIntEQ(wc_ecc_sign_hash(digest, digestlen, sig, &siglen, &rng, NULL),
         WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
+#if (!defined(HAVE_FIPS) || FIPS_VERSION_GT(7,0)) && !defined(HAVE_SELFTEST)
+    ExpectIntEQ(wc_ecc_sign_hash(digest, WC_MAX_DIGEST_SIZE+1, sig, &siglen,
+        &rng, &key), WC_NO_ERR_TRACE(BAD_LENGTH_E));
+#endif
 
 #ifdef HAVE_ECC_VERIFY
     ExpectIntEQ(wc_ecc_verify_hash(sig, siglen, digest, digestlen, &verify,
@@ -457,6 +461,10 @@ int test_wc_ecc_signVerify_hash(void)
         WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
     ExpectIntEQ(wc_ecc_verify_hash(sig, siglen, digest, digestlen, &verify,
         NULL), WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
+#if (!defined(HAVE_FIPS) || FIPS_VERSION_GT(7,0)) && !defined(HAVE_SELFTEST)
+    ExpectIntEQ(wc_ecc_verify_hash(sig, siglen, digest, WC_MAX_DIGEST_SIZE+1,
+        &verify, &key), WC_NO_ERR_TRACE(BAD_LENGTH_E));
+#endif
 #endif /* HAVE_ECC_VERIFY */
 
     DoExpectIntEQ(wc_FreeRng(&rng), 0);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6716,6 +6716,9 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     if (in == NULL || out == NULL || outlen == NULL || key == NULL) {
         return ECC_BAD_ARG_E;
     }
+    if (inlen > WC_MAX_DIGEST_SIZE) {
+        return BAD_LENGTH_E;
+    }
 
 #ifdef WOLF_CRYPTO_CB
     #ifndef WOLF_CRYPTO_CB_FIND
@@ -8495,6 +8498,9 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
 
     if (sig == NULL || hash == NULL || res == NULL || key == NULL) {
         return ECC_BAD_ARG_E;
+    }
+    if (hashlen > WC_MAX_DIGEST_SIZE) {
+        return BAD_LENGTH_E;
     }
 
 #ifdef WOLF_CRYPTO_CB

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -31118,7 +31118,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t srtpkdf_test(void)
 #define HAVE_ECC_DETERMINISTIC_K
 #define ECC_DIGEST_SIZE     WC_SHA256_DIGEST_SIZE
 #else
-#define ECC_DIGEST_SIZE     MAX_ECC_BYTES
+#define ECC_DIGEST_SIZE     WC_MAX_DIGEST_SIZE
 #endif
 #define ECC_SIG_SIZE        ECC_MAX_SIG_SIZE
 


### PR DESCRIPTION
# Description

Validate that the hash passed in is of an appropriate length - not greater than the maximum digest size.

Fixes #9417

# Testing

Standard testing.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
