### PR TITLE
Fix Fenrir 376

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -33565,7 +33565,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der, RsaKey* rsaKey,
 
     if (rsaKey == NULL && eccKey == NULL && ed25519Key == NULL &&
         dsaKey == NULL && ed448Key == NULL && falconKey == NULL &&
-        falconKey == NULL) {
+        dilithiumKey == NULL && sphincsKey == NULL) {
         return PUBLIC_KEY_E;
     }
 


### PR DESCRIPTION
# Description

Fix copy-paste error in EncodeCertReq guard check where falconKey was checked twice instead of including dilithiumKey and sphincsKey