### PR TITLE
bsdkm: sys time wrapper.

### DIFF
--- a/bsdkm/bsdkm_wc_port.h
+++ b/bsdkm/bsdkm_wc_port.h
@@ -50,7 +50,7 @@ static inline time_t wolfkmod_time(time_t * tloc) {
     }
     return _now;
 }
-#define	XTIME(tp) wolfkmod_time((tp))
+#define XTIME wolfkmod_time
 
 /* needed to prevent wolfcrypt/src/asn.c version shadowing
  * extern global version from /usr/src/sys/sys/systm.h */


### PR DESCRIPTION
## Description

FreeBSD kernel does not allow `<time.h` or `TIME(3)`.

Add a small wrapper that XTIME macro can use.

## Testing

```
fips_hash=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
./configure --enable-freebsdkm --enable-cryptonly --enable-all-crypto --enable-crypttests --enable-fips=v6 \
  CFLAGS="-DWOLFCRYPT_FIPS_CORE_HASH_VALUE=$fips_hash -DWOLFSSL_BSDKM_VERBOSE_DEBUG" && \
  make && sudo kldload bsdkm/libwolfssl.ko
```

