### PR TITLE
pin OpenVPN version until BN_bn2binpad is added

### DIFF
--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -42,8 +42,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # List of refs to test
-        ref: [ release/2.6, master ]
+        # Pinned refs: avoid OpenVPN master until wolfSSL adds any new OpenSSL
+        # APIs it adopts (e.g. BN_bn2binpad). release/2.6 + latest stable tag.
+        ref: [ release/2.6, v2.6.19 ]
     name: ${{ matrix.ref }}
     if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Latest OpenVPN master added new API that needs to be added to wolfSSL. For now pinning the test to the last stable release of OpenVPN.

```
ssl_verify_openssl.c: In function ‘extract_x509_field_ssl’:
ssl_verify_openssl.c:234:56: warning: passing argument 1 of ‘wolfSSL_X509_NAME_ENTRY_get_data’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  234 |     const ASN1_STRING *asn1 = X509_NAME_ENTRY_get_data(x509ne);
      |                                                        ^~~~~~
In file included from /home/runner/work/wolfssl/wolfssl/build-dir/include/wolfssl/openssl/ssl.h:39,
                 from /home/runner/work/wolfssl/wolfssl/build-dir/include/wolfssl/openssl/x509.h:27,
                 from ssl_verify_openssl.h:33,
                 from ssl_verify_openssl.c:37:
/home/runner/work/wolfssl/wolfssl/build-dir/include/wolfssl/ssl.h:2344:92: note: expected ‘WOLFSSL_X509_NAME_ENTRY *’ but argument is of type ‘const X509_NAME_ENTRY *’ {aka ‘const WOLFSSL_X509_NAME_ENTRY *’}
 2344 | WOLFSSL_API WOLFSSL_ASN1_STRING* wolfSSL_X509_NAME_ENTRY_get_data(WOLFSSL_X509_NAME_ENTRY* in);
      |                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~^~
ssl_verify_openssl.c:239:35: warning: passing argument 2 of ‘wolfSSL_ASN1_STRING_to_UTF8’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  239 |     if (ASN1_STRING_to_UTF8(&buf, asn1) < 0)
      |                                   ^~~~
/home/runner/work/wolfssl/wolfssl/build-dir/include/wolfssl/ssl.h:2051:87: note: expected ‘WOLFSSL_ASN1_STRING *’ but argument is of type ‘const ASN1_STRING *’ {aka ‘const WOLFSSL_ASN1_STRING *’}
 2051 | WOLFSSL_API int wolfSSL_ASN1_STRING_to_UTF8(unsigned char **out, WOLFSSL_ASN1_STRING *in);
      |                                                                  ~~~~~~~~~~~~~~~~~~~~~^~
ssl_verify_openssl.c: In function ‘backend_x509_get_serial_hex’:
ssl_verify_openssl.c:323:5: warning: implicit declaration of function ‘BN_bn2binpad’; did you mean ‘BN_bn2bin’? [-Wimplicit-function-declaration]
  323 |     BN_bn2binpad(bn_serial, buf, len_serial);
      |     ^~~~~~~~~~~~
      |     BN_bn2bin
```