### PR TITLE
Enable wolfSSL_i2d_X509_NAME_canon to handle blank optional fields

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -11630,15 +11630,20 @@ int wolfSSL_i2d_X509_NAME_canon(WOLFSSL_X509_NAME* name, unsigned char** out)
             }
             nameStr = (const char*)wolfSSL_ASN1_STRING_data(cano_data);
 
-            ret = wc_EncodeNameCanonical(&names[i], nameStr, CTC_UTF8,
-                (byte)ConvertNIDToWolfSSL(entry->nid));
-            if (ret < 0) {
-                WC_FREE_VAR_EX(names, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-                wolfSSL_ASN1_STRING_free(cano_data);
-                WOLFSSL_MSG("EncodeName failed");
-                return WOLFSSL_FATAL_ERROR;
+            /* allow for blank values in the name structure, eg OU= */
+            if (nameStr)
+            {
+                ret = wc_EncodeNameCanonical(&names[i], nameStr, CTC_UTF8,
+                    (byte)ConvertNIDToWolfSSL(entry->nid));
+                if (ret < 0) {
+                    WC_FREE_VAR_EX(names, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                    wolfSSL_ASN1_STRING_free(cano_data);
+                    WOLFSSL_MSG("EncodeName failed");
+                    return WOLFSSL_FATAL_ERROR;
+                }
+                totalBytes += ret;
             }
-            totalBytes += ret;
+
             wolfSSL_ASN1_STRING_free(cano_data);
         }
     }


### PR DESCRIPTION
# Description

Currently, null item in the certificate name is considered an error, but having a blank optional field should be OK.

Fixes zd20913

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
