### PR TITLE
Run rng-tools in docker

### DIFF
--- a/.github/workflows/rng-tools.yml
+++ b/.github/workflows/rng-tools.yml
@@ -101,7 +101,9 @@ jobs:
           # Retry up to five times
           for i in {1..5}; do
             TEST_RES=0
-            LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib make check || TEST_RES=$?
+            time timeout -s SIGKILL 1m docker run -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
+              -w `pwd` -e LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib \
+              ubuntu:latest bash -c "make check" || TEST_RES=$?
             if [ "$TEST_RES" -eq "0" ]; then
                break
             fi


### PR DESCRIPTION
When running locally I noticed that sometimes the `rngd` is still running after the test fails/hangs. I suspect this may be the reason that is is more flaky recently.
