### PR TITLE
Fix switch case handling in TLSX_IsGroupSupported function

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -4490,6 +4490,7 @@ static int TLSX_IsGroupSupported(int namedGroup)
         #if defined(HAVE_CURVE25519) && ECC_MIN_KEY_SZ <= 256
             case WOLFSSL_X25519MLKEM512:
         #endif
+            break;
         #endif
         #ifndef WOLFSSL_NO_ML_KEM_768
             case WOLFSSL_ML_KEM_768:
@@ -4501,6 +4502,7 @@ static int TLSX_IsGroupSupported(int namedGroup)
         #if defined(HAVE_CURVE448) && ECC_MIN_KEY_SZ <= 448
             case WOLFSSL_X448MLKEM768:
         #endif
+            break;
         #endif
         #ifndef WOLFSSL_NO_ML_KEM_1024
             case WOLFSSL_ML_KEM_1024:


### PR DESCRIPTION
Fix missing `break` statements in ML-KEM group switch cases causing `TLSX_IsGroupSupported()` function to return failure even if the group is supported.

# Description
In `src/tls.c`, the function `TLSX_IsGroupSupported` will return 0 (failure) when:
1. Parameter `namedGroup` is WOLFSSL_ML_KEM_512 or WOLFSSL_ML_KEM_768 or their hybrid variants.
2. WOLFSSL_NO_ML_KEM_512 and/or WOLFSSL_NO_ML_KEM_768 are not defined and WOLFSSL_NO_ML_KEM_1024 is defined.

In this case the execution will not reach `break` since it is present inside `!WOLFSSL_NO_ML_KEM_1024` code block.

To fix this, add `break;` at the end of `!WOLFSSL_NO_ML_KEM_512` and `!WOLFSSL_NO_ML_KEM_768` blocks to handle the flow individually.

# Testing

1. Added ML_KEM (ML_KEM768) support in user_settings.h
```c
    #define WOLFSSL_HAVE_MLKEM
    #define WOLFSSL_WC_MLKEM

    #define WOLFSSL_NO_ML_KEM_512
    // #define WOLFSSL_NO_ML_KEM_768
    #define WOLFSSL_NO_ML_KEM_1024
```
2. Integrated wolfSSL layer into PSoC6 build system and built for TARGET CY8CPROTO-062-4343W board on ModusToolbox™ IDE.
3. TLS1.3 is failing for this configuration, but succeeding if WOLFSSL_NO_ML_KEM_1024 is not defined.
4. Adding break statements individually for each block resolved the issue.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
