### PR TITLE
warning for 'type' may be used uninitialiized

### DIFF
--- a/src/ssl_api_pk.c
+++ b/src/ssl_api_pk.c
@@ -51,7 +51,7 @@ static int check_cert_key_dev(word32 keyOID, byte* privKey, word32 privSz,
     const byte* pubKey, word32 pubSz, int label, int id, void* heap, int devId)
 {
     int ret = 0;
-    int type;
+    int type = 0;
     void *pkey = NULL;
 
     if (privKey == NULL) {


### PR DESCRIPTION
Warning seen when running wolfHSM GitHub actions test (https://github.com/wolfSSL/wolfHSM/actions/runs/21739337416/job/62711340285?pr=270).

```
cc  -std=c90 -Werror -Wall -Wextra -ffunction-sections -fdata-sections -O2 -D_POSIX_C_SOURCE=200809L -DWOLFSSL_USER_SETTINGS -DWOLFHSM_CFG -DWOLFHSM_CFG_TEST_POSIX -DWOLFHSM_CFG_DMA -I. -I./config -I./bench_modules -I../wolfssl -I../ -I..//port/posix -c -o Build/ssl.o ../wolfssl/src/ssl.c
In file included from ../wolfssl/wolfssl/wolfcrypt/libwolfssl_sources.h:46,
                 from ../wolfssl/src/ssl.c:22:
In function ‘check_cert_key_dev’,
    inlined from ‘check_cert_key.constprop’ at ../wolfssl/src/ssl_api_pk.c:241:19:
../wolfssl/wolfssl/wolfcrypt/types.h:765:21: error: ‘type’ may be used uninitialized [-Werror=maybe-uninitialized]
  765 |                     wolfSSL_Free(xp, h, t); } while (0)
      |                     ^~~~~~~~~~~~~~~~~~~~~~
../wolfssl/src/ssl_api_pk.c:183:5: note: in expansion of macro ‘XFREE’
  183 |     XFREE(pkey, heap, type);
      |     ^~~~~
In file included from ../wolfssl/src/ssl.c:198:
../wolfssl/src/ssl_api_pk.c: In function ‘check_cert_key.constprop’:
../wolfssl/src/ssl_api_pk.c:54:9: note: ‘type’ was declared here
   54 |     int type;
      |         ^~~~
cc1: all warnings being treated as errors
make: *** [Makefile:193: Build/ssl.o] Error 1
```