### PR TITLE
Fix UAF in callback wrapper and add input validation guards

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8013,9 +8013,16 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         FreeTimeoutInfo(&ssl->timeoutInfo, ssl->heap);
 
         if (hsCb) {
+            HandShakeInfo savedHandShakeInfo;
             FinishHandShakeInfo(&ssl->handShakeInfo);
-            (hsCb)(&ssl->handShakeInfo);
+            XMEMCPY(&savedHandShakeInfo, &ssl->handShakeInfo,
+                     sizeof(HandShakeInfo));
             ssl->hsInfoOn = 0;
+            /* Null out the ssl pointer -- the callback must not free the
+             * session through it, and ssl may already have been freed by
+             * toCb above. */
+            savedHandShakeInfo.ssl = NULL;
+            (hsCb)(&savedHandShakeInfo);
         }
         return ret;
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8118,9 +8118,16 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         FreeTimeoutInfo(&ssl->timeoutInfo, ssl->heap);
 
         if (hsCb) {
+            HandShakeInfo savedHandShakeInfo;
             FinishHandShakeInfo(&ssl->handShakeInfo);
-            (hsCb)(&ssl->handShakeInfo);
+            XMEMCPY(&savedHandShakeInfo, &ssl->handShakeInfo,
+                     sizeof(HandShakeInfo));
             ssl->hsInfoOn = 0;
+            /* Null out the ssl pointer -- the callback must not free the
+             * session through it, and ssl may already have been freed by
+             * toCb above. */
+            savedHandShakeInfo.ssl = NULL;
+            (hsCb)(&savedHandShakeInfo);
         }
         return ret;
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -455,6 +455,21 @@ static int test_wc_LoadStaticMemory_ex(void)
     ExpectIntEQ(wc_LoadStaticMemory_ex(NULL, 0, NULL, NULL, NULL, 0, 0, 0),
             WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
+    /* Set the bucket list size to 0. */
+    heap = NULL;
+    ExpectIntEQ(wc_LoadStaticMemory_ex(&heap,
+                0, sizeList, distList,
+                staticMemory, (word32)sizeof(staticMemory),
+                0, 1),
+            WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+#ifndef WOLFSSL_STATIC_MEMORY_LEAN
+    ExpectIntEQ(wolfSSL_StaticBufferSz_ex(0, sizeList, distList,
+                staticMemory, (word32)sizeof(staticMemory),
+                WOLFMEM_GENERAL),
+            WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+#endif
+
     /* Set the heap pointer to NULL. */
     ExpectIntEQ(wc_LoadStaticMemory_ex(NULL,
                 WOLFMEM_DEF_BUCKETS, sizeList, distList,
@@ -31768,6 +31783,11 @@ static int test_wc_CryptoCb_TLS(int tlsVer,
 static int test_wc_CryptoCb(void)
 {
     EXPECT_DECLS;
+#if defined(WOLF_CRYPTO_CB)
+    ExpectIntEQ(wc_CryptoCb_RegisterDevice(INVALID_DEVID, NULL, NULL),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+#endif
+
 #if defined(WOLF_CRYPTO_CB) && \
     (!defined(WOLF_CRYPTO_CB_ONLY_SHA256) && !defined(WOLF_CRYPTO_CB_ONLY_AES) && \
      !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(WOLF_CRYPTO_CB_ONLY_RSA))

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -403,6 +403,10 @@ int wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx)
 {
     int rc = 0;
 
+    if (devId == INVALID_DEVID) {
+        return BAD_FUNC_ARG;
+    }
+
     /* find existing or new */
     CryptoCb* dev = wc_CryptoCb_GetDevice(devId);
     if (dev == NULL)

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -442,6 +442,10 @@ int wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx)
 {
     int rc = 0;
 
+    if (devId == INVALID_DEVID) {
+        return BAD_FUNC_ARG;
+    }
+
     /* find existing or new */
     CryptoCb* dev = wc_CryptoCb_GetDevice(devId);
     if (dev == NULL)

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -715,6 +715,9 @@ int wc_LoadStaticMemory_ex(WOLFSSL_HEAP_HINT** pHint,
     if (pHint == NULL || buf == NULL || sizeList == NULL || distList == NULL) {
         return BAD_FUNC_ARG;
     }
+    if (listSz == 0) {
+        return BAD_FUNC_ARG;
+    }
 
     /* Cap the listSz to the actual number of items allocated in the list. */
     if (listSz > WOLFMEM_MAX_BUCKETS) {
@@ -829,6 +832,9 @@ int wolfSSL_StaticBufferSz_ex(unsigned int listSz,
     WOLFSSL_ENTER("wolfSSL_StaticBufferSz_ex");
 
     if (buffer == NULL || sizeList == NULL || distList == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    if (listSz == 0) {
         return BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -716,6 +716,9 @@ int wc_LoadStaticMemory_ex(WOLFSSL_HEAP_HINT** pHint,
     if (pHint == NULL || buf == NULL || sizeList == NULL || distList == NULL) {
         return BAD_FUNC_ARG;
     }
+    if (listSz == 0) {
+        return BAD_FUNC_ARG;
+    }
 
     /* Cap the listSz to the actual number of items allocated in the list. */
     if (listSz > WOLFMEM_MAX_BUCKETS) {
@@ -830,6 +833,9 @@ int wolfSSL_StaticBufferSz_ex(unsigned int listSz,
     WOLFSSL_ENTER("wolfSSL_StaticBufferSz_ex");
 
     if (buffer == NULL || sizeList == NULL || distList == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    if (listSz == 0) {
         return BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -3694,6 +3694,8 @@ static int Pkcs11ECDSASig_Decode(const byte* in, word32 inSz, byte* sig,
         ret = ASN_PARSE_E;
     if (ret == 0 && (len = in[i++]) > sz + 1)
         ret = ASN_PARSE_E;
+    if (ret == 0 && len == 0)
+        ret = ASN_PARSE_E;
     /* Check there is space for INT data */
     if (ret == 0 && i + len > inSz)
         ret = ASN_PARSE_E;
@@ -3717,6 +3719,8 @@ static int Pkcs11ECDSASig_Decode(const byte* in, word32 inSz, byte* sig,
     if (ret == 0 && tag != ASN_INTEGER)
         ret = ASN_PARSE_E;
     if (ret == 0 && (len = in[i++]) > sz + 1)
+        ret = ASN_PARSE_E;
+    if (ret == 0 && len == 0)
         ret = ASN_PARSE_E;
     /* Check there is space for INT data */
     if (ret == 0 && i + len > inSz)
@@ -3762,6 +3766,12 @@ static int Pkcs11GetEccParams(Pkcs11Session* session, CK_OBJECT_HANDLE privKey,
         ret = WC_HW_E;
     }
     PKCS11_DUMP_TEMPLATE("Ec Params", template, 1);
+    if (ret == 0) {
+        if (template[0].ulValueLen < 2 ||
+                template[0].ulValueLen > sizeof(oid)) {
+            ret = WC_HW_E;
+        }
+    }
     if (ret == 0) {
         /* PKCS #11 wraps the OID in ASN.1 */
         curveId = wc_ecc_get_curve_id_from_oid(oid + 2,

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -3698,6 +3698,8 @@ static int Pkcs11ECDSASig_Decode(const byte* in, word32 inSz, byte* sig,
         ret = ASN_PARSE_E;
     if (ret == 0 && (len = in[i++]) > sz + 1)
         ret = ASN_PARSE_E;
+    if (ret == 0 && len == 0)
+        ret = ASN_PARSE_E;
     /* Check there is space for INT data */
     if (ret == 0 && i + len > inSz)
         ret = ASN_PARSE_E;
@@ -3721,6 +3723,8 @@ static int Pkcs11ECDSASig_Decode(const byte* in, word32 inSz, byte* sig,
     if (ret == 0 && tag != ASN_INTEGER)
         ret = ASN_PARSE_E;
     if (ret == 0 && (len = in[i++]) > sz + 1)
+        ret = ASN_PARSE_E;
+    if (ret == 0 && len == 0)
         ret = ASN_PARSE_E;
     /* Check there is space for INT data */
     if (ret == 0 && i + len > inSz)
@@ -3766,6 +3770,12 @@ static int Pkcs11GetEccParams(Pkcs11Session* session, CK_OBJECT_HANDLE privKey,
         ret = WC_HW_E;
     }
     PKCS11_DUMP_TEMPLATE("Ec Params", template, 1);
+    if (ret == 0) {
+        if (template[0].ulValueLen < 2 ||
+                template[0].ulValueLen > sizeof(oid)) {
+            ret = WC_HW_E;
+        }
+    }
     if (ret == 0) {
         /* PKCS #11 wraps the OID in ASN.1 */
         curveId = wc_ecc_get_curve_id_from_oid(oid + 2,


### PR DESCRIPTION
## Summary
- Fix use-after-free in `wolfSSL_ex_wrapper()` where `HandShakeCallBack` could free the ssl session via `info->ssl`, then the wrapper would write to freed memory (`ssl->hsInfoOn = 0`)
- Reject `INVALID_DEVID` in `wc_CryptoCb_RegisterDevice()` — sentinel value should not consume a callback slot
- Reject `listSz == 0` in `wolfSSL_SetStaticMemory()` — zero buckets causes incorrect size calculations downstream
- Fix ECDSA signature parsing in PKCS#11: reject `len == 0` INTEGER components (prevents `len--` underflow into massive memcpy) and validate ECC OID length (prevents overread on short/oversized token responses)

## Status
Early PR — fixes only, regression tests still need to be written. Each fix is traceable to a public-API PoC confirmed under ASan.

## Test plan
- [x] Existing test suite passes
- [ ] Add testing