### PR TITLE
Fix the OSS-Fuzz build error caused by the warning of unused variables in ecc_map_ex

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2704,7 +2704,6 @@ int ecc_projective_dbl_point(ecc_point *P, ecc_point *R, mp_int* a,
 int ecc_map_ex(ecc_point* P, mp_int* modulus, mp_digit mp, int ct)
 {
     int err = MP_OKAY;
-    mp_int *x, *y, *z;
     (void)ct;
 
     if (P == NULL || modulus == NULL){
@@ -2719,6 +2718,7 @@ int ecc_map_ex(ecc_point* P, mp_int* modulus, mp_digit mp, int ct)
         DECL_MP_INT_SIZE_DYN(ry, mp_bitsused(modulus), MAX_ECC_BITS_USE);
         DECL_MP_INT_SIZE_DYN(rz, mp_bitsused(modulus), MAX_ECC_BITS_USE);
         #endif
+	mp_int *x, *y, *z;
 
         /* special case for point at infinity */
         if (mp_cmp_d(P->z, 0) == MP_EQ) {


### PR DESCRIPTION
# Description
This PR fixes a fuzzing build error caused by unused variables (x, y, z) in wolfcrypt/src/ecc.c when compiling with -Werror and specific configurations .
In the function ecc_map_ex, the variables x, y, and z were declared at the top of the function but are only used within a specific #if !defined(WOLFSSL_SP_MATH) block. When WOLFSSL_SP_MATH is defined, these variables remain unused, triggering a -Wunused-variable error in strict build environments like OSS-Fuzz.

The fix moves the declaration of these variables into the inner scope where they are actually used, resolving the warning/error without changing any logic.
Fixes build error seen in OSS-Fuzz environments.

# Testing
git clone https://github.com/google/oss-fuzz.git
git clone https://github.com/wolfSSL/wolfssl.git
cd oss-fuzz/
python3.10 infra/helper.py build_fuzzers wolfssl ~/wolfssl  --sanitizer address --engine honggfuzz --architecture x86_64

In this way, you can see the same error message as described below.
After using the PR code, the fuzzing build can be successfully carried out.

Fuzzing build error URL
[https://oss-fuzz-build-logs.storage.googleapis.com/index.html#wolfssl](url)
