### PR TITLE
Fix DRBG_internal alloc in wc_RNG_HealthTestLocal

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1735,7 +1735,7 @@ static int wc_RNG_HealthTestLocal(WC_RNG* rng, int reseed, void* heap,
 
     WC_ALLOC_VAR_EX(check, byte, RNG_HEALTH_TEST_CHECK_SIZE, heap,
         DYNAMIC_TYPE_TMP_BUFFER, return MEMORY_E);
-    WC_ALLOC_VAR_EX(drbg, DRBG_internal, sizeof(DRBG_internal), heap,
+    WC_ALLOC_VAR_EX(drbg, DRBG_internal, 1, heap,
         DYNAMIC_TYPE_TMP_BUFFER, WC_DO_NOTHING);
     #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
     if (drbg == NULL) {


### PR DESCRIPTION
# Description

Fix allocation of `DRBG_internal` to 1 element of `DRBG_internal`

Fixes #9846 

# Testing

Confirmed visually

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
