### PR TITLE
Regression test fixes

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -71,6 +71,16 @@ jobs:
           '--enable-sessionexport --enable-dtls --enable-dtls13',
           '--enable-sessionexport',
           '--disable-examples CPPFLAGS=-DWOLFSSL_NO_MALLOC',
+          'CPPFLAGS=-DNO_WOLFSSL_CLIENT',
+          'CPPFLAGS=-DNO_WOLFSSL_SERVER',
+          'CPPFLAGS=-DWOLFSSL_NO_CLIENT_AUTH',
+          'CPPFLAGS=''-DNO_WOLFSSL_CLIENT -DWOLFSSL_NO_CLIENT_AUTH''',
+          'CPPFLAGS=''-DNO_WOLFSSL_SERVER -DWOLFSSL_NO_CLIENT_AUTH''',
+          '--enable-all CPPFLAGS=-DNO_WOLFSSL_CLIENT',
+          '--enable-all CPPFLAGS=-DNO_WOLFSSL_SERVER',
+          '--enable-all CPPFLAGS=-DWOLFSSL_NO_CLIENT_AUTH',
+          '--enable-all CPPFLAGS=''-DNO_WOLFSSL_CLIENT -DWOLFSSL_NO_CLIENT_AUTH''',
+          '--enable-all CPPFLAGS=''-DNO_WOLFSSL_SERVER -DWOLFSSL_NO_CLIENT_AUTH''',
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1209,8 +1209,10 @@ static const char* client_usage_msg[][79] = {
 #endif
         "-l <str>    Cipher suite list (: delimited)\n",                /* 8 */
 #ifndef NO_CERTS
+#ifndef WOLFSSL_NO_CLIENT_AUTH
         "-c <file>   Certificate file,           default",              /* 9 */
         "-k <file>   Key file,                   default",              /* 10 */
+#endif
         "-A <file>   Certificate Authority file, default",              /* 11 */
 #endif
 #ifndef NO_DH
@@ -1261,7 +1263,7 @@ static const char* client_usage_msg[][79] = {
         "            The string parameter is optional.\n",              /* 29 */
 #endif
         "-f          Fewer packets/group messages\n",                   /* 30 */
-#ifndef NO_CERTS
+#if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CLIENT_AUTH)
         "-x          Disable client cert/key loading\n",                /* 31 */
 #endif
         "-X          Driven by eXternal test case\n",                   /* 32 */
@@ -1329,7 +1331,8 @@ static const char* client_usage_msg[][79] = {
 #ifdef HAVE_CURVE25519
         "-t          Use X25519 for key exchange\n",                    /* 56 */
 #endif
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH) && \
+    !defined(WOLFSSL_NO_CLIENT_AUTH)
         "-Q          Support requesting certificate post-handshake\n",  /* 57 */
 #endif
 #ifdef WOLFSSL_EARLY_DATA
@@ -1467,8 +1470,10 @@ static const char* client_usage_msg[][79] = {
 #endif
         "-l <str>    暗号スイートリスト (区切り文字 :)\n",               /* 8 */
 #ifndef NO_CERTS
+#ifndef WOLFSSL_NO_CLIENT_AUTH
         "-c <file>   証明書ファイル,  既定値",                           /* 9 */
         "-k <file>   鍵ファイル,      既定値",                          /* 10 */
+#endif
         "-A <file>   認証局ファイル,  既定値",                          /* 11 */
 #endif
 #ifndef NO_DH
@@ -1518,7 +1523,7 @@ static const char* client_usage_msg[][79] = {
         "-i <str>    クライアント主導のネゴシエーションを強制する\n",   /* 29 */
 #endif
         "-f          より少ないパケット/グループメッセージを使用する\n",/* 30 */
-#ifndef NO_CERTS
+#if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CLIENT_AUTH)
         "-x          クライアントの証明書/鍵のロードを無効する\n",      /* 31 */
 #endif
         "-X          外部テスト・ケースにより動作する\n",               /* 32 */
@@ -1589,7 +1594,8 @@ static const char* client_usage_msg[][79] = {
 #ifdef HAVE_CURVE25519
         "-t          X25519を鍵交換に使用する\n",                       /* 56 */
 #endif
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH) && \
+    !defined(WOLFSSL_NO_CLIENT_AUTH)
         "-Q          ポストハンドシェークの証明要求をサポートする\n",   /* 57 */
 #endif
 #ifdef WOLFSSL_EARLY_DATA
@@ -1766,8 +1772,10 @@ static void Usage(void)
 #endif
     printf("%s", msg[++msgid]); /* -l */
 #ifndef NO_CERTS
+#ifndef WOLFSSL_NO_CLIENT_AUTH
     printf("%s %s\n", msg[++msgid], cliCertFile); /* -c */
     printf("%s %s\n", msg[++msgid], cliKeyFile);  /* -k */
+#endif
     printf("%s %s\n", msg[++msgid], caCertFile);  /* -A */
 #endif
 #ifndef NO_DH
@@ -1805,7 +1813,7 @@ static void Usage(void)
     printf("%s", msg[++msgid]); /* -i */
 #endif
     printf("%s", msg[++msgid]); /* -f */
-#ifndef NO_CERTS
+#if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CLIENT_AUTH)
     printf("%s", msg[++msgid]); /* -x */
 #endif
     printf("%s", msg[++msgid]); /* -X */
@@ -1868,7 +1876,8 @@ static void Usage(void)
 #ifdef HAVE_CURVE25519
     printf("%s", msg[++msgid]); /* -t */
 #endif
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH) && \
+    !defined(WOLFSSL_NO_CLIENT_AUTH)
     printf("%s", msg[++msgid]); /* -Q */
 #endif
 #ifdef WOLFSSL_EARLY_DATA
@@ -2823,7 +2832,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
             case 'Q' :
                 #if defined(WOLFSSL_TLS13) && \
-                                            defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+                    defined(WOLFSSL_POST_HANDSHAKE_AUTH) && \
+                    !defined(WOLFSSL_NO_CLIENT_AUTH)
                     postHandAuth = 1;
                 #endif
                 break;

--- a/scripts/crl-revoked.test
+++ b/scripts/crl-revoked.test
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+[ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
+                                  && exit 1
+
+if ! ./examples/client/client | grep "Client not compiled in!" ; then
+    echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
 #crl.test
 # if we can, isolate the network namespace to eliminate port collisions.
 if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then

--- a/scripts/dtlscid.test
+++ b/scripts/dtlscid.test
@@ -3,6 +3,22 @@
 # dtlscid.test
 # Copyright wolfSSL 2022-2024
 
+[ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
+                                  && exit 0
+
+[ ! -x ./examples/server/server ] && printf '\n\n%s\n' "Server doesn't exist" \
+                                  && exit 0
+
+if ! ./examples/client/client | grep "Client not compiled in!" ; then
+    echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
+if ! ./examples/server/server | grep "Server not compiled in!" ; then
+    echo 'skipping crl-revoked.test because server not compiled in.' 1>&2
+    exit 77
+fi
+
 # if we can, isolate the network namespace to eliminate port collisions.
 if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then
      if [[ -z "$NETWORK_UNSHARE_HELPER_CALLED" ]]; then

--- a/scripts/ocsp-stapling-with-ca-as-responder.test
+++ b/scripts/ocsp-stapling-with-ca-as-responder.test
@@ -23,6 +23,22 @@ if [[ -z "${RETRIES_REMAINING-}" ]]; then
     export RETRIES_REMAINING=2
 fi
 
+[ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
+                                  && exit 1
+
+[ ! -x ./examples/server/server ] && printf '\n\n%s\n' "Server doesn't exist" \
+                                  && exit 1
+
+if ! ./examples/client/client | grep "Client not compiled in!" ; then
+    echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
+if ! ./examples/server/server | grep "Server not compiled in!" ; then
+    echo 'skipping crl-revoked.test because server not compiled in.' 1>&2
+    exit 77
+fi
+
 if ! ./examples/client/client -V | grep -q 3; then
     echo 'skipping ocsp-stapling-with-ca-as-responder.test because TLS1.2 is not available.' 1>&2
     exit 77

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -17,6 +17,22 @@ if test "$WOLFSSL_EXTERNAL_TEST" == "0"; then
     exit 77
 fi
 
+[ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
+                                  && exit 1
+
+[ ! -x ./examples/server/server ] && printf '\n\n%s\n' "Server doesn't exist" \
+                                  && exit 1
+
+if ! ./examples/client/client | grep "Client not compiled in!" ; then
+    echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
+if ! ./examples/server/server | grep "Server not compiled in!" ; then
+    echo 'skipping crl-revoked.test because server not compiled in.' 1>&2
+    exit 77
+fi
+
 if ! ./examples/client/client -V | grep -q 3; then
     echo 'skipping ocsp-stapling.test because TLS1.2 is not available.' 1>&2
     exit 77

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -24,6 +24,22 @@ if [[ -z "${RETRIES_REMAINING-}" ]]; then
     export RETRIES_REMAINING=2
 fi
 
+[ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
+                                  && exit 1
+
+[ ! -x ./examples/server/server ] && printf '\n\n%s\n' "Server doesn't exist" \
+                                  && exit 1
+
+if ! ./examples/client/client | grep "Client not compiled in!" ; then
+    echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
+if ! ./examples/server/server | grep "Server not compiled in!" ; then
+    echo 'skipping crl-revoked.test because server not compiled in.' 1>&2
+    exit 77
+fi
+
 if ! ./examples/client/client -V | grep -q 3; then
     echo 'skipping ocsp-stapling2.test because TLS1.2 is not available.' 1>&2
     exit 77

--- a/scripts/ocsp-stapling_tls13multi.test
+++ b/scripts/ocsp-stapling_tls13multi.test
@@ -24,6 +24,22 @@ if [[ -z "${RETRIES_REMAINING-}" ]]; then
     export RETRIES_REMAINING=2
 fi
 
+[ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
+                                  && exit 1
+
+[ ! -x ./examples/server/server ] && printf '\n\n%s\n' "Server doesn't exist" \
+                                  && exit 1
+
+if ! ./examples/client/client | grep "Client not compiled in!" ; then
+    echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
+if ! ./examples/server/server | grep "Server not compiled in!" ; then
+    echo 'skipping crl-revoked.test because server not compiled in.' 1>&2
+    exit 77
+fi
+
 if ! ./examples/client/client -V | grep -q 4; then
     tls13=no
 

--- a/scripts/pkcallbacks.test
+++ b/scripts/pkcallbacks.test
@@ -2,6 +2,14 @@
 
 #pkcallbacks.test
 
+[ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
+                                  && exit 1
+
+if ! ./examples/client/client | grep "Client not compiled in!" ; then
+    echo 'skipping pkcallbacks.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
 # if we can, isolate the network namespace to eliminate port collisions.
 if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then
      if [[ -z "$NETWORK_UNSHARE_HELPER_CALLED" ]]; then

--- a/scripts/psk.test
+++ b/scripts/psk.test
@@ -88,6 +88,10 @@ fi
 if [ $? -eq 0 ]; then
     exit 0
 fi
+./examples/client/client '-?' 2>&1 | grep -- 'Disable client cert/key loading'
+if [ $? -eq 0 ]; then
+    CLIENT_AUTH_ENABLED=1
+fi
 
 # Usual psk server / psk client. This use case is tested in
 # tests/unit.test and is used here for just checking if PSK is enabled
@@ -144,19 +148,21 @@ if [ $? -ne 0 ]; then
     fi
     echo ""
 
-    # check fail if no auth, psk server with non psk client
-    echo "Checking fail when not sending peer cert"
-    port=0
-    ./examples/server/server -j -R "$ready_file" -p $port &
-    server_pid=$!
-    create_port
-    ./examples/client/client -x -p $port
-    RESULT=$?
-    remove_ready_file
-    if [ $RESULT -eq 0 ]; then
-        echo -e "\n\nClient connected when supposed to fail"
-        do_cleanup
-        exit 1
+    if [ "$CLIENT_AUTH_ENABLED" != "" ]; then
+        # check fail if no auth, psk server with non psk client
+        echo "Checking fail when not sending peer cert"
+        port=0
+        ./examples/server/server -j -R "$ready_file" -p $port &
+        server_pid=$!
+        create_port
+        ./examples/client/client -x -p $port
+        RESULT=$?
+        remove_ready_file
+        if [ $RESULT -eq 0 ]; then
+            echo -e "\n\nClient connected when supposed to fail"
+            do_cleanup
+            exit 1
+        fi
     fi
 fi
 

--- a/src/crl.c
+++ b/src/crl.c
@@ -519,7 +519,8 @@ int CheckCertCRL_ex(WOLFSSL_CRL* crl, byte* issuerHash, byte* serial,
 #if defined(OPENSSL_ALL) && defined(WOLFSSL_CERT_GEN) && \
     (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT)) && \
     !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR) && \
-    !defined(NO_STDIO_FILESYSTEM)
+    !defined(NO_STDIO_FILESYSTEM) && \
+    (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH))
     /* if not find entry in the CRL list, it looks at the folder that sets  */
     /* by LOOKUP_ctrl because user would want to use hash_dir.              */
     /* Loading <issuer-hash>.rN form CRL file if find at the folder,        */

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -1849,7 +1849,7 @@ static int _Dtls13HandshakeRecv(WOLFSSL* ssl, byte* input, word32 size,
     isComplete = isFirst && fragLength == messageLength;
 
     if (!isComplete && !Dtls13AcceptFragmented(ssl, (enum HandShakeType)handshakeType)) {
-#ifdef WOLFSSL_DTLS_CH_FRAG
+#if defined(WOLFSSL_DTLS_CH_FRAG) && !defined(NO_WOLFSSL_SERVER)
         byte tls13 = 0;
         /* check if the first CH fragment contains a valid cookie */
         if (ssl->options.dtls13ChFrag && !ssl->options.dtlsStateful &&

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3666,6 +3666,7 @@ int wolfSSL_CTX_UseTruncatedHMAC(WOLFSSL_CTX* ctx)
 #endif /* NO_WOLFSSL_CLIENT */
 #endif /* HAVE_TRUNCATED_HMAC */
 
+#ifndef NO_WOLFSSL_CLIENT
 #ifdef HAVE_CERTIFICATE_STATUS_REQUEST
 
 int wolfSSL_UseOCSPStapling(WOLFSSL* ssl, byte status_type, byte options)
@@ -3717,6 +3718,7 @@ int wolfSSL_CTX_UseOCSPStaplingV2(WOLFSSL_CTX* ctx, byte status_type,
 }
 
 #endif /* HAVE_CERTIFICATE_STATUS_REQUEST_V2 */
+#endif /* !NO_WOLFSSL_CLIENT */
 
 /* Elliptic Curves */
 #if defined(HAVE_SUPPORTED_CURVES)
@@ -22198,6 +22200,7 @@ int wolfSSL_set_tlsext_status_ocsp_resp_multi(WOLFSSL* ssl, unsigned char *resp,
     return WOLFSSL_SUCCESS;
 }
 
+#ifndef NO_WOLFSSL_SERVER
 void wolfSSL_CTX_set_ocsp_status_verify_cb(WOLFSSL_CTX* ctx,
         ocspVerifyStatusCb cb, void* cbArg)
 {
@@ -22206,6 +22209,7 @@ void wolfSSL_CTX_set_ocsp_status_verify_cb(WOLFSSL_CTX* ctx,
         ctx->ocspStatusVerifyCbArg = cbArg;
     }
 }
+#endif
 #endif
 
 #if defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || \

--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -716,7 +716,8 @@ void wolfSSL_CertManagerSetUnknownExtCallback(WOLFSSL_CERT_MANAGER* cm,
 }
 #endif /* WC_ASN_UNKNOWN_EXT_CB */
 
-#if !defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
 /* Verify the certificate.
  *
  * Uses the verification callback if available.
@@ -796,7 +797,8 @@ int CM_VerifyBuffer_ex(WOLFSSL_CERT_MANAGER* cm, const unsigned char* buff,
 
     (void)fatal;
 
-#ifndef NO_WOLFSSL_CM_VERIFY
+#if !defined(NO_WOLFSSL_CM_VERIFY) && \
+    (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH))
     /* Use callback to perform verification too if available. */
     if ((!fatal) && cm->verifyCallback) {
         WC_DECLARE_VAR(args, ProcPeerCertArgs, 1, 0);
@@ -884,11 +886,12 @@ int wolfSSL_CertManagerVerifyBuffer(WOLFSSL_CERT_MANAGER* cm,
 
     return ret;
 }
-#endif /* !NO_WOLFSSL_CLIENT || !WOLFSSL_NO_CLIENT_AUTH */
+#endif /* (!NO_WOLFSSL_CLIENT || !WOLFSSL_NO_CLIENT_AUTH) || OPENSSL_EXTRA */
 
 #ifndef NO_FILESYSTEM
 
-#if !defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
 /* Verify the certificate loaded from a file.
  *
  * Uses the verification callback if available.

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -770,11 +770,13 @@ static int ProcessBufferTryDecodeEd448(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
                 WOLFSSL_MSG("ED448 private key too small");
                 ret = ECC_KEY_SIZE_E;
             }
+        #if !defined(WOLFSSL_NO_CLIENT_AUTH) && !defined(NO_ED448_CLIENT_AUTH)
             if (ssl != NULL) {
                 /* Ed448 requires caching enabled for tracking message
                  * hash used in EdDSA_Update for signing */
                 ssl->options.cacheMessages = 1;
             }
+        #endif
         }
         /* Not an Ed448 key but check whether we know what it is. */
         else if (*keyFormat == 0) {

--- a/tests/api/test_certman.c
+++ b/tests/api/test_certman.c
@@ -497,20 +497,29 @@ int test_wolfSSL_CertManagerLoadCABufferType(void)
         (sword32)ca_cert_sz, CERT_FILETYPE, 0,
         WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_USER_CA),
         WOLFSSL_SUCCESS);
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
         int1_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
+#endif
     ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, int1_cert_buf,
         (sword32)int1_cert_sz, CERT_FILETYPE, 0,
         WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_USER_INTER),
         WOLFSSL_SUCCESS);
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
         int2_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
+#endif
     ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, int2_cert_buf,
         (sword32)int2_cert_sz, CERT_FILETYPE, 0,
         WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_USER_INTER),
         WOLFSSL_SUCCESS);
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
         client_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
+#endif
     ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, client_cert_buf,
         (sword32)client_cert_sz, CERT_FILETYPE, 0,
         WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_USER_INTER),
@@ -521,25 +530,34 @@ int test_wolfSSL_CertManagerLoadCABufferType(void)
 
     /* Intermediate certs have been unloaded, but CA cert is still
        loaded.  Expect first level intermediate to verify, rest to fail. */
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
         int1_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
     ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
         int2_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
     ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
         client_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
+#endif
 
     ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, int1_cert_buf,
         (sword32)int1_cert_sz, CERT_FILETYPE, 0,
         WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_TEMP_CA),
         WOLFSSL_SUCCESS);
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
         int2_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
+#endif
     ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, int2_cert_buf,
         (sword32)int2_cert_sz, CERT_FILETYPE, 0,
         WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_CHAIN_CA),
         WOLFSSL_SUCCESS);
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
         client_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
+#endif
     ExpectIntEQ(wolfSSL_CertManagerLoadCABufferType(cm, client_cert_buf,
         (sword32)client_cert_sz, CERT_FILETYPE, 0,
         WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS, WOLFSSL_USER_INTER),
@@ -547,39 +565,51 @@ int test_wolfSSL_CertManagerLoadCABufferType(void)
 
     ExpectIntEQ(wolfSSL_CertManagerUnloadTypeCerts(cm, WOLFSSL_USER_INTER),
         WOLFSSL_SUCCESS);
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
         int1_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
         int2_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
         client_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
+#endif
 
     ExpectIntEQ(wolfSSL_CertManagerUnloadTypeCerts(cm, WOLFSSL_CHAIN_CA),
         WOLFSSL_SUCCESS);
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
         int1_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
         int2_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
     ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
         client_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
+#endif
 
     ExpectIntEQ(wolfSSL_CertManagerUnloadTypeCerts(cm, WOLFSSL_TEMP_CA),
         WOLFSSL_SUCCESS);
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
         int1_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
     ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
         int2_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
     ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
         client_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
+#endif
 
     ExpectIntEQ(wolfSSL_CertManagerUnloadTypeCerts(cm, WOLFSSL_USER_CA),
         WOLFSSL_SUCCESS);
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)) || \
+    defined(OPENSSL_EXTRA)
     ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, int1_cert_buf,
         int1_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
     ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, int2_cert_buf,
         int2_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
     ExpectIntNE(wolfSSL_CertManagerVerifyBuffer(cm, client_cert_buf,
         client_cert_sz, CERT_FILETYPE), WOLFSSL_SUCCESS);
+#endif
 
     if (cm)
         wolfSSL_CertManagerFree(cm);

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -346,7 +346,7 @@ int test_tls_certreq_order(void)
 }
 
 #if !defined(WOLFSSL_NO_TLS12) && !defined(NO_RSA) && defined(HAVE_ECC) && \
-    !defined(NO_WOLFSSL_SERVER)
+    !defined(NO_WOLFSSL_SERVER) && !defined(WOLFSSL_NO_CLIENT_AUTH)
 /* Called when writing. */
 static int CsSend(WOLFSSL* ssl, char* buf, int sz, void* ctx)
 {
@@ -382,7 +382,7 @@ int test_tls12_bad_cv_sig_alg(void)
 {
     EXPECT_DECLS;
 #if !defined(WOLFSSL_NO_TLS12) && !defined(NO_RSA) && defined(HAVE_ECC) && \
-    !defined(NO_WOLFSSL_SERVER)
+    !defined(NO_WOLFSSL_SERVER) && !defined(WOLFSSL_NO_CLIENT_AUTH)
     byte clientMsgs[] = {
         /* Client Hello */
         0x16, 0x03, 0x03, 0x00, 0xe7,

--- a/tests/test-fails.conf
+++ b/tests/test-fails.conf
@@ -183,6 +183,7 @@
 -c ./certs/server-ecc.pem
 -k ./certs/ecc-key.pem
 -A ./certs/client-cert.pem
+-H verifyFail
 -H exitWithRet
 
 # client

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -341,7 +341,6 @@ static int test_crl_monitor(void)
     for (i = 0; i < CRL_MONITOR_TEST_ROUNDS; i++) {
         int expectFail;
         if (i % 2 == 0) {
-
             /* succeed on even rounds */
             (void)XSNPRINTF(buf, sizeof(buf), "%s/%s", tmpDir, "crl.pem");
             if (STAGE_FILE("certs/crl/crl.pem", buf) != 0) {
@@ -384,7 +383,11 @@ static int test_crl_monitor(void)
                 fprintf(stderr, "[%d] Failed to remove file %s\n", i, buf);
                 goto cleanup;
             }
+        #ifndef WOLFSSL_NO_CLIENT_AUTH
             expectFail = 1;
+        #else
+            expectFail = 0;
+        #endif
         }
         /* Give server a moment to register the file change */
         XSLEEP_MS(100);

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -12347,7 +12347,7 @@ int wc_AesGcmDecryptFinal(Aes* aes, const byte* authTag, word32 authTagSz)
         {
             ALIGN32 byte calcTag[WC_AES_BLOCK_SIZE];
             /* Calculate authentication tag. */
-            ret = AesGcmFinal_C(aes, calcTag, authTagSz);
+            ret = AesGcmFinal_C(aes, calcTag, WC_AES_BLOCK_SIZE);
             if (ret == 0) {
                 /* Check calculated tag matches the one passed in. */
                 if (ConstantCompare(authTag, calcTag, (int)authTagSz) != 0) {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3403,8 +3403,8 @@ WOLFSSL_LOCAL int TLSX_ValidateSupportedCurves(const WOLFSSL* ssl, byte first,
                                                byte second, word32* ecdhCurveOID);
 WOLFSSL_LOCAL int TLSX_SupportedCurve_CheckPriority(WOLFSSL* ssl);
 WOLFSSL_LOCAL int TLSX_SupportedFFDHE_Set(WOLFSSL* ssl);
-WOLFSSL_LOCAL int TLSX_SupportedCurve_IsSupported(WOLFSSL* ssl, word16 name);
 #endif
+WOLFSSL_LOCAL int TLSX_SupportedCurve_IsSupported(WOLFSSL* ssl, word16 name);
 WOLFSSL_LOCAL int TLSX_SupportedCurve_Preferred(WOLFSSL* ssl,
                                                             int checkSupported);
 WOLFSSL_LOCAL int TLSX_SupportedCurve_Parse(const WOLFSSL* ssl,


### PR DESCRIPTION
# Description

Mostly combinations of NO_WOLFSSL_CLIENT, NO_WOLFSSL_SERVER and WOLFSSL_NO_CLIENT_AUTH were failing.
Added configurations to CI loop.

wc_AesGcmDecryptFinal: use WC_AES_BLOCK_SIZE to satisfy compiler.

# Testing

Regression testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
