### PR TITLE
Fix missing header includes and conditional compilation issue for PSoC6 port.

### DIFF
--- a/wolfcrypt/src/port/cypress/psoc6_crypto.c
+++ b/wolfcrypt/src/port/cypress/psoc6_crypto.c
@@ -36,10 +36,10 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h>
-#include <wolfssl/wolfcrypt/random.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
+#include <wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h>
+#include <wolfssl/wolfcrypt/random.h>
 
 #include "cy_crypto_core_hw_v2.h"
 #include "cy_crypto_core_mem.h"
@@ -54,8 +54,19 @@
 #include "cy_crypto_common.h"
 #include "cy_crypto_core_aes.h"
 #include "cy_crypto_core_aes_v2.h"
-
 #endif /* NO_AES */
+
+#ifndef NO_SHA256
+#include "wolfssl/wolfcrypt/sha256.h"
+#endif
+
+#ifdef WOLFSSL_SHA3
+#include "wolfssl/wolfcrypt/sha3.h"
+#endif
+
+#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
+#include "wolfssl/wolfcrypt/sha512.h"
+#endif
 
 #if defined(PSOC6_HASH_SHA3)
 
@@ -1102,7 +1113,10 @@ int wc_Psoc6_Aes_SetKey(Aes* aes, const byte* userKey, word32 len,
     /* Store key information in wolfSSL structure */
     aes->keylen = len;
     aes->rounds = len / 4 + 6;
-    aes->left   = 0;
+
+#if defined(WOLFSSL_AES_CFB)
+    aes->left = 0;
+#endif
 
     XMEMCPY(aes->key, userKey, len);
 


### PR DESCRIPTION
Fix missing header includes and conditional compilation issue in PSoC6 crypto hardware acceleration port.
Guard the `aes->left = 0` assignment to enable when WOLFSSL_AES_CFB is defined.

# Description

### 1. Added Required SHA Header Includes

Added conditional includes based on enabled hash algorithms to fix the compilation issues

```c
#ifndef NO_SHA256
#include "wolfssl/wolfcrypt/sha256.h"
#endif

#ifdef WOLFSSL_SHA3
#include "wolfssl/wolfcrypt/sha3.h" 
#endif

#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
#include "wolfssl/wolfcrypt/sha512.h"
#endif
```

### 2. Guarded `aes->left` Assignment

Wrapped the `aes->left = 0` assignment with the appropriate conditional:

```c
#if defined(WOLFSSL_AES_CFB)
    aes->left   = 0;
#endif
```

# Testing

Tested with CY8CPROTO-062-4343W board on ModusToolbox™ IDE with tests present in wolfcrypt/test/test.c:wolfcrypt_test()
PSoC6 PDL library: [mtb-pdl-cat1](https://github.com/Infineon/mtb-pdl-cat1)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
