### PR TITLE
20251124-memory_test-wolfSSL_Atomic_Ptr_CompareExchange

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7633,7 +7633,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_CTX_get0_privatekey(const WOLFSSL_CTX* ctx)
 #ifdef WOLFSSL_ATOMIC_OPS
             WOLFSSL_EVP_PKEY *current_pkey = NULL;
             if (! wolfSSL_Atomic_Ptr_CompareExchange(
-                    (void **)&ctx->privateKeyPKey,
+                    (void * volatile *)&ctx->privateKeyPKey,
                     (void **)&current_pkey, res))
             {
                 wolfSSL_EVP_PKEY_free(res);

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1359,7 +1359,7 @@ int wolfSSL_Atomic_Uint_CompareExchange(
 }
 
 int wolfSSL_Atomic_Ptr_CompareExchange(
-    void **c, void **expected_ptr, void *new_ptr)
+    void * volatile *c, void **expected_ptr, void *new_ptr)
 {
     uintptr_t exp = (uintptr_t)*expected_ptr;
     int ret = atomic_fcmpset_ptr((uintptr_t *)c, &exp, (uintptr_t)new_ptr);
@@ -1456,7 +1456,7 @@ int wolfSSL_Atomic_Uint_CompareExchange(
 }
 
 int wolfSSL_Atomic_Ptr_CompareExchange(
-    void **c, void **expected_ptr, void *new_ptr)
+    void * volatile *c, void **expected_ptr, void *new_ptr)
 {
     /* use gcc-built-in __atomic_compare_exchange_n(), not
      * atomic_compare_exchange_strong_explicit(), to sidestep _Atomic type
@@ -1551,7 +1551,7 @@ int wolfSSL_Atomic_Uint_CompareExchange(
 }
 
 int wolfSSL_Atomic_Ptr_CompareExchange(
-    void **c, void **expected_ptr, void *new_ptr)
+    void * volatile *c, void **expected_ptr, void *new_ptr)
 {
     return __atomic_compare_exchange_n(
         c, expected_ptr, new_ptr, 0 /* weak */,
@@ -1651,7 +1651,7 @@ int wolfSSL_Atomic_Uint_CompareExchange(
 }
 
 int wolfSSL_Atomic_Ptr_CompareExchange(
-    void ** c, void **expected_ptr, void *new_ptr)
+    void * volatile * c, void **expected_ptr, void *new_ptr)
 {
 #ifdef _WIN64
     LONG64 actual_ptr = InterlockedCompareExchange64(

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -20061,8 +20061,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memory_test(void)
 #endif
         int int_expected;
         unsigned int uint_expected;
-        void * a_ptr = NULL;
-        void * ptr_expected = NULL;
 
         if (WOLFSSL_ATOMIC_LOAD(a_int) != -2)
             return WC_TEST_RET_ENC_NC;
@@ -20134,12 +20132,17 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memory_test(void)
         if (WOLFSSL_ATOMIC_LOAD(a_uint) != 7)
             return WC_TEST_RET_ENC_NC;
 
-        a_ptr = NULL;
-        ptr_expected = NULL;
-        if (! wolfSSL_Atomic_Ptr_CompareExchange(&a_ptr, &ptr_expected, &ret))
-            return WC_TEST_RET_ENC_NC;
-        if (a_ptr != &ret)
-            return WC_TEST_RET_ENC_NC;
+        {
+            void * volatile a_ptr = NULL;
+            void * ptr_expected = NULL;
+            static const char s[] = "";
+            if (! wolfSSL_Atomic_Ptr_CompareExchange(&a_ptr,
+                                                     &ptr_expected,
+                                                     (void *)&s))
+                return WC_TEST_RET_ENC_NC;
+            if (a_ptr != s)
+                return WC_TEST_RET_ENC_NC;
+        }
     }
 
     return ret;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3806,7 +3806,10 @@ struct WOLFSSL_CTX {
     int         altPrivateKeyDevId;
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
 #ifdef OPENSSL_ALL
-    WOLFSSL_EVP_PKEY* privateKeyPKey;
+    /* note it is the privateKeyPKey pointer that is volatile, not the object it
+     * points to:
+     */
+    WOLFSSL_EVP_PKEY* volatile privateKeyPKey;
 #endif
     WOLFSSL_CERT_MANAGER* cm;      /* our cert manager, ctx owns SSL will use */
 #endif

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -552,7 +552,7 @@
     #define WOLFSSL_ATOMIC_STORE(x, val) (x) = (val)
 #endif /* WOLFSSL_NO_ATOMICS */
 
-/* WOLFSSL_ATOMIC_COERCE_INT() needs to accept either a regular int or an
+/* WOLFSSL_ATOMIC_COERCE_INT() needs to accept either a regular int or a
  * wolfSSL_Atomic_Int as its argument, and evaluate to a regular int.
  * Allows a user-supplied override definition with type introspection.
  */
@@ -593,7 +593,7 @@
     WOLFSSL_API int wolfSSL_Atomic_Uint_CompareExchange(
         wolfSSL_Atomic_Uint* c, unsigned int *expected_i, unsigned int new_i);
     WOLFSSL_API int wolfSSL_Atomic_Ptr_CompareExchange(
-        void** c, void **expected_ptr, void *new_ptr);
+        void* volatile * c, void **expected_ptr, void *new_ptr);
 #else
     /* Code using these fallback implementations in non-SINGLE_THREADED builds
      * needs to arrange its own explicit fallback to int for wolfSSL_Atomic_Int
@@ -632,14 +632,14 @@
         }
     }
     static WC_INLINE int wolfSSL_Atomic_Ptr_CompareExchange(
-        void **c, void *expected_ptr, void *new_ptr)
+        void * volatile *c, void *expected_ptr, void *new_ptr)
     {
-        if (*(char **)c == *(char **)expected_ptr) {
-            *(char **)c = (char *)new_ptr;
+        if (*(char * volatile *)c == *(char **)expected_ptr) {
+            *(char * volatile *)c = (char *)new_ptr;
             return 1;
         }
         else {
-            *(char **)expected_ptr = *(char **)c;
+            *(char * volatile *)expected_ptr = *(char **)c;
             return 0;
         }
     }


### PR DESCRIPTION
`wolfcrypt/src/wc_port.c` and `wolfssl/wolfcrypt/wc_port.h`: add `volatile` attribute to `wolfSSL_Atomic_Uint_CompareExchange()` first arg, for pedantic accuracy;

`wolfssl/internal.h` and `src/ssl.c`: add `volatile` attribute to `WOLFSSL_CTX.privateKeyPKey` pointer, for pedantic accuracy;

`wolfcrypt/test/test.c`: in `memory_test()`, use compatible pointers for all operands in the `wolfSSL_Atomic_Ptr_CompareExchange()` test, to avoid undefined behavior.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
clang-tidy-all-sp-all
clang-tidy-single-threaded
```
