### PR TITLE
Add Zephyr support for TRACK_MEMORY

### DIFF
--- a/.wolfssl_known_macro_extras
+++ b/.wolfssl_known_macro_extras
@@ -1104,6 +1104,7 @@ __thumb__
 __ti__
 __x86_64__
 __xtensa__
+__ZEPHYR__
 byte
 configTICK_RATE_HZ
 fallthrough

--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -79,7 +79,8 @@
     !defined(WOLFSSL_STATIC_MEMORY)
 
 #define DO_MEM_STATS
-#if (defined(__linux__) && !defined(WOLFSSL_KERNEL_MODE)) || defined(__MACH__)
+#if (defined(__linux__) && !defined(WOLFSSL_KERNEL_MODE)) || \
+    defined(__MACH__) || defined(__ZEPHYR__)
     #define DO_MEM_LIST
 #endif
 


### PR DESCRIPTION
Add Zephyr support for `TRACK_MEMORY`. Useful to trace memory allocations on a broad range of microcontroller.