### PR TITLE
QUIC transport parameters are carried in the ClientHello and the EncryptedExtensions messages

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -16812,7 +16812,6 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
                 if (IsAtLeastTLSv1_3(ssl->version) &&
                         msgType != client_hello &&
-                        msgType != server_hello &&
                         msgType != encrypted_extensions) {
                     return EXT_NOT_ALLOWED;
                 }


### PR DESCRIPTION
F-298
