### PR TITLE
Fix integer overflow in _wc_Hash_Grow and TI hashUpdate

### DIFF
--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -1954,12 +1954,17 @@ int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type, word32* flags)
 int _wc_Hash_Grow(byte** msg, word32* used, word32* len, const byte* in,
                         int inSz, void* heap)
 {
-    if (*len < *used + inSz) {
+    word32 newSz;
+
+    if (!WC_SAFE_SUM_WORD32(*used, (word32)inSz, newSz)) {
+        return BUFFER_E;
+    }
+    if (*len < newSz) {
         if (*msg == NULL) {
-            *msg = (byte*)XMALLOC(*used + inSz, heap, DYNAMIC_TYPE_TMP_BUFFER);
+            *msg = (byte*)XMALLOC(newSz, heap, DYNAMIC_TYPE_TMP_BUFFER);
         }
         else {
-            byte* pt = (byte*)XREALLOC(*msg, *used + inSz, heap,
+            byte* pt = (byte*)XREALLOC(*msg, newSz, heap,
                     DYNAMIC_TYPE_TMP_BUFFER);
             if (pt == NULL) {
                 return MEMORY_E;
@@ -1969,7 +1974,7 @@ int _wc_Hash_Grow(byte** msg, word32* used, word32* len, const byte* in,
         if (*msg == NULL) {
             return MEMORY_E;
         }
-        *len = *used + inSz;
+        *len = newSz;
     }
     XMEMCPY(*msg + *used, in, inSz);
     *used += inSz;

--- a/wolfcrypt/src/port/ti/ti-hash.c
+++ b/wolfcrypt/src/port/ti/ti-hash.c
@@ -75,18 +75,22 @@ static int hashInit(wolfssl_TI_Hash *hash)
 static int hashUpdate(wolfssl_TI_Hash *hash, const byte* data, word32 len)
 {
     void *p;
+    word32 newSz;
 
     if ((hash== NULL) || (data == NULL))return BAD_FUNC_ARG;
 
-    if (hash->len < hash->used+len) {
+    if (!WC_SAFE_SUM_WORD32(hash->used, len, newSz)) {
+        return BAD_FUNC_ARG;
+    }
+    if (hash->len < newSz) {
         if (hash->msg == NULL) {
-            p = XMALLOC(hash->used+len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            p = XMALLOC(newSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         } else {
-            p = XREALLOC(hash->msg, hash->used+len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            p = XREALLOC(hash->msg, newSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
         if (p == 0)return 1;
         hash->msg = p;
-        hash->len = hash->used+len;
+        hash->len = newSz;
     }
     XMEMCPY(hash->msg+hash->used, data, len);
     hash->used += len;


### PR DESCRIPTION
## Summary

Fix integer overflow in hash buffer size computation that could lead to heap buffer overflow.

## Problem

Both `_wc_Hash_Grow()` (hash.c) and `hashUpdate()` (ti-hash.c) compute the new buffer size as `used + inSz` without overflow checking. If `used` is near `UINT32_MAX`, the addition wraps to a small value, causing:

1. Small allocation (`XMALLOC` with wrapped size)
2. Large write (`XMEMCPY` with original `inSz`) → **heap overflow**

Same pattern as the SE050 fix in #9954.

## Fix

Use `WC_SAFE_SUM_WORD32()` to detect overflow before the addition:

```c
word32 newSz;
if (!WC_SAFE_SUM_WORD32(*used, (word32)inSz, newSz)) {
    return BUFFER_E;  // overflow detected
}
```

Then use `newSz` for all allocation and length comparisons.

## Files Changed

- `wolfcrypt/src/hash.c` — `_wc_Hash_Grow()` (requires `WOLFSSL_HASH_KEEP`)
- `wolfcrypt/src/port/ti/ti-hash.c` — `hashUpdate()` (requires `WOLFSSL_TI_HASH`)

## Severity

Low — requires ~4GB of hash input to trigger, which will OOM on most systems first. But defense-in-depth is the right call, and this keeps the codebase consistent with the SE050 fix.

Fixes #9955

CLA: Previously signed (on file from PR #9932).