### PR TITLE
Add signed-length validation to d2i, PEM, and buffer-load APIs

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -834,7 +834,7 @@ int BufferLoadCRL(WOLFSSL_CRL* crl, const byte* buff, long sz, int type,
 
     WOLFSSL_ENTER("BufferLoadCRL");
 
-    if (crl == NULL || buff == NULL || sz == 0)
+    if (crl == NULL || buff == NULL || sz <= 0)
         return BAD_FUNC_ARG;
 
     if (type == WOLFSSL_FILETYPE_PEM) {
@@ -1160,7 +1160,7 @@ int GetCRLInfo(WOLFSSL_CRL* crl, CrlInfo* info, const byte* buff,
 
     WOLFSSL_ENTER("GetCRLInfo");
 
-    if (crl == NULL || info == NULL || buff == NULL || sz == 0)
+    if (crl == NULL || info == NULL || buff == NULL || sz <= 0)
         return BAD_FUNC_ARG;
 
     if (type == WOLFSSL_FILETYPE_PEM) {

--- a/src/crl.c
+++ b/src/crl.c
@@ -849,7 +849,7 @@ int BufferLoadCRL(WOLFSSL_CRL* crl, const byte* buff, long sz, int type,
 
     WOLFSSL_ENTER("BufferLoadCRL");
 
-    if (crl == NULL || buff == NULL || sz == 0)
+    if (crl == NULL || buff == NULL || sz <= 0)
         return BAD_FUNC_ARG;
 
     if (type == WOLFSSL_FILETYPE_PEM) {
@@ -1175,7 +1175,7 @@ int GetCRLInfo(WOLFSSL_CRL* crl, CrlInfo* info, const byte* buff,
 
     WOLFSSL_ENTER("GetCRLInfo");
 
-    if (crl == NULL || info == NULL || buff == NULL || sz == 0)
+    if (crl == NULL || info == NULL || buff == NULL || sz <= 0)
         return BAD_FUNC_ARG;
 
     if (type == WOLFSSL_FILETYPE_PEM) {

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -1239,6 +1239,8 @@ OcspResponse* wolfSSL_d2i_OCSP_RESPONSE(OcspResponse** response,
 
     if (data == NULL)
         return NULL;
+    if (len <= 0)
+        return NULL;
 
     if (response != NULL)
         resp = *response;

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -1272,6 +1272,8 @@ OcspResponse* wolfSSL_d2i_OCSP_RESPONSE(OcspResponse** response,
 
     if (data == NULL)
         return NULL;
+    if (*data == NULL)
+        return NULL;
     if (len <= 0)
         return NULL;
 

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -1272,6 +1272,8 @@ OcspResponse* wolfSSL_d2i_OCSP_RESPONSE(OcspResponse** response,
 
     if (data == NULL)
         return NULL;
+    if (len <= 0)
+        return NULL;
 
     if (response != NULL)
         resp = *response;

--- a/src/pk_ec.c
+++ b/src/pk_ec.c
@@ -450,6 +450,8 @@ static WOLFSSL_EC_GROUP* wolfssl_ec_group_d2i(WOLFSSL_EC_GROUP** group,
 
     if (in_pp == NULL || *in_pp == NULL)
         return NULL;
+    if (inSz <= 0)
+        return NULL;
 
     in = *in_pp;
 
@@ -4975,6 +4977,9 @@ WOLFSSL_ECDSA_SIG* wolfSSL_d2i_ECDSA_SIG(WOLFSSL_ECDSA_SIG** sig,
 
     /* Validate parameter. */
     if (pp == NULL) {
+        err = 1;
+    }
+    if ((!err) && (len <= 0)) {
         err = 1;
     }
     if (!err) {

--- a/src/pk_ec.c
+++ b/src/pk_ec.c
@@ -5000,7 +5000,7 @@ WOLFSSL_ECDSA_SIG* wolfSSL_d2i_ECDSA_SIG(WOLFSSL_ECDSA_SIG** sig,
     WOLFSSL_ECDSA_SIG *s = NULL;
 
     /* Validate parameter. */
-    if (pp == NULL) {
+    if (pp == NULL || *pp == NULL) {
         err = 1;
     }
     if ((!err) && (len <= 0)) {

--- a/src/pk_ec.c
+++ b/src/pk_ec.c
@@ -449,6 +449,8 @@ static WOLFSSL_EC_GROUP* wolfssl_ec_group_d2i(WOLFSSL_EC_GROUP** group,
 
     if (in_pp == NULL || *in_pp == NULL)
         return NULL;
+    if (inSz <= 0)
+        return NULL;
 
     in = *in_pp;
 
@@ -4999,6 +5001,9 @@ WOLFSSL_ECDSA_SIG* wolfSSL_d2i_ECDSA_SIG(WOLFSSL_ECDSA_SIG** sig,
 
     /* Validate parameter. */
     if (pp == NULL) {
+        err = 1;
+    }
+    if ((!err) && (len <= 0)) {
         err = 1;
     }
     if (!err) {

--- a/src/pk_rsa.c
+++ b/src/pk_rsa.c
@@ -454,6 +454,10 @@ WOLFSSL_RSA *wolfSSL_d2i_RSAPublicKey(WOLFSSL_RSA **out,
         WOLFSSL_ERROR_MSG("Bad argument");
         err = 1;
     }
+    if ((!err) && (derSz <= 0)) {
+        WOLFSSL_ERROR_MSG("Bad argument");
+        err = 1;
+    }
     /* Create a new RSA key to return. */
     if ((!err) && ((rsa = wolfSSL_RSA_new()) == NULL)) {
         WOLFSSL_ERROR_MSG("RSA_new failed");
@@ -500,6 +504,10 @@ WOLFSSL_RSA *wolfSSL_d2i_RSAPrivateKey(WOLFSSL_RSA **out,
 
     /* Validate parameters. */
     if (derBuf == NULL) {
+        WOLFSSL_ERROR_MSG("Bad argument");
+        err = 1;
+    }
+    if ((!err) && (derSz <= 0)) {
         WOLFSSL_ERROR_MSG("Bad argument");
         err = 1;
     }

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -913,7 +913,7 @@ WOLFSSL_ASN1_BIT_STRING* wolfSSL_d2i_ASN1_BIT_STRING(
 
     WOLFSSL_ENTER("wolfSSL_d2i_ASN1_BIT_STRING");
 
-    if (src == NULL || *src == NULL || len == 0)
+    if (src == NULL || *src == NULL || len <= 0)
         return NULL;
 
     if (GetASNTag(*src, &idx, &tag, (word32)len) < 0)
@@ -2984,7 +2984,7 @@ static WOLFSSL_ASN1_STRING* d2i_ASN1_STRING(WOLFSSL_ASN1_STRING** out,
 
     WOLFSSL_ENTER("d2i_ASN1_STRING");
 
-    if (src == NULL || *src == NULL || len == 0)
+    if (src == NULL || *src == NULL || len <= 0)
         return NULL;
 
     if (GetASNTag(*src, &idx, &tag, (word32)len) < 0)
@@ -3159,6 +3159,11 @@ int wolfSSL_ASN1_STRING_set(WOLFSSL_ASN1_STRING* asn1, const void* data, int sz)
     }
 
     if (ret == 1) {
+        /* Cast to size_t BEFORE adding 1 to prevent signed overflow
+         * when sz == INT_MAX. By this point sz >= 0 (negative sz is
+         * handled above as OpenSSL -1/strlen compat). */
+        size_t allocSz = (size_t)sz + 1;
+
         /* Dispose of any existing dynamic data. */
         if (asn1->isDynamic) {
             XFREE(asn1->data, NULL, DYNAMIC_TYPE_OPENSSL);
@@ -3166,9 +3171,9 @@ int wolfSSL_ASN1_STRING_set(WOLFSSL_ASN1_STRING* asn1, const void* data, int sz)
         }
 
         /* Check string will fit - including NUL. */
-        if (sz + 1 > CTC_NAME_SIZE) {
+        if (allocSz > CTC_NAME_SIZE) {
             /* Allocate new buffer. */
-            asn1->data = (char*)XMALLOC((size_t)(sz + 1), NULL,
+            asn1->data = (char*)XMALLOC(allocSz, NULL,
                 DYNAMIC_TYPE_OPENSSL);
             if (asn1->data == NULL) {
                 ret = 0;

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -2386,6 +2386,10 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff, long sz,
     if ((ret == 0) && (type == CHAIN_CERT_TYPE)) {
         ret = BAD_FUNC_ARG;
     }
+    /* Reject negative size - would wrap to huge word32. */
+    if ((ret == 0) && (sz < 0)) {
+        ret = BAD_FUNC_ARG;
+    }
 
 #ifdef WOLFSSL_SMALL_STACK
     if (ret == 0) {

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -2423,6 +2423,10 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff, long sz,
     if ((ret == 0) && (type == CHAIN_CERT_TYPE)) {
         ret = BAD_FUNC_ARG;
     }
+    /* Reject negative size - would wrap to huge word32. */
+    if ((ret == 0) && (sz < 0)) {
+        ret = BAD_FUNC_ARG;
+    }
 
 #ifdef WOLFSSL_SMALL_STACK
     if (ret == 0) {

--- a/src/x509.c
+++ b/src/x509.c
@@ -4130,7 +4130,7 @@ static WOLFSSL_X509* d2i_X509orX509REQ(WOLFSSL_X509** x509,
 
     WOLFSSL_ENTER("wolfSSL_X509_d2i");
 
-    if (in != NULL && len != 0
+    if (in != NULL && len > 0
     #ifndef WOLFSSL_CERT_REQ
             && req == 0
     #else
@@ -11202,7 +11202,7 @@ WOLFSSL_X509_ALGOR* wolfSSL_d2i_X509_ALGOR(WOLFSSL_X509_ALGOR** out,
 
     WOLFSSL_ENTER("wolfSSL_d2i_X509_ALGOR");
 
-    if (src == NULL || *src == NULL || len == 0)
+    if (src == NULL || *src == NULL || len <= 0)
         return NULL;
 
     if (GetAlgoId(*src, &idx, &oid, oidIgnoreType, (word32)len) != 0)

--- a/src/x509.c
+++ b/src/x509.c
@@ -4147,7 +4147,7 @@ static WOLFSSL_X509* d2i_X509orX509REQ(WOLFSSL_X509** x509,
 
     WOLFSSL_ENTER("wolfSSL_X509_d2i");
 
-    if (in != NULL && len != 0
+    if (in != NULL && len > 0
     #ifndef WOLFSSL_CERT_REQ
             && req == 0
     #else
@@ -11291,7 +11291,7 @@ WOLFSSL_X509_ALGOR* wolfSSL_d2i_X509_ALGOR(WOLFSSL_X509_ALGOR** out,
 
     WOLFSSL_ENTER("wolfSSL_d2i_X509_ALGOR");
 
-    if (src == NULL || *src == NULL || len == 0)
+    if (src == NULL || *src == NULL || len <= 0)
         return NULL;
 
     if (GetAlgoId(*src, &idx, &oid, oidIgnoreType, (word32)len) != 0)

--- a/tests/api.c
+++ b/tests/api.c
@@ -2516,6 +2516,28 @@ static int test_wolfSSL_CTX_use_certificate_buffer(void)
 
 } /* END test_wolfSSL_CTX_use_certificate_buffer */
 
+static int test_ProcessBuffer_negative_size(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_CERTS) && !defined(NO_TLS) && !defined(NO_WOLFSSL_SERVER) && \
+    defined(USE_CERT_BUFFERS_2048) && !defined(NO_RSA)
+    WOLFSSL_CTX* ctx = NULL;
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
+
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_buffer(ctx,
+        server_cert_der_2048, -1, WOLFSSL_FILETYPE_ASN1),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_buffer(ctx,
+        server_cert_der_2048, sizeof_server_cert_der_2048,
+        WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 static int test_wolfSSL_use_certificate_buffer(void)
 {
     EXPECT_DECLS;
@@ -12159,6 +12181,12 @@ static int test_wc_PemToDer(void)
 
     XMEMSET(&info, 0, sizeof(info));
 
+    {
+        const byte dummy = 'X';
+        ExpectIntEQ(wc_PemToDer(&dummy, -1, CERT_TYPE, &pDer, NULL,
+            &info, &eccKey), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    }
+
     ExpectIntEQ(ret = load_file(ca_cert, &cert_buf, &cert_sz), 0);
     ExpectIntEQ(ret = wc_PemToDer(cert_buf, (long int)cert_sz, CERT_TYPE, &pDer, NULL,
         &info, &eccKey), 0);
@@ -12330,6 +12358,10 @@ static int test_wc_KeyPemToDer(void)
     ExpectIntEQ(wc_KeyPemToDer(cert_buf, -1, (byte*)&cert_der, cert_sz, ""),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_KeyPemToDer(cert_buf, 0, (byte*)&cert_der, cert_sz, ""),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    /* Bad arg: NULL der buffer with negative pemSz (NULL-deref guard). */
+    ExpectIntEQ(wc_KeyPemToDer(cert_buf, -1, NULL, 0, ""),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
     /* Test normal operation */
@@ -23478,6 +23510,13 @@ static int test_wc_SetIssueBuffer(void)
 
     ExpectIntEQ(0, wc_SetIssuerBuffer(&forgedCert, peerCertBuf, peerCertSz));
 
+    /* Negative-size rejection: pin both wc_SetIssuerBuffer and
+     * wc_SetSubjectBuffer (representatives for the seven wc_Set* siblings). */
+    ExpectIntEQ(wc_SetIssuerBuffer(&forgedCert, peerCertBuf, -1),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_SetSubjectBuffer(&forgedCert, peerCertBuf, -1),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
     wolfSSL_FreeX509(x509);
 #endif
     return EXPECT_RESULT();
@@ -27379,6 +27418,9 @@ static int test_wolfSSL_CTX_LoadCRL_largeCRLnum(void)
         WOLFSSL_SUCCESS);
     AssertIntEQ(XMEMCMP(
         crlInfo.crlNumber, exp_crlnum, XSTRLEN(exp_crlnum)), 0);
+    ExpectIntEQ(wolfSSL_CertManagerGetCRLInfo(
+        cm, &crlInfo, crlLrgCrlNumBuff, -1, WOLFSSL_FILETYPE_PEM),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     /* Expect to fail loading CRL because of >21 octets CRL number */
     ExpectIntEQ(wolfSSL_CertManagerLoadCRLFile(cm, crl_lrgcrlnum2,
                                                 WOLFSSL_FILETYPE_PEM),
@@ -40624,6 +40666,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_CTX_use_certificate),
     TEST_DECL(test_wolfSSL_CTX_use_certificate_file),
     TEST_DECL(test_wolfSSL_CTX_use_certificate_buffer),
+    TEST_DECL(test_ProcessBuffer_negative_size),
     TEST_DECL(test_wolfSSL_use_certificate_buffer),
     TEST_DECL(test_wolfSSL_CTX_use_PrivateKey_file),
     TEST_DECL(test_wolfSSL_CTX_use_RSAPrivateKey_file),

--- a/tests/api/test_ossl_ec.c
+++ b/tests/api/test_ossl_ec.c
@@ -1555,6 +1555,11 @@ int test_wolfSSL_ECDSA_SIG(void)
     sig = NULL;
 
     ExpectNull(wolfSSL_d2i_ECDSA_SIG(NULL, NULL, sizeof(sigData)));
+    /* Reject non-positive length and *pp == NULL (PR #10207). */
+    cp = sigData;
+    ExpectNull(wolfSSL_d2i_ECDSA_SIG(NULL, &cp, -1));
+    cp = NULL;
+    ExpectNull(wolfSSL_d2i_ECDSA_SIG(NULL, &cp, sizeof(sigData)));
     cp = sigDataBad;
     ExpectNull(wolfSSL_d2i_ECDSA_SIG(NULL, &cp, sizeof(sigDataBad)));
     cp = sigData;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -23815,10 +23815,10 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
     const char* headerEnd   = NULL;
     const char* footerEnd   = NULL;
     const char* consumedEnd = NULL;
-    const char* bufferEnd   = (const char*)(buff + longSz);
+    const char* bufferEnd   = NULL;
     long        neededSz;
     int         ret         = 0;
-    word32      sz          = (word32)longSz;
+    word32      sz          = 0;
     int         encrypted_key = 0;
     DerBuffer*  der;
     word32      algId = 0;
@@ -23838,6 +23838,14 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
 #endif
 
     WOLFSSL_ENTER("PemToDer");
+
+    /* Reject negative size - would wrap word32 and corrupt pointer arithmetic. */
+    if (longSz < 0) {
+        return BAD_FUNC_ARG;
+    }
+
+    bufferEnd = (const char*)(buff + longSz);
+    sz        = (word32)longSz;
 
     /* get PEM header and footer based on type */
     ret = wc_PemGetHeaderFooter(type, &header, &footer);
@@ -24322,7 +24330,7 @@ int wc_KeyPemToDer(const unsigned char* pem, int pemSz,
 
     WOLFSSL_ENTER("wc_KeyPemToDer");
 
-    if (pem == NULL || (buff != NULL && buffSz <= 0)) {
+    if (pem == NULL || pemSz < 0 || (buff != NULL && buffSz <= 0)) {
         WOLFSSL_MSG("Bad pem der args");
         return BAD_FUNC_ARG;
     }
@@ -24373,7 +24381,7 @@ int wc_CertPemToDer(const unsigned char* pem, int pemSz,
 
     WOLFSSL_ENTER("wc_CertPemToDer");
 
-    if (pem == NULL || buff == NULL || buffSz <= 0) {
+    if (pem == NULL || pemSz < 0 || buff == NULL || buffSz <= 0) {
         WOLFSSL_MSG("Bad pem der args");
         return BAD_FUNC_ARG;
     }
@@ -24420,7 +24428,7 @@ int wc_PubKeyPemToDer(const unsigned char* pem, int pemSz,
 
     WOLFSSL_ENTER("wc_PubKeyPemToDer");
 
-    if (pem == NULL || (buff != NULL && buffSz <= 0)) {
+    if (pem == NULL || pemSz < 0 || (buff != NULL && buffSz <= 0)) {
         WOLFSSL_MSG("Bad pem der args");
         return BAD_FUNC_ARG;
     }
@@ -29113,6 +29121,9 @@ int wc_SetAuthKeyIdFromCert(Cert *cert, const byte *der, int derSz)
     if (cert == NULL) {
         ret = BAD_FUNC_ARG;
     }
+    else if (derSz < 0) {
+        ret = BAD_FUNC_ARG;
+    }
     else {
         /* Check if decodedCert is cached */
         if (cert->der != der) {
@@ -29583,6 +29594,9 @@ int wc_SetIssuerBuffer(Cert* cert, const byte* der, int derSz)
     if (cert == NULL) {
         ret = BAD_FUNC_ARG;
     }
+    else if (derSz < 0) {
+        ret = BAD_FUNC_ARG;
+    }
     else {
         cert->selfSigned = 0;
 
@@ -29612,6 +29626,9 @@ int wc_SetSubjectBuffer(Cert* cert, const byte* der, int derSz)
     if (cert == NULL) {
         ret = BAD_FUNC_ARG;
     }
+    else if (derSz < 0) {
+        ret = BAD_FUNC_ARG;
+    }
     else {
         /* Check if decodedCert is cached */
         if (cert->der != der) {
@@ -29637,6 +29654,9 @@ int wc_SetSubjectRaw(Cert* cert, const byte* der, int derSz)
     int ret = 0;
 
     if (cert == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else if (derSz < 0) {
         ret = BAD_FUNC_ARG;
     }
     else {
@@ -29671,6 +29691,9 @@ int wc_SetIssuerRaw(Cert* cert, const byte* der, int derSz)
     int ret = 0;
 
     if (cert == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else if (derSz < 0) {
         ret = BAD_FUNC_ARG;
     }
     else {
@@ -29710,6 +29733,9 @@ int wc_SetAltNamesBuffer(Cert* cert, const byte* der, int derSz)
     if (cert == NULL) {
        ret = BAD_FUNC_ARG;
     }
+    else if (derSz < 0) {
+        ret = BAD_FUNC_ARG;
+    }
     else {
         /* Check if decodedCert is cached */
         if (cert->der != der) {
@@ -29736,6 +29762,9 @@ int wc_SetDatesBuffer(Cert* cert, const byte* der, int derSz)
 
     if (cert == NULL) {
      ret = BAD_FUNC_ARG;
+    }
+    else if (derSz < 0) {
+        ret = BAD_FUNC_ARG;
     }
     else {
         /* Check if decodedCert is cached */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -24671,10 +24671,10 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
     const char* headerEnd   = NULL;
     const char* footerEnd   = NULL;
     const char* consumedEnd = NULL;
-    const char* bufferEnd   = (const char*)(buff + longSz);
+    const char* bufferEnd   = NULL;
     long        neededSz;
     int         ret         = 0;
-    word32      sz          = (word32)longSz;
+    word32      sz          = 0;
     int         encrypted_key = 0;
     DerBuffer*  der;
     word32      algId = 0;
@@ -24694,6 +24694,14 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
 #endif
 
     WOLFSSL_ENTER("PemToDer");
+
+    /* Reject negative size - would wrap word32 and corrupt pointer arithmetic. */
+    if (longSz < 0) {
+        return BAD_FUNC_ARG;
+    }
+
+    bufferEnd = (const char*)(buff + longSz);
+    sz        = (word32)longSz;
 
     /* get PEM header and footer based on type */
     ret = wc_PemGetHeaderFooter(type, &header, &footer);
@@ -29958,6 +29966,9 @@ int wc_SetAuthKeyIdFromCert(Cert *cert, const byte *der, int derSz)
     if (cert == NULL) {
         ret = BAD_FUNC_ARG;
     }
+    else if (derSz < 0) {
+        ret = BAD_FUNC_ARG;
+    }
     else {
         /* Check if decodedCert is cached */
         if (cert->der != der) {
@@ -30462,6 +30473,9 @@ int wc_SetIssuerBuffer(Cert* cert, const byte* der, int derSz)
     if (cert == NULL) {
         ret = BAD_FUNC_ARG;
     }
+    else if (derSz < 0) {
+        ret = BAD_FUNC_ARG;
+    }
     else {
         cert->selfSigned = 0;
 
@@ -30491,6 +30505,9 @@ int wc_SetSubjectBuffer(Cert* cert, const byte* der, int derSz)
     if (cert == NULL) {
         ret = BAD_FUNC_ARG;
     }
+    else if (derSz < 0) {
+        ret = BAD_FUNC_ARG;
+    }
     else {
         /* Check if decodedCert is cached */
         if (cert->der != der) {
@@ -30516,6 +30533,9 @@ int wc_SetSubjectRaw(Cert* cert, const byte* der, int derSz)
     int ret = 0;
 
     if (cert == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else if (derSz < 0) {
         ret = BAD_FUNC_ARG;
     }
     else {
@@ -30550,6 +30570,9 @@ int wc_SetIssuerRaw(Cert* cert, const byte* der, int derSz)
     int ret = 0;
 
     if (cert == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else if (derSz < 0) {
         ret = BAD_FUNC_ARG;
     }
     else {
@@ -30589,6 +30612,9 @@ int wc_SetAltNamesBuffer(Cert* cert, const byte* der, int derSz)
     if (cert == NULL) {
        ret = BAD_FUNC_ARG;
     }
+    else if (derSz < 0) {
+        ret = BAD_FUNC_ARG;
+    }
     else {
         /* Check if decodedCert is cached */
         if (cert->der != der) {
@@ -30615,6 +30641,9 @@ int wc_SetDatesBuffer(Cert* cert, const byte* der, int derSz)
 
     if (cert == NULL) {
      ret = BAD_FUNC_ARG;
+    }
+    else if (derSz < 0) {
+        ret = BAD_FUNC_ARG;
     }
     else {
         /* Check if decodedCert is cached */

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -1099,12 +1099,18 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
 {
     int ret;
     WOLFSSL_EVP_PKEY* key = NULL;
-    const byte* der = *pp;
+    const byte* der;
     word32 idx = 0;
     int len = 0;
     int cnt = 0;
     word32 algId;
-    word32 keyLen = (word32)length;
+    word32 keyLen;
+
+    if (pp == NULL || *pp == NULL || length <= 0)
+        return NULL;
+
+    der = *pp;
+    keyLen = (word32)length;
 
     /* Take off PKCS#8 wrapper if found. */
     if ((len = ToTraditionalInline_ex(der, &idx, keyLen, &algId)) >= 0) {

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -1240,7 +1240,7 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey(int type, WOLFSSL_EVP_PKEY** out,
     (void)opt;
 
     /* Validate parameters. */
-    if (in == NULL || inSz < 0) {
+    if (in == NULL || *in == NULL || inSz <= 0) {
         WOLFSSL_MSG("Bad argument");
         return NULL;
     }

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -1464,12 +1464,18 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
 {
     int ret;
     WOLFSSL_EVP_PKEY* key = NULL;
-    const byte* der = *pp;
+    const byte* der;
     word32 idx = 0;
     int len = 0;
     int cnt = 0;
     word32 algId;
-    word32 keyLen = (word32)length;
+    word32 keyLen;
+
+    if (pp == NULL || *pp == NULL || length <= 0)
+        return NULL;
+
+    der = *pp;
+    keyLen = (word32)length;
 
     /* Take off PKCS#8 wrapper if found. */
     if ((len = ToTraditionalInline_ex(der, &idx, keyLen, &algId)) >= 0) {


### PR DESCRIPTION
Internal security review found that ~25 public API entry points accept signed
length parameters (long/int) and cast them to word32 or size_t without rejecting
negative values first. A negative length wraps to a huge unsigned value, giving
ASN.1 parsers and memcpy calls a bogus bound.

Three main areas fixed:

- d2i_* OpenSSL compat wrappers (ECDSA_SIG, RSA, X509, OCSP, etc.) — add
  len <= 0 guards before the (word32) casts
- ProcessBuffer and PemToDer shared sinks — one guard each closes ~20 buffer-load
  entry points and all PEM conversion paths respectively
- Certgen helpers (wc_SetIssuerBuffer, wc_SetSubjectBuffer, etc.) — reject
  negative derSz before forwarding to wc_SetCert_LoadDer

Also fixes an integer overflow in wolfSSL_ASN1_STRING_set where sz == INT_MAX
caused sz + 1 to wrap, bypassing the buffer size check.

8 locations were audited and confirmed already safe (existing guards catch
negatives). Those are left unchanged.

Tests cover ProcessBuffer, wc_Set*Buffer, and d2i_ECDSA_SIG (negative len + NULL deref).