### PR TITLE
Curve25519 x64 ASM: nct invert needs vzeroupper

### DIFF
--- a/wolfcrypt/src/fe_x25519_asm.S
+++ b/wolfcrypt/src/fe_x25519_asm.S
@@ -21779,6 +21779,7 @@ L__mod_inv_avx2__3_no_add_prime:
         movq	%r8, 8(%rdi)
         movq	%r10, 16(%rdi)
         movq	%r12, 24(%rdi)
+        vzeroupper
         popq	%rbx
         popq	%r15
         popq	%r14


### PR DESCRIPTION
# Description

When ymm registers used, vzeroupper is required at end.

# Testing

./configure --enable-curve25519 --enable-intelasm --enable-ed25519

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
