### PR TITLE
 Fix AArch64 assembly syntax causing clang-21 crash

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-sha3-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-sha3-asm.S
@@ -92,7 +92,7 @@ _BlockSha3_crypto:
 	add  x1, x1, :lo12:L_SHA3_transform_crypto_r
 #else
 	adrp x1, L_SHA3_transform_crypto_r@PAGE
-	add  x1, x1, :lo12:L_SHA3_transform_crypto_r@PAGEOFF
+	add  x1, x1, L_SHA3_transform_crypto_r@PAGEOFF
 #endif /* __APPLE__ */
 #ifdef __APPLE__
 .arch_extension sha3
@@ -268,7 +268,7 @@ _BlockSha3_base:
 	add  x27, x27, :lo12:L_SHA3_transform_base_r
 #else
 	adrp x27, L_SHA3_transform_base_r@PAGE
-	add  x27, x27, :lo12:L_SHA3_transform_base_r@PAGEOFF
+	add  x27, x27, L_SHA3_transform_base_r@PAGEOFF
 #endif /* __APPLE__ */
 	ldp	x1, x2, [x0]
 	ldp	x3, x4, [x0, #16]

--- a/wolfcrypt/src/port/arm/armv8-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm.S
@@ -165,14 +165,14 @@ _Transform_Sha512_Len_neon:
 	add  x3, x3, :lo12:L_SHA512_transform_neon_len_k
 #else
 	adrp x3, L_SHA512_transform_neon_len_k@PAGE
-	add  x3, x3, :lo12:L_SHA512_transform_neon_len_k@PAGEOFF
+	add  x3, x3, L_SHA512_transform_neon_len_k@PAGEOFF
 #endif /* __APPLE__ */
 #ifndef __APPLE__
 	adrp x27, L_SHA512_transform_neon_len_r8
 	add  x27, x27, :lo12:L_SHA512_transform_neon_len_r8
 #else
 	adrp x27, L_SHA512_transform_neon_len_r8@PAGE
-	add  x27, x27, :lo12:L_SHA512_transform_neon_len_r8@PAGEOFF
+	add  x27, x27, L_SHA512_transform_neon_len_r8@PAGEOFF
 #endif /* __APPLE__ */
 	ld1	{v11.16b}, [x27]
 	# Load digest into working vars


### PR DESCRIPTION
# Description

The wolfssl ARM assembly files were mixing ELF syntax (`:lo12:`) with Darwin syntax (`@PAGEOFF`) in the same instruction, which causes a clang-21 assembler crash with the error `"cannot apply another specifier to MCSpecifierExpr"`. On Darwin/Apple platforms, `@PAGEOFF` already represents the low 12 bits of the address, so the `:lo12:` prefix is redundant and incorrect. This was causing `UNREACHABLE` assertion failures in `AsmParser.cpp` when building with clang-21.
The fix removes the `:lo12:` prefix from instructions using `@PAGEOFF` on Apple platforms in both `armv8-sha3-asm.S` and `armv8-sha512-asm.S`.

# Testing

Confirmed the build didn't crash with new clang on Mac.
