### PR TITLE
Remove PQC-based buffer size increase for PreMasterSecret

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10295,8 +10295,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
             args->idx += OPAQUE16_LEN;
 
             /* Signature data. */
-            if ((args->idx - args->begin) + args->sz > totalSz ||
-                                                       args->sz > ENCRYPT_LEN) {
+            if ((args->idx - args->begin) + args->sz > totalSz) {
                 ERROR_OUT(BUFFER_ERROR, exit_dcv);
             }
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1526,15 +1526,10 @@ enum Misc {
     MAXEARLYDATASZ_LEN = 4,     /* maxEarlyDataSz size in ticket */
 #endif
 #endif
-#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
-    ENCRYPT_LEN     = 5120,     /* Allow 5k byte buffer for dilithium and
-                                 * hybridization with other algs. */
-#else
 #ifndef NO_PSK
     ENCRYPT_LEN     = (ENCRYPT_BASE_BITS / 8) + MAX_PSK_KEY_LEN + 2,
 #else
     ENCRYPT_LEN     = (ENCRYPT_BASE_BITS / 8),
-#endif
 #endif
     SIZEOF_SENDER   =  4,       /* clnt or srvr           */
     FINISHED_SZ     = 36,       /* WC_MD5_DIGEST_SIZE + WC_SHA_DIGEST_SIZE */


### PR DESCRIPTION
The size of the PreMasterSecret buffer is based on the `ENCRYPT_LEN` constant, which has been increased to 5kB for PQC support (Dilithium and Falcon, as their signatures are that large).

However, only in the TLS 1.2 case, the PreMasterSecret buffer is used to store signatures. In the TLS 1.3 path, only actual symmetric secrets are stored in that buffer, which are much smaller (the "old" size of the constant without the PQC increase).

As PQC is only allowed in TLS 1.3 and NOT in TLS 1.2, we can revert that size increase, saving around 4,5kB of dynamic memory during the handshake.
