### PR TITLE
Dilithium: fix API so that context length is byte

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -65,7 +65,7 @@ A heap buffer out of bounds write case existed in wolfSSL version 5.8.4 and earl
 * Support for STM32 HMAC hardware by @dgarske (PR 9745).
 * Add STM32G0 hardware crypto support by @danielinux (PR 9707).
 * Misc STM32 fixes and testing improvements by @dgarske, @LinuxJedi (PRs 9446, 9563).
-* Various Thumb2 AES/SP ASM enhancements and fixes by @SparkiDev (PRs 9464, 9491, 9547, 9615, 9767) 
+* Various Thumb2 AES/SP ASM enhancements and fixes by @SparkiDev (PRs 9464, 9491, 9547, 9615, 9767)
 * Add Zephyr 4.1+ build compatibility for wolfssl_tls_sock sample by @night1rider (PR 9765)
 
 ## Rust wrapper

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -9797,8 +9797,8 @@ static int dilithium_verify_mu(dilithium_key* key, const byte* mu,
  * @return  Other negative when an error occurs.
  */
 static int dilithium_verify_ctx_msg(dilithium_key* key, const byte* ctx,
-    word32 ctxLen, const byte* msg, word32 msgLen, const byte* sig,
-    word32 sigLen, int* res)
+    byte ctxLen, const byte* msg, word32 msgLen, const byte* sig, word32 sigLen,
+    int* res)
 {
     int ret = 0;
     byte tr[DILITHIUM_TR_SZ];
@@ -9887,8 +9887,8 @@ static int dilithium_verify_msg(dilithium_key* key, const byte* msg,
  * @return  Other negative when an error occurs.
  */
 static int dilithium_verify_ctx_hash(dilithium_key* key, const byte* ctx,
-    word32 ctxLen, int hashAlg, const byte* hash, word32 hashLen,
-    const byte* sig, word32 sigLen, int* res)
+    byte ctxLen, int hashAlg, const byte* hash, word32 hashLen, const byte* sig,
+    word32 sigLen, int* res)
 {
     int ret = 0;
     byte tr[DILITHIUM_TR_SZ];
@@ -10480,7 +10480,7 @@ int wc_dilithium_sign_ctx_hash_with_seed(const byte* ctx, byte ctxLen,
  *          0 otherwise.
  */
 int wc_dilithium_verify_ctx_msg(const byte* sig, word32 sigLen, const byte* ctx,
-    word32 ctxLen, const byte* msg, word32 msgLen, int* res, dilithium_key* key)
+    byte ctxLen, const byte* msg, word32 msgLen, int* res, dilithium_key* key)
 {
     int ret = 0;
 
@@ -10591,8 +10591,8 @@ int wc_dilithium_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
  *          0 otherwise.
  */
 int wc_dilithium_verify_ctx_hash(const byte* sig, word32 sigLen,
-    const byte* ctx, word32 ctxLen, int hashAlg, const byte* hash,
-    word32 hashLen, int* res, dilithium_key* key)
+    const byte* ctx, byte ctxLen, int hashAlg, const byte* hash, word32 hashLen,
+    int* res, dilithium_key* key)
 {
     int ret = 0;
 

--- a/wolfssl/wolfcrypt/dilithium.h
+++ b/wolfssl/wolfcrypt/dilithium.h
@@ -838,11 +838,11 @@ int wc_dilithium_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
     word32 msgLen, int* res, dilithium_key* key);
 WOLFSSL_API
 int wc_dilithium_verify_ctx_msg(const byte* sig, word32 sigLen, const byte* ctx,
-    word32 ctxLen, const byte* msg, word32 msgLen, int* res,
+    byte ctxLen, const byte* msg, word32 msgLen, int* res,
     dilithium_key* key);
 WOLFSSL_API
 int wc_dilithium_verify_ctx_hash(const byte* sig, word32 sigLen,
-    const byte* ctx, word32 ctxLen, int hashAlg, const byte* hash,
+    const byte* ctx, byte ctxLen, int hashAlg, const byte* hash,
     word32 hashLen, int* res, dilithium_key* key);
 
 #ifndef WC_NO_CONSTRUCTORS

--- a/wrapper/rust/wolfssl-wolfcrypt/src/dilithium.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/dilithium.rs
@@ -1236,7 +1236,7 @@ impl Dilithium {
             return Err(sys::wolfCrypt_ErrorCodes_BUFFER_E);
         }
         let sig_len = sig.len() as u32;
-        let ctx_len = ctx.len() as u32;
+        let ctx_len = ctx.len() as u8;
         let msg_len = msg.len() as u32;
         let mut res = 0i32;
         let rc = unsafe {
@@ -1282,7 +1282,7 @@ impl Dilithium {
             return Err(sys::wolfCrypt_ErrorCodes_BUFFER_E);
         }
         let sig_len = sig.len() as u32;
-        let ctx_len = ctx.len() as u32;
+        let ctx_len = ctx.len() as u8;
         let hash_len = hash.len() as u32;
         let mut res = 0i32;
         let rc = unsafe {


### PR DESCRIPTION
# Description

Only allowed to have a context length of 0..255 bytes. Make all context len parameters type byte.

# Testing

--enable-mldsa
