### PR TITLE
Fix libssh2 workflow with Docker 29

### DIFF
--- a/.github/workflows/libssh2.yml
+++ b/.github/workflows/libssh2.yml
@@ -67,16 +67,21 @@ jobs:
           ref: libssh2-${{ matrix.ref }}
           path: libssh2
 
+      - name: Update libssh2 test to use a stable version of debian
+        working-directory: libssh2
+        run: |
+            sed -i 's/testing-slim/oldstable-slim/' tests/openssh_server/Dockerfile
+
       - name: Build libssh2
         working-directory: libssh2
         run: |
           autoreconf -fi
           ./configure --with-crypto=wolfssl --with-libwolfssl-prefix=$GITHUB_WORKSPACE/build-dir
+          make -j
 
-      - name: Update libssh2 test to use a stable version of debian
+      - name: Pre-build Docker image to avoid concurrent docker build race
         working-directory: libssh2
-        run: |
-            sed -i 's/testing-slim/oldstable-slim/' tests/openssh_server/Dockerfile
+        run: docker build -t libssh2/openssh_server tests/openssh_server
 
       - name: Run libssh2 tests
         working-directory: libssh2
@@ -85,6 +90,6 @@ jobs:
       - name: Confirm libssh2 built with wolfSSL
         run: ldd libssh2/src/.libs/libssh2.so | grep wolfssl
 
-      - name: print server logs
+      - name: print test logs
         if: ${{ failure() }}
         run: tail -n +1 libssh2/tests/*.log


### PR DESCRIPTION
# Description

The [libssh2 workflow](https://github.com/wolfSSL/wolfssl/actions/workflows/libssh2.yml) started failing today with docker errors:

```
Error running command 'docker build --quiet -t libssh2/openssh_server %s' (exit 256): ERROR: failed to build: failed to solve: image "docker.io/libssh2/openssh_server:latest": already exists
```

Investigation shows that this is due to a [recent update](https://github.com/actions/runner-images/releases) of the `ubuntu-24.04` runner which pulled in Docker 29.  A [github issue](https://github.com/docker/buildx/issues/3576) on Docker indicates an issue with concurrent `docker build`s. So it was required to pre-build the docker image. Alternatively, removing the `-j` option with `make -j check` seems to work.

# Testing

Existing yaml.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
