### PR TITLE
ci: preserve membrowse push-to-master runs from cancellation

### DIFF
--- a/.github/workflows/membrowse-report.yml
+++ b/.github/workflows/membrowse-report.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
# Description
Use unique concurrency group per commit for push events so that sequential merges to master don't cancel each other's queued runs. This ensures every master commit gets analyzed for memory tracking.