### PR TITLE
Fixes for PSK Handshake without Diffie-Hellman

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -37122,6 +37122,14 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
 #endif
 
+#if !defined(NO_PSK)
+        if(havePSK && ssl->options.noPskDheKe) {
+            /* In this case, no keyshare extension is sent from the client and
+             * we can exit the verification successfully. */
+            return 1;
+        }
+#endif
+
 #ifdef WOLFSSL_TLS13
         if (IsAtLeastTLSv1_3(ssl->version) &&
                                       ssl->options.side == WOLFSSL_SERVER_END) {
@@ -37345,7 +37353,11 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
         if (IsAtLeastTLSv1_3(ssl->version) &&
-                                      ssl->options.side == WOLFSSL_SERVER_END) {
+            ssl->options.side == WOLFSSL_SERVER_END
+#if !defined(NO_PSK)
+            && !ssl->options.noPskDheKe
+#endif
+        ) {
             ret = TLSX_KeyShare_Setup(ssl, cs.clientKSE);
             if (ret != 0)
                 return ret;

--- a/src/tls.c
+++ b/src/tls.c
@@ -14681,6 +14681,8 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
             #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
                 if (ssl->options.resuming && ssl->session->namedGroup != 0)
                     namedGroup = ssl->session->namedGroup;
+                else if (ssl->options.noPskDheKe)
+                    namedGroup = WOLFSSL_NAMED_GROUP_INVALID;
                 else
             #endif
                 if (ssl->numGroups > 0) {


### PR DESCRIPTION
* Make sure no KeyShare is sent from the client when DH is disabled in PSK mode
* Fix server error in Suite matching in case no KeyShare is present

Found while testing PSK-only handshakes on embedded devices where client-side KeyShare generation is costly.
