### PR TITLE
20260415-confusing_globals

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15086,7 +15086,7 @@ void crypto_ex_cb_free_data(void *obj, CRYPTO_EX_cb_ctx* cb_ctx,
 }
 
 /**
- * get_ex_new_index is a helper function for the following
+ * wolfssl_local_get_ex_new_index is a helper function for the following
  * xx_get_ex_new_index functions:
  *  - wolfSSL_CRYPTO_get_ex_new_index
  *  - wolfSSL_CTX_get_ex_new_index
@@ -15095,7 +15095,7 @@ void crypto_ex_cb_free_data(void *obj, CRYPTO_EX_cb_ctx* cb_ctx,
  * Returns an index number greater or equal to zero on success,
  * -1 on failure.
  */
-int wolfssl_get_ex_new_index(int class_index, long ctx_l, void* ctx_ptr,
+int wolfssl_local_get_ex_new_index(int class_index, long ctx_l, void* ctx_ptr,
         WOLFSSL_CRYPTO_EX_new* new_func, WOLFSSL_CRYPTO_EX_dup* dup_func,
         WOLFSSL_CRYPTO_EX_free* free_func)
 {
@@ -15161,8 +15161,8 @@ int wolfSSL_CTX_get_ex_new_index(long idx, void* arg,
 
     WOLFSSL_ENTER("wolfSSL_CTX_get_ex_new_index");
 
-    return wolfssl_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_SSL_CTX, idx, arg,
-                                    new_func, dup_func, free_func);
+    return wolfssl_local_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_SSL_CTX, idx,
+                                    arg, new_func, dup_func, free_func);
 }
 
 /* Return the index that can be used for the WOLFSSL structure to store
@@ -15175,8 +15175,8 @@ int wolfSSL_get_ex_new_index(long argValue, void* arg,
 {
     WOLFSSL_ENTER("wolfSSL_get_ex_new_index");
 
-    return wolfssl_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_SSL, argValue, arg,
-            cb1, cb2, cb3);
+    return wolfssl_local_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_SSL, argValue,
+            arg, cb1, cb2, cb3);
 }
 #endif /* HAVE_EX_DATA_CRYPTO */
 
@@ -19170,7 +19170,7 @@ int wolfSSL_CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,
 {
     WOLFSSL_ENTER("wolfSSL_CRYPTO_get_ex_new_index");
 
-    return wolfssl_get_ex_new_index(class_index, argl, argp, new_func,
+    return wolfssl_local_get_ex_new_index(class_index, argl, argp, new_func,
             dup_func, free_func);
 }
 #endif /* HAVE_EX_DATA_CRYPTO */

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -4198,12 +4198,12 @@ int wolfSSL_CTX_use_PrivateKey_Id(WOLFSSL_CTX* ctx, const unsigned char* id,
  * @return  1 on success.
  * @return  0 on failure.
  */
-int wolfSSL_CTX_use_PrivateKey_id(WOLFSSL_CTX* ctx, const unsigned char* id,
+int wolfSSL_CTX_use_PrivateKey_Id_ex(WOLFSSL_CTX* ctx, const unsigned char* id,
     long sz, int devId, long keySz)
 {
     int ret;
 
-    WOLFSSL_ENTER("wolfSSL_CTX_use_PrivateKey_id");
+    WOLFSSL_ENTER("wolfSSL_CTX_use_PrivateKey_Id_ex");
 
     ret = wolfSSL_CTX_use_PrivateKey_Id(ctx, id, sz, devId);
     if (ret == 1) {
@@ -4211,7 +4211,7 @@ int wolfSSL_CTX_use_PrivateKey_id(WOLFSSL_CTX* ctx, const unsigned char* id,
         ctx->privateKeySz = (int)keySz;
     }
 
-    WOLFSSL_LEAVE("wolfSSL_CTX_use_PrivateKey_id", ret);
+    WOLFSSL_LEAVE("wolfSSL_CTX_use_PrivateKey_Id_ex", ret);
     return ret;
 }
 
@@ -4294,19 +4294,19 @@ int wolfSSL_CTX_use_AltPrivateKey_Id(WOLFSSL_CTX* ctx, const unsigned char* id,
     return ret;
 }
 
-int wolfSSL_CTX_use_AltPrivateKey_id(WOLFSSL_CTX* ctx, const unsigned char* id,
-    long sz, int devId, long keySz)
+int wolfSSL_CTX_use_AltPrivateKey_Id_ex(WOLFSSL_CTX* ctx,
+    const unsigned char* id, long sz, int devId, long keySz)
 {
     int ret;
 
-    WOLFSSL_ENTER("wolfSSL_CTX_use_AltPrivateKey_id");
+    WOLFSSL_ENTER("wolfSSL_CTX_use_AltPrivateKey_Id_ex");
 
     ret = wolfSSL_CTX_use_AltPrivateKey_Id(ctx, id, sz, devId);
     if (ret == 1) {
         ctx->altPrivateKeySz = (word32)keySz;
     }
 
-    WOLFSSL_LEAVE("wolfSSL_CTX_use_AltPrivateKey_id", ret);
+    WOLFSSL_LEAVE("wolfSSL_CTX_use_AltPrivateKey_Id_ex", ret);
     return ret;
 }
 
@@ -4606,7 +4606,7 @@ int wolfSSL_use_PrivateKey_Id(WOLFSSL* ssl, const unsigned char* id,
  * @return  1 on success.
  * @return  0 on failure.
  */
-int wolfSSL_use_PrivateKey_id(WOLFSSL* ssl, const unsigned char* id,
+int wolfSSL_use_PrivateKey_Id_ex(WOLFSSL* ssl, const unsigned char* id,
     long sz, int devId, long keySz)
 {
     int ret = wolfSSL_use_PrivateKey_Id(ssl, id, sz, devId);
@@ -4703,8 +4703,8 @@ int wolfSSL_use_AltPrivateKey_Id(WOLFSSL* ssl, const unsigned char* id, long sz,
     return ret;
 }
 
-int wolfSSL_use_AltPrivateKey_id(WOLFSSL* ssl, const unsigned char* id, long sz,
-    int devId, long keySz)
+int wolfSSL_use_AltPrivateKey_Id_ex(WOLFSSL* ssl, const unsigned char* id,
+    long sz, int devId, long keySz)
 {
     int ret = wolfSSL_use_AltPrivateKey_Id(ssl, id, sz, devId);
     if (ret == 1) {

--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -4366,8 +4366,8 @@ int wolfSSL_SESSION_get_ex_new_index(long ctx_l,void* ctx_ptr,
         WOLFSSL_CRYPTO_EX_free* free_func)
 {
     WOLFSSL_ENTER("wolfSSL_SESSION_get_ex_new_index");
-    return wolfssl_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_SSL_SESSION, ctx_l,
-            ctx_ptr, new_func, dup_func, free_func);
+    return wolfssl_local_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_SSL_SESSION,
+            ctx_l, ctx_ptr, new_func, dup_func, free_func);
 }
 #endif /* HAVE_EX_DATA_CRYPTO */
 #endif /* HAVE_EX_DATA */

--- a/src/x509.c
+++ b/src/x509.c
@@ -15463,7 +15463,7 @@ int wolfSSL_X509_get_ex_new_index(int idx, void *arg,
 {
     WOLFSSL_ENTER("wolfSSL_X509_get_ex_new_index");
 
-    return wolfssl_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_X509, idx, arg,
+    return wolfssl_local_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_X509, idx, arg,
                                     new_func, dup_func, free_func);
 }
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -1703,8 +1703,8 @@ static int test_dual_alg_ecdsa_mldsa(void)
 static int test_wolfSSL_use_AltPrivateKey_Id(void)
 {
     EXPECT_DECLS;
-#if defined(WOLFSSL_DUAL_ALG_CERTS) && !defined(NO_TLS) && \
-    !defined(NO_WOLFSSL_CLIENT)
+#if defined(WOLF_PRIVATE_KEY_ID) && defined(WOLFSSL_DUAL_ALG_CERTS) && \
+    !defined(NO_TLS) && !defined(NO_WOLFSSL_CLIENT)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL*     ssl = NULL;
     const unsigned char id[] = { 0x01, 0x02, 0x03, 0x04 };
@@ -1724,7 +1724,8 @@ static int test_wolfSSL_use_AltPrivateKey_Id(void)
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
-#endif /* WOLFSSL_DUAL_ALG_CERTS && !NO_TLS && !NO_WOLFSSL_CLIENT */
+#endif /* WOLF_PRIVATE_KEY_ID && WOLFSSL_DUAL_ALG_CERTS && !NO_TLS && */
+       /* !NO_WOLFSSL_CLIENT                                          */
     return EXPECT_RESULT();
 }
 
@@ -1735,8 +1736,8 @@ static int test_wolfSSL_use_AltPrivateKey_Id(void)
 static int test_wolfSSL_use_AltPrivateKey_Label(void)
 {
     EXPECT_DECLS;
-#if defined(WOLFSSL_DUAL_ALG_CERTS) && !defined(NO_TLS) && \
-    !defined(NO_WOLFSSL_CLIENT)
+#if defined(WOLF_PRIVATE_KEY_ID) && defined(WOLFSSL_DUAL_ALG_CERTS) && \
+    !defined(NO_TLS) && !defined(NO_WOLFSSL_CLIENT)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL*     ssl = NULL;
 
@@ -1754,7 +1755,8 @@ static int test_wolfSSL_use_AltPrivateKey_Label(void)
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
-#endif /* WOLFSSL_DUAL_ALG_CERTS && !NO_TLS && !NO_WOLFSSL_CLIENT */
+#endif /* WOLF_PRIVATE_KEY_ID && WOLFSSL_DUAL_ALG_CERTS && !NO_TLS && */
+       /* !NO_WOLFSSL_CLIENT                                          */
     return EXPECT_RESULT();
 }
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -7336,7 +7336,7 @@ WOLFSSL_LOCAL void crypto_ex_cb_free_data(void *obj, CRYPTO_EX_cb_ctx* cb_ctx,
         WOLFSSL_CRYPTO_EX_DATA* ex_data);
 WOLFSSL_LOCAL int crypto_ex_cb_dup_data(const WOLFSSL_CRYPTO_EX_DATA *in,
         WOLFSSL_CRYPTO_EX_DATA *out, CRYPTO_EX_cb_ctx* cb_ctx);
-WOLFSSL_LOCAL int wolfssl_get_ex_new_index(int class_index, long ctx_l,
+WOLFSSL_LOCAL int wolfssl_local_get_ex_new_index(int class_index, long ctx_l,
         void* ctx_ptr, WOLFSSL_CRYPTO_EX_new* new_func,
         WOLFSSL_CRYPTO_EX_dup* dup_func, WOLFSSL_CRYPTO_EX_free* free_func);
 #endif /* HAVE_EX_DATA_CRYPTO */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3769,6 +3769,8 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
     WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_Id_ex(WOLFSSL_CTX* ctx,
                                                   const unsigned char* id, long sz,
                                                   int devId, long keySz);
+    /* backward compatibility mapping for old confusable name. */
+    #define wolfSSL_CTX_use_PrivateKey_id wolfSSL_CTX_use_PrivateKey_Id_ex
     WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_Id(WOLFSSL_CTX* ctx,
                                                   const unsigned char* id, long sz,
                                                   int devId);
@@ -3791,6 +3793,8 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
     WOLFSSL_API int wolfSSL_CTX_use_AltPrivateKey_Id_ex(WOLFSSL_CTX* ctx,
                                 const unsigned char* id, long sz,
                                 int devId, long keySz);
+    /* backward compatibility mapping for old confusable name. */
+    #define wolfSSL_CTX_use_AltPrivateKey_id wolfSSL_CTX_use_AltPrivateKey_Id_ex
     WOLFSSL_API int wolfSSL_CTX_use_AltPrivateKey_Id(WOLFSSL_CTX* ctx,
                                 const unsigned char* id, long sz, int devId);
     WOLFSSL_API int wolfSSL_CTX_use_AltPrivateKey_Label(WOLFSSL_CTX* ctx,
@@ -3806,6 +3810,8 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
                                                long sz, int format);
     WOLFSSL_API int wolfSSL_use_PrivateKey_Id_ex(WOLFSSL* ssl, const unsigned char* id,
                                               long sz, int devId, long keySz);
+    /* backward compatibility mapping for old confusable name. */
+    #define wolfSSL_use_PrivateKey_id wolfSSL_use_PrivateKey_Id_ex
     WOLFSSL_API int wolfSSL_use_PrivateKey_Id(WOLFSSL* ssl, const unsigned char* id,
                                               long sz, int devId);
     WOLFSSL_API int wolfSSL_use_PrivateKey_Label(WOLFSSL* ssl, const char* label, int devId);
@@ -3822,6 +3828,8 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
     WOLFSSL_API int wolfSSL_use_AltPrivateKey_Id_ex(WOLFSSL* ssl,
                                 const unsigned char* id, long sz,
                                 int devId, long keySz);
+    /* backward compatibility mapping for old confusable name. */
+    #define wolfSSL_use_AltPrivateKey_id wolfSSL_use_AltPrivateKey_Id_ex
     WOLFSSL_API int wolfSSL_use_AltPrivateKey_Id(WOLFSSL* ssl,
                                 const unsigned char* id, long sz, int devId);
     WOLFSSL_API int wolfSSL_use_AltPrivateKey_Label(WOLFSSL* ssl,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3765,7 +3765,8 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
                                                const unsigned char* in, long sz, int format);
     WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_buffer(WOLFSSL_CTX* ctx,
                                                const unsigned char* in, long sz, int format);
-    WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_id(WOLFSSL_CTX* ctx,
+#ifdef WOLF_PRIVATE_KEY_ID
+    WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_Id_ex(WOLFSSL_CTX* ctx,
                                                   const unsigned char* id, long sz,
                                                   int devId, long keySz);
     WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_Id(WOLFSSL_CTX* ctx,
@@ -3773,6 +3774,7 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
                                                   int devId);
     WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_Label(WOLFSSL_CTX* ctx, const char* label,
                                                      int devId);
+#endif /* WOLF_PRIVATE_KEY_ID */
     WOLFSSL_API int wolfSSL_CTX_use_certificate_chain_buffer_format(WOLFSSL_CTX* ctx,
                                                const unsigned char* in, long sz, int format);
     WOLFSSL_API int wolfSSL_CTX_use_certificate_chain_buffer(WOLFSSL_CTX* ctx,
@@ -3786,7 +3788,7 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     WOLFSSL_API int wolfSSL_CTX_use_AltPrivateKey_buffer(WOLFSSL_CTX* ctx,
                                 const unsigned char* in, long sz, int format);
-    WOLFSSL_API int wolfSSL_CTX_use_AltPrivateKey_id(WOLFSSL_CTX* ctx,
+    WOLFSSL_API int wolfSSL_CTX_use_AltPrivateKey_Id_ex(WOLFSSL_CTX* ctx,
                                 const unsigned char* id, long sz,
                                 int devId, long keySz);
     WOLFSSL_API int wolfSSL_CTX_use_AltPrivateKey_Id(WOLFSSL_CTX* ctx,
@@ -3802,7 +3804,7 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
                                            const unsigned char* der, int derSz);
     WOLFSSL_API int wolfSSL_use_PrivateKey_buffer(WOLFSSL* ssl, const unsigned char* in,
                                                long sz, int format);
-    WOLFSSL_API int wolfSSL_use_PrivateKey_id(WOLFSSL* ssl, const unsigned char* id,
+    WOLFSSL_API int wolfSSL_use_PrivateKey_Id_ex(WOLFSSL* ssl, const unsigned char* id,
                                               long sz, int devId, long keySz);
     WOLFSSL_API int wolfSSL_use_PrivateKey_Id(WOLFSSL* ssl, const unsigned char* id,
                                               long sz, int devId);
@@ -3815,14 +3817,16 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     WOLFSSL_API int wolfSSL_use_AltPrivateKey_buffer(WOLFSSL* ssl,
                                 const unsigned char* in, long sz, int format);
-    WOLFSSL_API int wolfSSL_use_AltPrivateKey_id(WOLFSSL* ssl,
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
+#ifdef WOLF_PRIVATE_KEY_ID
+    WOLFSSL_API int wolfSSL_use_AltPrivateKey_Id_ex(WOLFSSL* ssl,
                                 const unsigned char* id, long sz,
                                 int devId, long keySz);
     WOLFSSL_API int wolfSSL_use_AltPrivateKey_Id(WOLFSSL* ssl,
                                 const unsigned char* id, long sz, int devId);
     WOLFSSL_API int wolfSSL_use_AltPrivateKey_Label(WOLFSSL* ssl,
                                 const char* label, int devId);
-#endif
+#endif /* WOLF_PRIVATE_KEY_ID */
 
     #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
         defined(KEEP_OUR_CERT)


### PR DESCRIPTION
`src/ssl_load.c`, `wolfssl/ssl.h`, `tests/api.c`: rename `wolfSSL*PrivateKey_id()` to `wolfSSL*PrivateKey_Id_ex()`, and add missing `WOLF_PRIVATE_KEY_ID` gating.

`src/ssl.c`, `src/ssl_sess.c`, `src/x509.c`, `wolfssl/internal.h`: rename `wolfssl_get_ex_new_index()` to `wolfssl_local_get_ex_new_index()`.

tested with
```
wolfssl-multi-test.sh ...
super-quick-check
check-for-bad-symbols
```

Note `check-for-bad-symbols` is the old `check-for-unprefixed-symbols`, now with callouts to a newly implemented `check_libwolfssl_for_confusing_globals()` for each sub-scenario.  Currently `check_libwolfssl_for_confusing_globals()` just checks for globals (either public or hidden) that have the same name when case-folded.  There is one unavoidable exception, `wolfSSL_Free()` and `wolfSSL_free()`, the former our public name for our `free()` wrapper, the latter our public name for our API to free a `WOLFSSL *`.  Both were added in v3.3.3 (Jan 9 2015), both deriving from CyaSSL variants added in v2.0.2 (Dec 5 2011).  We're stuck with those.
