### PR TITLE
Rust wrapper: enable cargo clippy and fix several clippy warnings

### DIFF
--- a/wrapper/rust/wolfssl/Makefile
+++ b/wrapper/rust/wolfssl/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all
 all:
 	cargo build
+	cargo clippy
 	cargo doc
 
 .PHONY: test

--- a/wrapper/rust/wolfssl/build.rs
+++ b/wrapper/rust/wolfssl/build.rs
@@ -55,15 +55,12 @@ fn generate_bindings() -> Result<()> {
         .clang_arg(format!("-I{}", wolfssl_base_dir()?))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
-        .map_err(|_| io::Error::new(io::ErrorKind::Other, "Failed to generate bindings"))?;
+        .map_err(|_| io::Error::other("Failed to generate bindings"))?;
 
     bindings
         .write_to_file(bindings_path())
         .map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("Couldn't write bindings: {}", e),
-            )
+            io::Error::other(format!("Couldn't write bindings: {}", e))
         })
 }
 

--- a/wrapper/rust/wolfssl/src/wolfcrypt/ecc.rs
+++ b/wrapper/rust/wolfssl/src/wolfcrypt/ecc.rs
@@ -1362,6 +1362,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(ecc_import)]
+    #[allow(clippy::too_many_arguments)]
     pub fn export_ex(&mut self, qx: &mut [u8], qx_len: &mut u32,
             qy: &mut [u8], qy_len: &mut u32, d: &mut [u8], d_len: &mut u32,
             hex: bool) -> Result<(), i32> {

--- a/wrapper/rust/wolfssl/src/wolfcrypt/kdf.rs
+++ b/wrapper/rust/wolfssl/src/wolfcrypt/kdf.rs
@@ -339,11 +339,9 @@ pub fn tls13_hkdf_extract_ex(typ: i32, salt: Option<&[u8]>, key: Option<&mut [u8
     let mut ikm_buf = [0u8; sys::WC_MAX_DIGEST_SIZE as usize];
     let mut ikm_ptr = ikm_buf.as_mut_ptr();
     let mut ikm_size = 0u32;
-    if let Some(key) = key {
-        if key.len() > 0 {
-            ikm_ptr = key.as_mut_ptr();
-            ikm_size = key.len() as u32;
-        }
+    if let Some(key) = key && !key.is_empty() {
+        ikm_ptr = key.as_mut_ptr();
+        ikm_size = key.len() as u32;
     }
     if out.len() != HMAC::get_hmac_size_by_type(typ)? {
         return Err(sys::wolfCrypt_ErrorCodes_BUFFER_E);
@@ -473,6 +471,7 @@ pub fn tls13_hkdf_expand_label(typ: i32, key: &[u8], protocol: &[u8], label: &[u
 /// }
 /// ```
 #[cfg(kdf_tls13)]
+#[allow(clippy::too_many_arguments)]
 pub fn tls13_hkdf_expand_label_ex(typ: i32, key: &[u8], protocol: &[u8], label: &[u8], info: &[u8], out: &mut [u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
     let key_size = key.len() as u32;
     let protocol_size = protocol.len() as u32;

--- a/wrapper/rust/wolfssl/src/wolfcrypt/random.rs
+++ b/wrapper/rust/wolfssl/src/wolfcrypt/random.rs
@@ -30,22 +30,20 @@ wolfSSL `WC_RNG` object. It ensures proper initialization and deallocation.
 ```rust
 use wolfssl::wolfcrypt::random::RNG;
 
-fn main() {
-    // Create a RNG instance.
-    let mut rng = RNG::new().expect("Failed to create RNG");
+// Create a RNG instance.
+let mut rng = RNG::new().expect("Failed to create RNG");
 
-    // Generate a single random byte value.
-    let byte = rng.generate_byte().expect("Failed to generate a single byte");
+// Generate a single random byte value.
+let byte = rng.generate_byte().expect("Failed to generate a single byte");
 
-    // Generate a random block.
-    let mut buffer = [0u32; 8];
-    rng.generate_block(&mut buffer).expect("Failed to generate a block");
-}
+// Generate a random block.
+let mut buffer = [0u32; 8];
+rng.generate_block(&mut buffer).expect("Failed to generate a block");
 ```
 */
 
 use crate::sys;
-use std::mem::{size_of, MaybeUninit};
+use std::mem::{size_of_val, MaybeUninit};
 
 /// A cryptographically secure random number generator based on the wolfSSL
 /// library.
@@ -138,7 +136,7 @@ impl RNG {
     /// library return code on failure.
     pub fn new_with_nonce_ex<T>(nonce: &mut [T], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let ptr = nonce.as_mut_ptr() as *mut u8;
-        let size: u32 = (nonce.len() * size_of::<T>()) as u32;
+        let size: u32 = size_of_val(nonce) as u32;
         let mut rng: MaybeUninit<RNG> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -320,7 +318,7 @@ impl RNG {
     /// library return code on failure.
     pub fn generate_block<T>(&mut self, buf: &mut [T]) -> Result<(), i32> {
         let ptr = buf.as_mut_ptr() as *mut u8;
-        let size: u32 = (buf.len() * size_of::<T>()) as u32;
+        let size: u32 = size_of_val(buf) as u32;
         let rc = unsafe { sys::wc_RNG_GenerateBlock(&mut self.wc_rng, ptr, size) };
         if rc == 0 {
             Ok(())

--- a/wrapper/rust/wolfssl/src/wolfcrypt/sha.rs
+++ b/wrapper/rust/wolfssl/src/wolfcrypt/sha.rs
@@ -2098,7 +2098,7 @@ impl SHAKE128 {
         if dout_size % (Self::SQUEEZE_BLOCK_SIZE as u32) != 0 {
             return Err(sys::wolfCrypt_ErrorCodes_BUFFER_E);
         }
-        let n_blocks = (dout_size / (Self::SQUEEZE_BLOCK_SIZE as u32)) as u32;
+        let n_blocks = dout_size / (Self::SQUEEZE_BLOCK_SIZE as u32);
         let rc = unsafe {
             sys::wc_Shake128_SqueezeBlocks(&mut self.wc_shake, dout.as_mut_ptr(), n_blocks)
         };
@@ -2368,7 +2368,7 @@ impl SHAKE256 {
         if dout_size % (Self::SQUEEZE_BLOCK_SIZE as u32) != 0 {
             return Err(sys::wolfCrypt_ErrorCodes_BUFFER_E);
         }
-        let n_blocks = (dout_size / (Self::SQUEEZE_BLOCK_SIZE as u32)) as u32;
+        let n_blocks = dout_size / (Self::SQUEEZE_BLOCK_SIZE as u32);
         let rc = unsafe {
             sys::wc_Shake256_SqueezeBlocks(&mut self.wc_shake, dout.as_mut_ptr(), n_blocks)
         };


### PR DESCRIPTION
# Description

Rust wrapper: enable cargo clippy and fix several clippy warnings

Cargo Clippy is a linter for Rust code that identifies common mistakes and suggests improvements to make the code more idiomatic, readable, and performant.

# Testing

Unit tests / CI

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
