### PR TITLE
Fix issues found during src/ code review

### DIFF
--- a/src/ssl_ech.c
+++ b/src/ssl_ech.c
@@ -580,6 +580,10 @@ int SetEchConfigsEx(WOLFSSL_EchConfig** outputConfigs, void* heap,
         ato16(echConfig, &hpkePubkeyLen);
         echConfig += 2;
         /* hpke public_key */
+        if (hpkePubkeyLen > HPKE_Npk_MAX) {
+            ret = BUFFER_E;
+            break;
+        }
         XMEMCPY(workingConfig->receiverPubkey, echConfig, hpkePubkeyLen);
         echConfig += hpkePubkeyLen;
         /* cipherSuitesLen */


### PR DESCRIPTION
- ECH: add bounds check on hpkePubkeyLen against HPKE_Npk_MAX to prevent heap buffer overflow from untrusted ECH config data

- Sniffer: fix reassembly memory limit check typo, MaxRecoveryMemory -1 should be MaxRecoveryMemory != -1

- Sniffer: add bounds check in IPv6 extension header parsing loop to prevent OOB read when next_header never matches TCP or NO_NEXT_HEADER

- Sniffer: validate tlsFragOffset + rhSize against tlsFragSize before XMEMCPY in both TLS handshake fragment reassembly paths

- Internal: use WC_SAFE_SUM_WORD32 in GrowAnOutputBuffer to prevent integer overflow on allocation size, matching existing pattern in GrowOutputBuffer