### PR TITLE
Add null check in wolfSSL_EVP_PKEY_encrypt_init / _decrypt_init

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3152,8 +3152,8 @@ int wolfSSL_EVP_PKEY_decrypt(WOLFSSL_EVP_PKEY_CTX *ctx,
  */
 int wolfSSL_EVP_PKEY_decrypt_init(WOLFSSL_EVP_PKEY_CTX *ctx)
 {
-    if (ctx == NULL || ctx->pkey == NULL) return WOLFSSL_FAILURE;
     WOLFSSL_ENTER("wolfSSL_EVP_PKEY_decrypt_init");
+    if (ctx == NULL || ctx->pkey == NULL) return WOLFSSL_FAILURE;
     switch (ctx->pkey->type) {
     case WC_EVP_PKEY_RSA:
         ctx->op = WC_EVP_PKEY_OP_DECRYPT;
@@ -3256,8 +3256,8 @@ int wolfSSL_EVP_PKEY_encrypt(WOLFSSL_EVP_PKEY_CTX *ctx,
  */
 int wolfSSL_EVP_PKEY_encrypt_init(WOLFSSL_EVP_PKEY_CTX *ctx)
 {
-    if (ctx == NULL || ctx->pkey == NULL) return WOLFSSL_FAILURE;
     WOLFSSL_ENTER("wolfSSL_EVP_PKEY_encrypt_init");
+    if (ctx == NULL || ctx->pkey == NULL) return WOLFSSL_FAILURE;
 
     switch (ctx->pkey->type) {
     case WC_EVP_PKEY_RSA:

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3152,7 +3152,7 @@ int wolfSSL_EVP_PKEY_decrypt(WOLFSSL_EVP_PKEY_CTX *ctx,
  */
 int wolfSSL_EVP_PKEY_decrypt_init(WOLFSSL_EVP_PKEY_CTX *ctx)
 {
-    if (ctx == NULL) return WOLFSSL_FAILURE;
+    if (ctx == NULL || ctx->pkey == NULL) return WOLFSSL_FAILURE;
     WOLFSSL_ENTER("wolfSSL_EVP_PKEY_decrypt_init");
     switch (ctx->pkey->type) {
     case WC_EVP_PKEY_RSA:
@@ -3256,7 +3256,7 @@ int wolfSSL_EVP_PKEY_encrypt(WOLFSSL_EVP_PKEY_CTX *ctx,
  */
 int wolfSSL_EVP_PKEY_encrypt_init(WOLFSSL_EVP_PKEY_CTX *ctx)
 {
-    if (ctx == NULL) return WOLFSSL_FAILURE;
+    if (ctx == NULL || ctx->pkey == NULL) return WOLFSSL_FAILURE;
     WOLFSSL_ENTER("wolfSSL_EVP_PKEY_encrypt_init");
 
     switch (ctx->pkey->type) {


### PR DESCRIPTION
# Description

Add null check in wolfSSL_EVP_PKEY_encrypt_init / _decrypt_init

Fixes f276 and f277

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
