### PR TITLE
Define HAVE_LIMITS_H in options.h rather than config.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,17 +148,6 @@ check_type_size("long" SIZEOF_LONG)
 check_type_size("time_t" SIZEOF_TIME_T)
 check_type_size("uintptr_t" HAVE_UINTPTR_T)
 
-# SIZEOF_LONG/SIZEOF_LONG_LONG are exposed to applications through options.h
-# (see cmake/options.h.in) so that application code computes the same
-# CTC_SETTINGS as the library. The in-tree build does not include options.h,
-# so define them here for the library and test programs.
-if(HAVE_SIZEOF_LONG)
-    add_definitions("-DSIZEOF_LONG=${SIZEOF_LONG}")
-endif()
-if(HAVE_SIZEOF_LONG_LONG)
-    add_definitions("-DSIZEOF_LONG_LONG=${SIZEOF_LONG_LONG}")
-endif()
-
 # By default, HAVE___UINT128_T gets defined as TRUE,
 # but we want it as 1.
 if(HAVE___UINT128_T)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,14 @@ check_include_file("sys/stat.h" HAVE_SYS_STAT_H)
 check_include_file("sys/types.h" HAVE_SYS_TYPES_H)
 check_include_file("unistd.h" HAVE_UNISTD_H)
 
+# types.h depends on HAVE_LIMITS_H, and it is defined in options.h (rather than
+# config.h) so that applications consuming wolfSSL headers see it. The in-tree
+# build, however, is configured through config.h/compile definitions and does
+# not include options.h, so define it here as well.
+if(HAVE_LIMITS_H)
+    add_definitions("-DHAVE_LIMITS_H")
+endif()
+
 include(CheckFunctionExists)
 
 # TODO: Also check if these functions are declared by the
@@ -139,6 +147,17 @@ check_type_size("long long" SIZEOF_LONG_LONG)
 check_type_size("long" SIZEOF_LONG)
 check_type_size("time_t" SIZEOF_TIME_T)
 check_type_size("uintptr_t" HAVE_UINTPTR_T)
+
+# SIZEOF_LONG/SIZEOF_LONG_LONG are exposed to applications through options.h
+# (see cmake/options.h.in) so that application code computes the same
+# CTC_SETTINGS as the library. The in-tree build does not include options.h,
+# so define them here for the library and test programs.
+if(HAVE_SIZEOF_LONG)
+    add_definitions("-DSIZEOF_LONG=${SIZEOF_LONG}")
+endif()
+if(HAVE_SIZEOF_LONG_LONG)
+    add_definitions("-DSIZEOF_LONG_LONG=${SIZEOF_LONG_LONG}")
+endif()
 
 # By default, HAVE___UINT128_T gets defined as TRUE,
 # but we want it as 1.

--- a/cmake/config.in
+++ b/cmake/config.in
@@ -19,9 +19,6 @@
 /* Define to 1 if you have the `gmtime_r' function. */
 #cmakedefine HAVE_GMTIME_R @HAVE_GMTIME_R@
 
-/* Define to 1 if you have the <limits.h> header file. */
-#cmakedefine HAVE_LIMITS_H @HAVE_LIMITS_H@
-
 /* Define to 1 if you have the <pcap/pcap.h> header file. */
 #cmakedefine HAVE_PCAP_PCAP_H @HAVE_PCAP_PCAP_H@
 

--- a/cmake/config.in
+++ b/cmake/config.in
@@ -49,12 +49,6 @@
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "@CMAKE_PROJECT_NAME@"
 
-/* The size of `long', as computed by sizeof. */
-#cmakedefine SIZEOF_LONG @SIZEOF_LONG@
-
-/* The size of `long long', as computed by sizeof. */
-#cmakedefine SIZEOF_LONG_LONG @SIZEOF_LONG_LONG@
-
 /* The size of `time_t', as computed by sizeof. */
 #cmakedefine SIZEOF_TIME_T @SIZEOF_TIME_T@
 

--- a/cmake/config.in
+++ b/cmake/config.in
@@ -49,6 +49,12 @@
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "@CMAKE_PROJECT_NAME@"
 
+/* The size of `long', as computed by sizeof. */
+#cmakedefine SIZEOF_LONG @SIZEOF_LONG@
+
+/* The size of `long long', as computed by sizeof. */
+#cmakedefine SIZEOF_LONG_LONG @SIZEOF_LONG_LONG@
+
 /* The size of `time_t', as computed by sizeof. */
 #cmakedefine SIZEOF_TIME_T @SIZEOF_TIME_T@
 

--- a/cmake/options.h.in
+++ b/cmake/options.h.in
@@ -33,14 +33,14 @@ extern "C" {
 #endif
 
 #ifndef WOLFSSL_OPTIONS_IGNORE_SYS
-/* Since types.h depends on HAVE_LIMITS_H, we must define it in options.h. */
-#undef HAVE_LIMITS_H
-#cmakedefine HAVE_LIMITS_H @HAVE_LIMITS_H@
 #undef _GNU_SOURCE
 #cmakedefine _GNU_SOURCE
 #undef _POSIX_THREADS
 #cmakedefine _POSIX_THREADS
 #endif
+/* Since types.h depends on HAVE_LIMITS_H, we must define it in options.h. */
+#undef HAVE_LIMITS_H
+#cmakedefine HAVE_LIMITS_H @HAVE_LIMITS_H@
 #undef ASIO_USE_WOLFSSL
 #cmakedefine ASIO_USE_WOLFSSL
 #undef BOOST_ASIO_USE_WOLFSSL

--- a/cmake/options.h.in
+++ b/cmake/options.h.in
@@ -33,6 +33,9 @@ extern "C" {
 #endif
 
 #ifndef WOLFSSL_OPTIONS_IGNORE_SYS
+/* Since types.h depends on HAVE_LIMITS_H, we must define it in options.h. */
+#undef HAVE_LIMITS_H
+#cmakedefine HAVE_LIMITS_H @HAVE_LIMITS_H@
 #undef _GNU_SOURCE
 #cmakedefine _GNU_SOURCE
 #undef _POSIX_THREADS

--- a/cmake/options.h.in
+++ b/cmake/options.h.in
@@ -38,14 +38,9 @@ extern "C" {
 #undef _POSIX_THREADS
 #cmakedefine _POSIX_THREADS
 #endif
-/* Since types.h depends on HAVE_LIMITS_H, SIZEOF_LONG and SIZEOF_LONG_LONG,
- * we must define them in options.h. */
+/* Since types.h depends on HAVE_LIMITS_H, we must define it in options.h. */
 #undef HAVE_LIMITS_H
 #cmakedefine HAVE_LIMITS_H @HAVE_LIMITS_H@
-#undef SIZEOF_LONG
-#cmakedefine SIZEOF_LONG @SIZEOF_LONG@
-#undef SIZEOF_LONG_LONG
-#cmakedefine SIZEOF_LONG_LONG @SIZEOF_LONG_LONG@
 #undef ASIO_USE_WOLFSSL
 #cmakedefine ASIO_USE_WOLFSSL
 #undef BOOST_ASIO_USE_WOLFSSL

--- a/cmake/options.h.in
+++ b/cmake/options.h.in
@@ -38,9 +38,14 @@ extern "C" {
 #undef _POSIX_THREADS
 #cmakedefine _POSIX_THREADS
 #endif
-/* Since types.h depends on HAVE_LIMITS_H, we must define it in options.h. */
+/* Since types.h depends on HAVE_LIMITS_H, SIZEOF_LONG and SIZEOF_LONG_LONG,
+ * we must define them in options.h. */
 #undef HAVE_LIMITS_H
 #cmakedefine HAVE_LIMITS_H @HAVE_LIMITS_H@
+#undef SIZEOF_LONG
+#cmakedefine SIZEOF_LONG @SIZEOF_LONG@
+#undef SIZEOF_LONG_LONG
+#cmakedefine SIZEOF_LONG_LONG @SIZEOF_LONG_LONG@
 #undef ASIO_USE_WOLFSSL
 #cmakedefine ASIO_USE_WOLFSSL
 #undef BOOST_ASIO_USE_WOLFSSL

--- a/configure.ac
+++ b/configure.ac
@@ -204,7 +204,9 @@ then
     fi
 fi
 
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stddef.h time.h sys/ioctl.h sys/socket.h sys/time.h errno.h sys/un.h ctype.h sys/random.h])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stddef.h time.h sys/ioctl.h sys/socket.h sys/time.h errno.h sys/un.h ctype.h sys/random.h])
+# Special case: Since types.h depends on HAVE_LIMITS_H, we must define it in options.h.
+AC_CHECK_HEADER([limits.h], [AM_CPPFLAGS="$AM_CPPFLAGS -DHAVE_LIMITS_H=1"], [])
 AC_CHECK_LIB([network],[socket])
 AC_C_BIGENDIAN
 AC_C___ATOMIC

--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,15 @@ fi
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stddef.h time.h sys/ioctl.h sys/socket.h sys/time.h errno.h sys/un.h ctype.h sys/random.h])
 # Special case: Since types.h depends on HAVE_LIMITS_H, we must define it in options.h.
 AC_CHECK_HEADER([limits.h], [AM_CPPFLAGS="$AM_CPPFLAGS -DHAVE_LIMITS_H=1"], [])
+# Propagate the measured integer sizes (from AC_CHECK_SIZEOF above) into
+# options.h. The library obtains these from config.h, but config.h is not
+# available to applications; without them, application code falls back to the
+# limits.h/architecture heuristics in types.h and can compute a CTC_SETTINGS
+# value that disagrees with the library's CheckRunTimeSettings().
+AS_IF([test "x$ac_cv_sizeof_long" != "x"],
+    [AM_CPPFLAGS="$AM_CPPFLAGS -DSIZEOF_LONG=$ac_cv_sizeof_long"])
+AS_IF([test "x$ac_cv_sizeof_long_long" != "x"],
+    [AM_CPPFLAGS="$AM_CPPFLAGS -DSIZEOF_LONG_LONG=$ac_cv_sizeof_long_long"])
 AC_CHECK_LIB([network],[socket])
 AC_C_BIGENDIAN
 AC_C___ATOMIC

--- a/configure.ac
+++ b/configure.ac
@@ -207,15 +207,6 @@ fi
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stddef.h time.h sys/ioctl.h sys/socket.h sys/time.h errno.h sys/un.h ctype.h sys/random.h])
 # Special case: Since types.h depends on HAVE_LIMITS_H, we must define it in options.h.
 AC_CHECK_HEADER([limits.h], [AM_CPPFLAGS="$AM_CPPFLAGS -DHAVE_LIMITS_H=1"], [])
-# Propagate the measured integer sizes (from AC_CHECK_SIZEOF above) into
-# options.h. The library obtains these from config.h, but config.h is not
-# available to applications; without them, application code falls back to the
-# limits.h/architecture heuristics in types.h and can compute a CTC_SETTINGS
-# value that disagrees with the library's CheckRunTimeSettings().
-AS_IF([test "x$ac_cv_sizeof_long" != "x"],
-    [AM_CPPFLAGS="$AM_CPPFLAGS -DSIZEOF_LONG=$ac_cv_sizeof_long"])
-AS_IF([test "x$ac_cv_sizeof_long_long" != "x"],
-    [AM_CPPFLAGS="$AM_CPPFLAGS -DSIZEOF_LONG_LONG=$ac_cv_sizeof_long_long"])
 AC_CHECK_LIB([network],[socket])
 AC_C_BIGENDIAN
 AC_C___ATOMIC

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -231,6 +231,15 @@ typedef const char wcchar[];
                 (ULONG_MAX == 0xffffffffUL)
             #define SIZEOF_LONG 4
         #endif
+        /* On LP64 (e.g. 64-bit Linux/macOS) long is 8 bytes. Detect it from the
+         * target's own limits.h so CTC_SETTINGS matches the library, which gets
+         * SIZEOF_LONG=8 from config.h. This must be derived per-target (not
+         * baked into options.h), so LLP64 targets such as Windows correctly get
+         * SIZEOF_LONG=4 from the branch above. */
+        #if !defined(SIZEOF_LONG) && defined(ULONG_MAX) && \
+                (ULONG_MAX == 0xffffffffffffffffULL)
+            #define SIZEOF_LONG 8
+        #endif
         #if !defined(SIZEOF_LONG_LONG) && defined(ULLONG_MAX) && \
                 (ULLONG_MAX == 0xffffffffffffffffULL)
             #define SIZEOF_LONG_LONG 8


### PR DESCRIPTION
# Description

Required since types.h depends on this definition and config.h isn't consistently available at runtime.
Fixes #9936.

# Testing

Tested build and confirmed HAVE_LIMITS_H definition moved as expected.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
