### PR TITLE
Fix memory leak in case of handshake error

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8711,6 +8711,10 @@ void wolfSSL_ResourceFree(WOLFSSL* ssl)
         }
     #endif
 #endif
+#if defined(HAVE_DILITHIUM)
+    FreeKey(ssl, DYNAMIC_TYPE_DILITHIUM, (void**)&ssl->peerDilithiumKey);
+    ssl->peerDilithiumKeyPresent = 0;
+#endif
 #if defined(HAVE_FALCON)
     FreeKey(ssl, DYNAMIC_TYPE_FALCON, (void**)&ssl->peerFalconKey);
     ssl->peerFalconKeyPresent = 0;


### PR DESCRIPTION
Make sure a peer Dilithium key is properly freed in case the handshake fails.
