### PR TITLE
wolfssl/wolfcrypt/types.h: avoid error w/ clang defining GCC >= 5

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -2088,7 +2088,7 @@ WOLFSSL_API word32 CheckRunTimeSettings(void);
     #define WC_MP_TO_RADIX
 #endif
 
-#if defined(__GNUC__) && __GNUC__ > 5
+#if defined(__GNUC__) && __GNUC__ > 5 && !defined(__clang__)
     #define PRAGMA_GCC_DIAG_PUSH _Pragma("GCC diagnostic push")
     #define PRAGMA_GCC(str) _Pragma(str)
     #define PRAGMA_GCC_DIAG_POP _Pragma("GCC diagnostic pop")


### PR DESCRIPTION
# Description

clang defines __GNUC__ for compatibility with gcc. The version of gcc it identifies itself as can be configured at clang build time, or by passing -fgnuc-version=x.y

While it currently defaults to setting __GNUC__ to 4, there are use cases for using "clang -fgnuc-version=15.2" or similar (typically working around constructs like
```
#if __GNUC__ < 10
// slow, unoptimized code path that works with ancient gcc
#else
// optimized code path that makes use of intrinsics available
// in modern gcc (and clang)
#endif
```

Without this patch, wolfssl's types.h errors out on being built with clang claiming to be a newer version of gcc - resulting in a duplicate definition of PRAGMA.

Don't add the gcc pragma definitions if clang is used.

# Testing

```
CFLAGS="-O2 -fgnuc-version=15.1" CXXFLAGS="-O2 -fgnuc-version=15.1" cmake .....
make
```