### PR TITLE
Correct SHA256 final endianness on MMCAU platforms

### DIFF
--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1728,7 +1728,7 @@ static WC_INLINE int Transform_Sha256_Len(wc_Sha256* sha256, const byte* data,
                 2 * sizeof(word32));
         }
     #endif
-    #if defined(WOLFSSL_ARMASM)
+    #if defined(WOLFSSL_ARMASM) && !defined(FREESCALE_MMCAU_SHA)
         ByteReverseWords( &sha256->buffer[WC_SHA256_PAD_SIZE / sizeof(word32)],
             &sha256->buffer[WC_SHA256_PAD_SIZE / sizeof(word32)],
             2 * sizeof(word32));


### PR DESCRIPTION
# Description

Corrects SHA256 final-block endianness handling on MMCAU based platforms to prevent redundant byte reversal and ensure correct digest output.

Fixes zd#

# Testing

Tested on NXP K70 hardware with both WOLFSSL_ARMASM and FREESCALE_MMCAU_SHA enabled, confirming correct SHA256 results.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
