### PR TITLE
Fix wolfSSL_get_ciphers_compat() to return NULL for empty cipher list

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16098,6 +16098,12 @@ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
                 break;
             }
         }
+
+        /* If no ciphers were added, free empty stack and return NULL */
+        if (ssl->suitesStack != NULL && wolfSSL_sk_num(ssl->suitesStack) == 0) {
+            wolfSSL_sk_CIPHER_free(ssl->suitesStack);
+            ((WOLFSSL*)ssl)->suitesStack = NULL;
+        }
     }
     return ssl->suitesStack;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -19272,6 +19272,39 @@ static int test_wolfSSL_get_ciphers_compat(void)
     return EXPECT_RESULT();
 }
 
+/* Test that wolfSSL_get_ciphers_compat returns NULL (not an empty stack)
+ * when no ciphers are available for a given protocol configuration.
+ * wolfSSL_get_ciphers_compat() is mapped to SSL_get_ciphers(), which has
+ * an expected return of NULL when no ciphers are available. */
+static int test_wolfSSL_get_ciphers_compat_empty(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_TLS) && !defined(NO_WOLFSSL_CLIENT)
+    const SSL_METHOD *method = NULL;
+    SSL_CTX *ctx = NULL;
+    WOLFSSL *ssl = NULL;
+    STACK_OF(SSL_CIPHER) *ciphers = NULL;
+
+    ExpectNotNull(method = SSLv23_client_method());
+    ExpectNotNull(ctx = SSL_CTX_new(method));
+    ExpectNotNull(ssl = SSL_new(ctx));
+
+    /* Disable all protocol versions via options mask so that
+     * sslCipherMinMaxCheck filters out every cipher suite */
+    wolfSSL_set_options(ssl, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 |
+        SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3);
+
+    ciphers = wolfSSL_get_ciphers_compat(ssl);
+
+    /* Must be NULL, not a non-NULL empty stack */
+    ExpectNull(ciphers);
+
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 static int test_wolfSSL_CTX_ctrl(void)
 {
     EXPECT_DECLS;
@@ -34136,6 +34169,7 @@ TEST_CASE testCases[] = {
 #ifdef OPENSSL_ALL
     TEST_DECL(test_wolfSSL_sk_CIPHER_description),
     TEST_DECL(test_wolfSSL_get_ciphers_compat),
+    TEST_DECL(test_wolfSSL_get_ciphers_compat_empty),
 
     TEST_DECL(test_wolfSSL_CTX_ctrl),
 #endif /* OPENSSL_ALL */


### PR DESCRIPTION
# Description

This PR fixes `wolfSSL_get_ciphers_compat()` to return `NULL` when no cipher suites pass filtering, instead of returning a non-NULL empty stack.

The refactoring of `wolfSSL_get_ciphers_compat()` in commit fb824962440c (PR #9831) changed the function to pre-allocate the cipher stack before the population loop. When all ciphers are filtered out, the function now returns a non-NULL empty stack instead of NULL.

Since `wolfSSL_get_ciphers_compat()` is defined as `SSL_get_ciphers()`, it should return `NULL` when no ciphers are available, consistent with OpenSSL behavior (the pre-refactoring behavior).

# Testing

Adds regression test `test_wolfSSL_get_ciphers_compat_empty()`. Caught when running wolfssljni JUnit tests.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
