### PR TITLE
Fix DecodeSubjInfoAcc rejecting certs without id-ad-caRepository

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -22420,8 +22420,11 @@ static int DecodeSubjInfoAcc(const byte* input, word32 sz, DecodedCert* cert)
 
     if (cert->extSubjInfoAccCaRepo == NULL ||
             cert->extSubjInfoAccCaRepoSz == 0) {
-        WOLFSSL_MSG("SubjectInfoAccess missing an URL.");
-        ret = ASN_PARSE_E;
+        /* Not all SIA extensions contain id-ad-caRepository.  RFC 5280
+         * section 4.2.2.2 permits any access method; for example,
+         * ISO 15118-20 EV-charging PKI certificates carry only custom
+         * access-method OIDs.  Log a message but do not reject the cert. */
+        WOLFSSL_MSG("SubjectInfoAccess: no caRepository URI found.");
     }
 
     WOLFSSL_LEAVE("DecodeSubjInfoAcc", ret);


### PR DESCRIPTION
## Summary

`DecodeSubjInfoAcc()` currently returns `ASN_PARSE_E` when the Subject Information Access (SIA) extension does not contain an `id-ad-caRepository` (OID 1.3.6.1.5.5.7.48.5) access description. This is overly strict.

**RFC 5280 section 4.2.2.2** defines SIA as a `SEQUENCE OF AccessDescription` where each entry may use *any* access method OID — `id-ad-caRepository` is only one possibility. The existing code references the Federal PKI `fpki-x509-cert-profile-common` profile (section 5.3) which does require `caRepository`, but this is a profile-specific constraint, not an RFC 5280 requirement.

## Real-world impact

**ISO 15118-20** (Electric Vehicle charging) PKI certificates include SIA extensions with custom access-method OIDs defined under arc `2.40.246.14.20.0` (ISO/IEC 15118-20 Plug & Charge). These certificates are structurally valid per RFC 5280 but are rejected by wolfSSL with `ASN_PARSE_E`, preventing interoperability with ISO 15118-20 charging infrastructure.

This was discovered and validated on production EV charging equipment (SECC) parsing contract certificate chains from Keysight EV simulators.

## Change

When no `caRepository` URI is found in the SIA extension, log a debug message via `WOLFSSL_MSG()` but **do not** set `ret = ASN_PARSE_E`. The extension is still fully parsed and any `caRepository` entries that are present are still extracted — only the hard failure for missing entries is removed.

## Test plan

- Existing wolfSSL test suite should continue to pass (no test asserts `ASN_PARSE_E` for missing `caRepository`)
- Certificates with `id-ad-caRepository` in SIA continue to work identically
- Certificates with non-standard SIA access methods (e.g., ISO 15118-20) now parse successfully