### PR TITLE
Fix sniffer CreateSession

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -5244,6 +5244,7 @@ static SnifferSession* CreateSession(IpInfo* ipInfo, TcpInfo* tcpInfo,
         }
         if (HashInit(newHash) != 0) {
             SetError(EXTENDED_MASTER_HASH_STR, error, NULL, 0);
+            XFREE(newHash, NULL, DYNAMIC_TYPE_HASHES);
             XFREE(session, NULL, DYNAMIC_TYPE_SNIFFER_SESSION);
             return NULL;
         }


### PR DESCRIPTION
# Description

Added `XFREE(newHash, NULL, DYNAMIC_TYPE_HASHES)` in the `HashInit` failure path, before freeing session.

Fixes f19

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
