### PR TITLE
Enhance extra user data value and external cookie length max size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10376,9 +10376,10 @@ case "$ENABLED_EX_DATA" in
 no) ;;
 yes) AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA"
      ;;
-[[1-9]]|[[1-9]][[0-9]]) AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA -DMAX_EX_DATA=$ENABLED_EX_DATA"
+[[1-9]]|[[1-9]][[0-9]]|[[1-9]][[0-9]][[0-9]]|[[1-9]][[0-9]][[0-9]][[0-9]])
+       AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA -DMAX_EX_DATA=$ENABLED_EX_DATA"
        ;;
-*) AC_MSG_ERROR([Invalid argument to --enable-context-extra-user-data -- must be yes, no, or a number from 1 to 99])
+*) AC_MSG_ERROR([Invalid argument to --enable-context-extra-user-data -- must be yes, no, or a number from 1 to 9999])
    ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -10379,7 +10379,7 @@ yes) AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA"
 [[1-9]]|[[1-9]][[0-9]]|[[1-9]][[0-9]][[0-9]]|[[1-9]][[0-9]][[0-9]][[0-9]])
        AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA -DMAX_EX_DATA=$ENABLED_EX_DATA"
        ;;
-*) AC_MSG_ERROR([Invalid argument to --enable-context-extra-user-data -- must be yes, no, or a number from 1 to 9999 (note: each index reserves one pointer per object, so large values increase memory use)])  
+*) AC_MSG_ERROR([Invalid argument to --enable-context-extra-user-data -- must be yes, no, or a number from 1 to 9999 (note: each index reserves one pointer per object, so large values increase memory use)])
    ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -10379,7 +10379,7 @@ yes) AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA"
 [[1-9]]|[[1-9]][[0-9]]|[[1-9]][[0-9]][[0-9]]|[[1-9]][[0-9]][[0-9]][[0-9]])
        AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA -DMAX_EX_DATA=$ENABLED_EX_DATA"
        ;;
-*) AC_MSG_ERROR([Invalid argument to --enable-context-extra-user-data -- must be yes, no, or a number from 1 to 9999])
+*) AC_MSG_ERROR([Invalid argument to --enable-context-extra-user-data -- must be yes, no, or a number from 1 to 9999 (note: each index reserves one pointer per object, so large values increase memory use)])  
    ;;
 esac
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1444,8 +1444,12 @@ enum {
 
 #ifndef WOLFSSL_COOKIE_LEN
 /* Maximum size for a DTLS cookie */
-#define WOLFSSL_COOKIE_LEN 32 
+#define WOLFSSL_COOKIE_LEN 32
 #endif 
+
+#if WOLFSSL_COOKIE_LEN > 255
+#error "WOLFSSL_COOKIE_LEN must be <= 255 per RFC 6347 (opaque<0..2^8-1>)"
+#endif
 
 #if defined(WOLFSSL_TLS13) || !defined(NO_PSK)
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1445,7 +1445,7 @@ enum {
 #ifndef WOLFSSL_COOKIE_LEN
 /* Maximum size for a DTLS cookie */
 #define WOLFSSL_COOKIE_LEN 32
-#endif 
+#endif
 
 #if WOLFSSL_COOKIE_LEN > 255
 #error "WOLFSSL_COOKIE_LEN must be <= 255 per RFC 6347 (opaque<0..2^8-1>)"

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1569,7 +1569,7 @@ enum Misc {
     SEED_LEN     = RAN_LEN * 2, /* tls prf seed length    */
     ID_LEN       = 32,         /* session id length       */
     COOKIE_SECRET_SZ = 14,     /* dtls cookie secret size */
-    MAX_COOKIE_LEN = 32,       /* max dtls cookie size    */
+    MAX_COOKIE_LEN = 255,      /* max dtls cookie size per RFC 6347 (opaque<0..2^8-1>) */
     COOKIE_SZ    = 20,         /* use a 20 byte cookie    */
     SUITE_LEN    =  2,         /* cipher suite sz length  */
     ENUM_LEN     =  1,         /* always a byte           */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1446,6 +1446,11 @@ enum {
 
 #define TLS13_TICKET_NONCE_MAX_SZ 255
 
+#ifndef WOLFSSL_COOKIE_LEN
+/* Maximum size for a DTLS cookie */
+#define WOLFSSL_COOKIE_LEN 32 
+#endif 
+
 #if (defined(HAVE_FIPS) &&                                                     \
     !(defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3))) &&                    \
     defined(TLS13_TICKET_NONCE_STATIC_SZ)
@@ -1569,7 +1574,7 @@ enum Misc {
     SEED_LEN     = RAN_LEN * 2, /* tls prf seed length    */
     ID_LEN       = 32,         /* session id length       */
     COOKIE_SECRET_SZ = 14,     /* dtls cookie secret size */
-    MAX_COOKIE_LEN = 254,      /* max dtls cookie size per RFC 6347 (opaque<0..2^8-1>) more than 254 can be malformed / malicious  */
+    MAX_COOKIE_LEN = WOLFSSL_COOKIE_LEN, /* max dtls cookie size */
     COOKIE_SZ    = 20,         /* use a 20 byte cookie    */
     SUITE_LEN    =  2,         /* cipher suite sz length  */
     ENUM_LEN     =  1,         /* always a byte           */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1569,7 +1569,7 @@ enum Misc {
     SEED_LEN     = RAN_LEN * 2, /* tls prf seed length    */
     ID_LEN       = 32,         /* session id length       */
     COOKIE_SECRET_SZ = 14,     /* dtls cookie secret size */
-    MAX_COOKIE_LEN = 255,      /* max dtls cookie size per RFC 6347 (opaque<0..2^8-1>) */
+    MAX_COOKIE_LEN = 254,      /* max dtls cookie size per RFC 6347 (opaque<0..2^8-1>) more than 254 */
     COOKIE_SZ    = 20,         /* use a 20 byte cookie    */
     SUITE_LEN    =  2,         /* cipher suite sz length  */
     ENUM_LEN     =  1,         /* always a byte           */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1569,7 +1569,7 @@ enum Misc {
     SEED_LEN     = RAN_LEN * 2, /* tls prf seed length    */
     ID_LEN       = 32,         /* session id length       */
     COOKIE_SECRET_SZ = 14,     /* dtls cookie secret size */
-    MAX_COOKIE_LEN = 254,      /* max dtls cookie size per RFC 6347 (opaque<0..2^8-1>) more than 254 */
+    MAX_COOKIE_LEN = 254,      /* max dtls cookie size per RFC 6347 (opaque<0..2^8-1>) more than 254 can be malfored / malicious  */
     COOKIE_SZ    = 20,         /* use a 20 byte cookie    */
     SUITE_LEN    =  2,         /* cipher suite sz length  */
     ENUM_LEN     =  1,         /* always a byte           */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1569,7 +1569,7 @@ enum Misc {
     SEED_LEN     = RAN_LEN * 2, /* tls prf seed length    */
     ID_LEN       = 32,         /* session id length       */
     COOKIE_SECRET_SZ = 14,     /* dtls cookie secret size */
-    MAX_COOKIE_LEN = 254,      /* max dtls cookie size per RFC 6347 (opaque<0..2^8-1>) more than 254 can be malfored / malicious  */
+    MAX_COOKIE_LEN = 254,      /* max dtls cookie size per RFC 6347 (opaque<0..2^8-1>) more than 254 can be malformed / malicious  */
     COOKIE_SZ    = 20,         /* use a 20 byte cookie    */
     SUITE_LEN    =  2,         /* cipher suite sz length  */
     ENUM_LEN     =  1,         /* always a byte           */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1442,14 +1442,14 @@ enum {
  */
 #define AEAD_SM4_CCM_LIMIT                       w64From32(0, (1 << 10) - 1)
 
-#if defined(WOLFSSL_TLS13) || !defined(NO_PSK)
-
-#define TLS13_TICKET_NONCE_MAX_SZ 255
-
 #ifndef WOLFSSL_COOKIE_LEN
 /* Maximum size for a DTLS cookie */
 #define WOLFSSL_COOKIE_LEN 32 
 #endif 
+
+#if defined(WOLFSSL_TLS13) || !defined(NO_PSK)
+
+#define TLS13_TICKET_NONCE_MAX_SZ 255
 
 #if (defined(HAVE_FIPS) &&                                                     \
     !(defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3))) &&                    \


### PR DESCRIPTION
# Description
Enhance configuration limits and fix max size constants to align with RFCs and large-scale deployment needs.

1. SSL_get_ex_new_index limit raised - --enable-context-extra-user-data now accepts values up to 9999 (was 99). Large platforms with high-scale operations need more than 99 ex_data indices. I've encountered it since my code uses : 
    SSL_EX_DATA_IND_DTLS_SESSION = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
    SSL_EX_DATA_IND_PSK          = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL); 
and on "Strong" machines in which i had 50+ cores running it which means (2x50) I failed to initialize an index for a DTLS session.

2. DTLS MAX_COOKIE_LEN raised to 254 - RFC 6347 defines cookie as opaque<0..2^8-1>, so max valid length is 255. Set to 254 to prevent buffer overflow attempts at boundary. Previous value of 32 was too restrictive for legitimate external cookie use. I've encountered it while trying to inject an external cookie which had valid length of more than 32 . 

# Testing
Build configuration tested with --enable-context-extra-user-data values: 1, 99, 100, 999, 9999
Verified configure.ac pattern matching rejects invalid inputs (0, 10000, strings)
DTLS cookie handling reviewed for buffer safety with new MAX_COOKIE_LEN


