### PR TITLE
Fix issues found in static analysis

### DIFF
--- a/wolfcrypt/src/chacha20_poly1305.c
+++ b/wolfcrypt/src/chacha20_poly1305.c
@@ -422,7 +422,7 @@ static WC_INLINE int wc_XChaCha20Poly1305_crypt_oneshot(
 
     if (aead->poly.leftover) {
         if ((ret = wc_Poly1305_Pad(&aead->poly, (word32)aead->poly.leftover)) < 0)
-            return ret;
+            goto out;
     }
 
 #ifdef WORD64_AVAILABLE

--- a/wolfcrypt/src/compress.c
+++ b/wolfcrypt/src/compress.c
@@ -230,7 +230,10 @@ int wc_DeCompressDynamic(byte** out, int maxSz, int memoryType,
 
     stream.next_out  = tmp;
     stream.avail_out = (uInt)tmpSz;
-    if ((uLong)stream.avail_out != tmpSz) return DECOMPRESS_INIT_E;
+    if ((uLong)stream.avail_out != tmpSz) {
+        XFREE(tmp, heap, memoryType);
+        return DECOMPRESS_INIT_E;
+    }
 
     stream.zalloc = (alloc_func)myAlloc;
     stream.zfree  = (free_func)myFree;

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -9953,19 +9953,17 @@ static int oqs_dilithium_sign_msg(const byte* msg, word32 msgLen, byte* sig,
 
     if (ret == 0) {
         ret = wolfSSL_liboqsRngMutexLock(rng);
+        if (ret == 0) {
+            if (OQS_SIG_sign(oqssig, sig, &localOutLen, msg, msgLen, key->k)
+                == OQS_ERROR) {
+                ret = BAD_FUNC_ARG;
+            }
+        }
+        if (ret == 0) {
+            *sigLen = (word32)localOutLen;
+        }
+        wolfSSL_liboqsRngMutexUnlock();
     }
-
-    if ((ret == 0) &&
-        (OQS_SIG_sign(oqssig, sig, &localOutLen, msg, msgLen, key->k)
-         == OQS_ERROR)) {
-        ret = BAD_FUNC_ARG;
-    }
-
-    if (ret == 0) {
-        *sigLen = (word32)localOutLen;
-    }
-
-    wolfSSL_liboqsRngMutexUnlock();
 
     if (oqssig != NULL) {
         OQS_SIG_free(oqssig);

--- a/wolfcrypt/src/sphincs.c
+++ b/wolfcrypt/src/sphincs.c
@@ -131,19 +131,17 @@ int wc_sphincs_sign_msg(const byte* in, word32 inLen, byte* out, word32 *outLen,
 
     if (ret == 0) {
         ret = wolfSSL_liboqsRngMutexLock(rng);
+        if (ret == 0) {
+            if (OQS_SIG_sign(oqssig, out, &localOutLen, in, inLen, key->k)
+                == OQS_ERROR) {
+                ret = BAD_FUNC_ARG;
+            }
+        }
+        if (ret == 0) {
+            *outLen = (word32)localOutLen;
+        }
+        wolfSSL_liboqsRngMutexUnlock();
     }
-
-    if ((ret == 0) &&
-        (OQS_SIG_sign(oqssig, out, &localOutLen, in, inLen, key->k)
-         == OQS_ERROR)) {
-        ret = BAD_FUNC_ARG;
-    }
-
-    if (ret == 0) {
-        *outLen = (word32)localOutLen;
-    }
-
-    wolfSSL_liboqsRngMutexUnlock();
 
     if (oqssig != NULL) {
         OQS_SIG_free(oqssig);


### PR DESCRIPTION
- Fix missing cleanup on error in wc_XChaCha20Poly1305_crypt_oneshot: change early return to goto out so ForceZero and free are called
- Fix memory leak in wc_DeCompressDynamic: free tmp buffer before early return on avail_out size check failure
- Fix unconditional mutex unlock in PQC sign functions (falcon, sphincs, dilithium): only call unlock when lock was acquired
- Remove dead oqssig NULL checks in falcon sign/verify that are unreachable after the preceding SIG_TYPE_E assignment