### PR TITLE
Fix RSA-OAEP to allow zero-length plaintext per RFC 8017

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3443,10 +3443,9 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
         return BAD_FUNC_ARG;
     }
 
-    /* For OAEP padding (RFC 8017, Section 7.1.1), zero-length messages are
-     * permitted with respect to the message-length constraint in step 1b:
-     * mLen <= k - 2*hLen - 2. For other padding types, a zero-length input
-     * is invalid. */
+    /* RFC 8017 Section 7.1.1 step 1b permits mLen == 0 for OAEP because
+     * the message-length bound (mLen <= k - 2*hLen - 2) is satisfied.
+     * Other padding types require non-empty input. */
     if (in == NULL || (inLen == 0 && pad_type != WC_RSA_OAEP_PAD)) {
         return BAD_FUNC_ARG;
     }
@@ -3847,11 +3846,12 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
             ret = ctMaskSelInt(ctMaskLTE(ret, (int)outLen), ret,
                                WC_NO_ERR_TRACE(RSA_BUFFER_E));
     #ifndef WOLFSSL_RSA_DECRYPT_TO_0_LEN
-            /* RFC 8017 Section 7.1.2: OAEP decryption may produce a valid
-             * zero-length message. Only reject ret==0 for non-OAEP types. */
+            /* RFC 8017 Section 7.1.2 step 3g: OAEP decryption may yield a
+             * valid zero-length message (mLen == 0). Only reject ret == 0
+             * for non-OAEP padding types. */
             {
-                int zeroOk = ctMaskEq(pad_type, WC_RSA_OAEP_PAD);
-                ret = ctMaskSelInt(ctMaskNotEq(ret, 0) | zeroOk, ret,
+                byte zeroOkMask = ctMaskEq(pad_type, WC_RSA_OAEP_PAD);
+                ret = ctMaskSelInt(ctMaskNotEq(ret, 0) | zeroOkMask, ret,
                                    WC_NO_ERR_TRACE(RSA_BUFFER_E));
             }
     #endif

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1773,8 +1773,10 @@ static int RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
         c = c + (pkcsBlock[idx++] ^ 0x01); /* separator value is 0x01 */
         c = c + (pkcsBlock[0]     ^ 0x00); /* Y, the first value, should be 0 */
 
-        /* Return 0 data length on error. */
-        idx = ctMaskSelWord32(ctMaskEq(c, 0), idx, pkcsBlockLen);
+        /* On error, set idx past the end so the return value is negative.
+         * This distinguishes padding errors (ret == -1) from a valid
+         * zero-length message (ret == 0), which RFC 8017 permits. */
+        idx = ctMaskSelWord32(ctMaskEq(c, 0), idx, pkcsBlockLen + 1);
     }
 
     /* adjust pointer to correct location in array and return size of M */
@@ -3437,7 +3439,15 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
     RsaPadding padding;
 #endif
 
-    if (in == NULL || inLen == 0 || out == NULL || key == NULL) {
+    if (out == NULL || key == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* For OAEP padding (RFC 8017, Section 7.1.1), zero-length messages are
+     * permitted with respect to the message-length constraint in step 1b:
+     * mLen <= k - 2*hLen - 2. For other padding types, a zero-length input
+     * is invalid. */
+    if (in == NULL || (inLen == 0 && pad_type != WC_RSA_OAEP_PAD)) {
         return BAD_FUNC_ARG;
     }
 
@@ -3837,8 +3847,13 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
             ret = ctMaskSelInt(ctMaskLTE(ret, (int)outLen), ret,
                                WC_NO_ERR_TRACE(RSA_BUFFER_E));
     #ifndef WOLFSSL_RSA_DECRYPT_TO_0_LEN
-            ret = ctMaskSelInt(ctMaskNotEq(ret, 0), ret,
-                               WC_NO_ERR_TRACE(RSA_BUFFER_E));
+            /* RFC 8017 Section 7.1.2: OAEP decryption may produce a valid
+             * zero-length message. Only reject ret==0 for non-OAEP types. */
+            {
+                int zeroOk = ctMaskEq(pad_type, WC_RSA_OAEP_PAD);
+                ret = ctMaskSelInt(ctMaskNotEq(ret, 0) | zeroOk, ret,
+                                   WC_NO_ERR_TRACE(RSA_BUFFER_E));
+            }
     #endif
 #else
             if (outLen < (word32)ret)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -25801,8 +25801,9 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
      * corrupted ciphertext still produces a negative error code. */
     #ifndef NO_SHA256
     #ifndef WOLFSSL_RSA_PUBLIC_ONLY
+    #ifndef WOLFSSL_SE050
     {
-        byte emptyIn = 0;
+        byte emptyBuf = 0;
         XMEMSET(out, 0, outSz);
         XMEMSET(plain, 0, plainSz);
         do {
@@ -25810,7 +25811,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
             if (ret >= 0) {
-                ret = wc_RsaPublicEncrypt_ex(&emptyIn, 0, out, outSz, key, rng,
+                ret = wc_RsaPublicEncrypt_ex(&emptyBuf, 0, out, outSz, key, rng,
                     WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256,
                     NULL, 0);
             }
@@ -25850,6 +25851,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ERROR_OUT(WC_TEST_RET_ENC_NC, exit_rsa);
         ret = 0;
     }
+    #endif /* WOLFSSL_SE050 */
     #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
     #endif /* NO_SHA256 */
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -25796,6 +25796,63 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
     TEST_SLEEP();
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
 
+    /* RFC 8017 Section 7.1: OAEP permits zero-length messages. Verify
+     * encrypt/decrypt round-trip succeeds with inLen == 0 and that
+     * corrupted ciphertext still produces a negative error code. */
+    #ifndef NO_SHA256
+    #ifndef WOLFSSL_RSA_PUBLIC_ONLY
+    {
+        byte emptyIn = 0;
+        XMEMSET(out, 0, outSz);
+        XMEMSET(plain, 0, plainSz);
+        do {
+    #if defined(WOLFSSL_ASYNC_CRYPT)
+            ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+    #endif
+            if (ret >= 0) {
+                ret = wc_RsaPublicEncrypt_ex(&emptyIn, 0, out, outSz, key, rng,
+                    WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256,
+                    NULL, 0);
+            }
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+        if (ret < 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
+
+        idx = (word32)ret;
+        do {
+    #if defined(WOLFSSL_ASYNC_CRYPT)
+            ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+    #endif
+            if (ret >= 0) {
+                ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, plainSz, key,
+                    WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256,
+                    NULL, 0);
+            }
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
+        TEST_SLEEP();
+
+        /* Corrupt the ciphertext and verify decryption returns an error,
+         * not a zero-length success. */
+        out[idx / 2] ^= 0x01;
+        do {
+    #if defined(WOLFSSL_ASYNC_CRYPT)
+            ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+    #endif
+            if (ret >= 0) {
+                ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, plainSz, key,
+                    WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256,
+                    NULL, 0);
+            }
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+        if (ret >= 0)
+            ERROR_OUT(WC_TEST_RET_ENC_NC, exit_rsa);
+        ret = 0;
+    }
+    #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+    #endif /* NO_SHA256 */
+
 exit_rsa:
     WC_FREE_VAR(in, HEAP_HINT);
     WC_FREE_VAR(out, HEAP_HINT);


### PR DESCRIPTION
## Summary

**Encrypt side**: `RsaPublicEncryptEx()` rejected `inLen == 0` unconditionally with `BAD_FUNC_ARG`. RFC 8017 Section 7.1.1 (RSAES-OAEP-ENCRYPT) permits zero-length messages: the message-length constraint `mLen <= k - 2*hLen - 2` is satisfied by `mLen = 0`. Gate the `inLen == 0` rejection on `pad_type != WC_RSA_OAEP_PAD`.

**Decrypt side**: `RsaUnPad_OAEP()` deliberately returned 0 on padding errors (as a chosen-ciphertext defense — see the `ctMaskSelWord32` on the error path). This meant that padding errors and valid empty messages both produced `ret == 0`, making them indistinguishable. Previously this was fine because `RsaPrivateDecryptEx()` rejected all `ret == 0` results. But naively allowing `ret == 0` for OAEP (to support empty messages) would silently accept invalid OAEP ciphertext as a successful empty-message decryption.

**Fix**: Change the error sentinel in `RsaUnPad_OAEP()` from `pkcsBlockLen` to `pkcsBlockLen + 1`, so the return value on padding error becomes `-1` (via unsigned wraparound to `(int)(pkcsBlockLen - (pkcsBlockLen + 1))`) instead of `0`. Valid empty messages still return `0`. In `RsaPrivateDecryptEx()`, use constant-time masking (`ctMaskEq(pad_type, WC_RSA_OAEP_PAD)`) to allow `ret == 0` specifically for OAEP, while preserving the existing rejection of zero-length results for other padding types.

**Constant-time properties preserved**: The only change to `RsaUnPad_OAEP` is the value of the constant passed to `ctMaskSelWord32` on the error path (`pkcsBlockLen + 1` instead of `pkcsBlockLen`). The control flow, number of operations, and timing characteristics are identical. The `*output` pointer on the error path points one byte past the buffer end (`pkcsBlock + pkcsBlockLen + 1`), but this is safe because `ret < 0` prevents any caller from dereferencing or copying from it (the copy path is guarded by `ret >= 0`).

Both OpenSSL and BoringSSL accept empty OAEP plaintexts. Found via Wycheproof test vectors.

## Spec references

- [RFC 8017 Section 7.1.1 — RSAES-OAEP-ENCRYPT](https://www.rfc-editor.org/rfc/rfc8017#section-7.1.1): Step 1b constrains `mLen <= k - 2*hLen - 2`; `mLen = 0` is valid
- [RFC 8017 Section 7.1.2 — RSAES-OAEP-DECRYPT](https://www.rfc-editor.org/rfc/rfc8017#section-7.1.2): Step 3g outputs `M` which may be the empty string

## Test plan

- [ ] RSA-OAEP encrypt/decrypt round-trip with zero-length plaintext succeeds
- [ ] RSA-OAEP decrypt of invalid ciphertext returns error (not empty success)
- [ ] Existing RSA-OAEP tests pass
- [ ] Non-OAEP padding types still reject zero-length input
- [ ] Run existing wolfSSL test suite