### PR TITLE
OpenSSL compatibility layer extension

### DIFF
--- a/.codespellexcludelines
+++ b/.codespellexcludelines
@@ -19,3 +19,5 @@ rsource "Kconfig.tls-generic"
 /* functions added to support above needed, removed TOOM and KARATSUBA */
 #include <sys/systm.h>
  * extern global version from /usr/src/sys/sys/systm.h */
+            return "UE";
+    ExpectStrEQ(wolfSSL_alert_desc_string(unsupported_extension), "UE");

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12202,7 +12202,7 @@ const char* wolfSSL_alert_desc_string(int alertID)
         case missing_extension:
             return "ME";
         case unsupported_extension:
-            return "XE";
+            return "UE";
         case unrecognized_name:
             return "UN";
         case bad_certificate_status_response:

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12202,7 +12202,7 @@ const char* wolfSSL_alert_desc_string(int alertID)
         case missing_extension:
             return "ME";
         case unsupported_extension:
-            return "UE";
+            return "XE";
         case unrecognized_name:
             return "UN";
         case bad_certificate_status_response:

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12127,11 +12127,95 @@ const char* wolfSSL_alert_type_string_long(int alertID)
     return AlertTypeToString(alertID);
 }
 
+const char* wolfSSL_alert_type_string(int alertID)
+{
+    WOLFSSL_ENTER("wolfSSL_alert_type_string");
+
+    switch (alertID) {
+        case alert_warning:
+            return "W";
+        case alert_fatal:
+            return "F";
+        default:
+            return "U";
+    }
+}
+
 const char* wolfSSL_alert_desc_string_long(int alertID)
 {
     WOLFSSL_ENTER("wolfSSL_alert_desc_string_long");
 
     return AlertTypeToString(alertID);
+}
+
+const char* wolfSSL_alert_desc_string(int alertID)
+{
+    WOLFSSL_ENTER("wolfSSL_alert_desc_string");
+
+    switch (alertID) {
+        case close_notify:
+            return "CN";
+        case unexpected_message:
+            return "UM";
+        case bad_record_mac:
+            return "BM";
+        case record_overflow:
+            return "RO";
+        case decompression_failure:
+            return "DF";
+        case handshake_failure:
+            return "HF";
+        case no_certificate:
+            return "NC";
+        case bad_certificate:
+            return "BC";
+        case unsupported_certificate:
+            return "UC";
+        case certificate_revoked:
+            return "CR";
+        case certificate_expired:
+            return "CE";
+        case certificate_unknown:
+            return "CU";
+        case illegal_parameter:
+            return "IP";
+        case unknown_ca:
+            return "CA";
+        case access_denied:
+            return "AD";
+        case decode_error:
+            return "DE";
+        case decrypt_error:
+            return "DC";
+        case wolfssl_alert_protocol_version:
+            return "PV";
+        case insufficient_security:
+            return "IS";
+        case internal_error:
+            return "IE";
+        case inappropriate_fallback:
+            return "IF";
+        case user_canceled:
+            return "US";
+        case no_renegotiation:
+            return "NR";
+        case missing_extension:
+            return "ME";
+        case unsupported_extension:
+            return "UE";
+        case unrecognized_name:
+            return "UN";
+        case bad_certificate_status_response:
+            return "BR";
+        case unknown_psk_identity:
+            return "UP";
+        case certificate_required:
+            return "CQ";
+        case no_application_protocol:
+            return "AP";
+        default:
+            return "UK";
+    }
 }
 #endif /* !NO_TLS */
 

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -2013,6 +2013,121 @@ int test_wolfSSL_EVP_MD_ecc_signing(void)
 }
 
 
+int test_wolfSSL_EVP_DigestSign(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_EXTRA) && !defined(NO_RSA) && defined(USE_CERT_BUFFERS_2048)
+    WOLFSSL_EVP_PKEY* privKey = NULL;
+    WOLFSSL_EVP_PKEY* pubKey = NULL;
+    const unsigned char testData[] = "Hi There";
+    WOLFSSL_EVP_MD_CTX mdCtx;
+    int ret;
+    const unsigned char* cp;
+    const unsigned char* p;
+    unsigned char sig[2048/8];
+    size_t sigSz;
+
+    cp = client_key_der_2048;
+    ExpectNotNull((privKey = wolfSSL_d2i_PrivateKey(EVP_PKEY_RSA, NULL, &cp,
+                                                  sizeof_client_key_der_2048)));
+    p = client_keypub_der_2048;
+    ExpectNotNull((pubKey = wolfSSL_d2i_PUBKEY(NULL, &p,
+                                               sizeof_client_keypub_der_2048)));
+
+    /* One-shot sign: query size first */
+    wolfSSL_EVP_MD_CTX_init(&mdCtx);
+    ExpectIntEQ(wolfSSL_EVP_DigestSignInit(&mdCtx, NULL, wolfSSL_EVP_sha256(),
+                                                             NULL, privKey), 1);
+    sigSz = 0;
+    ExpectIntEQ(wolfSSL_EVP_DigestSign(&mdCtx, NULL, &sigSz, testData,
+                                       (unsigned int)XSTRLEN((const char*)testData)), 1);
+    ExpectIntGT((int)sigSz, 0);
+    ret = wolfSSL_EVP_MD_CTX_cleanup(&mdCtx);
+    ExpectIntEQ(ret, 1);
+
+    /* One-shot sign: actually produce the signature */
+    wolfSSL_EVP_MD_CTX_init(&mdCtx);
+    ExpectIntEQ(wolfSSL_EVP_DigestSignInit(&mdCtx, NULL, wolfSSL_EVP_sha256(),
+                                                             NULL, privKey), 1);
+    sigSz = sizeof(sig);
+    ExpectIntEQ(wolfSSL_EVP_DigestSign(&mdCtx, sig, &sigSz, testData,
+                                       (unsigned int)XSTRLEN((const char*)testData)), 1);
+    ExpectIntGT((int)sigSz, 0);
+    ret = wolfSSL_EVP_MD_CTX_cleanup(&mdCtx);
+    ExpectIntEQ(ret, 1);
+
+    /* One-shot verify */
+    wolfSSL_EVP_MD_CTX_init(&mdCtx);
+    ExpectIntEQ(wolfSSL_EVP_DigestVerifyInit(&mdCtx, NULL,
+                wolfSSL_EVP_sha256(), NULL, pubKey), 1);
+    ExpectIntEQ(wolfSSL_EVP_DigestVerify(&mdCtx, sig, sigSz, testData,
+                                         (unsigned int)XSTRLEN((const char*)testData)), 1);
+    ret = wolfSSL_EVP_MD_CTX_cleanup(&mdCtx);
+    ExpectIntEQ(ret, 1);
+
+    /* One-shot sign + verify with NULL ctx should fail */
+    ExpectIntEQ(wolfSSL_EVP_DigestSign(NULL, sig, &sigSz, testData,
+                                       (unsigned int)XSTRLEN((const char*)testData)),
+                WOLFSSL_FAILURE);
+    ExpectIntEQ(wolfSSL_EVP_DigestVerify(NULL, sig, sigSz, testData,
+                                         (unsigned int)XSTRLEN((const char*)testData)),
+                WOLFSSL_FAILURE);
+
+    wolfSSL_EVP_PKEY_free(pubKey);
+    wolfSSL_EVP_PKEY_free(privKey);
+#endif
+    return EXPECT_RESULT();
+}
+
+
+int test_wolfSSL_EVP_DigestSign_ecc(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC) && defined(USE_CERT_BUFFERS_256)
+    WOLFSSL_EVP_PKEY* privKey = NULL;
+    WOLFSSL_EVP_PKEY* pubKey = NULL;
+    const unsigned char testData[] = "ECC one-shot test";
+    WOLFSSL_EVP_MD_CTX mdCtx;
+    int ret;
+    const unsigned char* cp;
+    const unsigned char* p;
+    unsigned char sig[256];
+    size_t sigSz;
+
+    cp = ecc_clikey_der_256;
+    ExpectNotNull(privKey = wolfSSL_d2i_PrivateKey(EVP_PKEY_EC, NULL, &cp,
+                                                   sizeof_ecc_clikey_der_256));
+    p = ecc_clikeypub_der_256;
+    ExpectNotNull((pubKey = wolfSSL_d2i_PUBKEY(NULL, &p,
+                                                sizeof_ecc_clikeypub_der_256)));
+
+    /* One-shot sign */
+    wolfSSL_EVP_MD_CTX_init(&mdCtx);
+    ExpectIntEQ(wolfSSL_EVP_DigestSignInit(&mdCtx, NULL, wolfSSL_EVP_sha256(),
+                                                             NULL, privKey), 1);
+    sigSz = sizeof(sig);
+    ExpectIntEQ(wolfSSL_EVP_DigestSign(&mdCtx, sig, &sigSz, testData,
+                                       (unsigned int)XSTRLEN((const char*)testData)), 1);
+    ExpectIntGT((int)sigSz, 0);
+    ret = wolfSSL_EVP_MD_CTX_cleanup(&mdCtx);
+    ExpectIntEQ(ret, 1);
+
+    /* One-shot verify */
+    wolfSSL_EVP_MD_CTX_init(&mdCtx);
+    ExpectIntEQ(wolfSSL_EVP_DigestVerifyInit(&mdCtx, NULL,
+                wolfSSL_EVP_sha256(), NULL, pubKey), 1);
+    ExpectIntEQ(wolfSSL_EVP_DigestVerify(&mdCtx, sig, sigSz, testData,
+                                         (unsigned int)XSTRLEN((const char*)testData)), 1);
+    ret = wolfSSL_EVP_MD_CTX_cleanup(&mdCtx);
+    ExpectIntEQ(ret, 1);
+
+    wolfSSL_EVP_PKEY_free(pubKey);
+    wolfSSL_EVP_PKEY_free(privKey);
+#endif
+    return EXPECT_RESULT();
+}
+
+
 int test_wolfSSL_EVP_PKEY_encrypt(void)
 {
     EXPECT_DECLS;

--- a/tests/api/test_evp_pkey.h
+++ b/tests/api/test_evp_pkey.h
@@ -58,6 +58,8 @@ int test_wolfSSL_EVP_PKEY_sign_verify_ec(void);
 int test_wolfSSL_EVP_MD_rsa_signing(void);
 int test_wc_RsaPSS_DigitalSignVerify(void);
 int test_wolfSSL_EVP_MD_ecc_signing(void);
+int test_wolfSSL_EVP_DigestSign(void);
+int test_wolfSSL_EVP_DigestSign_ecc(void);
 int test_wolfSSL_EVP_PKEY_encrypt(void);
 int test_wolfSSL_EVP_PKEY_derive(void);
 int test_wolfSSL_EVP_PKEY_print_public(void);
@@ -101,6 +103,8 @@ int test_wolfSSL_EVP_PKEY_ed448(void);
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_MD_rsa_signing),              \
     TEST_DECL_GROUP("evp_pkey", test_wc_RsaPSS_DigitalSignVerify),             \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_MD_ecc_signing),              \
+    TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_DigestSign),                  \
+    TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_DigestSign_ecc),              \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_encrypt),                \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_derive),                 \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_print_public),           \

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -1103,6 +1103,9 @@ int test_tls12_corrupted_finished(void)
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_free(ssl_s);
     wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
 
 int test_wolfSSL_alert_type_string(void)
 {

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -31,6 +31,7 @@
 #include <tests/utils.h>
 #include <tests/api/test_tls.h>
 #include <wolfssl/internal.h>
+#include <wolfssl/openssl/ssl.h>
 
 
 int test_utils_memio_move_message(void)
@@ -1102,6 +1103,17 @@ int test_tls12_corrupted_finished(void)
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_free(ssl_s);
     wolfSSL_CTX_free(ctx_s);
+
+int test_wolfSSL_alert_type_string(void)
+{
+    EXPECT_DECLS;
+#ifndef NO_TLS
+    /* wolfSSL_alert_type_string returns short code for alert level */
+    ExpectStrEQ(wolfSSL_alert_type_string(alert_warning), "W");
+    ExpectStrEQ(wolfSSL_alert_type_string(alert_fatal), "F");
+    ExpectStrEQ(wolfSSL_alert_type_string(0), "U");
+    ExpectStrEQ(wolfSSL_alert_type_string(-1), "U");
+    ExpectStrEQ(wolfSSL_alert_type_string(99), "U");
 #endif
     return EXPECT_RESULT();
 }
@@ -1162,6 +1174,47 @@ int test_tls12_peerauth_failsafe(void)
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_free(ssl_s);
     wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
+
+int test_wolfSSL_alert_desc_string(void)
+{
+    EXPECT_DECLS;
+#ifndef NO_TLS
+    /* wolfSSL_alert_desc_string returns short 2-letter code */
+    ExpectStrEQ(wolfSSL_alert_desc_string(close_notify), "CN");
+    ExpectStrEQ(wolfSSL_alert_desc_string(unexpected_message), "UM");
+    ExpectStrEQ(wolfSSL_alert_desc_string(bad_record_mac), "BM");
+    ExpectStrEQ(wolfSSL_alert_desc_string(record_overflow), "RO");
+    ExpectStrEQ(wolfSSL_alert_desc_string(decompression_failure), "DF");
+    ExpectStrEQ(wolfSSL_alert_desc_string(handshake_failure), "HF");
+    ExpectStrEQ(wolfSSL_alert_desc_string(no_certificate), "NC");
+    ExpectStrEQ(wolfSSL_alert_desc_string(bad_certificate), "BC");
+    ExpectStrEQ(wolfSSL_alert_desc_string(unsupported_certificate), "UC");
+    ExpectStrEQ(wolfSSL_alert_desc_string(certificate_revoked), "CR");
+    ExpectStrEQ(wolfSSL_alert_desc_string(certificate_expired), "CE");
+    ExpectStrEQ(wolfSSL_alert_desc_string(certificate_unknown), "CU");
+    ExpectStrEQ(wolfSSL_alert_desc_string(illegal_parameter), "IP");
+    ExpectStrEQ(wolfSSL_alert_desc_string(unknown_ca), "CA");
+    ExpectStrEQ(wolfSSL_alert_desc_string(access_denied), "AD");
+    ExpectStrEQ(wolfSSL_alert_desc_string(decode_error), "DE");
+    ExpectStrEQ(wolfSSL_alert_desc_string(decrypt_error), "DC");
+    ExpectStrEQ(wolfSSL_alert_desc_string(wolfssl_alert_protocol_version), "PV");
+    ExpectStrEQ(wolfSSL_alert_desc_string(insufficient_security), "IS");
+    ExpectStrEQ(wolfSSL_alert_desc_string(internal_error), "IE");
+    ExpectStrEQ(wolfSSL_alert_desc_string(inappropriate_fallback), "IF");
+    ExpectStrEQ(wolfSSL_alert_desc_string(user_canceled), "US");
+    ExpectStrEQ(wolfSSL_alert_desc_string(no_renegotiation), "NR");
+    ExpectStrEQ(wolfSSL_alert_desc_string(missing_extension), "ME");
+    ExpectStrEQ(wolfSSL_alert_desc_string(unsupported_extension), "UE");
+    ExpectStrEQ(wolfSSL_alert_desc_string(unrecognized_name), "UN");
+    ExpectStrEQ(wolfSSL_alert_desc_string(bad_certificate_status_response), "BR");
+    ExpectStrEQ(wolfSSL_alert_desc_string(unknown_psk_identity), "UP");
+    ExpectStrEQ(wolfSSL_alert_desc_string(certificate_required), "CQ");
+    ExpectStrEQ(wolfSSL_alert_desc_string(no_application_protocol), "AP");
+    /* Unknown alert description returns "UK" */
+    ExpectStrEQ(wolfSSL_alert_desc_string(255), "UK");
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -1107,8 +1107,7 @@ int test_tls12_corrupted_finished(void)
 int test_wolfSSL_alert_type_string(void)
 {
     EXPECT_DECLS;
-#if !defined(NO_TLS) && (defined(OPENSSL_EXTRA) || \
-    defined(OPENSSL_EXTRA_X509_SMALL))
+#if !defined(NO_TLS) && defined(OPENSSL_EXTRA)
     ExpectStrEQ(wolfSSL_alert_type_string(alert_warning), "W");
     ExpectStrEQ(wolfSSL_alert_type_string(alert_fatal), "F");
     ExpectStrEQ(wolfSSL_alert_type_string(0), "U");
@@ -1181,8 +1180,7 @@ int test_tls12_peerauth_failsafe(void)
 int test_wolfSSL_alert_desc_string(void)
 {
     EXPECT_DECLS;
-#if !defined(NO_TLS) && (defined(OPENSSL_EXTRA) || \
-    defined(OPENSSL_EXTRA_X509_SMALL))
+#if !defined(NO_TLS) && defined(OPENSSL_EXTRA)
     ExpectStrEQ(wolfSSL_alert_desc_string(close_notify), "CN");
     ExpectStrEQ(wolfSSL_alert_desc_string(unexpected_message), "UM");
     ExpectStrEQ(wolfSSL_alert_desc_string(bad_record_mac), "BM");

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -31,7 +31,7 @@
 #include <tests/utils.h>
 #include <tests/api/test_tls.h>
 #include <wolfssl/internal.h>
-#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl.h>
 
 
 int test_utils_memio_move_message(void)
@@ -1107,8 +1107,8 @@ int test_tls12_corrupted_finished(void)
 int test_wolfSSL_alert_type_string(void)
 {
     EXPECT_DECLS;
-#ifndef NO_TLS
-    /* wolfSSL_alert_type_string returns short code for alert level */
+#if !defined(NO_TLS) && (defined(OPENSSL_EXTRA) || \
+    defined(OPENSSL_EXTRA_X509_SMALL))
     ExpectStrEQ(wolfSSL_alert_type_string(alert_warning), "W");
     ExpectStrEQ(wolfSSL_alert_type_string(alert_fatal), "F");
     ExpectStrEQ(wolfSSL_alert_type_string(0), "U");
@@ -1181,8 +1181,8 @@ int test_tls12_peerauth_failsafe(void)
 int test_wolfSSL_alert_desc_string(void)
 {
     EXPECT_DECLS;
-#ifndef NO_TLS
-    /* wolfSSL_alert_desc_string returns short 2-letter code */
+#if !defined(NO_TLS) && (defined(OPENSSL_EXTRA) || \
+    defined(OPENSSL_EXTRA_X509_SMALL))
     ExpectStrEQ(wolfSSL_alert_desc_string(close_notify), "CN");
     ExpectStrEQ(wolfSSL_alert_desc_string(unexpected_message), "UM");
     ExpectStrEQ(wolfSSL_alert_desc_string(bad_record_mac), "BM");
@@ -1207,7 +1207,7 @@ int test_wolfSSL_alert_desc_string(void)
     ExpectStrEQ(wolfSSL_alert_desc_string(user_canceled), "US");
     ExpectStrEQ(wolfSSL_alert_desc_string(no_renegotiation), "NR");
     ExpectStrEQ(wolfSSL_alert_desc_string(missing_extension), "ME");
-    ExpectStrEQ(wolfSSL_alert_desc_string(unsupported_extension), "UE");
+    ExpectStrEQ(wolfSSL_alert_desc_string(unsupported_extension), "XE");
     ExpectStrEQ(wolfSSL_alert_desc_string(unrecognized_name), "UN");
     ExpectStrEQ(wolfSSL_alert_desc_string(bad_certificate_status_response), "BR");
     ExpectStrEQ(wolfSSL_alert_desc_string(unknown_psk_identity), "UP");

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -1208,7 +1208,7 @@ int test_wolfSSL_alert_desc_string(void)
     ExpectStrEQ(wolfSSL_alert_desc_string(user_canceled), "US");
     ExpectStrEQ(wolfSSL_alert_desc_string(no_renegotiation), "NR");
     ExpectStrEQ(wolfSSL_alert_desc_string(missing_extension), "ME");
-    ExpectStrEQ(wolfSSL_alert_desc_string(unsupported_extension), "XE");
+    ExpectStrEQ(wolfSSL_alert_desc_string(unsupported_extension), "UE");
     ExpectStrEQ(wolfSSL_alert_desc_string(unrecognized_name), "UN");
     ExpectStrEQ(wolfSSL_alert_desc_string(bad_certificate_status_response), "BR");
     ExpectStrEQ(wolfSSL_alert_desc_string(unknown_psk_identity), "UP");

--- a/tests/api/test_tls.h
+++ b/tests/api/test_tls.h
@@ -53,7 +53,7 @@ int test_wolfSSL_alert_desc_string(void);
         TEST_DECL_GROUP("tls", test_tls_set_session_min_downgrade),            \
         TEST_DECL_GROUP("tls", test_tls_set_curves_list_ecc_fallback),         \
         TEST_DECL_GROUP("tls", test_tls12_corrupted_finished),                 \
-        TEST_DECL_GROUP("tls", test_tls12_peerauth_failsafe),                  \         
+        TEST_DECL_GROUP("tls", test_tls12_peerauth_failsafe),                  \
         TEST_DECL_GROUP("tls", test_wolfSSL_alert_type_string),                \
         TEST_DECL_GROUP("tls", test_wolfSSL_alert_desc_string)
 

--- a/tests/api/test_tls.h
+++ b/tests/api/test_tls.h
@@ -36,6 +36,8 @@ int test_tls_set_session_min_downgrade(void);
 int test_tls_set_curves_list_ecc_fallback(void);
 int test_tls12_corrupted_finished(void);
 int test_tls12_peerauth_failsafe(void);
+int test_wolfSSL_alert_type_string(void);
+int test_wolfSSL_alert_desc_string(void);
 
 #define TEST_TLS_DECLS                                                         \
         TEST_DECL_GROUP("tls", test_utils_memio_move_message),                 \
@@ -51,6 +53,8 @@ int test_tls12_peerauth_failsafe(void);
         TEST_DECL_GROUP("tls", test_tls_set_session_min_downgrade),            \
         TEST_DECL_GROUP("tls", test_tls_set_curves_list_ecc_fallback),         \
         TEST_DECL_GROUP("tls", test_tls12_corrupted_finished),                 \
-        TEST_DECL_GROUP("tls", test_tls12_peerauth_failsafe)
+        TEST_DECL_GROUP("tls", test_tls12_peerauth_failsafe),                  \         
+        TEST_DECL_GROUP("tls", test_wolfSSL_alert_type_string),                \
+        TEST_DECL_GROUP("tls", test_wolfSSL_alert_desc_string)
 
 #endif /* TESTS_API_TEST_TLS_H */

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -4984,7 +4984,7 @@ int wolfSSL_EVP_DigestSign(WOLFSSL_EVP_MD_CTX *ctx, unsigned char *sigret,
         return WOLFSSL_FAILURE;
 
     if (sigret != NULL) {
-        if (tbs == NULL || tbslen == 0)
+        if (tbs == NULL)
             return WOLFSSL_FAILURE;
         if (wolfSSL_EVP_DigestSignUpdate(ctx, tbs, (unsigned int)tbslen)
                 != WOLFSSL_SUCCESS)

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -4974,6 +4974,25 @@ int wolfSSL_EVP_DigestSignFinal(WOLFSSL_EVP_MD_CTX *ctx, unsigned char *sig,
     return ret;
 }
 
+int wolfSSL_EVP_DigestSign(WOLFSSL_EVP_MD_CTX *ctx, unsigned char *sigret,
+                           size_t *siglen, const unsigned char *tbs,
+                           size_t tbslen)
+{
+    WOLFSSL_ENTER("EVP_DigestSign");
+
+    if (ctx == NULL || siglen == NULL)
+        return WOLFSSL_FAILURE;
+
+    if (sigret != NULL) {
+        if (tbs == NULL || tbslen == 0)
+            return WOLFSSL_FAILURE;
+        if (wolfSSL_EVP_DigestSignUpdate(ctx, tbs, (unsigned int)tbslen)
+                != WOLFSSL_SUCCESS)
+            return WOLFSSL_FAILURE;
+    }
+    return wolfSSL_EVP_DigestSignFinal(ctx, sigret, siglen);
+}
+
 int wolfSSL_EVP_DigestVerifyInit(WOLFSSL_EVP_MD_CTX *ctx,
                                  WOLFSSL_EVP_PKEY_CTX **pctx,
                                  const WOLFSSL_EVP_MD *type,
@@ -5068,6 +5087,21 @@ int wolfSSL_EVP_DigestVerifyFinal(WOLFSSL_EVP_MD_CTX *ctx,
     }
 
     return WOLFSSL_FAILURE;
+}
+
+int wolfSSL_EVP_DigestVerify(WOLFSSL_EVP_MD_CTX *ctx,
+                             const unsigned char *sigret, size_t siglen,
+                             const unsigned char *tbs, size_t tbslen)
+{
+    WOLFSSL_ENTER("EVP_DigestVerify");
+
+    if (ctx == NULL || sigret == NULL || tbs == NULL)
+        return WOLFSSL_FAILURE;
+
+    if (wolfSSL_EVP_DigestVerifyUpdate(ctx, tbs, tbslen) != WOLFSSL_SUCCESS)
+        return WOLFSSL_FAILURE;
+
+    return wolfSSL_EVP_DigestVerifyFinal(ctx, sigret, siglen);
 }
 
 

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -856,11 +856,19 @@ WOLFSSL_API int wolfSSL_EVP_DigestSignUpdate(WOLFSSL_EVP_MD_CTX *ctx,
                                              const void *d, unsigned int cnt);
 WOLFSSL_API int wolfSSL_EVP_DigestSignFinal(WOLFSSL_EVP_MD_CTX *ctx,
                                             unsigned char *sig, size_t *siglen);
+WOLFSSL_API int wolfSSL_EVP_DigestSign(WOLFSSL_EVP_MD_CTX *ctx,
+                                       unsigned char *sigret, size_t *siglen,
+                                       const unsigned char *tbs, size_t tbslen);
 WOLFSSL_API int wolfSSL_EVP_DigestVerifyUpdate(WOLFSSL_EVP_MD_CTX *ctx,
                                                const void *d, size_t cnt);
 WOLFSSL_API int wolfSSL_EVP_DigestVerifyFinal(WOLFSSL_EVP_MD_CTX *ctx,
                                               const unsigned char *sig,
                                               size_t siglen);
+WOLFSSL_API int wolfSSL_EVP_DigestVerify(WOLFSSL_EVP_MD_CTX *ctx,
+                                         const unsigned char *sigret,
+                                         size_t siglen,
+                                         const unsigned char *tbs,
+                                         size_t tbslen);
 
 WOLFSSL_API int wolfSSL_EVP_BytesToKey(const WOLFSSL_EVP_CIPHER* type,
                        const WOLFSSL_EVP_MD* md, const byte* salt,
@@ -1306,9 +1314,11 @@ WOLFSSL_API int wolfSSL_EVP_SignInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
 #define EVP_DigestSignInit     wolfSSL_EVP_DigestSignInit
 #define EVP_DigestSignUpdate   wolfSSL_EVP_DigestSignUpdate
 #define EVP_DigestSignFinal    wolfSSL_EVP_DigestSignFinal
+#define EVP_DigestSign         wolfSSL_EVP_DigestSign
 #define EVP_DigestVerifyInit   wolfSSL_EVP_DigestVerifyInit
 #define EVP_DigestVerifyUpdate wolfSSL_EVP_DigestVerifyUpdate
 #define EVP_DigestVerifyFinal  wolfSSL_EVP_DigestVerifyFinal
+#define EVP_DigestVerify       wolfSSL_EVP_DigestVerify
 #define EVP_BytesToKey         wolfSSL_EVP_BytesToKey
 
 #define EVP_get_cipherbyname wolfSSL_EVP_get_cipherbyname

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2614,7 +2614,9 @@ WOLFSSL_API unsigned long wolfSSL_ERR_peek_error(void);
 WOLFSSL_API int           wolfSSL_GET_REASON(int);
 
 WOLFSSL_API const char* wolfSSL_alert_type_string_long(int alertID);
+WOLFSSL_API const char* wolfSSL_alert_type_string(int alertID);
 WOLFSSL_API const char* wolfSSL_alert_desc_string_long(int alertID);
+WOLFSSL_API const char* wolfSSL_alert_desc_string(int alertID);
 WOLFSSL_API const char* wolfSSL_state_string_long(const WOLFSSL* ssl);
 
 WOLFSSL_API WOLFSSL_RSA* wolfSSL_RSA_generate_key(int len, unsigned long e,


### PR DESCRIPTION
# Description
As part of integarting to WolfSSL using the compatibility layer i've had some missing functionalities which were pretty straight forward to implement .

1. **`SSL_alert_type_string` / `SSL_alert_desc_string`**: Short-form alert string functions that return 1-2 character codes for TLS alert types and descriptions (e.g., "W" for warning, "F" for fatal, "CN" for close_notify). The macros were defined but pointed to non-existent `wolfSSL_alert_type_string` and `wolfSSL_alert_desc_string` functions, causing linker errors.
2. **`EVP_DigestSign` / `EVP_DigestVerify`**: One-shot convenience wrappers that combine Init+Update+Final operations into a single call. The multi-step variants (Init/Update/Final) existed, but the one-shot functions were missing.
All functions follow OpenSSL semantics and include proper error handling.
Please describe the scope of the fix or feature addition.

# Testing

- **Unit tests added**: 
  - `test_wolfSSL_alert_type_string`: Tests all alert level codes (warning, fatal, unknown)
  - `test_wolfSSL_alert_desc_string`: Tests all 30 TLS alert description codes
  - `test_wolfSSL_EVP_DigestSign`: Tests RSA one-shot sign/verify with size query
  - `test_wolfSSL_EVP_DigestSign_ecc`: Tests ECC one-shot sign/verify
- **Compilation verified**: All modified files compile cleanly with existing build configuration
- **Symbol verification**: Confirmed all four new functions are exported in object files

# Checklist
 - [* ] added tests

