### PR TITLE
Prefer ARMASM over MMCAU for AES CBC when both enabled

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -5887,7 +5887,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
     }
     #endif /* HAVE_AES_DECRYPT */
 
-#elif defined(FREESCALE_MMCAU)
+#elif defined(FREESCALE_MMCAU) && !defined(WOLFSSL_ARMASM)
     int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     {
         int offset = 0;


### PR DESCRIPTION
# Description

When both `FREESCALE_MMCAU` and `WOLFSSL_ARMASM` are enabled, AES CBC processing prefers ARM assembly over MMCAU to achieve better performance.

# Testing

Verified on NXP K65 hardware with correct AES CBC outputs.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
