### PR TITLE
Cancel resumption if protocol changes

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5275,6 +5275,12 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
 #endif /* WOLFSSL_DTLS13 */
 
+            if (ssl->options.resuming) {
+                WOLFSSL_MSG("Attempted resumption: negotiated version"
+                        " downgraded from TLS 1.3, falling back to full handshake");
+                ssl->options.resuming = 0;
+            }
+
             return DoServerHello(ssl, input, inOutIdx, helloSz);
         }
     }
@@ -5391,6 +5397,11 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
 #ifndef WOLFSSL_NO_TLS12
         ssl->options.tls1_3 = 0;
+        if (ssl->options.resuming) {
+            WOLFSSL_MSG("Attempted resumption: negotiated version"
+                    " downgraded from TLS 1.3, falling back to full handshake");
+            ssl->options.resuming = 0;
+        }
         return DoServerHello(ssl, input, inOutIdx, helloSz);
 #else
         SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
@@ -5562,6 +5573,11 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         else
             ssl->chVersion.minor = TLSv1_2_MINOR;
         /* Complete TLS v1.2 processing of ServerHello. */
+        if (ssl->options.resuming) {
+            WOLFSSL_MSG("Attempted resumption negotiated version"
+                    " downgraded from TLS 1.3, falling back to full handshake");
+            ssl->options.resuming = 0;
+        }
         ret = DoServerHello(ssl, input, inOutIdx, helloSz);
 #else
         WOLFSSL_MSG("Client using higher version, fatal error");


### PR DESCRIPTION
# Description

Sets `ssl->options.resuming = 0` if downgrade occurs from `DoTls13ServerHello()`. Necessary when attempted resumption with protocol from original connection is not accepted by server. Allows client to expect a full handshake.

TLSv1.3 resumption downgrading to TLSv1.2 will fail after processing ServerHello as the client will expect incorrect message from server and will fail.

# Testing

Modified `client-tis-resume.c` and `server-tis.c` example. After first connection using `wolfSSLv23_server_method()`, `server-tis.c` will create a new context that uses `wolfTLSv1_2_server_method()` before receiving resumption ClientHello message.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
