### PR TITLE
Run check for IP address in wolfSSL_X509_check_host()

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -14190,6 +14190,13 @@ int wolfSSL_X509_check_host(WOLFSSL_X509 *x, const char *chk, size_t chklen,
         chklen--;
     }
 
+#ifdef WOLFSSL_IP_ALT_NAME
+    ret = CheckIPAddr(dCert, (char *)chk);
+    if (ret == 0) {
+        goto out;
+    }
+#endif /* WOLFSSL_IP_ALT_NAME */
+
     ret = CheckHostName(dCert, (char *)chk, chklen, flags, 0);
 
 out:


### PR DESCRIPTION
# Description

If `WOLFSSL_IP_ALT_NAME` is defined, the value of `chk` will be checked using `CheckIPAddr()` before attempting to run `CheckHostName()` if no IP address is matched.

Change affects SunJSSE tests
- HttpsURLConnection: DNSIdentities.java, Identities.java, IPAddressDNSIdentities.java, IPAddressIPIdentities.java, IPIdentities.java
- Misc: ServerIdentityTest.java

# Testing

`./configure --enable-all && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
