### PR TITLE
ecc: reject compressed EC points with incorrect length

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -9469,7 +9469,14 @@ int wc_ecc_import_point_der_ex(const byte* in, word32 inLen,
 
     if (pointType == ECC_POINT_COMP_EVEN || pointType == ECC_POINT_COMP_ODD) {
 #ifdef HAVE_COMP_KEY
-        compressed = 1;
+        /* Compressed point must be exactly 1 + field_element_size bytes.
+         * Reject truncated inputs (e.g. a bare 0x02/0x03 byte). */
+        if (inLen == (word32)ecc_sets[curve_idx].size + 1) {
+            compressed = 1;
+        }
+        else {
+            err = ECC_BAD_ARG_E;
+        }
 #else
         err = NOT_COMPILED_IN;
 #endif


### PR DESCRIPTION
## Summary

`wc_ecc_import_point_der_ex` accepts a single byte `0x02` or `0x03` as a valid compressed EC point for all NIST curves (P-256, P-384, P-521). It treats the missing X coordinate bytes as zeros, successfully decompresses the point (which lands on the curve), and `wc_ecc_check_key` passes the result. This allows ECDH key agreement with a crafted 1-byte peer public key.

## Root Cause

The function validates the format byte (`0x02`/`0x03`/`0x04`) but does not validate that the input length matches the expected size for the curve. A compressed point should be exactly `1 + field_element_size` bytes (33 for P-256, 49 for P-384, 67 for P-521). The existing `inLen & 1 == 0` check (must be odd) passes for a single byte.

## Reproducer

```c
// P-256: single-byte compressed point
unsigned char bad_point[] = { 0x02 };
ecc_point *pt = wc_ecc_new_point();
// This succeeds before the fix, returns ECC_BAD_ARG_E after
int ret = wc_ecc_import_point_der_ex(bad_point, 1, curve_idx, pt, 0);
```

Also reproducible via the OpenSSL compat layer:
```c
unsigned char bad_point[] = { 0x02 };
EC_POINT *pt = EC_POINT_new(group);
// Returns 1 (success) before fix
EC_POINT_oct2point(group, pt, bad_point, 1, NULL);
```

## Security Impact

An attacker can supply a 1-byte "public key" (`0x02` or `0x03`) to an ECDH key agreement. wolfSSL will decompress this to the curve point with X=0, compute a shared secret, and return it to the caller. This is a peer public key validation bypass. In protocols that rely on the crypto library to reject malformed keys (e.g., TLS), this could lead to key compromise via a small number of crafted handshakes.

## Fix

Added a length check in `wc_ecc_import_point_der_ex` immediately after identifying a compressed point type. Verifies that `inLen - 1 == ecc_sets[curve_idx].size`. Returns `ECC_BAD_ARG_E` if the length doesn't match.

The non-`_ex` wrapper `wc_ecc_import_point_der` delegates to `_ex`, so it's automatically fixed.

## Test Plan

- [ ] Verify compressed point import with correct length still works for P-256, P-384, P-521
- [ ] Verify 1-byte `0x02` / `0x03` is rejected for all curves
- [ ] Verify BoringSSL/Wycheproof ECDH test vectors pass (these include single-byte error cases)
- [ ] Run existing wolfSSL test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)