### PR TITLE
Add missing include in asn.h

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -83,6 +83,9 @@ that can be serialized and deserialized in a cross-platform way.
     #include <wolfssl/wolfcrypt/md5.h>
 #endif
 #include <wolfssl/wolfcrypt/sha256.h>
+#if defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
+    #include <wolfssl/wolfcrypt/sha512.h>
+#endif
 #ifdef WOLFSSL_SM3
     #include <wolfssl/wolfcrypt/sm3.h>
 #endif


### PR DESCRIPTION
wolfssl/wolfcrypt/asn.h uses WC_SHA384_DIGEST_SIZE and WC_SHA512_DIGEST_SIZE, but did not include wolfssl/wolfcrypt/sha512.h directly. This relied on transitive include order and broke builds where asn.h is  parsed before hash.h/sha512.h, such as hash.c with SHA-384 enabled.

Regression introduced in #9761



