### PR TITLE
20260415-trace-errcodes-fixes-and-tests

### DIFF
--- a/.github/workflows/trackmemory.yml
+++ b/.github/workflows/trackmemory.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         config: [
           # Add new configs here
-          '--enable-all CFLAGS="-DWC_RNG_SEED_CB -DWOLFSSL_TRACK_MEMORY -DWOLFSSL_DEBUG_MEMORY"',
+          '--enable-all --enable-debug-trace-errcodes CFLAGS="-DWC_RNG_SEED_CB -DWOLFSSL_TRACK_MEMORY -DWOLFSSL_DEBUG_MEMORY"',
           '--enable-smallstack --enable-all CFLAGS="-DWC_RNG_SEED_CB  -DWOLFSSL_TRACK_MEMORY -DWOLFSSL_DEBUG_MEMORY"',
-          '--enable-smallstackcache --enable-smallstack --enable-all CFLAGS="-DWC_RNG_SEED_CB  -DWOLFSSL_TRACK_MEMORY -DWOLFSSL_DEBUG_MEMORY"',
+          '--enable-smallstackcache --enable-smallstack --enable-all --enable-debug-trace-errcodes CFLAGS="-DWC_RNG_SEED_CB  -DWOLFSSL_TRACK_MEMORY -DWOLFSSL_DEBUG_MEMORY"',
 # Note the below smallstackcache tests are crucial coverage for the Linux kernel
 # module, when targeting a kernel with the randomness patch (linuxkm/patches/)
 # applied.

--- a/tests/api/test_aes.c
+++ b/tests/api/test_aes.c
@@ -8754,7 +8754,8 @@ int test_wc_AesCtr_MonteCarlo(void)
 int test_wc_AesGcm_MonteCarlo(void)
 {
     EXPECT_DECLS;
-#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(HAVE_AES_DECRYPT)
+#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(HAVE_AES_DECRYPT) && \
+    !defined(WOLFSSL_AFALG) && !defined(WOLFSSL_DEVCRYPTO)
     static const word32 keySizes[] = {
 #ifdef WOLFSSL_AES_128
         16,
@@ -8815,7 +8816,9 @@ int test_wc_AesGcm_MonteCarlo(void)
     WC_FREE_VAR(plain,     NULL);
     WC_FREE_VAR(cipher,    NULL);
     WC_FREE_VAR(decrypted, NULL);
-#endif
+#endif /* !NO_AES && HAVE_AESGCM && HAVE_AES_DECRYPT && !WOLFSSL_AFALG && */
+       /* !WOLFSSL_DEVCRYPTO                                              */
+
     return EXPECT_RESULT();
 }
 

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -1870,6 +1870,33 @@ int wc_backtrace_render(void) {
 
 #include <backtrace.h>
 
+#ifdef XFILE
+
+static XFILE wolfssl_backtrace_file = XBADFILE;
+
+XFILE wc_backtrace_set_fp(XFILE new_fp) {
+    XFILE old_fp = wolfssl_backtrace_file;
+    if (new_fp == NULL)
+        wolfssl_backtrace_file = XBADFILE;
+    else
+        wolfssl_backtrace_file = new_fp;
+    return old_fp;
+}
+
+#define WOLFSSL_BACKTRACE_PRINTF(...) (                             \
+    (wolfssl_backtrace_file == XBADFILE) ?                          \
+     WOLFSSL_DEBUG_PRINTF(__VA_ARGS__) :                            \
+     WOLFSSL_DEBUG_PRINTF_FN(wolfssl_backtrace_file, __VA_ARGS__))
+
+#else /* !XFILE */
+
+/* libbacktrace doesn't support any targets with no XFILE, but keep it buildable
+ * just in case.
+ */
+#define WOLFSSL_BACKTRACE_PRINTF(...) WOLFSSL_DEBUG_PRINTF(__VA_ARGS__)
+
+#endif /* !XFILE */
+
 static int backtrace_callback(void *data, uintptr_t pc, const char *filename,
                               int lineno, const char *function)
 {
@@ -1880,20 +1907,20 @@ static int backtrace_callback(void *data, uintptr_t pc, const char *filename,
         *(int *)data = 1;
         return 0;
     }
-    WOLFSSL_DEBUG_PRINTF("    #%d %p in %s %s:%d\n", (*(int *)data)++,
+    WOLFSSL_BACKTRACE_PRINTF("    #%d %p in %s %s:%d\n", (*(int *)data)++,
                          (void *)pc, function, filename, lineno);
     return 0;
 }
 
 static void backtrace_error(void *data, const char *msg, int errnum) {
     (void)data;
-    WOLFSSL_DEBUG_PRINTF("ERR TRACE: error %d while backtracing: %s",
+    WOLFSSL_BACKTRACE_PRINTF("ERR TRACE: error %d while backtracing: %s",
                          errnum, msg);
 }
 
 static void backtrace_creation_error(void *data, const char *msg, int errnum) {
     (void)data;
-    WOLFSSL_DEBUG_PRINTF("ERR TRACE: internal error %d "
+    WOLFSSL_BACKTRACE_PRINTF("ERR TRACE: internal error %d "
             "while initializing backtrace facility: %s", errnum, msg);
 }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -41506,31 +41506,31 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
 
 #ifdef WOLFSSL_SE050
-    #define RARE_ED_BAD_ENC_E   WC_HW_E
-    #define RARE_ED_BAD_SIG_E   WC_HW_E
+    #define RARE_ED_BAD_ENC_E   WC_NO_ERR_TRACE(WC_HW_E)
+    #define RARE_ED_BAD_SIG_E   WC_NO_ERR_TRACE(WC_HW_E)
 #else
-    #define RARE_ED_BAD_ENC_E   BAD_FUNC_ARG
-    #define RARE_ED_BAD_SIG_E   SIG_VERIFY_E
+    #define RARE_ED_BAD_ENC_E   WC_NO_ERR_TRACE(BAD_FUNC_ARG)
+    #define RARE_ED_BAD_SIG_E   WC_NO_ERR_TRACE(SIG_VERIFY_E)
 #endif
 
         ret = wc_ed25519_verify_msg(rareEd1, sizeof(rareEd1), msgs[0], msgSz[0],
                 &verify, key);
-        if (ret != WC_NO_ERR_TRACE(RARE_ED_BAD_ENC_E))
+        if (ret != RARE_ED_BAD_ENC_E)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
 
         ret = wc_ed25519_verify_msg(rareEd2, sizeof(rareEd2), msgs[0], msgSz[0],
                 &verify, key);
-        if (ret != WC_NO_ERR_TRACE(RARE_ED_BAD_ENC_E))
+        if (ret != RARE_ED_BAD_ENC_E)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
 
         ret = wc_ed25519_verify_msg(rareEd3, sizeof(rareEd3), msgs[0], msgSz[0],
                 &verify, key);
-        if (ret != WC_NO_ERR_TRACE(RARE_ED_BAD_ENC_E))
+        if (ret != RARE_ED_BAD_ENC_E)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
 
         ret = wc_ed25519_verify_msg(rareEd4, sizeof(rareEd4), msgs[0], msgSz[0],
                 &verify, key);
-        if (ret != WC_NO_ERR_TRACE(RARE_ED_BAD_SIG_E))
+        if (ret != RARE_ED_BAD_SIG_E)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
 
     #undef RARE_ED_BAD_ENC_E

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -582,6 +582,9 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
 #ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
     WOLFSSL_API int wc_debug_trace_error_codes_enabled(void);
     WOLFSSL_API int wc_debug_trace_error_codes_set(int state);
+    #ifdef XFILE
+        WOLFSSL_API XFILE wc_backtrace_set_fp(XFILE new_fp);
+    #endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
`wolfcrypt/test/test.c`: in `ed25519_test()`, fix `RARE_ED_BAD_ENC_E` and `RARE_ED_BAD_SIG_E` macros to use `WC_NO_ERR_TRACE()` safely;

`.github/workflows/trackmemory.yml`: add `--enable-debug-trace-errcodes` to a couple scenarios.

`wolfcrypt/src/logging.c` and `wolfssl/wolfcrypt/logging.h`: add `wc_backtrace_set_fp()`.

`tests/api/test_aes.c`: fix gating for `test_wc_AesGcm_MonteCarlo()` to exclude `WOLFSSL_AFALG` and `WOLFSSL_DEVCRYPTO`.

tested with
```
wolfssl-multi-test.sh ...
super-quick-check
all-gcc-c99-backtrace
cppcheck-all-debug-backtrace
clang-tidy-all-debug-backtrace
all-afalg
defaults-afalg
```
