### PR TITLE
Fix prefix for WC_ALL_ARGS_NOT_NULL

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -3032,9 +3032,8 @@ WC_ALL_ARGS_NOT_NULL static WARN_UNUSED_RESULT int AesEncrypt_preFetchOpt(
 #else
 #define AesEncrypt_preFetchOpt(aes, inBlock, outBlock, prefetch_ptr) \
     wc_AesEncrypt(aes, inBlock, outBlock)
-static WARN_UNUSED_RESULT int wc_AesEncrypt(
+WC_ALL_ARGS_NOT_NULL static WARN_UNUSED_RESULT int wc_AesEncrypt(
     Aes* aes, const byte* inBlock, byte* outBlock)
-    WC_ALL_ARGS_NOT_NULL
 #endif
 {
 #if defined(MAX3266X_AES)


### PR DESCRIPTION
# Description

Fixes issue introduced by https://github.com/wolfSSL/wolfssl/pull/9797

Found with config:
```
--disable-oldtls --enable-debug --enable-debug-code-points --enable-debug-trace-errcodes --enable-tls13 --enable-sha512 --enable-sha3 --enable-curve25519 --enable-rsapss --enable-aes-bitsliced --enable-keygen --enable-opensslextra --enable-earlydata --enable-psk --enable-tlsx --enable-aesni --enable-intelasm --enable-keylog-export
```

# Testing

Clean build

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
