### PR TITLE
20260117-fix-test_wolfSSL_EVP_sm3

### DIFF
--- a/tests/api/test_evp_digest.c
+++ b/tests/api/test_evp_digest.c
@@ -140,7 +140,6 @@ int test_wolfSSL_EVP_sm3(void)
     ExpectIntEQ(sz, WC_SM3_DIGEST_SIZE);
     for (chunk = 1; chunk <= WC_SM3_BLOCK_SIZE + 1; chunk++) {
         for (i = 0; i + chunk <= (word32)sizeof(data); i += chunk) {
-        for (i = 0; i + chunk <= (word32)sizeof(data); i += chunk) {
             ExpectIntEQ(EVP_DigestUpdate(mdCtx, data + i, chunk),
                 WOLFSSL_SUCCESS);
         }


### PR DESCRIPTION
`tests/api/test_evp_digest.c`: fix for copy-paste error in `test_wolfSSL_EVP_sm3()`, introduced in 43d831ff06.

detected by and tested with
```
wolfssl-multi-test.sh ...
 quantum-safe-wolfssl-wolfsm-all-cross-aarch64-armasm-unittest
 quantum-safe-wolfssl-wolfsm-all-cross-aarch64-noasm-unittest
 quantum-safe-wolfssl-wolfsm-all-cross-aarch64_be-all-noasm-unittest
 wolfsm-all-gcc-latest
 wolfsm-all-clang-tidy
 wolfsm-all-sanitizer
```
