### PR TITLE
Coverity: fix more null derefs

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -37201,7 +37201,7 @@ int wc_EccPrivateKeyDecode(const byte* input, word32* inOutIdx, ecc_key* key,
                 key, curve_id);
     }
 
-    FREE_ASNGETDATA(dataASN, key->heap);
+    FREE_ASNGETDATA(dataASN, key != NULL ? key->heap : NULL);
     return ret;
 #endif
 }


### PR DESCRIPTION
# Description

Adds on to #9960, should clear 558861

# Testing

`./configure --enable-all && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
