### PR TITLE
Fix GetLength return value check in ASN1_INTEGER functions

### DIFF
--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -1016,7 +1016,7 @@ int wolfSSL_ASN1_INTEGER_get_length(const WOLFSSL_ASN1_INTEGER* ai)
     if (ai->data[0] == ASN_INTEGER) {
         word32 idx = 1;
         int len = 0;
-        if (GetLength(ai->data, &idx, &len, (word32)ai->length) > 0 &&
+        if (GetLength(ai->data, &idx, &len, (word32)ai->length) >= 0 &&
                 idx + (word32)len == (word32)ai->length) {
             return len;
         }
@@ -1043,7 +1043,7 @@ const unsigned char* wolfSSL_ASN1_INTEGER_get0_data(const WOLFSSL_ASN1_INTEGER* 
     if (ai->data[0] == ASN_INTEGER) {
         word32 idx = 1;
         int len = 0;
-        if (GetLength(ai->data, &idx, &len, (word32)ai->length) > 0 &&
+        if (GetLength(ai->data, &idx, &len, (word32)ai->length) >= 0 &&
                 idx + (word32)len == (word32)ai->length) {
             return ai->data + idx;
         }


### PR DESCRIPTION
Change GetLength() return check from > 0 to >= 0 in wolfSSL_ASN1_INTEGER_get_length
and wolfSSL_ASN1_INTEGER_get0_data. GetLength returns the decoded length (≥ 0) on
success and negative error codes on failure, so checking > 0 incorrectly excluded
zero-length values, making the DER-stripping logic dead code.
