### PR TITLE
Fix hostap repo clone URL

### DIFF
--- a/.github/workflows/hostap-vm.yml
+++ b/.github/workflows/hostap-vm.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Checkout hostap
         if: steps.cache.outputs.cache-hit != 'true'
-        run: git clone git://w1.fi/hostap.git hostap
+        run: git clone https://w1.fi/hostap.git hostap
 
   build_uml_linux:
     name: Build UML (UserMode Linux)


### PR DESCRIPTION
# Description

Fix hostap repo clone URL

Fix errors like https://github.com/wolfSSL/wolfssl/actions/runs/21031394003/job/60471585256?pr=9659

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
