### PR TITLE
Improve HMAC and SHA-2 Zeroing

### DIFF
--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -1406,7 +1406,9 @@ void wc_HmacFree(Hmac* hmac)
     HmacFreeHash(hmac->macType, &hmac->o_hash);
 #endif
 
-    ForceZero(hmac, sizeof(*hmac));
+    ForceZero(hmac->ipad, sizeof(hmac->ipad));
+    ForceZero(hmac->opad, sizeof(hmac->opad));
+    ForceZero(hmac->innerHash, sizeof(hmac->innerHash));
 }
 #endif /* WOLFSSL_KCAPI_HMAC */
 

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -1307,6 +1307,78 @@ int wc_HmacInit_Label(Hmac* hmac, const char* label, void* heap, int devId)
 }
 #endif /* WOLF_PRIVATE_KEY_ID */
 
+/* Free hash state. */
+static void HmacFreeHash(int macType, wc_HmacHash* hash)
+{
+    switch (macType) {
+    #ifndef NO_MD5
+        case WC_MD5:
+            wc_Md5Free(&hash->md5);
+            break;
+    #endif /* !NO_MD5 */
+
+    #ifndef NO_SHA
+        case WC_SHA:
+            wc_ShaFree(&hash->sha);
+            break;
+    #endif /* !NO_SHA */
+
+    #ifdef WOLFSSL_SHA224
+        case WC_SHA224:
+            wc_Sha224Free(&hash->sha224);
+            break;
+    #endif /* WOLFSSL_SHA224 */
+    #ifndef NO_SHA256
+        case WC_SHA256:
+            wc_Sha256Free(&hash->sha256);
+            break;
+    #endif /* !NO_SHA256 */
+
+    #ifdef WOLFSSL_SHA384
+        case WC_SHA384:
+            wc_Sha384Free(&hash->sha384);
+            break;
+    #endif /* WOLFSSL_SHA384 */
+    #ifdef WOLFSSL_SHA512
+        case WC_SHA512:
+            wc_Sha512Free(&hash->sha512);
+            break;
+    #endif /* WOLFSSL_SHA512 */
+
+    #ifdef WOLFSSL_SHA3
+    #ifndef WOLFSSL_NOSHA3_224
+        case WC_SHA3_224:
+            wc_Sha3_224_Free(&hash->sha3);
+            break;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_256
+        case WC_SHA3_256:
+            wc_Sha3_256_Free(&hash->sha3);
+            break;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_384
+        case WC_SHA3_384:
+            wc_Sha3_384_Free(&hash->sha3);
+            break;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_512
+        case WC_SHA3_512:
+            wc_Sha3_512_Free(&hash->sha3);
+            break;
+    #endif
+    #endif /* WOLFSSL_SHA3 */
+
+    #ifdef WOLFSSL_SM3
+        case WC_SM3:
+            wc_Sm3Free(&hash->sm3);
+            break;
+    #endif
+
+        default:
+            break;
+    }
+}
+
 /* Free Hmac from use with async device */
 void wc_HmacFree(Hmac* hmac)
 {
@@ -1328,117 +1400,11 @@ void wc_HmacFree(Hmac* hmac)
     wolfAsync_DevCtxFree(&hmac->asyncDev, WOLFSSL_ASYNC_MARKER_HMAC);
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
-    switch (hmac->macType) {
-    #ifndef NO_MD5
-        case WC_MD5:
-            wc_Md5Free(&hmac->hash.md5);
-        #ifdef WOLFSSL_HMAC_COPY_HASH
-            wc_Md5Free(&hmac->i_hash.md5);
-            wc_Md5Free(&hmac->o_hash.md5);
-        #endif
-            break;
-    #endif /* !NO_MD5 */
-
-    #ifndef NO_SHA
-        case WC_SHA:
-            wc_ShaFree(&hmac->hash.sha);
-        #ifdef WOLFSSL_HMAC_COPY_HASH
-            wc_ShaFree(&hmac->i_hash.sha);
-            wc_ShaFree(&hmac->o_hash.sha);
-        #endif
-            break;
-    #endif /* !NO_SHA */
-
-    #ifdef WOLFSSL_SHA224
-        case WC_SHA224:
-            wc_Sha224Free(&hmac->hash.sha224);
-        #ifdef WOLFSSL_HMAC_COPY_HASH
-            wc_Sha224Free(&hmac->i_hash.sha224);
-            wc_Sha224Free(&hmac->o_hash.sha224);
-        #endif
-            break;
-    #endif /* WOLFSSL_SHA224 */
-    #ifndef NO_SHA256
-        case WC_SHA256:
-            wc_Sha256Free(&hmac->hash.sha256);
-        #ifdef WOLFSSL_HMAC_COPY_HASH
-            wc_Sha256Free(&hmac->i_hash.sha256);
-            wc_Sha256Free(&hmac->o_hash.sha256);
-        #endif
-            break;
-    #endif /* !NO_SHA256 */
-
-    #ifdef WOLFSSL_SHA384
-        case WC_SHA384:
-            wc_Sha384Free(&hmac->hash.sha384);
-        #ifdef WOLFSSL_HMAC_COPY_HASH
-            wc_Sha384Free(&hmac->i_hash.sha384);
-            wc_Sha384Free(&hmac->o_hash.sha384);
-        #endif
-            break;
-    #endif /* WOLFSSL_SHA384 */
-    #ifdef WOLFSSL_SHA512
-        case WC_SHA512:
-            wc_Sha512Free(&hmac->hash.sha512);
-        #ifdef WOLFSSL_HMAC_COPY_HASH
-            wc_Sha512Free(&hmac->i_hash.sha512);
-            wc_Sha512Free(&hmac->o_hash.sha512);
-        #endif
-            break;
-    #endif /* WOLFSSL_SHA512 */
-
-    #ifdef WOLFSSL_SHA3
-    #ifndef WOLFSSL_NOSHA3_224
-        case WC_SHA3_224:
-            wc_Sha3_224_Free(&hmac->hash.sha3);
-        #ifdef WOLFSSL_HMAC_COPY_HASH
-            wc_Sha3_224_Free(&hmac->i_hash.sha3);
-            wc_Sha3_224_Free(&hmac->o_hash.sha3);
-        #endif
-            break;
-    #endif
-    #ifndef WOLFSSL_NOSHA3_256
-        case WC_SHA3_256:
-            wc_Sha3_256_Free(&hmac->hash.sha3);
-        #ifdef WOLFSSL_HMAC_COPY_HASH
-            wc_Sha3_256_Free(&hmac->i_hash.sha3);
-            wc_Sha3_256_Free(&hmac->o_hash.sha3);
-        #endif
-            break;
-    #endif
-    #ifndef WOLFSSL_NOSHA3_384
-        case WC_SHA3_384:
-            wc_Sha3_384_Free(&hmac->hash.sha3);
-        #ifdef WOLFSSL_HMAC_COPY_HASH
-            wc_Sha3_384_Free(&hmac->i_hash.sha3);
-            wc_Sha3_384_Free(&hmac->o_hash.sha3);
-        #endif
-            break;
-    #endif
-    #ifndef WOLFSSL_NOSHA3_512
-        case WC_SHA3_512:
-            wc_Sha3_512_Free(&hmac->hash.sha3);
-        #ifdef WOLFSSL_HMAC_COPY_HASH
-            wc_Sha3_512_Free(&hmac->i_hash.sha3);
-            wc_Sha3_512_Free(&hmac->o_hash.sha3);
-        #endif
-            break;
-    #endif
-    #endif /* WOLFSSL_SHA3 */
-
-    #ifdef WOLFSSL_SM3
-        case WC_SM3:
-            wc_Sm3Free(&hmac->hash.sm3);
-        #ifdef WOLFSSL_HMAC_COPY_HASH
-            wc_Sm3Free(&hmac->i_hash.sm3);
-            wc_Sm3Free(&hmac->o_hash.sm3);
-        #endif
-            break;
-    #endif
-
-        default:
-            break;
-    }
+    HmacFreeHash(hmac->macType, &hmac->hash);
+#ifdef WOLFSSL_HMAC_COPY_HASH
+    HmacFreeHash(hmac->macType, &hmac->i_hash);
+    HmacFreeHash(hmac->macType, &hmac->o_hash);
+#endif
 
     ForceZero(hmac, sizeof(*hmac));
 }

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -2347,7 +2347,19 @@ static WC_INLINE int Transform_Sha256_Len(wc_Sha256* sha256, const byte* data,
     #if defined(PSOC6_HASH_SHA2)
         wc_Psoc6_Sha_Free();
     #endif
+    #if !defined(FREESCALE_LTC_SHA) && \
+        !(defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)) && \
+        !defined(STM32_HASH_SHA2) && \
+        !defined(WOLFSSL_SILABS_SE_ACCEL) && \
+        !defined(WOLFSSL_IMXRT_DCP) && \
+        !defined(PSOC6_HASH_SHA2)
+        /* PSA compiles out the free function completely */
+        ForceZero(sha224->buffer, sizeof(sha224->buffer));
+        if (sha224->hiLen != 0 || sha224->loLen != 0)
+            ForceZero(sha224->digest, sizeof(sha224->digest));
+    #else
         ForceZero(sha224, sizeof(*sha224));
+    #endif
     }
 #endif /* !defined(WOLFSSL_HAVE_PSA) || defined(WOLFSSL_PSA_NO_HASH)  */
 #endif /*  WOLFSSL_SHA224 */
@@ -2494,7 +2506,19 @@ void wc_Sha256Free(wc_Sha256* sha256)
     wc_Psoc6_Sha_Free();
 #endif
 
+#if !defined(FREESCALE_LTC_SHA) && \
+    !(defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)) && \
+    !defined(STM32_HASH_SHA2) && \
+    !defined(WOLFSSL_SILABS_SE_ACCEL) && \
+    !defined(WOLFSSL_IMXRT_DCP) && \
+    !defined(PSOC6_HASH_SHA2)
+    /* PSA compiles out the free function completely */
+    ForceZero(sha256->buffer, sizeof(sha256->buffer));
+    if (sha256->hiLen != 0 || sha256->loLen != 0)
+        ForceZero(sha256->digest, sizeof(sha256->digest));
+#else
     ForceZero(sha256, sizeof(*sha256));
+#endif
 } /* wc_Sha256Free */
 
 #endif /* !defined(WOLFSSL_HAVE_PSA) || defined(WOLFSSL_PSA_NO_HASH) */

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -1688,7 +1688,13 @@ void wc_Sha512Free(wc_Sha512* sha512)
     wc_Psoc6_Sha_Free();
 #endif
 
+#if !defined(PSOC6_HASH_SHA2)
+    ForceZero(sha512->buffer, sizeof(sha512->buffer));
+    if (!(sha512->hiLen == 0 && sha512->loLen == 0))
+        ForceZero(sha512->digest, sizeof(sha512->digest));
+#else
     ForceZero(sha512, sizeof(*sha512));
+#endif
 }
 #endif
 
@@ -2176,7 +2182,13 @@ void wc_Sha384Free(wc_Sha384* sha384)
     wc_MXC_TPU_SHA_Free(&(sha384->mxcCtx));
 #endif
 
+#if !defined(PSOC6_HASH_SHA2)
+    ForceZero(sha384->buffer, sizeof(sha384->buffer));
+    if (!(sha384->hiLen == 0 && sha384->loLen == 0))
+        ForceZero(sha384->digest, sizeof(sha384->digest));
+#else
     ForceZero(sha384, sizeof(*sha384));
+#endif
 }
 
 #endif


### PR DESCRIPTION
# Description

In HMAC avoid zeroing the hash struct twice (once in ForceZero(Hmac) and one inside wc_Sha*Free.
In HMAC forceZero only sensitive fields.
In Sha*Free forceZero only sensitive fields.
Refactor out Hash clean-up from HmacFree.
