### PR TITLE
Unit test updates for XChacha20-Poly1305

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -31093,7 +31093,7 @@ TEST_CASE testCases[] = {
     TEST_CHACHA_DECLS,
     /* Poly1305 */
     TEST_POLY1305_DECLS,
-    /* Chacha20-Poly1305 */
+    /* Chacha20-Poly1305 and Xchacha20-Poly1305 */
     TEST_CHACHA20_POLY1305_DECLS,
     /* Camellia */
     TEST_CAMELLIA_DECLS,

--- a/tests/api/test_chacha20_poly1305.c
+++ b/tests/api/test_chacha20_poly1305.c
@@ -154,3 +154,132 @@ int test_wc_ChaCha20Poly1305_aead(void)
     return EXPECT_RESULT();
 } /* END test_wc_ChaCha20Poly1305_aead */
 
+/*
+ * Testing wc_XChaCha20Poly1305_Encrypt() and wc_XChaCha20Poly1305_Decrypt()
+ * Test vector from Draft IRTF CFRG XChaCha Appendix A.3
+ */
+int test_wc_XChaCha20Poly1305_aead(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_POLY1305) && defined(HAVE_XCHACHA)
+    const byte key[] = {
+        0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
+        0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f,
+        0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97,
+        0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d, 0x9e, 0x9f
+    };
+    /* XChaCha uses a 24-byte nonce */
+    const byte nonce[] = {
+        0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
+        0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f,
+        0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57
+    };
+    const byte plaintext[] = {
+        0x4c, 0x61, 0x64, 0x69, 0x65, 0x73, 0x20, 0x61,
+        0x6e, 0x64, 0x20, 0x47, 0x65, 0x6e, 0x74, 0x6c,
+        0x65, 0x6d, 0x65, 0x6e, 0x20, 0x6f, 0x66, 0x20,
+        0x74, 0x68, 0x65, 0x20, 0x63, 0x6c, 0x61, 0x73,
+        0x73, 0x20, 0x6f, 0x66, 0x20, 0x27, 0x39, 0x39,
+        0x3a, 0x20, 0x49, 0x66, 0x20, 0x49, 0x20, 0x63,
+        0x6f, 0x75, 0x6c, 0x64, 0x20, 0x6f, 0x66, 0x66,
+        0x65, 0x72, 0x20, 0x79, 0x6f, 0x75, 0x20, 0x6f,
+        0x6e, 0x6c, 0x79, 0x20, 0x6f, 0x6e, 0x65, 0x20,
+        0x74, 0x69, 0x70, 0x20, 0x66, 0x6f, 0x72, 0x20,
+        0x74, 0x68, 0x65, 0x20, 0x66, 0x75, 0x74, 0x75,
+        0x72, 0x65, 0x2c, 0x20, 0x73, 0x75, 0x6e, 0x73,
+        0x63, 0x72, 0x65, 0x65, 0x6e, 0x20, 0x77, 0x6f,
+        0x75, 0x6c, 0x64, 0x20, 0x62, 0x65, 0x20, 0x69,
+        0x74, 0x2e
+    };
+    const byte aad[] = {
+        0x50, 0x51, 0x52, 0x53, 0xc0, 0xc1, 0xc2, 0xc3,
+        0xc4, 0xc5, 0xc6, 0xc7
+    };
+    /* Expected combined ciphertext + 16-byte tag */
+    const byte expected[] = {
+        0xbd, 0x6d, 0x17, 0x9d, 0x3e, 0x83, 0xd4, 0x3b, 0x95, 0x76, 0x57, 0x94,
+        0x93, 0xc0, 0xe9, 0x39, 0x57, 0x2a, 0x17, 0x00, 0x25, 0x2b, 0xfa, 0xcc,
+        0xbe, 0xd2, 0x90, 0x2c, 0x21, 0x39, 0x6c, 0xbb, 0x73, 0x1c, 0x7f, 0x1b,
+        0x0b, 0x4a, 0xa6, 0x44, 0x0b, 0xf3, 0xa8, 0x2f, 0x4e, 0xda, 0x7e, 0x39,
+        0xae, 0x64, 0xc6, 0x70, 0x8c, 0x54, 0xc2, 0x16, 0xcb, 0x96, 0xb7, 0x2e,
+        0x12, 0x13, 0xb4, 0x52, 0x2f, 0x8c, 0x9b, 0xa4, 0x0d, 0xb5, 0xd9, 0x45,
+        0xb1, 0x1b, 0x69, 0xb9, 0x82, 0xc1, 0xbb, 0x9e, 0x3f, 0x3f, 0xac, 0x2b,
+        0xc3, 0x69, 0x48, 0x8f, 0x76, 0xb2, 0x38, 0x35, 0x65, 0xd3, 0xff, 0xf9,
+        0x21, 0xf9, 0x66, 0x4c, 0x97, 0x63, 0x7d, 0xa9, 0x76, 0x88, 0x12, 0xf6,
+        0x15, 0xc6, 0x8b, 0x13, 0xb5, 0x2e,
+        /* Authentication Tag */
+        0xc0, 0x87, 0x59, 0x24, 0xc1, 0xc7, 0x98, 0x79, 0x47, 0xde, 0xaf, 0xd8,
+        0x78, 0x0a, 0xcf, 0x49
+    };
+
+    byte out[256];
+    byte plain_out[256];
+    word32 outLen = sizeof(plaintext) + 16;
+
+    XMEMSET(out, 0, sizeof(out));
+    XMEMSET(plain_out, 0, sizeof(plain_out));
+
+    /* Test Encrypt (One-shot) */
+    ExpectIntEQ(wc_XChaCha20Poly1305_Encrypt(out, sizeof(out), plaintext,
+        sizeof(plaintext), aad, sizeof(aad), nonce, sizeof(nonce),
+        key, sizeof(key)), 0);
+    ExpectIntEQ(XMEMCMP(out, expected, outLen), 0);
+
+    /* Test Decrypt (One-shot) */
+    ExpectIntEQ(wc_XChaCha20Poly1305_Decrypt(plain_out, sizeof(plain_out), out,
+        outLen, aad, sizeof(aad), nonce, sizeof(nonce),
+        key, sizeof(key)), 0);
+    ExpectIntEQ(XMEMCMP(plain_out, plaintext, sizeof(plaintext)), 0);
+
+    /* Test Encrypt bad args. */
+    ExpectIntEQ(wc_XChaCha20Poly1305_Encrypt(NULL, sizeof(out), plaintext,
+        sizeof(plaintext), aad, sizeof(aad), nonce, sizeof(nonce),
+        key, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_XChaCha20Poly1305_Encrypt(out, sizeof(out), NULL,
+        sizeof(plaintext), aad, sizeof(aad), nonce, sizeof(nonce),
+        key, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_XChaCha20Poly1305_Encrypt(out, sizeof(out), plaintext,
+        sizeof(plaintext), NULL, sizeof(aad), nonce, sizeof(nonce),
+        key, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_XChaCha20Poly1305_Encrypt(out, sizeof(out), plaintext,
+        sizeof(plaintext), aad, sizeof(aad), NULL, sizeof(nonce),
+        key, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_XChaCha20Poly1305_Encrypt(out, sizeof(out), plaintext,
+        sizeof(plaintext), aad, sizeof(aad), nonce, sizeof(nonce),
+        NULL, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    /* Wrong nonce size (12 instead of 24) */
+    ExpectIntEQ(wc_XChaCha20Poly1305_Encrypt(out, sizeof(out), plaintext,
+        sizeof(plaintext), aad, sizeof(aad), nonce, 12,
+        key, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    /* Wrong key size */
+    ExpectIntEQ(wc_XChaCha20Poly1305_Encrypt(out, sizeof(out), plaintext,
+        sizeof(plaintext), aad, sizeof(aad), nonce, sizeof(nonce),
+        key, 16), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    /* Test Decrypt bad args. */
+    ExpectIntEQ(wc_XChaCha20Poly1305_Decrypt(NULL, sizeof(plain_out), out,
+        outLen, aad, sizeof(aad), nonce, sizeof(nonce),
+        key, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_XChaCha20Poly1305_Decrypt(plain_out, sizeof(plain_out), NULL,
+        outLen, aad, sizeof(aad), nonce, sizeof(nonce),
+        key, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_XChaCha20Poly1305_Decrypt(plain_out, sizeof(plain_out), out,
+        outLen, NULL, sizeof(aad), nonce, sizeof(nonce),
+        key, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_XChaCha20Poly1305_Decrypt(plain_out, sizeof(plain_out), out,
+        outLen, aad, sizeof(aad), NULL, sizeof(nonce),
+        key, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_XChaCha20Poly1305_Decrypt(plain_out, sizeof(plain_out), out,
+        outLen, aad, sizeof(aad), nonce, sizeof(nonce),
+        NULL, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    /* Wrong nonce size (12 instead of 24) */
+    ExpectIntEQ(wc_XChaCha20Poly1305_Decrypt(plain_out, sizeof(plain_out), out,
+        outLen, aad, sizeof(aad), nonce, 12,
+        key, sizeof(key)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    /* Wrong key size */
+    ExpectIntEQ(wc_XChaCha20Poly1305_Decrypt(plain_out, sizeof(plain_out), out,
+        outLen, aad, sizeof(aad), nonce, sizeof(nonce),
+        key, 16), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+#endif
+    return EXPECT_RESULT();
+} /* END test_wc_XChaCha20Poly1305_aead */

--- a/tests/api/test_chacha20_poly1305.h
+++ b/tests/api/test_chacha20_poly1305.h
@@ -25,8 +25,10 @@
 #include <tests/api/api_decl.h>
 
 int test_wc_ChaCha20Poly1305_aead(void);
+int test_wc_XChaCha20Poly1305_aead(void);
 
-#define TEST_CHACHA20_POLY1305_DECLS                                    \
-    TEST_DECL_GROUP("chacha20-poly1305", test_wc_ChaCha20Poly1305_aead)
+#define TEST_CHACHA20_POLY1305_DECLS                                     \
+    TEST_DECL_GROUP("chacha20-poly1305", test_wc_ChaCha20Poly1305_aead), \
+    TEST_DECL_GROUP("xchacha20-poly1305", test_wc_XChaCha20Poly1305_aead)
 
 #endif /* WOLFCRYPT_TEST_CHACHA20_POLY1305_H */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -19844,6 +19844,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t XChaCha20Poly1305_test(void) {
     };
 
     wc_test_ret_t ret;
+    ChaChaPoly_Aead aead;
 
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
@@ -19885,6 +19886,177 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t XChaCha20Poly1305_test(void) {
 
     if (XMEMCMP(buf2, Plaintext, sizeof Plaintext))
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+    /* Test wc_XChaCha20Poly1305_Init bad parameters */
+    ret = wc_XChaCha20Poly1305_Init(NULL, AAD, sizeof AAD,
+                                    IV, sizeof IV,
+                                    Key, sizeof Key, 1);
+    if (ret == 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_XChaCha20Poly1305_Init(&aead, AAD, sizeof AAD,
+                                    NULL, sizeof IV,
+                                    Key, sizeof Key, 1);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_XChaCha20Poly1305_Init(&aead, AAD, sizeof AAD,
+                                    IV, sizeof IV,
+                                    NULL, sizeof Key, 1);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    /* Wrong nonce size (12 instead of 24) */
+    ret = wc_XChaCha20Poly1305_Init(&aead, AAD, sizeof AAD,
+                                    IV, CHACHA20_POLY1305_AEAD_IV_SIZE,
+                                    Key, sizeof Key, 1);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    /* Wrong key size (16 instead of 32) */
+    ret = wc_XChaCha20Poly1305_Init(&aead, AAD, sizeof AAD,
+                                    IV, sizeof IV,
+                                    Key, 16, 1);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    /* Test wc_XChaCha20Poly1305_Encrypt bad parameters */
+    ret = wc_XChaCha20Poly1305_Encrypt(NULL, sizeof Ciphertext + sizeof Tag,
+                                       Plaintext, sizeof Plaintext,
+                                       AAD, sizeof AAD,
+                                       IV, sizeof IV,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_XChaCha20Poly1305_Encrypt(buf1, sizeof Ciphertext + sizeof Tag,
+                                       NULL, sizeof Plaintext,
+                                       AAD, sizeof AAD,
+                                       IV, sizeof IV,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_XChaCha20Poly1305_Encrypt(buf1, sizeof Ciphertext + sizeof Tag,
+                                       Plaintext, sizeof Plaintext,
+                                       NULL, sizeof AAD,
+                                       IV, sizeof IV,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_XChaCha20Poly1305_Encrypt(buf1, sizeof Ciphertext + sizeof Tag,
+                                       Plaintext, sizeof Plaintext,
+                                       AAD, sizeof AAD,
+                                       NULL, sizeof IV,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_XChaCha20Poly1305_Encrypt(buf1, sizeof Ciphertext + sizeof Tag,
+                                       Plaintext, sizeof Plaintext,
+                                       AAD, sizeof AAD,
+                                       IV, sizeof IV,
+                                       NULL, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    /* Wrong nonce size (12 instead of 24) */
+    ret = wc_XChaCha20Poly1305_Encrypt(buf1, sizeof Ciphertext + sizeof Tag,
+                                       Plaintext, sizeof Plaintext,
+                                       AAD, sizeof AAD,
+                                       IV, CHACHA20_POLY1305_AEAD_IV_SIZE,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    /* Wrong key size (16 instead of 32) */
+    ret = wc_XChaCha20Poly1305_Encrypt(buf1, sizeof Ciphertext + sizeof Tag,
+                                       Plaintext, sizeof Plaintext,
+                                       AAD, sizeof AAD,
+                                       IV, sizeof IV,
+                                       Key, 16);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    /* Insufficient buffer space */
+    ret = wc_XChaCha20Poly1305_Encrypt(buf1, sizeof Plaintext,
+                                       Plaintext, sizeof Plaintext,
+                                       AAD, sizeof AAD,
+                                       IV, sizeof IV,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    /* Test wc_XChaCha20Poly1305_Decrypt bad parameters */
+    ret = wc_XChaCha20Poly1305_Decrypt(NULL, sizeof Plaintext,
+                                       buf1, sizeof Ciphertext + sizeof Tag,
+                                       AAD, sizeof AAD,
+                                       IV, sizeof IV,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_XChaCha20Poly1305_Decrypt(buf2, sizeof Plaintext,
+                                       NULL, sizeof Ciphertext + sizeof Tag,
+                                       AAD, sizeof AAD,
+                                       IV, sizeof IV,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_XChaCha20Poly1305_Decrypt(buf2, sizeof Plaintext,
+                                       buf1, sizeof Ciphertext + sizeof Tag,
+                                       NULL, sizeof AAD,
+                                       IV, sizeof IV,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_XChaCha20Poly1305_Decrypt(buf2, sizeof Plaintext,
+                                       buf1, sizeof Ciphertext + sizeof Tag,
+                                       AAD, sizeof AAD,
+                                       NULL, sizeof IV,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_XChaCha20Poly1305_Decrypt(buf2, sizeof Plaintext,
+                                       buf1, sizeof Ciphertext + sizeof Tag,
+                                       AAD, sizeof AAD,
+                                       IV, sizeof IV,
+                                       NULL, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    /* Wrong nonce size (12 instead of 24) */
+    ret = wc_XChaCha20Poly1305_Decrypt(buf2, sizeof Plaintext,
+                                       buf1, sizeof Ciphertext + sizeof Tag,
+                                       AAD, sizeof AAD,
+                                       IV, CHACHA20_POLY1305_AEAD_IV_SIZE,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    /* Wrong key size (16 instead of 32) */
+    ret = wc_XChaCha20Poly1305_Decrypt(buf2, sizeof Plaintext,
+                                       buf1, sizeof Ciphertext + sizeof Tag,
+                                       AAD, sizeof AAD,
+                                       IV, sizeof IV,
+                                       Key, 16);
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    /* Insufficient buffer space */
+    ret = wc_XChaCha20Poly1305_Decrypt(buf2, sizeof Plaintext - 1,
+                                       buf1, sizeof Ciphertext + sizeof Tag,
+                                       AAD, sizeof AAD,
+                                       IV, sizeof IV,
+                                       Key, sizeof Key);
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = 0;
 
   out:
 


### PR DESCRIPTION
# Description

Add API unit test for XChacha20Poly1305 to Chacha20Poly1305 test file. Expand XChacha20Poly1305 unit test.

Adds on to PR #9692

\* Xchacha will be enabled if configuring with `--enable-all` on non-fips builds

# Testing

`./configure --enable-xchacha && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
