### PR TITLE
20260407-fips-ready-WC_FIPS_186_4

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -461,7 +461,7 @@
     (WOLFSSL_FIPS_VERSION_CODE != WOLFSSL_MAKE_FIPS_VERSION3(major,minor,patch))
 
 #if defined(HAVE_FIPS) && !defined(WC_FIPS_186_5) && !defined(WC_FIPS_186_4)
-    #if FIPS_VERSION3_GE(7,0,0)
+    #if FIPS_VERSION3_GE(7,0,0) && !defined(WOLFSSL_FIPS_READY)
         #ifndef WC_FIPS_186_5
             #define WC_FIPS_186_5
         #endif


### PR DESCRIPTION
`wolfssl/wolfcrypt/settings.h`: for `fips-ready`, set `WC_FIPS_186_4`, not `_5`, to match v5/v6.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
fips-140-3-ready-optest-acvp-sp-asm
fips-140-3-dev-optest-acvp-sp-asm
```
with `WOLFSSL_FIPS_READY` mapping to v5/v6 ACVP vector set (with SHA-1) to assure proper exercise of more permissive FIPS 186-4 settings.
