### PR TITLE
Added --enable-certgencache to os-check

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -65,6 +65,7 @@ jobs:
            --enable-cert-setup-cb --enable-sessioncerts',
           '--disable-sni --disable-ecc --disable-tls13 --disable-secure-renegotiation-info',
           'CPPFLAGS=-DWOLFSSL_BLIND_PRIVATE_KEY',
+          '--enable-all --enable-certgencache',
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'


### PR DESCRIPTION
This pull request makes a minor update to the build configuration in the `.github/workflows/os-check.yml` workflow. The change adds two new build flags to the job's configuration.

* Added `--enable-all` and `--enable-certgencache` flags to the build options in the `jobs:` section of `.github/workflows/os-check.yml`, allowing for a more comprehensive build and enabling certificate generation caching.
