### PR TITLE
TLS 1.2 message order check: certificate before CKE

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -18066,6 +18066,12 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                 WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
+            if (!ssl->options.resuming && ssl->options.verifyPeer &&
+                    !ssl->options.usingPSK_cipher &&
+                    !ssl->options.usingAnon_cipher &&
+                    !ssl->msgsReceived.got_certificate) {
+                return OUT_OF_ORDER_E;
+            }
             if (ssl->msgsReceived.got_certificate_verify||
                     ssl->msgsReceived.got_change_cipher ||
                     ssl->msgsReceived.got_finished) {


### PR DESCRIPTION
# Description

Make sure we received a Certificate message before the ClientKeyExchange when a certificate is requested. (Certificate message will be empty when client has no valid certificate.)

Fixes #9650

# Testing

Scripts provided in Issue.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
