### PR TITLE
Fix compilation, crypt test and unit test failures when selftest is enabled

### DIFF
--- a/tests/api/test_dsa.c
+++ b/tests/api/test_dsa.c
@@ -117,7 +117,7 @@ int test_wc_DsaSignVerify(void)
     ExpectIntEQ(wc_DsaVerify(hash, signature, NULL, &answer), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_DsaVerify(hash, signature, &key, NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
-#if !defined(HAVE_FIPS) && defined(WOLFSSL_PUBLIC_MP)
+#if !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS) && defined(WOLFSSL_PUBLIC_MP)
     /* hard set q to 0 and test fail case */
     mp_free(&key.q);
     ExpectIntEQ(mp_init(&key.q), 0);

--- a/tests/api/test_ecc.c
+++ b/tests/api/test_ecc.c
@@ -676,7 +676,8 @@ int test_wc_ecc_export_x963_ex(void)
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_ecc_export_x963_ex(&key, out, NULL, COMP),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-#if defined(HAVE_FIPS) && (!defined(FIPS_VERSION_LT) || FIPS_VERSION_LT(5,3))
+#if (defined(HAVE_FIPS) && (!defined(FIPS_VERSION_LT) || FIPS_VERSION_LT(5,3)))\
+    || defined(HAVE_SELFTEST)
     ExpectIntEQ(wc_ecc_export_x963_ex(&key, out, &badOutLen, COMP),
         WC_NO_ERR_TRACE(BUFFER_E));
 #else

--- a/tests/api/test_ossl_ec.c
+++ b/tests/api/test_ossl_ec.c
@@ -610,7 +610,7 @@ int test_wolfSSL_EC_POINT(void)
     hexStr = EC_POINT_point2hex(group, Gxy, POINT_CONVERSION_COMPRESSED, ctx);
     ExpectNotNull(hexStr);
     ExpectStrEQ(hexStr, compG);
-    #ifdef HAVE_COMP_KEY
+    #if defined(HAVE_COMP_KEY) && !defined(HAVE_SELFTEST)
     ExpectNotNull(get_point = EC_POINT_hex2point
                                             (group, hexStr, get_point, ctx));
     ExpectIntEQ(EC_POINT_cmp(group, Gxy, get_point, ctx), 0);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -13211,7 +13211,8 @@ static int SetEccPublicKey(byte* output, ecc_key* key, int outLen,
     if (ret == 0) {
         /* Calculate the size of the encoded public point. */
         PRIVATE_KEY_UNLOCK();
-    #if defined(HAVE_COMP_KEY) && defined(HAVE_FIPS) && FIPS_VERSION3_LT(6,0,0)
+    #if defined(HAVE_COMP_KEY) && \
+    (defined(HAVE_SELFTEST) || (defined(HAVE_FIPS) && FIPS_VERSION3_LT(6,0,0)))
         /* in earlier versions of FIPS the get length functionality is not
          * available with compressed keys */
         pubSz = key->dp ? key->dp->size : MAX_ECC_BYTES;

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -163,12 +163,19 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
             byte l[WC_AES_BLOCK_SIZE];
 
             XMEMSET(l, 0, WC_AES_BLOCK_SIZE);
+#ifndef HAVE_SELFTEST
             ret = wc_AesEncryptDirect(&cmac->aes, l, l);
             if (ret == 0) {
                 ShiftAndXorRb(cmac->k1, l);
                 ShiftAndXorRb(cmac->k2, cmac->k1);
                 ForceZero(l, WC_AES_BLOCK_SIZE);
             }
+#else
+            wc_AesEncryptDirect(&cmac->aes, l, l);
+            ShiftAndXorRb(cmac->k1, l);
+            ShiftAndXorRb(cmac->k2, cmac->k1);
+            ForceZero(l, WC_AES_BLOCK_SIZE);
+#endif
         }
         break;
 #endif /* !NO_AES && WOLFSSL_AES_DIRECT */
@@ -233,12 +240,19 @@ int wc_CmacUpdate(Cmac* cmac, const byte* in, word32 inSz)
                 if (cmac->totalSz != 0) {
                     xorbuf(cmac->buffer, cmac->digest, WC_AES_BLOCK_SIZE);
                 }
+#ifndef HAVE_SELFTEST
                 ret = wc_AesEncryptDirect(&cmac->aes, cmac->digest,
                         cmac->buffer);
                 if (ret == 0) {
                     cmac->totalSz += WC_AES_BLOCK_SIZE;
                     cmac->bufferSz = 0;
                 }
+#else
+                wc_AesEncryptDirect(&cmac->aes, cmac->digest,
+                        cmac->buffer);
+                cmac->totalSz += WC_AES_BLOCK_SIZE;
+                cmac->bufferSz = 0;
+#endif
             }
         }
     }; break;
@@ -332,10 +346,15 @@ int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
             }
             xorbuf(cmac->buffer, cmac->digest, WC_AES_BLOCK_SIZE);
             xorbuf(cmac->buffer, subKey, WC_AES_BLOCK_SIZE);
+#ifndef HAVE_SELFTEST
             ret = wc_AesEncryptDirect(&cmac->aes, cmac->digest, cmac->buffer);
             if (ret == 0) {
                 XMEMCPY(out, cmac->digest, *outSz);
             }
+#else
+            wc_AesEncryptDirect(&cmac->aes, cmac->digest, cmac->buffer);
+            XMEMCPY(out, cmac->digest, *outSz);
+#endif
         }; break;
     #endif /* !NO_AES && WOLFSSL_AES_DIRECT */
         default:


### PR DESCRIPTION
# Description

Fix compilation, crypt test and unit test failures when selftest is enabled.

Fixes zd#21037

# Testing

Run unit test
```
./configure --enable-selftest --enable-opensslextra --enable-sha512 --enable-pkcs7 --enable-pkcs12 --enable-keygen --enable-certgen --enable-certreq --enable-renegotiation-indication --enable-sha224 --disable-chacha --disable-poly1305 --enable-savesession --enable-session-ticket --enable-tls13 --enable-aesccm --enable-aesgcm --enable-wpas --disable-dependency-tracking --disable-md5 --enable-ecc --enable-curve25519 --enable-rc2 --enable-certext --disable-fips
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
