### PR TITLE
use heap hint with dilithium benchmark

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -15474,9 +15474,9 @@ void bench_dilithiumKeySign(byte level)
     }
 #endif
 
-    ret = wc_dilithium_init(key);
+    ret = wc_dilithium_init_ex(key, HEAP_HINT, devId);
     if (ret != 0) {
-        printf("wc_dilithium_init failed %d\n", ret);
+        printf("wc_dilithium_init_ex failed %d\n", ret);
         goto out;
     }
 


### PR DESCRIPTION
The was found when answering a direct email support question about ml-dsa with static memory. I tested with the configure `./configure --enable-mldsa --enable-mlkem --enable-staticmemory CPPFLAGS="-DBENCH_EMBEDDED -DWOLFSSL_NO_MALLOC -DWOLFMEM_DIST=49,10,6,14,5,6,16,1,1 -DWOLFMEM_BUCKETS=64,128,256,512,1024,2432,4096,8192,131072 -DWOLFSSL_DEBUG_MEMORY -DWOLFSSL_DEBUG_MEMORY_PRINT -DWOLFSSL_STATIC_MEMORY_TEST_SZ=200000" && make && ./wolfcrypt/benchmark/benchmark -ml-dsa`