### PR TITLE
[TLS 1.2, TLS 1.3] Fail immediately if server sends empty certificate message for TLS 1.2 and beyond

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -15608,14 +15608,14 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 /* Empty certificate message. */
                 if ((ssl->options.side == WOLFSSL_SERVER_END) &&
                     (ssl->options.mutualAuth || (ssl->options.failNoCert &&
-                                             IsAtLeastTLSv1_3(ssl->version)))) {
+                                             IsAtLeastTLSv1_2(ssl)))) {
                     WOLFSSL_MSG("No peer cert from Client");
                     ret = NO_PEER_CERT;
                     WOLFSSL_ERROR_VERBOSE(ret);
                     DoCertFatalAlert(ssl, ret);
                 }
                 else if ((ssl->options.side == WOLFSSL_CLIENT_END) &&
-                         IsAtLeastTLSv1_3(ssl->version)) {
+                         IsAtLeastTLSv1_2(ssl)) {
                     WOLFSSL_MSG("No peer cert from Server");
                     ret = NO_PEER_CERT;
                     WOLFSSL_ERROR_VERBOSE(ret);


### PR DESCRIPTION
# Description

For TLS 1.2, the client accepts an empty certificate message from the server. This violates [RFC 5246 section 7.4.2](https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.2). However, for TLS 1.3 the client will properly fail immediately when receiving an empty certificate message from the server.

So to fix this, I modified the empty cert check to include both TLS 1.2 and TLS 1.3.

Fixes #9651

# Testing

Reproduction steps in #9651
