### PR TITLE
Fix Qt jenkins nightly failure

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10470,7 +10470,8 @@ const char* wolfSSL_CIPHER_get_name(const WOLFSSL_CIPHER* cipher)
         return NULL;
     }
 
-    #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && !defined(NO_ERROR_STRINGS)
+    #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && !defined(NO_ERROR_STRINGS) && \
+        !defined(WOLFSSL_QT)
         return GetCipherNameIana(cipher->cipherSuite0, cipher->cipherSuite);
     #else
         return wolfSSL_get_cipher_name_from_suite(cipher->cipherSuite0,


### PR DESCRIPTION
Revert [pr9831](url) changes for `src\ssl.c`
Qt assumes OpenSSL cipher names rather than IANA names

# Description

Fix Qt jenkins nightly failure

# Testing

Run Qt unit test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
