### PR TITLE
evp: fix EVP_PKEY_cmp for EC keys after DER deserialization

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -4188,12 +4188,52 @@ int wolfSSL_EVP_PKEY_cmp(const WOLFSSL_EVP_PKEY *a, const WOLFSSL_EVP_PKEY *b)
 #endif /* !NO_RSA */
 #ifdef HAVE_ECC
     case WC_EVP_PKEY_EC:
-        if (a->ecc == NULL || a->ecc->internal == NULL ||
-            b->ecc == NULL || b->ecc->internal == NULL ||
-            wc_ecc_size((ecc_key*)a->ecc->internal) <= 0 ||
-            wc_ecc_size((ecc_key*)b->ecc->internal) <= 0 ||
+    {
+        ecc_key* ecc_key_a;
+        ecc_key* ecc_key_b;
+
+        if (a->ecc == NULL || b->ecc == NULL ||
             a->ecc->group == NULL || b->ecc->group == NULL) {
             return ret;
+        }
+
+        /* Ensure internal ecc_key is synced from external representation.
+         * After d2i_PrivateKey, the external BIGNUMs may be set but the
+         * internal ecc_key.pubkey may not be populated. */
+        if (a->ecc->inSet == 0) {
+            if (SetECKeyInternal((WOLFSSL_EC_KEY*)a->ecc) != 1) {
+                return ret;
+            }
+        }
+        if (b->ecc->inSet == 0) {
+            if (SetECKeyInternal((WOLFSSL_EC_KEY*)b->ecc) != 1) {
+                return ret;
+            }
+        }
+
+        if (a->ecc->internal == NULL || b->ecc->internal == NULL ||
+            wc_ecc_size((ecc_key*)a->ecc->internal) <= 0 ||
+            wc_ecc_size((ecc_key*)b->ecc->internal) <= 0) {
+            return ret;
+        }
+
+        ecc_key_a = (ecc_key*)a->ecc->internal;
+        ecc_key_b = (ecc_key*)b->ecc->internal;
+
+        /* If a key was imported as private-only (e.g. RFC 5915 without the
+         * optional public key), the pubkey point will not be populated.
+         * Derive it from the private key so the comparison can succeed. */
+        if (ecc_key_a->type == ECC_PRIVATEKEY_ONLY) {
+            if (wc_ecc_make_pub(ecc_key_a, NULL) != MP_OKAY) {
+                return ret;
+            }
+            ecc_key_a->type = ECC_PRIVATEKEY;
+        }
+        if (ecc_key_b->type == ECC_PRIVATEKEY_ONLY) {
+            if (wc_ecc_make_pub(ecc_key_b, NULL) != MP_OKAY) {
+                return ret;
+            }
+            ecc_key_b->type = ECC_PRIVATEKEY;
         }
 
         /* check curve */
@@ -4201,11 +4241,12 @@ int wolfSSL_EVP_PKEY_cmp(const WOLFSSL_EVP_PKEY *a, const WOLFSSL_EVP_PKEY *b)
             return WS_RETURN_CODE(ret, WOLFSSL_FAILURE);
         }
 
-        if (wc_ecc_cmp_point(&((ecc_key*)a->ecc->internal)->pubkey,
-                             &((ecc_key*)b->ecc->internal)->pubkey) != 0) {
+        if (wc_ecc_cmp_point(&ecc_key_a->pubkey,
+                             &ecc_key_b->pubkey) != 0) {
             return WS_RETURN_CODE(ret, WOLFSSL_FAILURE);
         }
         break;
+    }
 #endif /* HAVE_ECC */
     default:
         return WS_RETURN_CODE(ret, -2);


### PR DESCRIPTION
## Summary

`wolfSSL_EVP_PKEY_cmp` returns "not equal" for EC keys that are identical but one was deserialized from DER. This breaks the OpenSSL API contract that `EVP_PKEY_cmp` compares key material regardless of how the `EVP_PKEY` objects were constructed.

## Reproducer

```c
// Generate an EC P-256 key
EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
EVP_PKEY_keygen_init(ctx);
EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, NID_X9_62_prime256v1);
EVP_PKEY *original = NULL;
EVP_PKEY_keygen(ctx, &original);

// Serialize to RFC 5915 DER (ECPrivateKey without optional public key)
EC_KEY *ec = EVP_PKEY_get0_EC_KEY(original);
unsigned char *der = NULL;
int der_len = i2d_ECPrivateKey(ec, &der);

// Deserialize back
const unsigned char *p = der;
EC_KEY *ec2 = d2i_ECPrivateKey(NULL, &p, der_len);
EVP_PKEY *deserialized = EVP_PKEY_new();
EVP_PKEY_assign_EC_KEY(deserialized, ec2);

// Compare — returns -1 (not equal) instead of 0 (equal)
int result = wolfSSL_EVP_PKEY_cmp(original, deserialized);
// Expected: 0 (match), Actual: -1 (no match)
```

## Root Cause

Two issues compound:

**1. `inSet` not checked before accessing `ecc->internal`**

After `d2i_PrivateKey` or `d2i_ECPrivateKey`, the external WOLFSSL_EC_KEY fields (BIGNUMs for private key, WOLFSSL_EC_POINT for public key) are populated, but the internal wolfCrypt `ecc_key` struct may not be synced. The `inSet` flag tracks this. `wolfSSL_EVP_PKEY_cmp` accessed `ecc->internal` without checking `inSet` or calling `SetECKeyInternal` to sync.

**2. Private-only keys have empty `pubkey` point**

When `wc_EccPrivateKeyDecode` parses an RFC 5915 `ECPrivateKey` that omits the optional public key field (which is valid per the RFC), it calls `wc_ecc_import_private_key_ex` with `pub=NULL, pubSz=0`. This sets `ecc_key.type = ECC_PRIVATEKEY_ONLY` and leaves `ecc_key.pubkey` as all zeros. The comparison then compared a populated pubkey against zeros → "not equal".

## Fix

In the `WC_EVP_PKEY_EC` case of `wolfSSL_EVP_PKEY_cmp`:

1. Call `SetECKeyInternal()` if `inSet == 0` to sync external → internal representation
2. If `ecc_key.type == ECC_PRIVATEKEY_ONLY`, call `wc_ecc_make_pub()` to derive the public key from the private key before comparing

This ensures the comparison works regardless of how the key was constructed — generated, imported with public key, or imported private-only.

## Test Plan

- [ ] Generate EC key, serialize to PKCS#8, deserialize, `EVP_PKEY_cmp` returns match
- [ ] Generate EC key, serialize to RFC 5915 (without optional public key), deserialize, `EVP_PKEY_cmp` returns match
- [ ] Two different EC keys still return "not equal"
- [ ] RSA key comparison still works (unchanged code path)
- [ ] Run existing wolfSSL test suite
