### PR TITLE
AES-GCM, 4-bit table, Big Endian: fast impl of GMULT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3179,7 +3179,7 @@ then
     ENABLED_AESGCM=no
 fi
 
-if test "$ENABLED_AESGCM" = "yes" && test "$ac_cv_c_bigendian" != "yes"
+if test "$ENABLED_AESGCM" = "yes"
 then
     ENABLED_AESGCM="4bit"
 fi

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -47,7 +47,7 @@ typedef struct Gcm {
     /* key-based fast multiplication table. */
     ALIGN16 byte M0[256][16];
 #elif defined(GCM_TABLE_4BIT)
-    #if defined(BIG_ENDIAN_ORDER) || defined(WC_16BIT_CPU)
+    #if defined(WC_16BIT_CPU)
         ALIGN16 byte M0[16][16];
     #else
         ALIGN16 byte M0[32][16];


### PR DESCRIPTION
# Description

Add fast implementation GMULT for big-endian platforms like PowerPC and PowerPC64.
Speeds up AES-GCM.

# Testing

./configure --disable-shared LDFLAGS=--static --host=powerpc CC=powerpc-linux-gnu-gcc
./configure --disable-shared LDFLAGS=--static --host=powerpc64 CC=powerpc64-linux-gnu-gcc

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
