### PR TITLE
Improve wc_HmacUpdate to return early if input length == 0

### DIFF
--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -814,6 +814,9 @@ int wc_HmacUpdate(Hmac* hmac, const byte* msg, word32 length)
     if (hmac == NULL || (msg == NULL && length > 0)) {
         return BAD_FUNC_ARG;
     }
+    if (length == 0) {
+        return 0; /* nothing to do, return success */
+    }
 
 #ifdef WOLF_CRYPTO_CB
     if (hmac->devId != INVALID_DEVID) {


### PR DESCRIPTION
# Description

Improve wc_HmacUpdate to return early if input length == 0. The wc_HKDF_ex calls like this. Fixes QAT issues with HKDF test.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
