### PR TITLE
Added comment with empty hash use

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1197,6 +1197,8 @@ int DeriveHandshakeSecret(WOLFSSL* ssl)
         return ret;
 #endif
 
+    /* Derive-Secret(., "derived", "") per RFC 8446 Section 7.1.
+     * Empty hash (NULL, 0) is required by the TLS 1.3 key schedule. */
     ret = DeriveKeyMsg(ssl, key, -1, ssl->arrays->secret,
                         derivedLabel, DERIVED_LABEL_SZ,
                         NULL, 0, ssl->specs.mac_algorithm);
@@ -1232,6 +1234,8 @@ int DeriveMasterSecret(WOLFSSL* ssl)
         return ret;
 #endif
 
+    /* Derive-Secret(., "derived", "") per RFC 8446 Section 7.1.
+     * Empty hash (NULL, 0) is required by the TLS 1.3 key schedule. */
     ret = DeriveKeyMsg(ssl, key, -1, ssl->arrays->preMasterSecret,
                         derivedLabel, DERIVED_LABEL_SZ,
                         NULL, 0, ssl->specs.mac_algorithm);


### PR DESCRIPTION
This pull request clarifies the implementation of the TLS 1.3 key schedule by adding comments that reference the relevant section of RFC 8446. The comments explain the use of an empty hash during the "derived" secret derivation process in both the handshake and master secret derivation functions. No functional changes were made; only documentation was improved for clarity.