### PR TITLE
20260324-wc_PKCS12_PBKDF_ex-bugprone-inc-dec-in-conditions

### DIFF
--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -687,9 +687,12 @@ int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
         PKCS12_ByteReverseWords(Bw, Bw, v);
 #endif
         /* Increment B by 1. */
-        k = nwc;
-        while ((k-- > 0) && (++Bw[k] == 0))
-            ;
+        for (k = nwc; k > 0; ) {
+            --k;
+            ++Bw[k];
+            if (Bw[k] != 0)
+                break;
+        }
 
 #ifndef BIG_ENDIAN_ORDER
         PKCS12_ByteReverseWords((PKCS12_WORD*)I, (PKCS12_WORD*)I, nBlocks * v);


### PR DESCRIPTION
`wolfcrypt/src/pwdbased.c`: in `wc_PKCS12_PBKDF_ex()`, refactor the "Increment B by 1" loop to avoid `bugprone-inc-dec-in-conditions`.

tested with
```
wolfssl-multi-test.sh ...
clang-tidy-all-sp-all
quantum-safe-wolfssl-all-clang-tidy
quantum-safe-wolfssl-all-intelasm-sp-asm-sanitizer
quantum-safe-wolfssl-all-noasm-sanitizer
check-source-text
```
