### PR TITLE
Enable hardware acceleration for AES on PSoC6.

### DIFF
--- a/wolfcrypt/src/port/cypress/README.md
+++ b/wolfcrypt/src/port/cypress/README.md
@@ -1,6 +1,6 @@
 # PSoC6 Hardware Crypto Port for wolfSSL
 
-This directory provides a hardware-accelerated cryptography port for Cypress PSoC6 devices, integrating the PSoC6 hardware crypto block with the wolfSSL cryptography library. The implementation leverages the PSoC6 hardware to accelerate various cryptographic hash and ECC operations, improving performance and reducing CPU load.
+This directory provides a hardware-accelerated cryptography port for Cypress PSoC6 devices, integrating the PSoC6 hardware crypto block with the wolfSSL cryptography library. The implementation leverages the PSoC6 hardware to accelerate various cryptographic operations including hash functions, AES encryption/decryption, and ECC verification, improving performance and reducing CPU load.
 
 ## Implemented Features
 
@@ -21,68 +21,126 @@ The following hash algorithms are implemented using the PSoC6 hardware crypto bl
 
 All hash operations are offloaded to the PSoC6 hardware, with mutex protection for thread safety.
 
-### 2. Hardware-Accelerated ECDSA Verification
+### 2. Hardware-Accelerated AES Functions
+
+The following AES cipher modes are implemented using the PSoC6 hardware crypto block:
+
+- **AES Block Operations**
+  - Single-block encryption/decryption: `wc_Psoc6_Aes_Encrypt`, `wc_Psoc6_Aes_Decrypt`
+  - Direct AES operations: `wc_Psoc6_Aes_EncryptDirect`, `wc_Psoc6_Aes_DecryptDirect` (enabled with `WOLFSSL_AES_DIRECT`)
+  - Supports AES-128, AES-192, and AES-256 key sizes
+
+- **AES-ECB (Electronic Codebook) Mode**
+  - Multi-block encryption: `wc_Psoc6_Aes_EcbEncrypt`
+  - Multi-block decryption: `wc_Psoc6_Aes_EcbDecrypt`
+  - Enabled with `HAVE_AES_ECB`
+
+- **AES-CBC (Cipher Block Chaining) Mode**
+  - Multi-block encryption with IV chaining: `wc_Psoc6_Aes_CbcEncrypt`
+  - Multi-block decryption with IV chaining: `wc_Psoc6_Aes_CbcDecrypt`
+  - Automatically enabled with `HAVE_AES_CBC`
+
+- **AES-CFB (Cipher Feedback) Mode**
+  - Stream encryption: `wc_Psoc6_Aes_CfbEncrypt`
+  - Stream decryption: `wc_Psoc6_Aes_CfbDecrypt`
+  - Enabled with `WOLFSSL_AES_CFB`
+
+- **AES-GCM (Galois/Counter Mode)**
+  - Authenticated encryption: `wc_Psoc6_Aes_GcmEncrypt`
+  - Authenticated decryption with tag verification: `wc_Psoc6_Aes_GcmDecrypt`
+  - Provides both confidentiality and authenticity
+  - Enabled with `HAVE_AESGCM`
+
+All AES operations are offloaded to the PSoC6 hardware with mutex protection for thread safety.
+### 3. Hardware-Accelerated ECDSA Verification
 
 - **ECDSA Signature Verification**
   - Function: `psoc6_ecc_verify_hash_ex`
   - Uses PSoC6 hardware to verify ECDSA signatures for supported curves (up to secp521r1).
   - Enabled when `HAVE_ECC` is defined.
 
-### 3. Crypto Block Initialization and Resource Management
+### 4. Crypto Block Initialization and Resource Management
 
 - **Initialization**
   - Function: `psoc6_crypto_port_init`
   - Enables the PSoC6 crypto hardware block.
 - **Resource Cleanup**
-  - Function: `wc_Psoc6_Sha_Free`
-  - Clears and synchronizes the hardware register buffer.
+  - Hash functions: `wc_Psoc6_Sha_Free` — Clears and synchronizes the hardware register buffer
+  - AES functions: `wc_Psoc6_Aes_Free` — Frees internal AES buffers and state
 
 ## Enable Hardware Acceleration
 
-To enable PSoC6 hardware crypto acceleration for hash and ECC algorithms, ensure the following macros are defined:
+To enable PSoC6 hardware crypto acceleration, ensure the following macros are defined:
 
-- `WOLFSSL_PSOC6_CRYPTO` — Enables the PSoC6 hardware crypto port.
+### Core Macro
+- `WOLFSSL_PSOC6_CRYPTO` — Enables the PSoC6 hardware crypto port (required for all features)
+
+### Hash Function Macros
 - The following are defined in `psoc6_crypto.h` and control which hardware hash accelerations are available:
-  - `PSOC6_HASH_SHA1` — Enables SHA-1 hardware acceleration.
-  - `PSOC6_HASH_SHA2` — Enables SHA-2 family (SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224, SHA-512/256) hardware acceleration.
-  - `PSOC6_HASH_SHA3` — Enables SHA-3 family hardware acceleration.
-- To enable the corresponding algorithms in wolfSSL, define the following macros as needed (typically in your `wolfssl/wolfcrypt/settings.h` or build system):
-  - `WOLFSSL_SHA224` — Enable SHA-224 support.
-  - `WOLFSSL_SHA384` — Enable SHA-384 support.
-  - `WOLFSSL_SHA512` — Enable SHA-512, SHA-512/224, SHA-512/256 support.
-  - `WOLFSSL_SHA3` — Enable SHA-3 support.
-  - `WOLFSSL_SHAKE128`, `WOLFSSL_SHAKE256` — Enable SHAKE support.
-  - `HAVE_ECC` — Enable ECC and ECDSA support.
+  - `PSOC6_HASH_SHA1` — Enables SHA-1 hardware acceleration
+  - `PSOC6_HASH_SHA2` — Enables SHA-2 family hardware acceleration
+  - `PSOC6_HASH_SHA3` — Enables SHA-3 family hardware acceleration
+- To enable the corresponding algorithms in wolfSSL, define these macros (typically in your `wolfssl/wolfcrypt/settings.h` or build system):
+  - `WOLFSSL_SHA224` — Enable SHA-224 support
+  - `WOLFSSL_SHA384` — Enable SHA-384 support
+  - `WOLFSSL_SHA512` — Enable SHA-512, SHA-512/224, SHA-512/256 support
+  - `WOLFSSL_SHA3` — Enable SHA-3 support
+  - `WOLFSSL_SHAKE128`, `WOLFSSL_SHAKE256` — Enable SHAKE support
 
-**Example: Enabling SHA-1, SHA-2, and SHA-3 Hardware Acceleration**
+### AES Function Macros
+- AES hardware acceleration is automatically enabled when `NO_AES` is not defined
+- To enable specific AES modes, define:
+  - `HAVE_AES_ECB` — Enable AES-ECB mode
+  - `HAVE_AES_CBC` — Enable AES-CBC mode (typically enabled by default)
+  - `HAVE_AES_DECRYPT` — Enable AES decryption functions
+  - `WOLFSSL_AES_DIRECT` — Enable direct AES block operations
+  - `WOLFSSL_AES_CFB` — Enable AES-CFB mode
+  - `HAVE_AESGCM` — Enable AES-GCM authenticated encryption
+
+### ECC Function Macros
+- `HAVE_ECC` — Enable ECC and ECDSA support
+
+**Example: Enabling Full Hardware Acceleration**
 
 In your build configuration or `wolfssl/wolfcrypt/settings.h`:
 ```c
 #define WOLFSSL_PSOC6_CRYPTO
+
+/* Hash functions */
 #define WOLFSSL_SHA224
 #define WOLFSSL_SHA384
 #define WOLFSSL_SHA512
 #define WOLFSSL_SHA3
 #define WOLFSSL_SHAKE128
 #define WOLFSSL_SHAKE256
+
+/* AES cipher modes */
+#define HAVE_AES_ECB
+#define HAVE_AES_CBC
+#define HAVE_AES_DECRYPT
+#define WOLFSSL_AES_DIRECT
+#define WOLFSSL_AES_CFB
+#define HAVE_AESGCM
+
+/* ECC */
 #define HAVE_ECC
 ```
-- No need to define `PSOC6_HASH_SHA1`, `PSOC6_HASH_SHA2`, or `PSOC6_HASH_SHA3` yourself; they are defined in `psoc6_crypto.h`.
+- Note: `PSOC6_HASH_SHA1`, `PSOC6_HASH_SHA2`, and `PSOC6_HASH_SHA3` are automatically defined in `psoc6_crypto.h`; you don't need to define them explicitly.
 
 ## File Overview
 
 - `psoc6_crypto.h`
   Header file declaring the hardware crypto interface and configuration macros.
 - `psoc6_crypto.c`
-  Implementation of the hardware-accelerated hash and ECC functions for PSoC6.
+  Implementation of the hardware-accelerated hash, AES, and ECC functions for PSoC6.
 
 ## Integration Notes
 
 - The port expects the PSoC6 PDL (Peripheral Driver Library) to be available and included in your project.
 - The hardware crypto block is initialized on first use; no manual initialization is required unless you wish to call `psoc6_crypto_port_init` directly.
-- Hash operations are mutex-protected for thread safety.
+- Hash and AES operations are mutex-protected for thread safety.
 - ECC hardware operations are not mutex-protected; if you use ECC functions from multiple threads, you must provide your own synchronization.
-- The implementation is designed to be compatible with the wolfSSL API, so existing code using wolfSSL hash/ECC functions will automatically benefit from hardware acceleration when enabled.
+- The implementation is designed to be compatible with the wolfSSL API, so existing code using wolfSSL hash/AES/ECC functions will automatically benefit from hardware acceleration when enabled.
 
 ---
 

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -22,7 +22,7 @@
 #include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if (defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)) && \
-    !defined(WOLFSSL_PSOC6_CRYPTO) && !defined(WOLFSSL_RISCV_ASM)
+    !defined(WOLFSSL_RISCV_ASM)
 
 /* determine if we are using Espressif SHA hardware acceleration */
 #undef WOLFSSL_USE_ESP32_CRYPT_HASH_HW

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -156,6 +156,9 @@ WOLFSSL_LOCAL void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c,
     #include <wolfssl/wolfcrypt/port/maxim/maxq10xx.h>
 #endif
 
+#if defined(WOLFSSL_PSOC6_CRYPTO)
+    #include "cy_crypto_common.h"
+#endif /* WOLFSSL_PSOC6_CRYPTO */
 
 #ifdef __cplusplus
     extern "C" {
@@ -433,6 +436,12 @@ struct Aes {
 #ifdef WOLFSSL_AES_CTS
     byte ctsBlock[WC_AES_BLOCK_SIZE * 2];
 #endif
+#if defined(WOLFSSL_PSOC6_CRYPTO)
+    cy_stc_crypto_aes_state_t aes_state;
+#ifdef HAVE_AESGCM
+    cy_stc_crypto_aes_gcm_state_t aes_gcm_state;
+#endif
+#endif /* WOLFSSL_PSOC6_CRYPTO */
 };
 
 #ifndef WC_AES_TYPE_DEFINED

--- a/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
+++ b/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
@@ -30,10 +30,26 @@
 
 #include "cy_pdl.h"
 
-/* SHA1, SHA2 and SHA3 are supported for PSOC6 */
-#define PSOC6_HASH_SHA1
-#define PSOC6_HASH_SHA2
-#define PSOC6_HASH_SHA3
+/* Enable SHA-1 hardware acceleration if SHA-1 is enabled in wolfSSL */
+#if !defined(NO_SHA)
+    #define PSOC6_HASH_SHA1
+#endif
+
+/* Enable SHA-2 family hardware acceleration if any SHA-2 variant is enabled */
+#if !defined(NO_SHA256) || defined(WOLFSSL_SHA224) || \
+    defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
+    #define PSOC6_HASH_SHA2
+#endif
+
+/* Enable SHA-3 hardware acceleration if SHA-3 is enabled in wolfSSL */
+#if defined(WOLFSSL_SHA3)
+    #define PSOC6_HASH_SHA3
+#endif
+
+/* Enable AES support for PSOC6. */
+#ifndef NO_AES
+    #define PSOC6_CRYPTO_AES
+#endif /* !NO_AES */
 
 typedef enum {
     WC_PSOC6_SHA1       = 0,
@@ -48,12 +64,12 @@ typedef enum {
 #if defined(PSOC6_HASH_SHA1) || defined(PSOC6_HASH_SHA2)
 int wc_Psoc6_Sha1_Sha2_Init(void* sha, wc_psoc6_hash_sha1_sha2_t hash_mode,
                             int init_hash);
-#endif
+#endif /* PSOC6_HASH_SHA1 || PSOC6_HASH_SHA2 */
 
 #if defined(PSOC6_HASH_SHA1) || defined(PSOC6_HASH_SHA2) ||                    \
     defined(PSOC6_HASH_SHA3)
-void wc_Psoc6_Sha_Free(void);
-#endif
+int wc_Psoc6_Sha_Free(void);
+#endif /* PSOC6_HASH_SHA1 || PSOC6_HASH_SHA2 || PSOC6_HASH_SHA3 */
 
 #if defined(WOLFSSL_SHA3) && defined(PSOC6_HASH_SHA3)
 
@@ -62,6 +78,67 @@ int wc_Psoc6_Sha3_Update(void* sha3, const byte* data, word32 len, byte p);
 int wc_Psoc6_Sha3_Final(void* sha3, byte padChar, byte* hash, byte p, word32 l);
 int wc_Psoc6_Shake_SqueezeBlocks(void* shake, byte* out, word32 blockCnt);
 #endif /* WOLFSSL_SHA3 && PSOC6_HASH_SHA3 */
+
+/* AES functions */
+#if defined(PSOC6_CRYPTO_AES)
+struct Aes; /* Forward declaration */
+
+int wc_Psoc6_Aes_SetKey(struct Aes* aes, const byte* userKey, word32 keylen,
+                        const byte* iv, int dir);
+void wc_Psoc6_Aes_Free(struct Aes* aes);
+int wc_Psoc6_Aes_Encrypt(struct Aes* aes, const byte* in, byte* out);
+#ifdef HAVE_AES_DECRYPT
+int wc_Psoc6_Aes_Decrypt(struct Aes* aes, const byte* in, byte* out);
+#endif /* HAVE_AES_DECRYPT */
+
+#ifdef WOLFSSL_AES_DIRECT
+int wc_Psoc6_Aes_EncryptDirect(struct Aes* aes, byte* out, const byte* in);
+#ifdef HAVE_AES_DECRYPT
+int wc_Psoc6_Aes_DecryptDirect(struct Aes* aes, byte* out, const byte* in);
+#endif /* HAVE_AES_DECRYPT */
+#endif /* WOLFSSL_AES_DIRECT */
+
+#ifdef HAVE_AES_ECB
+int wc_Psoc6_Aes_EcbEncrypt(struct Aes* aes, byte* out, const byte* in,
+                            word32 sz);
+#ifdef HAVE_AES_DECRYPT
+int wc_Psoc6_Aes_EcbDecrypt(struct Aes* aes, byte* out, const byte* in,
+                            word32 sz);
+#endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_ECB */
+
+#ifdef HAVE_AES_CBC
+int wc_Psoc6_Aes_CbcEncrypt(struct Aes* aes, byte* out, const byte* in,
+                            word32 sz);
+#ifdef HAVE_AES_DECRYPT
+int wc_Psoc6_Aes_CbcDecrypt(struct Aes* aes, byte* out, const byte* in,
+                            word32 sz);
+#endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_CBC */
+
+#ifdef WOLFSSL_AES_CFB
+int wc_Psoc6_Aes_CfbEncrypt(struct Aes* aes, byte* out, const byte* in,
+                            word32 sz);
+#ifdef HAVE_AES_DECRYPT
+int wc_Psoc6_Aes_CfbDecrypt(struct Aes* aes, byte* out, const byte* in,
+                            word32 sz);
+#endif /* HAVE_AES_DECRYPT */
+#endif /* WOLFSSL_AES_CFB */
+
+#ifdef HAVE_AESGCM
+int wc_Psoc6_Aes_Gcm_SetKey(struct Aes* aes, const byte* key, word32 len);
+int wc_Psoc6_Aes_GcmEncrypt(struct Aes* aes, byte* out, const byte* in,
+                            word32 sz, const byte* iv, word32 ivSz,
+                            byte* authTag, word32 authTagSz, const byte* authIn,
+                            word32 authInSz);
+#ifdef HAVE_AES_DECRYPT
+int wc_Psoc6_Aes_GcmDecrypt(struct Aes* aes, byte* out, const byte* in,
+                            word32 sz, const byte* iv, word32 ivSz,
+                            const byte* authTag, word32 authTagSz,
+                            const byte* authIn, word32 authInSz);
+#endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AESGCM */
+#endif /* NO_AES */
 
 #ifdef HAVE_ECC
 


### PR DESCRIPTION
# Description

Enable hardware acceleration for AES encryption/decryption on PSoC6 devices.
Currently supports ECB, CBC, CFB, and GCM modes.
Adjusted the aes.h header to include PSoC6 specific definitions and structures.
Updated README for PSoC6 port.

# Testing

Tested with CY8CPROTO-062-4343W board on ModusToolbox™ IDE with tests present in wolfcrypt/test/test.c:wolfcrypt_test()
PSoC6 PDL library: [mtb-pdl-cat1](https://github.com/Infineon/mtb-pdl-cat1)

Sample project present in [wolfssl_psoc6.zip](https://github.com/user-attachments/files/22840314/wolfcrypt_psoc6.zip) can be used for testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [X] updated appropriate READMEs
 - [ ] Updated manual and documentation

