### PR TITLE
pkcs7: add RSA-PSS support for SignedData

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -53,6 +53,8 @@ jobs:
           '--enable-opensslall --enable-opensslextra CPPFLAGS=-DWC_RNG_SEED_CB',
           '--enable-opensslall --enable-opensslextra
             CPPFLAGS=''-DWC_RNG_SEED_CB -DWOLFSSL_NO_GETPID'' ',
+          # PKCS#7 with RSA-PSS (CMS RSASSA-PSS signers)
+          '--enable-pkcs7 CPPFLAGS=-DWC_RSA_PSS',
           '--enable-opensslextra CPPFLAGS=''-DWOLFSSL_NO_CA_NAMES'' ',
           '--enable-opensslextra=x509small',
           'CPPFLAGS=''-DWOLFSSL_EXTRA'' ',

--- a/doc/dox_comments/header_files/cryptocb.h
+++ b/doc/dox_comments/header_files/cryptocb.h
@@ -52,6 +52,17 @@
                 }
             }
         #endif
+        #if defined(WC_RSA_PSS) && !defined(NO_RSA)
+            if (info->pk.type == WC_PK_TYPE_RSA_PSS) {
+                // RSA-PSS sign/verify
+                ret = wc_RsaPSS_Sign_ex(
+                    info->pk.rsa.in, info->pk.rsa.inLen,
+                    info->pk.rsa.out, *info->pk.rsa.outLen,
+                    WC_HASH_TYPE_SHA256, WC_MGF1SHA256,
+                    RSA_PSS_SALT_LEN_DEFAULT,
+                    info->pk.rsa.key, info->pk.rsa.rng);
+            }
+        #endif
         #ifdef HAVE_ECC
             if (info->pk.type == WC_PK_TYPE_ECDSA_SIGN) {
                 // ECDSA

--- a/doc/dox_comments/header_files/doxygen_pages.h
+++ b/doc/dox_comments/header_files/doxygen_pages.h
@@ -51,6 +51,7 @@
         <li>\ref MD5</li>
         <li>\ref Password</li>
         <li>\ref PKCS7</li>
+        <li>\ref PKCS7_RSA_PSS</li>
         <li>\ref PKCS11</li>
         <li>\ref Poly1305</li>
         <li>\ref RIPEMD</li>
@@ -96,5 +97,14 @@
 
     \sa wc_CryptoCb_AesSetKey
     \sa \ref Crypto Callbacks
+*/
+/*!
+    \page PKCS7_RSA_PSS PKCS#7 RSA-PSS (CMS)
+    PKCS#7 SignedData supports RSA-PSS signers (CMS RSASSA-PSS). When WC_RSA_PSS
+    is defined, use wc_PKCS7_InitWithCert with a signer certificate that has
+    RSA-PSS (id-RSASSA-PSS) and set hashOID and optional rng; encode produces
+    full RSASSA-PSS-params (hashAlgorithm, mgfAlgorithm, saltLength,
+    trailerField). Verify accepts NULL, empty, or absent parameters with
+    RFC defaults. See \ref PKCS7 for the main API.
 */
 

--- a/doc/dox_comments/header_files/pkcs7.h
+++ b/doc/dox_comments/header_files/pkcs7.h
@@ -147,7 +147,7 @@ int  wc_PKCS7_EncodeData(wc_PKCS7* pkcs7, byte* output,
 
     \brief This function builds the PKCS7 signed data content type, encoding
     the PKCS7 structure into a buffer containing a parsable PKCS7
-    signed data packet.
+    signed data packet. For RSA-PSS signers (WC_RSA_PSS), see \ref PKCS7_RSA_PSS.
 
     \return Success On successfully encoding the PKCS7 data into the buffer,
     returns the index parsed up to in the PKCS7 structure. This index also

--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -23,7 +23,7 @@ Example wolfSSL configuration file templates for use when autoconf is not availa
 * `user_settings_openssl_compat.h`: OpenSSL compatibility layer for drop-in replacement. Enables OPENSSL_ALL and related APIs.
 * `user_settings_baremetal.h`: Bare metal configuration. No filesystem, static memory only, minimal footprint.
 * `user_settings_rsa_only.h`: RSA-only configuration (no ECC). For legacy systems requiring RSA cipher suites.
-* `user_settings_pkcs7.h`: PKCS#7/CMS configuration for signing and encryption. S/MIME, firmware signing.
+* `user_settings_pkcs7.h`: PKCS#7/CMS configuration for signing and encryption. S/MIME, firmware signing. For RSA-PSS SignedData (CMS RSASSA-PSS), define `WC_RSA_PSS`; see doxygen \ref PKCS7_RSA_PSS.
 * `user_settings_ca.h`: Certificate Authority / PKI operations. Certificate generation, signing, CRL, OCSP.
 * `user_settings_wolfboot_keytools.h`: wolfBoot key generation and signing tool. Supports ECC, RSA, ED25519, ED448, and post-quantum (ML-DSA/Dilithium, LMS, XMSS).
 * `user_settings_wolfssh.h`: Minimum options for building wolfSSH. See comment at top for ./configure used to generate.

--- a/examples/configs/user_settings_pkcs7.h
+++ b/examples/configs/user_settings_pkcs7.h
@@ -115,6 +115,7 @@ extern "C" {
     #undef NO_RSA
     #define WOLFSSL_KEY_GEN
     #define WC_RSA_NO_PADDING
+    #define WC_RSA_PSS  /* RSA-PSS SignedData (id-RSASSA-PSS); see PKCS7_RSA_PSS */
 #else
     #define NO_RSA
 #endif

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -28,11 +28,13 @@ int test_SetAsymKeyDer(void);
 int test_GetSetShortInt(void);
 int test_wc_IndexSequenceOf(void);
 int test_wolfssl_local_MatchBaseName(void);
+int test_wc_DecodeRsaPssParams(void);
 
 #define TEST_ASN_DECLS                                              \
     TEST_DECL_GROUP("asn", test_SetAsymKeyDer),                     \
     TEST_DECL_GROUP("asn", test_GetSetShortInt),                    \
     TEST_DECL_GROUP("asn", test_wc_IndexSequenceOf),                \
-    TEST_DECL_GROUP("asn", test_wolfssl_local_MatchBaseName)
+    TEST_DECL_GROUP("asn", test_wolfssl_local_MatchBaseName),       \
+    TEST_DECL_GROUP("asn", test_wc_DecodeRsaPssParams)
 
 #endif /* WOLFCRYPT_TEST_ASN_H */

--- a/tests/api/test_pkcs7.h
+++ b/tests/api/test_pkcs7.h
@@ -29,6 +29,10 @@ int test_wc_PKCS7_Init(void);
 int test_wc_PKCS7_InitWithCert(void);
 int test_wc_PKCS7_EncodeData(void);
 int test_wc_PKCS7_EncodeSignedData(void);
+#if defined(HAVE_PKCS7) && defined(WC_RSA_PSS) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_SHA256)
+int test_wc_PKCS7_EncodeSignedData_RSA_PSS(void);
+#endif
 int test_wc_PKCS7_EncodeSignedData_ex(void);
 int test_wc_PKCS7_VerifySignedData_RSA(void);
 int test_wc_PKCS7_VerifySignedData_ECC(void);
@@ -55,10 +59,19 @@ int test_wc_PKCS7_VerifySignedData_PKCS7ContentSeq(void);
     TEST_DECL_GROUP("pkcs7", test_wc_PKCS7_New),                \
     TEST_DECL_GROUP("pkcs7", test_wc_PKCS7_Init)
 
+#if defined(HAVE_PKCS7) && defined(WC_RSA_PSS) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_SHA256)
+#define TEST_PKCS7_RSA_PSS_SD_DECL \
+    TEST_DECL_GROUP("pkcs7_sd", test_wc_PKCS7_EncodeSignedData_RSA_PSS),
+#else
+#define TEST_PKCS7_RSA_PSS_SD_DECL
+#endif
+
 #define TEST_PKCS7_SIGNED_DATA_DECLS                                    \
     TEST_DECL_GROUP("pkcs7_sd", test_wc_PKCS7_InitWithCert),            \
     TEST_DECL_GROUP("pkcs7_sd", test_wc_PKCS7_EncodeData),              \
     TEST_DECL_GROUP("pkcs7_sd", test_wc_PKCS7_EncodeSignedData),        \
+    TEST_PKCS7_RSA_PSS_SD_DECL                                           \
     TEST_DECL_GROUP("pkcs7_sd", test_wc_PKCS7_EncodeSignedData_ex),     \
     TEST_DECL_GROUP("pkcs7_sd", test_wc_PKCS7_VerifySignedData_RSA),    \
     TEST_DECL_GROUP("pkcs7_sd", test_wc_PKCS7_VerifySignedData_ECC),    \

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -17147,5 +17147,4 @@ int wc_AesCtsDecryptFinal(Aes* aes, byte* out, word32* outSz)
 
 #endif /* WOLFSSL_AES_CTS */
 
-
 #endif /* !NO_AES */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2506,6 +2506,12 @@ WOLFSSL_LOCAL word32 SetSet(word32 len, byte* output);
 WOLFSSL_API word32 SetAlgoID(int algoOID, byte* output, int type, int curveSz);
 WOLFSSL_LOCAL word32 SetAlgoIDEx(int algoOID, byte* output, int type, int curveSz,
                                 byte absentParams);
+#if defined(WC_RSA_PSS) && !defined(NO_RSA)
+WOLFSSL_LOCAL word32 wc_EncodeRsaPssAlgoId(int hashOID, int saltLen, byte* out,
+                                           word32 outSz);
+WOLFSSL_TEST_VIS int wc_DecodeRsaPssParams(const byte* params, word32 sz,
+    enum wc_HashType* hash, int* mgf, int* saltLen);
+#endif
 WOLFSSL_LOCAL int SetMyVersion(word32 version, byte* output, int header);
 WOLFSSL_LOCAL int SetSerialNumber(const byte* sn, word32 snSz, byte* output,
     word32 outputSz, int maxSnSz);

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -388,6 +388,13 @@ struct wc_PKCS7 {
     CallbackEccSignRawDigest eccSignRawDigestCb;
 #endif
 
+#if defined(WC_RSA_PSS) && !defined(NO_RSA)
+    int pssSaltLen;   /* RSASSA-PSS params from SignerInfo; valid when */
+    int pssHashType;  /* pssParamsPresent == 1; else verify path uses  */
+    int pssMgf;       /* RSA_PSS_SALT_LEN_DEFAULT / digest algo defaults */
+    byte pssParamsPresent;
+#endif
+
     /* !! NEW DATA MEMBERS MUST BE ADDED AT END !! */
 };
 


### PR DESCRIPTION
Add full RSA-PSS (RSASSA-PSS) support to PKCS#7 SignedData encoding and verification.

This change enables `SignerInfo.signatureAlgorithm` to use id-RSASSA-PSS with explicit RSASSA-PSS-params (hash, MGF1, salt length), as required by RFC 4055 and CMS profiles.

**Key changes:**
- Add RSA-PSS encode and verify paths for PKCS7 SignedData
- Encode full RSASSA-PSS AlgorithmIdentifier parameters
- Decode RSA-PSS parameters from SignerInfo for verification
- Treat RSA-PSS like ECDSA (sign raw digest, not DigestInfo)
- Fix certificate signatureAlgorithm parameter length handling
- Add API test coverage for RSA-PSS SignedData

This resolves failures when using RSA-PSS signer certificates (e.g. -173 invalid signature algorithm) and maintains backward compatibility with RSA PKCS#1 v1.5 and ECDSA.


---

# Testing

- **API:** New test `test_wc_PKCS7_EncodeSignedData_RSA_PSS` (guarded by `HAVE_PKCS7`, `WC_RSA_PSS`, RSA, filesystem, SHA-256). Uses `certs/rsapss/client-rsapss.der` and `client-rsapss-priv.der`; encodes SignedData and optionally round-trip verifies.
- **CI:** `os-check.yml` updated with build `--enable-pkcs7 CPPFLAGS=-DWC_RSA_PSS`.
- **Manual:** Encode/verify with RSA-PSS signer cert; existing RSA and ECDSA SignedData tests unchanged.

---

# Checklist

- [x] added tests
- [x] updated/added doxygen (PKCS7_RSA_PSS page; cryptocb RSA-PSS notes; pkcs7.h EncodeSignedData \ref)
- [x] updated appropriate READMEs (examples/configs/README.md; user_settings_pkcs7.h with WC_RSA_PSS)
- [x] Updated manual and documentation (doxygen; main README/ChangeLog at merge time)