### PR TITLE
Don't force enable MD5 with --enable-jni

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7977,7 +7977,6 @@ then
 
     if test "x$ENABLED_OPENSSLEXTRA" = "xno"
     then
-        ENABLED_MD5="yes"
         ENABLED_OPENSSLEXTRA="yes"
         AM_CFLAGS="$AM_CFLAGS -DOPENSSL_EXTRA"
     fi


### PR DESCRIPTION
# Description

Currently, when compiling with `--enable-jni`, MD5 gets enabled when enabling OPENSSLEXTRA, but this complicates FIPS builds where you might want to disable MD5 to keep non-certified algorithms out.

Related to https://github.com/wolfSSL/wolfssl-containers/pull/10

# Testing

```
./autogen.sh
./configure --enable-jni --disable-md5
make
make check
```

