### PR TITLE
Add IAR support to WC_OFFSETOF macro

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1233,7 +1233,7 @@ binding for XSNPRINTF
 #ifndef WC_OFFSETOF
     #if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 4))
         #define WC_OFFSETOF(type, field) __builtin_offsetof(type, field)
-    #elif defined(__WATCOMC__)
+    #elif defined(__WATCOMC__) || defined(__IAR_SYSTEMS_ICC__)
         #include <stddef.h>
         #define WC_OFFSETOF    offsetof
     #else


### PR DESCRIPTION
# Description

Add IAR compiler support to `WC_OFFSETOF` by using the standard `offsetof` macro.

# Testing

Built wolfSSL with IAR Embedded Workbench v9.70.2 and verified successful compilation.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
