### PR TITLE
Fix PEM input validation and zeroize sensitive key buffers

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -11869,6 +11869,10 @@ static int test_wc_CertPemToDer(void)
         (int)cert_dersz, CERT_TYPE), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_CertPemToDer(cert_buf, (int)cert_sz, cert_der, -1,
         CERT_TYPE), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_CertPemToDer(cert_buf, -1, cert_der, (int)cert_dersz,
+        CERT_TYPE), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_CertPemToDer(cert_buf, 0, cert_der, (int)cert_dersz,
+        CERT_TYPE), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
     if (cert_der != NULL)
         free(cert_der);
@@ -11925,6 +11929,12 @@ static int test_wc_KeyPemToDer(void)
     ExpectIntEQ(wc_KeyPemToDer(cert_buf, cert_sz, (byte*)&cert_der, 0, ""),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
+    /* Bad arg: negative or zero pemSz */
+    ExpectIntEQ(wc_KeyPemToDer(cert_buf, -1, (byte*)&cert_der, cert_sz, ""),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_KeyPemToDer(cert_buf, 0, (byte*)&cert_der, cert_sz, ""),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
     /* Test normal operation */
     cert_dersz = cert_sz; /* DER will be smaller than PEM */
     ExpectNotNull(cert_der = (byte*)malloc((size_t)cert_dersz));
@@ -11968,6 +11978,10 @@ static int test_wc_PubKeyPemToDer(void)
     ExpectIntEQ(load_file(key, &cert_buf, &cert_sz), 0);
     cert_dersz = cert_sz; /* DER will be smaller than PEM */
     ExpectNotNull(cert_der = (byte*)malloc(cert_dersz));
+    ExpectIntEQ(wc_PubKeyPemToDer(cert_buf, -1, cert_der, (int)cert_dersz),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_PubKeyPemToDer(cert_buf, 0, cert_der, (int)cert_dersz),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntGE(wc_PubKeyPemToDer(cert_buf, (int)cert_sz, cert_der,
         (int)cert_dersz), 0);
     if (cert_der != NULL) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -24322,7 +24322,7 @@ int wc_KeyPemToDer(const unsigned char* pem, int pemSz,
 
     WOLFSSL_ENTER("wc_KeyPemToDer");
 
-    if (pem == NULL || (buff != NULL && buffSz <= 0)) {
+    if (pem == NULL || (buff != NULL && buffSz <= 0) || pemSz <= 0) {
         WOLFSSL_MSG("Bad pem der args");
         return BAD_FUNC_ARG;
     }
@@ -24373,7 +24373,7 @@ int wc_CertPemToDer(const unsigned char* pem, int pemSz,
 
     WOLFSSL_ENTER("wc_CertPemToDer");
 
-    if (pem == NULL || buff == NULL || buffSz <= 0) {
+    if (pem == NULL || buff == NULL || buffSz <= 0 || pemSz <= 0) {
         WOLFSSL_MSG("Bad pem der args");
         return BAD_FUNC_ARG;
     }
@@ -24420,7 +24420,7 @@ int wc_PubKeyPemToDer(const unsigned char* pem, int pemSz,
 
     WOLFSSL_ENTER("wc_PubKeyPemToDer");
 
-    if (pem == NULL || (buff != NULL && buffSz <= 0)) {
+    if (pem == NULL || (buff != NULL && buffSz <= 0) || pemSz <= 0) {
         WOLFSSL_MSG("Bad pem der args");
         return BAD_FUNC_ARG;
     }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7666,6 +7666,11 @@ int wc_ecc_gen_deterministic_k(const byte* hash, word32 hashSz,
     /* 3.2 c. Set K = 0x00 0x00 ... */
     XMEMSET(K, 0x00, KSz);
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Add("wc_ecc_gen_deterministic_k K", K, KSz);
+    wc_MemZero_Add("wc_ecc_gen_deterministic_k V", V, VSz);
+#endif
+
     if (ret == 0) {
         ret = mp_init(z1); /* always init z1 and free z1 */
     }
@@ -7808,6 +7813,8 @@ int wc_ecc_gen_deterministic_k(const byte* hash, word32 hashSz,
     }
 
     ForceZero(x, MAX_ECC_BYTES);
+    ForceZero(K, WC_MAX_DIGEST_SIZE);
+    ForceZero(V, WC_MAX_DIGEST_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(z1, heap, DYNAMIC_TYPE_ECC_BUFFER);
     XFREE(x, heap, DYNAMIC_TYPE_PRIVATE_KEY);
@@ -7816,6 +7823,8 @@ int wc_ecc_gen_deterministic_k(const byte* hash, word32 hashSz,
     XFREE(h1, heap, DYNAMIC_TYPE_DIGEST);
 #elif defined(WOLFSSL_CHECK_MEM_ZERO)
     wc_MemZero_Check(x, MAX_ECC_BYTES);
+    wc_MemZero_Check(K, WC_MAX_DIGEST_SIZE);
+    wc_MemZero_Check(V, WC_MAX_DIGEST_SIZE);
 #endif
 
     return ret;

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1976,6 +1976,7 @@ static int wc_PKCS12_create_key_bag(WC_PKCS12* pkcs12, WC_RNG* rng,
     word32 sz;
     word32 i;
     word32 tmpSz;
+    word32 tmpAllocSz;
     int ret;
 
     /* get max size for shrouded key */
@@ -2014,6 +2015,7 @@ static int wc_PKCS12_create_key_bag(WC_PKCS12* pkcs12, WC_RNG* rng,
     }
 
     /* shroud key */
+    tmpAllocSz = length;
     tmp = (byte*)XMALLOC(length, heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (tmp == NULL) {
         return MEMORY_E;
@@ -2022,11 +2024,13 @@ static int wc_PKCS12_create_key_bag(WC_PKCS12* pkcs12, WC_RNG* rng,
     ret =  wc_PKCS12_shroud_key(pkcs12, rng, tmp, &length, key, keySz,
             algo, pass, passSz, iter);
     if (ret < 0) {
+        ForceZero(tmp, tmpAllocSz);
         XFREE(tmp, heap, DYNAMIC_TYPE_TMP_BUFFER);
         return ret;
     }
     length = (word32)ret;
     XMEMCPY(out + idx, tmp, (size_t)length);
+    ForceZero(tmp, tmpAllocSz);
     XFREE(tmp, heap, DYNAMIC_TYPE_TMP_BUFFER);
     totalSz += length;
 
@@ -2357,6 +2361,7 @@ static byte* PKCS12_create_key_content(WC_PKCS12* pkcs12, int nidKey,
 {
     byte*  keyBuf;
     word32 keyBufSz = 0;
+    word32 keyBufAllocSz = 0;
     byte* keyCi = NULL;
     word32 tmpSz;
     int ret;
@@ -2406,6 +2411,7 @@ static byte* PKCS12_create_key_content(WC_PKCS12* pkcs12, int nidKey,
 
     /* account for sequence around bag */
     keyBufSz += MAX_SEQ_SZ;
+    keyBufAllocSz = keyBufSz;
     keyBuf = (byte*)XMALLOC(keyBufSz, heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (keyBuf == NULL) {
         WOLFSSL_MSG("Memory error creating keyBuf buffer");
@@ -2415,6 +2421,7 @@ static byte* PKCS12_create_key_content(WC_PKCS12* pkcs12, int nidKey,
     ret = wc_PKCS12_create_key_bag(pkcs12, rng, keyBuf + MAX_SEQ_SZ, &keyBufSz,
             key, keySz, algo, iter, pass, (int)passSz);
     if (ret < 0) {
+        ForceZero(keyBuf, keyBufAllocSz);
         XFREE(keyBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
         WOLFSSL_MSG("Error creating key bag");
         return NULL;
@@ -2437,18 +2444,21 @@ static byte* PKCS12_create_key_content(WC_PKCS12* pkcs12, int nidKey,
     ret = wc_PKCS12_encrypt_content(pkcs12, rng, NULL, keyCiSz,
             NULL, keyBufSz, algo, pass, (int)passSz, iter, WC_PKCS12_DATA);
     if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
+        ForceZero(keyBuf, keyBufAllocSz);
         XFREE(keyBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
         WOLFSSL_MSG("Error getting key encrypt content size");
         return NULL;
     }
     keyCi = (byte*)XMALLOC(*keyCiSz, heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (keyCi == NULL) {
+        ForceZero(keyBuf, keyBufAllocSz);
         XFREE(keyBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
         return NULL;
     }
 
     ret = wc_PKCS12_encrypt_content(pkcs12, rng, keyCi, keyCiSz,
             keyBuf, keyBufSz, algo, pass, (int)passSz, iter, WC_PKCS12_DATA);
+    ForceZero(keyBuf, keyBufAllocSz);
     XFREE(keyBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (ret < 0 ) {
         XFREE(keyCi, heap, DYNAMIC_TYPE_TMP_BUFFER);


### PR DESCRIPTION
Fixes F-2682, F-2209, F-2210, F-2211

  - Reject negative pemSz in wc_CertPemToDer / wc_PubKeyPemToDer (prevents word32 wrap →       
  out-of-bounds XSTRNSTR).                                                                     
  - Zero HMAC-DRBG K and V in wc_ecc_gen_deterministic_k before free (RFC 6979 state could leak nonce/private key).                                                                         
  - Zero PKCS#12 key-bag tmp and keyBuf buffers at all free sites in wc_PKCS12_create_key_bag / wc_PKCS12_create (held raw private-key material).     
  
    
Added negative/zero pemSz assertions to                  test_wc_CertPemToDer and test_wc_PubKeyPemToDer

