### PR TITLE
evp: check ivLen in wolfSSL_EVP_CIPHER_CTX_set_iv_length.

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -8449,10 +8449,15 @@ void wolfSSL_EVP_init(void)
                                              int ivLen)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_CIPHER_CTX_set_iv_length");
-        if (ctx)
-            ctx->ivSz= ivLen;
-        else
+        if (ctx == NULL) {
             return WOLFSSL_FAILURE;
+        }
+
+        if (ivLen < 0 || ivLen > (int) sizeof(ctx->iv)) {
+            return WOLFSSL_FAILURE;
+        }
+
+        ctx->ivSz = ivLen;
 
         return WOLFSSL_SUCCESS;
     }


### PR DESCRIPTION
## Description

Check input `ivLen` in wolfSSL_EVP_CIPHER_CTX_set_iv_length.

Fixes zd#21326.
