### PR TITLE
Improve log message and error code for invalid HelloRetryRequest - fix #9653

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5677,7 +5677,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #endif
                 ) {
             SendAlert(ssl, alert_fatal, illegal_parameter);
-            return DUPLICATE_MSG_E;
+            return EXT_MISSING;
         }
 
         ssl->options.tls1_3 = 1;

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -2355,7 +2355,9 @@ int test_tls13_same_ch(void)
     ExpectIntEQ(test_memio_inject_message(&test_ctx, 1, (char*)hrr,
             sizeof(hrr)), 0);
     ExpectIntEQ(wolfSSL_connect(ssl_c), -1);
-    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), DUPLICATE_MSG_E);
+    /* issue 9653: use a more appropriate error than DUPLICATE_MSG_E.
+     * Since the cause of this is missing extension, return that. */
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), EXT_MISSING);
 
     wolfSSL_free(ssl_c);
     wolfSSL_CTX_free(ctx_c);


### PR DESCRIPTION
# Description

Improve log message and error code for invalid HelloRetryRequest - fix #9653

# Testing

  * verified reproducer for issue #9653 no longer shows Duplicate HandShake message Error.
  * verified unit tests pass with updated test case

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
