### PR TITLE
Set hashType in ports

### DIFF
--- a/wolfcrypt/src/port/caam/caam_sha.c
+++ b/wolfcrypt/src/port/caam/caam_sha.c
@@ -376,7 +376,13 @@ int wc_Sha384Final(wc_Sha384* sha, byte* out)
 #ifdef WOLFSSL_SHA512
 int wc_InitSha512_ex(wc_Sha512* sha, void* heap, int devId)
 {
-    return _InitSha(sha, heap, devId, SHA512_DIGEST_SIZE, CAAM_SHA512);
+    int ret = _InitSha(sha, heap, devId, SHA512_DIGEST_SIZE, CAAM_SHA512);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+    if (ret == 0) {
+        sha->hashType = WC_HASH_TYPE_SHA512;
+    }
+#endif
+    return ret;
 }
 
 

--- a/wolfcrypt/src/port/cypress/psoc6_crypto.c
+++ b/wolfcrypt/src/port/cypress/psoc6_crypto.c
@@ -536,6 +536,11 @@ int wc_InitSha512_ex(wc_Sha512* sha, void* heap, int devid)
         /* Release the lock */
         wolfSSL_CryptHwMutexUnLock();
     }
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+    if (ret == 0) {
+        sha->hashType = WC_HASH_TYPE_SHA512;
+    }
+#endif
     return ret;
 }
 
@@ -606,6 +611,11 @@ int wc_InitSha512_224_ex(wc_Sha512* sha, void* heap, int devid)
         /* Release the lock */
         wolfSSL_CryptHwMutexUnLock();
     }
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+    if (ret == 0) {
+        sha->hashType = WC_HASH_TYPE_SHA512_224;
+    }
+#endif
     return ret;
 }
 
@@ -658,6 +668,11 @@ int wc_InitSha512_256_ex(wc_Sha512* sha, void* heap, int devid)
         /* Release the lock */
         wolfSSL_CryptHwMutexUnLock();
     }
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+    if (ret == 0) {
+        sha->hashType = WC_HASH_TYPE_SHA512_256;
+    }
+#endif
     return ret;
 }
 

--- a/wolfcrypt/src/port/kcapi/kcapi_hash.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_hash.c
@@ -427,10 +427,17 @@ static const char WC_NAME_SHA512[] = "sha512";
 /* create KCAPI handle for SHA512 operation */
 int wc_InitSha512_ex(wc_Sha512* sha, void* heap, int devid)
 {
+    int ret;
     if (sha == NULL) {
         return BAD_FUNC_ARG;
     }
-    return KcapiHashInit(&sha->kcapi, heap, devid, WC_NAME_SHA512);
+    ret = KcapiHashInit(&sha->kcapi, heap, devid, WC_NAME_SHA512);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+    if (ret == 0) {
+        sha->hashType = WC_HASH_TYPE_SHA512;
+    }
+#endif
+    return ret;
 }
 
 
@@ -473,13 +480,20 @@ int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst)
 #if !defined(WOLFSSL_NOSHA512_224)
 static const char WC_NAME_SHA512_224[] = "sha512-224";
 
-/* create KCAPI handle for SHA512 operation */
+/* create KCAPI handle for SHA512/224 operation */
 int wc_InitSha512_224_ex(wc_Sha512* sha, void* heap, int devid)
 {
+    int ret;
     if (sha == NULL) {
         return BAD_FUNC_ARG;
     }
-    return KcapiHashInit(&sha->kcapi, heap, devid, WC_NAME_SHA512_224);
+    ret = KcapiHashInit(&sha->kcapi, heap, devid, WC_NAME_SHA512_224);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+    if (ret == 0) {
+        sha->hashType = WC_HASH_TYPE_SHA512_224;
+    }
+#endif
+    return ret;
 }
 
 
@@ -512,13 +526,20 @@ int wc_Sha512_224Copy(wc_Sha512* src, wc_Sha512* dst)
 #if !defined(WOLFSSL_NOSHA512_256)
 static const char WC_NAME_SHA512_256[] = "sha512-256";
 
-/* create KCAPI handle for SHA512 operation */
+/* create KCAPI handle for SHA512/256 operation */
 int wc_InitSha512_256_ex(wc_Sha512* sha, void* heap, int devid)
 {
+    int ret;
     if (sha == NULL) {
         return BAD_FUNC_ARG;
     }
-    return KcapiHashInit(&sha->kcapi, heap, devid, WC_NAME_SHA512_256);
+    ret = KcapiHashInit(&sha->kcapi, heap, devid, WC_NAME_SHA512_256);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+    if (ret == 0) {
+        sha->hashType = WC_HASH_TYPE_SHA512_256;
+    }
+#endif
+    return ret;
 }
 
 

--- a/wolfcrypt/src/port/maxim/max3266x.c
+++ b/wolfcrypt/src/port/maxim/max3266x.c
@@ -1136,6 +1136,9 @@ WOLFSSL_API int wc_InitSha512_ex(wc_Sha512* sha512, void* heap, int devId)
     (void)devId;
     XMEMSET(sha512, 0, sizeof(*sha512));
     sha512->heap = heap;
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+    sha512->hashType = WC_HASH_TYPE_SHA512;
+#endif
     return 0;
 }
 

--- a/wolfcrypt/src/port/riscv/riscv-64-sha512.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-sha512.c
@@ -999,6 +999,9 @@ int wc_InitSha512_ex(wc_Sha512* sha512, void* heap, int devId)
     int ret = InitSha512(sha512, heap, devId);
     if (ret == 0) {
         InitSha512_State(sha512);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+        sha512->hashType = WC_HASH_TYPE_SHA512;
+#endif
     }
     return ret;
 }
@@ -1302,6 +1305,9 @@ int wc_InitSha512_224_ex(wc_Sha512* sha512, void* heap, int devId)
     int ret = InitSha512(sha512, heap, devId);
     if (ret == 0) {
         InitSha512_224_State(sha512);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+        sha512->hashType = WC_HASH_TYPE_SHA512_224;
+#endif
     }
     return ret;
 }
@@ -1402,6 +1408,9 @@ int wc_InitSha512_256_ex(wc_Sha512* sha512, void* heap, int devId)
     int ret = InitSha512(sha512, heap, devId);
     if (ret == 0) {
         InitSha512_256_State(sha512);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+        sha512->hashType = WC_HASH_TYPE_SHA512_256;
+#endif
     }
     return ret;
 }

--- a/wolfcrypt/src/port/silabs/silabs_hash.c
+++ b/wolfcrypt/src/port/silabs/silabs_hash.c
@@ -277,6 +277,7 @@ int wc_Sha384Final(wc_Sha384* sha, byte* hash)
 #ifdef WOLFSSL_SILABS_SHA512
 int wc_InitSha512_ex(wc_Sha512* sha, void* heap, int devId)
 {
+    int ret;
     if (sha == NULL) {
         return BAD_FUNC_ARG;
     }
@@ -284,7 +285,13 @@ int wc_InitSha512_ex(wc_Sha512* sha, void* heap, int devId)
     (void)devId;
     (void)heap;
 
-    return wc_silabs_se_hash_init(&sha->silabsCtx, WC_HASH_TYPE_SHA512);
+    ret = wc_silabs_se_hash_init(&sha->silabsCtx, WC_HASH_TYPE_SHA512);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+    if (ret == 0) {
+        sha->hashType = WC_HASH_TYPE_SHA512;
+    }
+#endif
+    return ret;
 }
 
 

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -179,17 +179,31 @@
 #elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
     int wc_InitSha512(wc_Sha512* sha512)
     {
+        int ret;
         if (sha512 == NULL)
             return BAD_FUNC_ARG;
-        return se050_hash_init(&sha512->se050Ctx, NULL);
+        ret = se050_hash_init(&sha512->se050Ctx, NULL);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+        if (ret == 0) {
+            sha512->hashType = WC_HASH_TYPE_SHA512;
+        }
+#endif
+        return ret;
     }
     int wc_InitSha512_ex(wc_Sha512* sha512, void* heap, int devId)
     {
+        int ret;
         if (sha512 == NULL) {
             return BAD_FUNC_ARG;
         }
         (void)devId;
-        return se050_hash_init(&sha512->se050Ctx, heap);
+        ret = se050_hash_init(&sha512->se050Ctx, heap);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+        if (ret == 0) {
+            sha512->hashType = WC_HASH_TYPE_SHA512;
+        }
+#endif
+        return ret;
     }
     int wc_Sha512Update(wc_Sha512* sha512, const byte* data, word32 len)
     {
@@ -252,6 +266,9 @@
 
         XMEMSET(sha512, 0, sizeof(wc_Sha512));
         wc_Stm32_Hash_Init(&sha512->stmCtx);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+        sha512->hashType = WC_HASH_TYPE_SHA512;
+#endif
         return 0;
     }
 
@@ -2375,6 +2392,9 @@ int wc_InitSha512_224_ex(wc_Sha512* sha512, void* heap, int devId)
 
     XMEMSET(sha512, 0, sizeof(wc_Sha512));
     wc_Stm32_Hash_Init(&sha512->stmCtx);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+    sha512->hashType = WC_HASH_TYPE_SHA512_224;
+#endif
     return 0;
 }
 
@@ -2518,6 +2538,9 @@ int wc_Sha512_224Transform(wc_Sha512* sha, const unsigned char* data)
 
         XMEMSET(sha512, 0, sizeof(wc_Sha512));
         wc_Stm32_Hash_Init(&sha512->stmCtx);
+#if defined(WOLFSSL_SHA512_HASHTYPE)
+        sha512->hashType = WC_HASH_TYPE_SHA512_256;
+#endif
         return 0;
     }
 


### PR DESCRIPTION
# Description

Ensures `hashType` is set for port implementations so downstream logic can differentiate between the sha512 modes.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
