### PR TITLE
Fix issues in TLS Extension size calculations

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -2135,7 +2135,7 @@ static void TLSX_SNI_FreeAll(SNI* list, void* heap)
 }
 
 /** Tells the buffered size of the SNI objects in a list. */
-static word16 TLSX_SNI_GetSize(SNI* list)
+WOLFSSL_TEST_VIS word16 TLSX_SNI_GetSize(SNI* list)
 {
     SNI* sni;
     word32 length = OPAQUE16_LEN; /* list length */
@@ -3241,15 +3241,19 @@ word16 TLSX_CSR_GetSize_ex(CertificateStatusRequest* csr, byte isRequest,
         if (csr->ssl != NULL && SSL_CM(csr->ssl) != NULL &&
                 SSL_CM(csr->ssl)->ocsp_stapling != NULL &&
                 SSL_CM(csr->ssl)->ocsp_stapling->statusCb != NULL) {
+            if (WOLFSSL_MAX_16BIT - OPAQUE8_LEN - OPAQUE24_LEN <
+                    csr->ssl->ocspCsrResp[idx].length) {
+                return 0;
+            }
             size = OPAQUE8_LEN + OPAQUE24_LEN +
                     csr->ssl->ocspCsrResp[idx].length;
-            if (size > WOLFSSL_MAX_16BIT)
-                return 0;
             return (word16)size;
         }
-        size = OPAQUE8_LEN + OPAQUE24_LEN + csr->responses[idx].length;
-        if (size > WOLFSSL_MAX_16BIT)
+        if (WOLFSSL_MAX_16BIT - OPAQUE8_LEN - OPAQUE24_LEN <
+                csr->responses[idx].length) {
             return 0;
+        }
+        size = OPAQUE8_LEN + OPAQUE24_LEN + csr->responses[idx].length;
         return (word16)size;
     }
 #else

--- a/src/tls.c
+++ b/src/tls.c
@@ -2147,7 +2147,7 @@ WOLFSSL_TEST_VIS word16 TLSX_SNI_GetSize(SNI* list)
 
         switch (sni->type) {
             case WOLFSSL_SNI_HOST_NAME:
-                length += (word16)XSTRLEN((char*)sni->data.host_name);
+                length += (word32)XSTRLEN((char*)sni->data.host_name);
             break;
         }
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -2138,7 +2138,7 @@ static void TLSX_SNI_FreeAll(SNI* list, void* heap)
 static word16 TLSX_SNI_GetSize(SNI* list)
 {
     SNI* sni;
-    word16 length = OPAQUE16_LEN; /* list length */
+    word32 length = OPAQUE16_LEN; /* list length */
 
     while ((sni = list)) {
         list = sni->next;
@@ -2150,9 +2150,13 @@ static word16 TLSX_SNI_GetSize(SNI* list)
                 length += (word16)XSTRLEN((char*)sni->data.host_name);
             break;
         }
+
+        if (length > WOLFSSL_MAX_16BIT) {
+            return 0;
+        }
     }
 
-    return length;
+    return (word16)length;
 }
 
 /** Writes the SNI objects of a list in a buffer. */
@@ -3216,7 +3220,7 @@ static void TLSX_CSR_Free(CertificateStatusRequest* csr, void* heap)
 word16 TLSX_CSR_GetSize_ex(CertificateStatusRequest* csr, byte isRequest,
                                                              int idx)
 {
-    word16 size = 0;
+    word32 size = 0;
 
     /* shut up compiler warnings */
     (void) csr; (void) isRequest;
@@ -3237,15 +3241,21 @@ word16 TLSX_CSR_GetSize_ex(CertificateStatusRequest* csr, byte isRequest,
         if (csr->ssl != NULL && SSL_CM(csr->ssl) != NULL &&
                 SSL_CM(csr->ssl)->ocsp_stapling != NULL &&
                 SSL_CM(csr->ssl)->ocsp_stapling->statusCb != NULL) {
-            return OPAQUE8_LEN + OPAQUE24_LEN + csr->ssl->ocspCsrResp[idx].length;
+            size = OPAQUE8_LEN + OPAQUE24_LEN +
+                    csr->ssl->ocspCsrResp[idx].length;
+            if (size > WOLFSSL_MAX_16BIT)
+                return 0;
+            return (word16)size;
         }
-        return (word16)(OPAQUE8_LEN + OPAQUE24_LEN +
-                csr->responses[idx].length);
+        size = OPAQUE8_LEN + OPAQUE24_LEN + csr->responses[idx].length;
+        if (size > WOLFSSL_MAX_16BIT)
+            return 0;
+        return (word16)size;
     }
 #else
     (void)idx;
 #endif
-    return size;
+    return (word16)size;
 }
 
 #if (defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_SERVER))
@@ -3855,7 +3865,7 @@ static void TLSX_CSR2_FreeAll(CertificateStatusRequestItemV2* csr2, void* heap)
 static word16 TLSX_CSR2_GetSize(CertificateStatusRequestItemV2* csr2,
                                                                  byte isRequest)
 {
-    word16 size = 0;
+    word32 size = 0;
 
     /* shut up compiler warnings */
     (void) csr2; (void) isRequest;
@@ -3876,11 +3886,15 @@ static word16 TLSX_CSR2_GetSize(CertificateStatusRequestItemV2* csr2,
                         size += OCSP_NONCE_EXT_SZ;
                 break;
             }
+
+            if (size > WOLFSSL_MAX_16BIT) {
+                return 0;
+            }
         }
     }
 #endif
 
-    return size;
+    return (word16)size;
 }
 
 static int TLSX_CSR2_Write(CertificateStatusRequestItemV2* csr2,

--- a/tests/api.c
+++ b/tests/api.c
@@ -32914,6 +32914,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_certificate_authorities_certificate_request),
     TEST_DECL(test_certificate_authorities_client_hello),
     TEST_DECL(test_TLSX_TCA_Find),
+    TEST_DECL(test_TLSX_SNI_GetSize_overflow),
     TEST_DECL(test_wolfSSL_wolfSSL_UseSecureRenegotiation),
     TEST_DECL(test_wolfSSL_SCR_Reconnect),
     TEST_DECL(test_wolfSSL_SCR_check_enabled),

--- a/tests/api/test_tls_ext.h
+++ b/tests/api/test_tls_ext.h
@@ -27,5 +27,6 @@ int test_wolfSSL_DisableExtendedMasterSecret(void);
 int test_certificate_authorities_certificate_request(void);
 int test_certificate_authorities_client_hello(void);
 int test_TLSX_TCA_Find(void);
+int test_TLSX_SNI_GetSize_overflow(void);
 
 #endif /* TESTS_API_TEST_TLS_EMS_H */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3169,6 +3169,9 @@ struct TLSX {
     struct TLSX* next; /* List Behavior   */
 };
 
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define TLSX_Find wolfSSL_TLSX_Find
+#endif
 WOLFSSL_TEST_VIS TLSX* TLSX_Find(TLSX* list, TLSX_Type type);
 WOLFSSL_LOCAL void  TLSX_Remove(TLSX** list, TLSX_Type type, void* heap);
 WOLFSSL_LOCAL void  TLSX_FreeAll(TLSX* list, void* heap);
@@ -3237,6 +3240,9 @@ WOLFSSL_LOCAL int TLSX_UseSNI(TLSX** extensions, byte type, const void* data,
 WOLFSSL_LOCAL byte TLSX_SNI_Status(TLSX* extensions, byte type);
 WOLFSSL_LOCAL word16 TLSX_SNI_GetRequest(TLSX* extensions, byte type,
                                                 void** data, byte ignoreStatus);
+#ifdef WOLFSSL_API_PREFIX_MAP
+    #define TLSX_SNI_GetSize wolfSSL_TLSX_SNI_GetSize
+#endif
 WOLFSSL_TEST_VIS word16 TLSX_SNI_GetSize(SNI* list);
 
 #ifndef NO_WOLFSSL_SERVER

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3169,7 +3169,7 @@ struct TLSX {
     struct TLSX* next; /* List Behavior   */
 };
 
-WOLFSSL_LOCAL TLSX* TLSX_Find(TLSX* list, TLSX_Type type);
+WOLFSSL_TEST_VIS TLSX* TLSX_Find(TLSX* list, TLSX_Type type);
 WOLFSSL_LOCAL void  TLSX_Remove(TLSX** list, TLSX_Type type, void* heap);
 WOLFSSL_LOCAL void  TLSX_FreeAll(TLSX* list, void* heap);
 WOLFSSL_LOCAL int   TLSX_SupportExtensions(WOLFSSL* ssl);
@@ -3237,6 +3237,7 @@ WOLFSSL_LOCAL int TLSX_UseSNI(TLSX** extensions, byte type, const void* data,
 WOLFSSL_LOCAL byte TLSX_SNI_Status(TLSX* extensions, byte type);
 WOLFSSL_LOCAL word16 TLSX_SNI_GetRequest(TLSX* extensions, byte type,
                                                 void** data, byte ignoreStatus);
+WOLFSSL_TEST_VIS word16 TLSX_SNI_GetSize(SNI* list);
 
 #ifndef NO_WOLFSSL_SERVER
 WOLFSSL_LOCAL void   TLSX_SNI_SetOptions(TLSX* extensions, byte type,


### PR DESCRIPTION
# Description

Three GetSize functions in src/tls.c use word16 (16-bit) variables to accumulate extension sizes in loops. With enough extensions, the value wraps past 65535 back to a small number, causing under-allocation of buffers.

Fix applied to all three functions:

* `TLSX_SNI_GetSize()`
* `TLSX_CSR_GetSize_ex()`
* `TLSX_CSR2_GetSize()`

Fixes zd21239

# Testing

Added test case `test_TLSX_SNI_GetSize_overflow`

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation

Credit for finding issue to:
```
Muhammad Arya Arjuna (pelioro)
```
