### PR TITLE
Fix wc_ecc_sign_hash_ex with Intel QA

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7437,7 +7437,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 
        #ifndef HAVE_CAVIUM_V
            mp_clear(e);
-           mp_clear(k);
+           mp_forcezero(k);
        #endif
            wc_ecc_curve_free(curve);
            FREE_CURVE_SPECS();


### PR DESCRIPTION
# Description

Fix `wc_ecc_sign_hash_ex` with Intel QA

Fixes f379

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
