### PR TITLE
ci: rebuild mbedtls/nss in test job on cache miss

### DIFF
--- a/.github/workflows/mbedtls.yml
+++ b/.github/workflows/mbedtls.yml
@@ -48,7 +48,7 @@ jobs:
           mkdir build
           cd build
           cmake ..
-          make -j
+          make -j$(nproc)
           # convert key to pem format
           openssl pkey -in framework/data_files/cli-rsa-sha256.key.der -text > framework/data_files/cli-rsa-sha256.key.pem
           openssl pkey -in framework/data_files/server2.key.der -text > framework/data_files/server2.key.pem
@@ -58,18 +58,38 @@ jobs:
     if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-24.04
     needs: build_mbedtls
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Disable IPv6 (IMPORTANT, OTHERWISE DTLS MBEDTLS CLIENT WON'T CONNECT)
         run: echo 1 | sudo tee /proc/sys/net/ipv6/conf/lo/disable_ipv6
 
       - name: Checking if we have mbed in cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v4
         id: cache
         with:
           path: mbedtls
           key: mbedtls-${{ env.MBED_REF }}
-          fail-on-cache-miss: true
+
+      - name: Checkout mbedtls (fallback on cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: Mbed-TLS/mbedtls
+          ref: ${{ env.MBED_REF }}
+          path: mbedtls
+          fetch-depth: 1
+
+      - name: Compile mbedtls (fallback on cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: mbedtls
+        run: |
+          git submodule update --init
+          mkdir build
+          cd build
+          cmake ..
+          make -j$(nproc)
+          openssl pkey -in framework/data_files/cli-rsa-sha256.key.der -text > framework/data_files/cli-rsa-sha256.key.pem
+          openssl pkey -in framework/data_files/server2.key.der -text > framework/data_files/server2.key.pem
 
       - name: Build wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1

--- a/.github/workflows/nss.yml
+++ b/.github/workflows/nss.yml
@@ -66,15 +66,43 @@ jobs:
     if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-24.04
     needs: build_nss
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Checking if we have nss in cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v4
         id: cache
         with:
           path: dist
           key: nss-${{ env.NSS_REF }}
-          fail-on-cache-miss: true
+
+      - name: Checkout wolfSSL CI actions (fallback on cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          fetch-depth: 1
+
+      - name: Install dependencies (fallback on cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/install-apt-deps
+        with:
+          packages: gyp ninja-build
+
+      - name: Checkout nss (fallback on cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: nss-dev/nss
+          ref: ${{ env.NSS_REF }}
+          path: nss
+          fetch-depth: 1
+
+      - name: Compile nss (fallback on cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          hg clone https://hg.mozilla.org/projects/nspr
+          cd nss
+          ./build.sh
 
       - name: Build wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1


### PR DESCRIPTION
The test jobs used actions/cache/restore with fail-on-cache-miss, which aborted when the cache key was scoped to another PR or had been evicted, even though the build job reported success.

Drop fail-on-cache-miss and add a fallback rebuild in the test job, gated on the cache-hit output. Fast path is unchanged; on miss the test job rebuilds locally and proceeds.

Fixes issue with PR #10189 