### PR TITLE
20260402-x25519-fe_cmov_table-const-base

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
@@ -827,14 +827,15 @@ WC_OMIT_FRAME_POINTER int fe_isnegative(const fe a)
         defined(WOLFSSL_CURVE25519_USE_ED25519)
 #ifndef WC_NO_CACHE_RESISTANT
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, const fe* base_p,
+    signed char b_p)
 #else
-WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, fe* base, signed char b)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, const fe* base, signed char b)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register fe* r asm ("r0") = (fe*)r_p;
-    register fe* base asm ("r1") = (fe*)base_p;
+    register const fe* base asm ("r1") = (const fe*)base_p;
     register signed char b asm ("r2") = (signed char)b_p;
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
@@ -2372,14 +2373,15 @@ WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, fe* base, signed char b)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, const fe* base_p,
+    signed char b_p)
 #else
-WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, fe* base, signed char b)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, const fe* base, signed char b)
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register fe* r asm ("r0") = (fe*)r_p;
-    register fe* base asm ("r1") = (fe*)base_p;
+    register const fe* base asm ("r1") = (const fe*)base_p;
     register signed char b asm ("r2") = (signed char)b_p;
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 

--- a/wolfcrypt/src/port/arm/armv8-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/armv8-curve25519_c.c
@@ -255,7 +255,7 @@ int fe_isnegative(const fe a)
     return (word32)(size_t)a;
 }
 
-void fe_cmov_table(fe* r, fe* base, signed char b)
+void fe_cmov_table(fe* r, const fe* base, signed char b)
 {
     __asm__ __volatile__ (
         "stp	x29, x30, [sp, #-32]!\n\t"
@@ -463,8 +463,8 @@ void fe_cmov_table(fe* r, fe* base, signed char b)
         "stp	x12, x13, [%x[r], #64]\n\t"
         "stp	x14, x15, [%x[r], #80]\n\t"
         "ldp	x29, x30, [sp], #32\n\t"
-        : [r] "+r" (r), [base] "+r" (base), [b] "+r" (b)
-        :
+        : [r] "+r" (r), [b] "+r" (b)
+        : [base] "r" (base)
         : "memory", "cc", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10",
             "x11", "x12", "x13", "x14", "x15", "x16", "x17", "x19", "x20",
             "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28"

--- a/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
@@ -574,14 +574,15 @@ WC_OMIT_FRAME_POINTER int fe_isnegative(const fe a)
 #if defined(HAVE_ED25519_MAKE_KEY) || defined(HAVE_ED25519_SIGN) || defined(WOLFSSL_CURVE25519_USE_ED25519)
 #ifndef WC_NO_CACHE_RESISTANT
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, const fe* base_p,
+    signed char b_p)
 #else
-WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, fe* base, signed char b)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, const fe* base, signed char b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register fe* r __asm__ ("r0") = (fe*)r_p;
-    register fe* base __asm__ ("r1") = (fe*)base_p;
+    register const fe* base __asm__ ("r1") = (const fe*)base_p;
     register signed char b __asm__ ("r2") = (signed char)b_p;
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
@@ -1558,14 +1559,15 @@ WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, fe* base, signed char b)
 
 #else
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r_p, const fe* base_p,
+    signed char b_p)
 #else
-WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, fe* base, signed char b)
+WC_OMIT_FRAME_POINTER void fe_cmov_table(fe* r, const fe* base, signed char b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register fe* r __asm__ ("r0") = (fe*)r_p;
-    register fe* base __asm__ ("r1") = (fe*)base_p;
+    register const fe* base __asm__ ("r1") = (const fe*)base_p;
     register signed char b __asm__ ("r2") = (signed char)b_p;
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 


### PR DESCRIPTION
armasm: in prototypes for `fe_cmov_table()`, declare the `base` arg as `const fe*`.

followup to #10120

tested with
```
wolfssl-multi-test.sh ...
cross-armv7a-armasm-fips-140-3-dev-sp-all-testsuite-sanitizer
cross-aarch64-armasm-fips-140-3-dev-all-unittest
cross-armv7m-armasm-thumb-sp-asm-all-crypto-only
cross-armv7m-armasm-thumb-fips-140-3-dev-sp-asm-all-crypto-only
cross-armv6zk-all-armasm cross-armv7a-all
quantum-safe-wolfssl-cross-aarch64-armasm-unittest
```
