### PR TITLE
Use proper bitfield macro WC_BITFIELD for new AIA fields

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2075,8 +2075,8 @@ struct DecodedCert {
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
     WOLFSSL_AIA_ENTRY extAuthInfoList[WOLFSSL_MAX_AIA_ENTRIES];
-    byte    extAuthInfoListSz:7;
-    byte    extAuthInfoListOverflow:1;
+    WC_BITFIELD extAuthInfoListSz:7;
+    WC_BITFIELD extAuthInfoListOverflow:1;
 };
 
 #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)


### PR DESCRIPTION
# Description

#9728 introduced new bitfields to `struct DecodedCert`, but did not use `WC_BITFIELD`. 

Fixes errors:
```
error: type of bit-field 'extAuthInfoListSz' is a GCC extension [-Werror=pedantic]
```

and 
```
error: type of bit-field 'extAuthInfoListOverflow' is a GCC extension [-Werror=pedantic]
```

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
