### PR TITLE
check if ctx and ssl are null when checking public key in certificate

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -1607,6 +1607,9 @@ static int ProcessBufferCertPublicKey(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
 #ifndef NO_RSA
     word32 idx;
 #endif
+    if (ctx == NULL && ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
 
     /* Get key size and check unless not verifying. */
     switch (cert->keyOID) {


### PR DESCRIPTION
# Description

Adds a check for when both `ssl` and `ctx` are null, returns `BAD_FUNC_ARG` if true. Fixes CID 551515.

# Testing

`./configure --enable-all && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
