### PR TITLE
Fix haproxy CI: VTest2 repo archived, use `last` tag

### DIFF
--- a/.github/workflows/haproxy.yml
+++ b/.github/workflows/haproxy.yml
@@ -82,12 +82,12 @@ jobs:
       working-directory: build-dir/haproxy-${{matrix.haproxy_ref}}
       run: make clean && make TARGET=linux-glibc USE_OPENSSL_WOLFSSL=1 SSL_LIB=$GITHUB_WORKSPACE/build-dir/lib SSL_INC=$GITHUB_WORKSPACE/build-dir/include ADDLIB=-Wl,-rpath,$GITHUB_WORKSPACE/build-dir/lib CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
 
-      # wlallemand/VTest used in v3.1.0 is no longer available
-    - name: Patch build-vtest.sh for v3.1.0
-      if: matrix.haproxy_ref == 'v3.1.0'
+      # VTest2 has moved off GitHub; use the last known good tag
+    - name: Patch build-vtest.sh for VTest2 migration
       working-directory: build-dir/haproxy-${{ matrix.haproxy_ref }}/scripts
       run: |
-        sed -i 's|https://github.com/wlallemand/VTest/archive/refs/heads/haproxy-sd_notify.tar.gz|https://github.com/vtest/VTest2/archive/main.tar.gz|' build-vtest.sh
+        sed -i 's|https://github.com/wlallemand/VTest/archive/refs/heads/haproxy-sd_notify.tar.gz|https://github.com/vtest/VTest2/archive/refs/tags/last.tar.gz|' build-vtest.sh
+        sed -i 's|https://github.com/vtest/VTest2/archive/main.tar.gz|https://github.com/vtest/VTest2/archive/refs/tags/last.tar.gz|' build-vtest.sh
 
     - name: Build haproxy vtest
       working-directory: build-dir/haproxy-${{matrix.haproxy_ref}}


### PR DESCRIPTION
The vtest/VTest2 GitHub repo was archived on 2026-02-18 and its main branch Makefile now exits with "THIS REPOSITORY HAS MOVED". The maintainers tagged the last buildable commit as `last`.

Patch build-vtest.sh for both haproxy versions in the matrix:
- v3.1.0 still references wlallemand/VTest (removed long ago)
- v3.2.0 references vtest/VTest2 main branch (now broken)

# Description

The vtest/VTest2 GitHub repo was archived on 2026-02-18 and its main branch Makefile now exits with "THIS REPOSITORY HAS MOVED". The maintainers tagged the last buildable commit as last.
Patch build-vtest.sh for both haproxy versions in the matrix:
v3.1.0 still references wlallemand/VTest (removed long ago)
v3.2.0 references vtest/VTest2 main branch (now broken)
Both sed replacements point to https://github.com/vtest/VTest2/archive/refs/tags/last.tar.gz.
Fixes zd# N/A (CI infrastructure fix)
Fixes zd#

# Testing

- Verified the last tag exists on the archived vtest/VTest2 GitHub repo (commit 803dcd0, Feb 17 2026)
- Verified the tarball URL (refs/tags/last.tar.gz) is downloadable from the archived repo
- Confirmed the sed patterns match the actual URLs in haproxy v3.1.0 and v3.2.0 scripts/build-vtest.sh
- HAPROXY test should pass now
# Checklist

- [x] added tests — N/A, CI-only change
- [x] updated/added doxygen — N/A
- [x] updated appropriate READMEs — N/A
- [x] Updated manual and documentation — N/A
