### PR TITLE
asn: add HAVE_OCSP_RESPONDER guard, to fix wolfboot build.

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -46194,6 +46194,7 @@ int wc_VerifyX509Acert(const byte* acert, word32 acertSz,
 
 #endif /* WOLFSSL_ACERT && WOLFSSL_ASN_TEMPLATE */
 
+#ifdef HAVE_OCSP_RESPONDER
 int AsnHashesHash(AsnHashes* hashes, const byte* data, word32 dataSz)
 {
     int ret = 0;
@@ -46264,6 +46265,7 @@ const byte* AsnHashesGetHash(const AsnHashes* hashes, int hashAlg, int* size)
             return NULL;
     }
 }
+#endif /* HAVE_OCSP_RESPONDER */
 
 #ifdef WOLFSSL_SEP
 


### PR DESCRIPTION
## Description

Add `HAVE_OCSP_RESPONDER` define guard around  `int AsnHashesHash(` and friends in `asn.c`. These functions are only used with the OCSP responder.

Fixes wolfboot build with wolfssl master.

## Testing

Build wolfboot sim example with `lib/wolfssl` set to master.

```
cp config/examples/sim.config .config
make distclean; make
```
