### PR TITLE
20260413-cross-riscv64-all-asm-fips-dev

### DIFF
--- a/src/include.am
+++ b/src/include.am
@@ -518,6 +518,10 @@ endif
 endif
 endif
 
+if BUILD_RISCV_ASM
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/riscv/riscv-64-aes.c
+endif BUILD_RISCV_ASM
+
 if BUILD_SHA
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha.c
 endif

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -1234,7 +1234,7 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(Aes* aes, const byte* inBlock,
 /* implemented in wolfcrypt/src/port/psa/psa_aes.c */
 
 #elif defined(WOLFSSL_RISCV_ASM)
-/* implemented in wolfcrypt/src/port/risc-v/riscv-64-aes.c */
+/* implemented in wolfcrypt/src/port/riscv/riscv-64-aes.c */
 
 #elif defined(WOLFSSL_SILABS_SE_ACCEL)
 /* implemented in wolfcrypt/src/port/silabs/silabs_aes.c */
@@ -12892,7 +12892,7 @@ int wc_AesCcmCheckTagSize(int sz)
 }
 
 #if defined(WOLFSSL_RISCV_ASM)
-    /* implementation located in wolfcrypt/src/port/risc-v/riscv-64-aes.c */
+    /* implementation located in wolfcrypt/src/port/riscv/riscv-64-aes.c */
 
 #elif defined(HAVE_COLDFIRE_SEC)
     #error "Coldfire SEC doesn't currently support AES-CCM mode"

--- a/wolfcrypt/src/port/riscv/riscv-64-aes.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-aes.c
@@ -21,6 +21,11 @@
 
 #include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
+#if FIPS_VERSION3_GE(2,0,0)
+    /* set NO_WRAPPERS before headers, use direct internal f()s not wrappers */
+    #define FIPS_NO_WRAPPERS
+#endif
+
 #include <wolfssl/wolfcrypt/port/riscv/riscv-64-asm.h>
 
 #if !defined(NO_AES)
@@ -35,6 +40,15 @@
 #endif
 
 #ifdef WOLFSSL_RISCV_ASM
+
+#if FIPS_VERSION3_GE(6,0,0)
+    const unsigned int wolfCrypt_FIPS_aes_ro_sanity[2] =
+                                                     { 0x1a2b3c4d, 0x00000002 };
+    int wolfCrypt_FIPS_AES_sanity(void)
+    {
+        return 0;
+    }
+#endif
 
 /* Copy a 16-byte value from in to out.
  *


### PR DESCRIPTION
`src/include.am`, `wolfcrypt/src/aes.c`, `wolfcrypt/src/port/riscv/riscv-64-aes.c`: initial buildability of fips-dev with `--enable-riscv-asm`.

tested with
```
wolfssl-multi-test.sh ...
cross-riscv64-all-asm
cross-riscv64-all-asm-fips-dev
check-source-text
```
but note that `cross-riscv64-all-asm-fips-dev` reports FIPS hash instability.
