### PR TITLE
Fix regressions (fast math MAX_ENCODED_SIG_SZ; DTLS export IV buffer size)

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1000,7 +1000,9 @@ static int ExportKeyState(WOLFSSL* ssl, byte* exp, word32 len, byte ver,
     XMEMCPY(exp + idx, keys->aead_exp_IV, AEAD_MAX_EXP_SZ);
     idx += AEAD_MAX_EXP_SZ;
 
-    sz = (small)? 0: ssl->specs.iv_size;
+    sz = (small) ? 0 :
+         (ssl->specs.iv_size > AEAD_MAX_IMP_SZ ? AEAD_MAX_IMP_SZ
+                                               : ssl->specs.iv_size);
     if (idx + (sz * 2) + OPAQUE8_LEN > len) {
         WOLFSSL_MSG("Buffer not large enough for imp IVs");
         return BUFFER_E;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -2315,7 +2315,7 @@ enum Max_ASN {
     MAX_ENCODED_SIG_SZ  = 5120,
 #elif !defined(NO_RSA)
 #if defined(USE_FAST_MATH) && defined(FP_MAX_BITS)
-    MAX_ENCODED_SIG_SZ  = FP_MAX_BITS / 8,
+    MAX_ENCODED_SIG_SZ  = FP_MAX_BITS / 16,
 #elif (defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_SP_MATH)) && \
     defined(SP_INT_BITS)
     MAX_ENCODED_SIG_SZ  = WC_BITS_TO_BYTES(SP_INT_BITS),


### PR DESCRIPTION
# Description

(see commit messages)

Fixes zd#21621

# Testing

```
./configure --enable-dtls --enable-sessionexport --enable-fastmath CFLAGS="-DFP_MAX_BITS=8192"
make check
```
