### PR TITLE
Coverity change 03042026

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -13192,7 +13192,7 @@ static WOLFSSL_X509 *loadX509orX509REQFromPemBio(WOLFSSL_BIO *bp,
             pem = newPem;
             pemSz = newSz;
         }
-        else if (i > pemSz) {
+        else if (i >= pemSz) {
             /* Buffer full for non-streaming source - this shouldn't happen */
             break;
         }


### PR DESCRIPTION
# Description

Prevent out of bounds read (off by one) in loadX509orX509REQFromPemBio() when `i == pemSz`

Fixes CID - 558955 Out-of-bounds read

