### PR TITLE
Fix compilation checks in test scripts

### DIFF
--- a/scripts/benchmark.test
+++ b/scripts/benchmark.test
@@ -2,6 +2,19 @@
 
 #benchmark.test
 
+[ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
+                                  && exit 1
+
+if ./examples/client/client -? 2>&1 | grep "Client not compiled in!" ; then
+    echo 'skipping benchmark.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
+if ./examples/server/server -? 2>&1 | grep "Server not compiled in!" ; then
+    echo 'skipping benchmark.test because server not compiled in.' 1>&2
+    exit 77
+fi
+
 if [ "$#" -lt 2 ]; then
     echo "Usage: $0 [mode] [num] [clientargs] [serverargs]" >&2
     echo "    [mode]: 1=Connection Rate (TPS), 2=Throughput Bytes" >&2

--- a/scripts/crl-revoked.test
+++ b/scripts/crl-revoked.test
@@ -3,8 +3,13 @@
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
                                   && exit 1
 
-if ! ./examples/client/client | grep "Client not compiled in!" ; then
+if ./examples/client/client -? 2>&1 | grep "Client not compiled in!" ; then
     echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
+if ./examples/server/server -? 2>&1 | grep "Server not compiled in!" ; then
+    echo 'skipping crl-revoked.test because server not compiled in.' 1>&2
     exit 77
 fi
 

--- a/scripts/dtls.test
+++ b/scripts/dtls.test
@@ -16,6 +16,19 @@ DO_DELAY_TEST=${DO_DELAY_TEST:-0}
 
 #set -x # enable debug output
 
+[ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
+                                  && exit 1
+
+if ./examples/client/client -? 2>&1 | grep "Client not compiled in!" ; then
+    echo 'skipping dtls.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
+if ./examples/server/server -? 2>&1 | grep "Server not compiled in!" ; then
+    echo 'skipping dtls.test because server not compiled in.' 1>&2
+    exit 77
+fi
+
 # bwrap execution environment to avoid port conflicts
 if [ "${AM_BWRAPPED-}" != "yes" ]; then
     bwrap_path="$(command -v bwrap)"

--- a/scripts/dtlscid.test
+++ b/scripts/dtlscid.test
@@ -9,13 +9,13 @@
 [ ! -x ./examples/server/server ] && printf '\n\n%s\n' "Server doesn't exist" \
                                   && exit 0
 
-if ! ./examples/client/client | grep "Client not compiled in!" ; then
-    echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+if ./examples/client/client -? 2>&1 | grep "Client not compiled in!" ; then
+    echo 'skipping dtlscid.test because client not compiled in.' 1>&2
     exit 77
 fi
 
-if ! ./examples/server/server | grep "Server not compiled in!" ; then
-    echo 'skipping crl-revoked.test because server not compiled in.' 1>&2
+if ./examples/server/server -? 2>&1 | grep "Server not compiled in!" ; then
+    echo 'skipping dtlscid.test because server not compiled in.' 1>&2
     exit 77
 fi
 

--- a/scripts/ocsp-stapling-with-ca-as-responder.test
+++ b/scripts/ocsp-stapling-with-ca-as-responder.test
@@ -29,13 +29,13 @@ fi
 [ ! -x ./examples/server/server ] && printf '\n\n%s\n' "Server doesn't exist" \
                                   && exit 1
 
-if ! ./examples/client/client | grep "Client not compiled in!" ; then
-    echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+if ./examples/client/client -? 2>&1 | grep "Client not compiled in!" ; then
+    echo 'skipping ocsp-stapling-with-ca-as-responder.test because client not compiled in.' 1>&2
     exit 77
 fi
 
-if ! ./examples/server/server | grep "Server not compiled in!" ; then
-    echo 'skipping crl-revoked.test because server not compiled in.' 1>&2
+if ./examples/server/server -? 2>&1 | grep "Server not compiled in!" ; then
+    echo 'skipping ocsp-stapling-with-ca-as-responder.test because server not compiled in.' 1>&2
     exit 77
 fi
 

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -23,13 +23,13 @@ fi
 [ ! -x ./examples/server/server ] && printf '\n\n%s\n' "Server doesn't exist" \
                                   && exit 1
 
-if ! ./examples/client/client | grep "Client not compiled in!" ; then
-    echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+if ./examples/client/client -? 2>&1 | grep "Client not compiled in!" ; then
+    echo 'skipping ocsp-stapling.test because client not compiled in.' 1>&2
     exit 77
 fi
 
-if ! ./examples/server/server | grep "Server not compiled in!" ; then
-    echo 'skipping crl-revoked.test because server not compiled in.' 1>&2
+if ./examples/server/server -? 2>&1 | grep "Server not compiled in!" ; then
+    echo 'skipping ocsp-stapling.test because server not compiled in.' 1>&2
     exit 77
 fi
 

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -30,13 +30,13 @@ fi
 [ ! -x ./examples/server/server ] && printf '\n\n%s\n' "Server doesn't exist" \
                                   && exit 1
 
-if ! ./examples/client/client | grep "Client not compiled in!" ; then
-    echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+if ./examples/client/client -? 2>&1 | grep "Client not compiled in!" ; then
+    echo 'skipping ocsp-stapling2.test because client not compiled in.' 1>&2
     exit 77
 fi
 
-if ! ./examples/server/server | grep "Server not compiled in!" ; then
-    echo 'skipping crl-revoked.test because server not compiled in.' 1>&2
+if ./examples/server/server -? 2>&1 | grep "Server not compiled in!" ; then
+    echo 'skipping ocsp-stapling2.test because server not compiled in.' 1>&2
     exit 77
 fi
 

--- a/scripts/ocsp-stapling_tls13multi.test
+++ b/scripts/ocsp-stapling_tls13multi.test
@@ -30,13 +30,13 @@ fi
 [ ! -x ./examples/server/server ] && printf '\n\n%s\n' "Server doesn't exist" \
                                   && exit 1
 
-if ! ./examples/client/client | grep "Client not compiled in!" ; then
-    echo 'skipping crl-revoked.test because client not compiled in.' 1>&2
+if ./examples/client/client -? 2>&1 | grep "Client not compiled in!" ; then
+    echo 'skipping ocsp-stapling_tls13multi.test because client not compiled in.' 1>&2
     exit 77
 fi
 
-if ! ./examples/server/server | grep "Server not compiled in!" ; then
-    echo 'skipping crl-revoked.test because server not compiled in.' 1>&2
+if ./examples/server/server -? 2>&1 | grep "Server not compiled in!" ; then
+    echo 'skipping ocsp-stapling_tls13multi.test because server not compiled in.' 1>&2
     exit 77
 fi
 

--- a/scripts/pkcallbacks.test
+++ b/scripts/pkcallbacks.test
@@ -5,8 +5,13 @@
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
                                   && exit 1
 
-if ! ./examples/client/client | grep "Client not compiled in!" ; then
+if ./examples/client/client -? 2>&1 | grep "Client not compiled in!" ; then
     echo 'skipping pkcallbacks.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
+if ./examples/server/server -? 2>&1 | grep "Server not compiled in!" ; then
+    echo 'skipping pkcallbacks.test because server not compiled in.' 1>&2
     exit 77
 fi
 

--- a/scripts/rsapss.test
+++ b/scripts/rsapss.test
@@ -2,6 +2,19 @@
 
 # rsapss.test
 
+[ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
+                                  && exit 1
+
+if ./examples/client/client -? 2>&1 | grep "Client not compiled in!" ; then
+    echo 'skipping rsapss.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
+if ./examples/server/server -? 2>&1 | grep "Server not compiled in!" ; then
+    echo 'skipping rsapss.test because server not compiled in.' 1>&2
+    exit 77
+fi
+
 if ! ./examples/client/client -V | grep -q 4; then
     echo "skipping because TLS 1.3 not enabled in this build"
     exit 0

--- a/scripts/trusted_peer.test
+++ b/scripts/trusted_peer.test
@@ -3,6 +3,19 @@
 # trusted_peer.test
 # copyright wolfSSL 2016
 
+[ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
+                                  && exit 1
+
+if ./examples/client/client -? 2>&1 | grep "Client not compiled in!" ; then
+    echo 'skipping trusted_peer.test because client not compiled in.' 1>&2
+    exit 77
+fi
+
+if ./examples/server/server -? 2>&1 | grep "Server not compiled in!" ; then
+    echo 'skipping trusted_peer.test because server not compiled in.' 1>&2
+    exit 77
+fi
+
 # if we can, isolate the network namespace to eliminate port collisions.
 if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then
      if [[ -z "$NETWORK_UNSHARE_HELPER_CALLED" ]]; then


### PR DESCRIPTION
Correct the logic for checking if the client and server examples are compiled
in the test scripts. The previous logic was inverted, causing the tests to
always skip if the examples *were* compiled.
