### PR TITLE
Fix for loop exit condition.

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1910,7 +1910,7 @@ static int TLSX_ALPN_ParseAndSet(WOLFSSL *ssl, const byte *input, word16 length,
         return BUFFER_ERROR;
 
     /* validating length of entries before accepting */
-    for (s = input + offset; (s - input) < size; s += wlen) {
+    for (s = input + offset; (s - input) < length; s += wlen) {
         wlen = *s++;
         if (wlen == 0 || (s + wlen - input) > length)
             return BUFFER_ERROR;


### PR DESCRIPTION
size should be length.  
s includes offset, so it must be compared against length, not size.
This is because size is only what is after offset.

Fixes ZD 21271