### PR TITLE
Hardening in GeneratePrivateDh186 and wc_DhImportKeyPair

### DIFF
--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -2404,7 +2404,7 @@ int wc_DhImportKeyPair(DhKey* key, const byte* priv, word32 privSz,
     }
     if (havePriv) {
         if (mp_read_unsigned_bin(&key->priv, priv, privSz) != MP_OKAY) {
-            mp_clear(&key->priv);
+            mp_forcezero(&key->priv);
             havePriv = 0;
         } else {
             WOLFSSL_MSG("DH Private Key Set");

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -1157,8 +1157,9 @@ static int GeneratePrivateDh186(DhKey* key, WC_RNG* rng, byte* priv,
         if (err == MP_OKAY)
             err = mp_read_unsigned_bin(tmpX, cBuf, cSz);
         if (err != MP_OKAY) {
-            mp_clear(tmpX);
+            mp_forcezero(tmpX);
             mp_clear(tmpQ);
+            ForceZero(cBuf, cSz);
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
             XFREE(cBuf, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmpQ, key->heap, DYNAMIC_TYPE_DH);


### PR DESCRIPTION
# Description

Use force zero to harden operations in DH component.

Fixes:
* f283
* f287

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
