### PR TITLE
20260223-fix2-configure-kernel-mode-defaults

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1610,7 +1610,7 @@ then
         test "$enable_fpecc" = "" && enable_fpecc=yes
         test "$enable_supportedcurves" = "" && enable_supportedcurves=yes
     fi
-    test "$enabled_rng" != "no" && test "$enable_rng_bank" = "" && enable_rng_bank=yes
+    test "$enable_rng" != "no" && test "$enable_rng_bank" = "" && enable_rng_bank=yes
     if test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -ge 6
     then
         test "$enable_aes" != "no" && test "$enable_aescfb" = "" && enable_aescfb=yes


### PR DESCRIPTION
`configure.ac`: fix typo, `$enabled_rng` for `$enable_rng`, in `KERNEL_MODE_DEFAULTS` setup added in a21dad9555.

addresses neglected Copilot review in #9820

tested with `wolfssl-multi-test.sh ... check-source-text check-configure`
