### PR TITLE
wolfEntropy: Add ARM Generic Timer virtual counter as time src

### DIFF
--- a/wolfcrypt/src/wolfentropy.c
+++ b/wolfcrypt/src/wolfentropy.c
@@ -131,7 +131,8 @@ static WC_INLINE word64 Entropy_TimeHiRes(void)
 
     return cnt;
 }
-#elif !defined(ENTROPY_MEMUSE_THREAD) && (_POSIX_C_SOURCE >= 199309L)
+#elif !defined(ENTROPY_MEMUSE_THREAD) && defined(_POSIX_C_SOURCE) && \
+    (_POSIX_C_SOURCE >= 199309L)
 /* Get the high resolution time counter.
  *
  * @return  64-bit time that is the nanoseconds of current time.


### PR DESCRIPTION
# Description

Required for wolfEntropy on ARM32 in kernel space (where `clock_gettime` is not available). Uses the ARM Generic Timer virtual counter (CNTVCT) via coprocessor p15 as a high res time source.

# Testing

wolfcrypt test on customer hardware

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
