### PR TITLE
Nightly-multi-test valgrind fix

### DIFF
--- a/wolfcrypt/src/wc_mlkem_poly.c
+++ b/wolfcrypt/src/wc_mlkem_poly.c
@@ -2292,7 +2292,7 @@ static int mlkem_gen_matrix_k2_avx2(sword16* a, byte* seed, int transposed)
     byte *rand = NULL;
     word64 *state = NULL;
 #else
-    byte rand[4 * GEN_MATRIX_SIZE + 2];
+    byte rand[4 * GEN_MATRIX_SIZE + 4];
     word64 state[25 * 4];
 #endif
     unsigned int ctr0;
@@ -2302,7 +2302,7 @@ static int mlkem_gen_matrix_k2_avx2(sword16* a, byte* seed, int transposed)
     byte* p;
 
 #ifdef WOLFSSL_SMALL_STACK
-    rand = (byte*)XMALLOC(4 * GEN_MATRIX_SIZE + 2, NULL,
+    rand = (byte*)XMALLOC(4 * GEN_MATRIX_SIZE + 4, NULL,
                           DYNAMIC_TYPE_TMP_BUFFER);
     state = (word64*)XMALLOC(sizeof(word64) * 25 * 4, NULL,
                           DYNAMIC_TYPE_TMP_BUFFER);
@@ -2313,9 +2313,11 @@ static int mlkem_gen_matrix_k2_avx2(sword16* a, byte* seed, int transposed)
     }
 #endif
 
-    /* Loading 64 bits, only using 48 bits. Loading 2 bytes more than used. */
+    /* Loading 64 bits, only using 48 bits. Loading 4 bytes more than used. */
     rand[4 * GEN_MATRIX_SIZE + 0] = 0xff;
     rand[4 * GEN_MATRIX_SIZE + 1] = 0xff;
+    rand[4 * GEN_MATRIX_SIZE + 2] = 0xff;
+    rand[4 * GEN_MATRIX_SIZE + 3] = 0xff;
 
     if (!transposed) {
         state[4*4 + 0] = 0x1f0000 + 0x000;
@@ -2403,7 +2405,7 @@ static int mlkem_gen_matrix_k3_avx2(sword16* a, byte* seed, int transposed)
     byte *rand = NULL;
     word64 *state = NULL;
 #else
-    byte rand[4 * GEN_MATRIX_SIZE + 2];
+    byte rand[4 * GEN_MATRIX_SIZE + 4];
     word64 state[25 * 4];
 #endif
     unsigned int ctr0;
@@ -2413,7 +2415,7 @@ static int mlkem_gen_matrix_k3_avx2(sword16* a, byte* seed, int transposed)
     byte* p;
 
 #ifdef WOLFSSL_SMALL_STACK
-    rand = (byte*)XMALLOC(4 * GEN_MATRIX_SIZE + 2, NULL,
+    rand = (byte*)XMALLOC(4 * GEN_MATRIX_SIZE + 4, NULL,
                           DYNAMIC_TYPE_TMP_BUFFER);
     state = (word64*)XMALLOC(sizeof(word64) * 25 * 4, NULL,
                           DYNAMIC_TYPE_TMP_BUFFER);
@@ -2424,9 +2426,11 @@ static int mlkem_gen_matrix_k3_avx2(sword16* a, byte* seed, int transposed)
     }
 #endif
 
-    /* Loading 64 bits, only using 48 bits. Loading 2 bytes more than used. */
+    /* Loading 64 bits, only using 48 bits. Loading 4 bytes more than used. */
     rand[4 * GEN_MATRIX_SIZE + 0] = 0xff;
     rand[4 * GEN_MATRIX_SIZE + 1] = 0xff;
+    rand[4 * GEN_MATRIX_SIZE + 2] = 0xff;
+    rand[4 * GEN_MATRIX_SIZE + 3] = 0xff;
 
     for (k = 0; k < 2; k++) {
         for (i = 0; i < 4; i++) {
@@ -2559,7 +2563,7 @@ static int mlkem_gen_matrix_k4_avx2(sword16* a, byte* seed, int transposed)
     byte *rand = NULL;
     word64 *state = NULL;
 #else
-    byte rand[4 * GEN_MATRIX_SIZE + 2];
+    byte rand[4 * GEN_MATRIX_SIZE + 4];
     word64 state[25 * 4];
 #endif
     unsigned int ctr0;
@@ -2569,7 +2573,7 @@ static int mlkem_gen_matrix_k4_avx2(sword16* a, byte* seed, int transposed)
     byte* p;
 
 #ifdef WOLFSSL_SMALL_STACK
-    rand = (byte*)XMALLOC(4 * GEN_MATRIX_SIZE + 2, NULL,
+    rand = (byte*)XMALLOC(4 * GEN_MATRIX_SIZE + 4, NULL,
                           DYNAMIC_TYPE_TMP_BUFFER);
     state = (word64*)XMALLOC(sizeof(word64) * 25 * 4, NULL,
                           DYNAMIC_TYPE_TMP_BUFFER);
@@ -2580,9 +2584,11 @@ static int mlkem_gen_matrix_k4_avx2(sword16* a, byte* seed, int transposed)
     }
 #endif
 
-    /* Loading 64 bits, only using 48 bits. Loading 2 bytes more than used. */
+    /* Loading 64 bits, only using 48 bits. Loading 4 bytes more than used. */
     rand[4 * GEN_MATRIX_SIZE + 0] = 0xff;
     rand[4 * GEN_MATRIX_SIZE + 1] = 0xff;
+    rand[4 * GEN_MATRIX_SIZE + 2] = 0xff;
+    rand[4 * GEN_MATRIX_SIZE + 3] = 0xff;
 
     for (k = 0; k < 4; k++) {
         for (i = 0; i < 4; i++) {


### PR DESCRIPTION
# Description

Increase rand buffer, fix valgrind invalid read size 16

# Testing
```
./configure --srcdir=. --disable-jobserver --enable-option-checking=fatal \
--enable-all --enable-acert --enable-dtls13 --enable-dtls-mtu --enable-dtls-frag-ch \
--enable-dtlscid --enable-quic --with-sys-crypto-policy --enable-intelasm \
--enable-sp-math-all --enable-smallstack --enable-smallstackcache \
CPPFLAGS= "-DNO_WOLFSSL_CIPHER_SUITE_TEST -DWOLFSSL_OLD_PRIME_CHECK -pedantic -Wdeclaration-after-statement -Wnull-dereference -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE -Werror" \
CFLAGS="-DTEST_ALWAYS_RUN_TO_END -g -fno-omit-frame-pointer" LDFLAGS="-g -fno-omit-frame-pointer -lm"

make

LD_LIBRARY_PATH=./src/.libs valgrind --leak-check=full --show-leak-kinds=all \
--errors-for-leak-kinds=all  --show-reachable=yes  --leak-resolution=high \
--track-fds=yes --track-origins=yes --fullpath-after=  --error-exitcode=10 \
./testsuite/.libs/testsuite.test
```