### PR TITLE
Fix stm32.c type warnings

### DIFF
--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -1034,7 +1034,7 @@ int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     if (hashlen > STM32_MAX_ECC_SIZE) {
         return ECC_BAD_ARG_E;
     }
-    else if (hashlen > size) {
+    else if ((int)hashlen > size) {
         /* in the case that hashlen is larger than key size place hash at
          * beginning of buffer */
         XMEMCPY(Hashbin, hash, size);
@@ -1141,7 +1141,7 @@ int stm32_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
     if (hashlen > STM32_MAX_ECC_SIZE) {
         return ECC_BAD_ARG_E;
     }
-    else if (hashlen > size) {
+    else if ((int)hashlen > size) {
         /* in the case that hashlen is larger than key size place hash at
          * beginning of buffer */
         XMEMCPY(Hashbin, hash, size);

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -30,6 +30,8 @@
 
 #ifdef STM32_HASH
 
+#include <stdint.h> /* for uint32_t */
+
 #define WOLFSSL_NO_HASH_RAW
 
 #ifdef HASH_DIGEST


### PR DESCRIPTION
# Description

Fix stm32.c type warnings

# Testing

wolfBoot with `stm32wb-pka-1mb.config` reports:

```
/home/davidgarske/GitHub/wolfboot/lib/wolfssl/wolfcrypt/src/port/st/stm32.c
/home/davidgarske/GitHub/wolfboot/lib/wolfssl/wolfcrypt/src/port/st/stm32.c: In function 'stm32_ecc_verify_hash_ex':
/home/davidgarske/GitHub/wolfboot/lib/wolfssl/wolfcrypt/src/port/st/stm32.c:1037:22: error: comparison of integer expressions of different signedness: 'word32' {aka 'unsigned int'} and 'int' [-Werror=sign-compare]
 1037 |     else if (hashlen > size) {
      |                      ^
/home/davidgarske/GitHub/wolfboot/lib/wolfssl/wolfcrypt/src/port/st/stm32.c: In function 'stm32_ecc_sign_hash_ex':
/home/davidgarske/GitHub/wolfboot/lib/wolfssl/wolfcrypt/src/port/st/stm32.c:1144:22: error: comparison of integer expressions of different signedness: 'word32' {aka 'unsigned int'} and 'int' [-Werror=sign-compare]
 1144 |     else if (hashlen > size) {
      |                      ^
cc1: all warnings being treated as errors
make: *** [Makefile:554: /home/davidgarske/GitHub/wolfboot/lib/wolfssl/wolfcrypt/src/port/st/stm32.o] Error 1
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
