### PR TITLE
Fix GetObjectId bounds in PKCS12 ContentInfo parsing

### DIFF
--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -328,7 +328,7 @@ static int GetSafeContent(WC_PKCS12* pkcs12, const byte* input,
 
             curIdx = localIdx;
             if ((ret = GetObjectId(input, &localIdx, &oid, oidIgnoreType,
-                                                           (word32)size)) < 0) {
+                                       curIdx + (word32)curSz)) < 0) {
                 WOLFSSL_LEAVE("Get object id failed", ret);
                 freeSafe(safe, pkcs12->heap);
                 return ret;


### PR DESCRIPTION
## Summary

- Bound `GetObjectId()` by the ContentInfo SEQUENCE end (`curIdx + curSz`) instead of the full buffer size (`(word32)size`)
- This prevents the OID TLV from being parsed past the SEQUENCE boundary in the first place, complementing the post-check added in PR #10018

## Context

PR #10018 added a post-check that catches when `GetObjectId()` advances `localIdx` past the ContentInfo SEQUENCE boundary. However, `GetObjectId()` itself still receives the full buffer size as `maxIdx`, so it parses the OID TLV beyond the SEQUENCE boundary before the post-check rejects it.

This change bounds `GetObjectId()` at the source, so it rejects an oversized OID immediately during parsing rather than after the fact. The post-check from #10018 remains as defense-in-depth.

## Test plan

- Existing `test_wc_d2i_PKCS12_oid_underflow` test (added in #10018) covers this path
- Crafted PKCS12 with OID extending past SEQUENCE boundary is rejected with `ASN_PARSE_E` (now by `GetObjectId` directly, rather than the post-check)