### PR TITLE
Add sanity checks in key export

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5726,6 +5726,13 @@ int wolfSSL_export_keying_material(WOLFSSL *ssl,
         return WOLFSSL_FAILURE;
     }
 
+    /* Sanity check contextLen to prevent integer overflow when cast to word32
+     * and to ensure it fits in the 2-byte length encoding (max 65535). */
+    if (use_context && contextLen > UINT16_MAX) {
+        WOLFSSL_MSG("contextLen too large");
+        return WOLFSSL_FAILURE;
+    }
+
     /* clientRandom + serverRandom
      * OR
      * clientRandom + serverRandom + ctx len encoding + ctx */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5728,7 +5728,7 @@ int wolfSSL_export_keying_material(WOLFSSL *ssl,
 
     /* Sanity check contextLen to prevent integer overflow when cast to word32
      * and to ensure it fits in the 2-byte length encoding (max 65535). */
-    if (use_context && contextLen > 0xFFFF) {
+    if (use_context && contextLen > WOLFSSL_MAX_16BIT) {
         WOLFSSL_MSG("contextLen too large");
         return WOLFSSL_FAILURE;
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5728,7 +5728,7 @@ int wolfSSL_export_keying_material(WOLFSSL *ssl,
 
     /* Sanity check contextLen to prevent integer overflow when cast to word32
      * and to ensure it fits in the 2-byte length encoding (max 65535). */
-    if (use_context && contextLen > UINT16_MAX) {
+    if (use_context && contextLen > 0xFFFF) {
         WOLFSSL_MSG("contextLen too large");
         return WOLFSSL_FAILURE;
     }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1024,7 +1024,7 @@ int Tls13_Exporter(WOLFSSL* ssl, unsigned char *out, size_t outLen,
         return ret;
 
     /* Sanity check contextLen to prevent truncation when cast to word32. */
-    if (contextLen > UINT32_MAX) {
+    if (contextLen > 0xFFFFFFFFU) {
         return BAD_FUNC_ARG;
     }
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1023,6 +1023,11 @@ int Tls13_Exporter(WOLFSSL* ssl, unsigned char *out, size_t outLen,
     if (ret != 0)
         return ret;
 
+    /* Sanity check contextLen to prevent truncation when cast to word32. */
+    if (contextLen > UINT32_MAX) {
+        return BAD_FUNC_ARG;
+    }
+
     /* Hash(context_value) */
     ret = wc_Hash(hashType, context, (word32)contextLen, hashOut, WC_MAX_DIGEST_SIZE);
     if (ret != 0)

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1024,7 +1024,7 @@ int Tls13_Exporter(WOLFSSL* ssl, unsigned char *out, size_t outLen,
         return ret;
 
     /* Sanity check contextLen to prevent truncation when cast to word32. */
-    if (contextLen > 0xFFFFFFFFU) {
+    if (contextLen > WOLFSSL_MAX_32BIT) {
         return BAD_FUNC_ARG;
     }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -24070,6 +24070,11 @@ static int test_export_keying_material_cb(WOLFSSL_CTX *ctx, WOLFSSL *ssl)
             NULL, 0, 0), 0);
     ExpectIntEQ(wolfSSL_export_keying_material(ssl, ekm, sizeof(ekm),
             "key expansion", XSTR_SIZEOF("key expansion"), NULL, 0, 0), 0);
+    /* contextLen overflow: values exceeding UINT16_MAX must be rejected to
+     * prevent integer overflow in seedLen calculation (ZD #21242). */
+    ExpectIntEQ(wolfSSL_export_keying_material(ssl, ekm, sizeof(ekm),
+            "Test label", XSTR_SIZEOF("Test label"), ekm,
+            (size_t)UINT16_MAX + 1, 1), 0);
 
     return EXPECT_RESULT();
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -24074,7 +24074,7 @@ static int test_export_keying_material_cb(WOLFSSL_CTX *ctx, WOLFSSL *ssl)
      * prevent integer overflow in seedLen calculation (ZD #21242). */
     ExpectIntEQ(wolfSSL_export_keying_material(ssl, ekm, sizeof(ekm),
             "Test label", XSTR_SIZEOF("Test label"), ekm,
-            (size_t)UINT16_MAX + 1, 1), 0);
+            (size_t)0xFFFF + 1, 1), 0);
 
     return EXPECT_RESULT();
 }


### PR DESCRIPTION
# Description

Resolve a casting overflow condition in 

  1. src/ssl.c — TLS 1.2 path (line 5731)                   

  Added a bounds check on contextLen before the seedLen calculation.

  2. src/tls13.c — TLS 1.3 path (line 1027)

  Added a bounds check on contextLen against UINT32_MAX

Fixes zd21242

# Testing

Added test case to `test_export_keying_material_cb`

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation

Credit for finding issue to:
```
Muhammad Arya Arjuna (pelioro)
```