### PR TITLE
20260221-configure-all-crypto-fpecc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1471,6 +1471,7 @@ then
     test "$enable_sep" = "" && enable_sep=yes
     test "$enable_hkdf" = "" && enable_hkdf=yes
     test "$enable_eccencrypt" = "" && test "$enable_ecc" != "no" && enable_eccencrypt=yes
+    test "$enable_fpecc" = "" && test "$enable_ecc" != "no" && enable_fpecc=yes
     test "$enable_psk" = "" && enable_psk=yes
     test "$enable_cmac" = "" && enable_cmac=yes
     test "$enable_cmac_kdf" = "" && enable_cmac_kdf=yes


### PR DESCRIPTION
`configure.ac`: restore fpecc to `enable-all-crypto`, accidentally removed in f376ae210e.

tested with
```
wolfssl-multi-test.sh ...
'.*cust-kernel.*'
```

History on this:
Before #9800, fpecc was excluded from `ENABLED_LINUXKM_PIE` builds, with this note:
```
    # the compiler optimizer generates a weird out-of-bounds bss reference for
    # find_hole() in the FP_ECC implementation.
    if test "$ENABLED_LINUXKM_PIE" != yes
    then
        test "$enable_fpecc" = "" && test "$enable_ecc" != "no" && enable_fpecc=yes
```

After #9800, the ELF addend is compensated in each relocation, so all reconstructed symbol offsets are strictly in-bounds, and fpecc is safe in linuxkm-pie builds.

Meanwhile, the complete removal of fpecc from all-crypto was purely an editing error.
