### PR TITLE
20260108-DEFAULT_MAX_CLASSIC_ASYM_KEY_BITS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -314,6 +314,11 @@ AC_ARG_ENABLE([32bit],
     [ ENABLED_32BIT=no ]
     )
 
+if test "$ENABLED_32BIT" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWC_32BIT_CPU"
+fi
+
 # 16-bit compiler support
 AC_ARG_ENABLE([16bit],
     [AS_HELP_STRING([--enable-16bit],[Enables 16-bit support (default: disabled)])],
@@ -941,9 +946,21 @@ AC_ARG_ENABLE([fasthugemath],
     [ ENABLED_FASTHUGEMATH=no ]
     )
 
+# ssl bump build
+AC_ARG_ENABLE([bump],
+    [AS_HELP_STRING([--enable-bump],[Enable SSL Bump build (default: disabled)])],
+    [ ENABLED_BUMP=$enableval ],
+    [ ENABLED_BUMP=no ]
+    )
+
 if test "$ENABLED_BUMP" = "yes"
 then
-    ENABLED_FASTHUGEMATH="yes"
+    AM_CFLAGS="$AM_CFLAGS -DLARGE_STATIC_BUFFERS -DWOLFSSL_CERT_GEN -DWOLFSSL_KEY_GEN -DHUGE_SESSION_CACHE -DWOLFSSL_DER_LOAD -DWOLFSSL_ALT_NAMES -DWOLFSSL_TEST_CERT"
+    DEFAULT_MAX_CLASSIC_ASYM_KEY_BITS=4096
+    if test "$ENABLED_SP_MATH" = "no" && test "$ENABLED_SP_MATH_ALL" = "no"
+    then
+        ENABLED_FASTHUGEMATH="yes"
+    fi
 fi
 
 if test "$ENABLED_FASTHUGEMATH" = "yes"
@@ -951,7 +968,8 @@ then
     ENABLED_FASTMATH="yes"
 fi
 
-if test "$host_cpu" = "x86_64" || test "$host_cpu" = "amd64"
+if (test "$host_cpu" = "x86_64" || test "$host_cpu" = "amd64") &&
+    test "$ENABLED_32BIT" != "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_X86_64_BUILD"
 fi
@@ -2488,13 +2506,6 @@ AC_ARG_ENABLE([qt],
     [ ENABLED_QT=no ]
     )
 
-# ssl bump build
-AC_ARG_ENABLE([bump],
-    [AS_HELP_STRING([--enable-bump],[Enable SSL Bump build (default: disabled)])],
-    [ ENABLED_BUMP=$enableval ],
-    [ ENABLED_BUMP=no ]
-    )
-
 # SNIFFER
 AC_ARG_ENABLE([sniffer],
    [AS_HELP_STRING([--enable-sniffer],[Enable wolfSSL sniffer support (default: disabled)])],
@@ -2797,14 +2808,6 @@ if test "$ENABLED_FORTRESS" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DFORTRESS -DWOLFSSL_ALWAYS_VERIFY_CB -DWOLFSSL_AES_COUNTER -DWOLFSSL_AES_DIRECT -DWOLFSSL_DER_LOAD -DWOLFSSL_KEY_GEN"
 fi
-
-
-if test "$ENABLED_BUMP" = "yes"
-then
-    AM_CFLAGS="$AM_CFLAGS -DLARGE_STATIC_BUFFERS -DWOLFSSL_CERT_GEN -DWOLFSSL_KEY_GEN -DHUGE_SESSION_CACHE -DWOLFSSL_DER_LOAD -DWOLFSSL_ALT_NAMES -DWOLFSSL_TEST_CERT"
-    DEFAULT_MAX_CLASSIC_ASYM_KEY_BITS=4096
-fi
-
 
 # lean TLS build (TLS 1.2 client only (no client auth), ECC256, AES128 and SHA256 w/o Shamir)
 AC_ARG_ENABLE([leantls],

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3349,7 +3349,8 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 /* if desktop type system and fastmath increase default max bits */
-#if defined(WOLFSSL_X86_64_BUILD) || defined(WOLFSSL_AARCH64_BUILD)
+#if defined(WOLFSSL_X86_64_BUILD) || defined(WOLFSSL_AARCH64_BUILD) || \
+    defined(OPENSSL_EXTRA)
     #if defined(USE_FAST_MATH) && !defined(FP_MAX_BITS)
         #if MIN_FFDHE_FP_MAX_BITS <= 8192
             #define FP_MAX_BITS     8192

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -307,8 +307,11 @@ typedef const char wcchar[];
 #endif
 
 #if defined(WORD64_AVAILABLE) && !defined(WC_16BIT_CPU)
-    /* These platforms have 64-bit CPU registers.  */
-    #if (defined(__alpha__) || defined(__ia64__) || defined(_ARCH_PPC64) || \
+    #if defined(WC_64BIT_CPU)
+        /* explicitly configured for 64 bit. */
+    #elif defined(WC_32BIT_CPU)
+        /* explicitly configured for 32 bit. */
+    #elif (defined(__alpha__) || defined(__ia64__) || defined(_ARCH_PPC64) || \
         (defined(__mips64) && \
          ((defined(_ABI64) && (_MIPS_SIM == _ABI64)) || \
           (defined(_ABIO64) && (_MIPS_SIM == _ABIO64)))) || \
@@ -317,6 +320,7 @@ typedef const char wcchar[];
         (defined(__riscv_xlen) && (__riscv_xlen == 64)) || defined(_M_ARM64) || \
         defined(__aarch64__) || defined(__ppc64__) || \
         (defined(__DCC__) && (defined(__LP64) || defined(__LP64__)))
+        /* The above platforms have 64-bit CPU registers. */
         #define WC_64BIT_CPU
     #elif (defined(sun) || defined(__sun)) && \
           (defined(LP64) || defined(_LP64))


### PR DESCRIPTION
`configure.ac`: if `ENABLED_32BIT`, add `-DWC_32BIT_CPU` to `AM_CFLAGS`, and don't add `WOLFSSL_X86_64_BUILD` to `AM_CFLAGS`; fix handling for `--enable-bump`;

`wolfssl/wolfcrypt/settings.h`: classify `OPENSSL_EXTRA` as "desktop type system" in bump up of default `FP_MAX_BITS` and `SP_INT_BITS`;

`wolfssl/wolfcrypt/types.h`: if `WC_32BIT_CPU`, don't define `WC_64BIT_CPU`.

fixes #7929 when combined with `--enable-opensslextra`.

tested with `wolfssl-multi-test.sh ... check-configure cross-powerpc32-asm-ocsp-test`, the latter of which runs the reproducer in #7929 on emulated-ppc32 using some new logic I've just added to multi-test.

also tested with `wolfssl-multi-test.sh ... '.*-m32.*'`
