### PR TITLE
20260407-SHA3-unaligned-access

### DIFF
--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -615,19 +615,8 @@ static word64 Load64BitLittleEndian(const byte* a)
     return n;
 }
 #elif defined(WC_SHA3_FAULT_HARDEN)
-static WC_INLINE word64 Load64Unaligned(const unsigned char *a)
-{
-#ifdef WC_64BIT_CPU
-    return *(word64*)a;
-#elif defined(WC_32BIT_CPU)
-    return (((word64)((word32*)a)[1]) << 32) |
-                     ((word32*)a)[0];
-#else
-    return (((word64)((word16*)a)[3]) << 48) |
-           (((word64)((word16*)a)[2]) << 32) |
-           (((word64)((word16*)a)[1]) << 16) |
-                     ((word16*)a)[0];
-#endif
+static WC_INLINE word64 Load64Unaligned(const unsigned char *a) {
+    return readUnalignedWord64(a);
 }
 
 /* Convert the array of bytes, in little-endian order, to a 64-bit integer.


### PR DESCRIPTION
`wolfcrypt/src/sha3.c`: fix `Load64Unaligned()` implementation with unaligned integer access when `WC_SHA3_FAULT_HARDEN` && !`BIG_ENDIAN_ORDER`.

tested with
```

LIBWOLFSSL_CONFIGURE_ARGS_OVERRIDE='--enable-faultharden --disable-dual-alg-certs' wolfssl-multi-test.sh ...
check-source-text
cross-riscv64-all-asm
clang-tidy-all-sp-all
quantum-safe-wolfssl-all-intelasm-sp-asm-sanitizer
quantum-safe-wolfssl-all-noasm-sanitizer
benchmark-wolfcrypt-noasm-all
benchmark-wolfcrypt-intelasm-sp-asm-all
```

fixes #10043
