### PR TITLE
Wdeclaration-after-statement fixes

### DIFF
--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -19,6 +19,8 @@ jobs:
         config: [
           # Add new configs here
           '--enable-rsa --enable-keygen --disable-dh CFLAGS="-DWOLFSSL_NO_MALLOC -DRSA_MIN_SIZE=1024 -pedantic -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE"',
+          '--enable-ecc --enable-rsa --enable-keygen --enable-ed25519 --enable-curve25519 --enable-ed448 --enable-curve448 --enable-mlkem CFLAGS="-DWOLFSSL_NO_MALLOC -pedantic -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE"',
+          '--enable-ecc --enable-rsa --enable-keygen --enable-ed25519 --enable-curve25519 --enable-ed448 --enable-curve448 --enable-mlkem --enable-staticmemory CFLAGS="-DWOLFSSL_NO_MALLOC -pedantic -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE"',
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -909,6 +909,10 @@ int SuiteTest(int argc, char** argv)
     char argv0[3][80];
     char* myArgv[3];
 
+#ifdef WOLFSSL_STATIC_MEMORY
+    byte memory[200000];
+#endif
+
     printf(" Begin Cipher Suite Tests\n");
 
     /* setup */
@@ -917,10 +921,6 @@ int SuiteTest(int argc, char** argv)
     myArgv[2] = argv0[2];
     args.argv = myArgv;
     XSTRLCPY(argv0[0], "SuiteTest", sizeof(argv0[0]));
-
-#ifdef WOLFSSL_STATIC_MEMORY
-    byte memory[200000];
-#endif
 
     cipherSuiteCtx = wolfSSL_CTX_new(wolfSSLv23_client_method());
     if (cipherSuiteCtx == NULL) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -21039,7 +21039,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memory_test(void)
 {
     wc_test_ret_t ret = 0;
     word32 j = 0; /* used in embedded const pointer test */
-    WOLFSSL_ENTER("memory_test");
 
 #if defined(COMPLEX_MEM_TEST) || defined(WOLFSSL_STATIC_MEMORY)
     int i;
@@ -21052,6 +21051,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memory_test(void)
               /* pad to account for if head of buffer is not at set memory
                * alignment when tests are ran */
 #endif
+
+    WOLFSSL_ENTER("memory_test");
 
 #ifdef WOLFSSL_STATIC_MEMORY
     /* check macro settings */


### PR DESCRIPTION
Minor fixes for `-Wdeclaration-after-statement` fixes and `WOLFSSL_STATIC_MEMORY` usage, identified while working on https://github.com/wolfSSL/wolfHSM/pull/291.
