### PR TITLE
Exclude Config.cmake.in in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -386,6 +386,7 @@ IDE/**/DerivedData
 CMakeFiles/
 CMakeCache.txt
 cmake_install.cmake
+!cmake/Config.cmake.in
 
 # GDB Settings
 \.gdbinit


### PR DESCRIPTION
# Description

Add an explicit exception to .gitignore to exclude `Config.cmake.in`

Fixes #9731

# Testing

Confirmed with .gitignore:config.*

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
