### PR TITLE
check that we are resuming in write_early_data + minor fixes

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -14430,6 +14430,8 @@ int  wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz);
     \return BAD_FUNC_ARG if a pointer parameter is NULL, sz is less than 0 or
     not using TLSv1.3.
     \return SIDE_ERROR if called with a server.
+    \return BAD_STATE_E if invoked without a valid session or without a valid
+    PSK cb
     \return WOLFSSL_FATAL_ERROR if the connection is not made.
     \return the amount of early data written in bytes if successful.
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -14990,8 +14990,9 @@ int wolfSSL_get_max_early_data(WOLFSSL* ssl)
  * sz     The size of the early data in bytes.
  * outSz  The number of early data bytes written.
  * returns BAD_FUNC_ARG when: ssl, data or outSz is NULL; sz is negative;
- * or not using TLS v1.3. SIDE ERROR when not a server. Otherwise the number of
- * early data bytes written.
+ * or not using TLS v1.3. SIDE ERROR when not a server. BAD_STATE_E if invoked
+ * without a valid session or without a valid PSK CB.
+ * Otherwise the number of early data bytes written.
  */
 int wolfSSL_write_early_data(WOLFSSL* ssl, const void* data, int sz, int* outSz)
 {
@@ -15010,8 +15011,7 @@ int wolfSSL_write_early_data(WOLFSSL* ssl, const void* data, int sz, int* outSz)
 
     /* Early data requires PSK or session resumption */
     if (!EarlyDataPossible(ssl)) {
-        ssl->error = BAD_STATE_E;
-        return WOLFSSL_FATAL_ERROR;
+        return BAD_STATE_E;
     }
 
     if (ssl->options.handShakeState == NULL_STATE) {

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -764,8 +764,9 @@ int test_tls13_apis(void)
     ExpectIntEQ(wolfSSL_write_early_data(clientTls12Ssl, earlyData,
         sizeof(earlyData), &outSz), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 #endif
+    /* invoking without session or psk cbs */
     ExpectIntEQ(wolfSSL_write_early_data(clientSsl, earlyData,
-        sizeof(earlyData), &outSz), WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR));
+        sizeof(earlyData), &outSz), WC_NO_ERR_TRACE(BAD_STATE_E));
 #endif
 
     ExpectIntEQ(wolfSSL_read_early_data(NULL, earlyDataBuffer,


### PR DESCRIPTION
# Description

1. check that we are resuming or using PSK when invoking `wolfSSL_write_early_data`, error otherwise
2. set `ssl->earlyData == expecting_early_data` only on the first `wolfSSL_write_early_data` invocation
3. merge consecutive section guarded by the same macro 