### PR TITLE
20260207-fixes

### DIFF
--- a/src/ssl_api_pk.c
+++ b/src/ssl_api_pk.c
@@ -663,8 +663,9 @@ int wolfSSL_CTX_SetTmpEC_DHE_Sz(WOLFSSL_CTX* ctx, word16 sz)
         if (sz < ECC_MINSIZE) {
             ret = BAD_FUNC_ARG;
         }
+        else
     #endif
-        else if (sz > ECC_MAXSIZE) {
+        if (sz > ECC_MAXSIZE) {
             ret = BAD_FUNC_ARG;
         }
         else {

--- a/src/ssl_p7p12.c
+++ b/src/ssl_p7p12.c
@@ -1206,12 +1206,14 @@ PKCS7* wolfSSL_SMIME_read_PKCS7(WOLFSSL_BIO* in,
                 /* If line endings were added, the initial length may be
                  * exceeded. */
                 if ((canonPos + canonLineLen) >= canonSize) {
+                    char* newCanonSection;
                     canonSize = canonPos + canonLineLen;
-                    canonSection = (char*)XREALLOC(canonSection, canonSize,
+                    newCanonSection = (char*)XREALLOC(canonSection, canonSize,
                                                    NULL, DYNAMIC_TYPE_PKCS7);
-                    if (canonSection == NULL) {
+                    if (newCanonSection == NULL) {
                         goto error;
                     }
+                    canonSection = newCanonSection;
                 }
                 XMEMCPY(&canonSection[canonPos], canonLine,
                         (int)canonLineLen - 1);


### PR DESCRIPTION
`src/ssl_api_pk.c`: in `wolfSSL_CTX_SetTmpEC_DHE_Sz()`, fix gate-dependent syntax error in `if` construct;

`src/ssl_p7p12.c`: in `wolfSSL_SMIME_read_PKCS7()`, fix `memleakOnRealloc`.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
clang-tidy-all-sp-all
cppcheck-force-source
```
