### PR TITLE
add back WOLFSSL_QT macro guard for get cipher name behavior

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10470,7 +10470,8 @@ const char* wolfSSL_CIPHER_get_name(const WOLFSSL_CIPHER* cipher)
         return NULL;
     }
 
-    #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && !defined(NO_ERROR_STRINGS)
+    #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && !defined(NO_ERROR_STRINGS) && \
+        !defined(WOLFSSL_QT)
         return GetCipherNameIana(cipher->cipherSuite0, cipher->cipherSuite);
     #else
         return wolfSSL_get_cipher_name_from_suite(cipher->cipherSuite0,

--- a/tests/api.c
+++ b/tests/api.c
@@ -13584,7 +13584,8 @@ static int test_wolfSSL_get_client_ciphers_on_result(WOLFSSL* ssl) {
         ExpectIntEQ(sk_SSL_CIPHER_num(ciphers), 1);
         current = sk_SSL_CIPHER_value(ciphers, 0);
         ExpectNotNull(current);
-    #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && !defined(NO_ERROR_STRINGS)
+    #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && !defined(NO_ERROR_STRINGS) && \
+        !defined(WOLFSSL_QT)
         ExpectStrEQ("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
             SSL_CIPHER_get_name(current));
     #else
@@ -26524,7 +26525,7 @@ static int test_wolfSSL_crypto_policy_ciphers(void)
 
         /* We return a different cipher string depending on build settings. */
         #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && \
-        !defined(NO_ERROR_STRINGS)
+        !defined(NO_ERROR_STRINGS) && !defined(WOLFSSL_QT)
         found = crypto_policy_cipher_found(ssl, "AES_128", 0);
         ExpectIntEQ(found, !is_future);
 


### PR DESCRIPTION
This adds back in the WOLFSSL_QT guard that was removed in https://github.com/wolfSSL/wolfssl/pull/9831