### PR TITLE
Aes Free callback support

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -35753,6 +35753,23 @@ static int test_CryptoCb_Func(int thisDevId, wc_CryptoInfo* info, void* ctx)
                     break;
             }
         }
+        else if (info->free.algo == WC_ALGO_TYPE_CIPHER) {
+            switch (info->free.type) {
+    #ifndef NO_AES
+                case WC_CIPHER_AES:
+                {
+                    Aes* aes = (Aes*)info->free.obj;
+                    aes->devId = INVALID_DEVID;
+                    wc_AesFree(aes);
+                    ret = 0;
+                    break;
+                }
+    #endif
+                default:
+                    ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
+                    break;
+            }
+        }
         else {
             ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
         }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -62528,6 +62528,23 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
                     break;
             }
         }
+        else if (info->free.algo == WC_ALGO_TYPE_CIPHER) {
+            switch (info->free.type) {
+#ifndef NO_AES
+                case WC_CIPHER_AES:
+                {
+                    Aes* aes = (Aes*)info->free.obj;
+                    aes->devId = INVALID_DEVID;
+                    wc_AesFree(aes);
+                    ret = 0;
+                    break;
+                }
+#endif
+                default:
+                    ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
+                    break;
+            }
+        }
         else {
             ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
         }


### PR DESCRIPTION
### Add FREE Callback Support for AES devCtx Cleanup

Implements `WOLF_CRYPTO_CB_FREE` callback support to prevent memory leaks from
dynamically allocated `devCtx` structures. The `wc_AesFree()` function doesn't
free `aes->devCtx` - it only zeros the pointer, so port implementations that
allocate custom context structures via `XMALLOC` and store them in `devCtx`
will leak memory. This change adds FREE callback check to `wc_AesFree()`
(following the SHA function pattern), allowing port implementations to free
`devCtx` before standard cleanup proceeds.

The recommended approach for port implementations is to perform custom cleanup
for `devCtx` in the FREE callback, set `devId=INVALID_DEVID` to prevent callback
recursion, then call `wc_AesFree()` again to complete standard cleanup of the
AES structure. This enables users to call the standard `wc_AesFree()` API
without needing to manually free `devCtx` before losing the memory pointer.
