### PR TITLE
20260309 Coverity changes for Sunday build

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -28242,8 +28242,11 @@ static wc_test_ret_t openssl_aes_test(void)
         int  num = 0;
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        if ((enc == NULL) || (dec == NULL))
+        if ((enc == NULL) || (dec == NULL)) {
+            XFREE(enc, HEAP_HINT, DYNAMIC_TYPE_AES);
+            XFREE(dec, HEAP_HINT, DYNAMIC_TYPE_AES);
             return MEMORY_E;
+        }
 #endif
 
         XMEMCPY(iv, setIv, sizeof(setIv));


### PR DESCRIPTION
# Description

Resource leak - 330394: free enc and dec before returning

Resource leak - 330390: Return using ERROR_OUT instead of return ret

Use after free - 330389/330393: move `(void)` calls before freeing variables.

Wrong sizeof argument (SIZEOF_MISMATCH) - 330388: use `MAX_ECIES_TEST_SZ` instead of sizeof in `XSTRLCPY()`

# Testing

`./configure --enable-all && make check`
`./configure --enable-all --enable-smallstack && make check`

