### PR TITLE
Ensure the length computed by CheckHeaders in the SSL sniffer does not exceed the actual size of the packets.

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -5521,7 +5521,7 @@ static int CheckHeaders(IpInfo* ipInfo, TcpInfo* tcpInfo, const byte* packet,
     *sslBytes = (int)(packet + ipInfo->total - *sslFrame);
 
     /* Ensure sslBytes does not exceed the actual size. */
-    if (*sslBytes > (int)(length - (*sslFrame - packet))) {
+    if (*sslBytes > (int)(length - (ipInfo->length + tcpInfo->length))) {
         SetError(PACKET_HDR_SHORT_STR, error, NULL, 0);
         return WOLFSSL_FATAL_ERROR;
     }


### PR DESCRIPTION
# Description

Fixes zd#21325

Thanks to Haruto Kimura (Stella) for the report.

# Testing

Provided reproducer + built in tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
