### PR TITLE
fix for shadows global declaration warning

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -42234,11 +42234,11 @@ static int DisplaySecTrustError(CFErrorRef error, SecTrustRef trust)
     /* Description */
     desc = CFErrorCopyDescription(error);
     if (desc) {
-        char buffer[256];
-        if (CFStringGetCString(desc, buffer, sizeof(buffer),
+        char buf[256];
+        if (CFStringGetCString(desc, buf, sizeof(buf),
                                kCFStringEncodingUTF8)) {
             WOLFSSL_MSG_EX("SecTrustEvaluateWithError Error description: %s\n",
-                           buffer);
+                           buf);
         }
         CFRelease(desc);
     }


### PR DESCRIPTION
On my local machine was hitting this warning with `./configure --enable-all && make`

```
ake install  CC       tests/api/unit_test-test_ossl_x509_ext.o
src/internal.c: In function 'DisplaySecTrustError':
src/internal.c:42224:14: warning: declaration of 'buffer' shadows a global declaration [-Wshadow]
42224 |         char buffer[256];
      |              ^~~~~~
In file included from src/internal.c:95:
./wolfssl/internal.h:2129:29: note: shadowed declaration is here
 2129 | typedef WOLFSSL_BUFFER_INFO buffer;
      |                             ^~~~~~
   ```
   
   ```
   bash-3.2$ gcc -v
Using built-in specs.
Target: x86_64-apple-darwin22.6.0
gcc version 15.2.0 (GCC) 
```