### PR TITLE
Fix for building RISC-V 64-bit without SHA512

### DIFF
--- a/wolfcrypt/src/port/riscv/riscv-64-sha512.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-sha512.c
@@ -22,7 +22,7 @@
 #include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #ifdef WOLFSSL_RISCV_ASM
-#if !defined(NO_SHA512) || defined(WOLFSSL_SHA384)
+#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 
 #if FIPS_VERSION3_LT(6,0,0) && defined(HAVE_FIPS)
     #undef HAVE_FIPS
@@ -984,7 +984,7 @@ static WC_INLINE void Sha512Final(wc_Sha512* sha512, byte* hash, int hashLen)
 }
 
 
-#ifndef NO_SHA512
+#ifdef WOLFSSL_SHA512
 
 /* Initialize SHA-512 object for hashing.
  *
@@ -1494,7 +1494,7 @@ int wc_Sha512_256Transform(wc_Sha512* sha512, const unsigned char* data)
 
 #endif /* !HAVE_FIPS && !HAVE_SELFTEST */
 
-#endif /* !NO_SHA512 */
+#endif /* WOLFSSL_SHA512 */
 
 
 #ifdef WOLFSSL_SHA384
@@ -1737,5 +1737,5 @@ int wc_Sha384Copy(wc_Sha384* src, wc_Sha384* dst)
 
 #endif /* WOLFSSL_SHA384 */
 
-#endif /* !NO_SHA512 || WOLFSSL_SHA384 */
+#endif /* WOLFSSL_SHA512 || WOLFSSL_SHA384 */
 #endif /* WOLFSSL_RISCV_ASM */


### PR DESCRIPTION
# Description

Fix for building RISC-V 64-bit without SHA512. It was incorrectly using NO_SHA512.

# Testing

```
./configure flags: --enable-riscv-asm --enable-dilithium --enable-mlkem --enable-sp=yes --disable-sha512
---
Note: Make sure your application includes "wolfssl/options.h" before any other wolfSSL headers.
      You can define "WOLFSSL_USE_OPTIONS_H" in your application to include this automatically.
make -j5  all-recursive
make[1]: Entering directory '/root/wolfssl'
make[2]: Entering directory '/root/wolfssl'
make[2]: warning: -j5 forced in submake: resetting jobserver mode.
  CC       wolfcrypt/benchmark/benchmark.o
  CC       wolfcrypt/src/src_libwolfssl_la-hmac.lo
  CC       wolfcrypt/src/src_libwolfssl_la-hash.lo
  CC       wolfcrypt/src/src_libwolfssl_la-cpuid.lo
  CC       wolfcrypt/src/src_libwolfssl_la-kdf.lo
  CC       wolfcrypt/src/src_libwolfssl_la-random.lo
  CC       wolfcrypt/src/src_libwolfssl_la-sha256.lo
  CC       wolfcrypt/src/port/riscv/src_libwolfssl_la-riscv-64-sha256.lo
  CC       wolfcrypt/src/src_libwolfssl_la-rsa.lo
  CC       wolfcrypt/src/src_libwolfssl_la-sp_c32.lo
  CC       wolfcrypt/src/src_libwolfssl_la-sp_c64.lo
  CC       wolfcrypt/src/src_libwolfssl_la-sp_int.lo
  CC       wolfcrypt/src/src_libwolfssl_la-aes.lo
  CC       wolfcrypt/src/port/riscv/src_libwolfssl_la-riscv-64-aes.lo
  CC       wolfcrypt/src/src_libwolfssl_la-sha.lo
  CC       wolfcrypt/src/port/riscv/src_libwolfssl_la-riscv-64-sha512.lo
  CC       wolfcrypt/src/src_libwolfssl_la-sha3.lo
wolfcrypt/src/port/riscv/riscv-64-sha512.c:997:5: error: no previous prototype for 'wc_InitSha512_ex' [-Werror=missing-prototypes]
  997 | int wc_InitSha512_ex(wc_Sha512* sha512, void* heap, int devId)
      |     ^~~~~~~~~~~~~~~~
wolfcrypt/src/port/riscv/riscv-64-sha512.c:1012:5: error: no previous prototype for 'wc_InitSha512' [-Werror=missing-prototypes]
 1012 | int wc_InitSha512(wc_Sha512* sha512)
      |     ^~~~~~~~~~~~~
wolfcrypt/src/port/riscv/riscv-64-sha512.c:1021:6: error: no previous prototype for 'wc_Sha512Free' [-Werror=missing-prototypes]
 1021 | void wc_Sha512Free(wc_Sha512* sha512)
      |      ^~~~~~~~~~~~~
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
