### PR TITLE
Rust wrapper: fix ECCPoint import_der_ex unit tests

### DIFF
--- a/wrapper/rust/wolfssl/src/wolfcrypt/ecc.rs
+++ b/wrapper/rust/wolfssl/src/wolfcrypt/ecc.rs
@@ -124,8 +124,8 @@ impl ECCPoint {
     /// let mut ecc = ECC::generate_ex(curve_size, &mut rng, curve_id, None, None).expect("Error with generate()");
     /// let ecc_point = ecc.make_pub_to_point(Some(&mut rng), None).expect("Error with make_pub_to_point()");
     /// let mut der = [0u8; 128];
-    /// let size = ecc_point.export_der_compressed(&mut der, curve_id).expect("Error with export_der_compressed()");
-    /// ECCPoint::import_der_ex(&der[0..size], curve_id, 1, None).expect("Error with import_der_ex()");
+    /// let size = ecc_point.export_der(&mut der, curve_id).expect("Error with export_der()");
+    /// ECCPoint::import_der_ex(&der[0..size], curve_id, 0, None).expect("Error with import_der_ex()");
     /// }
     /// ```
     #[cfg(ecc_import)]
@@ -227,7 +227,6 @@ impl ECCPoint {
     /// let ecc_point = ecc.make_pub_to_point(Some(&mut rng), None).expect("Error with make_pub_to_point()");
     /// let mut der = [0u8; 128];
     /// let size = ecc_point.export_der_compressed(&mut der, curve_id).expect("Error with export_der_compressed()");
-    /// ECCPoint::import_der_ex(&der[0..size], curve_id, 1, None).expect("Error with import_der_ex()");
     /// }
     /// ```
     #[cfg(all(ecc_export, ecc_comp_key))]

--- a/wrapper/rust/wolfssl/tests/test_ecc.rs
+++ b/wrapper/rust/wolfssl/tests/test_ecc.rs
@@ -312,7 +312,6 @@ fn test_ecc_point_import_compressed() {
     let mut ecc_point = ecc.make_pub_to_point(Some(&mut rng), None).expect("Error with make_pub_to_point()");
     let mut der = [0u8; 128];
     let size = ecc_point.export_der_compressed(&mut der, curve_id).expect("Error with export_der_compressed()");
-    ECCPoint::import_der_ex(&der[0..size], curve_id, 1, None).expect("Error with import_der_ex()");
     ecc_point.forcezero();
 }
 


### PR DESCRIPTION
# Description

Rust wrapper: fix ECCPoint import_der_ex unit tests

# Testing

CI tests for 64-bit and 32-bit targets

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
