### PR TITLE
Add STM32G0 hardware crypto support

### DIFF
--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -152,7 +152,7 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
             defined(WOLFSSL_STM32L5) || defined(WOLFSSL_STM32H7) || \
             defined(WOLFSSL_STM32U5) || defined(WOLFSSL_STM32H5) || \
             defined(WOLFSSL_STM32MP13) || defined(WOLFSSL_STM32H7S) || \
-            defined(WOLFSSL_STM32N6))
+            defined(WOLFSSL_STM32N6) || defined(WOLFSSL_STM32G0))
         /* Hardware supports AES GCM acceleration */
         #define STM32_CRYPTO_AES_GCM
     #endif
@@ -168,8 +168,10 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
         #define STM32_HAL_V2
     #endif
     #if defined(WOLFSSL_STM32L4) || defined(WOLFSSL_STM32L5) || \
-        defined(WOLFSSL_STM32U5) || defined(WOLFSSL_STM32H5)
-        #if defined(WOLFSSL_STM32L4) || defined(WOLFSSL_STM32U5)
+        defined(WOLFSSL_STM32U5) || defined(WOLFSSL_STM32H5) || \
+        defined(WOLFSSL_STM32G0)
+        #if defined(WOLFSSL_STM32L4) || defined(WOLFSSL_STM32U5) || \
+            defined(WOLFSSL_STM32G0)
             #define STM32_CRYPTO_AES_ONLY /* crypto engine only supports AES */
         #endif
         #if defined(WOLFSSL_STM32H5)
@@ -187,7 +189,8 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
         (defined(WOLFSSL_STM32F7) || defined(WOLFSSL_STM32L5) || \
          defined(WOLFSSL_STM32H7) || defined(WOLFSSL_STM32U5) || \
          defined(WOLFSSL_STM32H5) || defined(WOLFSSL_STM32MP13) || \
-         defined(WOLFSSL_STM32H7S) || defined(WOLFSSL_STM32N6))
+         defined(WOLFSSL_STM32H7S) || defined(WOLFSSL_STM32N6) || \
+         defined(WOLFSSL_STM32G0))
         #define STM32_HAL_V2
     #endif
 


### PR DESCRIPTION
Enables support for AES crypto accelerator in port/, on STM32G0, per ST RM0444 ch. 20.