### PR TITLE
Mlkem cryptocb sha3 hashtype not reset after final call

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -105,6 +105,7 @@ jobs:
           '--enable-sessionexport --enable-dtls --enable-dtls13',
           '--enable-cryptocb --enable-aesgcm CPPFLAGS="-DWOLF_CRYPTO_CB_AES_SETKEY -DWOLF_CRYPTO_CB_FREE"',
           '--disable-tls --enable-cryptocb --enable-aesgcm CPPFLAGS="-DWOLF_CRYPTO_CB_AES_SETKEY -DWOLF_CRYPTO_CB_FREE"',
+          '--enable-cryptocb --enable-keygen CPPFLAGS="-DWOLF_CRYPTO_CB_FIND"',
           '--disable-examples CPPFLAGS=-DWOLFSSL_NO_MALLOC',
           'CPPFLAGS=-DNO_WOLFSSL_CLIENT',
           'CPPFLAGS=-DNO_WOLFSSL_SERVER',

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -646,6 +646,12 @@ static int InitSha3(wc_Sha3* sha3)
 #ifdef WOLFSSL_HASH_FLAGS
     sha3->flags = 0;
 #endif
+#ifdef WOLF_CRYPTO_CB
+    /* Cached hash variant is tied to sponge state; clear it whenever the
+     * state is reset so reuse for a different SHA3 variant dispatches
+     * correctly through the crypto callback. */
+    sha3->hashType = WC_HASH_TYPE_NONE;
+#endif
 
 #ifdef USE_INTEL_SPEEDUP
     {

--- a/wolfcrypt/src/wc_mlkem.c
+++ b/wolfcrypt/src/wc_mlkem.c
@@ -602,11 +602,11 @@ int wc_MlKemKey_MakeKey(MlKemKey* key, WC_RNG* rng)
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if ((ret == 0)
-    #ifndef WOLF_CRYPTO_CB_FIND
-        && (key->devId != INVALID_DEVID)
-    #endif
-    ) {
+#ifndef WOLF_CRYPTO_CB_FIND
+    if ((ret == 0) && (key->devId != INVALID_DEVID)) {
+#else
+    if (ret == 0) {
+#endif
         ret = wc_CryptoCb_MakePqcKemKey(rng, WC_PQC_KEM_TYPE_KYBER,
                                         key->type, key);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
@@ -1287,11 +1287,11 @@ int wc_MlKemKey_Encapsulate(MlKemKey* key, unsigned char* c, unsigned char* k,
     if (ret == 0) {
         ret = wc_MlKemKey_CipherTextSize(key, &ctlen);
     }
-    if ((ret == 0)
-    #ifndef WOLF_CRYPTO_CB_FIND
-        && (key->devId != INVALID_DEVID)
-    #endif
-    ) {
+#ifndef WOLF_CRYPTO_CB_FIND
+    if ((ret == 0) && (key->devId != INVALID_DEVID)) {
+#else
+    if (ret == 0) {
+#endif
         ret = wc_CryptoCb_PqcEncapsulate(c, ctlen, k, KYBER_SS_SZ, rng,
                                          WC_PQC_KEM_TYPE_KYBER, key);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
@@ -1767,11 +1767,11 @@ int wc_MlKemKey_Decapsulate(MlKemKey* key, unsigned char* ss,
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if ((ret == 0)
-    #ifndef WOLF_CRYPTO_CB_FIND
-        && (key->devId != INVALID_DEVID)
-    #endif
-    ) {
+#ifndef WOLF_CRYPTO_CB_FIND
+    if ((ret == 0) && (key->devId != INVALID_DEVID)) {
+#else
+    if (ret == 0) {
+#endif
         ret = wc_CryptoCb_PqcDecapsulate(ct, ctSz, ss, KYBER_SS_SZ,
                                          WC_PQC_KEM_TYPE_KYBER, key);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))


### PR DESCRIPTION
## Issue

`wc_Sha3Update` and `wc_Sha3Final` cache `sha3->hashType` on first use and pass it to `wc_CryptoCb_Sha3Hash` for dispatch. The state reset at the end of `wc_Sha3Final` (via `InitSha3`) only cleared the sponge bytes, leaving `hashType` latched. Any caller that legitimately reuses a single `wc_Sha3` across SHA3 variants (mlkem reuses `key->hash` for SHA3-512 `MLKEM_HASH_G` in MakeKey, then SHA3-256 `MLKEM_HASH_H` in EncodePublicKey/DecodePrivateKey) would have the second op dispatched through the crypto callback as the first op's algorithm. That produces a wrong `key->h`, fails `wc_MlKemKey_DecodePrivateKey` with `MLKEM_PUB_HASH_E`, and in the SHA3-512 over a 32 byte buffer case overwrites adjacent fields.

The software path was unaffected because it keys off the `p` block count parameter every call. The callback path only stayed hidden because the `devId != INVALID_DEVID` guard usually kept it cold. `-DWOLF_CRYPTO_CB_FIND` removes that guard and makes it reliably trigger.

## Fix

Clear `sha3->hashType` inside `InitSha3` and `wc_Sha3Final` already calls `InitSha3` for its end of op reset, so the the sha3 struct will reinit and subsequent Update/Final calls can determine the correct type from `p`.

Also fix -Wparentheses-equality error when WOLF_CRYPTO_CB_FIND is defined with clang

## Test

New `--enable-cryptocb --enable-keygen -DWOLF_CRYPTO_CB_FIND` entry in `.github/workflows/os-check.yml` reproduces the failure on master and passes with this fix.
