### PR TITLE
Guard against negative length in BIO, I/O callbacks and PKCS12 PBKDF

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -281,6 +281,10 @@ int wolfSSL_BIO_read(WOLFSSL_BIO* bio, void* buf, int len)
         }
     }
 
+    if (len < 0) {
+        return WOLFSSL_BIO_ERROR;
+    }
+
     /* start at end of list (or a WOLFSSL_BIO_SSL object since it takes care of
      * the rest of the chain) and work backwards */
     while (bio != NULL && bio->next != NULL && bio->type != WOLFSSL_BIO_SSL) {
@@ -691,6 +695,10 @@ int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
         if (ret <= 0) {
             return ret;
         }
+    }
+
+    if (len < 0) {
+        return WOLFSSL_BIO_ERROR;
     }
 
     while (bio != NULL && ret >= 0) {
@@ -1572,6 +1580,10 @@ int wolfSSL_BIO_nread(WOLFSSL_BIO *bio, char **buf, int num)
             return 0;
         }
 
+        if (num < 0) {
+            return WOLFSSL_BIO_ERROR;
+        }
+
         /* get amount able to read and set buffer pointer */
         sz = wolfSSL_BIO_nread0(bio, buf);
         if (sz < 0) {
@@ -1624,6 +1636,10 @@ int wolfSSL_BIO_nwrite(WOLFSSL_BIO *bio, char **buf, int num)
         if (num == 0) {
             *buf = (char*)bio->ptr.mem_buf_data + bio->wrIdx;
             return 0;
+        }
+
+        if (num < 0) {
+            return WOLFSSL_BIO_ERROR;
         }
 
         if (bio->wrIdx < bio->rdIdx) {
@@ -3161,6 +3177,14 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
         WOLFSSL_ENTER("wolfSSL_BIO_push");
         if (top == NULL) {
             return append;
+        }
+        {
+            WOLFSSL_BIO* cur = append;
+            while (cur != NULL) {
+                if (cur == top)
+                    return top; /* would create cycle */
+                cur = cur->next;
+            }
         }
         top->next = append;
         if (append != NULL) {

--- a/src/bio.c
+++ b/src/bio.c
@@ -272,6 +272,10 @@ int wolfSSL_BIO_read(WOLFSSL_BIO* bio, void* buf, int len)
     WOLFSSL_ENTER("wolfSSL_BIO_read");
     }
 
+    if (len < 0) {
+        return WOLFSSL_BIO_ERROR;
+    }
+
     /* info cb, abort if user returns <= 0*/
     if (front != NULL && front->infoCb != NULL) {
         ret = (int)front->infoCb(front, WOLFSSL_BIO_CB_READ, (const char*)buf,
@@ -279,10 +283,6 @@ int wolfSSL_BIO_read(WOLFSSL_BIO* bio, void* buf, int len)
         if (ret <= 0) {
             return ret;
         }
-    }
-
-    if (len < 0) {
-        return WOLFSSL_BIO_ERROR;
     }
 
     /* start at end of list (or a WOLFSSL_BIO_SSL object since it takes care of
@@ -694,6 +694,10 @@ int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
 
     WOLFSSL_ENTER("wolfSSL_BIO_write");
 
+    if (len < 0) {
+        return WOLFSSL_BIO_ERROR;
+    }
+
     /* info cb, abort if user returns <= 0*/
     if (front != NULL && front->infoCb != NULL) {
         ret = (int)front->infoCb(front, WOLFSSL_BIO_CB_WRITE,
@@ -701,10 +705,6 @@ int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
         if (ret <= 0) {
             return ret;
         }
-    }
-
-    if (len < 0) {
-        return WOLFSSL_BIO_ERROR;
     }
 
     while (bio != NULL && ret >= 0) {

--- a/src/bio.c
+++ b/src/bio.c
@@ -281,6 +281,10 @@ int wolfSSL_BIO_read(WOLFSSL_BIO* bio, void* buf, int len)
         }
     }
 
+    if (len < 0) {
+        return WOLFSSL_BIO_ERROR;
+    }
+
     /* start at end of list (or a WOLFSSL_BIO_SSL object since it takes care of
      * the rest of the chain) and work backwards */
     while (bio != NULL && bio->next != NULL && bio->type != WOLFSSL_BIO_SSL) {
@@ -697,6 +701,10 @@ int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
         if (ret <= 0) {
             return ret;
         }
+    }
+
+    if (len < 0) {
+        return WOLFSSL_BIO_ERROR;
     }
 
     while (bio != NULL && ret >= 0) {
@@ -1569,6 +1577,10 @@ int wolfSSL_BIO_nread(WOLFSSL_BIO *bio, char **buf, int num)
             return 0;
         }
 
+        if (num < 0) {
+            return WOLFSSL_BIO_ERROR;
+        }
+
         /* get amount able to read and set buffer pointer */
         sz = wolfSSL_BIO_nread0(bio, buf);
         if (sz < 0) {
@@ -1621,6 +1633,10 @@ int wolfSSL_BIO_nwrite(WOLFSSL_BIO *bio, char **buf, int num)
         if (num == 0) {
             *buf = (char*)bio->ptr.mem_buf_data + bio->wrIdx;
             return 0;
+        }
+
+        if (num < 0) {
+            return WOLFSSL_BIO_ERROR;
         }
 
         if (bio->wrIdx < bio->rdIdx) {
@@ -3136,6 +3152,14 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
         WOLFSSL_ENTER("wolfSSL_BIO_push");
         if (top == NULL) {
             return append;
+        }
+        {
+            WOLFSSL_BIO* cur = append;
+            while (cur != NULL) {
+                if (cur == top)
+                    return top; /* would create cycle */
+                cur = cur->next;
+            }
         }
         top->next = append;
         if (append != NULL) {

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -674,6 +674,9 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     WOLFSSL_ENTER("EmbedReceiveFrom");
     (void)ret; /* possibly unused */
 
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
+
     XMEMSET(&lclPeer, 0, sizeof(lclPeer));
 
 #ifdef WOLFSSL_RW_THREADED
@@ -917,6 +920,9 @@ int EmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 
     WOLFSSL_ENTER("EmbedSendTo");
 
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
+
     if (!isDGramSock(sd)) {
         /* Probably a TCP socket. peer and peerSz MUST be NULL and 0 */
     }
@@ -963,6 +969,9 @@ int EmbedReceiveFromMcast(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 
     WOLFSSL_ENTER("EmbedReceiveFromMcast");
 
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
+
     recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, (size_t)sz, ssl->rflags, NULL, NULL);
 
     recvd = TranslateIoReturnCode(recvd, sd, SOCKET_RECEIVING);
@@ -992,6 +1001,9 @@ int EmbedGenerateCookie(WOLFSSL* ssl, byte *buf, int sz, void *ctx)
     int  ret = 0;
 
     (void)ctx;
+
+    if (sz < 0)
+        return BAD_FUNC_ARG;
 
     XMEMSET(&peer, 0, sizeof(peer));
     if (getpeername(sd, (SOCKADDR*)&peer, &peerSz) != 0) {
@@ -1221,6 +1233,9 @@ int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags)
 {
     int recvd;
 
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
+
     recvd = (int)RECV_FUNCTION(sd, buf, (size_t)sz, rdFlags);
     recvd = TranslateIoReturnCode(recvd, sd, SOCKET_RECEIVING);
 
@@ -1230,6 +1245,9 @@ int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags)
 int wolfIO_Send(SOCKET_T sd, char *buf, int sz, int wrFlags)
 {
     int sent;
+
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
 
     sent = (int)SEND_FUNCTION(sd, buf, (size_t)sz, wrFlags);
     sent = TranslateIoReturnCode(sent, sd, SOCKET_SENDING);
@@ -1244,6 +1262,9 @@ int wolfIO_RecvFrom(SOCKET_T sd, WOLFSSL_BIO_ADDR *addr, char *buf, int sz, int 
     int recvd;
     socklen_t addr_len = (socklen_t)sizeof(*addr);
 
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
+
     recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, (size_t)sz, rdFlags,
                                             addr ? &addr->sa : NULL,
                                             addr ? &addr_len : 0);
@@ -1256,6 +1277,9 @@ int wolfIO_SendTo(SOCKET_T sd, WOLFSSL_BIO_ADDR *addr, char *buf, int sz, int wr
 {
     int sent;
     socklen_t addr_len = addr ? wolfSSL_BIO_ADDR_size(addr) : 0;
+
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
 
     sent = (int)DTLS_SENDTO_FUNCTION(sd, buf, (size_t)sz, wrFlags,
                                          addr ? &addr->sa : NULL,

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -675,6 +675,9 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     WOLFSSL_ENTER("EmbedReceiveFrom");
     (void)ret; /* possibly unused */
 
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
+
     XMEMSET(&lclPeer, 0, sizeof(lclPeer));
 
 #ifdef WOLFSSL_RW_THREADED
@@ -918,6 +921,9 @@ int EmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 
     WOLFSSL_ENTER("EmbedSendTo");
 
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
+
     if (!isDGramSock(sd)) {
         /* Probably a TCP socket. peer and peerSz MUST be NULL and 0 */
     }
@@ -964,6 +970,9 @@ int EmbedReceiveFromMcast(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 
     WOLFSSL_ENTER("EmbedReceiveFromMcast");
 
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
+
     recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, (size_t)sz, ssl->rflags, NULL, NULL);
 
     recvd = TranslateIoReturnCode(recvd, sd, SOCKET_RECEIVING);
@@ -993,6 +1002,9 @@ int EmbedGenerateCookie(WOLFSSL* ssl, byte *buf, int sz, void *ctx)
     int  ret = 0;
 
     (void)ctx;
+
+    if (sz < 0)
+        return BAD_FUNC_ARG;
 
     XMEMSET(&peer, 0, sizeof(peer));
     if (getpeername(sd, (SOCKADDR*)&peer, &peerSz) != 0) {
@@ -1222,6 +1234,9 @@ int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags)
 {
     int recvd;
 
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
+
     recvd = (int)RECV_FUNCTION(sd, buf, (size_t)sz, rdFlags);
     recvd = TranslateIoReturnCode(recvd, sd, SOCKET_RECEIVING);
 
@@ -1231,6 +1246,9 @@ int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags)
 int wolfIO_Send(SOCKET_T sd, char *buf, int sz, int wrFlags)
 {
     int sent;
+
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
 
     sent = (int)SEND_FUNCTION(sd, buf, (size_t)sz, wrFlags);
     sent = TranslateIoReturnCode(sent, sd, SOCKET_SENDING);
@@ -1245,6 +1263,9 @@ int wolfIO_RecvFrom(SOCKET_T sd, WOLFSSL_BIO_ADDR *addr, char *buf, int sz, int 
     int recvd;
     socklen_t addr_len = (socklen_t)sizeof(*addr);
 
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
+
     recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, (size_t)sz, rdFlags,
                                             addr ? &addr->sa : NULL,
                                             addr ? &addr_len : 0);
@@ -1257,6 +1278,9 @@ int wolfIO_SendTo(SOCKET_T sd, WOLFSSL_BIO_ADDR *addr, char *buf, int sz, int wr
 {
     int sent;
     socklen_t addr_len = addr ? wolfSSL_BIO_ADDR_size(addr) : 0;
+
+    if (sz < 0)
+        return WOLFSSL_CBIO_ERR_GENERAL;
 
     sent = (int)DTLS_SENDTO_FUNCTION(sd, buf, (size_t)sz, wrFlags,
                                          addr ? &addr->sa : NULL,

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -439,8 +439,22 @@ int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
     /* with passLen checked at the top of the function for >= 0 then passLen
      * must be 1 or greater here and is always 'true' */
     pLen = v * (((word32)passLen + v - 1) / v);
+
+    /* Guard against overflow in iLen = sLen + pLen and totalLen = dLen + iLen.
+     * Individual sLen/pLen values fit in word32 (max 0x80000000 for INT_MAX
+     * inputs), but their sum can overflow. */
+    if (sLen > 0xFFFFFFFFU - pLen) {
+        WC_FREE_VAR_EX(Ai, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        WC_FREE_VAR_EX(B, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        return BAD_FUNC_ARG;
+    }
     iLen = sLen + pLen;
 
+    if (iLen > 0xFFFFFFFFU - v) {
+        WC_FREE_VAR_EX(Ai, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        WC_FREE_VAR_EX(B, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        return BAD_FUNC_ARG;
+    }
     totalLen = dLen + sLen + pLen;
 
     if (totalLen > sizeof(staticBuffer)) {
@@ -632,8 +646,19 @@ int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
     sLen = v * (((word32)saltLen + v - 1) / v);
     /* RFC 7292 B.2 step 3: P = password repeated to ceil(passLen/v)*v bytes */
     pLen = v * (((word32)passLen + v - 1) / v);
+
+    /* Guard against overflow in iLen = sLen + pLen and totalLen = v + iLen.
+     * Individual sLen/pLen values fit in word32 (max 0x80000000 for INT_MAX
+     * inputs), but their sum can overflow. */
+    if (sLen > 0xFFFFFFFFU - pLen) {
+        return BAD_FUNC_ARG;
+    }
     /* RFC 7292 B.2 step 4: I = S || P */
     iLen = sLen + pLen;
+
+    if (iLen > 0xFFFFFFFFU - v) {
+        return BAD_FUNC_ARG;
+    }
     totalLen = v + iLen;
 
     nwc     = v / (word32)sizeof(PKCS12_WORD);

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -453,7 +453,7 @@ int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
     }
     iLen = sLen + pLen;
 
-    if (iLen > 0xFFFFFFFFU - v) {
+    if (iLen > 0xFFFFFFFFU - dLen) {
         WC_FREE_VAR_EX(Ai, heap, DYNAMIC_TYPE_TMP_BUFFER);
         WC_FREE_VAR_EX(B, heap, DYNAMIC_TYPE_TMP_BUFFER);
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -442,8 +442,22 @@ int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
     /* with passLen checked at the top of the function for >= 0 then passLen
      * must be 1 or greater here and is always 'true' */
     pLen = v * (((word32)passLen + v - 1) / v);
+
+    /* Guard against overflow in iLen = sLen + pLen and totalLen = dLen + iLen.
+     * Individual sLen/pLen values fit in word32 (max 0x80000000 for INT_MAX
+     * inputs), but their sum can overflow. */
+    if (sLen > 0xFFFFFFFFU - pLen) {
+        WC_FREE_VAR_EX(Ai, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        WC_FREE_VAR_EX(B, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        return BAD_FUNC_ARG;
+    }
     iLen = sLen + pLen;
 
+    if (iLen > 0xFFFFFFFFU - v) {
+        WC_FREE_VAR_EX(Ai, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        WC_FREE_VAR_EX(B, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        return BAD_FUNC_ARG;
+    }
     totalLen = dLen + sLen + pLen;
 
     if (totalLen > sizeof(staticBuffer)) {
@@ -635,8 +649,19 @@ int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
     sLen = v * (((word32)saltLen + v - 1) / v);
     /* RFC 7292 B.2 step 3: P = password repeated to ceil(passLen/v)*v bytes */
     pLen = v * (((word32)passLen + v - 1) / v);
+
+    /* Guard against overflow in iLen = sLen + pLen and totalLen = v + iLen.
+     * Individual sLen/pLen values fit in word32 (max 0x80000000 for INT_MAX
+     * inputs), but their sum can overflow. */
+    if (sLen > 0xFFFFFFFFU - pLen) {
+        return BAD_FUNC_ARG;
+    }
     /* RFC 7292 B.2 step 4: I = S || P */
     iLen = sLen + pLen;
+
+    if (iLen > 0xFFFFFFFFU - v) {
+        return BAD_FUNC_ARG;
+    }
     totalLen = v + iLen;
 
     nwc     = v / (word32)sizeof(PKCS12_WORD);


### PR DESCRIPTION
## Summary
- **src/bio.c**: Guard against BIO self-referential chain (UAF) and negative `nread`/`nwrite` lengths in `wolfSSL_BIO_nread`/`wolfSSL_BIO_nwrite`
- **src/wolfio.c**: Guard against negative `sz` in `EmbedSend` and `EmbedReceive`
- **wolfcrypt/src/pwdbased.c**: Add `pLen`/`sLen`/`totalLen` overflow checks in `wc_PKCS12_PBKDF_ex`

## Note
The PKCS12 parse fix for stale `ci->dataSz` bounds (zd21568) is covered by #10172 — this PR is complementary to that fix.