### PR TITLE
fix for acert builds

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -13614,6 +13614,32 @@ static int CopyBaseEntry(Base_entry** to, Base_entry* from, void* heap)
         *  OPENSSL_EXTRA_X509_SMALL) && !IGNORE_NAME_CONSTRAINTS */
 
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS) || \
+    defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+    defined(WOLFSSL_ACERT)
+/* Copy an ASN-encoded date (type + length + data) into a WOLFSSL_ASN1_TIME.
+ * srcDate: ASN date buffer where [0]=type, [1]=length, [2..]=date bytes.
+ * srcDateLen: total length of srcDate (0 means no date present). */
+static void CopyDateToASN1_TIME(const byte* srcDate, int srcDateLen,
+                                WOLFSSL_ASN1_TIME* dst)
+{
+    if (srcDateLen >= 2) {
+        /* Clamp the date length to the maximum allowed size.
+         * This needs to match the size of WOLFSSL_ASN1_TIME minus the
+         * the type and length fields. */
+        const int maxSz = CTC_DATE_SIZE - 2;
+        const int copySz = (int)min(srcDate[1], maxSz);
+        dst->type = srcDate[0];
+        dst->length = copySz;
+        XMEMCPY(dst->data, &srcDate[2], copySz);
+    }
+    else {
+        dst->length = 0;
+    }
+}
+#endif /* KEEP_PEER_CERT || SESSION_CERTS || OPENSSL_EXTRA ||
+        *  OPENSSL_EXTRA_X509_SMALL || WOLFSSL_ACERT */
+
+#if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS) || \
     defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 void CopyDecodedName(WOLFSSL_X509_NAME* name, DecodedCert* dCert, int nameType)
 {
@@ -13758,27 +13784,6 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
     return ret;
 }
 #endif /* WOLFSSL_CERT_REQ */
-
-/* Copy an ASN-encoded date (type + length + data) into a WOLFSSL_ASN1_TIME.
- * srcDate: ASN date buffer where [0]=type, [1]=length, [2..]=date bytes.
- * srcDateLen: total length of srcDate (0 means no date present). */
-static void CopyDateToASN1_TIME(const byte* srcDate, int srcDateLen,
-                                WOLFSSL_ASN1_TIME* dst)
-{
-    if (srcDateLen >= 2) {
-        /* Clamp the date length to the maximum allowed size.
-         * This needs to match the size of WOLFSSL_ASN1_TIME minus the
-         * the type and length fields. */
-        const int maxSz = CTC_DATE_SIZE - 2;
-        const int copySz = (int)min(srcDate[1], maxSz);
-        dst->type = srcDate[0];
-        dst->length = copySz;
-        XMEMCPY(dst->data, &srcDate[2], copySz);
-    }
-    else {
-        dst->length = 0;
-    }
-}
 
 /* Copy parts X509 needs from Decoded cert, 0 on success */
 int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)


### PR DESCRIPTION
Fix for `./configure --enable-acert && make` which also fixes wolfHSM CI tests.

Error was:

```
cc  -Wno-cpp -std=c99 -Wall -Werror -Wextra -ggdb -g3 -fsanitize=address -D_POSIX_C_SOURCE=200809L -DWOLFSSL_USER_SETTINGS -DWOLFHSM_CFG -DWOLFHSM_CFG_DEBUG -DWOLFHSM_CFG_DEBUG_VERBOSE -DWOLFHSM_CFG_ENABLE_AUTHENTICATION -I. -I./config -I./../ -I../../../wolfssl -I../../../ -I../../..//port/posix -c -o Build/wh_posix_server_cfg.o wh_posix_server_cfg.c
../../../wolfssl/src/internal.c: In function ‘CopyDecodedAcertToX509’:
../../../wolfssl/src/internal.c:14247:5: error: implicit declaration of function ‘CopyDateToASN1_TIME’ [-Werror=implicit-function-declaration]
14247 |     CopyDateToASN1_TIME(dAcert->beforeDate, dAcert->beforeDateLen,
      |     ^~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:184: Build/internal.o] Error 1
make: *** Waiting for unfinished jobs....
```