### PR TITLE
Fix pathlen not copied in ASN1_OBJECT_dup and not marked set in X509_add_ext

### DIFF
--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -2026,9 +2026,17 @@ WOLFSSL_ASN1_OBJECT* wolfSSL_ASN1_OBJECT_dup(WOLFSSL_ASN1_OBJECT* obj)
         dupl->objSz = obj->objSz;
     #ifdef OPENSSL_EXTRA
         dupl->ca    = obj->ca;
+        if (obj->pathlen != NULL) {
+            dupl->pathlen = wolfSSL_ASN1_INTEGER_dup(obj->pathlen);
+            if (dupl->pathlen == NULL) {
+                WOLFSSL_MSG("ASN1 pathlen alloc error");
+                wolfSSL_ASN1_OBJECT_free(dupl);
+                dupl = NULL;
+            }
+        }
     #endif
         /* Check for encoding. */
-        if (obj->obj) {
+        if (dupl != NULL && obj->obj) {
             /* Allocate memory for ASN.1 OBJECT_ID DER encoding. */
             dupl->obj = (const unsigned char*)XMALLOC(obj->objSz, NULL,
                 DYNAMIC_TYPE_ASN1);

--- a/src/x509.c
+++ b/src/x509.c
@@ -1357,6 +1357,7 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext,
             if (ext->obj->pathlen) {
                 x509->pathLength = (word32)ext->obj->pathlen->length;
                 x509->basicConstPlSet = 1;
+                x509->pathLengthSet = 1;
             }
             x509->basicConstSet = 1;
         }

--- a/tests/api/test_ossl_asn1.c
+++ b/tests/api/test_ossl_asn1.c
@@ -870,6 +870,37 @@ int test_wolfSSL_ASN1_OBJECT(void)
     s.objSz = sizeof(der);
     ExpectNotNull(a = wolfSSL_ASN1_OBJECT_dup(&s));
     ASN1_OBJECT_free(a);
+    a = NULL;
+    ASN1_OBJECT_free(&s);
+
+    /* Test dup copies pathlen when set */
+    XMEMSET(&s, 0, sizeof(ASN1_OBJECT));
+    s.type = NID_basic_constraints;
+    s.ca = 1;
+    s.pathlen = wolfSSL_ASN1_INTEGER_new();
+    ExpectNotNull(s.pathlen);
+    if (s.pathlen != NULL) {
+        s.pathlen->length = 5;
+    }
+    ExpectNotNull(a = wolfSSL_ASN1_OBJECT_dup(&s));
+    if (a != NULL) {
+        ExpectIntEQ(a->ca, 1);
+        ExpectNotNull(a->pathlen);
+        if (a->pathlen != NULL) {
+            ExpectIntEQ(a->pathlen->length, 5);
+        }
+    }
+    ASN1_OBJECT_free(a);
+    a = NULL;
+
+    /* Test dup with NULL pathlen leaves it NULL */
+    wolfSSL_ASN1_INTEGER_free(s.pathlen);
+    s.pathlen = NULL;
+    ExpectNotNull(a = wolfSSL_ASN1_OBJECT_dup(&s));
+    if (a != NULL) {
+        ExpectNull(a->pathlen);
+    }
+    ASN1_OBJECT_free(a);
     ASN1_OBJECT_free(&s);
 #endif /* OPENSSL_EXTRA */
     return EXPECT_RESULT();

--- a/tests/api/test_ossl_x509_ext.c
+++ b/tests/api/test_ossl_x509_ext.c
@@ -282,6 +282,7 @@ static int test_X509_add_basic_constraints(WOLFSSL_X509* x509)
     ExpectIntEQ(wolfSSL_X509_add_ext(x509, ext, -1), WOLFSSL_SUCCESS);
     ExpectIntEQ(x509->isCa, 0);
     ExpectIntEQ(x509->pathLength, 2);
+    ExpectIntEQ(x509->pathLengthSet, 1);
     if (ext != NULL && ext->obj != NULL) {
         /* Add second time to without path length. */
         ext->obj->ca = 1;
@@ -290,6 +291,7 @@ static int test_X509_add_basic_constraints(WOLFSSL_X509* x509)
     ExpectIntEQ(wolfSSL_X509_add_ext(x509, ext, -1), WOLFSSL_SUCCESS);
     ExpectIntEQ(x509->isCa, 1);
     ExpectIntEQ(x509->pathLength, 2);
+    ExpectIntEQ(x509->pathLengthSet, 1);
     ExpectIntEQ(wolfSSL_X509_get_isSet_pathLength(NULL), 0);
     ExpectIntEQ(wolfSSL_X509_get_isSet_pathLength(x509), 1);
     ExpectIntEQ(wolfSSL_X509_get_pathLength(NULL), 0);


### PR DESCRIPTION
# Description

This PR:
- Fixes `wolfSSL_ASN1_OBJECT_dup()` to duplicate the `pathlen` ASN1_INTEGER field, with cleanup on allocation failure.
- Fixes `wolfSSL_X509_add_ext()` to set `pathLengthSet = 1` when adding a basic constraints extension that includes a path length.

# Testing

Simple unit tests added. Originally caught when doing Java/JNI feature expansion work.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
