### PR TITLE
20260412-clang-23_pre20260331

### DIFF
--- a/tests/api/test_ossl_x509_str.c
+++ b/tests/api/test_ossl_x509_str.c
@@ -1074,6 +1074,7 @@ int test_X509_STORE_InvalidCa(void)
     ExpectIntEQ(X509_STORE_CTX_init(ctx, str, cert, untrusted), 1);
     ExpectIntEQ(X509_verify_cert(ctx), 1);
     ExpectIntEQ(last_errcode, X509_V_ERR_INVALID_CA);
+    (void)last_errdepth;
     /* Defense in depth: ctx->error must not be clobbered back to X509_V_OK
      * by the later successful verification of the intermediate against the
      * trusted root.  The worst-seen error must persist. */

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -4231,6 +4231,8 @@ static void* benchmarks_do(void* args)
     if (bench_all || (bench_kdf_algs & BENCH_SRTP_KDF)) {
         bench_srtpkdf();
     }
+#else
+    (void)bench_kdf_algs;
 #endif
 
 #ifdef HAVE_SCRYPT
@@ -4400,6 +4402,7 @@ static void* benchmarks_do(void* args)
     }
 #endif
 #endif
+    (void)bench_pq_hash_sig_algs;
 
 #if defined(HAVE_ECC) && !defined(WC_NO_RNG)
     if (bench_all || (bench_asym_algs & BENCH_ECC_MAKEKEY) ||

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -562,7 +562,9 @@ static int InitSha256(wc_Sha256* sha256)
                                          word32 len);
                                                                     /* = NULL */
     static int transform_check = 0;
+    #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
     static int Transform_Sha256_is_vectorized = 0;
+    #endif
 
     static WC_INLINE int inline_XTRANSFORM(wc_Sha256* S, const byte* D) {
         int ret;
@@ -607,14 +609,18 @@ static int InitSha256(wc_Sha256* sha256)
             if (IS_INTEL_AVX1(intel_flags)) {
                 Transform_Sha256_p = Transform_Sha256_AVX1_Sha;
                 Transform_Sha256_Len_p = Transform_Sha256_AVX1_Sha_Len;
+            #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
                 Transform_Sha256_is_vectorized = 1;
+            #endif
             }
             else
         #endif
             {
                 Transform_Sha256_p = Transform_Sha256_SSE2_Sha;
                 Transform_Sha256_Len_p = Transform_Sha256_SSE2_Sha_Len;
+            #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
                 Transform_Sha256_is_vectorized = 1;
+            #endif
             }
         }
         else
@@ -624,14 +630,18 @@ static int InitSha256(wc_Sha256* sha256)
             if (IS_INTEL_BMI2(intel_flags)) {
                 Transform_Sha256_p = Transform_Sha256_AVX2_RORX;
                 Transform_Sha256_Len_p = Transform_Sha256_AVX2_RORX_Len;
+            #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
                 Transform_Sha256_is_vectorized = 1;
+            #endif
             }
             else
         #endif
             {
                 Transform_Sha256_p = Transform_Sha256_AVX2;
                 Transform_Sha256_Len_p = Transform_Sha256_AVX2_Len;
+            #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
                 Transform_Sha256_is_vectorized = 1;
+            #endif
             }
         }
         else
@@ -642,14 +652,18 @@ static int InitSha256(wc_Sha256* sha256)
             if (IS_INTEL_BMI2(intel_flags)) {
                 Transform_Sha256_p = Transform_Sha256_AVX1_RORX;
                 Transform_Sha256_Len_p = Transform_Sha256_AVX1_RORX_Len;
+            #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
                 Transform_Sha256_is_vectorized = 1;
+            #endif
             }
             else
         #endif
             {
                 Transform_Sha256_p = Transform_Sha256_AVX1;
                 Transform_Sha256_Len_p = Transform_Sha256_AVX1_Len;
+            #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
                 Transform_Sha256_is_vectorized = 1;
+            #endif
             }
         }
         else
@@ -657,7 +671,9 @@ static int InitSha256(wc_Sha256* sha256)
         {
             Transform_Sha256_p = Transform_Sha256;
             Transform_Sha256_Len_p = NULL;
+        #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
             Transform_Sha256_is_vectorized = 0;
+        #endif
         }
 
         transform_check = 1;

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -722,7 +722,9 @@ static int InitSha512_256(wc_Sha512* sha512)
     static int (*Transform_Sha512_p)(wc_Sha512* sha512) = _Transform_Sha512;
     static int (*Transform_Sha512_Len_p)(wc_Sha512* sha512, word32 len) = NULL;
     static int transform_check = 0;
+    #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
     static int Transform_Sha512_is_vectorized = 0;
+    #endif
 
     static WC_INLINE int Transform_Sha512(wc_Sha512 *sha512) {
         int ret;
@@ -764,14 +766,18 @@ static int InitSha512_256(wc_Sha512* sha512)
             if (IS_INTEL_BMI2(intel_flags)) {
                 Transform_Sha512_p = Transform_Sha512_AVX2_RORX;
                 Transform_Sha512_Len_p = Transform_Sha512_AVX2_RORX_Len;
+            #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
                 Transform_Sha512_is_vectorized = 1;
+            #endif
             }
             else
         #endif
             {
                 Transform_Sha512_p = Transform_Sha512_AVX2;
                 Transform_Sha512_Len_p = Transform_Sha512_AVX2_Len;
+            #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
                 Transform_Sha512_is_vectorized = 1;
+            #endif
             }
         }
         else
@@ -782,14 +788,18 @@ static int InitSha512_256(wc_Sha512* sha512)
             if (IS_INTEL_BMI2(intel_flags)) {
                 Transform_Sha512_p = Transform_Sha512_AVX1_RORX;
                 Transform_Sha512_Len_p = Transform_Sha512_AVX1_RORX_Len;
+            #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
                 Transform_Sha512_is_vectorized = 1;
+            #endif
             }
             else
         #endif
             {
                 Transform_Sha512_p = Transform_Sha512_AVX1;
                 Transform_Sha512_Len_p = Transform_Sha512_AVX1_Len;
+            #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
                 Transform_Sha512_is_vectorized = 1;
+            #endif
             }
         }
         else
@@ -797,7 +807,9 @@ static int InitSha512_256(wc_Sha512* sha512)
         {
             Transform_Sha512_p = _Transform_Sha512;
             Transform_Sha512_Len_p = NULL;
+        #ifdef WOLFSSL_USE_SAVE_VECTOR_REGISTERS
             Transform_Sha512_is_vectorized = 0;
+        #endif
         }
 
         transform_check = 1;


### PR DESCRIPTION
fixes for clang `-Wunused-but-set-global`s (coverage added by LLVM 23_pre20260331).

detected by and tested with
```
wolfssl-multi-test.sh ...
'.*clang.*'
super-quick-check
```
