### PR TITLE
TLS 1.3: duplicate extension alert code fix

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -35235,6 +35235,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             case WC_NO_ERR_TRACE(INVALID_PARAMETER):
             case WC_NO_ERR_TRACE(HRR_COOKIE_ERROR):
             case WC_NO_ERR_TRACE(BAD_BINDER):
+            case WC_NO_ERR_TRACE(DUPLICATE_TLS_EXT_E):
                 return illegal_parameter;
             case WC_NO_ERR_TRACE(INCOMPLETE_DATA):
                 return missing_extension;

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -34,17 +34,19 @@ int test_tls13_same_ch(void);
 int test_tls13_hrr_different_cs(void);
 int test_tls13_sg_missing(void);
 int test_tls13_ks_missing(void);
+int test_tls13_duplicate_extension(void);
 
-#define TEST_TLS13_DECLS                                   \
-    TEST_DECL_GROUP("tls13", test_tls13_apis),             \
-    TEST_DECL_GROUP("tls13", test_tls13_cipher_suites),    \
-    TEST_DECL_GROUP("tls13", test_tls13_bad_psk_binder),   \
-    TEST_DECL_GROUP("tls13", test_tls13_rpk_handshake),    \
-    TEST_DECL_GROUP("tls13", test_tls13_pq_groups),        \
-    TEST_DECL_GROUP("tls13", test_tls13_early_data),       \
-    TEST_DECL_GROUP("tls13", test_tls13_same_ch),          \
-    TEST_DECL_GROUP("tls13", test_tls13_hrr_different_cs), \
-    TEST_DECL_GROUP("tls13", test_tls13_sg_missing),       \
-    TEST_DECL_GROUP("tls13", test_tls13_ks_missing)
+#define TEST_TLS13_DECLS                                      \
+    TEST_DECL_GROUP("tls13", test_tls13_apis),                \
+    TEST_DECL_GROUP("tls13", test_tls13_cipher_suites),       \
+    TEST_DECL_GROUP("tls13", test_tls13_bad_psk_binder),      \
+    TEST_DECL_GROUP("tls13", test_tls13_rpk_handshake),       \
+    TEST_DECL_GROUP("tls13", test_tls13_pq_groups),           \
+    TEST_DECL_GROUP("tls13", test_tls13_early_data),          \
+    TEST_DECL_GROUP("tls13", test_tls13_same_ch),             \
+    TEST_DECL_GROUP("tls13", test_tls13_hrr_different_cs),    \
+    TEST_DECL_GROUP("tls13", test_tls13_sg_missing),          \
+    TEST_DECL_GROUP("tls13", test_tls13_ks_missing),          \
+    TEST_DECL_GROUP("tls13", test_tls13_duplicate_extension)
 
 #endif /* WOLFCRYPT_TEST_TLS13_H */


### PR DESCRIPTION
# Description

The specification states to return illegal_parameter when a message is syntactically correct but semantically invalid. (RFC 8446 section 6, Paragraph 5)

Fixes #9520

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
