### PR TITLE
tests: Unbreak the build on FreeBSD-based systems

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -52,7 +52,7 @@
 
 #include <stdlib.h>
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 #include <unistd.h>
 #include <sys/wait.h>
 #endif


### PR DESCRIPTION
... by using the same additional includes as on Linux.

Fixes:

      CC       tests/api/unit_test-test_rsa.o
    tests/api.c:19554:9: error: call to undeclared function 'waitpid'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimplicit-function-declaration]
     19554 |         waitpid(pid, &waitstatus, 0);
	   |         ^

Tested on ElectroBSD amd64 14.3-STABLE.

# Description

Please describe the scope of the fix or feature addition.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
