### PR TITLE
initialize i_shaCopy to prevent undefined behavior

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -4863,6 +4863,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t sha256_test(void)
 #endif
 
     XMEMSET(&shaCopy, 0, sizeof(shaCopy));
+#ifndef NO_WOLFSSL_SHA256_INTERLEAVE
+    XMEMSET(&i_shaCopy, 0, sizeof(i_shaCopy));
+#endif
 
     for (i = 0; i < times; ++i) {
         ret = wc_Sha256Update(&sha, (byte*)test_sha[i].input,


### PR DESCRIPTION
i_shaCopy was declared but never initialized, causing garbage values
that led to undefined behavior when passed to functions such as
wc_Sha256Copy() and wc_Sha256Free(), resulting in a system hang.

Initialize i_shaCopy with XMEMSET() before use, consistent with
shaCopy initialization.

Issue introduced from https://github.com/wolfSSL/wolfssl/commit/fb82bdbc355ed25149e5c69412a3d9c5dd4ed5a4

Relevant diff from the commit:
```diff
-    ret = wc_InitSha256_ex(&shaCopy, HEAP_HINT, devId);
-    if (ret != 0) {
-        wc_Sha256Free(&sha);
-        return WC_TEST_RET_ENC_EC(ret);
-    }
-#ifndef NO_WOLFSSL_SHA256_INTERLEAVE
-    ret = wc_InitSha256_ex(&i_shaCopy, HEAP_HINT, devId);
-    if (ret != 0) {
-        wc_Sha256Free(&sha);
-        wc_Sha256Free(&i_sha);
-        return WC_TEST_RET_ENC_EC(ret);
-    }
-#endif
+    XMEMSET(&shaCopy, 0, sizeof(shaCopy));
```

This change replaced explicit initialization with zeroing, but missed i_shaCopy, causing the issue.

