### PR TITLE
Fix for WOLFSSL_BLIND_PRIVATE_KEY and WOLFSSL_DUAL_ALG_CERTS

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7136,7 +7136,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     ssl->buffers.altKey   = ctx->altPrivateKey;
 #else
     if (ctx->altPrivateKey != NULL) {
-        ret = AllocCopyDer(&ssl->buffers.altkey, ctx->altPrivateKey->buffer,
+        ret = AllocCopyDer(&ssl->buffers.altKey, ctx->altPrivateKey->buffer,
             ctx->altPrivateKey->length, ctx->altPrivateKey->type,
             ctx->altPrivateKey->heap);
         if (ret != 0) {


### PR DESCRIPTION
Fix typo for when both `WOLFSSL_BLIND_PRIVATE_KEY` and `WOLFSSL_DUAL_ALG_CERTS` are enabled.
