### PR TITLE
Fix null check in ECDSA encode

### DIFF
--- a/src/pk_ec.c
+++ b/src/pk_ec.c
@@ -5019,7 +5019,7 @@ int wolfSSL_i2d_ECDSA_SIG(const WOLFSSL_ECDSA_SIG *sig, unsigned char **pp)
         #ifdef WOLFSSL_I2D_ECDSA_SIG_ALLOC
         if ((pp != NULL) && (*pp == NULL)) {
             *pp = (unsigned char *)XMALLOC(len, NULL, DYNAMIC_TYPE_OPENSSL);
-            if (*pp != NULL) {
+            if (*pp == NULL) {
                 WOLFSSL_MSG("malloc error");
                 return 0;
             }


### PR DESCRIPTION
# Description

Stumbled upon this null check which I believe is incorrect.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
