### PR TITLE
Fix potential length mismatch in non realloc case in wolfSSL_BIO_set_conn_hostname.

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -2849,7 +2849,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
                 tmp = b->ip;
                 b->ip = (char*)XMALLOC(newLen+1, b->heap, DYNAMIC_TYPE_OPENSSL);
                 if (b->ip != NULL && tmp != NULL) {
-                    XMEMCPY(b->ip, tmp, newLen);
+                    XMEMCPY(b->ip, tmp, currLen < newLen ? currLen : newLen);
                     XFREE(tmp, b->heap, DYNAMIC_TYPE_OPENSSL);
                     tmp = NULL;
             }


### PR DESCRIPTION
Thanks to Cal Page for the report.

# Description

Partially fixes zd#21528

# Testing

Built in tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
