### PR TITLE
minor coverity fixes for tls ech code

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5094,10 +5094,10 @@ static int EchCheckAcceptance(WOLFSSL* ssl, byte* label, word16 labelSz,
     ret = EchCalcAcceptance(ssl, label, labelSz, input, acceptOffset, helloSz,
             msgType == hello_retry_request, acceptConfirmation);
 
-    tmpHashes = ssl->hsHashes;
-    ssl->hsHashes = ssl->hsHashesEch;
-
     if (ret == 0) {
+        tmpHashes = ssl->hsHashes;
+        ssl->hsHashes = ssl->hsHashesEch;
+
         /* last 8 bytes must match the expand output */
         ret = ConstantCompare(acceptConfirmation, input + acceptOffset,
             ECH_ACCEPT_CONFIRMATION_SZ);
@@ -5126,9 +5126,10 @@ static int EchCheckAcceptance(WOLFSSL* ssl, byte* label, word16 labelSz,
             FreeHandshakeHashes(ssl);
             ssl->hsHashesEch = NULL;
         }
+
+        ssl->hsHashes = tmpHashes;
     }
 
-    ssl->hsHashes = tmpHashes;
     return ret;
 }
 #endif /* HAVE_ECH */
@@ -6806,25 +6807,28 @@ static int EchWriteAcceptance(WOLFSSL* ssl, byte* label, word16 labelSz,
             helloSz - headerSz, msgType == hello_retry_request,
             output + acceptOffset);
 
-    tmpHashes = ssl->hsHashes;
-    ssl->hsHashes = ssl->hsHashesEch;
+    if (ret == 0) {
+        tmpHashes = ssl->hsHashes;
+        ssl->hsHashes = ssl->hsHashesEch;
 
-    /* after HRR, hsHashesEch must contain:
-     * message_hash(ClientHelloInner1) || HRR (actual, not zeros) */
-    if (ret == 0 && msgType == hello_retry_request) {
-        ret = HashRaw(ssl, output, helloSz);
-    }
-    /* normal TLS code will calculate transcript of ServerHello */
-    else if (ret == 0) {
-        ssl->options.echAccepted = 1;
+        /* after HRR, hsHashesEch must contain:
+         * message_hash(ClientHelloInner1) || HRR (actual, not zeros) */
+        if (msgType == hello_retry_request) {
+            ret = HashRaw(ssl, output, helloSz);
+        }
+        /* normal TLS code will calculate transcript of ServerHello */
+        else {
+            ssl->options.echAccepted = 1;
+
+            ssl->hsHashes = tmpHashes;
+            FreeHandshakeHashes(ssl);
+            tmpHashes = ssl->hsHashesEch;
+            ssl->hsHashesEch = NULL;
+        }
 
         ssl->hsHashes = tmpHashes;
-        FreeHandshakeHashes(ssl);
-        tmpHashes = ssl->hsHashesEch;
-        ssl->hsHashesEch = NULL;
     }
 
-    ssl->hsHashes = tmpHashes;
     return ret;
 }
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -13818,7 +13818,8 @@ static THREAD_RETURN WOLFSSL_THREAD server_task_ech(void* args)
     if (callbacks->ctx_ready)
         callbacks->ctx_ready(ctx);
 
-    AssertNotNull(ssl = wolfSSL_new(ctx));
+    ssl = wolfSSL_new(ctx);
+    AssertNotNull(ssl);
 
     /* set the sni for the server */
     AssertIntEQ(WOLFSSL_SUCCESS,

--- a/wolfcrypt/src/hpke.c
+++ b/wolfcrypt/src/hpke.c
@@ -472,7 +472,7 @@ static int wc_HpkeLabeledExtract(Hpke* hpke, byte* suite_id,
     }
 
     /* check that sum of len's will not overflow */
-    remaining = MAX_HPKE_LABEL_SZ;
+    remaining = (word32)MAX_HPKE_LABEL_SZ;
     if ((word32)HPKE_VERSION_STR_LEN > remaining) {
         return BUFFER_E;
     }
@@ -541,16 +541,11 @@ static int wc_HpkeLabeledExpand(Hpke* hpke, byte* suite_id, word32 suite_id_len,
     }
 
     /* check that sum of len's will not overflow */
-    remaining = MAX_HPKE_LABEL_SZ;
-    if (2U > remaining){
+    remaining = (word32)MAX_HPKE_LABEL_SZ;
+    if (2U + (word32)HPKE_VERSION_STR_LEN > remaining) {
         return BUFFER_E;
     }
-    remaining -= 2U;
-
-    if ((word32)HPKE_VERSION_STR_LEN > remaining) {
-        return BUFFER_E;
-    }
-    remaining -= (word32)HPKE_VERSION_STR_LEN;
+    remaining -= 2U + (word32)HPKE_VERSION_STR_LEN;
 
     if (suite_id_len > remaining) {
         return BUFFER_E;


### PR DESCRIPTION
# Description

hsHashes pointer was being cached and restored even on error. A free'd pointer was never accessed but it does waste cycles. Moved both instances of this inside an `if` block.

Assert macro in tests/api.c was flagged as potentially removing the assignment. Broke the assignment out and asserted after.

Deadcode in hpke overflow checks. ~Used~ `wc_static_assert` ~macro to check constant lengths at compile time rather than runtime.~ Combined two constant checks in `wc_HpkeLabeledExpand` into one check and left `wc_HpkeLabeledExtract` alone. Didn't use `wc_static_assert` since it causes issues.

Fixes several coverity issues.

# Testing

Simple changes that shouldn't change any overarching logic. Just did a `make check`.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
