### PR TITLE
do not enable TLSX with --enable-ech

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2222,7 +2222,6 @@ then
     test "$enable_ecc" = "" && enable_ecc=yes
     test "$enable_curve25519" = "" && enable_curve25519=yes
     test "$enable_sha256" = "" && enable_sha256=yes
-    test "$enable_tlsx" = "" && enable_tlsx=yes
     test "$enable_sni" = "" && enable_sni=yes
     test "$enable_tls13" = "" && enable_tls13=yes
 fi


### PR DESCRIPTION
# Description

--enable-ech was pulling in --enable-tlsx, which enables all TLS extensions in bulk. ECH does not **need** most of these.

The --enable-tlsx dependency was redundant to begin with. HAVE_TLS_EXTENSIONS, the only thing ECH actually needs from it, is already provided by --enable-tls13, which ECH already enables directly.                                                                    
                                                                                                                                            
Removing the line fixes the --enable-ech --enable-harden-tls combination without affecting any ECH functionality. Thus solving GH #10067.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
