### PR TITLE
Fix AKID CA lookup

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5760,7 +5760,7 @@ Signer* GetCAByAKID(void* vp, const byte* issuer, word32 issuerSz,
     for (row = 0; row < CA_TABLE_SIZE && ret == NULL; row++) {
         for (signers = cm->caTable[row]; signers != NULL;
                 signers = signers->next) {
-            if (XMEMCMP(signers->subjectNameHash, nameHash, SIGNER_DIGEST_SIZE)
+            if (XMEMCMP(signers->issuerNameHash, nameHash, SIGNER_DIGEST_SIZE)
                     == 0 && XMEMCMP(signers->serialHash, serialHash,
                                     SIGNER_DIGEST_SIZE) == 0) {
                 ret = signers;

--- a/tests/api/test_x509.h
+++ b/tests/api/test_x509.h
@@ -23,8 +23,10 @@
 #define WOLFCRYPT_TEST_X509_H
 
 int test_x509_rfc2818_verification_callback(void);
+int test_x509_GetCAByAKID(void);
 
 #define TEST_X509_DECLS                                                        \
-    TEST_DECL_GROUP("x509", test_x509_rfc2818_verification_callback)
+    TEST_DECL_GROUP("x509", test_x509_rfc2818_verification_callback),          \
+    TEST_DECL_GROUP("x509", test_x509_GetCAByAKID)
 
 #endif /* WOLFCRYPT_TEST_X509_H */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -26077,7 +26077,7 @@ int FillSigner(Signer* signer, DecodedCert* cert, int type, DerBuffer *der)
     #endif
         XMEMCPY(signer->subjectNameHash, cert->subjectHash,
                 SIGNER_DIGEST_SIZE);
-    #if defined(HAVE_OCSP) || defined(HAVE_CRL)
+    #if defined(HAVE_OCSP) || defined(HAVE_CRL) || defined(WOLFSSL_AKID_NAME)
         XMEMCPY(signer->issuerNameHash, cert->issuerHash,
                 SIGNER_DIGEST_SIZE);
     #endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -6694,6 +6694,10 @@ WOLFSSL_LOCAL WC_RNG* WOLFSSL_RSA_GetRNG(WOLFSSL_RSA *rsa, WC_RNG **tmpRNG,
                                                              DecodedCert* cert);
     #endif
 
+    #ifdef WOLFSSL_API_PREFIX_MAP
+        #define GetCAByAKID wolfSSL_GetCAByAKID
+    #endif
+
     #ifndef GetCA
         WOLFSSL_LOCAL Signer* GetCA(void* vp, byte* hash);
     #endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -6694,14 +6694,14 @@ WOLFSSL_LOCAL WC_RNG* WOLFSSL_RSA_GetRNG(WOLFSSL_RSA *rsa, WC_RNG **tmpRNG,
                                                              DecodedCert* cert);
     #endif
 
-    #ifdef WOLFSSL_API_PREFIX_MAP
-        #define GetCAByAKID wolfSSL_GetCAByAKID
-    #endif
 
     #ifndef GetCA
         WOLFSSL_LOCAL Signer* GetCA(void* vp, byte* hash);
     #endif
     #if defined(WOLFSSL_AKID_NAME) && !defined(GetCAByAKID)
+        #ifdef WOLFSSL_API_PREFIX_MAP
+            #define GetCAByAKID wolfSSL_GetCAByAKID
+        #endif
         WOLFSSL_TEST_VIS Signer* GetCAByAKID(void* vp, const byte* issuer,
                 word32 issuerSz, const byte* serial, word32 serialSz);
     #endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -6698,7 +6698,7 @@ WOLFSSL_LOCAL WC_RNG* WOLFSSL_RSA_GetRNG(WOLFSSL_RSA *rsa, WC_RNG **tmpRNG,
         WOLFSSL_LOCAL Signer* GetCA(void* vp, byte* hash);
     #endif
     #if defined(WOLFSSL_AKID_NAME) && !defined(GetCAByAKID)
-        WOLFSSL_LOCAL Signer* GetCAByAKID(void* vp, const byte* issuer,
+        WOLFSSL_TEST_VIS Signer* GetCAByAKID(void* vp, const byte* issuer,
                 word32 issuerSz, const byte* serial, word32 serialSz);
     #endif
     #if defined(HAVE_OCSP) && !defined(GetCAByKeyHash)

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2060,7 +2060,7 @@ typedef enum MimeStatus
 #endif /* HAVE_SMIME */
 
 WOLFSSL_LOCAL int HashIdAlg(word32 oidSum);
-WOLFSSL_LOCAL int CalcHashId(const byte* data, word32 len, byte* hash);
+WOLFSSL_TEST_VIS int CalcHashId(const byte* data, word32 len, byte* hash);
 WOLFSSL_LOCAL int CalcHashId_ex(const byte* data, word32 len, byte* hash,
     int hashAlg);
 WOLFSSL_LOCAL int GetHashId(const byte* id, int length, byte* hash,

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1957,7 +1957,7 @@ struct Signer {
 #endif /* !IGNORE_NAME_CONSTRAINTS */
     byte    subjectNameHash[SIGNER_DIGEST_SIZE];
                                      /* sha hash of names in certificate */
-    #if defined(HAVE_OCSP) || defined(HAVE_CRL)
+    #if defined(HAVE_OCSP) || defined(HAVE_CRL) || defined(WOLFSSL_AKID_NAME)
         byte    issuerNameHash[SIGNER_DIGEST_SIZE];
                                      /* sha hash of issuer names in certificate.
                                       * Used in OCSP to check for authorized

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2059,21 +2059,6 @@ typedef enum MimeStatus
 } MimeStatus;
 #endif /* HAVE_SMIME */
 
-WOLFSSL_LOCAL int HashIdAlg(word32 oidSum);
-WOLFSSL_TEST_VIS int CalcHashId(const byte* data, word32 len, byte* hash);
-WOLFSSL_LOCAL int CalcHashId_ex(const byte* data, word32 len, byte* hash,
-    int hashAlg);
-WOLFSSL_LOCAL int GetHashId(const byte* id, int length, byte* hash,
-    int hashAlg);
-WOLFSSL_LOCAL int GetName(DecodedCert* cert, int nameType, int maxIdx);
-
-#ifdef ASN_BER_TO_DER
-WOLFSSL_API int wc_BerToDer(const byte* ber, word32 berSz, byte* der,
-                                word32* derSz);
-#endif
-WOLFSSL_LOCAL int StreamOctetString(const byte* inBuf, word32 inBufSz,
-    byte* out, word32* outSz, word32* idx);
-
 #ifdef WOLFSSL_API_PREFIX_MAP
     #define FreeAltNames wc_FreeAltNames
     #define AltNameNew wc_AltNameNew
@@ -2098,7 +2083,23 @@ WOLFSSL_LOCAL int StreamOctetString(const byte* inBuf, word32 inBufSz,
     #define GetASNTag wc_GetASNTag
     #define SetAlgoID wc_SetAlgoID
     #define SetAsymKeyDer wc_SetAsymKeyDer
+    #define CalcHashId wc_CalcHashId
 #endif /* WOLFSSL_API_PREFIX_MAP */
+
+WOLFSSL_LOCAL int HashIdAlg(word32 oidSum);
+WOLFSSL_TEST_VIS int CalcHashId(const byte* data, word32 len, byte* hash);
+WOLFSSL_LOCAL int CalcHashId_ex(const byte* data, word32 len, byte* hash,
+    int hashAlg);
+WOLFSSL_LOCAL int GetHashId(const byte* id, int length, byte* hash,
+    int hashAlg);
+WOLFSSL_LOCAL int GetName(DecodedCert* cert, int nameType, int maxIdx);
+
+#ifdef ASN_BER_TO_DER
+WOLFSSL_API int wc_BerToDer(const byte* ber, word32 berSz, byte* der,
+                                word32* derSz);
+#endif
+WOLFSSL_LOCAL int StreamOctetString(const byte* inBuf, word32 inBufSz,
+    byte* out, word32* outSz, word32* idx);
 
 WOLFSSL_ASN_API void FreeAltNames(DNS_entry* altNames, void* heap);
 WOLFSSL_ASN_API DNS_entry* AltNameNew(void* heap);


### PR DESCRIPTION
The `authorityCertIssuer` field refers to the Issuer field of the CA being looked up and not its Subject field.

Addresses zd#20860