### PR TITLE
20251206-old-fips-test_wc_RsaPublicEncryptDecrypt

### DIFF
--- a/tests/api/test_rsa.c
+++ b/tests/api/test_rsa.c
@@ -785,18 +785,15 @@ int test_wc_RsaPublicEncryptDecrypt(void)
     WC_DECLARE_VAR(in, byte, TEST_STRING_SZ, NULL);
     WC_DECLARE_VAR(plain, byte, TEST_STRING_SZ, NULL);
     WC_DECLARE_VAR(cipher, byte, TEST_RSA_BYTES, NULL);
-    WC_DECLARE_VAR(shortPlain, byte, TEST_STRING_SZ - 4, NULL);
 
     WC_ALLOC_VAR(in, byte, TEST_STRING_SZ, NULL);
     WC_ALLOC_VAR(plain, byte, TEST_STRING_SZ, NULL);
     WC_ALLOC_VAR(cipher, byte, TEST_RSA_BYTES, NULL);
-    WC_ALLOC_VAR(shortPlain, byte, TEST_STRING_SZ - 4, NULL);
 
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
     ExpectNotNull(in);
     ExpectNotNull(plain);
     ExpectNotNull(cipher);
-    ExpectNotNull(shortPlain);
 #endif
     ExpectNotNull(XMEMCPY(in, inStr, inLen));
 
@@ -823,11 +820,20 @@ int test_wc_RsaPublicEncryptDecrypt(void)
     ExpectIntEQ(XMEMCMP(plain, inStr, plainLen), 0);
     /* Pass bad args - tested in another testing function.*/
 
-    /* Test for when plain length is less than required. */
-    ExpectIntEQ(wc_RsaPrivateDecrypt(cipher, cipherLenResult, shortPlain,
-        TEST_STRING_SZ - 4, &key), RSA_BUFFER_E);
+#if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || FIPS_VERSION3_GE(7,0,0))
+    {
+        WC_DECLARE_VAR(shortPlain, byte, TEST_STRING_SZ - 4, NULL);
+        WC_ALLOC_VAR(shortPlain, byte, TEST_STRING_SZ - 4, NULL);
+    #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+        ExpectNotNull(shortPlain);
+    #endif
+        /* Test for when plain length is less than required. */
+        ExpectIntEQ(wc_RsaPrivateDecrypt(cipher, cipherLenResult, shortPlain,
+                                         TEST_STRING_SZ - 4, &key), RSA_BUFFER_E);
+        WC_FREE_VAR(shortPlain, NULL);
+    }
+#endif /* !HAVE_SELFTEST && (!HAVE_FIPS || FIPS_VERSION3_GE(7,0,0)) */
 
-    WC_FREE_VAR(shortPlain, NULL);
     WC_FREE_VAR(in, NULL);
     WC_FREE_VAR(plain, NULL);
     WC_FREE_VAR(cipher, NULL);


### PR DESCRIPTION
`tests/api/test_rsa.c`: in `test_wc_RsaPublicEncryptDecrypt()`, add FIPS gate around new test coverage from #9454 (23c5678797).

detected by and tested with
```
wolfssl-multi-test.sh ...
cross-aarch64-armasm-fips-140-3-v5-unittest-sanitizer
cross-aarch64-armasm-fips-140-3-v5-all-crypto-unittest-sanitizer
cross-aarch64-armasm-fips-140-3-v6-unittest-sanitizer
cross-aarch64-armasm-fips-140-3-v6-all-unittest-sanitizer
sp-all-asm-smallstack-sanitizer-fips-140-3
sp-all-asm-smallstack-sanitizer-fips-140-3-pilot
```
