### PR TITLE
ci: membrowse integration

### DIFF
--- a/.github/membrowse-targets.json
+++ b/.github/membrowse-targets.json
@@ -1,0 +1,42 @@
+[
+  {
+    "target_name": "gcc-arm-cortex-m4",
+    "port": "gcc-arm",
+    "board": "cortex-m4",
+    "setup_cmd": "sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib",
+    "build_cmd": "test -f IDE/GCC-ARM/Header/user_settings.h && mkdir -p IDE/GCC-ARM/Header-gen && { cat IDE/GCC-ARM/Header/user_settings.h; printf '#define NO_CRYPT_TEST\\n#define NO_CRYPT_BENCHMARK\\n'; } > IDE/GCC-ARM/Header-gen/user_settings.h && cd IDE/GCC-ARM && make -f Makefile.test TOOLCHAIN=arm-none-eabi- FIPS=0 USER_SETTINGS_DIR=./Header-gen CFLAGS_EXTRA='-Wno-cpp -DWOLFCRYPT_ONLY -DWOLFSSL_NO_SOCK' LDFLAGS='-mcpu=cortex-m4 -mthumb -mabi=aapcs --specs=nosys.specs --specs=nano.specs -Wl,-Map=./Build/WolfCryptTest.map -Wl,-ereset_handler -flto -Wl,--defsym=__stack_process_end__=0x20010000'",
+    "elf": "IDE/GCC-ARM/Build/WolfCryptTest.elf",
+    "ld": "IDE/GCC-ARM/linker.ld",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "gcc-arm-cortex-m4-min-ecc",
+    "port": "gcc-arm",
+    "board": "cortex-m4-min-ecc",
+    "setup_cmd": "sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib",
+    "build_cmd": "test -f examples/configs/user_settings_min_ecc.h && mkdir -p IDE/GCC-ARM/Header-gen && { cat examples/configs/user_settings_min_ecc.h; printf '#define WOLFSSL_GENERAL_ALIGNMENT 4\\n#define SINGLE_THREADED\\n#define WOLFSSL_SMALL_STACK\\n#define NO_FILESYSTEM\\n#define NO_WRITEV\\n#define NO_MAIN_DRIVER\\n#define NO_DEV_RANDOM\\n#define BENCH_EMBEDDED\\n#define USE_CERT_BUFFERS_256\\n#define WOLFSSL_IGNORE_FILE_WARN\\n#define USE_WOLF_ARM_STARTUP\\n#define WOLFSSL_USER_CURRTIME\\n#define WOLFSSL_GMTIME\\n#define USER_TICKS\\nextern unsigned long my_time(unsigned long* timer);\\n#define XTIME my_time\\n#define CUSTOM_RAND_TYPE unsigned int\\nextern unsigned int my_rng_seed_gen(void);\\n#undef CUSTOM_RAND_GENERATE\\n#define CUSTOM_RAND_GENERATE my_rng_seed_gen\\n#define HAVE_HASHDRBG\\n#define NO_CRYPT_TEST\\n#define NO_CRYPT_BENCHMARK\\n'; } > IDE/GCC-ARM/Header-gen/user_settings.h && cd IDE/GCC-ARM && make -f Makefile.test TOOLCHAIN=arm-none-eabi- FIPS=0 USER_SETTINGS_DIR=./Header-gen CFLAGS_EXTRA='-Wno-cpp -DWOLFSSL_NO_SOCK -DWOLFCRYPT_ONLY' LDFLAGS='-mcpu=cortex-m4 -mthumb -mabi=aapcs --specs=nosys.specs --specs=nano.specs -Wl,-Map=./Build/WolfCryptTest.map -Wl,-ereset_handler -flto -Wl,--defsym=__stack_process_end__=0x20010000'",
+    "elf": "IDE/GCC-ARM/Build/WolfCryptTest.elf",
+    "ld": "IDE/GCC-ARM/linker.ld",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "gcc-arm-cortex-m4-tls12",
+    "port": "gcc-arm",
+    "board": "cortex-m4-tls12",
+    "setup_cmd": "sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib",
+    "build_cmd": "test -f examples/configs/user_settings_tls12.h && mkdir -p IDE/GCC-ARM/Header-gen && { cat examples/configs/user_settings_tls12.h; printf '#define WOLFSSL_GENERAL_ALIGNMENT 4\\n#define SINGLE_THREADED\\n#define WOLFSSL_SMALL_STACK\\n#define NO_FILESYSTEM\\n#define NO_WRITEV\\n#define NO_MAIN_DRIVER\\n#define NO_DEV_RANDOM\\n#define BENCH_EMBEDDED\\n#define USE_CERT_BUFFERS_256\\n#define USE_CERT_BUFFERS_2048\\n#define WOLFSSL_IGNORE_FILE_WARN\\n#define USE_WOLF_ARM_STARTUP\\n#define WOLFSSL_USER_CURRTIME\\n#define WOLFSSL_GMTIME\\n#define USER_TICKS\\nextern unsigned long my_time(unsigned long* timer);\\n#define XTIME my_time\\n#define CUSTOM_RAND_TYPE unsigned int\\nextern unsigned int my_rng_seed_gen(void);\\n#undef CUSTOM_RAND_GENERATE\\n#define CUSTOM_RAND_GENERATE my_rng_seed_gen\\n#define HAVE_HASHDRBG\\n#define NO_CRYPT_TEST\\n#define NO_CRYPT_BENCHMARK\\n'; } > IDE/GCC-ARM/Header-gen/user_settings.h && cd IDE/GCC-ARM && make -f Makefile.test TOOLCHAIN=arm-none-eabi- FIPS=0 USER_SETTINGS_DIR=./Header-gen CFLAGS_EXTRA='-Wno-cpp -DWOLFSSL_NO_SOCK' LDFLAGS='-mcpu=cortex-m4 -mthumb -mabi=aapcs --specs=nosys.specs --specs=nano.specs -Wl,-Map=./Build/WolfCryptTest.map -Wl,-ereset_handler -flto -Wl,--defsym=__stack_process_end__=0x20010000'",
+    "elf": "IDE/GCC-ARM/Build/WolfCryptTest.elf",
+    "ld": "IDE/GCC-ARM/linker.ld",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "gcc-arm-cortex-m4-baremetal",
+    "port": "gcc-arm",
+    "board": "cortex-m4-baremetal",
+    "setup_cmd": "sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib",
+    "build_cmd": "test -f examples/configs/user_settings_baremetal.h && mkdir -p IDE/GCC-ARM/Header-gen && { cat examples/configs/user_settings_baremetal.h; printf '#define WOLFSSL_GENERAL_ALIGNMENT 4\\n#define SINGLE_THREADED\\n#define WOLFSSL_SMALL_STACK\\n#define NO_FILESYSTEM\\n#define NO_WRITEV\\n#define NO_MAIN_DRIVER\\n#define NO_DEV_RANDOM\\n#define BENCH_EMBEDDED\\n#define USE_CERT_BUFFERS_256\\n#define USE_CERT_BUFFERS_2048\\n#define WOLFSSL_IGNORE_FILE_WARN\\n#define USE_WOLF_ARM_STARTUP\\n#define WOLFSSL_USER_CURRTIME\\n#define WOLFSSL_GMTIME\\n#define USER_TICKS\\nextern unsigned long my_time(unsigned long* timer);\\n#define XTIME my_time\\n#define CUSTOM_RAND_TYPE unsigned int\\nextern unsigned int my_rng_seed_gen(void);\\n#undef CUSTOM_RAND_GENERATE\\n#define CUSTOM_RAND_GENERATE my_rng_seed_gen\\n#define HAVE_HASHDRBG\\n#define NO_CRYPT_TEST\\n#define NO_CRYPT_BENCHMARK\\n'; } > IDE/GCC-ARM/Header-gen/user_settings.h && cd IDE/GCC-ARM && make -f Makefile.test TOOLCHAIN=arm-none-eabi- FIPS=0 USER_SETTINGS_DIR=./Header-gen CFLAGS_EXTRA='-Wno-cpp -DWOLFSSL_NO_SOCK -DWOLFCRYPT_ONLY' LDFLAGS='-mcpu=cortex-m4 -mthumb -mabi=aapcs --specs=nosys.specs --specs=nano.specs -Wl,-Map=./Build/WolfCryptTest.map -Wl,-ereset_handler -flto -Wl,--defsym=__stack_process_end__=0x20010000'",
+    "elf": "IDE/GCC-ARM/Build/WolfCryptTest.elf",
+    "ld": "IDE/GCC-ARM/linker.ld",
+    "linker_vars": ""
+  }
+]

--- a/.github/workflows/membrowse-comment.yml
+++ b/.github/workflows/membrowse-comment.yml
@@ -1,0 +1,31 @@
+name: Membrowse Comment
+
+on:
+  workflow_run:
+    workflows: [Membrowse Memory Report]
+    types:
+      - completed
+
+jobs:
+  post-comment:
+    runs-on: ubuntu-24.04
+    # Run the comment job even if some of the builds fail
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Post Membrowse PR comment
+        if: ${{ env.MEMBROWSE_API_KEY != '' }}
+        uses: membrowse/membrowse-action/comment-action@v1
+        with:
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          commit: ${{ github.event.workflow_run.head_sha }}
+        env:
+          MEMBROWSE_API_KEY: ${{ secrets.MEMBROWSE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/membrowse-onboard.yml
+++ b/.github/workflows/membrowse-onboard.yml
@@ -1,0 +1,54 @@
+name: Onboard to Membrowse
+
+on:
+  workflow_dispatch:
+    inputs:
+      num_commits:
+        description: 'Number of commits to process'
+        required: true
+        default: '100'
+        type: string
+
+jobs:
+  load-targets:
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Load target matrix
+        id: set-matrix
+        run: echo "matrix=$(jq -c '.' .github/membrowse-targets.json)" >> $GITHUB_OUTPUT
+
+  onboard:
+    needs: load-targets
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install packages
+        run: ${{ matrix.setup_cmd }}
+
+      - name: Run Membrowse Onboard Action
+        uses: membrowse/membrowse-action/onboard-action@v1
+        with:
+          target_name: ${{ matrix.target_name }}
+          num_commits: ${{ github.event.inputs.num_commits }}
+          build_script: ${{ matrix.build_cmd }}
+          elf: ${{ matrix.elf }}
+          ld: ${{ matrix.ld }}
+          linker_vars: ${{ matrix.linker_vars }}
+          binary_search: 'true'
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}

--- a/.github/workflows/membrowse-report.yml
+++ b/.github/workflows/membrowse-report.yml
@@ -1,0 +1,58 @@
+name: Membrowse Memory Report
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  load-targets:
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Load target matrix
+        id: set-matrix
+        run: echo "matrix=$(jq -c '.' .github/membrowse-targets.json)" >> $GITHUB_OUTPUT
+
+  analyze:
+    needs: load-targets
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install packages
+        run: ${{ matrix.setup_cmd }}
+
+      - name: Build firmware
+        run: ${{ matrix.build_cmd }}
+
+      - name: Run Membrowse PR Action
+        id: analyze
+        uses: membrowse/membrowse-action@v1
+        with:
+          target_name: ${{ matrix.target_name }}
+          elf: ${{ matrix.elf }}
+          ld: ${{ matrix.ld }}
+          linker_vars: ${{ matrix.linker_vars }}
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}
+          verbose: INFO
+

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ More info can be found on-line at: https://wolfssl.com/wolfSSL/Docs.html
 
 [Additional wolfSSL Examples](https://github.com/wolfssl/wolfssl-examples)
 
+[wolfSSL MemBrowse Dashboard](https://membrowse.com/public/wolfSSL/wolfssl)
+
 # Directory structure
 
 ```


### PR DESCRIPTION
# Description

MemBrowse memory footprint tracking in CI (Following a discussion with wolfSSL team)

I've configured four targets in membrowse-targets.json, all on Cortex-M4 with minimal test code linked so it doesn't affect the memory tracking:
- gcc-arm-cortex-m4
- gcc-arm-cortex-m4-baremetal
- gcc-arm-cortex-m4-min-ecc
- gcc-arm-cortex-m4-tls12

It includes:
- membrowse-targets.json - defines the build targets with setup and build commands
- membrowse-report.yml - runs on every push to master and on PRs
- membrowse-comment.yml - comments on PRs with a memory usage summary
- membrowse-onboard.yml - one-time workflow to load historical reports

To get started:
1. Create an account at [membrowse.com](http://membrowse.com/)
2. Create a project to get an API key.
3. Set it as a GitHub secret called MEMBROWSE_API_KEY

The workflows will handle the rest.

Full docs are available at [docs.membrowse.com](http://docs.membrowse.com/).

Happy to help if any questions come up during integration.
