### PR TITLE
cyignore sslSniffer due to main() conflicts

### DIFF
--- a/.cyignore
+++ b/.cyignore
@@ -27,6 +27,8 @@ $(SEARCH_wolfssl)/wolfcrypt/src/sm3_asm.S
 $(SEARCH_wolfssl)/wolfcrypt/src/sp_x86_64_asm.S
 $(SEARCH_wolfssl)/wolfcrypt/src/sp_sm2_x86_64_asm.S
 $(SEARCH_wolfssl)/wolfcrypt/src/wc_kyber_asm.S
+$(SEARCH_wolfssl)/wolfcrypt/src/wc_mldsa_asm.S
+$(SEARCH_wolfssl)/wolfcrypt/src/wc_mlkem_asm.S
 
 $(SEARCH_wolfssl)/wolfcrypt/src/port/arm/armv8-32-aes-asm.S
 $(SEARCH_wolfssl)/wolfcrypt/src/port/arm/armv8-32-curve25519.S


### PR DESCRIPTION
# Description

When building for an embedded device, and wanting to include benchmark.c, one would use NO_MAIN_FUNCTION so that wolfcyrpt_benchmark_main() can be called from the application main(). However, sslSniffer/snifftest.c gates main() with NO_MAIN_DRIVER. So if I disable main() in snifftets.c, I lose wolfcrypt_benchmark_main() in benchmark.c. One solution would be to change benchmark.c to not block the wolfcrypt_benchmark_main function but that might impact more than just benchmark.c, so it is easier to just add another .cygnore for sslSniffer. It would be nice to have NO_SSLSNIFFER to exclude the entire sniffer, but again, that would touch code.

# Testing

I built a simple PSOC6/PSOCEdge application and using NO_MAIN_FUNCTION + MAIN_NO_ARGS, I can easily link in the benchmarks without needing to change the github repo: it can be configured just with user_settings.h, and if I want a sniffer, I can use NO_CRYPT_BENCHMARK.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation

NO_MAIN_FUNCTION and MAIN_NO_ARG are not documented, nor is .cyignore, so there's no place to update this. Also no tests for .cyignore.