### PR TITLE
Address Zephyr and C++ compatibility issues

### DIFF
--- a/wolfssl/openssl/conf.h
+++ b/wolfssl/openssl/conf.h
@@ -24,12 +24,12 @@
 #ifndef WOLFSSL_conf_H_
 #define WOLFSSL_conf_H_
 
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/version.h>
+
 #ifdef __cplusplus
     extern "C" {
 #endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/version.h>
 
 typedef struct WOLFSSL_CONF_VALUE {
     char *section;
@@ -37,8 +37,16 @@ typedef struct WOLFSSL_CONF_VALUE {
     char *value;
 } WOLFSSL_CONF_VALUE;
 
+#ifdef  __cplusplus
+} /* extern "C" */
+#endif
+
 /* ssl.h requires WOLFSSL_CONF_VALUE */
 #include <wolfssl/ssl.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 typedef struct WOLFSSL_CONF {
     void *meth_data;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -270,9 +270,19 @@ typedef struct WOLFSSL_BY_DIR       WOLFSSL_BY_DIR;
 /* redeclare guard */
 #define WOLFSSL_TYPES_DEFINED
 
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#include <wolfssl/wolfio.h>
+
 /* The WOLFSSL_RSA type is required in all build configurations. */
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 #include <wolfssl/openssl/rsa.h>
+#endif
+
+#ifdef __cplusplus
+    extern "C" {
 #endif
 
 #ifndef WC_RNG_TYPE_DEFINED /* guard on redeclaration */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -270,8 +270,6 @@ typedef struct WOLFSSL_BY_DIR       WOLFSSL_BY_DIR;
 /* redeclare guard */
 #define WOLFSSL_TYPES_DEFINED
 
-#include <wolfssl/wolfio.h>
-
 /* The WOLFSSL_RSA type is required in all build configurations. */
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 #include <wolfssl/openssl/rsa.h>
@@ -2157,12 +2155,6 @@ WOLFSSL_API int wolfSSL_BIO_set_mem_buf(WOLFSSL_BIO* bio, WOLFSSL_BUF_MEM* bufMe
                                         int closeFlag);
 #endif
 WOLFSSL_API int wolfSSL_BIO_get_len(WOLFSSL_BIO *bio);
-
-#ifdef WOLFSSL_HAVE_BIO_ADDR
-WOLFSSL_API WOLFSSL_BIO_ADDR *wolfSSL_BIO_ADDR_new(void);
-WOLFSSL_API void wolfSSL_BIO_ADDR_free(WOLFSSL_BIO_ADDR *addr);
-WOLFSSL_API void wolfSSL_BIO_ADDR_clear(WOLFSSL_BIO_ADDR *addr);
-#endif /* WOLFSSL_HAVE_BIO_ADDR */
 
 #endif /* !NO_BIO */
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2594,6 +2594,10 @@ extern void uITRON4_free(void *p) ;
 #endif /*(WOLFSSL_APACHE_MYNEWT)*/
 
 #ifdef WOLFSSL_ZEPHYR
+    #ifdef __cplusplus
+        }  /* extern "C" */
+    #endif
+
     #include <version.h>
 #if KERNEL_VERSION_NUMBER >= 0x30100
     #include <zephyr/kernel.h>
@@ -2605,6 +2609,10 @@ extern void uITRON4_free(void *p) ;
     #include <sys/util.h>
 #endif
     #include <stdlib.h>
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
     #define WOLFSSL_DH_CONST
     #define NO_WRITEV

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -283,8 +283,6 @@
 #elif defined(WOLFSSL_APACHE_MYNEWT)
     /* do nothing */
 #elif defined(WOLFSSL_ZEPHYR)
-    /* Zephyr SDK can use a cpp compiler which will cause
-     * problems with extern "C" linkage if not handled */
     #ifdef __cplusplus
         }  /* extern "C" */
     #endif
@@ -994,7 +992,15 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFGETS(b,s,f) -2 /* Not ported yet */
 
 #elif defined(WOLFSSL_ZEPHYR)
+    #ifdef __cplusplus
+        }  /* extern "C" */
+    #endif
+
     #include <zephyr/fs/fs.h>
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
     #define XFILE      struct fs_file_t*
 
@@ -1481,6 +1487,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define USE_WOLF_TIME_T
 
 #elif defined(WOLFSSL_ZEPHYR)
+    #ifdef __cplusplus
+        }  /* extern "C" */
+    #endif
+
     #include <version.h>
     #ifndef _POSIX_C_SOURCE
         #if KERNEL_VERSION_NUMBER >= 0x30100
@@ -1498,6 +1508,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
         #else
             #warning "RTC support needs picolibc or newlib (nano)"
         #endif
+    #endif
+
+    #ifdef __cplusplus
+        extern "C" {
     #endif
 
     time_t z_time(time_t *timer);

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -176,6 +176,10 @@
         #include <lwip-socket.h>
         #include <errno.h>
     #elif defined(WOLFSSL_ZEPHYR)
+        #ifdef __cplusplus
+            }  /* extern "C" */
+        #endif
+
         #include <version.h>
         #if KERNEL_VERSION_NUMBER >= 0x30100
             #include <zephyr/net/socket.h>
@@ -187,6 +191,10 @@
             #ifdef CONFIG_POSIX_API
                 #include <posix/sys/socket.h>
             #endif
+        #endif
+
+        #ifdef __cplusplus
+            extern "C" {
         #endif
     #elif defined(MICROCHIP_PIC32)
         #include <sys/errno.h>

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -585,6 +585,10 @@ union WOLFSSL_BIO_ADDR {
 
 typedef union WOLFSSL_BIO_ADDR WOLFSSL_BIO_ADDR;
 
+WOLFSSL_API WOLFSSL_BIO_ADDR *wolfSSL_BIO_ADDR_new(void);
+WOLFSSL_API void wolfSSL_BIO_ADDR_free(WOLFSSL_BIO_ADDR *addr);
+WOLFSSL_API void wolfSSL_BIO_ADDR_clear(WOLFSSL_BIO_ADDR *addr);
+
 #if defined(WOLFSSL_DTLS) && defined(OPENSSL_EXTRA)
 WOLFSSL_API  int wolfIO_SendTo(SOCKET_T sd, WOLFSSL_BIO_ADDR *addr, char *buf, int sz, int wrFlags);
 WOLFSSL_API  int wolfIO_RecvFrom(SOCKET_T sd, WOLFSSL_BIO_ADDR *addr, char *buf, int sz, int rdFlags);

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -541,7 +541,11 @@
         typedef struct hostent          HOSTENT;
     #endif /* HAVE_SOCKADDR */
 
-    #if defined(HAVE_GETADDRINFO)
+    #if defined(WOLFSSL_ZEPHYR)
+        typedef struct zsock_addrinfo   ADDRINFO;
+        #define getaddrinfo             zsock_getaddrinfo
+        #define freeaddrinfo            zsock_freeaddrinfo
+    #elif defined(HAVE_GETADDRINFO)
         typedef struct addrinfo         ADDRINFO;
     #endif
 #endif /* WOLFSSL_NO_SOCK */
@@ -1002,6 +1006,8 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
         #endif
     #elif defined(FREESCALE_MQX)
         #define XINET_PTON(a,b,c,d) inet_pton((a),(b),(c),(d))
+    #elif defined(WOLFSSL_ZEPHYR)
+        #define XINET_PTON(a,b,c)   zsock_inet_pton((a),(b),(c))
     #else
         #define XINET_PTON(a,b,c)   inet_pton((a),(b),(c))
     #endif


### PR DESCRIPTION
- Define missing POSIX network functions for Zephyr
- Correct C++ linkage issues by adding `extern "C"` blocks in multiple files