### PR TITLE
Rust wrapper: fix no_std support

### DIFF
--- a/wrapper/rust/wolfssl-wolfcrypt/build.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/build.rs
@@ -55,6 +55,7 @@ fn generate_bindings() -> Result<()> {
         .header("headers.h")
         .clang_arg(format!("-I{}", wolfssl_base_dir()?))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .use_core()
         .generate()
         .map_err(|_| io::Error::other("Failed to generate bindings"))?;
 

--- a/wrapper/rust/wolfssl-wolfcrypt/src/aes.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/aes.rs
@@ -26,7 +26,7 @@ Encryption Standard (AES) functionality.
 #![cfg(aes)]
 
 use crate::sys;
-use std::mem::{size_of_val, MaybeUninit};
+use core::mem::{size_of_val, MaybeUninit};
 
 #[cfg(aes_wc_block_size)]
 pub const AES_BLOCK_SIZE: usize = sys::WC_AES_BLOCK_SIZE as usize;
@@ -88,7 +88,7 @@ impl CBC {
     ///
     /// A Result which is Ok(CBC) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let ws_aes = new_ws_aes(heap, dev_id)?;
         let cbc = CBC {ws_aes};
         Ok(cbc)
@@ -292,7 +292,7 @@ impl CCM {
     ///
     /// A Result which is Ok(CCM) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let ws_aes = new_ws_aes(heap, dev_id)?;
         let ccm = CCM {ws_aes};
         Ok(ccm)
@@ -487,7 +487,7 @@ impl CFB {
     ///
     /// A Result which is Ok(CFB) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let ws_aes = new_ws_aes(heap, dev_id)?;
         let cfb = CFB {ws_aes};
         Ok(cfb)
@@ -794,7 +794,7 @@ impl CTR {
     ///
     /// A Result which is Ok(CTR) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let ws_aes = new_ws_aes(heap, dev_id)?;
         let ctr = CTR {ws_aes};
         Ok(ctr)
@@ -1075,7 +1075,7 @@ impl ECB {
     ///
     /// A Result which is Ok(ECB) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let ws_aes = new_ws_aes(heap, dev_id)?;
         let ecb = ECB {ws_aes};
         Ok(ecb)
@@ -1276,7 +1276,7 @@ impl GCM {
     ///
     /// A Result which is Ok(GCM) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let ws_aes = new_ws_aes(heap, dev_id)?;
         let gcm = GCM {ws_aes};
         Ok(gcm)
@@ -1499,7 +1499,7 @@ impl GCMStream {
     ///
     /// A Result which is Ok(GCMStream) on success or an Err containing the
     /// wolfSSL library return code on failure.
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let ws_aes = new_ws_aes(heap, dev_id)?;
         let gcmstream = GCMStream {ws_aes};
         Ok(gcmstream)
@@ -1751,7 +1751,7 @@ impl OFB {
     ///
     /// A Result which is Ok(OFB) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let ws_aes = new_ws_aes(heap, dev_id)?;
         let ofb = OFB {ws_aes};
         Ok(ofb)
@@ -1945,7 +1945,7 @@ impl XTS {
     ///
     /// A Result which is Ok(XTS) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let ws_xtsaes = new_ws_xtsaes(heap, dev_id)?;
         let xts = XTS {ws_xtsaes};
         Ok(xts)
@@ -2307,7 +2307,7 @@ impl XTSStream {
     ///
     /// A Result which is Ok(XTSStream) on success or an Err containing the
     /// wolfSSL library return code on failure.
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let ws_xtsaes = new_ws_xtsaes(heap, dev_id)?;
         let ws_xtsaesstreamdata: MaybeUninit<sys::XtsAesStreamData> = MaybeUninit::uninit();
         let ws_xtsaesstreamdata = unsafe { ws_xtsaesstreamdata.assume_init() };
@@ -2533,7 +2533,7 @@ impl Drop for XTSStream {
     }
 }
 
-fn new_ws_aes(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<sys::Aes, i32> {
+fn new_ws_aes(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<sys::Aes, i32> {
     let heap = match heap {
         Some(heap) => heap,
         None => core::ptr::null_mut(),
@@ -2554,7 +2554,7 @@ fn new_ws_aes(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> R
 }
 
 #[cfg(any(aes_xts, aes_xts_stream))]
-fn new_ws_xtsaes(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<sys::XtsAes, i32> {
+fn new_ws_xtsaes(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<sys::XtsAes, i32> {
     let heap = match heap {
         Some(heap) => heap,
         None => core::ptr::null_mut(),

--- a/wrapper/rust/wolfssl-wolfcrypt/src/blake2.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/blake2.rs
@@ -26,7 +26,7 @@ functionality.
 #![cfg(any(blake2b, blake2s))]
 
 use crate::sys;
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 /// Context for BLAKE2b computation.
 #[cfg(blake2b)]

--- a/wrapper/rust/wolfssl-wolfcrypt/src/chacha20_poly1305.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/chacha20_poly1305.rs
@@ -26,7 +26,7 @@ ChaCha20-Poly1305 functionality.
 #![cfg(chacha20_poly1305)]
 
 use crate::sys;
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 pub struct ChaCha20Poly1305 {
     wc_ccp: sys::ChaChaPoly_Aead,

--- a/wrapper/rust/wolfssl-wolfcrypt/src/cmac.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/cmac.rs
@@ -26,7 +26,7 @@ Message Authentication Code (CMAC) functionality.
 #![cfg(cmac)]
 
 use crate::sys;
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 /// The `CMAC` struct manages the lifecycle of a wolfSSL `Cmac` object.
 ///
@@ -133,7 +133,7 @@ impl CMAC {
     /// ];
     /// let mut cmac = CMAC::new_ex(&key, None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(key: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(key: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let key_size = key.len() as u32;
         let mut ws_cmac: MaybeUninit<sys::Cmac> = MaybeUninit::uninit();
         let typ = sys::CmacType_WC_CMAC_AES as i32;
@@ -242,7 +242,7 @@ impl CMAC {
     /// }
     /// ```
     #[cfg(aes)]
-    pub fn generate_ex(&mut self, key: &[u8], data: &[u8], dout: &mut [u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn generate_ex(&mut self, key: &[u8], data: &[u8], dout: &mut [u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let key_size = key.len() as u32;
         let data_size = data.len() as u32;
         let mut dout_size = dout.len() as u32;
@@ -384,7 +384,7 @@ impl CMAC {
     /// }
     /// ```
     #[cfg(aes)]
-    pub fn verify_ex(&mut self, key: &[u8], data: &[u8], check: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<bool, i32> {
+    pub fn verify_ex(&mut self, key: &[u8], data: &[u8], check: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<bool, i32> {
         let key_size = key.len() as u32;
         let data_size = data.len() as u32;
         let check_size = check.len() as u32;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
@@ -28,7 +28,7 @@ functionality.
 #[cfg(random)]
 use crate::random::RNG;
 use crate::sys;
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 pub struct Curve25519Key {
     wc_key: sys::curve25519_key,

--- a/wrapper/rust/wolfssl-wolfcrypt/src/dh.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/dh.rs
@@ -31,7 +31,7 @@ wolfSSL `DhKey` object. It ensures proper initialization and deallocation.
 use crate::sys;
 #[cfg(random)]
 use crate::random::RNG;
-use std::mem::{MaybeUninit};
+use core::mem::{MaybeUninit};
 
 pub struct DH {
     wc_dhkey: sys::DhKey,
@@ -218,7 +218,7 @@ impl DH {
     /// }
     /// ```
     #[cfg(all(dh_keygen, random))]
-    pub fn generate_ex(rng: &mut RNG, modulus_size: i32, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex(rng: &mut RNG, modulus_size: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_dhkey: MaybeUninit<sys::DhKey> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -345,7 +345,7 @@ impl DH {
     /// let mut dh = DH::new_named_ex(DH::FFDHE_2048, None, None).expect("Error with new_named_ex()");
     /// }
     /// ```
-    pub fn new_named_ex(name: i32, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_named_ex(name: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_dhkey: MaybeUninit<sys::DhKey> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -555,7 +555,7 @@ impl DH {
     /// let dh = DH::new_from_pg_ex(&p, &g, None, None).expect("Error with new_from_pg_ex()");
     /// }
     /// ```
-    pub fn new_from_pg_ex(p: &[u8], g: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_from_pg_ex(p: &[u8], g: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let p_size = p.len() as u32;
         let g_size = g.len() as u32;
         let mut wc_dhkey: MaybeUninit<sys::DhKey> = MaybeUninit::uninit();
@@ -783,7 +783,7 @@ impl DH {
     /// let dh = DH::new_from_pgq_ex(&p, &g, &q, None, None).expect("Error with new_from_pgq_ex()");
     /// }
     /// ```
-    pub fn new_from_pgq_ex(p: &[u8], g: &[u8], q: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_from_pgq_ex(p: &[u8], g: &[u8], q: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let p_size = p.len() as u32;
         let g_size = g.len() as u32;
         let q_size = q.len() as u32;
@@ -1023,7 +1023,7 @@ impl DH {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn new_from_pgq_with_check_ex(p: &[u8], g: &[u8], q: &[u8], trusted: i32, rng: &mut RNG, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_from_pgq_with_check_ex(p: &[u8], g: &[u8], q: &[u8], trusted: i32, rng: &mut RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let p_size = p.len() as u32;
         let g_size = g.len() as u32;
         let q_size = q.len() as u32;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -31,12 +31,12 @@ wolfSSL `ecc_key` object. It ensures proper initialization and deallocation.
 use crate::sys;
 #[cfg(random)]
 use crate::random::RNG;
-use std::mem::{MaybeUninit};
+use core::mem::{MaybeUninit};
 
 /// Rust wrapper for wolfSSL `ecc_point` object.
 pub struct ECCPoint {
     wc_ecc_point: *mut sys::ecc_point,
-    heap: *mut std::os::raw::c_void,
+    heap: *mut core::ffi::c_void,
 }
 
 impl ECCPoint {
@@ -71,7 +71,7 @@ impl ECCPoint {
     /// }
     /// ```
     #[cfg(ecc_import)]
-    pub fn import_der(din: &[u8], curve_id: i32, heap: Option<*mut std::os::raw::c_void>) -> Result<Self, i32> {
+    pub fn import_der(din: &[u8], curve_id: i32, heap: Option<*mut core::ffi::c_void>) -> Result<Self, i32> {
         let curve_idx = unsafe { sys::wc_ecc_get_curve_idx(curve_id) };
         if curve_idx < 0 {
             return Err(curve_idx);
@@ -129,7 +129,7 @@ impl ECCPoint {
     /// }
     /// ```
     #[cfg(ecc_import)]
-    pub fn import_der_ex(din: &[u8], curve_id: i32, short_key_size: i32, heap: Option<*mut std::os::raw::c_void>) -> Result<Self, i32> {
+    pub fn import_der_ex(din: &[u8], curve_id: i32, short_key_size: i32, heap: Option<*mut core::ffi::c_void>) -> Result<Self, i32> {
         let curve_idx = unsafe { sys::wc_ecc_get_curve_idx(curve_id) };
         if curve_idx < 0 {
             return Err(curve_idx);
@@ -251,6 +251,7 @@ impl ECCPoint {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
@@ -401,6 +402,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
@@ -411,7 +413,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn generate(size: i32, rng: &mut RNG, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate(size: i32, rng: &mut RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -456,6 +458,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
@@ -468,7 +471,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn generate_ex(size: i32, rng: &mut RNG, curve_id: i32, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex(size: i32, rng: &mut RNG, curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -514,6 +517,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
@@ -526,7 +530,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn generate_ex2(size: i32, rng: &mut RNG, curve_id: i32, flags: i32, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex2(size: i32, rng: &mut RNG, curve_id: i32, flags: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -566,6 +570,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
@@ -601,6 +606,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
@@ -612,7 +618,7 @@ impl ECC {
     /// let mut ecc = ECC::import_der(&der, None, None).expect("Error with import_der()");
     /// }
     /// ```
-    pub fn import_der(der: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn import_der(der: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -655,6 +661,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
@@ -674,7 +681,7 @@ impl ECC {
     /// let mut ecc = ECC::import_public_der(&der, None, None).expect("Error with import_public_der()");
     /// }
     /// ```
-    pub fn import_public_der(der: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn import_public_der(der: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -743,7 +750,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(ecc_import)]
-    pub fn import_private_key(priv_buf: &[u8], pub_buf: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn import_private_key(priv_buf: &[u8], pub_buf: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -817,7 +824,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(ecc_import)]
-    pub fn import_private_key_ex(priv_buf: &[u8], pub_buf: &[u8], curve_id: i32, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn import_private_key_ex(priv_buf: &[u8], pub_buf: &[u8], curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -876,7 +883,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(ecc_import)]
-    pub fn import_raw(qx: &[u8], qy: &[u8], d: &[u8], curve_name: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn import_raw(qx: &[u8], qy: &[u8], d: &[u8], curve_name: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -936,7 +943,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(ecc_import)]
-    pub fn import_raw_ex(qx: &[u8], qy: &[u8], d: &[u8], curve_id: i32, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn import_raw_ex(qx: &[u8], qy: &[u8], d: &[u8], curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -1004,7 +1011,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(ecc_import)]
-    pub fn import_unsigned(qx: &[u8], qy: &[u8], d: &[u8], curve_id: i32, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn import_unsigned(qx: &[u8], qy: &[u8], d: &[u8], curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -1062,7 +1069,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(ecc_import)]
-    pub fn import_x963(din: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<ECC, i32> {
+    pub fn import_x963(din: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<ECC, i32> {
         let din_size = din.len() as u32;
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
@@ -1126,7 +1133,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(ecc_import)]
-    pub fn import_x963_ex(din: &[u8], curve_id: i32, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<ECC, i32> {
+    pub fn import_x963_ex(din: &[u8], curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<ECC, i32> {
         let din_size = din.len() as u32;
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
@@ -1172,6 +1179,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -1238,6 +1246,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -1290,6 +1299,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -1339,6 +1349,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
@@ -1643,6 +1654,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -1686,6 +1698,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -1699,7 +1712,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn make_pub_to_point(&mut self, rng: Option<&mut RNG>, heap: Option<*mut std::os::raw::c_void>) -> Result<ECCPoint, i32> {
+    pub fn make_pub_to_point(&mut self, rng: Option<&mut RNG>, heap: Option<*mut core::ffi::c_void>) -> Result<ECCPoint, i32> {
         let rng_ptr = match rng {
             Some(rng) => &mut rng.wc_rng,
             None => core::ptr::null_mut(),
@@ -1741,6 +1754,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ed25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ed25519.rs
@@ -27,7 +27,7 @@ This module provides a Rust wrapper for the wolfCrypt library's EdDSA Curve
 
 use crate::sys;
 use crate::random::RNG;
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 /// The `Ed25519` struct manages the lifecycle of a wolfSSL `ed25519_key`
 /// object.
@@ -97,7 +97,7 @@ impl Ed25519 {
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed25519::generate_ex(&mut rng, None, None).expect("Error with generate_ex()");
     /// ```
-    pub fn generate_ex(rng: &mut RNG, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex(rng: &mut RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut ws_key: MaybeUninit<sys::ed25519_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -165,7 +165,7 @@ impl Ed25519 {
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
     /// let ed = Ed25519::new_ex(None, None).expect("Error with new()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut ws_key: MaybeUninit<sys::ed25519_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ed448.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ed448.rs
@@ -27,7 +27,7 @@ This module provides a Rust wrapper for the wolfCrypt library's EdDSA Curve
 
 use crate::sys;
 use crate::random::RNG;
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 /// The `Ed448` struct manages the lifecycle of a wolfSSL `ed448_key`
 /// object.
@@ -96,7 +96,7 @@ impl Ed448 {
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed448::generate_ex(&mut rng, None, None).expect("Error with generate_ex()");
     /// ```
-    pub fn generate_ex(rng: &mut RNG, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex(rng: &mut RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut ws_key: MaybeUninit<sys::ed448_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -164,7 +164,7 @@ impl Ed448 {
     /// use wolfssl_wolfcrypt::ed448::Ed448;
     /// let ed = Ed448::new_ex(None, None).expect("Error with new()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut ws_key: MaybeUninit<sys::ed448_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,

--- a/wrapper/rust/wolfssl-wolfcrypt/src/hkdf.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/hkdf.rs
@@ -92,7 +92,7 @@ pub fn hkdf_extract(typ: i32, salt: Option<&[u8]>, key: &[u8], out: &mut [u8]) -
 /// let mut extract_out = [0u8; SHA256::DIGEST_SIZE];
 /// hkdf_extract_ex(HMAC::TYPE_SHA256, Some(salt), ikm, &mut extract_out, None, None).expect("Error with hkdf_extract_ex()");
 /// ```
-pub fn hkdf_extract_ex(typ: i32, salt: Option<&[u8]>, key: &[u8], out: &mut [u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+pub fn hkdf_extract_ex(typ: i32, salt: Option<&[u8]>, key: &[u8], out: &mut [u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
     let mut salt_ptr = core::ptr::null();
     let mut salt_size = 0u32;
     if let Some(salt) = salt {
@@ -191,7 +191,7 @@ pub fn hkdf_expand(typ: i32, key: &[u8], info: Option<&[u8]>, out: &mut [u8]) ->
 /// let mut expand_out = [0u8; 16];
 /// hkdf_expand_ex(HMAC::TYPE_SHA256, &extract_out, Some(info), &mut expand_out, None, None).expect("Error with hkdf_expand_ex()");
 /// ```
-pub fn hkdf_expand_ex(typ: i32, key: &[u8], info: Option<&[u8]>, out: &mut [u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+pub fn hkdf_expand_ex(typ: i32, key: &[u8], info: Option<&[u8]>, out: &mut [u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
     let key_size = key.len() as u32;
     let mut info_ptr = core::ptr::null();
     let mut info_size = 0u32;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/hmac.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/hmac.rs
@@ -26,7 +26,7 @@ functionality.
 #![cfg(hmac)]
 
 use crate::sys;
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 /// Rust wrapper for wolfSSL `Hmac` object.
 pub struct HMAC {
@@ -112,7 +112,7 @@ impl HMAC {
     /// let key = [0x42u8; 16];
     /// let mut hmac = HMAC::new_ex(HMAC::TYPE_SHA256, &key, None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(typ: i32, key: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(typ: i32, key: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let key_size = key.len() as u32;
         let mut wc_hmac: MaybeUninit<sys::Hmac> = MaybeUninit::uninit();
         let heap = match heap {
@@ -190,7 +190,7 @@ impl HMAC {
     /// let mut hmac = HMAC::new_allow_short_key_ex(HMAC::TYPE_SHA256, &key, None, None).expect("Error with new_allow_short_key_ex()");
     /// ```
     #[cfg(hmac_setkey_ex)]
-    pub fn new_allow_short_key_ex(typ: i32, key: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_allow_short_key_ex(typ: i32, key: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let key_size = key.len() as u32;
         let mut wc_hmac: MaybeUninit<sys::Hmac> = MaybeUninit::uninit();
         let heap = match heap {

--- a/wrapper/rust/wolfssl-wolfcrypt/src/kdf.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/kdf.rs
@@ -125,7 +125,7 @@ pub fn pbkdf2(password: &[u8], salt: &[u8], iterations: i32, typ: i32, out: &mut
 /// }
 /// ```
 #[cfg(kdf_pbkdf2)]
-pub fn pbkdf2_ex(password: &[u8], salt: &[u8], iterations: i32, typ: i32, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>, out: &mut [u8]) -> Result<(), i32> {
+pub fn pbkdf2_ex(password: &[u8], salt: &[u8], iterations: i32, typ: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>, out: &mut [u8]) -> Result<(), i32> {
     let password_size = password.len() as i32;
     let salt_size = salt.len() as i32;
     let out_size = out.len() as i32;
@@ -247,7 +247,7 @@ pub fn pkcs12_pbkdf(password: &[u8], salt: &[u8], iterations: i32, typ: i32, id:
 /// }
 /// ```
 #[cfg(kdf_pkcs12)]
-pub fn pkcs12_pbkdf_ex(password: &[u8], salt: &[u8], iterations: i32, typ: i32, id: i32, heap: Option<*mut std::os::raw::c_void>, out: &mut [u8]) -> Result<(), i32> {
+pub fn pkcs12_pbkdf_ex(password: &[u8], salt: &[u8], iterations: i32, typ: i32, id: i32, heap: Option<*mut core::ffi::c_void>, out: &mut [u8]) -> Result<(), i32> {
     let password_size = password.len() as i32;
     let salt_size = salt.len() as i32;
     let out_size = out.len() as i32;
@@ -330,7 +330,7 @@ pub fn tls13_hkdf_extract(typ: i32, salt: Option<&[u8]>, key: Option<&mut [u8]>,
 /// }
 /// ```
 #[cfg(all(hmac, kdf_tls13))]
-pub fn tls13_hkdf_extract_ex(typ: i32, salt: Option<&[u8]>, key: Option<&mut [u8]>, out: &mut [u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+pub fn tls13_hkdf_extract_ex(typ: i32, salt: Option<&[u8]>, key: Option<&mut [u8]>, out: &mut [u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
     let mut salt_ptr = core::ptr::null();
     let mut salt_size = 0u32;
     if let Some(salt) = salt {
@@ -473,7 +473,7 @@ pub fn tls13_hkdf_expand_label(typ: i32, key: &[u8], protocol: &[u8], label: &[u
 /// ```
 #[cfg(all(hmac, kdf_tls13))]
 #[allow(clippy::too_many_arguments)]
-pub fn tls13_hkdf_expand_label_ex(typ: i32, key: &[u8], protocol: &[u8], label: &[u8], info: &[u8], out: &mut [u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+pub fn tls13_hkdf_expand_label_ex(typ: i32, key: &[u8], protocol: &[u8], label: &[u8], info: &[u8], out: &mut [u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
     let key_size = key.len() as u32;
     let protocol_size = protocol.len() as u32;
     let label_size = label.len() as u32;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/lib.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/lib.rs
@@ -18,6 +18,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#![no_std]
+
 /* bindgen-generated bindings to the C library */
 pub mod sys;
 

--- a/wrapper/rust/wolfssl-wolfcrypt/src/prf.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/prf.rs
@@ -119,7 +119,7 @@ pub fn prf(secret: &[u8], seed: &[u8], hash_type: i32, dout: &mut [u8]) -> Resul
 /// prf_ex(&secret, &seed, PRF_HASH_SHA384, None, None, &mut out).expect("Error with prf_ex()");
 /// }
 /// ```
-pub fn prf_ex(secret: &[u8], seed: &[u8], hash_type: i32, heap: Option<*mut ::std::os::raw::c_void>, dev_id: Option<i32>, dout: &mut [u8]) -> Result<(), i32> {
+pub fn prf_ex(secret: &[u8], seed: &[u8], hash_type: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>, dout: &mut [u8]) -> Result<(), i32> {
     let secret_size = secret.len() as u32;
     let seed_size = seed.len() as u32;
     let dout_size = dout.len() as u32;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/random.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/random.rs
@@ -45,7 +45,7 @@ rng.generate_block(&mut buffer).expect("Failed to generate a block");
 #![cfg(random)]
 
 use crate::sys;
-use std::mem::{size_of_val, MaybeUninit};
+use core::mem::{size_of_val, MaybeUninit};
 
 /// A cryptographically secure random number generator based on the wolfSSL
 /// library.
@@ -86,7 +86,7 @@ impl RNG {
     ///
     /// A Result which is Ok(RNG) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         #[cfg(fips)]
         {
             let rc = unsafe {
@@ -145,7 +145,7 @@ impl RNG {
     ///
     /// A Result which is Ok(RNG) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    pub fn new_with_nonce_ex<T>(nonce: &mut [T], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_with_nonce_ex<T>(nonce: &mut [T], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         #[cfg(fips)]
         {
             let rc = unsafe {
@@ -237,7 +237,7 @@ impl RNG {
     /// RNG::health_test_ex(Some(&nonce), &seed_a, Some(&seed_b), &mut output, None, None).expect("Error with health_test_ex()");
     /// ```
     #[cfg(random_hashdrbg)]
-    pub fn health_test_ex(nonce: Option<&[u8]>, seed_a: &[u8], seed_b: Option<&[u8]>, output: &mut [u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn health_test_ex(nonce: Option<&[u8]>, seed_a: &[u8], seed_b: Option<&[u8]>, output: &mut [u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let mut nonce_ptr = core::ptr::null();
         let mut nonce_size = 0u32;
         if let Some(nonce) = nonce {

--- a/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
@@ -28,6 +28,7 @@ wolfSSL `RsaKey` object. It ensures proper initialization and deallocation.
 # Examples
 
 ```rust
+# extern crate std;
 #[cfg(random)]
 {
 use std::fs;
@@ -61,7 +62,7 @@ assert_eq!(plain_out[0..dec_len], *plain);
 use crate::sys;
 #[cfg(random)]
 use crate::random::RNG;
-use std::mem::{MaybeUninit};
+use core::mem::{MaybeUninit};
 
 /// The `RSA` struct manages the lifecycle of a wolfSSL `RsaKey` object.
 ///
@@ -141,6 +142,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -188,6 +190,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -214,7 +217,7 @@ impl RSA {
     /// assert_eq!(plain_out[0..dec_len], *plain);
     /// }
     /// ```
-    pub fn new_from_der_ex(der: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_from_der_ex(der: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_rsakey: MaybeUninit<sys::RsaKey> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -256,6 +259,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -303,6 +307,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -329,7 +334,7 @@ impl RSA {
     /// assert_eq!(plain_out[0..dec_len], *plain);
     /// }
     /// ```
-    pub fn new_public_from_der_ex(der: &[u8], heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_public_from_der_ex(der: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_rsakey: MaybeUninit<sys::RsaKey> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -444,7 +449,7 @@ impl RSA {
     /// }
     /// ```
     #[cfg(all(random, rsa_keygen))]
-    pub fn generate_ex(size: i32, e: i32, rng: &mut RNG, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex(size: i32, e: i32, rng: &mut RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_rsakey: MaybeUninit<sys::RsaKey> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -671,6 +676,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -729,6 +735,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -1117,6 +1124,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -1172,6 +1180,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;
@@ -1233,6 +1242,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
+    /// # extern crate std;
     /// #[cfg(random)]
     /// {
     /// use std::fs;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/sha.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/sha.rs
@@ -24,7 +24,7 @@ Algorithm (SHA) functionality.
 */
 
 use crate::sys;
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 /// Context for SHA-1 computation.
 #[cfg(sha)]
@@ -72,7 +72,7 @@ impl SHA {
     /// use wolfssl_wolfcrypt::sha::SHA;
     /// let sha = SHA::new_ex(None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_sha: MaybeUninit<sys::wc_Sha> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -135,7 +135,7 @@ impl SHA {
     /// let mut sha = SHA::new().expect("Error with new()");
     /// sha.init_ex(None, None).expect("Error with init_ex()");
     /// ```
-    pub fn init_ex(&mut self, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn init_ex(&mut self, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -275,7 +275,7 @@ impl SHA224 {
     /// use wolfssl_wolfcrypt::sha::SHA224;
     /// let sha = SHA224::new_ex(None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_sha224: MaybeUninit<sys::wc_Sha224> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -338,7 +338,7 @@ impl SHA224 {
     /// let mut sha = SHA224::new().expect("Error with new()");
     /// sha.init_ex(None, None).expect("Error with init_ex()");
     /// ```
-    pub fn init_ex(&mut self, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn init_ex(&mut self, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -478,7 +478,7 @@ impl SHA256 {
     /// use wolfssl_wolfcrypt::sha::SHA256;
     /// let sha = SHA256::new_ex(None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_sha256: MaybeUninit<sys::wc_Sha256> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -541,7 +541,7 @@ impl SHA256 {
     /// let mut sha = SHA256::new().expect("Error with new()");
     /// sha.init_ex(None, None).expect("Error with init_ex()");
     /// ```
-    pub fn init_ex(&mut self, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn init_ex(&mut self, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -681,7 +681,7 @@ impl SHA384 {
     /// use wolfssl_wolfcrypt::sha::SHA384;
     /// let sha = SHA384::new_ex(None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_sha384: MaybeUninit<sys::wc_Sha384> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -744,7 +744,7 @@ impl SHA384 {
     /// let mut sha = SHA384::new().expect("Error with new()");
     /// sha.init_ex(None, None).expect("Error with init_ex()");
     /// ```
-    pub fn init_ex(&mut self, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn init_ex(&mut self, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -884,7 +884,7 @@ impl SHA512 {
     /// use wolfssl_wolfcrypt::sha::SHA512;
     /// let sha = SHA512::new_ex(None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_sha512: MaybeUninit<sys::wc_Sha512> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -947,7 +947,7 @@ impl SHA512 {
     /// let mut sha = SHA512::new().expect("Error with new()");
     /// sha.init_ex(None, None).expect("Error with init_ex()");
     /// ```
-    pub fn init_ex(&mut self, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn init_ex(&mut self, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -1087,7 +1087,7 @@ impl SHA3_224 {
     /// use wolfssl_wolfcrypt::sha::SHA3_224;
     /// let sha = SHA3_224::new_ex(None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_sha3: MaybeUninit<sys::wc_Sha3> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -1150,7 +1150,7 @@ impl SHA3_224 {
     /// let mut sha = SHA3_224::new().expect("Error with new()");
     /// sha.init_ex(None, None).expect("Error with init_ex()");
     /// ```
-    pub fn init_ex(&mut self, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn init_ex(&mut self, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -1290,7 +1290,7 @@ impl SHA3_256 {
     /// use wolfssl_wolfcrypt::sha::SHA3_256;
     /// let sha = SHA3_256::new_ex(None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_sha3: MaybeUninit<sys::wc_Sha3> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -1353,7 +1353,7 @@ impl SHA3_256 {
     /// let mut sha = SHA3_256::new().expect("Error with new()");
     /// sha.init_ex(None, None).expect("Error with init_ex()");
     /// ```
-    pub fn init_ex(&mut self, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn init_ex(&mut self, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -1493,7 +1493,7 @@ impl SHA3_384 {
     /// use wolfssl_wolfcrypt::sha::SHA3_384;
     /// let sha = SHA3_384::new_ex(None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_sha3: MaybeUninit<sys::wc_Sha3> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -1556,7 +1556,7 @@ impl SHA3_384 {
     /// let mut sha = SHA3_384::new().expect("Error with new()");
     /// sha.init_ex(None, None).expect("Error with init_ex()");
     /// ```
-    pub fn init_ex(&mut self, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn init_ex(&mut self, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -1696,7 +1696,7 @@ impl SHA3_512 {
     /// use wolfssl_wolfcrypt::sha::SHA3_512;
     /// let sha = SHA3_512::new_ex(None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_sha3: MaybeUninit<sys::wc_Sha3> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -1759,7 +1759,7 @@ impl SHA3_512 {
     /// let mut sha = SHA3_512::new().expect("Error with new()");
     /// sha.init_ex(None, None).expect("Error with init_ex()");
     /// ```
-    pub fn init_ex(&mut self, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn init_ex(&mut self, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -1899,7 +1899,7 @@ impl SHAKE128 {
     /// use wolfssl_wolfcrypt::sha::SHAKE128;
     /// let sha = SHAKE128::new_ex(None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_shake: MaybeUninit<sys::wc_Shake> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -1964,7 +1964,7 @@ impl SHAKE128 {
     /// let mut sha = SHAKE128::new().expect("Error with new()");
     /// sha.init_ex(None, None).expect("Error with init_ex()");
     /// ```
-    pub fn init_ex(&mut self, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn init_ex(&mut self, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -2169,7 +2169,7 @@ impl SHAKE256 {
     /// use wolfssl_wolfcrypt::sha::SHAKE256;
     /// let sha = SHAKE256::new_ex(None, None).expect("Error with new_ex()");
     /// ```
-    pub fn new_ex(heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_ex(heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_shake: MaybeUninit<sys::wc_Shake> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -2234,7 +2234,7 @@ impl SHAKE256 {
     /// let mut sha = SHAKE256::new().expect("Error with new()");
     /// sha.init_ex(None, None).expect("Error with init_ex()");
     /// ```
-    pub fn init_ex(&mut self, heap: Option<*mut std::os::raw::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
+    pub fn init_ex(&mut self, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<(), i32> {
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),


### PR DESCRIPTION
# Description

Generate bindgen API with core instead of std
Replace C types using std:: with core::
Replace std::mem usage with core::mem

# Testing

Unit tests + ran with wolfGuard-boringtun.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
