### PR TITLE
C# Wrapper: ML-KEM and ML-DSA (Dilithium) Support

### DIFF
--- a/wrapper/CSharp/user_settings.h
+++ b/wrapper/CSharp/user_settings.h
@@ -91,6 +91,7 @@
 #define HAVE_MLKEM
 #define WOLFSSL_WC_MLKEM
 #define WOLFSSL_HAVE_MLKEM
+/* Required for PQC with DTLS 1.3 (auto-enabled in settings.h, explicit for clarity) */
 #define WOLFSSL_DTLS_CH_FRAG
 #define HAVE_DILITHIUM
 #define WOLFSSL_WC_DILITHIUM

--- a/wrapper/CSharp/user_settings.h
+++ b/wrapper/CSharp/user_settings.h
@@ -87,6 +87,16 @@
 #define ECC_TIMING_RESISTANT
 #define HAVE_COMP_KEY
 
+/* Enable ML-KEM, ML-DSA */
+#define HAVE_MLKEM
+#define WOLFSSL_WC_MLKEM
+#define WOLFSSL_HAVE_MLKEM
+#define WOLFSSL_DTLS_CH_FRAG
+#define HAVE_DILITHIUM
+#define WOLFSSL_WC_DILITHIUM
+#define WOLFSSL_SHAKE128
+#define WOLFSSL_SHAKE256
+
 /* Disable features */
 #define NO_PSK
 

--- a/wrapper/CSharp/wolfCrypt-Test/wolfCrypt-Test.cs
+++ b/wrapper/CSharp/wolfCrypt-Test/wolfCrypt-Test.cs
@@ -674,6 +674,299 @@ public class wolfCrypt_Test_CSharp
         if (publicKeyB != IntPtr.Zero) wolfcrypt.Curve25519FreeKey(publicKeyB);
     } /* END curve25519_test */
 
+    private static void mlkem_test(wolfcrypt.MlKemTypes type)
+    {
+        int ret = 0;
+        IntPtr keyA = IntPtr.Zero;
+        IntPtr keyB = IntPtr.Zero;
+        IntPtr heap = IntPtr.Zero;
+        int devId = wolfcrypt.INVALID_DEVID;
+        byte[] pubA = null;
+        byte[] privA = null;
+        byte[] cipherText = null;
+        byte[] sharedSecretA = null;
+        byte[] sharedSecretB = null;
+
+        try
+        {
+            Console.WriteLine("\nStarting " + type + " shared secret test ...");
+
+            /* Generate Key Pair */
+            Console.WriteLine("Testing ML-KEM Key Generation...");
+
+            Console.WriteLine("Generate Key Pair A...");
+            keyA = wolfcrypt.MlKemMakeKey(type, heap, devId);
+            if (keyA == IntPtr.Zero)
+            {
+                ret = -1;
+                Console.Error.WriteLine("Failed to generate key pair A.");
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine("Generate Key Pair B...");
+                keyB = wolfcrypt.MlKemMakeKey(type, heap, devId);
+                if (keyB == IntPtr.Zero)
+                {
+                    ret = -1;
+                    Console.Error.WriteLine("Failed to generate key pair B.");
+                }
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine("ML-KEM Key Generation test passed.");
+            }
+
+            /* Encode */
+            if (ret == 0)
+            {
+                Console.WriteLine("Testing ML-KEM Key Encode...");
+                ret = wolfcrypt.MlKemEncodePublicKey(keyA, out pubA);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to encode public key of A. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                ret = wolfcrypt.MlKemEncodePrivateKey(keyA, out privA);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to encode private key of A. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine("ML-KEM Key Encode test passed.");
+            }
+
+            /* Encapsulate */
+            if (ret == 0)
+            {
+                Console.WriteLine("Testing ML-KEM Encapsulation...");
+                ret = wolfcrypt.MlKemEncapsulate(keyA, out cipherText, out sharedSecretA);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to encapsulate. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine("ML-KEM Encapsulation test passed.");
+            }
+            
+            /* Decode */
+            if (ret == 0)
+            {
+                Console.WriteLine("Testing ML-KEM Decode...");
+                ret = wolfcrypt.MlKemDecodePrivateKey(keyB, privA);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to decode private key of A. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                ret = wolfcrypt.MlKemDecodePublicKey(keyB, pubA);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to decode public key of B. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine("ML-KEM Decode test passed.");
+            }
+
+            /* Decapsulate */
+            if (ret == 0)
+            {
+                Console.WriteLine("Testing ML-KEM Decapsulation...");
+                ret = wolfcrypt.MlKemDecapsulate(keyB, cipherText, out sharedSecretB);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to decapsulate. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine("ML-KEM Decapsulation test passed.");
+            }
+
+            /* Check */
+            if (ret == 0)
+            {
+                Console.WriteLine("Comparing Shared Secrets...");
+                if (!wolfcrypt.ByteArrayVerify(sharedSecretA, sharedSecretB))
+                {
+                    ret = -1;
+                    Console.Error.WriteLine($"Shared secrets do not match. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine("ML-KEM shared secret match.");
+            }
+
+            if (ret != 0)
+            {
+                throw new Exception("ML-KEM test failed.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"ML-KEM test failed: {ex.Message}");
+            throw;
+        }
+        finally
+        {
+            /* Cleanup */
+            if (keyA != IntPtr.Zero)
+            {
+                ret = wolfcrypt.MlKemFreeKey(ref keyA);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to free MlKem key A. Error code: {ret}");
+                }
+            }
+            if (keyB != IntPtr.Zero)
+            {
+                ret = wolfcrypt.MlKemFreeKey(ref keyB);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to free MlKem key B. Error code: {ret}");
+                }
+            }
+        }
+    } /* END mlkem_test */
+
+    private static void mldsa_test(wolfcrypt.MlDsaLevels level)
+    {
+        int ret = 0;
+        IntPtr key = IntPtr.Zero;
+        IntPtr heap = IntPtr.Zero;
+        int devId = wolfcrypt.INVALID_DEVID;
+        byte[] privateKey = null;
+        byte[] publicKey = null;
+        byte[] message = Encoding.UTF8.GetBytes("This is some data to sign with ML-DSA");
+        byte[] signature = null;
+
+        try
+        {
+            Console.WriteLine("\nStarting " + level + " key generation and signature test ...");
+
+            /* Generate Key */
+            Console.WriteLine("Testing ML-DSA Key Generation...");
+            key = wolfcrypt.DilithiumMakeKey(heap, devId, level);
+            if (key == IntPtr.Zero)
+            {
+                ret = -1;
+                Console.Error.WriteLine("Failed to generate keypair.");
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine("ML-DSA Key Generation test passed.");
+            }
+
+            /* Export */
+            if (ret == 0)
+            {
+                Console.WriteLine("Testing ML-DSA Key Export...");
+                ret = DilithiumExportPrivateKey(key, out privateKey);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to export private key. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                ret = DilithiumExportPublicKey(key, out publicKey);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to export public key. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine("ML-DSA Key Export test passed.");
+            }
+
+            /* Import */
+            if (ret == 0)
+            {
+                Console.WriteLine("Testing ML-DSA Key Import...");
+                ret = DilithiumImportPrivateKey(privateKey, key);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to import private key. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                ret = DilithiumImportPublicKey(publicKey, key);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to import public key. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine("ML-DSA Key Import test passed.");
+            }
+
+            /* Sign */
+            if (ret == 0)
+            {
+                Console.WriteLine("Testing ML-DSA Signature Creation...");
+                ret = wolfcrypt.DilithiumSignMsg(key, message, out signature);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to sign. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine($"ML-DSA Signature Creation test passed. Signature Length: {signature.Length}");
+            }
+
+            /* Verify */
+            if (ret == 0)
+            {
+                Console.WriteLine("Testing ML-DSA Signature Verification...");
+                ret = wolfcrypt.DilithiumVerifyMsg(key, message, signature);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to verify message. Error code: {ret}");
+                }
+            }
+            if (ret == 0)
+            {
+                Console.WriteLine("ML-DSA Signature Verification test passed.");
+            }
+
+            if (ret != 0)
+            {
+                throw new Exception("ML-DSA test failed.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"ML-DSA test failed: {ex.Message}");
+            throw;
+        }
+        finally
+        {
+            if (key != IntPtr.Zero)
+            {
+                ret = wolfcrypt.DilithiumFreeKey(ref key);
+                if (ret != 0)
+                {
+                    Console.Error.WriteLine($"Failed to free ML-DSA key. Error code: {ret}");
+                }
+            }
+        }
+
+    } /* END mldsa_test */
+
     private static void aes_gcm_test()
     {
         IntPtr aes = IntPtr.Zero;
@@ -1125,6 +1418,18 @@ public class wolfCrypt_Test_CSharp
             Console.WriteLine("\nStarting curve25519 test");
 
             curve25519_test(); /* curve25519 shared secret test */
+
+            Console.WriteLine("\nStarting ML-KEM test");
+
+            mlkem_test(wolfcrypt.MlKemTypes.ML_KEM_512); /* ML-KEM test */
+            mlkem_test(wolfcrypt.MlKemTypes.ML_KEM_768); /* ML-KEM test */
+            mlkem_test(wolfcrypt.MlKemTypes.ML_KEM_1024); /* ML-KEM test */
+
+            Console.WriteLine("\nStarting ML-DSA test");
+
+            mldsa_test(wolfcrypt.MlDsaLevels.ML_DSA_44); /* ML-DSA test */
+            mldsa_test(wolfcrypt.MlDsaLevels.ML_DSA_65); /* ML-DSA test */
+            mldsa_test(wolfcrypt.MlDsaLevels.ML_DSA_87); /* ML-DSA test */
 
             Console.WriteLine("\nStarting AES-GCM test");
 

--- a/wrapper/CSharp/wolfCrypt-Test/wolfCrypt-Test.cs
+++ b/wrapper/CSharp/wolfCrypt-Test/wolfCrypt-Test.cs
@@ -703,12 +703,12 @@ public class wolfCrypt_Test_CSharp
             }
             if (ret == 0)
             {
-                Console.WriteLine("Generate Key Pair B...");
-                keyB = wolfcrypt.MlKemMakeKey(type, heap, devId);
+                Console.WriteLine("Initialize Key B for decode...");
+                keyB = wolfcrypt.MlKemNew(type, heap, devId);
                 if (keyB == IntPtr.Zero)
                 {
                     ret = -1;
-                    Console.Error.WriteLine("Failed to generate key pair B.");
+                    Console.Error.WriteLine("Failed to initialize key B for decode.");
                 }
             }
             if (ret == 0)
@@ -769,7 +769,7 @@ public class wolfCrypt_Test_CSharp
                 ret = wolfcrypt.MlKemDecodePublicKey(keyB, pubA);
                 if (ret != 0)
                 {
-                    Console.Error.WriteLine($"Failed to decode public key of B. Error code: {ret}");
+                    Console.Error.WriteLine($"Failed to decode public key of A. Error code: {ret}");
                 }
             }
             if (ret == 0)

--- a/wrapper/CSharp/wolfCrypt-Test/wolfCrypt-Test.cs
+++ b/wrapper/CSharp/wolfCrypt-Test/wolfCrypt-Test.cs
@@ -843,6 +843,7 @@ public class wolfCrypt_Test_CSharp
     {
         int ret = 0;
         IntPtr key = IntPtr.Zero;
+        IntPtr importKey = IntPtr.Zero;
         IntPtr heap = IntPtr.Zero;
         int devId = wolfcrypt.INVALID_DEVID;
         byte[] privateKey = null;
@@ -856,7 +857,7 @@ public class wolfCrypt_Test_CSharp
 
             /* Generate Key */
             Console.WriteLine("Testing ML-DSA Key Generation...");
-            key = wolfcrypt.DilithiumMakeKey(heap, devId, level);
+            key = wolfcrypt.MlDsaMakeKey(heap, devId, level);
             if (key == IntPtr.Zero)
             {
                 ret = -1;
@@ -871,7 +872,7 @@ public class wolfCrypt_Test_CSharp
             if (ret == 0)
             {
                 Console.WriteLine("Testing ML-DSA Key Export...");
-                ret = wolfcrypt.DilithiumExportPrivateKey(key, out privateKey);
+                ret = wolfcrypt.MlDsaExportPrivateKey(key, out privateKey);
                 if (ret != 0)
                 {
                     Console.Error.WriteLine($"Failed to export private key. Error code: {ret}");
@@ -879,7 +880,7 @@ public class wolfCrypt_Test_CSharp
             }
             if (ret == 0)
             {
-                ret = wolfcrypt.DilithiumExportPublicKey(key, out publicKey);
+                ret = wolfcrypt.MlDsaExportPublicKey(key, out publicKey);
                 if (ret != 0)
                 {
                     Console.Error.WriteLine($"Failed to export public key. Error code: {ret}");
@@ -890,11 +891,22 @@ public class wolfCrypt_Test_CSharp
                 Console.WriteLine("ML-DSA Key Export test passed.");
             }
 
-            /* Import */
+            /* Import into a fresh key to test the full import workflow */
             if (ret == 0)
             {
                 Console.WriteLine("Testing ML-DSA Key Import...");
-                ret = wolfcrypt.DilithiumImportPrivateKey(privateKey, key);
+                /* Free the keygen key and create a fresh one for import */
+                wolfcrypt.MlDsaFreeKey(ref key);
+                importKey = wolfcrypt.MlDsaNew(heap, devId, level);
+                if (importKey == IntPtr.Zero)
+                {
+                    ret = -1;
+                    Console.Error.WriteLine("Failed to allocate key for import.");
+                }
+            }
+            if (ret == 0)
+            {
+                ret = wolfcrypt.MlDsaImportPrivateKey(privateKey, importKey);
                 if (ret != 0)
                 {
                     Console.Error.WriteLine($"Failed to import private key. Error code: {ret}");
@@ -902,7 +914,7 @@ public class wolfCrypt_Test_CSharp
             }
             if (ret == 0)
             {
-                ret = wolfcrypt.DilithiumImportPublicKey(publicKey, key);
+                ret = wolfcrypt.MlDsaImportPublicKey(publicKey, importKey);
                 if (ret != 0)
                 {
                     Console.Error.WriteLine($"Failed to import public key. Error code: {ret}");
@@ -913,11 +925,11 @@ public class wolfCrypt_Test_CSharp
                 Console.WriteLine("ML-DSA Key Import test passed.");
             }
 
-            /* Sign */
+            /* Sign with imported key */
             if (ret == 0)
             {
                 Console.WriteLine("Testing ML-DSA Signature Creation...");
-                ret = wolfcrypt.DilithiumSignMsg(key, message, out signature);
+                ret = wolfcrypt.MlDsaSignMsg(importKey, message, out signature);
                 if (ret != 0)
                 {
                     Console.Error.WriteLine($"Failed to sign. Error code: {ret}");
@@ -928,11 +940,11 @@ public class wolfCrypt_Test_CSharp
                 Console.WriteLine($"ML-DSA Signature Creation test passed. Signature Length: {signature.Length}");
             }
 
-            /* Verify */
+            /* Verify with imported key */
             if (ret == 0)
             {
                 Console.WriteLine("Testing ML-DSA Signature Verification...");
-                ret = wolfcrypt.DilithiumVerifyMsg(key, message, signature);
+                ret = wolfcrypt.MlDsaVerifyMsg(importKey, message, signature);
                 if (ret != 0)
                 {
                     Console.Error.WriteLine($"Failed to verify message. Error code: {ret}");
@@ -957,11 +969,11 @@ public class wolfCrypt_Test_CSharp
         {
             if (key != IntPtr.Zero)
             {
-                ret = wolfcrypt.DilithiumFreeKey(ref key);
-                if (ret != 0)
-                {
-                    Console.Error.WriteLine($"Failed to free ML-DSA key. Error code: {ret}");
-                }
+                wolfcrypt.MlDsaFreeKey(ref key);
+            }
+            if (importKey != IntPtr.Zero)
+            {
+                wolfcrypt.MlDsaFreeKey(ref importKey);
             }
         }
 

--- a/wrapper/CSharp/wolfCrypt-Test/wolfCrypt-Test.cs
+++ b/wrapper/CSharp/wolfCrypt-Test/wolfCrypt-Test.cs
@@ -871,7 +871,7 @@ public class wolfCrypt_Test_CSharp
             if (ret == 0)
             {
                 Console.WriteLine("Testing ML-DSA Key Export...");
-                ret = DilithiumExportPrivateKey(key, out privateKey);
+                ret = wolfcrypt.DilithiumExportPrivateKey(key, out privateKey);
                 if (ret != 0)
                 {
                     Console.Error.WriteLine($"Failed to export private key. Error code: {ret}");
@@ -879,7 +879,7 @@ public class wolfCrypt_Test_CSharp
             }
             if (ret == 0)
             {
-                ret = DilithiumExportPublicKey(key, out publicKey);
+                ret = wolfcrypt.DilithiumExportPublicKey(key, out publicKey);
                 if (ret != 0)
                 {
                     Console.Error.WriteLine($"Failed to export public key. Error code: {ret}");
@@ -894,7 +894,7 @@ public class wolfCrypt_Test_CSharp
             if (ret == 0)
             {
                 Console.WriteLine("Testing ML-DSA Key Import...");
-                ret = DilithiumImportPrivateKey(privateKey, key);
+                ret = wolfcrypt.DilithiumImportPrivateKey(privateKey, key);
                 if (ret != 0)
                 {
                     Console.Error.WriteLine($"Failed to import private key. Error code: {ret}");
@@ -902,7 +902,7 @@ public class wolfCrypt_Test_CSharp
             }
             if (ret == 0)
             {
-                ret = DilithiumImportPublicKey(publicKey, key);
+                ret = wolfcrypt.DilithiumImportPublicKey(publicKey, key);
                 if (ret != 0)
                 {
                     Console.Error.WriteLine($"Failed to import public key. Error code: {ret}");

--- a/wrapper/CSharp/wolfSSL_CSharp/wolfCrypt.cs
+++ b/wrapper/CSharp/wolfSSL_CSharp/wolfCrypt.cs
@@ -540,9 +540,9 @@ namespace wolfSSL.CSharp
         [DllImport(wolfssl_dll)]
         private static extern int wc_dilithium_import_public(byte[] input, uint inputLen, IntPtr key);
         [DllImport(wolfssl_dll)]
-        private static extern int wc_dilithium_sign_msg(byte[] msg, uint msgLen, byte[] sig, ref uint sigLen, IntPtr key, IntPtr rng);
+        private static extern int wc_dilithium_sign_ctx_msg(byte[] ctx, byte ctxLen, byte[] msg, uint msgLen, byte[] sig, ref uint sigLen, IntPtr key, IntPtr rng);
         [DllImport(wolfssl_dll)]
-        private static extern int wc_dilithium_verify_msg(byte[] sig, uint sigLen, byte[] msg, uint msgLen, ref int res, IntPtr key);
+        private static extern int wc_dilithium_verify_ctx_msg(byte[] sig, uint sigLen, byte[] ctx, byte ctxLen, byte[] msg, uint msgLen, ref int res, IntPtr key);
         [DllImport(wolfssl_dll)]
         private static extern int wc_MlDsaKey_GetPrivLen(IntPtr key, ref int len);
         [DllImport(wolfssl_dll)]
@@ -571,9 +571,9 @@ namespace wolfSSL.CSharp
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_dilithium_import_public(byte[] input, uint inputLen, IntPtr key);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int wc_dilithium_sign_msg(byte[] msg, uint msgLen, byte[] sig, ref uint sigLen, IntPtr key, IntPtr rng);
+        private static extern int wc_dilithium_sign_ctx_msg(byte[] ctx, byte ctxLen, byte[] msg, uint msgLen, byte[] sig, ref uint sigLen, IntPtr key, IntPtr rng);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int wc_dilithium_verify_msg(byte[] sig, uint sigLen, byte[] msg, uint msgLen, ref int res, IntPtr key);
+        private static extern int wc_dilithium_verify_ctx_msg(byte[] sig, uint sigLen, byte[] ctx, byte ctxLen, byte[] msg, uint msgLen, ref int res, IntPtr key);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_MlDsaKey_GetPrivLen(IntPtr key, ref int len);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
@@ -2982,18 +2982,15 @@ namespace wolfSSL.CSharp
         /// <returns>0 on success, negative value on error.</returns>
         public static int MlKemFreeKey(ref IntPtr key)
         {
-            int ret = 0;
+            int ret;
 
             if (key == IntPtr.Zero)
             {
                 return BAD_FUNC_ARG;
             }
 
-            if (key != IntPtr.Zero)
-            {
-                ret = wc_MlKemKey_Delete(key, IntPtr.Zero);
-                key = IntPtr.Zero;
-            }
+            ret = wc_MlKemKey_Delete(key, IntPtr.Zero);
+            key = IntPtr.Zero;
             return ret;
         }
 
@@ -3017,10 +3014,10 @@ namespace wolfSSL.CSharp
             try
             {
                 ret = wc_MlKemKey_PublicKeySize(key, ref pubLen);
-                if (ret !=0 || pubLen == 0)
+                if (ret != 0 || pubLen == 0)
                 {
                     log(ERROR_LOG, "Failed to get MlKem public key length. Error code: " + ret);
-                    return ret;
+                    return (ret != 0) ? ret : BAD_FUNC_ARG;
                 }
                 if (pubLen > int.MaxValue)
                 {
@@ -3066,10 +3063,10 @@ namespace wolfSSL.CSharp
             try
             {
                 ret = wc_MlKemKey_PrivateKeySize(key, ref privLen);
-                if (ret !=0 || privLen == 0)
+                if (ret != 0 || privLen == 0)
                 {
                     log(ERROR_LOG, "Failed to get MlKem private key length. Error code: " + ret);
-                    return ret;
+                    return (ret != 0) ? ret : BAD_FUNC_ARG;
                 }
                 if (privLen > int.MaxValue)
                 {
@@ -3123,14 +3120,14 @@ namespace wolfSSL.CSharp
                 if (ret != 0 || pubLen == 0)
                 {
                     log(ERROR_LOG, "Failed to get MlKem public key length. Error code: " + ret);
-                    return ret;
+                    return (ret != 0) ? ret : BAD_FUNC_ARG;
                 }
                 if ((uint)publicKey.Length != pubLen)
-                 {
-                     log(ERROR_LOG, "MlKem public key buffer length mismatch. Expected: " +
-                         pubLen + ", actual: " + publicKey.Length);
-                     return BUFFER_E;
-                 }
+                {
+                    log(ERROR_LOG, "MlKem public key buffer length mismatch. Expected: " +
+                        pubLen + ", actual: " + publicKey.Length);
+                    return BUFFER_E;
+                }
 
                 ret = wc_MlKemKey_DecodePublicKey(key, publicKey, pubLen);
                 if (ret != 0)
@@ -3172,12 +3169,12 @@ namespace wolfSSL.CSharp
             try
             {
                 ret = wc_MlKemKey_PrivateKeySize(key, ref privLen);
-                if (privLen == 0)
+                if (ret != 0 || privLen == 0)
                 {
                     log(ERROR_LOG, "Failed to get MlKem private key length. Error code: " + ret);
-                    return ret;
+                    return (ret != 0) ? ret : BAD_FUNC_ARG;
                 }
-                
+
                 if ((uint)privateKey.Length != privLen)
                 {
                     log(ERROR_LOG, "MlKem private key buffer length mismatch. Required: " + privLen +
@@ -3416,18 +3413,15 @@ namespace wolfSSL.CSharp
         /// <returns>0 on success, negative value on error.</returns>
         public static int DilithiumFreeKey(ref IntPtr key)
         {
-            int ret = 0;
+            int ret;
 
             if (key == IntPtr.Zero)
             {
                 return BAD_FUNC_ARG;
             }
 
-            if (key != IntPtr.Zero)
-            {
-                ret = wc_dilithium_delete(key, IntPtr.Zero);
-                key = IntPtr.Zero;
-            }
+            ret = wc_dilithium_delete(key, IntPtr.Zero);
+            key = IntPtr.Zero;
             return ret;
         }
 
@@ -3500,10 +3494,10 @@ namespace wolfSSL.CSharp
             try
             {
                 ret = wc_MlDsaKey_GetPrivLen(key, ref privLen);
-                if (privLen <= 0)
+                if (ret != 0 || privLen <= 0)
                 {
                     log(ERROR_LOG, "Failed to get Dilithium private key length. Error code: " + ret);
-                    return ret;
+                    return (ret != 0) ? ret : BAD_FUNC_ARG;
                 }
 
                 privateKey = new byte[privLen];
@@ -3550,10 +3544,10 @@ namespace wolfSSL.CSharp
             try
             {
                 ret = wc_MlDsaKey_GetPubLen(key, ref pubLen);
-                if (pubLen <= 0)
+                if (ret != 0 || pubLen <= 0)
                 {
                     log(ERROR_LOG, "Failed to get Dilithium public key length. Error code: " + ret);
-                    return ret;
+                    return (ret != 0) ? ret : BAD_FUNC_ARG;
                 }
 
                 publicKey = new byte[pubLen];
@@ -3602,10 +3596,10 @@ namespace wolfSSL.CSharp
             try
             {
                 ret = wc_MlDsaKey_GetSigLen(key, ref sigLen);
-                if (sigLen <= 0)
+                if (ret != 0 || sigLen <= 0)
                 {
                     log(ERROR_LOG, "Failed to get Dilithium signature length. Error code: " + ret);
-                    return ret;
+                    return (ret != 0) ? ret : BAD_FUNC_ARG;
                 }
 
                 sig = new byte[sigLen];
@@ -3614,9 +3608,10 @@ namespace wolfSSL.CSharp
                 if (rng == IntPtr.Zero)
                 {
                     log(ERROR_LOG, "Failed to create RNG for Dilithium signing.");
-                    return EXCEPTION_E;
+                    return MEMORY_E;
                 }
-                ret = wc_dilithium_sign_msg(msg, (uint)msg.Length, sig, ref outLen, key, rng);
+                /* FIPS 204 sign with empty context (ctx=null, ctxLen=0). */
+                ret = wc_dilithium_sign_ctx_msg(null, 0, msg, (uint)msg.Length, sig, ref outLen, key, rng);
                 if (ret != 0)
                 {
                     log(ERROR_LOG, "Failed to sign message with Dilithium key. Error code: " + ret);
@@ -3660,7 +3655,8 @@ namespace wolfSSL.CSharp
 
             try
             {
-                ret = wc_dilithium_verify_msg(sig, (uint)sig.Length, msg, (uint)msg.Length, ref res, key);
+                /* FIPS 204 verify with empty context (ctx=null, ctxLen=0). */
+                ret = wc_dilithium_verify_ctx_msg(sig, (uint)sig.Length, null, 0, msg, (uint)msg.Length, ref res, key);
                 if (ret != 0)
                 {
                     log(ERROR_LOG, "Failed to verify message with Dilithium key. Error code: " + ret);

--- a/wrapper/CSharp/wolfSSL_CSharp/wolfCrypt.cs
+++ b/wrapper/CSharp/wolfSSL_CSharp/wolfCrypt.cs
@@ -440,6 +440,147 @@ namespace wolfSSL.CSharp
         private extern static int wc_curve25519_export_private_raw(IntPtr key, IntPtr outPrivKey, IntPtr outPubKey);
 #endif
 
+        /********************************
+         * ML-KEM
+         */
+#if WindowsCE
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_CipherTextSize(IntPtr key, ref uint len);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_SharedSecretSize(IntPtr key, ref uint len);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_PrivateKeySize(IntPtr key, ref uint len);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_PublicKeySize(IntPtr key, ref uint len);
+        [DllImport(wolfssl_dll)]
+        private static extern IntPtr wc_MlKemKey_New(int type, IntPtr heap, int devId);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_Delete(IntPtr key, IntPtr key_p);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_Init(IntPtr key, int type, IntPtr heap, int devId);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_Free(IntPtr key);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_MakeKey(IntPtr key, IntPtr rng);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_MakeKeyWithRandom(IntPtr key, byte[] rand, int len);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_EncodePublicKey(IntPtr key, byte[] output, uint len);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_DecodePublicKey(IntPtr key, byte[] input, uint len);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_Encapsulate(IntPtr key, byte[] ct, byte[] ss, IntPtr rng);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_EncapsulateWithRandom(IntPtr key, byte[] ct, byte[] ss, byte[] rand, int len);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_Decapsulate(IntPtr key, byte[] ss, byte[] ct, uint len);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_EncodePrivateKey(IntPtr key, byte[] output, uint len);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlKemKey_DecodePrivateKey(IntPtr key, byte[] input, uint len);
+#else
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_CipherTextSize(IntPtr key, ref uint len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_SharedSecretSize(IntPtr key, ref uint len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_PrivateKeySize(IntPtr key, ref uint len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_PublicKeySize(IntPtr key, ref uint len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr wc_MlKemKey_New(int type, IntPtr heap, int devId);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_Delete(IntPtr key, IntPtr key_p);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_Init(IntPtr key, int type, IntPtr heap, int devId);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_Free(IntPtr key);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_MakeKey(IntPtr key, IntPtr rng);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_MakeKeyWithRandom(IntPtr key, byte[] rand, int len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_EncodePublicKey(IntPtr key, byte[] output, uint len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_DecodePublicKey(IntPtr key, byte[] input, uint len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_Encapsulate(IntPtr key, byte[] ct, byte[] ss, IntPtr rng);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_EncapsulateWithRandom(IntPtr key, byte[] ct, byte[] ss, byte[] rand, int len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_Decapsulate(IntPtr key, byte[] ss, byte[] ct, uint len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_EncodePrivateKey(IntPtr key, byte[] output, uint len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlKemKey_DecodePrivateKey(IntPtr key, byte[] input, uint len);
+#endif
+
+        /********************************
+         * ML-DSA
+         */
+#if WindowsCE
+        [DllImport(wolfssl_dll)]
+        private static extern IntPtr wc_dilithium_new(IntPtr heap, int devId);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_dilithium_delete(IntPtr key, IntPtr key_p);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_dilithium_init_ex(IntPtr key, IntPtr heap, int devId);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_dilithium_set_level(IntPtr key, byte level);
+        [DllImport(wolfssl_dll)]
+        private static extern void wc_dilithium_free(IntPtr key);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_dilithium_make_key(IntPtr key, IntPtr rng);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_dilithium_export_private(IntPtr key, byte[] output, ref uint outLen);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_dilithium_import_private(byte[] priv, uint privSz, IntPtr key);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_dilithium_export_public(IntPtr key, byte[] output, ref uint outLen);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_dilithium_import_public(byte[] input, uint inputLen, IntPtr key);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_dilithium_sign_msg(byte[] msg, uint msgLen, byte[] sig, ref uint sigLen, IntPtr key, IntPtr rng);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_dilithium_verify_msg(byte[] sig, uint sigLen, byte[] msg, uint msgLen, ref int res, IntPtr key);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlDsaKey_GetPrivLen(IntPtr key, ref int len);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlDsaKey_GetPubLen(IntPtr key, ref int len);
+        [DllImport(wolfssl_dll)]
+        private static extern int wc_MlDsaKey_GetSigLen(IntPtr key, ref int len);
+#else
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr wc_dilithium_new(IntPtr heap, int devId);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_dilithium_delete(IntPtr key, IntPtr key_p);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_dilithium_init_ex(IntPtr key, IntPtr heap, int devId);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_dilithium_set_level(IntPtr key, byte level);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern void wc_dilithium_free(IntPtr key);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_dilithium_make_key(IntPtr key, IntPtr rng);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_dilithium_export_private(IntPtr key, byte[] output, ref uint outLen);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_dilithium_import_private(byte[] priv, uint privSz, IntPtr key);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_dilithium_export_public(IntPtr key, byte[] output, ref uint outLen);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_dilithium_import_public(byte[] input, uint inputLen, IntPtr key);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_dilithium_sign_msg(byte[] msg, uint msgLen, byte[] sig, ref uint sigLen, IntPtr key, IntPtr rng);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_dilithium_verify_msg(byte[] sig, uint sigLen, byte[] msg, uint msgLen, ref int res, IntPtr key);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlDsaKey_GetPrivLen(IntPtr key, ref int len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlDsaKey_GetPubLen(IntPtr key, ref int len);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_MlDsaKey_GetSigLen(IntPtr key, ref int len);
+#endif
 
         /********************************
          * AES-GCM
@@ -637,6 +778,7 @@ namespace wolfSSL.CSharp
         public static readonly int ASN_SIG_CONFIRM_E  = -155;  /* ASN sig error, confirm failure */
         public static readonly int ASN_SIG_HASH_E     = -156;  /* ASN sig error, unsupported hash type */
         public static readonly int ASN_SIG_KEY_E      = -157;  /* ASN sig error, unsupported key type */
+        public static readonly int BAD_FUNC_ARG       = -173;  /* Bad function argument */
         public static readonly int SIG_VERIFY_E       = -229;  /* wolfcrypt signature verify error */
 
 
@@ -2762,6 +2904,792 @@ namespace wolfSSL.CSharp
             return;
         }
         /* END RAW Curve25519 */
+
+
+        /***********************************************************************
+         * ML-KEM
+         **********************************************************************/
+
+        // These APIs work by adding several options to wolfCrypt.
+        // Please refer to `../user_settings.h`.
+
+        /// <summary>
+        /// Create a new ML-KEM key pair and initialize it with random values
+        /// </summary>
+        /// <param name="type">ML-KEM parameter set type</param>
+        /// <param name="heap">Heap pointer for memory allocation</param>
+        /// <param name="devId">Device ID (if applicable)</param>
+        /// <returns>Pointer to the MlKem key structure, or IntPtr.Zero on failure</returns>
+        public static IntPtr MlKemMakeKey(MlKemTypes type, IntPtr heap, int devId)
+        {
+            int ret = 0;
+            IntPtr key = IntPtr.Zero;
+            IntPtr rng = IntPtr.Zero;
+            bool success = false;
+
+            try
+            {
+                key = wc_MlKemKey_New((int)type, heap, devId);
+                if (key == IntPtr.Zero)
+                {
+                    log(ERROR_LOG, "Failed to allocate or initialize MlKem key.");
+                    return IntPtr.Zero;
+                }
+
+                rng = RandomNew();
+                if (rng == IntPtr.Zero)
+                {
+                    log(ERROR_LOG, "Failed to create RNG for MlKem key.");
+                    return IntPtr.Zero;
+                }
+
+                ret = wc_MlKemKey_MakeKey(key, rng);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to make MlKem key. Error code: " + ret);
+                    return IntPtr.Zero;
+                }
+
+                success = true;
+                return key;
+            }
+            catch (Exception ex)
+            {
+                log(ERROR_LOG, "MlKem key creation exception: " + ex.ToString());
+                return IntPtr.Zero;
+            }
+            finally
+            {
+                if (rng != IntPtr.Zero)
+                {
+                    RandomFree(rng);
+                }
+                if (!success && key != IntPtr.Zero)
+                {
+                    ret = MlKemFreeKey(ref key);
+                    if (ret != 0)
+                    {
+                        log(ERROR_LOG, "Failed to free MlKem key. Error code: " + ret);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Free a MlKem key structure and release its memory
+        /// </summary>
+        /// <param name="key">Pointer to the MlKem key structure</param>
+        /// <returns>0 on success, negative value on error.</returns>
+        public static int MlKemFreeKey(ref IntPtr key)
+        {
+            int ret = 0;
+
+            if (key == IntPtr.Zero)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            if (key != IntPtr.Zero)
+            {
+                ret = wc_MlKemKey_Delete(key, IntPtr.Zero);
+                key = IntPtr.Zero;
+            }
+            return ret;
+        }
+
+        /// <summary>
+        /// Encode the ML-KEM public key to a byte array.
+        /// </summary>
+        /// <param name="key">Pointer to the MlKem key structure.</param>
+        /// <param name="publicKey">Output byte array containing the encoded public key.</param>
+        /// <returns>0 on success, negative value on error.</returns>
+        public static int MlKemEncodePublicKey(IntPtr key, out byte[] publicKey)
+        {
+            publicKey = null;
+            int ret = 0;
+            uint pubLen = 0;
+
+            if (key == IntPtr.Zero)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                ret = wc_MlKemKey_PublicKeySize(key, ref pubLen);
+                if (ret !=0 || pubLen == 0)
+                {
+                    log(ERROR_LOG, "Failed to get MlKem public key length. Error code: " + ret);
+                    return ret;
+                }
+                if (pubLen > int.MaxValue)
+                {
+                    log(ERROR_LOG, "MlKem public key length too large: " + pubLen);
+                    return BAD_FUNC_ARG;
+                }
+                publicKey = new byte[checked((int)pubLen)];
+
+                ret = wc_MlKemKey_EncodePublicKey(key, publicKey, pubLen);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to encode MlKem public key. Error code: " + ret);
+                    publicKey = null;
+                    return ret;
+                }
+            }
+            catch (Exception e)
+            {
+                log(ERROR_LOG, "MlKem encode public key exception: " + e.ToString());
+                publicKey = null;
+                return EXCEPTION_E;
+            }
+            return SUCCESS;
+        }
+
+        /// <summary>
+        /// Encode the ML-KEM private key to a byte array.
+        /// </summary>
+        /// <param name="key">Pointer to the MlKem key structure.</param>
+        /// <param name="privateKey">Output byte array containing the encoded private key.</param>
+        /// <returns>0 on success, negative value on error.</returns>
+        public static int MlKemEncodePrivateKey(IntPtr key, out byte[] privateKey)
+        {
+            privateKey = null;
+            int ret = 0;
+            uint privLen = 0;
+
+            if (key == IntPtr.Zero)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                ret = wc_MlKemKey_PrivateKeySize(key, ref privLen);
+                if (ret !=0 || privLen == 0)
+                {
+                    log(ERROR_LOG, "Failed to get MlKem private key length. Error code: " + ret);
+                    return ret;
+                }
+                if (privLen > int.MaxValue)
+                {
+                    log(ERROR_LOG, "MlKem private key length too large: " + privLen);
+                    return BAD_FUNC_ARG;
+                }
+
+                privateKey = new byte[checked((int)privLen)];
+                ret = wc_MlKemKey_EncodePrivateKey(key, privateKey, privLen);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to encode MlKem private key. Error code: " + ret);
+                    privateKey = null;
+                    return ret;
+                }
+            }
+            catch (Exception e)
+            {
+                log(ERROR_LOG, "MlKem encode private key exception: " + e.ToString());
+                privateKey = null;
+                return EXCEPTION_E;
+            }
+            return SUCCESS;
+        }
+
+        /// <summary>
+        /// Decode a ML-KEM public key from a byte array.
+        /// </summary>
+        /// <param name="key">Pointer to the MlKem key structure.</param>
+        /// <param name="publicKey">Encoded public key as byte array.</param>
+        /// <returns>0 on success, negative value on error.</returns>
+        public static int MlKemDecodePublicKey(IntPtr key, byte[] publicKey)
+        {
+            int ret = 0;
+            uint pubLen = 0;
+
+            if (key == IntPtr.Zero)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            if (publicKey == null)
+            {
+                log(ERROR_LOG, "MlKem decode public key called with null publicKey buffer.");
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                ret = wc_MlKemKey_PublicKeySize(key, ref pubLen);
+                if (ret != 0 || pubLen == 0)
+                {
+                    log(ERROR_LOG, "Failed to get MlKem public key length. Error code: " + ret);
+                    return ret;
+                }
+                if ((uint)publicKey.Length != pubLen)
+                 {
+                     log(ERROR_LOG, "MlKem public key buffer length mismatch. Expected: " +
+                         pubLen + ", actual: " + publicKey.Length);
+                     return BUFFER_E;
+                 }
+
+                ret = wc_MlKemKey_DecodePublicKey(key, publicKey, pubLen);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to decode MlKem public key. Error code: " + ret);
+                    return ret;
+                }
+            }
+            catch (Exception ex)
+            {
+                log(ERROR_LOG, "MlKem decode public key exception: " + ex.ToString());
+                return EXCEPTION_E;
+            }
+            return SUCCESS;
+        }
+
+        /// <summary>
+        /// Decode a ML-KEM private key from a byte array.
+        /// </summary>
+        /// <param name="key">Pointer to the MlKem key structure.</param>
+        /// <param name="privateKey">Encoded private key as byte array.</param>
+        /// <returns>0 on success, negative value on error.</returns>
+        public static int MlKemDecodePrivateKey(IntPtr key, byte[] privateKey)
+        {
+            int ret = 0;
+            uint privLen = 0;
+
+            if (key == IntPtr.Zero)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            if (privateKey == null)
+            {
+                log(ERROR_LOG, "MlKem private key buffer is null.");
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                ret = wc_MlKemKey_PrivateKeySize(key, ref privLen);
+                if (privLen == 0)
+                {
+                    log(ERROR_LOG, "Failed to get MlKem private key length. Error code: " + ret);
+                    return ret;
+                }
+                
+                if ((uint)privateKey.Length != privLen)
+                {
+                    log(ERROR_LOG, "MlKem private key buffer length mismatch. Required: " + privLen +
+                        ", provided: " + (uint)privateKey.Length);
+                    return BUFFER_E;
+                }
+
+                ret = wc_MlKemKey_DecodePrivateKey(key, privateKey, privLen);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to decode MlKem private key. Error code: " + ret);
+                    return ret;
+                }
+            }
+            catch (Exception ex)
+            {
+                log(ERROR_LOG, "MlKem decode private key exception: " + ex.ToString());
+                return EXCEPTION_E;
+            }
+            return SUCCESS;
+        }
+
+        /// <summary>
+        /// Perform ML-KEM encapsulation to generate a ciphertext and shared secret
+        /// </summary>
+        /// <param name="key">Pointer to the MlKem key structure</param>
+        /// <param name="ct">Output buffer for the ciphertext</param>
+        /// <param name="ss">Output buffer for the shared secret</param>
+        /// <returns>0 on success, otherwise an error code</returns>
+        public static int MlKemEncapsulate(IntPtr key, out byte[] ct, out byte[] ss)
+        {
+            int ret;
+            ct = null;
+            ss = null;
+            uint ctLen = 0;
+            uint ssLen = 0;
+            IntPtr rng = IntPtr.Zero;
+
+            if (key == IntPtr.Zero)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                ret = wc_MlKemKey_CipherTextSize(key, ref ctLen);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to determine ciphertext length. Error code: " + ret);
+                    return ret;
+                }
+                ret = wc_MlKemKey_SharedSecretSize(key, ref ssLen);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to determine shared secret length. Error code: " + ret);
+                    return ret;
+                }
+
+                if (ctLen > int.MaxValue || ssLen > int.MaxValue)
+                {
+                    log(ERROR_LOG, "MlKem sizes exceed maximum supported length.");
+                    return BAD_FUNC_ARG;
+                }
+                ct = new byte[checked((int)ctLen)];
+                ss = new byte[checked((int)ssLen)];
+
+                rng = RandomNew();
+                if (rng == IntPtr.Zero)
+                {
+                    log(ERROR_LOG, "Failed to create RNG for MlKem encapsulate.");
+                    return BAD_FUNC_ARG;
+                }
+                ret = wc_MlKemKey_Encapsulate(key, ct, ss, rng);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to encapsulate MlKem key. Error code: " + ret);
+                    return ret;
+                }
+            }
+            catch (Exception e)
+            {
+                log(ERROR_LOG, "MlKem encapsulate exception: " + e.ToString());
+                return EXCEPTION_E;
+            }
+            finally
+            {
+                if (rng != IntPtr.Zero)
+                {
+                    RandomFree(rng);
+                    rng = IntPtr.Zero;
+                }
+            }
+            return SUCCESS;
+        }
+
+        /// <summary>
+        /// Perform ML-KEM decapsulation to recover the shared secret from ciphertext
+        /// </summary>
+        /// <param name="key">Pointer to the MlKem key structure</param>
+        /// <param name="ct">Ciphertext buffer</param>
+        /// <param name="ss">Output buffer for the shared secret</param>
+        /// <returns>0 on success, otherwise an error code</returns>
+        public static int MlKemDecapsulate(IntPtr key, byte[] ct, out byte[] ss)
+        {
+            int ret;
+            ss = null;
+            uint ssLen = 0;
+
+            if (key == IntPtr.Zero || ct == null)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                ret = wc_MlKemKey_SharedSecretSize(key, ref ssLen);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to determine shared secret length. Error code: " + ret);
+                    return ret;
+                }
+                if (ssLen > int.MaxValue)
+                {
+                    log(ERROR_LOG, "Shared secret length too large. Length: " + ssLen);
+                    return BAD_FUNC_ARG;
+                }
+
+                ss = new byte[checked((int)ssLen)];
+                ret = wc_MlKemKey_Decapsulate(key, ss, ct, (uint)ct.Length);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to decapsulate MlKem key. Error code: " + ret);
+                    return ret;
+                }
+            }
+            catch (Exception e)
+            {
+                log(ERROR_LOG, "MlKem decapsulate exception: " + e.ToString());
+                return EXCEPTION_E;
+            }
+            return SUCCESS;
+        }
+
+        /********************************
+         * ENUMS
+         */
+        public enum MlKemTypes
+        {
+            ML_KEM_512 = 0,
+            ML_KEM_768 = 1,
+            ML_KEM_1024 = 2
+        }
+        /* END ML-KEM */
+
+
+        /***********************************************************************
+         * ML-DSA
+         **********************************************************************/
+
+        // These APIs work by adding several options to wolfCrypt.
+        // Please refer to `../user_settings.h`.
+
+        /// <summary>
+        /// Create a new Dilithium key pair and initialize it with random values
+        /// </summary>
+        /// <param name="heap">Heap pointer for memory allocation</param>
+        /// <param name="devId">Device ID (if applicable)</param>
+        /// <param name="level">Dilithium security level</param>
+        /// <returns>Pointer to the Dilithium key structure, or IntPtr.Zero on failure</returns>
+        public static IntPtr DilithiumMakeKey(IntPtr heap, int devId, MlDsaLevels level)
+        {
+            IntPtr key = IntPtr.Zero;
+            IntPtr rng = IntPtr.Zero;
+            int ret;
+            bool success = false;
+
+            try
+            {
+                key = wc_dilithium_new(heap, devId);
+                if (key == IntPtr.Zero)
+                {
+                    log(ERROR_LOG, "Failed to allocate and initialize Dilithium key.");
+                    return IntPtr.Zero;
+                }
+
+                ret = wc_dilithium_set_level(key, (byte)level);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to set Dilithium level. Error code: " + ret);
+                    return IntPtr.Zero;
+                }
+
+                rng = RandomNew();
+                if (rng == IntPtr.Zero)
+                {
+                    log(ERROR_LOG, "Failed to create RNG for Dilithium key.");
+                    return IntPtr.Zero;
+                }
+
+                ret = wc_dilithium_make_key(key, rng);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to make Dilithium key. Error code: " + ret);
+                    return IntPtr.Zero;
+                }
+
+                success = true;
+                return key;
+            }
+            catch (Exception ex)
+            {
+                log(ERROR_LOG, "Dilithium key creation exception: " + ex.ToString());
+                return IntPtr.Zero;
+            }
+            finally
+            {
+                if (rng != IntPtr.Zero)
+                {
+                    RandomFree(rng);
+                }
+                if (!success && key != IntPtr.Zero)
+                {
+                    ret = DilithiumFreeKey(ref key);
+                    if (ret != 0)
+                    {
+                        log(ERROR_LOG, "Failed to free Dilithium key. Error code: " + ret);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Free a Dilithium key structure and release its memory
+        /// </summary>
+        /// <param name="key">Pointer to the Dilithium key structure</param>
+        /// <returns>0 on success, negative value on error.</returns>
+        public static int DilithiumFreeKey(ref IntPtr key)
+        {
+            int ret = 0;
+
+            if (key == IntPtr.Zero)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            if (key != IntPtr.Zero)
+            {
+                ret = wc_dilithium_delete(key, IntPtr.Zero);
+                key = IntPtr.Zero;
+            }
+            return ret;
+        }
+
+        /// <summary>
+        /// Import a Dilithium public key from a byte array.
+        /// </summary>
+        /// <param name="publicKey">Byte array containing the public key (big-endian).</param>
+        /// <param name="key">Pointer to the Dilithium key structure (must be initialized).</param>
+        /// <returns>0 on success, negative value on error.</returns>
+        public static int DilithiumImportPublicKey(byte[] publicKey, IntPtr key)
+        {
+            if (publicKey == null || key == IntPtr.Zero)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                return wc_dilithium_import_public(publicKey, (uint)publicKey.Length, key);
+            }
+            catch (Exception e)
+            {
+                log(ERROR_LOG, "Dilithium import public key exception: " + e.ToString());
+                return EXCEPTION_E;
+            }
+        }
+
+        /// <summary>
+        /// Import a Dilithium private key from a byte array.
+        /// </summary>
+        /// <param name="privateKey">Byte array containing the private key.</param>
+        /// <param name="key">Pointer to the Dilithium key structure (must be initialized and have level set).</param>
+        /// <returns>0 on success, negative value on error.</returns>
+        public static int DilithiumImportPrivateKey(byte[] privateKey, IntPtr key)
+        {
+            if (privateKey == null || key == IntPtr.Zero)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                return wc_dilithium_import_private(privateKey, (uint)privateKey.Length, key);
+            }
+            catch (Exception e)
+            {
+                log(ERROR_LOG, "Dilithium import private key exception: " + e.ToString());
+                return EXCEPTION_E;
+            }
+        }
+
+        /// <summary>
+        /// Export a Dilithium private key to a byte array.
+        /// </summary>
+        /// <param name="key">Pointer to the Dilithium key structure.</param>
+        /// <param name="privateKey">Output byte array containing the private key.</param>
+        /// <returns>0 on success, negative value on error.</returns>
+        public static int DilithiumExportPrivateKey(IntPtr key, out byte[] privateKey)
+        {
+            privateKey = null;
+            int ret = 0;
+            int privLen = 0;
+            uint outLen;
+
+            if (key == IntPtr.Zero)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                ret = wc_MlDsaKey_GetPrivLen(key, ref privLen);
+                if (privLen <= 0)
+                {
+                    log(ERROR_LOG, "Failed to get Dilithium private key length. Error code: " + ret);
+                    return ret;
+                }
+
+                privateKey = new byte[privLen];
+                outLen = (uint)privLen;
+                ret = wc_dilithium_export_private(key, privateKey, ref outLen);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to export Dilithium private key. Error code: " + ret);
+                    privateKey = null;
+                    return ret;
+                }
+                if (outLen != (uint)privLen)
+                {
+                    Array.Resize(ref privateKey, (int)outLen);
+                }
+            }
+            catch (Exception e)
+            {
+                log(ERROR_LOG, "Dilithium export private key exception: " + e.ToString());
+                privateKey = null;
+                return EXCEPTION_E;
+            }
+            return SUCCESS;
+        }
+
+        /// <summary>
+        /// Export a Dilithium public key to a byte array.
+        /// </summary>
+        /// <param name="key">Pointer to the Dilithium key structure.</param>
+        /// <param name="publicKey">Output byte array containing the public key.</param>
+        /// <returns>0 on success, negative value on error.</returns>
+        public static int DilithiumExportPublicKey(IntPtr key, out byte[] publicKey)
+        {
+            publicKey = null;
+            int ret = 0;
+            int pubLen = 0;
+            uint outLen;
+
+            if (key == IntPtr.Zero)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                ret = wc_MlDsaKey_GetPubLen(key, ref pubLen);
+                if (pubLen <= 0)
+                {
+                    log(ERROR_LOG, "Failed to get Dilithium public key length. Error code: " + ret);
+                    return ret;
+                }
+
+                publicKey = new byte[pubLen];
+                outLen = (uint)pubLen;
+                ret = wc_dilithium_export_public(key, publicKey, ref outLen);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to export Dilithium public key. Error code: " + ret);
+                    publicKey = null;
+                    return ret;
+                }
+                if (outLen != (uint)pubLen)
+                {
+                    Array.Resize(ref publicKey, (int)outLen);
+                }
+            }
+            catch (Exception e)
+            {
+                log(ERROR_LOG, "Dilithium export public key exception: " + e.ToString());
+                publicKey = null;
+                return EXCEPTION_E;
+            }
+            return SUCCESS;
+        }
+
+        /// <summary>
+        /// Sign a message using a Dilithium private key
+        /// </summary>
+        /// <param name="key">Pointer to the Dilithium key structure</param>
+        /// <param name="msg">Message to sign</param>
+        /// <param name="sig">Output byte array for the signature</param>
+        /// <returns>0 on success, otherwise an error code</returns>
+        public static int DilithiumSignMsg(IntPtr key, byte[] msg, out byte[] sig)
+        {
+            int ret;
+            int sigLen = 0;
+            uint outLen;
+            sig = null;
+            IntPtr rng = IntPtr.Zero;
+
+            if (key == IntPtr.Zero || msg == null)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                ret = wc_MlDsaKey_GetSigLen(key, ref sigLen);
+                if (sigLen <= 0)
+                {
+                    log(ERROR_LOG, "Failed to get Dilithium signature length. Error code: " + ret);
+                    return ret;
+                }
+
+                sig = new byte[sigLen];
+                outLen = (uint)sigLen;
+                rng = RandomNew();
+                if (rng == IntPtr.Zero)
+                {
+                    log(ERROR_LOG, "Failed to create RNG for Dilithium signing.");
+                    return EXCEPTION_E;
+                }
+                ret = wc_dilithium_sign_msg(msg, (uint)msg.Length, sig, ref outLen, key, rng);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to sign message with Dilithium key. Error code: " + ret);
+                    return ret;
+                }
+                if (outLen != (uint)sigLen)
+                {
+                    Array.Resize(ref sig, (int)outLen);
+                }
+            }
+            catch (Exception e)
+            {
+                log(ERROR_LOG, "Dilithium sign message exception: " + e.ToString());
+                return EXCEPTION_E;
+            }
+            finally
+            {
+                if (rng != IntPtr.Zero){
+                    RandomFree(rng);
+                }
+            }
+            return SUCCESS;
+        }
+
+        /// <summary>
+        /// Verify a Dilithium signature
+        /// </summary>
+        /// <param name="key">Pointer to the Dilithium key structure</param>
+        /// <param name="msg">Message that was signed</param>
+        /// <param name="sig">Signature to verify</param>
+        /// <returns>0 if the signature is valid, otherwise an error code</returns>
+        public static int DilithiumVerifyMsg(IntPtr key, byte[] msg, byte[] sig)
+        {
+            int ret;
+            int res = 0;
+
+            if (key == IntPtr.Zero || msg == null || sig == null)
+            {
+                return BAD_FUNC_ARG;
+            }
+
+            try
+            {
+                ret = wc_dilithium_verify_msg(sig, (uint)sig.Length, msg, (uint)msg.Length, ref res, key);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to verify message with Dilithium key. Error code: " + ret);
+                    return ret;
+                }
+                if (res != 1)
+                {
+                    log(ERROR_LOG, "Dilithium signature verification failed (invalid signature).");
+                    return SIG_VERIFY_E;
+                }
+            }
+            catch (Exception e)
+            {
+                log(ERROR_LOG, "Dilithium verify message exception: " + e.ToString());
+                return EXCEPTION_E;
+            }
+            return SUCCESS;
+        }
+
+        /********************************
+         * ENUMS
+         */
+        public enum MlDsaLevels
+        {
+            ML_DSA_44 = 2,
+            ML_DSA_65 = 3,
+            ML_DSA_87 = 5
+        }
+        /* END ML-DSA */
 
 
         /***********************************************************************

--- a/wrapper/CSharp/wolfSSL_CSharp/wolfCrypt.cs
+++ b/wrapper/CSharp/wolfSSL_CSharp/wolfCrypt.cs
@@ -3248,7 +3248,7 @@ namespace wolfSSL.CSharp
                 if (rng == IntPtr.Zero)
                 {
                     log(ERROR_LOG, "Failed to create RNG for MlKem encapsulate.");
-                    return BAD_FUNC_ARG;
+                    return MEMORY_E;
                 }
                 ret = wc_MlKemKey_Encapsulate(key, ct, ss, rng);
                 if (ret != 0)
@@ -3293,6 +3293,19 @@ namespace wolfSSL.CSharp
 
             try
             {
+                uint ctLen = 0;
+                ret = wc_MlKemKey_CipherTextSize(key, ref ctLen);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to determine ciphertext length. Error code: " + ret);
+                    return ret;
+                }
+                if ((uint)ct.Length != ctLen)
+                {
+                    log(ERROR_LOG, "Ciphertext length mismatch. Expected: " + ctLen + ", got: " + ct.Length);
+                    return BUFFER_E;
+                }
+
                 ret = wc_MlKemKey_SharedSecretSize(key, ref ssLen);
                 if (ret != 0)
                 {
@@ -3341,16 +3354,16 @@ namespace wolfSSL.CSharp
         // Please refer to `../user_settings.h`.
 
         /// <summary>
-        /// Allocate and initialize a new Dilithium key (with level set) without
+        /// Allocate and initialize a new ML-DSA key (with level set) without
         /// generating key material. Use this when you intend to import an
-        /// existing key (e.g., before calling DilithiumImportPublicKey or
-        /// DilithiumImportPrivateKey).
+        /// existing key (e.g., before calling MlDsaImportPublicKey or
+        /// MlDsaImportPrivateKey).
         /// </summary>
         /// <param name="heap">Heap pointer for memory allocation</param>
         /// <param name="devId">Device ID (if applicable)</param>
-        /// <param name="level">Dilithium security level</param>
-        /// <returns>Pointer to the Dilithium key structure, or IntPtr.Zero on failure</returns>
-        public static IntPtr DilithiumNew(IntPtr heap, int devId, MlDsaLevels level)
+        /// <param name="level">ML-DSA security level</param>
+        /// <returns>Pointer to the ML-DSA key structure, or IntPtr.Zero on failure</returns>
+        public static IntPtr MlDsaNew(IntPtr heap, int devId, MlDsaLevels level)
         {
             IntPtr key = IntPtr.Zero;
             bool success = false;
@@ -3360,14 +3373,14 @@ namespace wolfSSL.CSharp
                 key = wc_dilithium_new(heap, devId);
                 if (key == IntPtr.Zero)
                 {
-                    log(ERROR_LOG, "Failed to allocate and initialize Dilithium key.");
+                    log(ERROR_LOG, "Failed to allocate and initialize ML-DSA key.");
                     return IntPtr.Zero;
                 }
 
                 int ret = wc_dilithium_set_level(key, (byte)level);
                 if (ret != 0)
                 {
-                    log(ERROR_LOG, "Failed to set Dilithium level. Error code: " + ret);
+                    log(ERROR_LOG, "Failed to set ML-DSA level. Error code: " + ret);
                     return IntPtr.Zero;
                 }
 
@@ -3376,30 +3389,30 @@ namespace wolfSSL.CSharp
             }
             catch (Exception ex)
             {
-                log(ERROR_LOG, "Dilithium key allocation exception: " + ex.ToString());
+                log(ERROR_LOG, "ML-DSA key allocation exception: " + ex.ToString());
                 return IntPtr.Zero;
             }
             finally
             {
                 if (!success && key != IntPtr.Zero)
                 {
-                    int ret = DilithiumFreeKey(ref key);
+                    int ret = MlDsaFreeKey(ref key);
                     if (ret != 0)
                     {
-                        log(ERROR_LOG, "Failed to free Dilithium key. Error code: " + ret);
+                        log(ERROR_LOG, "Failed to free ML-DSA key. Error code: " + ret);
                     }
                 }
             }
         }
 
         /// <summary>
-        /// Create a new Dilithium key pair and initialize it with random values
+        /// Create a new ML-DSA key pair and initialize it with random values
         /// </summary>
         /// <param name="heap">Heap pointer for memory allocation</param>
         /// <param name="devId">Device ID (if applicable)</param>
-        /// <param name="level">Dilithium security level</param>
-        /// <returns>Pointer to the Dilithium key structure, or IntPtr.Zero on failure</returns>
-        public static IntPtr DilithiumMakeKey(IntPtr heap, int devId, MlDsaLevels level)
+        /// <param name="level">ML-DSA security level</param>
+        /// <returns>Pointer to the ML-DSA key structure, or IntPtr.Zero on failure</returns>
+        public static IntPtr MlDsaMakeKey(IntPtr heap, int devId, MlDsaLevels level)
         {
             IntPtr key = IntPtr.Zero;
             IntPtr rng = IntPtr.Zero;
@@ -3411,28 +3424,28 @@ namespace wolfSSL.CSharp
                 key = wc_dilithium_new(heap, devId);
                 if (key == IntPtr.Zero)
                 {
-                    log(ERROR_LOG, "Failed to allocate and initialize Dilithium key.");
+                    log(ERROR_LOG, "Failed to allocate and initialize ML-DSA key.");
                     return IntPtr.Zero;
                 }
 
                 ret = wc_dilithium_set_level(key, (byte)level);
                 if (ret != 0)
                 {
-                    log(ERROR_LOG, "Failed to set Dilithium level. Error code: " + ret);
+                    log(ERROR_LOG, "Failed to set ML-DSA level. Error code: " + ret);
                     return IntPtr.Zero;
                 }
 
                 rng = RandomNew();
                 if (rng == IntPtr.Zero)
                 {
-                    log(ERROR_LOG, "Failed to create RNG for Dilithium key.");
+                    log(ERROR_LOG, "Failed to create RNG for ML-DSA key.");
                     return IntPtr.Zero;
                 }
 
                 ret = wc_dilithium_make_key(key, rng);
                 if (ret != 0)
                 {
-                    log(ERROR_LOG, "Failed to make Dilithium key. Error code: " + ret);
+                    log(ERROR_LOG, "Failed to make ML-DSA key. Error code: " + ret);
                     return IntPtr.Zero;
                 }
 
@@ -3441,7 +3454,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception ex)
             {
-                log(ERROR_LOG, "Dilithium key creation exception: " + ex.ToString());
+                log(ERROR_LOG, "ML-DSA key creation exception: " + ex.ToString());
                 return IntPtr.Zero;
             }
             finally
@@ -3452,21 +3465,21 @@ namespace wolfSSL.CSharp
                 }
                 if (!success && key != IntPtr.Zero)
                 {
-                    ret = DilithiumFreeKey(ref key);
+                    ret = MlDsaFreeKey(ref key);
                     if (ret != 0)
                     {
-                        log(ERROR_LOG, "Failed to free Dilithium key. Error code: " + ret);
+                        log(ERROR_LOG, "Failed to free ML-DSA key. Error code: " + ret);
                     }
                 }
             }
         }
 
         /// <summary>
-        /// Free a Dilithium key structure and release its memory
+        /// Free an ML-DSA key structure and release its memory
         /// </summary>
-        /// <param name="key">Pointer to the Dilithium key structure</param>
+        /// <param name="key">Pointer to the ML-DSA key structure</param>
         /// <returns>0 on success, negative value on error.</returns>
-        public static int DilithiumFreeKey(ref IntPtr key)
+        public static int MlDsaFreeKey(ref IntPtr key)
         {
             int ret;
 
@@ -3481,12 +3494,12 @@ namespace wolfSSL.CSharp
         }
 
         /// <summary>
-        /// Import a Dilithium public key from a byte array.
+        /// Import an ML-DSA public key from a byte array.
         /// </summary>
-        /// <param name="publicKey">Byte array containing the public key (big-endian).</param>
-        /// <param name="key">Pointer to the Dilithium key structure (must be initialized).</param>
+        /// <param name="publicKey">Byte array containing the serialized public key.</param>
+        /// <param name="key">Pointer to the ML-DSA key structure (must be initialized).</param>
         /// <returns>0 on success, negative value on error.</returns>
-        public static int DilithiumImportPublicKey(byte[] publicKey, IntPtr key)
+        public static int MlDsaImportPublicKey(byte[] publicKey, IntPtr key)
         {
             if (publicKey == null || key == IntPtr.Zero)
             {
@@ -3499,18 +3512,18 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Dilithium import public key exception: " + e.ToString());
+                log(ERROR_LOG, "ML-DSA import public key exception: " + e.ToString());
                 return EXCEPTION_E;
             }
         }
 
         /// <summary>
-        /// Import a Dilithium private key from a byte array.
+        /// Import an ML-DSA private key from a byte array.
         /// </summary>
         /// <param name="privateKey">Byte array containing the private key.</param>
-        /// <param name="key">Pointer to the Dilithium key structure (must be initialized and have level set).</param>
+        /// <param name="key">Pointer to the ML-DSA key structure (must be initialized and have level set).</param>
         /// <returns>0 on success, negative value on error.</returns>
-        public static int DilithiumImportPrivateKey(byte[] privateKey, IntPtr key)
+        public static int MlDsaImportPrivateKey(byte[] privateKey, IntPtr key)
         {
             if (privateKey == null || key == IntPtr.Zero)
             {
@@ -3523,18 +3536,18 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Dilithium import private key exception: " + e.ToString());
+                log(ERROR_LOG, "ML-DSA import private key exception: " + e.ToString());
                 return EXCEPTION_E;
             }
         }
 
         /// <summary>
-        /// Export a Dilithium private key to a byte array.
+        /// Export an ML-DSA private key to a byte array.
         /// </summary>
-        /// <param name="key">Pointer to the Dilithium key structure.</param>
+        /// <param name="key">Pointer to the ML-DSA key structure.</param>
         /// <param name="privateKey">Output byte array containing the private key.</param>
         /// <returns>0 on success, negative value on error.</returns>
-        public static int DilithiumExportPrivateKey(IntPtr key, out byte[] privateKey)
+        public static int MlDsaExportPrivateKey(IntPtr key, out byte[] privateKey)
         {
             privateKey = null;
             int ret = 0;
@@ -3551,7 +3564,7 @@ namespace wolfSSL.CSharp
                 ret = wc_MlDsaKey_GetPrivLen(key, ref privLen);
                 if (ret != 0 || privLen <= 0)
                 {
-                    log(ERROR_LOG, "Failed to get Dilithium private key length. Error code: " + ret);
+                    log(ERROR_LOG, "Failed to get ML-DSA private key length. Error code: " + ret);
                     return (ret != 0) ? ret : BAD_FUNC_ARG;
                 }
 
@@ -3560,7 +3573,7 @@ namespace wolfSSL.CSharp
                 ret = wc_dilithium_export_private(key, privateKey, ref outLen);
                 if (ret != 0)
                 {
-                    log(ERROR_LOG, "Failed to export Dilithium private key. Error code: " + ret);
+                    log(ERROR_LOG, "Failed to export ML-DSA private key. Error code: " + ret);
                     privateKey = null;
                     return ret;
                 }
@@ -3571,7 +3584,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Dilithium export private key exception: " + e.ToString());
+                log(ERROR_LOG, "ML-DSA export private key exception: " + e.ToString());
                 privateKey = null;
                 return EXCEPTION_E;
             }
@@ -3579,12 +3592,12 @@ namespace wolfSSL.CSharp
         }
 
         /// <summary>
-        /// Export a Dilithium public key to a byte array.
+        /// Export an ML-DSA public key to a byte array.
         /// </summary>
-        /// <param name="key">Pointer to the Dilithium key structure.</param>
+        /// <param name="key">Pointer to the ML-DSA key structure.</param>
         /// <param name="publicKey">Output byte array containing the public key.</param>
         /// <returns>0 on success, negative value on error.</returns>
-        public static int DilithiumExportPublicKey(IntPtr key, out byte[] publicKey)
+        public static int MlDsaExportPublicKey(IntPtr key, out byte[] publicKey)
         {
             publicKey = null;
             int ret = 0;
@@ -3601,7 +3614,7 @@ namespace wolfSSL.CSharp
                 ret = wc_MlDsaKey_GetPubLen(key, ref pubLen);
                 if (ret != 0 || pubLen <= 0)
                 {
-                    log(ERROR_LOG, "Failed to get Dilithium public key length. Error code: " + ret);
+                    log(ERROR_LOG, "Failed to get ML-DSA public key length. Error code: " + ret);
                     return (ret != 0) ? ret : BAD_FUNC_ARG;
                 }
 
@@ -3610,7 +3623,7 @@ namespace wolfSSL.CSharp
                 ret = wc_dilithium_export_public(key, publicKey, ref outLen);
                 if (ret != 0)
                 {
-                    log(ERROR_LOG, "Failed to export Dilithium public key. Error code: " + ret);
+                    log(ERROR_LOG, "Failed to export ML-DSA public key. Error code: " + ret);
                     publicKey = null;
                     return ret;
                 }
@@ -3621,7 +3634,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Dilithium export public key exception: " + e.ToString());
+                log(ERROR_LOG, "ML-DSA export public key exception: " + e.ToString());
                 publicKey = null;
                 return EXCEPTION_E;
             }
@@ -3629,13 +3642,13 @@ namespace wolfSSL.CSharp
         }
 
         /// <summary>
-        /// Sign a message using a Dilithium private key
+        /// Sign a message using an ML-DSA private key
         /// </summary>
-        /// <param name="key">Pointer to the Dilithium key structure</param>
+        /// <param name="key">Pointer to the ML-DSA key structure</param>
         /// <param name="msg">Message to sign</param>
         /// <param name="sig">Output byte array for the signature</param>
         /// <returns>0 on success, otherwise an error code</returns>
-        public static int DilithiumSignMsg(IntPtr key, byte[] msg, out byte[] sig)
+        public static int MlDsaSignMsg(IntPtr key, byte[] msg, out byte[] sig)
         {
             int ret;
             int sigLen = 0;
@@ -3653,7 +3666,7 @@ namespace wolfSSL.CSharp
                 ret = wc_MlDsaKey_GetSigLen(key, ref sigLen);
                 if (ret != 0 || sigLen <= 0)
                 {
-                    log(ERROR_LOG, "Failed to get Dilithium signature length. Error code: " + ret);
+                    log(ERROR_LOG, "Failed to get ML-DSA signature length. Error code: " + ret);
                     return (ret != 0) ? ret : BAD_FUNC_ARG;
                 }
 
@@ -3662,14 +3675,14 @@ namespace wolfSSL.CSharp
                 rng = RandomNew();
                 if (rng == IntPtr.Zero)
                 {
-                    log(ERROR_LOG, "Failed to create RNG for Dilithium signing.");
+                    log(ERROR_LOG, "Failed to create RNG for ML-DSA signing.");
                     return MEMORY_E;
                 }
                 /* FIPS 204 sign with empty context (ctx=null, ctxLen=0). */
                 ret = wc_dilithium_sign_ctx_msg(null, 0, msg, (uint)msg.Length, sig, ref outLen, key, rng);
                 if (ret != 0)
                 {
-                    log(ERROR_LOG, "Failed to sign message with Dilithium key. Error code: " + ret);
+                    log(ERROR_LOG, "Failed to sign message with ML-DSA key. Error code: " + ret);
                     return ret;
                 }
                 if (outLen != (uint)sigLen)
@@ -3679,7 +3692,7 @@ namespace wolfSSL.CSharp
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Dilithium sign message exception: " + e.ToString());
+                log(ERROR_LOG, "ML-DSA sign message exception: " + e.ToString());
                 return EXCEPTION_E;
             }
             finally
@@ -3692,13 +3705,13 @@ namespace wolfSSL.CSharp
         }
 
         /// <summary>
-        /// Verify a Dilithium signature
+        /// Verify an ML-DSA signature
         /// </summary>
-        /// <param name="key">Pointer to the Dilithium key structure</param>
+        /// <param name="key">Pointer to the ML-DSA key structure</param>
         /// <param name="msg">Message that was signed</param>
         /// <param name="sig">Signature to verify</param>
         /// <returns>0 if the signature is valid, otherwise an error code</returns>
-        public static int DilithiumVerifyMsg(IntPtr key, byte[] msg, byte[] sig)
+        public static int MlDsaVerifyMsg(IntPtr key, byte[] msg, byte[] sig)
         {
             int ret;
             int res = 0;
@@ -3714,18 +3727,18 @@ namespace wolfSSL.CSharp
                 ret = wc_dilithium_verify_ctx_msg(sig, (uint)sig.Length, null, 0, msg, (uint)msg.Length, ref res, key);
                 if (ret != 0)
                 {
-                    log(ERROR_LOG, "Failed to verify message with Dilithium key. Error code: " + ret);
+                    log(ERROR_LOG, "Failed to verify message with ML-DSA key. Error code: " + ret);
                     return ret;
                 }
                 if (res != 1)
                 {
-                    log(ERROR_LOG, "Dilithium signature verification failed (invalid signature).");
+                    log(ERROR_LOG, "ML-DSA signature verification failed (invalid signature).");
                     return SIG_VERIFY_E;
                 }
             }
             catch (Exception e)
             {
-                log(ERROR_LOG, "Dilithium verify message exception: " + e.ToString());
+                log(ERROR_LOG, "ML-DSA verify message exception: " + e.ToString());
                 return EXCEPTION_E;
             }
             return SUCCESS;

--- a/wrapper/CSharp/wolfSSL_CSharp/wolfCrypt.cs
+++ b/wrapper/CSharp/wolfSSL_CSharp/wolfCrypt.cs
@@ -457,21 +457,13 @@ namespace wolfSSL.CSharp
         [DllImport(wolfssl_dll)]
         private static extern int wc_MlKemKey_Delete(IntPtr key, IntPtr key_p);
         [DllImport(wolfssl_dll)]
-        private static extern int wc_MlKemKey_Init(IntPtr key, int type, IntPtr heap, int devId);
-        [DllImport(wolfssl_dll)]
-        private static extern int wc_MlKemKey_Free(IntPtr key);
-        [DllImport(wolfssl_dll)]
         private static extern int wc_MlKemKey_MakeKey(IntPtr key, IntPtr rng);
-        [DllImport(wolfssl_dll)]
-        private static extern int wc_MlKemKey_MakeKeyWithRandom(IntPtr key, byte[] rand, int len);
         [DllImport(wolfssl_dll)]
         private static extern int wc_MlKemKey_EncodePublicKey(IntPtr key, byte[] output, uint len);
         [DllImport(wolfssl_dll)]
         private static extern int wc_MlKemKey_DecodePublicKey(IntPtr key, byte[] input, uint len);
         [DllImport(wolfssl_dll)]
         private static extern int wc_MlKemKey_Encapsulate(IntPtr key, byte[] ct, byte[] ss, IntPtr rng);
-        [DllImport(wolfssl_dll)]
-        private static extern int wc_MlKemKey_EncapsulateWithRandom(IntPtr key, byte[] ct, byte[] ss, byte[] rand, int len);
         [DllImport(wolfssl_dll)]
         private static extern int wc_MlKemKey_Decapsulate(IntPtr key, byte[] ss, byte[] ct, uint len);
         [DllImport(wolfssl_dll)]
@@ -492,21 +484,13 @@ namespace wolfSSL.CSharp
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_MlKemKey_Delete(IntPtr key, IntPtr key_p);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int wc_MlKemKey_Init(IntPtr key, int type, IntPtr heap, int devId);
-        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int wc_MlKemKey_Free(IntPtr key);
-        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_MlKemKey_MakeKey(IntPtr key, IntPtr rng);
-        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int wc_MlKemKey_MakeKeyWithRandom(IntPtr key, byte[] rand, int len);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_MlKemKey_EncodePublicKey(IntPtr key, byte[] output, uint len);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_MlKemKey_DecodePublicKey(IntPtr key, byte[] input, uint len);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_MlKemKey_Encapsulate(IntPtr key, byte[] ct, byte[] ss, IntPtr rng);
-        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int wc_MlKemKey_EncapsulateWithRandom(IntPtr key, byte[] ct, byte[] ss, byte[] rand, int len);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_MlKemKey_Decapsulate(IntPtr key, byte[] ss, byte[] ct, uint len);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
@@ -524,11 +508,7 @@ namespace wolfSSL.CSharp
         [DllImport(wolfssl_dll)]
         private static extern int wc_dilithium_delete(IntPtr key, IntPtr key_p);
         [DllImport(wolfssl_dll)]
-        private static extern int wc_dilithium_init_ex(IntPtr key, IntPtr heap, int devId);
-        [DllImport(wolfssl_dll)]
         private static extern int wc_dilithium_set_level(IntPtr key, byte level);
-        [DllImport(wolfssl_dll)]
-        private static extern void wc_dilithium_free(IntPtr key);
         [DllImport(wolfssl_dll)]
         private static extern int wc_dilithium_make_key(IntPtr key, IntPtr rng);
         [DllImport(wolfssl_dll)]
@@ -555,11 +535,7 @@ namespace wolfSSL.CSharp
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_dilithium_delete(IntPtr key, IntPtr key_p);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int wc_dilithium_init_ex(IntPtr key, IntPtr heap, int devId);
-        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_dilithium_set_level(IntPtr key, byte level);
-        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern void wc_dilithium_free(IntPtr key);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_dilithium_make_key(IntPtr key, IntPtr rng);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
@@ -2914,6 +2890,33 @@ namespace wolfSSL.CSharp
         // Please refer to `../user_settings.h`.
 
         /// <summary>
+        /// Allocate and initialize a new ML-KEM key without generating key
+        /// material. Use this when you intend to import or decode an existing
+        /// key (e.g., before calling MlKemDecodePublicKey/MlKemDecodePrivateKey).
+        /// </summary>
+        /// <param name="type">ML-KEM parameter set type</param>
+        /// <param name="heap">Heap pointer for memory allocation</param>
+        /// <param name="devId">Device ID (if applicable)</param>
+        /// <returns>Pointer to the MlKem key structure, or IntPtr.Zero on failure</returns>
+        public static IntPtr MlKemNew(MlKemTypes type, IntPtr heap, int devId)
+        {
+            try
+            {
+                IntPtr key = wc_MlKemKey_New((int)type, heap, devId);
+                if (key == IntPtr.Zero)
+                {
+                    log(ERROR_LOG, "Failed to allocate or initialize MlKem key.");
+                }
+                return key;
+            }
+            catch (Exception ex)
+            {
+                log(ERROR_LOG, "MlKem key allocation exception: " + ex.ToString());
+                return IntPtr.Zero;
+            }
+        }
+
+        /// <summary>
         /// Create a new ML-KEM key pair and initialize it with random values
         /// </summary>
         /// <param name="type">ML-KEM parameter set type</param>
@@ -3336,6 +3339,58 @@ namespace wolfSSL.CSharp
 
         // These APIs work by adding several options to wolfCrypt.
         // Please refer to `../user_settings.h`.
+
+        /// <summary>
+        /// Allocate and initialize a new Dilithium key (with level set) without
+        /// generating key material. Use this when you intend to import an
+        /// existing key (e.g., before calling DilithiumImportPublicKey or
+        /// DilithiumImportPrivateKey).
+        /// </summary>
+        /// <param name="heap">Heap pointer for memory allocation</param>
+        /// <param name="devId">Device ID (if applicable)</param>
+        /// <param name="level">Dilithium security level</param>
+        /// <returns>Pointer to the Dilithium key structure, or IntPtr.Zero on failure</returns>
+        public static IntPtr DilithiumNew(IntPtr heap, int devId, MlDsaLevels level)
+        {
+            IntPtr key = IntPtr.Zero;
+            bool success = false;
+
+            try
+            {
+                key = wc_dilithium_new(heap, devId);
+                if (key == IntPtr.Zero)
+                {
+                    log(ERROR_LOG, "Failed to allocate and initialize Dilithium key.");
+                    return IntPtr.Zero;
+                }
+
+                int ret = wc_dilithium_set_level(key, (byte)level);
+                if (ret != 0)
+                {
+                    log(ERROR_LOG, "Failed to set Dilithium level. Error code: " + ret);
+                    return IntPtr.Zero;
+                }
+
+                success = true;
+                return key;
+            }
+            catch (Exception ex)
+            {
+                log(ERROR_LOG, "Dilithium key allocation exception: " + ex.ToString());
+                return IntPtr.Zero;
+            }
+            finally
+            {
+                if (!success && key != IntPtr.Zero)
+                {
+                    int ret = DilithiumFreeKey(ref key);
+                    if (ret != 0)
+                    {
+                        log(ERROR_LOG, "Failed to free Dilithium key. Error code: " + ret);
+                    }
+                }
+            }
+        }
 
         /// <summary>
         /// Create a new Dilithium key pair and initialize it with random values

--- a/wrapper/CSharp/wolfSSL_CSharp/wolfSSL.cs
+++ b/wrapper/CSharp/wolfSSL_CSharp/wolfSSL.cs
@@ -795,8 +795,6 @@ namespace wolfSSL.CSharp
             WOLFSSL_SECP521R1MLKEM1024    = 12109,
             WOLFSSL_X25519MLKEM512        = 12214,
             WOLFSSL_X448MLKEM768          = 12215,
-
-            WOLF_ENUM_DUMMY_LAST_ELEMENT = 0
         }
 
 

--- a/wrapper/CSharp/wolfSSL_CSharp/wolfSSL.cs
+++ b/wrapper/CSharp/wolfSSL_CSharp/wolfSSL.cs
@@ -767,16 +767,15 @@ namespace wolfSSL.CSharp
             WOLFSSL_X25519_KYBER_LEVEL3   = 25497,
             WOLFSSL_P256_KYBER_LEVEL3     = 25498,
 
-            /* Taken from draft-connolly-tls-mlkem-key-agreement, see:
-             * https://github.com/dconnolly/draft-connolly-tls-mlkem-key-agreement/
+            /* Taken from draft-ietf-tls-mlkem, see:
+             * https://datatracker.ietf.org/doc/draft-ietf-tls-mlkem/
              */
             WOLFSSL_ML_KEM_512 = 512,
             WOLFSSL_ML_KEM_768 = 513,
             WOLFSSL_ML_KEM_1024 = 514,
 
-            /* Taken from draft-kwiatkowski-tls-ecdhe-mlkem. see:
-             * https://github.com/post-quantum-cryptography/
-             *      draft-kwiatkowski-tls-ecdhe-mlkem/
+            /* Taken from draft-ietf-tls-ecdhe-mlkem, see:
+             * https://datatracker.ietf.org/doc/draft-ietf-tls-ecdhe-mlkem/
              */
             WOLFSSL_SECP256R1MLKEM768     = 4587,
             WOLFSSL_X25519MLKEM768        = 4588,

--- a/wrapper/CSharp/wolfSSL_CSharp/wolfSSL.cs
+++ b/wrapper/CSharp/wolfSSL_CSharp/wolfSSL.cs
@@ -509,6 +509,8 @@ namespace wolfSSL.CSharp
         private extern static int wolfSSL_shutdown(IntPtr ssl);
         [DllImport(wolfssl_dll)]
         private extern static void wolfSSL_free(IntPtr ssl);
+        [DllImport(wolfssl_dll)]
+        private static extern int wolfSSL_UseKeyShare(IntPtr ssl, ushort group);
 #else
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static IntPtr wolfSSL_new(IntPtr ctx);
@@ -524,6 +526,8 @@ namespace wolfSSL.CSharp
         private extern static int wolfSSL_shutdown(IntPtr ssl);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static void wolfSSL_free(IntPtr ssl);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wolfSSL_UseKeyShare(IntPtr ssl, ushort group);
 #endif
 
         /********************************
@@ -708,6 +712,93 @@ namespace wolfSSL.CSharp
         public static readonly int WOLFSSL_LOAD_FLAG_IGNORE_BAD_PATH_ERR = 0x00000008;
         public static readonly int WOLFSSL_LOAD_FLAG_IGNORE_ZEROFILE     = 0x00000010;
         public static readonly int WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS     = WOLFSSL_LOAD_FLAG_NONE;
+
+        /* from ssl.h */
+        public enum NamedGroup
+        {
+            WOLFSSL_NAMED_GROUP_INVALID = 0,
+
+            WOLFSSL_ECC_SECP160K1 = 15,
+            WOLFSSL_ECC_SECP160R1 = 16,
+            WOLFSSL_ECC_SECP160R2 = 17,
+            WOLFSSL_ECC_SECP192K1 = 18,
+            WOLFSSL_ECC_SECP192R1 = 19,
+            WOLFSSL_ECC_SECP224K1 = 20,
+            WOLFSSL_ECC_SECP224R1 = 21,
+            WOLFSSL_ECC_SECP256K1 = 22,
+            WOLFSSL_ECC_SECP256R1 = 23,
+            WOLFSSL_ECC_SECP384R1 = 24,
+            WOLFSSL_ECC_SECP521R1 = 25,
+            WOLFSSL_ECC_BRAINPOOLP256R1 = 26,
+            WOLFSSL_ECC_BRAINPOOLP384R1 = 27,
+            WOLFSSL_ECC_BRAINPOOLP512R1 = 28,
+            WOLFSSL_ECC_X25519    = 29,
+            WOLFSSL_ECC_X448      = 30,
+            WOLFSSL_ECC_BRAINPOOLP256R1TLS13 = 31,
+            WOLFSSL_ECC_BRAINPOOLP384R1TLS13 = 32,
+            WOLFSSL_ECC_BRAINPOOLP512R1TLS13 = 33,
+            WOLFSSL_ECC_SM2P256V1 = 41,
+            WOLFSSL_ECC_MAX       = 41,
+            WOLFSSL_ECC_MAX_AVAIL = 46,
+            /* Update use of disabled curves when adding value greater than 46. */
+
+            WOLFSSL_FFDHE_START = 256,
+            WOLFSSL_FFDHE_2048 = 256,
+            WOLFSSL_FFDHE_3072 = 257,
+            WOLFSSL_FFDHE_4096 = 258,
+            WOLFSSL_FFDHE_6144 = 259,
+            WOLFSSL_FFDHE_8192 = 260,
+            WOLFSSL_FFDHE_END = 511,
+
+            /* Old code points to keep compatibility with MlKem Round 3.
+             * Taken from OQS's openssl provider, see:
+             * https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/
+             *      oqs-kem-info.md
+             */
+            WOLFSSL_KYBER_LEVEL1          = 570, /* KYBER_512 */
+            WOLFSSL_KYBER_LEVEL3          = 572, /* KYBER_768 */
+            WOLFSSL_KYBER_LEVEL5          = 573, /* KYBER_1024 */
+
+            WOLFSSL_P256_KYBER_LEVEL1     = 12090,
+            WOLFSSL_P384_KYBER_LEVEL3     = 12092,
+            WOLFSSL_P521_KYBER_LEVEL5     = 12093,
+            WOLFSSL_X25519_KYBER_LEVEL1   = 12089,
+            WOLFSSL_X448_KYBER_LEVEL3     = 12176,
+            WOLFSSL_X25519_KYBER_LEVEL3   = 25497,
+            WOLFSSL_P256_KYBER_LEVEL3     = 25498,
+
+            /* Taken from draft-connolly-tls-mlkem-key-agreement, see:
+             * https://github.com/dconnolly/draft-connolly-tls-mlkem-key-agreement/
+             */
+            WOLFSSL_ML_KEM_512 = 512,
+            WOLFSSL_ML_KEM_768 = 513,
+            WOLFSSL_ML_KEM_1024 = 514,
+
+            /* Taken from draft-kwiatkowski-tls-ecdhe-mlkem. see:
+             * https://github.com/post-quantum-cryptography/
+             *      draft-kwiatkowski-tls-ecdhe-mlkem/
+             */
+            WOLFSSL_SECP256R1MLKEM768     = 4587,
+            WOLFSSL_X25519MLKEM768        = 4588,
+            WOLFSSL_SECP384R1MLKEM1024    = 4589,
+
+            /* Taken from OQS's openssl provider, see:
+             * https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/
+             *      oqs-kem-info.md
+             */
+            WOLFSSL_P256_ML_KEM_512_OLD   = 12103,
+            WOLFSSL_P384_ML_KEM_768_OLD   = 12104,
+            WOLFSSL_P521_ML_KEM_1024_OLD  = 12105,
+
+            WOLFSSL_SECP256R1MLKEM512     = 12107,
+            WOLFSSL_SECP384R1MLKEM768     = 12108,
+            WOLFSSL_SECP521R1MLKEM1024    = 12109,
+            WOLFSSL_X25519MLKEM512        = 12214,
+            WOLFSSL_X448MLKEM768          = 12215,
+
+            WOLF_ENUM_DUMMY_LAST_ELEMENT = 0
+        }
+
 
 
         private static IntPtr unwrap_ctx(IntPtr ctx)
@@ -1283,6 +1374,36 @@ namespace wolfSSL.CSharp
             catch (Exception e)
             {
                 log(ERROR_LOG, "wolfssl shutdwon error " + e.ToString());
+                return FAILURE;
+            }
+        }
+
+
+        /// <summary>
+        /// Creates a key share entry for the specified group on the given SSL/TLS connection.
+        /// </summary>
+        /// <param name="ssl">Pointer to the SSL structure to use.</param>
+        /// <param name="group">The key exchange group identifier to use for key share (e.g., TLS supported group ID).</param>
+        /// <returns>1 on success</returns>
+        public static int UseKeyShare(IntPtr ssl, NamedGroup group)
+        {
+            if (ssl == IntPtr.Zero)
+            {
+                return FAILURE;
+            }
+            try
+            {
+                IntPtr sslCtx = unwrap_ssl(ssl);
+                if (sslCtx == IntPtr.Zero)
+                {
+                    log(ERROR_LOG, "UseKeyShare ssl unwrap error");
+                    return FAILURE;
+                }
+                return wolfSSL_UseKeyShare(sslCtx, (ushort)group);
+            }
+            catch (Exception e)
+            {
+                log(ERROR_LOG, "wolfSSL_UseKeyShare error " + e.ToString());
                 return FAILURE;
             }
         }


### PR DESCRIPTION
# Description

Adds post-quantum ML-KEM and ML-DSA support to the wolfSSL C# wrapper, with
build/test instructions, peer review fixes, and a switch to FIPS 204 compliant
Dilithium APIs.

## Changes

- **ML-KEM** wrapper functions: `MlKemMakeKey`, `MlKemEncode/DecodePublicKey`,
  `MlKemEncode/DecodePrivateKey`, `MlKemEncapsulate`, `MlKemDecapsulate`,
  `MlKemFreeKey` (supports `ML_KEM_512`, `ML_KEM_768`, `ML_KEM_1024`).
- **ML-DSA (Dilithium)** wrapper functions: `DilithiumMakeKey`,
  `DilithiumExport/Import` for public/private keys, `DilithiumSignMsg`,
  `DilithiumVerifyMsg`, `DilithiumFreeKey` (supports `ML_DSA_44/65/87`).
- Sign/verify use the FIPS 204 `wc_dilithium_sign_ctx_msg` /
  `wc_dilithium_verify_ctx_msg` APIs (with `ctx=NULL/ctxLen=0`) so the wrapper
  works without `WOLFSSL_DILITHIUM_NO_CTX`.
- `user_settings.h`: enables `HAVE_MLKEM`, `WOLFSSL_WC_MLKEM`, `HAVE_DILITHIUM`,
  `WOLFSSL_WC_DILITHIUM`, `WOLFSSL_SHAKE128/256`, plus `WOLFSSL_DTLS_CH_FRAG`
  (required for PQC + DTLS 1.3).
- `NamedGroup` enum extended with `WOLFSSL_ML_KEM_512/768/1024` and the
  hybrid groups (`SECP256R1MLKEM768`, `X25519MLKEM768`, `SECP384R1MLKEM1024`).
- New `mlkem_test` and `mldsa_test` cases in `wolfCrypt-Test.cs` covering
  keygen, encode/decode (or export/import), and full encap/decap or
  sign/verify roundtrips for every parameter set.
- `README.md`: documents a sudo-free build with
  `--prefix=$(pwd)/install` and running the test via
  `LD_LIBRARY_PATH=./install/lib mono wrapper/CSharp/wolfcrypttest.exe` so
  mono picks up the freshly-built library instead of any stale system one.
- Peer review fixes: stricter return-code checks on `wc_MlKemKey_*Size` /
  `wc_MlDsaKey_Get*Len` callers, `MEMORY_E` (not `EXCEPTION_E`) on RNG alloc
  failure in `DilithiumSignMsg`, dead null re-checks removed from the Free
  helpers, indentation cleanup, consistent `wolfcrypt.` prefix in
  `mldsa_test`, and removal of the C-only `WOLF_ENUM_DUMMY_LAST_ELEMENT`
  from `NamedGroup`.

# Testing

- [x] `./autogen.sh && cp wrapper/CSharp/user_settings.h . && ./configure --enable-usersettings --prefix=$(pwd)/install && make && make install`
- [x] `cd wrapper/CSharp && mcs wolfCrypt-Test/wolfCrypt-Test.cs wolfSSL_CSharp/{wolfCrypt,wolfSSL,X509}.cs -OUT:wolfcrypttest.exe`
- [x] `LD_LIBRARY_PATH=./install/lib mono wrapper/CSharp/wolfcrypttest.exe` — all
      tests pass, including ML-KEM 512/768/1024 and ML-DSA 44/65/87
      (signature lengths 2420/3309/4627).

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
