### PR TITLE
20260323-InitSuites-ALL

### DIFF
--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -369,7 +369,7 @@ do_wolfssl_client() {
 
     if [ "$client_result" != 0 ]
     then
-        echo -e "client failed! Suite = $wolfSuite version = $version"
+        echo -e "wolfSSL client failed! Suite = $wolfSuite version = $version"
         do_cleanup
         exit 1
     fi
@@ -429,7 +429,7 @@ do_openssl_client() {
 
     if [ "$client_result" != 0 ]
     then
-        echo -e "client failed! Suite = $wolfSuite version = $version"
+        echo -e "OpenSSL client failed! Suite = $wolfSuite version = $version"
         do_cleanup
         exit 1
     fi

--- a/src/internal.c
+++ b/src/internal.c
@@ -28734,7 +28734,6 @@ static int ParseCipherList(Suites* suites,
     }
 
     if (next[0] == '\0' ||
-        XSTRCMP(next, "ALL") == 0 ||
         XSTRCMP(next, "DEFAULT") == 0 ||
         XSTRCMP(next, "HIGH") == 0)
     {
@@ -28749,6 +28748,25 @@ static int ParseCipherList(Suites* suites,
                 0,
 #endif
                 haveRSA, 1, 1, !haveRSA, 1, haveRSA, !haveRSA, 0, 0, 1,
+                1, 1, side
+        );
+        suites->setSuites = 1;
+        return 1; /* wolfSSL default */
+    }
+
+    if (XSTRCMP(next, "ALL") == 0)
+    {
+        /* Add all ciphersuites. Prefer RSA */
+#ifndef NO_RSA
+        haveRSA = 1;
+#endif
+        InitSuites(suites, version,
+#ifndef NO_CERTS
+                privateKeySz,
+#else
+                0,
+#endif
+                haveRSA, 1, 1, !haveRSA, 1, haveRSA, !haveRSA, 1, 1, 1,
                 1, 1, side
         );
         suites->setSuites = 1;


### PR DESCRIPTION
`src/internal.c`: in `ParseCipherList()`, if the list is "ALL", add anonymous and null ciphers too.

fixes regression from 54d6555194 in #9841, detected by `scripts/openssl.test` in `super-quick-check`.

tested with
```
./configure --enable-all
WOLFSSL_OPENSSL_TEST=1  scripts/openssl.test
```
