### PR TITLE
Fix cert chain size issue

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -4831,7 +4831,13 @@ static int wolfssl_add_to_chain(DerBuffer** chain, int weOwn, const byte* cert,
         /* Get length of previous chain. */
         len = oldChain->length;
     }
-    /* Allocate DER buffer bug enough to hold old and new certificates. */
+    /* Check for integer overflow in size calculation. */
+    if ((len > WOLFSSL_MAX_32BIT - CERT_HEADER_SZ) ||
+            (certSz > WOLFSSL_MAX_32BIT - CERT_HEADER_SZ - len)) {
+        WOLFSSL_MSG("wolfssl_add_to_chain overflow");
+        return 0;
+    }
+    /* Allocate DER buffer big enough to hold old and new certificates. */
     ret = AllocDer(&newChain, len + CERT_HEADER_SZ + certSz, CERT_TYPE, heap);
     if (ret != 0) {
         WOLFSSL_MSG("AllocDer error");

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -4835,13 +4835,16 @@ static int wolfssl_add_to_chain(DerBuffer** chain, int weOwn, const byte* cert,
     if ((len > WOLFSSL_MAX_32BIT - CERT_HEADER_SZ) ||
             (certSz > WOLFSSL_MAX_32BIT - CERT_HEADER_SZ - len)) {
         WOLFSSL_MSG("wolfssl_add_to_chain overflow");
-        return 0;
-    }
-    /* Allocate DER buffer big enough to hold old and new certificates. */
-    ret = AllocDer(&newChain, len + CERT_HEADER_SZ + certSz, CERT_TYPE, heap);
-    if (ret != 0) {
-        WOLFSSL_MSG("AllocDer error");
         res = 0;
+    }
+    if (res == 1) {
+        /* Allocate DER buffer big enough to hold old and new certificates. */
+        ret = AllocDer(&newChain, len + CERT_HEADER_SZ + certSz, CERT_TYPE,
+            heap);
+        if (ret != 0) {
+            WOLFSSL_MSG("AllocDer error");
+            res = 0;
+        }
     }
 
     if (res == 1) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -3554,6 +3554,9 @@ static int test_wolfSSL_add_to_chain_overflow(void)
         }
         ctx->certChain = fakeChain;
     }
+    else {
+        XFREE(fakeChain, ctx ? ctx->heap : NULL, DYNAMIC_TYPE_CERT);
+    }
 
     /* Try to add another cert - this MUST fail due to overflow guard. */
     ExpectNotNull(x509 = wolfSSL_X509_load_certificate_file(


### PR DESCRIPTION
# Description

In `wolfssl_add_to_chain`, the calculation len + CERT_HEADER_SZ + certSz uses word32, which could cause an overflow

Fixes zd21241

# Testing

Added test case `test_wolfSSL_add_to_chain_overflow` 

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
