### PR TITLE
Fix DecodeAuthKeyInternal not clearing cert->extAuthKeyIdSet

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -21414,6 +21414,9 @@ static int DecodeAuthKeyIdInternal(const byte* input, word32 sz,
         ret = GetHashId(extAuthKeyId, (int)extAuthKeyIdSz, cert->extAuthKeyId,
                         HashIdAlg(cert->signatureOID));
     }
+    else {
+        cert->extAuthKeyIdSet = 0;
+    }
 
 #ifdef WOLFSSL_AKID_NAME
     if (ret == 0 && extAuthKeyIdIssuerSz > 0) {


### PR DESCRIPTION
# Description

Prior to #9566 , cert->extAuthKeyIdSet was cleared if extAuthKeyIdSz was zero. Currently, cert->extAuthKeyIdSet is not cleared under the same condition.

Fixes zd21038

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
