### PR TITLE
Null deref check in Pkcs11ECDH

### DIFF
--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -2764,7 +2764,8 @@ static int Pkcs11ECDH(Pkcs11Session* session, wc_CryptoInfo* info)
 
     if (ret == 0) {
         secSz = *info->pk.ecdh.outlen;
-        if (secSz > (CK_ULONG)info->pk.ecdh.private_key->dp->size)
+        if (info->pk.ecdh.private_key->dp != NULL &&
+            secSz > (CK_ULONG)info->pk.ecdh.private_key->dp->size)
             secSz = info->pk.ecdh.private_key->dp->size;
 
         params.kdf             = CKD_NULL;


### PR DESCRIPTION
# Description

 `static int Pkcs11ECDH(Pkcs11Session* session, wc_CryptoInfo* info)` in the file `wc_pkcs11.c` attempts to access the field `info->pk.ecdh.private_key->dp->size` . However, the `dp` field is a null pointer for a private key from PKCS#11, which creates the hard fault.

Fixes zd20964

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
