### PR TITLE
Fixes from regression testing

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -2326,7 +2326,7 @@ int StoreCRL(WOLFSSL_CRL* crl, const char* file, int type)
 }
 #endif /* NO_FILESYSTEM */
 
-#if defined(OPENSSL_EXTRA)
+#if defined(OPENSSL_EXTRA) && !defined(NO_ASN_TIME)
 /* Create a new empty CRL object for generation.
  * Version is set to 2 by default. Use wolfSSL_X509_CRL_set_version() to
  * change it.
@@ -2601,6 +2601,8 @@ static int GetCrlSignBufSz(int tbsSz, int sigType, RsaKey* rsaKey,
     if (tbsSz <= 0)
         return BAD_FUNC_ARG;
 
+    (void)rsaKey;
+    (void)eccKey;
 #ifndef NO_RSA
     if (rsaKey != NULL) {
         sigSz = wc_RsaEncryptSize(rsaKey);
@@ -2666,8 +2668,8 @@ int wolfSSL_X509_CRL_sign(WOLFSSL_X509_CRL* crl, WOLFSSL_EVP_PKEY* pkey,
     }
 
     /* Determine signature type from digest and key type */
-#ifndef NO_RSA
     if (ret == WOLFSSL_SUCCESS) {
+#ifndef NO_RSA
         if (pkey->type == WC_EVP_PKEY_RSA) {
             if (md == wolfSSL_EVP_sha256()) {
                 sigType = CTC_SHA256wRSA;

--- a/src/internal.c
+++ b/src/internal.c
@@ -3159,6 +3159,9 @@ static void FreeCiphersSide(Ciphers *cipher, void* heap)
     XFREE(cipher->hmac, heap, DYNAMIC_TYPE_CIPHER);
     cipher->hmac = NULL;
 #endif
+
+    (void)cipher;
+    (void)heap;
 }
 
 /* Free ciphers */
@@ -8619,7 +8622,7 @@ void wolfSSL_ResourceFree(WOLFSSL* ssl)
     }
     FreeSuites(ssl);
     FreeHandshakeHashes(ssl);
-#ifdef HAVE_ECH
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     /* try to free the ech hashes in case we errored out */
     ssl->hsHashes = ssl->hsHashesEch;
     FreeHandshakeHashes(ssl);
@@ -39085,6 +39088,9 @@ static int AddPSKtoPreMasterSecret(WOLFSSL* ssl)
 #if defined(OPENSSL_ALL) && defined(KEEP_PEER_CERT) && \
     !defined(NO_CERT_IN_TICKET)
         internalTicketSz += peerCertSz;
+#endif
+#ifdef WOLFSSL_TICKET_ENC_CBC_HMAC
+        internalTicketSz = (internalTicketSz + 15) & (~0xf);
 #endif
         /* MAC is placed after the encrypted data */
         mac = et->enc_ticket + WOLFSSL_TICKET_ENC_SZ;

--- a/tests/api.c
+++ b/tests/api.c
@@ -17494,7 +17494,7 @@ static int test_wolfSSL_d2i_SSL_SESSION_bounds_check(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && defined(HAVE_EXT_CACHE) && \
-    defined(SESSION_CERTS)
+    defined(SESSION_CERTS) && !defined(NO_SESSION_CACHE)
     WOLFSSL_SESSION* sess = NULL;
     WOLFSSL_SESSION* restored = NULL;
     unsigned char* sessDer = NULL;
@@ -21925,7 +21925,8 @@ static int test_wolfSSL_X509_CRL_reason_critical_boolean(void)
 
 #if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)) && !defined(NO_CERTS) && \
     defined(HAVE_CRL) && !defined(NO_FILESYSTEM) && \
-    !defined(NO_STDIO_FILESYSTEM) && defined(WOLFSSL_CERT_GEN)
+    !defined(NO_STDIO_FILESYSTEM) && defined(WOLFSSL_CERT_GEN) && \
+    !defined(NO_ASN_TIME)
 /* Helper function to create, sign, and write a CRL */
 static int generate_crl_test(const char* keyFile, const char* certFile,
                              const char* derFile, const char* pemFile,
@@ -22173,7 +22174,8 @@ static int test_sk_X509_CRL_encode(void)
     EXPECT_DECLS;
 #if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)) && !defined(NO_CERTS) && \
     defined(HAVE_CRL) && !defined(NO_FILESYSTEM) && \
-    !defined(NO_STDIO_FILESYSTEM) && defined(WOLFSSL_CERT_GEN)
+    !defined(NO_STDIO_FILESYSTEM) && defined(WOLFSSL_CERT_GEN) && \
+    !defined(NO_ASN_TIME)
 #ifndef NO_RSA
     static const char* crlRsaPemFile = "./certs/crl/crlRsaOut.pem";
     static const char* crlRsaDerFile = "./certs/crl/crlRsaOut.der";
@@ -22212,7 +22214,8 @@ static int test_wolfSSL_X509_CRL_sign_large(void)
     EXPECT_DECLS;
 #if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)) && !defined(NO_CERTS) && \
     defined(HAVE_CRL) && !defined(NO_FILESYSTEM) && \
-    !defined(NO_STDIO_FILESYSTEM) && defined(WOLFSSL_CERT_GEN)
+    !defined(NO_STDIO_FILESYSTEM) && defined(WOLFSSL_CERT_GEN) && \
+    !defined(NO_ASN_TIME)
 #ifndef NO_RSA
     static const char* testRsaKeyFile  = "./certs/ca-key.pem";
     static const char* testRsaCertFile = "./certs/ca-cert.pem";

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -2739,7 +2739,9 @@ int test_key_share_mismatch(void)
     EXPECT_DECLS;
 #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13) && \
     defined(HAVE_SUPPORTED_CURVES) && defined(HAVE_ECC) && \
-    defined(BUILD_TLS_AES_128_GCM_SHA256)
+    defined(BUILD_TLS_AES_128_GCM_SHA256) && (!defined(WOLFSSL_SP_MATH) || \
+    (defined(WOLFSSL_SP_521) && !defined(WOLFSSL_SP_NO_256) && \
+     defined(WOLFSSL_SP_384)))
     /* Taken from payload in https://github.com/wolfSSL/wolfssl/issues/9362 */
     const byte ch1_bin[] = {
         0x16, 0x03, 0x03, 0x00, 0x96, 0x01, 0x00, 0x00, 0x92, 0x03, 0x03, 0x01,

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -5452,8 +5452,13 @@ static sword32 dilithium_mont_red(sword64 a)
 #endif
 }
 
-#if !defined(WOLFSSL_DILITHIUM_SMALL) || !defined(WOLFSSL_DILITHIUM_NO_SIGN)
-
+#if !defined(WOLFSSL_DILITHIUM_SMALL) || \
+    (!defined(WOLFSSL_DILITHIUM_NO_SIGN) || \
+     (defined(WOLFSSL_DILITHIUM_SMALL) && \
+      (!defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) || \
+       (!defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
+        !defined(WOLFSSL_DILITHIUM_VERIFY_SMALL_MEM)) || \
+       defined(WOLFSSL_DILITHIUM_CHECK_KEY))))
 /* Reduce 32-bit a modulo q. r = a mod q.
  *
  * Barrett reduction.
@@ -5470,8 +5475,7 @@ static sword32 dilithium_red(sword32 a)
     return (sword32)(a - (t << 23) + (t << 13) - t);
 #endif
 }
-
-#endif /* !WOLFSSL_DILITHIUM_SMALL || !WOLFSSL_DILITHIUM_NO_SIGN */
+#endif
 
 /* Zetas for NTT. */
 static const sword32 zetas[DILITHIUM_N] = {
@@ -7287,7 +7291,12 @@ static void dilithium_vec_mul(sword32* r, sword32* a, sword32* b, byte l)
 #endif
 #endif
 
-#ifndef WOLFSSL_DILITHIUM_NO_SIGN
+#if !defined(WOLFSSL_DILITHIUM_NO_SIGN) || \
+    (defined(WOLFSSL_DILITHIUM_SMALL) && \
+     (!defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) || \
+      (!defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
+       !defined(WOLFSSL_DILITHIUM_VERIFY_SMALL_MEM)) || \
+      defined(WOLFSSL_DILITHIUM_CHECK_KEY)))
 /* Modulo reduce values in polynomial. Range (-2^31)..(2^31-1).
  *
  * @param [in, out] a  Polynomial.
@@ -7331,6 +7340,13 @@ static void dilithium_poly_red(sword32* a)
     }
 }
 
+#if (defined(WOLFSSL_DILITHIUM_SMALL) && \
+     (!defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) || \
+      (!defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
+       !defined(WOLFSSL_DILITHIUM_VERIFY_SMALL_MEM)) || \
+      defined(WOLFSSL_DILITHIUM_CHECK_KEY))) || \
+    (!defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
+     !defined(WOLFSSL_DILITHIUM_SIGN_SMALL_MEM))
 /* Modulo reduce values in polynomials of vector. Range (-2^31)..(2^31-1).
  *
  * @param [in, out] a  Vector of polynomials.
@@ -7345,7 +7361,8 @@ static void dilithium_vec_red(sword32* a, byte l)
         a += DILITHIUM_N;
     }
 }
-#endif /* !WOLFSSL_DILITHIUM_NO_SIGN */
+#endif
+#endif
 
 #if (!defined(WOLFSSL_DILITHIUM_NO_SIGN) || \
      (!defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -3155,7 +3155,7 @@ static int PKCS7_EncodeSigned(wc_PKCS7* pkcs7,
             idx = ret;
             goto out;
         }
-#if defined(WC_RSA_PSS)
+#if !defined(NO_RSA) && defined(WC_RSA_PSS)
         if (digEncAlgoId == CTC_RSASSAPSS) {
             /* Salt length policy: always encode as hash digest length.
              * This is the common CMS/RFC 4055 profile and matches OpenSSL

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3027,9 +3027,6 @@ typedef enum {
     #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
     TLSX_SIGNATURE_ALGORITHMS_CERT  = TLSXT_SIGNATURE_ALGORITHMS_CERT,
     #endif
-    #if defined(WOLFSSL_DTLS_CID)
-    TLSX_CONNECTION_ID              = TLSXT_CONNECTION_ID,
-    #endif /* defined(WOLFSSL_DTLS_CID) */
     #ifdef WOLFSSL_QUIC
     TLSX_KEY_QUIC_TP_PARAMS         = TLSXT_KEY_QUIC_TP_PARAMS,
     #endif
@@ -3037,6 +3034,9 @@ typedef enum {
     TLSX_ECH                        = TLSXT_ECH,
     #endif
 #endif
+#if defined(WOLFSSL_DTLS_CID)
+    TLSX_CONNECTION_ID              = TLSXT_CONNECTION_ID,
+#endif /* defined(WOLFSSL_DTLS_CID) */
 #if defined(WOLFSSL_TLS13) || !defined(WOLFSSL_NO_TLS12) || !defined(NO_OLD_TLS)
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
     TLSX_PRE_SHARED_KEY             = TLSXT_PRE_SHARED_KEY,


### PR DESCRIPTION
# Description

CRL APIs not usable when NO_ASN_TIME defined.
WOLFSSL_TLS13 needs to be defined with HAVE_ECH.
When session ticket encrypted with CBC, must be a multiple of block size. Fix test define protection.
Fix ML-DSA protection of reduction functions.
Need !NO_RSA with WC_RSA_PSS.
Connection ID is not a DTLS 1.3 only extension.

# Testing

Regression testing.
