### PR TITLE
Add length check to Hmac_UpdateFinal_CT to prevent build error

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -937,6 +937,9 @@ static int Hmac_UpdateFinal_CT(Hmac* hmac, byte* digest, const byte* in,
     word32       realLen;
     byte         extraBlock;
 
+    if (macLen <= 0 || macLen > (int)sizeof(hmac->innerHash))
+        return BAD_FUNC_ARG;
+
     switch (hmac->macType) {
     #ifndef NO_SHA
         case WC_SHA:


### PR DESCRIPTION
# Description

Fix for the following compile issue:

```
In function ‘Hmac_UpdateFinal_CT’,
    inlined from ‘TLS_hmac’ at src/tls.c:1340:23:
src/tls.c:1072:50: error: writing 16 bytes into a region of size 0 [-Werror=stringop-overflow=]
 1072 |             ((unsigned char*)hmac->innerHash)[j] |= hashBlock[j] & isOutBlock;
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/tls.c: In function ‘TLS_hmac’:
src/tls.c:1277:12: note: at offset 560 into destination object ‘hmac’ of size 560
 1277 |     Hmac   hmac;
      |            ^~~~
```

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
