### PR TITLE
Fix wc_CmacFree() to use correct heap pointer from internal Aes structure

### DIFF
--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -71,7 +71,7 @@
  */
 int wc_CMAC_Grow(Cmac* cmac, const byte* in, int inSz)
 {
-    return _wc_Hash_Grow(&cmac->msg, &cmac->used, &cmac->len, in, inSz, NULL);
+    return _wc_Hash_Grow(&cmac->msg, &cmac->used, &cmac->len, in, inSz, cmac->aes.heap);
 }
 #endif /* WOLFSSL_HASH_KEEP */
 
@@ -257,7 +257,7 @@ int wc_CmacFree(Cmac* cmac)
     /* TODO: msg is leaked if wc_CmacFinal() is not called
      * e.g. when multiple calls to wc_CmacUpdate() and one fails but
      * wc_CmacFinal() not called. */
-    XFREE(cmac->msg, cmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(cmac->msg, cmac->aes.heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
     switch (cmac->type) {
 #if !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)


### PR DESCRIPTION
# Fix CMAC heap pointer reference in wc_CmacFree() and wc_CMAC_Grow()

## Issue
The `wc_CmacFree()` function was attempting to access `cmac->heap` which does not exist in the `Cmac` structure, thus causing a compile failure. Additionally, `wc_CMAC_Grow()` was passing `NULL` for the heap parameter, creating an pointer mismatch if the heap is non NULL. The `Cmac` structure contains an `Aes` member, and it is the `Aes` structure that has the `heap` field.

## How to Reproduce
```bash
./autogen.sh
./configure --enable-cmac CFLAGS="-DWOLFSSL_HASH_KEEP"
make
```

## Context: How heap is initialized
In `wc_InitCmac_ex()` (line 149: cmac.c), the heap parameter is passed to `wc_AesInit()`:
```c
ret = wc_AesInit(&cmac->aes, heap, devId);
```
This stores the heap pointer in `cmac->aes.heap`. So when allocating/freeing CMAC memory, we should use `cmac->aes.heap` to ensure we're using the same heap pointer throughout the CMAC lifecycle.

## Fix
Two changes in `wolfcrypt/src/cmac.c`:

1. **Line 74** - `wc_CMAC_Grow()`: Changed `NULL` to `cmac->aes.heap` when calling `_wc_Hash_Grow()` to ensure allocation uses the correct heap
2. **Line 260** - `wc_CmacFree()`: Changed `cmac->heap` to `cmac->aes.heap` to use the correct heap pointer for deallocation

