### PR TITLE
Add buffer size and callback checks to external wc_LmsKey_Sign

### DIFF
--- a/wolfcrypt/src/ext_lms.c
+++ b/wolfcrypt/src/ext_lms.c
@@ -840,6 +840,22 @@ int wc_LmsKey_Sign(LmsKey* key, byte * sig, word32 * sigSz, const byte * msg,
         return -1;
     }
 
+    if ((size_t)*sigSz < len) {
+        /* Signature buffer too small. */
+        WOLFSSL_MSG("error: LMS sig buffer too small");
+        return BUFFER_E;
+    }
+
+    if (key->write_private_key == NULL) {
+        WOLFSSL_MSG("error: LmsKey write/read callbacks are not set");
+        return BAD_FUNC_ARG;
+    }
+
+    if (key->context == NULL) {
+        WOLFSSL_MSG("error: LmsKey context is not set");
+        return BAD_FUNC_ARG;
+    }
+
     result = hss_generate_signature(key->working_key, LmsWritePrivKey,
                                     key, (const void *) msg, msgSz,
                                     sig, len, &key->info);


### PR DESCRIPTION
# Description

Apply similar fix as #10084 to external LMS to fix CI failures.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
