### PR TITLE
Fix undefined variable tls1 in InitSuites for PSK cipher suite

### DIFF
--- a/.github/workflows/psk.yml
+++ b/.github/workflows/psk.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         config: [
           # Add new configs here
+          '--enable-psk C_EXTRA_FLAGS="-DWOLFSSL_STATIC_PSK -DWOLFSSL_OLDTLS_SHA2_CIPHERSUITES"',
           '--enable-psk C_EXTRA_FLAGS=-DWOLFSSL_STATIC_PSK --disable-rsa --disable-ecc --disable-dh',
           '--disable-oldtls --disable-tls13 --enable-psk -disable-rsa --disable-dh -disable-ecc --disable-asn C_EXTRA_FLAGS=-DWOLFSSL_STATIC_PSK --enable-lowresource --enable-singlethreaded --disable-asm --disable-errorstrings --disable-pkcs12 --disable-sha3 --disable-sha224 --disable-sha384 --disable-sha512 --disable-sha --disable-md5 -disable-aescbc --disable-chacha --disable-poly1305 --disable-coding --disable-sp-math-all',
           '--disable-oldtls --disable-tlsv12 --enable-tls13 --enable-psk -disable-rsa --disable-dh -disable-ecc --disable-asn C_EXTRA_FLAGS=-DWOLFSSL_STATIC_PSK --enable-lowresource --enable-singlethreaded --disable-asm --disable-errorstrings --disable-pkcs12 --disable-sha3 --disable-sha224 --disable-sha384 --disable-sha512 --disable-sha --disable-md5 -disable-aescbc --disable-chacha --disable-poly1305 --disable-coding --disable-sp-math-all'

--- a/src/internal.c
+++ b/src/internal.c
@@ -4250,7 +4250,7 @@ void InitSuites(Suites* suites, ProtocolVersion pv, int keySz, word16 haveRSA,
 #ifndef WOLFSSL_OLDTLS_SHA2_CIPHERSUITES
     if (tls1_2 && havePSK && haveAES128)
 #else
-    if (tls1 && havePSK && haveAES128)
+    if (tls && havePSK && haveAES128)
 #endif
     {
         suites->suites[idx++] = CIPHER_BYTE;


### PR DESCRIPTION
# Description

Fix undefined variable `tls1` in `InitSuites()` for the `BUILD_TLS_PSK_WITH_AES_128_CBC_SHA256` cipher suite.

The `WOLFSSL_OLDTLS_SHA2_CIPHERSUITES` `#else` branch at `src/internal.c:4253` referenced an undeclared variable `tls1` instead of `tls` — a copy-paste typo from commit a975ba9e97 (2019-07-18). This caused a compilation failure when both `WOLFSSL_STATIC_PSK` and `WOLFSSL_OLDTLS_SHA2_CIPHERSUITES` were defined. In the default build the buggy line was dead code with no impact.

Also adds a CI matrix entry in `.github/workflows/psk.yml` to build with `WOLFSSL_OLDTLS_SHA2_CIPHERSUITES` enabled to prevent regressions.

# Testing

- Configured with `./configure --enable-psk CFLAGS="-DWOLFSSL_STATIC_PSK -DWOLFSSL_OLDTLS_SHA2_CIPHERSUITES"`
- Verified compilation fails **before** the fix and succeeds **after**
- Confirmed the fix is consistent with all other `WOLFSSL_OLDTLS_SHA2_CIPHERSUITES` else-branches in `InitSuites()`

# Checklist

- [x] added tests (CI config in `.github/workflows/psk.yml`)
- [ ] updated/added doxygen (N/A — no API change)
- [ ] updated appropriate READMEs (N/A)
- [ ] Updated manual and documentation (N/A)