### PR TITLE
Fix buffer overflow in wc_HpkeLabeledExtract via oversized ECH

### DIFF
--- a/src/ssl_ech.c
+++ b/src/ssl_ech.c
@@ -570,6 +570,13 @@ int SetEchConfigsEx(WOLFSSL_EchConfig** outputConfigs, void* heap,
         /* rawLen */
         workingConfig->rawLen = length + 4;
 
+        /* Reject configs whose raw encoding would overflow the fixed-size
+         * labeled_ikm buffer in wc_HpkeLabeledExtract */
+        if (workingConfig->rawLen > MAX_ECH_CONFIG_RAW_SZ) {
+            ret = BUFFER_E;
+            break;
+        }
+
         /* raw body */
         workingConfig->raw = (byte*)XMALLOC(workingConfig->rawLen,
             heap, DYNAMIC_TYPE_TMP_BUFFER);

--- a/src/tls.c
+++ b/src/tls.c
@@ -9986,6 +9986,10 @@ static int TLSX_KeyShare_ProcessPqcHybridClient(WOLFSSL* ssl,
         ssl->arrays->preMasterSz = ssSzEcc + ssSzPqc;
     }
 
+    if (ret != 0) {
+        ForceZero(ssl->arrays->preMasterSecret, ENCRYPT_LEN);
+    }
+
     TLSX_KeyShare_FreeAll(ecc_kse, ssl->heap);
     TLSX_KeyShare_FreeAll(pqc_kse, ssl->heap);
 

--- a/wolfcrypt/src/hpke.c
+++ b/wolfcrypt/src/hpke.c
@@ -473,6 +473,13 @@ static int wc_HpkeLabeledExtract(Hpke* hpke, byte* suite_id,
     WC_ALLOC_VAR_EX(labeled_ikm, byte, MAX_HPKE_LABEL_SZ, hpke->heap,
         DYNAMIC_TYPE_TMP_BUFFER, return MEMORY_E);
 
+    /* validate total size fits in the labeled_ikm buffer */
+    if (HPKE_VERSION_STR_LEN + suite_id_len + label_len + ikm_len
+            > MAX_HPKE_LABEL_SZ) {
+        WC_FREE_VAR_EX(labeled_ikm, hpke->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        return BUFFER_E;
+    }
+
     /* concat the labeled_ikm */
     /* version */
     XMEMCPY(labeled_ikm, HPKE_VERSION_STR, HPKE_VERSION_STR_LEN);
@@ -519,6 +526,14 @@ static int wc_HpkeLabeledExpand(Hpke* hpke, byte* suite_id, word32 suite_id_len,
 
     WC_ALLOC_VAR_EX(labeled_info, byte, MAX_HPKE_LABEL_SZ, hpke->heap,
         DYNAMIC_TYPE_TMP_BUFFER, return MEMORY_E);
+
+    /* validate total size fits in the labeled_info buffer
+     * total = I2OSP length prefix + version + suite_id + label + info */
+    if (HPKE_I2OSP_LEN_SZ + HPKE_VERSION_STR_LEN + suite_id_len + label_len
+            + infoSz > MAX_HPKE_LABEL_SZ) {
+        WC_FREE_VAR_EX(labeled_info, hpke->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        return BUFFER_E;
+    }
 
     /* copy length */
     ret = I2OSP((int)L, 2, labeled_info);

--- a/wolfssl/wolfcrypt/hpke.h
+++ b/wolfssl/wolfcrypt/hpke.h
@@ -86,6 +86,15 @@ extern const int hpkeSupportedAead[HPKE_SUPPORTED_AEAD_LEN];
 #define MAX_HPKE_LABEL_SZ 512
 #endif
 
+/* I2OSP encoded length prefix size in LabeledExpand (RFC 9180 Section 4) */
+#define HPKE_I2OSP_LEN_SZ 2
+
+/* Maximum raw ECH config length accepted by SetEchConfigsEx. The raw config
+ * is concatenated into a MAX_HPKE_LABEL_SZ buffer in wc_HpkeLabeledExtract
+ * along with version (7) + suite_id (HPKE_SUITE_ID_LEN) + label (~12) +
+ * TLS info prefix (8) overhead. */
+#define MAX_ECH_CONFIG_RAW_SZ (MAX_HPKE_LABEL_SZ - 50)
+
 typedef struct {
     void* heap;
     word32 kem;


### PR DESCRIPTION


SetEchConfigsEx accepted arbitrarily large ECH configs without bounds checking rawLen. This allowed attacker-controlled data (from DNS HTTPS records or TLS retry_configs) to overflow the fixed 512-byte labeled_ikm stack buffer in wc_HpkeLabeledExtract during ClientHello construction.

Add MAX_ECH_CONFIG_RAW_SZ to reject oversized configs at parse time, and add bounds checks in both wc_HpkeLabeledExtract and wc_HpkeLabeledExpand before writing into their fixed-size buffers.

Fixes ZD#21309