### PR TITLE
Rust wrapper: ECC: Allow import_private_*() calls with empty pub_buf slice

### DIFF
--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -711,10 +711,11 @@ impl ECC {
         }
         let mut wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
         let priv_size = priv_buf.len() as u32;
+        let pub_ptr = if pub_buf.len() == 0 {core::ptr::null()} else {pub_buf.as_ptr()};
         let pub_size = pub_buf.len() as u32;
         let rc = unsafe {
             sys::wc_ecc_import_private_key(priv_buf.as_ptr(), priv_size,
-                pub_buf.as_ptr(), pub_size, &mut wc_ecc_key)
+                pub_ptr, pub_size, &mut wc_ecc_key)
         };
         if rc != 0 {
             return Err(rc);
@@ -784,10 +785,11 @@ impl ECC {
         }
         let mut wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
         let priv_size = priv_buf.len() as u32;
+        let pub_ptr = if pub_buf.len() == 0 {core::ptr::null()} else {pub_buf.as_ptr()};
         let pub_size = pub_buf.len() as u32;
         let rc = unsafe {
             sys::wc_ecc_import_private_key_ex(priv_buf.as_ptr(), priv_size,
-                pub_buf.as_ptr(), pub_size, &mut wc_ecc_key, curve_id)
+                pub_ptr, pub_size, &mut wc_ecc_key, curve_id)
         };
         if rc != 0 {
             return Err(rc);

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
@@ -197,6 +197,8 @@ fn test_ecc_import_export_private() {
     let mut ecc2 = ECC::import_private_key(&d, x963, None, None).expect("Error with import_private_key()");
     let valid = ecc2.verify_hash(&signature, &hash).expect("Error with verify_hash()");
     assert_eq!(valid, true);
+
+    ECC::import_private_key(&d, &[], None, None).expect("Error with import_private_key()");
 }
 
 #[test]
@@ -221,6 +223,8 @@ fn test_ecc_import_export_private_ex() {
     let mut ecc2 = ECC::import_private_key_ex(&d, x963, curve_id, None, None).expect("Error with import_private_key_ex()");
     let valid = ecc2.verify_hash(&signature, &hash).expect("Error with verify_hash()");
     assert_eq!(valid, true);
+
+    ECC::import_private_key_ex(&d, &[], curve_id, None, None).expect("Error with import_private_key_ex()");
 }
 
 #[test]


### PR DESCRIPTION
# Description

Rust wrapper: ECC: Allow import_private_*() calls with empty pub_buf slice

C function expected pub to be NULL with a length of 0 but Rust actually passes a non-NULL pointer for an empty slice.

# Testing

How did you test?

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
