### PR TITLE
Fix to make sure a double free cannot occur with non-blocking async

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -18413,6 +18413,7 @@ void FreeSignatureCtx(SignatureCtx* sigCtx)
                 if (sigCtx->key.ecc->nb_ctx != NULL) {
                     XFREE(sigCtx->key.ecc->nb_ctx, sigCtx->heap,
                           DYNAMIC_TYPE_TMP_BUFFER);
+                    sigCtx->key.ecc->nb_ctx = NULL;
                 }
             #endif /* WC_ECC_NONBLOCK && WOLFSSL_ASYNC_CRYPT_SW &&
                       WC_ASYNC_ENABLE_ECC */
@@ -18488,6 +18489,7 @@ void FreeSignatureCtx(SignatureCtx* sigCtx)
     #ifndef WOLFSSL_NO_MALLOC
         sigCtx->key.ptr = NULL;
     #endif
+        sigCtx->keyOID = 0; /* mark key as freed (guards re-entry without malloc) */
     }
 #endif /* !NO_ASN_CRYPT */
 


### PR DESCRIPTION
# Description

Fix to make sure a double free cannot occur (ZD 21093)

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
