### PR TITLE
linuxkm/lkcapi_aes_glue.c: fix scatterwalk_map error handling in AesG…

### DIFF
--- a/linuxkm/lkcapi_aes_glue.c
+++ b/linuxkm/lkcapi_aes_glue.c
@@ -1148,12 +1148,11 @@ static int AesGcmCrypt_1(struct aead_request *req, int decrypt_p, int rfc4106_p)
         assoc = scatterwalk_map(&assocSgWalk);
 #endif
         if (unlikely(IS_ERR(assoc))) {
+            err = (int)PTR_ERR(assoc);
             pr_err("%s: scatterwalk_map failed: %ld\n",
                    crypto_tfm_alg_driver_name(crypto_aead_tfm(tfm)),
                    PTR_ERR(assoc));
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
-            scatterwalk_unmap(&assocSgWalk);
-#endif
+            assoc = NULL;
             goto out;
         }
     }
@@ -1355,12 +1354,11 @@ static int AesGcmCrypt_1(struct aead_request *req, int decrypt_p, int rfc4106_p)
         in_map = scatterwalk_map(&in_walk);
 #endif
         if (unlikely(IS_ERR(in_map))) {
+            err = (int)PTR_ERR(in_map);
             pr_err("%s: scatterwalk_map failed: %ld\n",
                    crypto_tfm_alg_driver_name(crypto_aead_tfm(tfm)),
-                   PTR_ERR(assoc));
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+                   PTR_ERR(in_map));
             in_map = NULL;
-#endif
             goto out;
         }
         assoc = in_map;
@@ -1374,12 +1372,11 @@ static int AesGcmCrypt_1(struct aead_request *req, int decrypt_p, int rfc4106_p)
         out_map = scatterwalk_map(&out_walk);
 #endif
         if (unlikely(IS_ERR(out_map))) {
+            err = (int)PTR_ERR(out_map);
             pr_err("%s: scatterwalk_map failed: %ld\n",
                    crypto_tfm_alg_driver_name(crypto_aead_tfm(tfm)),
-                   PTR_ERR(assoc));
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+                   PTR_ERR(out_map));
             out_map = NULL;
-#endif
             goto out;
         }
         out_text = out_map + req->assoclen;


### PR DESCRIPTION
…cmCrypt_1

When scatterwalk_map fails in either the stream or non-stream path, the code jumped to cleanup without setting err, causing the function to return 0 (success) despite the failure. This could cause the kernel crypto layer to treat uninitialized data as valid ciphertext/plaintext.

- Capture the error code (PTR_ERR) into err before goto out
- Fix PTR_ERR arguments that incorrectly used assoc instead of in_map/out_map (assoc was NULL or pointed to the wrong mapping)
- Make in_map/out_map NULL assignments unconditional (previously gated behind < 6.15, but the cleanup at out: checks these pointers on all kernel versions)
- Remove bogus scatterwalk_unmap of a failed walk in the stream path on >= 6.15

# Description

Please describe the scope of the fix or feature addition.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [NA] added tests
 - [NA] updated/added doxygen
 - [NA] updated appropriate READMEs
 - [NA] Updated manual and documentation
