### PR TITLE
Libevent integration for OpenSSL compatibility layer

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -4499,6 +4499,53 @@ int wolfSSL_BIO_get_mem_data(WOLFSSL_BIO* bio,void* p);
 /*!
     \ingroup IO
 
+    \brief This is used to set the init flag of a BIO, indicating whether
+    the BIO has been initialised and is ready for use. Typically called
+    from a custom BIO create callback.
+
+    \param bio WOLFSSL_BIO structure to set the init flag on.
+    \param init value to set (0 = not initialised, 1 = initialised).
+
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    // inside a custom BIO create callback
+    wolfSSL_BIO_set_init(bio, 1);
+    \endcode
+
+    \sa wolfSSL_BIO_get_init
+    \sa wolfSSL_BIO_new
+*/
+void wolfSSL_BIO_set_init(WOLFSSL_BIO* bio, int init);
+
+/*!
+    \ingroup IO
+
+    \brief This is used to retrieve the init flag of a BIO, indicating
+    whether the BIO has been initialised and is ready for use.
+
+    \return 1 if the BIO has been initialised.
+    \return 0 if the BIO has not been initialised or bio is NULL.
+
+    \param bio WOLFSSL_BIO structure to query.
+
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    // create bio with custom method
+    if (wolfSSL_BIO_get_init(bio)) {
+        // bio is ready
+    }
+    \endcode
+
+    \sa wolfSSL_BIO_set_init
+    \sa wolfSSL_BIO_new
+*/
+int wolfSSL_BIO_get_init(WOLFSSL_BIO* bio);
+
+/*!
+    \ingroup IO
+
     \brief Sets the file descriptor for bio to use.
 
     \return SSL_SUCCESS(1) upon success.

--- a/src/bio.c
+++ b/src/bio.c
@@ -2032,6 +2032,12 @@ void wolfSSL_BIO_set_init(WOLFSSL_BIO* bio, int init)
         bio->init = (byte)(init != 0);
 }
 
+int wolfSSL_BIO_get_init(WOLFSSL_BIO* bio)
+{
+    WOLFSSL_ENTER("wolfSSL_BIO_get_init");
+    return bio != NULL && bio->init;
+}
+
 /* If flag is 0 then blocking is set, if 1 then non blocking.
  * Always returns WOLFSSL_SUCCESS.
  */

--- a/tests/api/test_ossl_bio.c
+++ b/tests/api/test_ossl_bio.c
@@ -1803,5 +1803,41 @@ int test_wolfSSL_BIO_meth_type_large(void)
     return EXPECT_RESULT();
 }
 
+int test_wolfSSL_BIO_get_init(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_EXTRA)
+    BIO_METHOD* method = NULL;
+    BIO* bio = NULL;
+
+    /* BIO_new with a custom method that calls BIO_set_init(bio, 1) */
+    ExpectNotNull(method = BIO_meth_new(WOLFSSL_BIO_UNDEF, "get_init_test"));
+    ExpectIntEQ(BIO_meth_set_create(method, custom_bio_createCb),
+        WOLFSSL_SUCCESS);
+    ExpectIntEQ(BIO_meth_set_destroy(method, custom_bio_destroyCb),
+        WOLFSSL_SUCCESS);
+
+    ExpectNotNull(bio = BIO_new(method));
+
+    /* createCb calls BIO_set_init(bio, 1), so get_init should return 1 */
+    ExpectIntEQ(BIO_get_init(bio), 1);
+
+    /* Clear init and verify it returns 0 */
+    BIO_set_init(bio, 0);
+    ExpectIntEQ(BIO_get_init(bio), 0);
+
+    /* Set init back and verify */
+    BIO_set_init(bio, 1);
+    ExpectIntEQ(BIO_get_init(bio), 1);
+
+    /* NULL should return 0 */
+    ExpectIntEQ(BIO_get_init(NULL), 0);
+
+    BIO_free(bio);
+    BIO_meth_free(method);
+#endif
+    return EXPECT_RESULT();
+}
+
 #endif /* !NO_BIO */
 

--- a/tests/api/test_ossl_bio.h
+++ b/tests/api/test_ossl_bio.h
@@ -46,6 +46,7 @@ int test_wolfSSL_BIO_custom_method(void);
 int test_wolfSSL_BIO_set_conn_hostname(void);
 int test_wolfSSL_BIO_ctrl_pending_chain(void);
 int test_wolfSSL_BIO_meth_type_large(void);
+int test_wolfSSL_BIO_get_init(void);
 
 #define TEST_OSSL_BIO_DECLS                                       \
     TEST_DECL_GROUP("ossl_bio", test_wolfSSL_BIO_gets),           \
@@ -64,7 +65,8 @@ int test_wolfSSL_BIO_meth_type_large(void);
     TEST_DECL_GROUP("ossl_bio", test_wolfSSL_BIO_custom_method),  \
     TEST_DECL_GROUP("ossl_bio", test_wolfSSL_BIO_set_conn_hostname), \
     TEST_DECL_GROUP("ossl_bio", test_wolfSSL_BIO_ctrl_pending_chain), \
-    TEST_DECL_GROUP("ossl_bio", test_wolfSSL_BIO_meth_type_large)
+    TEST_DECL_GROUP("ossl_bio", test_wolfSSL_BIO_meth_type_large), \
+    TEST_DECL_GROUP("ossl_bio", test_wolfSSL_BIO_get_init)
 
 #define TEST_OSSL_BIO_TLS_DECLS                                   \
     TEST_DECL_GROUP("ossl_bio_tls", test_wolfSSL_BIO_connect),    \

--- a/wolfssl/openssl/bio.h
+++ b/wolfssl/openssl/bio.h
@@ -159,6 +159,7 @@
 
 /* BIO for 1.1.0 or later */
 #define BIO_set_init               wolfSSL_BIO_set_init
+#define BIO_get_init               wolfSSL_BIO_get_init
 #define BIO_get_data               wolfSSL_BIO_get_data
 #define BIO_set_data               wolfSSL_BIO_set_data
 #define BIO_get_shutdown           wolfSSL_BIO_get_shutdown

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2120,6 +2120,7 @@ WOLFSSL_API long wolfSSL_BIO_set_nbio(WOLFSSL_BIO* bio, long on);
 WOLFSSL_API int wolfSSL_BIO_get_mem_data(WOLFSSL_BIO* bio,void* p);
 
 WOLFSSL_API void wolfSSL_BIO_set_init(WOLFSSL_BIO* bio, int init);
+WOLFSSL_API int  wolfSSL_BIO_get_init(WOLFSSL_BIO* bio);
 WOLFSSL_API void wolfSSL_BIO_set_data(WOLFSSL_BIO* bio, void* ptr);
 WOLFSSL_API void* wolfSSL_BIO_get_data(WOLFSSL_BIO* bio);
 WOLFSSL_API void wolfSSL_BIO_set_shutdown(WOLFSSL_BIO* bio, int shut);


### PR DESCRIPTION
# Description
Part of integrating wolfSSL as an OpenSSL replacement for the third-party library libevent. libevent hardcodes OpenSSL internal struct tags (ssl_st, ssl_ctx_st, bio_st, etc.) in forward declarations, so struct tag compatibility defines were added to wolfssl/openssl/ssl.h. Additionally, BIO_get_init was missing from the wolfSSL API - libevent calls it on custom BIO methods so wolfSSL_BIO_get_init was implemented. 
A new --enable-libevent configure option installs OpenSSL drop-in symlinks for headers, libraries, and pkg-config.
Requires --enable-opensslall and --enable-opensslextra.

The bug which I fixed : 


# Testing
./configure --enable-libevent --enable-opensslall --enable-opensslextra && make - verified symlinks and pkg-config output.
./configure --enable-libevent alone - verified configure errors out requiring opensslall/opensslextra.
Built libevent against the resulting wolfssl install.

ontop of that I added a test for the newly added features: 
test_wolfSSL_BIO_get_init


# Checklist
 - [ *] added tests
 - [ *] updated/added doxygen

