### PR TITLE
 Use MinGW XINET_PTON definition for 32-bit MinGW as well as 64-bit. 

### DIFF
--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -1003,7 +1003,7 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
             #define XINET_PTON(a,b,c)   *(unsigned *)(c) = inet_addr((b))
         #endif
     #elif defined(USE_WINDOWS_API) /* Windows-friendly definition */
-        #if defined(__MINGW64__) && !defined(UNICODE)
+        #if (defined(__MINGW32__) || defined(__MINGW64__)) && !defined(UNICODE)
             #define XINET_PTON(a,b,c)   InetPton((a),(b),(c))
         #else
             #define XINET_PTON(a,b,c)   InetPton((a),(PCWSTR)(b),(c))


### PR DESCRIPTION
# Description

MinGW unconditionally uses InetPtonA which does not want the PCWSTR cast provided by the other XINET_PTON definition.  wolfSSL was only checking for 64-bit MinGW, but 32-bit MinGW needs this as well.

Fixes zd#21012

# Testing

Customer confirmed fix

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
