### PR TITLE
Address connection issues in ocsp-stapling test

### DIFF
--- a/certs/external/README.txt
+++ b/certs/external/README.txt
@@ -1,3 +1,2 @@
-ca_collection.pem contains the two possible Root CA's that login.live.com can
-return, either the Baltimore Cyber Trust Root CA or the DigiCert Global Sign
-Root CA.
+ca_collection.pem contains the Root CA certificates that login.live.com can
+return: DigiCert Global Root CA and DigiCert Global Root G2.

--- a/certs/external/ca_collection.pem
+++ b/certs/external/ca_collection.pem
@@ -1,63 +1,3 @@
-Certificate:
-    Data:
-        Version: 3 (0x2)
-        Serial Number:
-            08:3b:e0:56:90:42:46:b1:a1:75:6a:c9:59:91:c7:4a
-        Signature Algorithm: sha1WithRSAEncryption
-        Issuer: C = US, O = DigiCert Inc, OU = www.digicert.com, CN = DigiCert Global Root CA
-        Validity
-            Not Before: Nov 10 00:00:00 2006 GMT
-            Not After : Nov 10 00:00:00 2031 GMT
-        Subject: C = US, O = DigiCert Inc, OU = www.digicert.com, CN = DigiCert Global Root CA
-        Subject Public Key Info:
-            Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
-                Modulus:
-                    00:e2:3b:e1:11:72:de:a8:a4:d3:a3:57:aa:50:a2:
-                    8f:0b:77:90:c9:a2:a5:ee:12:ce:96:5b:01:09:20:
-                    cc:01:93:a7:4e:30:b7:53:f7:43:c4:69:00:57:9d:
-                    e2:8d:22:dd:87:06:40:00:81:09:ce:ce:1b:83:bf:
-                    df:cd:3b:71:46:e2:d6:66:c7:05:b3:76:27:16:8f:
-                    7b:9e:1e:95:7d:ee:b7:48:a3:08:da:d6:af:7a:0c:
-                    39:06:65:7f:4a:5d:1f:bc:17:f8:ab:be:ee:28:d7:
-                    74:7f:7a:78:99:59:85:68:6e:5c:23:32:4b:bf:4e:
-                    c0:e8:5a:6d:e3:70:bf:77:10:bf:fc:01:f6:85:d9:
-                    a8:44:10:58:32:a9:75:18:d5:d1:a2:be:47:e2:27:
-                    6a:f4:9a:33:f8:49:08:60:8b:d4:5f:b4:3a:84:bf:
-                    a1:aa:4a:4c:7d:3e:cf:4f:5f:6c:76:5e:a0:4b:37:
-                    91:9e:dc:22:e6:6d:ce:14:1a:8e:6a:cb:fe:cd:b3:
-                    14:64:17:c7:5b:29:9e:32:bf:f2:ee:fa:d3:0b:42:
-                    d4:ab:b7:41:32:da:0c:d4:ef:f8:81:d5:bb:8d:58:
-                    3f:b5:1b:e8:49:28:a2:70:da:31:04:dd:f7:b2:16:
-                    f2:4c:0a:4e:07:a8:ed:4a:3d:5e:b5:7f:a3:90:c3:
-                    af:27
-                Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Key Usage: critical
-                Digital Signature, Certificate Sign, CRL Sign
-            X509v3 Basic Constraints: critical
-                CA:TRUE
-            X509v3 Subject Key Identifier: 
-                03:DE:50:35:56:D1:4C:BB:66:F0:A3:E2:1B:1B:C3:97:B2:3D:D1:55
-            X509v3 Authority Key Identifier: 
-                keyid:03:DE:50:35:56:D1:4C:BB:66:F0:A3:E2:1B:1B:C3:97:B2:3D:D1:55
-
-    Signature Algorithm: sha1WithRSAEncryption
-         cb:9c:37:aa:48:13:12:0a:fa:dd:44:9c:4f:52:b0:f4:df:ae:
-         04:f5:79:79:08:a3:24:18:fc:4b:2b:84:c0:2d:b9:d5:c7:fe:
-         f4:c1:1f:58:cb:b8:6d:9c:7a:74:e7:98:29:ab:11:b5:e3:70:
-         a0:a1:cd:4c:88:99:93:8c:91:70:e2:ab:0f:1c:be:93:a9:ff:
-         63:d5:e4:07:60:d3:a3:bf:9d:5b:09:f1:d5:8e:e3:53:f4:8e:
-         63:fa:3f:a7:db:b4:66:df:62:66:d6:d1:6e:41:8d:f2:2d:b5:
-         ea:77:4a:9f:9d:58:e2:2b:59:c0:40:23:ed:2d:28:82:45:3e:
-         79:54:92:26:98:e0:80:48:a8:37:ef:f0:d6:79:60:16:de:ac:
-         e8:0e:cd:6e:ac:44:17:38:2f:49:da:e1:45:3e:2a:b9:36:53:
-         cf:3a:50:06:f7:2e:e8:c4:57:49:6c:61:21:18:d5:04:ad:78:
-         3c:2c:3a:80:6b:a7:eb:af:15:14:e9:d8:89:c1:b9:38:6c:e2:
-         91:6c:8a:ff:64:b9:77:25:57:30:c0:1b:24:a3:e1:dc:e9:df:
-         47:7c:b5:b4:24:08:05:30:ec:2d:bd:0b:bf:45:bf:50:b9:a9:
-         f3:eb:98:01:12:ad:c8:88:c6:98:34:5f:8d:0a:3c:c6:e9:d5:
-         95:95:6d:de
 -----BEGIN CERTIFICATE-----
 MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh
 MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
@@ -79,4 +19,27 @@ hMAtudXH/vTBH1jLuG2cenTnmCmrEbXjcKChzUyImZOMkXDiqw8cvpOp/2PV5Adg
 PnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls
 YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk
 CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=
+-----END CERTIFICATE-----
+
+-----BEGIN CERTIFICATE-----
+MIIDjjCCAnagAwIBAgIQAzrx5qcRqaC7KGSxHQn65TANBgkqhkiG9w0BAQsFADBh
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBH
+MjAeFw0xMzA4MDExMjAwMDBaFw0zODAxMTUxMjAwMDBaMGExCzAJBgNVBAYTAlVT
+MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j
+b20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IEcyMIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuzfNNNx7a8myaJCtSnX/RrohCgiN9RlUyfuI
+2/Ou8jqJkTx65qsGGmvPrC3oXgkkRLpimn7Wo6h+4FR1IAWsULecYxpsMNzaHxmx
+1x7e/dfgy5SDN67sH0NO3Xss0r0upS/kqbitOtSZpLYl6ZtrAGCSYP9PIUkY92eQ
+q2EGnI/yuum06ZIya7XzV+hdG82MHauVBJVJ8zUtluNJbd134/tJS7SsVQepj5Wz
+tCO7TG1F8PapspUwtP1MVYwnSlcUfIKdzXOS0xZKBgyMUNGPHgm+F6HmIcr9g+UQ
+vIOlCsRnKPZzFBQ9RnbDhxSJITRNrw9FDKZJobq7nMWxM4MphQIDAQABo0IwQDAP
+BgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNVHQ4EFgQUTiJUIBiV
+5uNu5g/6+rkS7QYXjzkwDQYJKoZIhvcNAQELBQADggEBAGBnKJRvDkhj6zHd6mcY
+1Yl9PMWLSn/pvtsrF9+wX3N3KjITOYFnQoQj8kVnNeyIv/iPsGEMNKSuIEyExtv4
+NeF22d+mQrvHRAiGfzZ0JFrabA0UWTW98kndth/Jsw1HKj2ZL7tcu7XUIOGZX1NG
+Fdtom/DzMNU+MeKNhJ7jitralj41E6Vf8PlwUHBHQRFXGU7Aj64GxJUTFy8bJZ91
+8rGOmaFvE7FBcf6IKshPECBV1/MUReXgRPTqh5Uykw7+U0b6LJ3/iyK5S9kJRaTe
+pLiaWN0bfVKfjllDiIGknibVb63dDcY3fe0Dkhvld1927jyNxF1WW6LZZm6zNTfl
+MrY=
 -----END CERTIFICATE-----

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -119,6 +119,29 @@ remove_single_rF(){
     fi
 }
 
+retry_with_backoff() {
+    local max_attempts=$1
+    shift
+    local attempt=1
+    local delay=1
+    local status=0
+
+    while :; do
+        "$@"
+        status=$?
+        if [ $status -eq 0 ]; then
+            return 0
+        fi
+        if [ $attempt -ge $max_attempts ]; then
+            return $status
+        fi
+        printf '%s\n' "Retry $attempt/$max_attempts failed, backing off ${delay}s..."
+        sleep $delay
+        attempt=$((attempt + 1))
+        delay=$((delay * 2))
+    done
+}
+
 #create a configure file for cert generation with the port 0 solution
 create_new_cnf() {
     printf '%s\n' "Random Port Selected: $1"
@@ -304,7 +327,7 @@ server=login.live.com
 ca=./certs/external/ca_collection.pem
 
 if [[ "$V4V6" == "4" ]]; then
-    ./examples/client/client -C -h $server -p 443 -A $ca -g -W 1
+    retry_with_backoff 3 ./examples/client/client -C -h $server -p 443 -A $ca -g -W 1
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 else


### PR DESCRIPTION
# Description

OCSP stapling test consistently failing, most often in the "Ubuntu-Macos-Windows" workflow (`os-check.yml`). 

Failure signature ([example](https://github.com/wolfSSL/wolfssl/actions/runs/21177773469/job/60911262629)):
```
connecting to login.live.com:443
wolfSSL_connect error -188, certificate verify failed
wolfSSL error: wolfSSL_connect failed
```

Changelog:
- Add retries when connecting with login.live.com
- Add "DigiCert Global G2 TLS RSA SHA256 2020 CA1" to `ca_collection.pem`
- Update documentation regarding previously removed Baltimore cert

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [x] updated appropriate READMEs
 - [ ] Updated manual and documentation
