### PR TITLE
Add bwrap network namespace isolation to scripts with listening ports

### DIFF
--- a/scripts/benchmark.test
+++ b/scripts/benchmark.test
@@ -2,6 +2,21 @@
 
 #benchmark.test
 
+# if we can, isolate the network namespace to eliminate port collisions.
+if [ -n "$NETWORK_UNSHARE_HELPER" ]; then
+     if [ -z "$NETWORK_UNSHARE_HELPER_CALLED" ]; then
+         export NETWORK_UNSHARE_HELPER_CALLED=yes
+         exec "$NETWORK_UNSHARE_HELPER" "$0" "$@" || exit $?
+     fi
+elif [ "${AM_BWRAPPED-}" != "yes" ]; then
+    bwrap_path="$(command -v bwrap)"
+    if [ -n "$bwrap_path" ]; then
+        export AM_BWRAPPED=yes
+        exec "$bwrap_path" --unshare-net --dev-bind / / "$0" "$@"
+    fi
+    unset AM_BWRAPPED
+fi
+
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
                                   && exit 1
 

--- a/scripts/openssl_srtp.test
+++ b/scripts/openssl_srtp.test
@@ -5,6 +5,21 @@
 
 set -e
 
+# if we can, isolate the network namespace to eliminate port collisions.
+if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then
+     if [[ -z "$NETWORK_UNSHARE_HELPER_CALLED" ]]; then
+         export NETWORK_UNSHARE_HELPER_CALLED=yes
+         exec "$NETWORK_UNSHARE_HELPER" "$0" "$@" || exit $?
+     fi
+elif [ "${AM_BWRAPPED-}" != "yes" ]; then
+    bwrap_path="$(command -v bwrap)"
+    if [ -n "$bwrap_path" ]; then
+        export AM_BWRAPPED=yes
+        exec "$bwrap_path" --unshare-net --dev-bind / / "$0" "$@"
+    fi
+    unset AM_BWRAPPED
+fi
+
 if ! test -n "$WOLFSSL_OPENSSL_TEST"; then
     echo "WOLFSSL_OPENSSL_TEST NOT set, won't run"
     exit 0

--- a/scripts/sniffer-gen.sh
+++ b/scripts/sniffer-gen.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 #set -x
 
+# if we can, isolate the network namespace to eliminate port collisions.
+if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then
+     if [[ -z "$NETWORK_UNSHARE_HELPER_CALLED" ]]; then
+         export NETWORK_UNSHARE_HELPER_CALLED=yes
+         exec "$NETWORK_UNSHARE_HELPER" "$0" "$@" || exit $?
+     fi
+elif [ "${AM_BWRAPPED-}" != "yes" ]; then
+    bwrap_path="$(command -v bwrap)"
+    if [ -n "$bwrap_path" ]; then
+        export AM_BWRAPPED=yes
+        exec "$bwrap_path" --cap-add ALL --unshare-net --dev-bind / / "$0" "$@"
+    fi
+    unset AM_BWRAPPED
+fi
+
 # Run this script from the wolfSSL root
 if [ ! -f wolfssl/ssl.h ]; then
     echo "Run from the wolfssl root"


### PR DESCRIPTION
Add NETWORK_UNSHARE_HELPER/bwrap wrapping to benchmark.test,
openssl_srtp.test, and sniffer-gen.sh to isolate network namespaces and
prevent port collisions when tests run concurrently. sniffer-gen.sh uses
--cap-add ALL (like dtls.test) since it runs tcpdump. ocsp-stapling.test
is excluded because it connects to external servers (login.live.com).
