### PR TITLE
Make sure large buffers are on the heap with SMALL_STACK

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -31,6 +31,8 @@
  * START OF TXT_DB API
  ******************************************************************************/
 
+#define LINE_BUFFER_SIZE 512 /* enough for a single row */
+
 #if defined(OPENSSL_ALL) && !defined(NO_BIO)
 /**
  * This function reads a tab delimetered CSV input and returns
@@ -149,8 +151,8 @@ long wolfSSL_TXT_DB_write(WOLFSSL_BIO *out, WOLFSSL_TXT_DB *db)
 {
     const WOLF_STACK_OF(WOLFSSL_STRING)* data;
     long totalLen = 0;
-    char buf[512]; /* Should be more than enough for a single row */
-    char* bufEnd = buf + sizeof(buf);
+    WC_DECLARE_VAR(buf, char, LINE_BUFFER_SIZE, NULL); /* enough for a single row */
+    char* bufEnd;
     int i;
 
     WOLFSSL_ENTER("wolfSSL_TXT_DB_write");
@@ -160,6 +162,10 @@ long wolfSSL_TXT_DB_write(WOLFSSL_BIO *out, WOLFSSL_TXT_DB *db)
         return WOLFSSL_FAILURE;
     }
 
+    WC_ALLOC_VAR_EX(buf, char, LINE_BUFFER_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER,
+                    return WOLFSSL_FAILURE);
+    bufEnd = buf + LINE_BUFFER_SIZE;
+
     data = db->data;
     while (data) {
         char** fields = (char**)data->data.string;
@@ -168,6 +174,7 @@ long wolfSSL_TXT_DB_write(WOLFSSL_BIO *out, WOLFSSL_TXT_DB *db)
 
         if (!fields) {
             WOLFSSL_MSG("Missing row");
+            WC_FREE_VAR_EX(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             return WOLFSSL_FAILURE;
         }
 
@@ -186,6 +193,7 @@ long wolfSSL_TXT_DB_write(WOLFSSL_BIO *out, WOLFSSL_TXT_DB *db)
                 }
                 else {
                     WOLFSSL_MSG("Data row is too big");
+                    WC_FREE_VAR_EX(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                     return WOLFSSL_FAILURE;
                 }
             }
@@ -194,17 +202,21 @@ long wolfSSL_TXT_DB_write(WOLFSSL_BIO *out, WOLFSSL_TXT_DB *db)
             }
             else {
                 WOLFSSL_MSG("Data row is too big");
+                WC_FREE_VAR_EX(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 return WOLFSSL_FAILURE;
             }
         }
         if (idx > buf)
             idx[-1] = '\n';
-        else
+        else {
+            WC_FREE_VAR_EX(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             return WOLFSSL_FAILURE;
+        }
         sz = (int)(idx - buf);
 
         if (wolfSSL_BIO_write(out, buf, sz) != sz) {
             WOLFSSL_MSG("wolfSSL_BIO_write error");
+            WC_FREE_VAR_EX(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             return WOLFSSL_FAILURE;
         }
         totalLen += sz;
@@ -212,6 +224,7 @@ long wolfSSL_TXT_DB_write(WOLFSSL_BIO *out, WOLFSSL_TXT_DB *db)
         data = data->next;
     }
 
+    WC_FREE_VAR_EX(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     return totalLen;
 }
 

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -212,7 +212,7 @@ static int CreateDtls12Cookie(const WOLFSSL* ssl, const WolfSSL_CH* ch,
                               byte* cookie)
 {
     int ret;
-    Hmac cookieHmac;
+    WC_DECLARE_VAR(cookieHmac, Hmac, 1, ssl->heap);
 
     if (ssl->buffers.dtlsCookieSecret.buffer == NULL ||
             ssl->buffers.dtlsCookieSecret.length == 0) {
@@ -220,38 +220,42 @@ static int CreateDtls12Cookie(const WOLFSSL* ssl, const WolfSSL_CH* ch,
         return COOKIE_ERROR;
     }
 
-    ret = wc_HmacInit(&cookieHmac, ssl->heap, ssl->devId);
+    WC_ALLOC_VAR_EX(cookieHmac, Hmac, 1, ssl->heap, DYNAMIC_TYPE_HMAC,
+                    return MEMORY_E);
+
+    ret = wc_HmacInit(cookieHmac, ssl->heap, ssl->devId);
     if (ret == 0) {
-        ret = wc_HmacSetKey(&cookieHmac, DTLS_COOKIE_TYPE,
+        ret = wc_HmacSetKey(cookieHmac, DTLS_COOKIE_TYPE,
             ssl->buffers.dtlsCookieSecret.buffer,
             ssl->buffers.dtlsCookieSecret.length);
         if (ret == 0) {
             /* peerLock not necessary. Still in handshake phase. */
-            ret = wc_HmacUpdate(&cookieHmac,
+            ret = wc_HmacUpdate(cookieHmac,
                    (const byte*)ssl->buffers.dtlsCtx.peer.sa,
                                 ssl->buffers.dtlsCtx.peer.sz);
         }
         if (ret == 0)
-            ret = wc_HmacUpdate(&cookieHmac, (byte*)ch->pv, OPAQUE16_LEN);
+            ret = wc_HmacUpdate(cookieHmac, (byte*)ch->pv, OPAQUE16_LEN);
         if (ret == 0)
-            ret = wc_HmacUpdate(&cookieHmac, (byte*)ch->random, RAN_LEN);
+            ret = wc_HmacUpdate(cookieHmac, (byte*)ch->random, RAN_LEN);
         if (ret == 0) {
-            ret = wc_HmacUpdate(&cookieHmac, (byte*)ch->sessionId.elements,
+            ret = wc_HmacUpdate(cookieHmac, (byte*)ch->sessionId.elements,
                     ch->sessionId.size);
         }
         if (ret == 0) {
-            ret = wc_HmacUpdate(&cookieHmac, (byte*)ch->cipherSuite.elements,
+            ret = wc_HmacUpdate(cookieHmac, (byte*)ch->cipherSuite.elements,
                 ch->cipherSuite.size);
         }
         if (ret == 0) {
-            ret = wc_HmacUpdate(&cookieHmac, (byte*)ch->compression.elements,
+            ret = wc_HmacUpdate(cookieHmac, (byte*)ch->compression.elements,
                 ch->compression.size);
         }
         if (ret == 0)
-            ret = wc_HmacFinal(&cookieHmac, cookie);
-        wc_HmacFree(&cookieHmac);
+            ret = wc_HmacFinal(cookieHmac, cookie);
+        wc_HmacFree(cookieHmac);
     }
 
+    WC_FREE_VAR_EX(cookieHmac, ssl->heap, DYNAMIC_TYPE_HMAC);
     return ret;
 }
 

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -489,29 +489,33 @@ int Dtls13HashClientHello(const WOLFSSL* ssl, byte* hash, int* hashSz,
     /* msg_type(1) + length (3) */
     byte header[OPAQUE32_LEN];
     int ret;
-    wc_HashAlg hashCtx;
+    WC_DECLARE_VAR(hashCtx, wc_HashAlg, 1, ssl->heap);
     int type = wolfSSL_GetHmacType_ex(specs);
 
     if (type < 0)
         return type;
 
+    WC_ALLOC_VAR_EX(hashCtx, wc_HashAlg, 1, ssl->heap, DYNAMIC_TYPE_HASHES,
+                    return MEMORY_E);
+
     header[0] = (byte)client_hello;
     c32to24(length, header + 1);
 
-    ret = wc_HashInit_ex(&hashCtx, (enum wc_HashType)type, ssl->heap, ssl->devId);
+    ret = wc_HashInit_ex(hashCtx, (enum wc_HashType)type, ssl->heap, ssl->devId);
     if (ret == 0) {
-        ret = wc_HashUpdate(&hashCtx, (enum wc_HashType)type, header, OPAQUE32_LEN);
+        ret = wc_HashUpdate(hashCtx, (enum wc_HashType)type, header, OPAQUE32_LEN);
         if (ret == 0)
-            ret = wc_HashUpdate(&hashCtx, (enum wc_HashType)type, body, length);
+            ret = wc_HashUpdate(hashCtx, (enum wc_HashType)type, body, length);
         if (ret == 0)
-            ret = wc_HashFinal(&hashCtx, (enum wc_HashType)type, hash);
+            ret = wc_HashFinal(hashCtx, (enum wc_HashType)type, hash);
         if (ret == 0) {
             *hashSz = wc_HashGetDigestSize((enum wc_HashType)type);
             if (*hashSz < 0)
                 ret = *hashSz;
         }
-        wc_HashFree(&hashCtx, (enum wc_HashType)type);
+        wc_HashFree(hashCtx, (enum wc_HashType)type);
     }
+    WC_FREE_VAR_EX(hashCtx, ssl->heap, DYNAMIC_TYPE_HASHES);
     return ret;
 }
 
@@ -2131,8 +2135,10 @@ static const byte snLabel[SN_LABEL_SZ + 1] = "sn";
  */
 int Dtls13DeriveSnKeys(WOLFSSL* ssl, int provision)
 {
-    byte key_dig[MAX_PRF_DIG];
     int ret = 0;
+    WC_DECLARE_VAR(key_dig, byte, MAX_PRF_DIG, ssl->heap);
+    WC_ALLOC_VAR_EX(key_dig, byte, MAX_PRF_DIG, ssl->heap, DYNAMIC_TYPE_DIGEST,
+                    return MEMORY_E);
 
     if (provision & PROVISION_CLIENT) {
         WOLFSSL_MSG("Derive SN Client key");
@@ -2159,8 +2165,9 @@ int Dtls13DeriveSnKeys(WOLFSSL* ssl, int provision)
 end:
     ForceZero(key_dig, MAX_PRF_DIG);
 #ifdef WOLFSSL_CHECK_MEM_ZERO
-    wc_MemZero_Check(key_dig, sizeof(key_dig));
+    wc_MemZero_Check(key_dig, MAX_PRF_DIG);
 #endif
+    WC_FREE_VAR_EX(key_dig, ssl->heap, DYNAMIC_TYPE_DIGEST);
     return ret;
 }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -18602,55 +18602,75 @@ static int SetStaticEphemeralKey(WOLFSSL_CTX* ctx,
         #ifdef HAVE_ECC
             if (keyAlgo == WC_PK_TYPE_NONE) {
                 word32 idx = 0;
-                ecc_key eccKey;
-                ret = wc_ecc_init_ex(&eccKey, heap, INVALID_DEVID);
+                WC_DECLARE_VAR(eccKey, ecc_key, 1, heap);
+                WC_ALLOC_VAR_EX(eccKey, ecc_key, 1, heap, DYNAMIC_TYPE_ECC,
+                                ret = MEMORY_E);
+                if (ret == 0)
+                    ret = wc_ecc_init_ex(eccKey, heap, INVALID_DEVID);
                 if (ret == 0) {
-                    ret = wc_EccPrivateKeyDecode(keyBuf, &idx, &eccKey, keySz);
+                    ret = wc_EccPrivateKeyDecode(keyBuf, &idx, eccKey, keySz);
                     if (ret == 0)
                         keyAlgo = WC_PK_TYPE_ECDH;
-                    wc_ecc_free(&eccKey);
+                    wc_ecc_free(eccKey);
+                    ret = 0; /* clear error to enable key-type detect cascade */
                 }
+                WC_FREE_VAR_EX(eccKey, heap, DYNAMIC_TYPE_ECC);
             }
         #endif
         #if !defined(NO_DH) && defined(WOLFSSL_DH_EXTRA)
             if (keyAlgo == WC_PK_TYPE_NONE) {
                 word32 idx = 0;
-                DhKey dhKey;
-                ret = wc_InitDhKey_ex(&dhKey, heap, INVALID_DEVID);
+                WC_DECLARE_VAR(dhKey, DhKey, 1, heap);
+                WC_ALLOC_VAR_EX(dhKey, DhKey, 1, heap, DYNAMIC_TYPE_DH,
+                                ret = MEMORY_E);
+                if (ret == 0)
+                    ret = wc_InitDhKey_ex(dhKey, heap, INVALID_DEVID);
                 if (ret == 0) {
-                    ret = wc_DhKeyDecode(keyBuf, &idx, &dhKey, keySz);
+                    ret = wc_DhKeyDecode(keyBuf, &idx, dhKey, keySz);
                     if (ret == 0)
                         keyAlgo = WC_PK_TYPE_DH;
-                    wc_FreeDhKey(&dhKey);
+                    wc_FreeDhKey(dhKey);
+                    ret = 0; /* clear error to enable key-type detect cascade */
                 }
+                WC_FREE_VAR_EX(dhKey, heap, DYNAMIC_TYPE_DH);
             }
         #endif
         #ifdef HAVE_CURVE25519
             if (keyAlgo == WC_PK_TYPE_NONE) {
                 word32 idx = 0;
-                curve25519_key x25519Key;
-                ret = wc_curve25519_init_ex(&x25519Key, heap, INVALID_DEVID);
+                WC_DECLARE_VAR(x25519Key, curve25519_key, 1, heap);
+                WC_ALLOC_VAR_EX(x25519Key, curve25519_key, 1, heap,
+                                DYNAMIC_TYPE_CURVE25519, ret = MEMORY_E);
+                if (ret == 0)
+                    ret = wc_curve25519_init_ex(x25519Key, heap, INVALID_DEVID);
                 if (ret == 0) {
                     ret = wc_Curve25519PrivateKeyDecode(keyBuf, &idx,
-                        &x25519Key, keySz);
+                        x25519Key, keySz);
                     if (ret == 0)
                         keyAlgo = WC_PK_TYPE_CURVE25519;
-                    wc_curve25519_free(&x25519Key);
+                    wc_curve25519_free(x25519Key);
+                    ret = 0; /* clear error to enable key-type detect cascade */
                 }
+                WC_FREE_VAR_EX(x25519Key, heap, DYNAMIC_TYPE_CURVE25519);
             }
         #endif
         #ifdef HAVE_CURVE448
             if (keyAlgo == WC_PK_TYPE_NONE) {
                 word32 idx = 0;
-                curve448_key x448Key;
-                ret = wc_curve448_init(&x448Key);
+                WC_DECLARE_VAR(x448Key, curve448_key, 1, heap);
+                WC_ALLOC_VAR_EX(x448Key, curve448_key, 1, heap,
+                                DYNAMIC_TYPE_CURVE448, ret = MEMORY_E);
+                if (ret == 0)
+                    ret = wc_curve448_init(x448Key);
                 if (ret == 0) {
-                    ret = wc_Curve448PrivateKeyDecode(keyBuf, &idx, &x448Key,
+                    ret = wc_Curve448PrivateKeyDecode(keyBuf, &idx, x448Key,
                         keySz);
                     if (ret == 0)
                         keyAlgo = WC_PK_TYPE_CURVE448;
-                    wc_curve448_free(&x448Key);
+                    wc_curve448_free(x448Key);
+                    ret = 0; /* clear error to enable key-type detect cascade */
                 }
+                WC_FREE_VAR_EX(x448Key, heap, DYNAMIC_TYPE_CURVE448);
             }
         #endif
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -987,29 +987,33 @@ static int Hmac_HashFinalRaw(Hmac* hmac, unsigned char* hash)
 static int Hmac_OuterHash(Hmac* hmac, unsigned char* mac)
 {
     int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
-    wc_HashAlg hash;
+    WC_DECLARE_VAR(hash, wc_HashAlg, 1, hmac ? hmac->heap : NULL);
     enum wc_HashType hashType = (enum wc_HashType)hmac->macType;
     int digestSz = wc_HashGetDigestSize(hashType);
     int blockSz = wc_HashGetBlockSize(hashType);
 
+    WC_ALLOC_VAR_EX(hash, wc_HashAlg, 1, hmac->heap, DYNAMIC_TYPE_HASHES,
+                    return MEMORY_E);
+
     if ((digestSz >= 0) && (blockSz >= 0)) {
-        ret = wc_HashInit(&hash, hashType);
+        ret = wc_HashInit(hash, hashType);
     }
     else {
         ret = BAD_FUNC_ARG;
     }
 
     if (ret == 0) {
-        ret = wc_HashUpdate(&hash, hashType, (byte*)hmac->opad,
+        ret = wc_HashUpdate(hash, hashType, (byte*)hmac->opad,
             (word32)blockSz);
         if (ret == 0)
-            ret = wc_HashUpdate(&hash, hashType, (byte*)hmac->innerHash,
+            ret = wc_HashUpdate(hash, hashType, (byte*)hmac->innerHash,
                 (word32)digestSz);
         if (ret == 0)
-            ret = wc_HashFinal(&hash, hashType, mac);
-        wc_HashFree(&hash, hashType);
+            ret = wc_HashFinal(hash, hashType, mac);
+        wc_HashFree(hash, hashType);
     }
 
+    WC_FREE_VAR_EX(hash, hmac->heap, DYNAMIC_TYPE_HASHES);
     return ret;
 }
 
@@ -1382,7 +1386,7 @@ static int TLS_hmac_SetInner(WOLFSSL* ssl, byte* inner, word32* innerSz,
 int TLS_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz, int padSz,
              int content, int verify, int epochOrder)
 {
-    Hmac   hmac;
+    WC_DECLARE_VAR(hmac, Hmac, 1, ssl ? ssl->heap : NULL);
     byte   myInner[TLS_HMAC_INNER_SZ];
     word32 innerSz = TLS_HMAC_INNER_SZ;
     int    ret = 0;
@@ -1392,6 +1396,9 @@ int TLS_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz, int padSz,
 
     if (ssl == NULL)
         return BAD_FUNC_ARG;
+
+    WC_ALLOC_VAR_EX(hmac, Hmac, 1, ssl->heap, DYNAMIC_TYPE_HMAC,
+                    return MEMORY_E);
 
 #ifdef HAVE_TRUNCATED_HMAC
     hashSz = ssl->truncated_hmac ? (byte)TRUNCATED_HMAC_SZ
@@ -1407,6 +1414,7 @@ int TLS_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz, int padSz,
         if (!WC_SAFE_SUM_WORD32(sz, hashSz, hmacSz) ||
             !WC_SAFE_SUM_WORD32(hmacSz, (word32)padSz, hmacSz) ||
             !WC_SAFE_SUM_WORD32(hmacSz, 1, hmacSz)) {
+            WC_FREE_VAR_EX(hmac, ssl->heap, DYNAMIC_TYPE_HMAC);
             return BUFFER_E;
         }
         totalSz = hmacSz;
@@ -1427,12 +1435,16 @@ int TLS_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz, int padSz,
 
     ret = TLS_hmac_SetInner(ssl, myInner, &innerSz, sz, content, verify,
                             epochOrder);
-    if (ret != 0)
+    if (ret != 0) {
+        WC_FREE_VAR_EX(hmac, ssl->heap, DYNAMIC_TYPE_HMAC);
         return ret;
+    }
 
-    ret = wc_HmacInit(&hmac, ssl->heap, ssl->devId);
-    if (ret != 0)
+    ret = wc_HmacInit(hmac, ssl->heap, ssl->devId);
+    if (ret != 0) {
+        WC_FREE_VAR_EX(hmac, ssl->heap, DYNAMIC_TYPE_HMAC);
         return ret;
+    }
 
 
 #ifdef WOLFSSL_DTLS
@@ -1441,7 +1453,7 @@ int TLS_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz, int padSz,
     else
 #endif
         macSecret = wolfSSL_GetMacSecret(ssl, verify);
-    ret = wc_HmacSetKey(&hmac, wolfSSL_GetHmacType(ssl),
+    ret = wc_HmacSetKey(hmac, wolfSSL_GetHmacType(ssl),
                                               macSecret,
                                               ssl->specs.hash_size);
 
@@ -1452,32 +1464,33 @@ int TLS_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz, int padSz,
     !defined(HAVE_SELFTEST)
     #ifdef HAVE_BLAKE2B
             if (wolfSSL_GetHmacType(ssl) == WC_HASH_TYPE_BLAKE2B) {
-                ret = Hmac_UpdateFinal(&hmac, digest, in,
+                ret = Hmac_UpdateFinal(hmac, digest, in,
                         totalSz, myInner, innerSz);
             }
             else
     #endif
             {
-                ret = Hmac_UpdateFinal_CT(&hmac, digest, in,
+                ret = Hmac_UpdateFinal_CT(hmac, digest, in,
                                       totalSz,
                                       (int)hashSz, myInner, innerSz);
 
             }
 #else
-            ret = Hmac_UpdateFinal(&hmac, digest, in, totalSz,
+            ret = Hmac_UpdateFinal(hmac, digest, in, totalSz,
                                         myInner, innerSz);
 #endif
         }
         else {
-            ret = wc_HmacUpdate(&hmac, myInner, innerSz);
+            ret = wc_HmacUpdate(hmac, myInner, innerSz);
             if (ret == 0)
-                ret = wc_HmacUpdate(&hmac, in, sz);                /* content */
+                ret = wc_HmacUpdate(hmac, in, sz);                /* content */
             if (ret == 0)
-                ret = wc_HmacFinal(&hmac, digest);
+                ret = wc_HmacFinal(hmac, digest);
         }
     }
 
-    wc_HmacFree(&hmac);
+    wc_HmacFree(hmac);
+    WC_FREE_VAR_EX(hmac, ssl->heap, DYNAMIC_TYPE_HMAC);
 
     return ret;
 }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3611,7 +3611,7 @@ int CreateCookieExt(const WOLFSSL* ssl, byte* hash, word16 hashSz,
 {
     int  ret;
     byte mac[WC_MAX_DIGEST_SIZE] = {0};
-    Hmac cookieHmac;
+    WC_DECLARE_VAR(cookieHmac, Hmac, 1, ssl->heap);
     byte cookieType = 0;
     byte macSz = 0;
     byte cookie[OPAQUE8_LEN + WC_MAX_DIGEST_SIZE + OPAQUE16_LEN * 2];
@@ -3661,29 +3661,33 @@ int CreateCookieExt(const WOLFSSL* ssl, byte* hash, word16 hashSz,
     #error "No digest to available to use with HMAC for cookies."
 #endif /* NO_SHA */
 
-    ret = wc_HmacInit(&cookieHmac, ssl->heap, ssl->devId);
+    WC_ALLOC_VAR_EX(cookieHmac, Hmac, 1, ssl->heap, DYNAMIC_TYPE_HMAC,
+                    return MEMORY_E);
+
+    ret = wc_HmacInit(cookieHmac, ssl->heap, ssl->devId);
     if (ret == 0) {
-        ret = wc_HmacSetKey(&cookieHmac, cookieType,
+        ret = wc_HmacSetKey(cookieHmac, cookieType,
                             ssl->buffers.tls13CookieSecret.buffer,
                             ssl->buffers.tls13CookieSecret.length);
     }
     if (ret == 0)
-        ret = wc_HmacUpdate(&cookieHmac, cookie, cookieSz);
+        ret = wc_HmacUpdate(cookieHmac, cookie, cookieSz);
 #ifdef WOLFSSL_DTLS13
     /* Tie cookie to peer address */
     if (ret == 0) {
         /* peerLock not necessary. Still in handshake phase. */
         if (ssl->options.dtls && ssl->buffers.dtlsCtx.peer.sz > 0) {
-            ret = wc_HmacUpdate(&cookieHmac,
+            ret = wc_HmacUpdate(cookieHmac,
                 (byte*)ssl->buffers.dtlsCtx.peer.sa,
                 ssl->buffers.dtlsCtx.peer.sz);
         }
     }
 #endif
     if (ret == 0)
-        ret = wc_HmacFinal(&cookieHmac, mac);
+        ret = wc_HmacFinal(cookieHmac, mac);
 
-    wc_HmacFree(&cookieHmac);
+    wc_HmacFree(cookieHmac);
+    WC_FREE_VAR_EX(cookieHmac, ssl->heap, DYNAMIC_TYPE_HMAC);
     if (ret != 0)
         return ret;
 
@@ -6672,7 +6676,7 @@ int TlsCheckCookie(const WOLFSSL* ssl, const byte* cookie, word16 cookieSz)
 {
     int  ret;
     byte mac[WC_MAX_DIGEST_SIZE] = {0};
-    Hmac cookieHmac;
+    WC_DECLARE_VAR(cookieHmac, Hmac, 1, ssl->heap);
     byte cookieType = 0;
     byte macSz = 0;
 
@@ -6702,29 +6706,33 @@ int TlsCheckCookie(const WOLFSSL* ssl, const byte* cookie, word16 cookieSz)
         return HRR_COOKIE_ERROR;
     cookieSz -= macSz;
 
-    ret = wc_HmacInit(&cookieHmac, ssl->heap, ssl->devId);
+    WC_ALLOC_VAR_EX(cookieHmac, Hmac, 1, ssl->heap, DYNAMIC_TYPE_HMAC,
+                    return MEMORY_E);
+
+    ret = wc_HmacInit(cookieHmac, ssl->heap, ssl->devId);
     if (ret == 0) {
-        ret = wc_HmacSetKey(&cookieHmac, cookieType,
+        ret = wc_HmacSetKey(cookieHmac, cookieType,
                             ssl->buffers.tls13CookieSecret.buffer,
                             ssl->buffers.tls13CookieSecret.length);
     }
     if (ret == 0)
-        ret = wc_HmacUpdate(&cookieHmac, cookie, cookieSz);
+        ret = wc_HmacUpdate(cookieHmac, cookie, cookieSz);
 #ifdef WOLFSSL_DTLS13
     /* Tie cookie to peer address */
     if (ret == 0) {
         /* peerLock not necessary. Still in handshake phase. */
         if (ssl->options.dtls && ssl->buffers.dtlsCtx.peer.sz > 0) {
-            ret = wc_HmacUpdate(&cookieHmac,
+            ret = wc_HmacUpdate(cookieHmac,
                 (byte*)ssl->buffers.dtlsCtx.peer.sa,
                 ssl->buffers.dtlsCtx.peer.sz);
         }
     }
 #endif
     if (ret == 0)
-        ret = wc_HmacFinal(&cookieHmac, mac);
+        ret = wc_HmacFinal(cookieHmac, mac);
 
-    wc_HmacFree(&cookieHmac);
+    wc_HmacFree(cookieHmac);
+    WC_FREE_VAR_EX(cookieHmac, ssl->heap, DYNAMIC_TYPE_HMAC);
     if (ret != 0)
         return ret;
 

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -3617,7 +3617,10 @@ static int dilithium_rej_bound_poly(wc_Shake* shake256, byte* seed, sword32* s,
 #else
     int ret;
     unsigned int j = 0;
-    byte z[DILITHIUM_GEN_S_BYTES];
+    WC_DECLARE_VAR(z, byte, DILITHIUM_GEN_S_BYTES, NULL);
+
+    WC_ALLOC_VAR_EX(z, byte, DILITHIUM_GEN_S_BYTES, NULL, DYNAMIC_TYPE_DILITHIUM,
+                    return MEMORY_E);
 
     /* Absorb seed and squeeze out some blocks. */
     ret = dilithium_squeeze256(shake256, seed, DILITHIUM_GEN_S_SEED_SZ, z,
@@ -3638,6 +3641,7 @@ static int dilithium_rej_bound_poly(wc_Shake* shake256, byte* seed, sword32* s,
         }
     }
 
+    WC_FREE_VAR_EX(z, NULL, DYNAMIC_TYPE_DILITHIUM);
     return ret;
 #endif
 }
@@ -4444,7 +4448,10 @@ static int dilithium_vec_expand_mask_c(wc_Shake* shake256, byte* seed,
 {
     int ret = 0;
     byte r;
-    byte v[DILITHIUM_MAX_V];
+    WC_DECLARE_VAR(v, byte, DILITHIUM_MAX_V, NULL);
+
+    WC_ALLOC_VAR_EX(v, byte, DILITHIUM_MAX_V, NULL, DYNAMIC_TYPE_DILITHIUM,
+                    return MEMORY_E);
 
     /* Step 2: For each polynomial of vector. */
     for (r = 0; (ret == 0) && (r < l); r++) {
@@ -4464,6 +4471,7 @@ static int dilithium_vec_expand_mask_c(wc_Shake* shake256, byte* seed,
         }
     }
 
+    WC_FREE_VAR_EX(v, NULL, DYNAMIC_TYPE_DILITHIUM);
     return ret;
 }
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5210,9 +5210,13 @@ int wc_ecc_shared_secret_ex(ecc_key* private_key, ecc_point* point,
                             byte* out, word32 *outlen)
 {
     int err;
-    ecc_key public_key;
+    WC_DECLARE_VAR(public_key, ecc_key, 1,
+                   private_key ? private_key->heap : NULL);
 
-    err = wc_ecc_init_ex(&public_key, private_key->heap, INVALID_DEVID);
+    WC_ALLOC_VAR_EX(public_key, ecc_key, 1, private_key->heap, DYNAMIC_TYPE_ECC,
+                    return MEMORY_E);
+
+    err = wc_ecc_init_ex(public_key, private_key->heap, INVALID_DEVID);
     if (err == MP_OKAY) {
         #if FIPS_VERSION3_GE(6,0,0)
         /* Since we are allowing a pass-through of ecc_make_key_ex_fips when
@@ -5233,24 +5237,25 @@ int wc_ecc_shared_secret_ex(ecc_key* private_key, ecc_point* point,
         }
         if (err == 0) { /* FIPS specific check */
         #endif
-        err = wc_ecc_set_curve(&public_key, private_key->dp->size,
+        err = wc_ecc_set_curve(public_key, private_key->dp->size,
                                private_key->dp->id);
         if (err == MP_OKAY) {
-            err = mp_copy(point->x, public_key.pubkey.x);
+            err = mp_copy(point->x, public_key->pubkey.x);
         }
         #if FIPS_VERSION3_GE(6,0,0)
         } /* end FIPS specific check */
         #endif
         if (err == MP_OKAY) {
-            err = mp_copy(point->y, public_key.pubkey.y);
+            err = mp_copy(point->y, public_key->pubkey.y);
         }
         if (err == MP_OKAY) {
-            err = wc_ecc_shared_secret(private_key, &public_key, out, outlen);
+            err = wc_ecc_shared_secret(private_key, public_key, out, outlen);
         }
 
-        wc_ecc_free(&public_key);
+        wc_ecc_free(public_key);
     }
 
+    WC_FREE_VAR_EX(public_key, private_key->heap, DYNAMIC_TYPE_ECC);
     return err;
 }
 #endif /* !WOLFSSL_ATECC508A && !WOLFSSL_CRYPTOCELL && !WOLFSSL_KCAPI_ECC */
@@ -7529,31 +7534,35 @@ static int _HMAC_K(byte* K, word32 KSz, byte* V, word32 VSz,
         const byte* h1, word32 h1Sz, byte* x, word32 xSz, byte* oct,
         byte* out, enum wc_HashType hashType, void* heap)
 {
-    Hmac hmac;
+    WC_DECLARE_VAR(hmac, Hmac, 1, heap);
     int  ret, init;
 
-    ret = init = wc_HmacInit(&hmac, heap, INVALID_DEVID);
+    WC_ALLOC_VAR_EX(hmac, Hmac, 1, heap, DYNAMIC_TYPE_HMAC,
+                    return MEMORY_E);
+
+    ret = init = wc_HmacInit(hmac, heap, INVALID_DEVID);
     if (ret == 0)
-        ret = wc_HmacSetKey(&hmac, (int)hashType, K, KSz);
+        ret = wc_HmacSetKey(hmac, (int)hashType, K, KSz);
 
     if (ret == 0)
-        ret = wc_HmacUpdate(&hmac, V, VSz);
+        ret = wc_HmacUpdate(hmac, V, VSz);
 
     if (ret == 0 && oct != NULL)
-        ret = wc_HmacUpdate(&hmac, oct, 1);
+        ret = wc_HmacUpdate(hmac, oct, 1);
 
     if (ret == 0)
-        ret = wc_HmacUpdate(&hmac, x, xSz);
+        ret = wc_HmacUpdate(hmac, x, xSz);
 
     if (ret == 0)
-        ret = wc_HmacUpdate(&hmac, h1, h1Sz);
+        ret = wc_HmacUpdate(hmac, h1, h1Sz);
 
     if (ret == 0)
-        ret = wc_HmacFinal(&hmac, out);
+        ret = wc_HmacFinal(hmac, out);
 
     if (init == 0)
-        wc_HmacFree(&hmac);
+        wc_HmacFree(hmac);
 
+    WC_FREE_VAR_EX(hmac, heap, DYNAMIC_TYPE_HMAC);
     return ret;
 }
 

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -172,7 +172,7 @@ static int ed25519_hash(ed25519_key* key, const byte* in, word32 inLen,
 {
     int ret;
 #ifndef WOLFSSL_ED25519_PERSISTENT_SHA
-    wc_Sha512 sha[1];
+    WC_DECLARE_VAR(sha, wc_Sha512, 1, key ? key->heap : NULL);
 #else
     wc_Sha512 *sha;
 #endif
@@ -185,6 +185,8 @@ static int ed25519_hash(ed25519_key* key, const byte* in, word32 inLen,
     sha = &key->sha;
     ret = ed25519_hash_reset(key);
 #else
+    WC_ALLOC_VAR_EX(sha, wc_Sha512, 1, key->heap, DYNAMIC_TYPE_HASHES,
+                    return MEMORY_E);
     ret = ed25519_hash_init(key, sha);
 #endif
     if (ret == 0) {
@@ -197,6 +199,9 @@ static int ed25519_hash(ed25519_key* key, const byte* in, word32 inLen,
     #endif
     }
 
+#ifndef WOLFSSL_ED25519_PERSISTENT_SHA
+    WC_FREE_VAR_EX(sha, key->heap, DYNAMIC_TYPE_HASHES);
+#endif
     return ret;
 }
 
@@ -429,8 +434,11 @@ int wc_ed25519_sign_msg_ex(const byte* in, word32 inLen, byte* out,
 #ifdef WOLFSSL_ED25519_PERSISTENT_SHA
         wc_Sha512 *sha = &key->sha;
 #else
-        wc_Sha512 sha[1];
-        ret = ed25519_hash_init(key, sha);
+        WC_DECLARE_VAR(sha, wc_Sha512, 1, key->heap);
+        WC_ALLOC_VAR_EX(sha, wc_Sha512, 1, key->heap, DYNAMIC_TYPE_HASHES,
+                        ret = MEMORY_E);
+        if (ret == 0)
+            ret = ed25519_hash_init(key, sha);
 #endif
 
         /* apply clamp */
@@ -457,6 +465,7 @@ int wc_ed25519_sign_msg_ex(const byte* in, word32 inLen, byte* out,
             ret = ed25519_hash_final(key, sha, nonce);
 #ifndef WOLFSSL_ED25519_PERSISTENT_SHA
         ed25519_hash_free(key, sha);
+        WC_FREE_VAR_EX(sha, key->heap, DYNAMIC_TYPE_HASHES);
 #endif
     }
 
@@ -485,8 +494,11 @@ int wc_ed25519_sign_msg_ex(const byte* in, word32 inLen, byte* out,
 #ifdef WOLFSSL_ED25519_PERSISTENT_SHA
         wc_Sha512 *sha = &key->sha;
 #else
-        wc_Sha512 sha[1];
-        ret = ed25519_hash_init(key, sha);
+        WC_DECLARE_VAR(sha, wc_Sha512, 1, key->heap);
+        WC_ALLOC_VAR_EX(sha, wc_Sha512, 1, key->heap, DYNAMIC_TYPE_HASHES,
+                        ret = MEMORY_E);
+        if (ret == 0)
+            ret = ed25519_hash_init(key, sha);
 #endif
 
         if (ret == 0 && (type == Ed25519ctx || type == Ed25519ph)) {
@@ -509,6 +521,7 @@ int wc_ed25519_sign_msg_ex(const byte* in, word32 inLen, byte* out,
             ret = ed25519_hash_final(key, sha, hram);
 #ifndef WOLFSSL_ED25519_PERSISTENT_SHA
         ed25519_hash_free(key, sha);
+        WC_FREE_VAR_EX(sha, key->heap, DYNAMIC_TYPE_HASHES);
 #endif
     }
 
@@ -895,7 +908,7 @@ int wc_ed25519_verify_msg_ex(const byte* sig, word32 sigLen, const byte* msg,
 #ifdef WOLFSSL_ED25519_PERSISTENT_SHA
     wc_Sha512 *sha;
 #else
-    wc_Sha512 sha[1];
+    WC_DECLARE_VAR(sha, wc_Sha512, 1, key ? key->heap : NULL);
 #endif
 
     /* sanity check on arguments */
@@ -922,8 +935,11 @@ int wc_ed25519_verify_msg_ex(const byte* sig, word32 sigLen, const byte* msg,
 #ifdef WOLFSSL_ED25519_PERSISTENT_SHA
     sha = &key->sha;
 #else
+    WC_ALLOC_VAR_EX(sha, wc_Sha512, 1, key->heap, DYNAMIC_TYPE_HASHES,
+                    return MEMORY_E);
     ret = ed25519_hash_init(key, sha);
     if (ret < 0) {
+        WC_FREE_VAR_EX(sha, key->heap, DYNAMIC_TYPE_HASHES);
         return ret;
     }
 #endif /* WOLFSSL_ED25519_PERSISTENT_SHA */
@@ -937,6 +953,7 @@ int wc_ed25519_verify_msg_ex(const byte* sig, word32 sigLen, const byte* msg,
 
 #ifndef WOLFSSL_ED25519_PERSISTENT_SHA
     ed25519_hash_free(key, sha);
+    WC_FREE_VAR_EX(sha, key->heap, DYNAMIC_TYPE_HASHES);
 #endif
 #endif /* WOLFSSL_SE050 */
     return ret;

--- a/wolfcrypt/src/ed448.c
+++ b/wolfcrypt/src/ed448.c
@@ -152,7 +152,7 @@ static int ed448_hash(ed448_key* key, const byte* in, word32 inLen,
 {
     int ret;
 #ifndef WOLFSSL_ED448_PERSISTENT_SHA
-    wc_Shake sha[1];
+    WC_DECLARE_VAR(sha, wc_Shake, 1, key ? key->heap : NULL);
 #else
     wc_Shake *sha;
 #endif
@@ -165,10 +165,16 @@ static int ed448_hash(ed448_key* key, const byte* in, word32 inLen,
     sha = &key->sha;
     ret = ed448_hash_reset(key);
 #else
+    WC_ALLOC_VAR_EX(sha, wc_Shake, 1, key->heap, DYNAMIC_TYPE_HASHES,
+                    return MEMORY_E);
     ret = ed448_hash_init(key, sha);
 #endif
-    if (ret < 0)
+    if (ret < 0) {
+    #ifndef WOLFSSL_ED448_PERSISTENT_SHA
+        WC_FREE_VAR_EX(sha, key->heap, DYNAMIC_TYPE_HASHES);
+    #endif
         return ret;
+    }
 
     ret = ed448_hash_update(key, sha, in, inLen);
     if (ret == 0)
@@ -176,6 +182,7 @@ static int ed448_hash(ed448_key* key, const byte* in, word32 inLen,
 
 #ifndef WOLFSSL_ED448_PERSISTENT_SHA
     ed448_hash_free(key, sha);
+    WC_FREE_VAR_EX(sha, key->heap, DYNAMIC_TYPE_HASHES);
 #endif
 
     return ret;
@@ -358,6 +365,9 @@ int wc_ed448_sign_msg_ex(const byte* in, word32 inLen, byte* out,
 #ifdef WOLFSSL_EDDSA_CHECK_PRIV_ON_SIGN
     byte     orig_k[ED448_KEY_SIZE];
 #endif
+#ifndef WOLFSSL_ED448_PERSISTENT_SHA
+    WC_DECLARE_VAR(sha, wc_Shake, 1, key ? key->heap : NULL);
+#endif
 
     /* sanity check on arguments */
     if ((in == NULL) || (out == NULL) || (outLen == NULL) || (key == NULL) ||
@@ -397,8 +407,10 @@ int wc_ed448_sign_msg_ex(const byte* in, word32 inLen, byte* out,
 #ifdef WOLFSSL_ED448_PERSISTENT_SHA
         wc_Shake *sha = &key->sha;
 #else
-        wc_Shake sha[1];
-        ret = ed448_hash_init(key, sha);
+        WC_ALLOC_VAR_EX(sha, wc_Shake, 1, key->heap, DYNAMIC_TYPE_HASHES,
+                        ret = MEMORY_E);
+        if (ret == 0)
+            ret = ed448_hash_init(key, sha);
 #endif
         /* apply clamp */
         az[0]  &= 0xfc;
@@ -434,7 +446,6 @@ int wc_ed448_sign_msg_ex(const byte* in, word32 inLen, byte* out,
 #ifdef WOLFSSL_ED448_PERSISTENT_SHA
         wc_Shake *sha = &key->sha;
 #else
-        wc_Shake sha[1];
         ret = ed448_hash_init(key, sha);
 #endif
         if (ret == 0)
@@ -476,6 +487,9 @@ int wc_ed448_sign_msg_ex(const byte* in, word32 inLen, byte* out,
         ed448_hash_free(key, sha);
 #endif
     }
+#ifndef WOLFSSL_ED448_PERSISTENT_SHA
+    WC_FREE_VAR_EX(sha, key->heap, DYNAMIC_TYPE_HASHES);
+#endif
 
     if (ret == 0) {
         sc448_reduce(hram);
@@ -807,7 +821,7 @@ int wc_ed448_verify_msg_ex(const byte* sig, word32 sigLen, const byte* msg,
 #ifdef WOLFSSL_ED448_PERSISTENT_SHA
     wc_Shake *sha;
 #else
-    wc_Shake sha[1];
+    WC_DECLARE_VAR(sha, wc_Shake, 1, key ? key->heap : NULL);
 #endif
 
     if (key == NULL)
@@ -822,9 +836,13 @@ int wc_ed448_verify_msg_ex(const byte* sig, word32 sigLen, const byte* msg,
 #ifdef WOLFSSL_ED448_PERSISTENT_SHA
     sha = &key->sha;
 #else
+    WC_ALLOC_VAR_EX(sha, wc_Shake, 1, key->heap, DYNAMIC_TYPE_HASHES,
+                    return MEMORY_E);
     ret = ed448_hash_init(key, sha);
-    if (ret < 0)
+    if (ret < 0) {
+        WC_FREE_VAR_EX(sha, key->heap, DYNAMIC_TYPE_HASHES);
         return ret;
+    }
 #endif
 
     ret = ed448_verify_msg_init_with_sha(sig, sigLen, key, sha,
@@ -836,6 +854,7 @@ int wc_ed448_verify_msg_ex(const byte* sig, word32 sigLen, const byte* msg,
 
 #ifndef WOLFSSL_ED448_PERSISTENT_SHA
     ed448_hash_free(key, sha);
+    WC_FREE_VAR_EX(sha, key->heap, DYNAMIC_TYPE_HASHES);
 #endif
 
     return ret;

--- a/wolfcrypt/src/falcon.c
+++ b/wolfcrypt/src/falcon.c
@@ -810,9 +810,10 @@ int wc_Falcon_PrivateKeyDecode(const byte* input, word32* inOutIdx,
                                      falcon_key* key, word32 inSz)
 {
     int ret = 0;
-    byte privKey[FALCON_MAX_PRV_KEY_SIZE], pubKey[FALCON_MAX_PUB_KEY_SIZE];
-    word32 privKeyLen = (word32)sizeof(privKey);
-    word32 pubKeyLen = (word32)sizeof(pubKey);
+    byte* privKey = NULL;
+    byte* pubKey = NULL;
+    word32 privKeyLen = FALCON_MAX_PRV_KEY_SIZE;
+    word32 pubKeyLen = FALCON_MAX_PUB_KEY_SIZE;
     int keytype = 0;
 
     if (input == NULL || inOutIdx == NULL || key == NULL || inSz == 0) {
@@ -829,6 +830,17 @@ int wc_Falcon_PrivateKeyDecode(const byte* input, word32* inOutIdx,
         return BAD_FUNC_ARG;
     }
 
+    privKey = (byte*)XMALLOC(FALCON_MAX_PRV_KEY_SIZE, NULL,
+                             DYNAMIC_TYPE_TMP_BUFFER);
+    if (privKey == NULL)
+        return MEMORY_E;
+    pubKey = (byte*)XMALLOC(FALCON_MAX_PUB_KEY_SIZE, NULL,
+                            DYNAMIC_TYPE_TMP_BUFFER);
+    if (pubKey == NULL) {
+        XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        return MEMORY_E;
+    }
+
     ret = DecodeAsymKey(input, inOutIdx, inSz, privKey, &privKeyLen,
                         pubKey, &pubKeyLen, keytype);
     if (ret == 0) {
@@ -840,6 +852,9 @@ int wc_Falcon_PrivateKeyDecode(const byte* input, word32* inOutIdx,
                                                pubKeyLen, key);
         }
     }
+
+    XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(pubKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     return ret;
 }
 
@@ -847,8 +862,8 @@ int wc_Falcon_PublicKeyDecode(const byte* input, word32* inOutIdx,
                                     falcon_key* key, word32 inSz)
 {
     int ret = 0;
-    byte pubKey[FALCON_MAX_PUB_KEY_SIZE];
-    word32 pubKeyLen = (word32)sizeof(pubKey);
+    WC_DECLARE_VAR(pubKey, byte, FALCON_MAX_PUB_KEY_SIZE, NULL);
+    word32 pubKeyLen = FALCON_MAX_PUB_KEY_SIZE;
     int keytype = 0;
 
     if (input == NULL || inOutIdx == NULL || key == NULL || inSz == 0) {
@@ -870,11 +885,16 @@ int wc_Falcon_PublicKeyDecode(const byte* input, word32* inOutIdx,
         return BAD_FUNC_ARG;
     }
 
+    WC_ALLOC_VAR_EX(pubKey, byte, FALCON_MAX_PUB_KEY_SIZE, NULL,
+                    DYNAMIC_TYPE_TMP_BUFFER, return MEMORY_E);
+
     ret = DecodeAsymKeyPublic(input, inOutIdx, inSz, pubKey, &pubKeyLen,
                               keytype);
     if (ret == 0) {
         ret = wc_falcon_import_public(pubKey, pubKeyLen, key);
     }
+
+    WC_FREE_VAR_EX(pubKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     return ret;
 }
 
@@ -895,8 +915,8 @@ int wc_Falcon_PublicKeyToDer(falcon_key* key, byte* output, word32 inLen,
                              int withAlg)
 {
     int    ret;
-    byte   pubKey[FALCON_MAX_PUB_KEY_SIZE];
-    word32 pubKeyLen = (word32)sizeof(pubKey);
+    WC_DECLARE_VAR(pubKey, byte, FALCON_MAX_PUB_KEY_SIZE, NULL);
+    word32 pubKeyLen = FALCON_MAX_PUB_KEY_SIZE;
     int    keytype = 0;
 
     if (key == NULL) {
@@ -913,12 +933,16 @@ int wc_Falcon_PublicKeyToDer(falcon_key* key, byte* output, word32 inLen,
         return BAD_FUNC_ARG;
     }
 
+    WC_ALLOC_VAR_EX(pubKey, byte, FALCON_MAX_PUB_KEY_SIZE, NULL,
+                    DYNAMIC_TYPE_TMP_BUFFER, return MEMORY_E);
+
     ret = wc_falcon_export_public(key, pubKey, &pubKeyLen);
     if (ret == 0) {
         ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, inLen, keytype,
                                   withAlg);
     }
 
+    WC_FREE_VAR_EX(pubKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     return ret;
 }
 #endif

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -229,13 +229,8 @@ int wc_PRF_TLSv1(byte* digest, word32 digLen, const byte* secret,
     const byte* md5_half;
     const byte* sha_half;
     byte*      md5_result;
-#ifdef WOLFSSL_SMALL_STACK
-    byte*      sha_result;
-    byte*      labelSeed;
-#else
-    byte       sha_result[MAX_PRF_DIG];    /* digLen is real size */
-    byte       labelSeed[MAX_PRF_LABSEED];
-#endif
+    WC_DECLARE_VAR(sha_result, byte, MAX_PRF_DIG, heap); /* digLen is real size */
+    WC_DECLARE_VAR(labelSeed, byte, MAX_PRF_LABSEED, heap);
 
     if (half > MAX_PRF_HALF ||
         labLen + seedLen > MAX_PRF_LABSEED ||
@@ -244,15 +239,11 @@ int wc_PRF_TLSv1(byte* digest, word32 digLen, const byte* secret,
         return BUFFER_E;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    sha_result = (byte*)XMALLOC(MAX_PRF_DIG, heap, DYNAMIC_TYPE_DIGEST);
-    labelSeed = (byte*)XMALLOC(MAX_PRF_LABSEED, heap, DYNAMIC_TYPE_DIGEST);
-    if (sha_result == NULL || labelSeed == NULL) {
-        XFREE(sha_result, heap, DYNAMIC_TYPE_DIGEST);
-        XFREE(labelSeed, heap, DYNAMIC_TYPE_DIGEST);
-        return MEMORY_E;
-    }
-#endif
+    WC_ALLOC_VAR_EX(sha_result, byte, MAX_PRF_DIG, heap, DYNAMIC_TYPE_DIGEST,
+                    return MEMORY_E);
+    WC_ALLOC_VAR_EX(labelSeed, byte, MAX_PRF_LABSEED, heap, DYNAMIC_TYPE_DIGEST,
+                    { WC_FREE_VAR_EX(sha_result, heap, DYNAMIC_TYPE_DIGEST);
+                      return MEMORY_E; });
 
     md5_half = secret;
     sha_half = secret + half - secLen % 2;
@@ -1335,24 +1326,30 @@ static int wc_KDA_KDF_iteration(const byte* z, word32 zSz, word32 counter,
     byte* output)
 {
     byte counterBuf[4];
-    wc_HashAlg hash;
+    WC_DECLARE_VAR(hash, wc_HashAlg, 1, NULL);
     int ret;
 
-    ret = wc_HashInit(&hash, hashType);
-    if (ret != 0)
+    WC_ALLOC_VAR_EX(hash, wc_HashAlg, 1, NULL, DYNAMIC_TYPE_HASHES,
+                    return MEMORY_E);
+
+    ret = wc_HashInit(hash, hashType);
+    if (ret != 0) {
+        WC_FREE_VAR_EX(hash, NULL, DYNAMIC_TYPE_HASHES);
         return ret;
+    }
     c32toa(counter, counterBuf);
-    ret = wc_HashUpdate(&hash, hashType, counterBuf, 4);
+    ret = wc_HashUpdate(hash, hashType, counterBuf, 4);
     if (ret == 0) {
-        ret = wc_HashUpdate(&hash, hashType, z, zSz);
+        ret = wc_HashUpdate(hash, hashType, z, zSz);
     }
     if (ret == 0 && fixedInfoSz > 0) {
-        ret = wc_HashUpdate(&hash, hashType, fixedInfo, fixedInfoSz);
+        ret = wc_HashUpdate(hash, hashType, fixedInfo, fixedInfoSz);
     }
     if (ret == 0) {
-        ret = wc_HashFinal(&hash, hashType, output);
+        ret = wc_HashFinal(hash, hashType, output);
     }
-    wc_HashFree(&hash, hashType);
+    wc_HashFree(hash, hashType);
+    WC_FREE_VAR_EX(hash, NULL, DYNAMIC_TYPE_HASHES);
     return ret;
 }
 

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -532,14 +532,15 @@ exit_gsd:
 static int wc_PKCS12_create_mac(WC_PKCS12* pkcs12, byte* data, word32 dataSz,
                          const byte* psw, word32 pswSz, byte* out, word32 outSz)
 {
-    Hmac     hmac;
+    WC_DECLARE_VAR(hmac, Hmac, 1, pkcs12 ? pkcs12->heap : NULL);
+    WC_DECLARE_VAR(unicodePasswd, byte, MAX_UNICODE_SZ,
+                   pkcs12 ? pkcs12->heap : NULL);
     MacData* mac;
     int ret, kLen;
     enum wc_HashType hashT;
     int idx = 0;
     int id  = 3; /* value from RFC 7292 indicating key is used for MAC */
     word32 i;
-    byte unicodePasswd[MAX_UNICODE_SZ];
     byte key[PKCS_MAX_KEY_SIZE];
 
     if (pkcs12 == NULL || pkcs12->signData == NULL || data == NULL ||
@@ -549,10 +550,18 @@ static int wc_PKCS12_create_mac(WC_PKCS12* pkcs12, byte* data, word32 dataSz,
 
     mac = pkcs12->signData;
 
+    WC_ALLOC_VAR_EX(unicodePasswd, byte, MAX_UNICODE_SZ, pkcs12->heap,
+                    DYNAMIC_TYPE_TMP_BUFFER, return MEMORY_E);
+    WC_ALLOC_VAR_EX(hmac, Hmac, 1, pkcs12->heap, DYNAMIC_TYPE_HMAC,
+                    { WC_FREE_VAR_EX(unicodePasswd, pkcs12->heap,
+                                     DYNAMIC_TYPE_TMP_BUFFER);
+                      return MEMORY_E; });
+
     /* unicode set up from asn.c */
-    if ((pswSz * 2 + 2) > (int)sizeof(unicodePasswd)) {
+    if ((pswSz * 2 + 2) > MAX_UNICODE_SZ) {
         WOLFSSL_MSG("PKCS12 max unicode size too small");
-        return UNICODE_SIZE_E;
+        ret = UNICODE_SIZE_E;
+        goto exit_mac;
     }
 
     for (i = 0; i < pswSz; i++) {
@@ -566,41 +575,44 @@ static int wc_PKCS12_create_mac(WC_PKCS12* pkcs12, byte* data, word32 dataSz,
     /* get hash type used and resulting size of HMAC key */
     hashT = wc_OidGetHash((int)mac->oid);
     if (hashT == WC_HASH_TYPE_NONE) {
-        ForceZero(unicodePasswd, MAX_UNICODE_SZ);
         WOLFSSL_MSG("Unsupported hash used");
-        return BAD_FUNC_ARG;
+        ret = BAD_FUNC_ARG;
+        goto exit_mac;
     }
     kLen = wc_HashGetDigestSize(hashT);
 
     /* check out buffer is large enough */
     if (kLen < 0 || outSz < (word32)kLen) {
-        ForceZero(unicodePasswd, MAX_UNICODE_SZ);
-        return BAD_FUNC_ARG;
+        ret = BAD_FUNC_ARG;
+        goto exit_mac;
     }
 
     /* idx contains size of unicodePasswd */
     ret = wc_PKCS12_PBKDF_ex(key, unicodePasswd, idx, mac->salt, (int)mac->saltSz,
                                   mac->itt, kLen, (int)hashT, id, pkcs12->heap);
-    ForceZero(unicodePasswd, MAX_UNICODE_SZ);
     if (ret < 0) {
-        return ret;
+        goto exit_mac;
     }
 
     /* now that key has been created use it to get HMAC hash on data */
-    if ((ret = wc_HmacInit(&hmac, pkcs12->heap, INVALID_DEVID)) != 0) {
-        return ret;
+    if ((ret = wc_HmacInit(hmac, pkcs12->heap, INVALID_DEVID)) != 0) {
+        goto exit_mac;
     }
-    ret = wc_HmacSetKey(&hmac, (int)hashT, key, (word32)kLen);
+    ret = wc_HmacSetKey(hmac, (int)hashT, key, (word32)kLen);
     if (ret == 0)
-        ret = wc_HmacUpdate(&hmac, data, dataSz);
+        ret = wc_HmacUpdate(hmac, data, dataSz);
     if (ret == 0)
-        ret = wc_HmacFinal(&hmac, out);
-    wc_HmacFree(&hmac);
+        ret = wc_HmacFinal(hmac, out);
+    wc_HmacFree(hmac);
 
-    if (ret != 0)
-        return ret;
+    if (ret == 0)
+        ret = kLen; /* same as digest size */
 
-    return kLen; /* same as digest size */
+exit_mac:
+    ForceZero(unicodePasswd, MAX_UNICODE_SZ);
+    WC_FREE_VAR_EX(unicodePasswd, pkcs12->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    WC_FREE_VAR_EX(hmac, pkcs12->heap, DYNAMIC_TYPE_HMAC);
+    return ret;
 }
 
 /* check mac on pkcs12, pkcs12->mac has been sanity checked before entering *

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -3800,24 +3800,30 @@ int wc_PKCS7_EncodeSignedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
         int hashSz;
         enum wc_HashType hashType;
         byte hashBuf[WC_MAX_DIGEST_SIZE];
-        wc_HashAlg hash;
+        WC_DECLARE_VAR(hash, wc_HashAlg, 1, pkcs7->heap);
+
+        WC_ALLOC_VAR_EX(hash, wc_HashAlg, 1, pkcs7->heap, DYNAMIC_TYPE_HASHES,
+                        return MEMORY_E);
 
         /* get hash type and size, validate hashOID */
         hashType = wc_OidGetHash(pkcs7->hashOID);
         hashSz = wc_HashGetDigestSize(hashType);
-        if (hashSz < 0)
+        if (hashSz < 0) {
+            WC_FREE_VAR_EX(hash, pkcs7->heap, DYNAMIC_TYPE_HASHES);
             return hashSz;
+        }
 
         /* calculate hash for content */
-        ret = wc_HashInit(&hash, hashType);
+        ret = wc_HashInit(hash, hashType);
         if (ret == 0) {
-            ret = wc_HashUpdate(&hash, hashType,
+            ret = wc_HashUpdate(hash, hashType,
                             pkcs7->content, pkcs7->contentSz);
             if (ret == 0) {
-                ret = wc_HashFinal(&hash, hashType, hashBuf);
+                ret = wc_HashFinal(hash, hashType, hashBuf);
             }
-            wc_HashFree(&hash, hashType);
+            wc_HashFree(hash, hashType);
         }
+        WC_FREE_VAR_EX(hash, pkcs7->heap, DYNAMIC_TYPE_HASHES);
         if (ret == 0) {
             ret = PKCS7_EncodeSigned(pkcs7, hashBuf, (word32)hashSz,
                 output, &outputSz, NULL, NULL);
@@ -4709,8 +4715,7 @@ static int wc_PKCS7_BuildSignedDataDigest(wc_PKCS7* pkcs7, byte* signedAttrib,
     byte algoId[MAX_ALGO_SZ];
     word32 digestInfoSeqSz, digestStrSz, algoIdSz;
     WC_DECLARE_VAR(digestInfo, byte, MAX_PKCS7_DIGEST_SZ, 0);
-
-    wc_HashAlg hash;
+    WC_DECLARE_VAR(hash, wc_HashAlg, 1, pkcs7 ? pkcs7->heap : NULL);
     enum wc_HashType hashType;
 
     /* check arguments */
@@ -4740,6 +4745,9 @@ static int wc_PKCS7_BuildSignedDataDigest(wc_PKCS7* pkcs7, byte* signedAttrib,
 
     WC_ALLOC_VAR_EX(digestInfo, byte, MAX_PKCS7_DIGEST_SZ, pkcs7->heap,
         DYNAMIC_TYPE_TMP_BUFFER, return MEMORY_E);
+    WC_ALLOC_VAR_EX(hash, wc_HashAlg, 1, pkcs7->heap, DYNAMIC_TYPE_HASHES,
+        { WC_FREE_VAR_EX(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+          return MEMORY_E; });
 
     XMEMSET(pkcs7Digest, 0, *pkcs7DigestSz);
     XMEMSET(digest,      0, WC_MAX_DIGEST_SIZE);
@@ -4751,9 +4759,10 @@ static int wc_PKCS7_BuildSignedDataDigest(wc_PKCS7* pkcs7, byte* signedAttrib,
         XMEMCPY(digest, hashBuf, hashBufSz);
     }
     else {
-        ret = wc_HashInit(&hash, hashType);
+        ret = wc_HashInit(hash, hashType);
         if (ret < 0) {
             WC_FREE_VAR_EX(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+            WC_FREE_VAR_EX(hash, pkcs7->heap, DYNAMIC_TYPE_HASHES);
             return ret;
         }
 
@@ -4761,20 +4770,21 @@ static int wc_PKCS7_BuildSignedDataDigest(wc_PKCS7* pkcs7, byte* signedAttrib,
             attribSetSz = SetSet(signedAttribSz, attribSet);
 
             /* calculate digest */
-            ret = wc_HashUpdate(&hash, hashType, attribSet, attribSetSz);
+            ret = wc_HashUpdate(hash, hashType, attribSet, attribSetSz);
             if (ret == 0)
-                ret = wc_HashUpdate(&hash, hashType, signedAttrib, signedAttribSz);
+                ret = wc_HashUpdate(hash, hashType, signedAttrib, signedAttribSz);
             if (ret == 0)
-                ret = wc_HashFinal(&hash, hashType, digest);
+                ret = wc_HashFinal(hash, hashType, digest);
         } else {
-            ret = wc_HashUpdate(&hash, hashType, pkcs7->content, pkcs7->contentSz);
+            ret = wc_HashUpdate(hash, hashType, pkcs7->content, pkcs7->contentSz);
             if (ret == 0)
-                ret = wc_HashFinal(&hash, hashType, digest);
+                ret = wc_HashFinal(hash, hashType, digest);
         }
 
-        wc_HashFree(&hash, hashType);
+        wc_HashFree(hash, hashType);
         if (ret < 0) {
             WC_FREE_VAR_EX(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+            WC_FREE_VAR_EX(hash, pkcs7->heap, DYNAMIC_TYPE_HASHES);
             return ret;
         }
     }
@@ -4804,6 +4814,7 @@ static int wc_PKCS7_BuildSignedDataDigest(wc_PKCS7* pkcs7, byte* signedAttrib,
     *plainDigestSz = hashSz;
 
     WC_FREE_VAR_EX(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    WC_FREE_VAR_EX(hash, pkcs7->heap, DYNAMIC_TYPE_HASHES);
     return 0;
 }
 

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -891,12 +891,22 @@ int wc_RNG_TestSeed(const byte* seed, word32 seedSz)
      * all counts to prevent timing side-channels.
      */
     {
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SMALL_STACK_CACHE)
+        word16* byteCounts = NULL;
+    #else
         word16 byteCounts[MAX_ENTROPY_BITS];
+    #endif
         word32 windowSize = min(seedSz, (word32)WC_RNG_SEED_APT_WINDOW);
         word32 windowStart = 0;
         word32 newIdx;
 
-        XMEMSET(byteCounts, 0, sizeof(byteCounts));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SMALL_STACK_CACHE)
+        byteCounts = (word16*)XMALLOC(MAX_ENTROPY_BITS * sizeof(word16), NULL,
+                                      DYNAMIC_TYPE_TMP_BUFFER);
+        if (byteCounts == NULL)
+            return MEMORY_E;
+    #endif
+        XMEMSET(byteCounts, 0, MAX_ENTROPY_BITS * sizeof(word16));
 
         /* Initialize counts for first window */
         for (i = 0; i < windowSize; i++) {
@@ -921,6 +931,10 @@ int wc_RNG_TestSeed(const byte* seed, word32 seedSz)
             /* Accumulate failure flag for new byte's count */
             aptFailed |= (byteCounts[seed[newIdx]] >= WC_RNG_SEED_APT_CUTOFF);
         }
+
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SMALL_STACK_CACHE)
+        XFREE(byteCounts, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    #endif
     }
 
     /* Set return code based on accumulated failure flags */

--- a/wolfcrypt/src/sakke.c
+++ b/wolfcrypt/src/sakke.c
@@ -6018,14 +6018,17 @@ static int sakke_modexp_loop(SakkeKey* key, const mp_int* b, mp_int* e,
     mp_int* t2 = &key->tmp.m2;
     mp_int* by = key->tmp.p1->z;
     mp_int* prime = &key->params.prime;
-    unsigned char eb[128];
+    WC_DECLARE_VAR(eb, unsigned char, SAKKE_EB_BUF_SIZE, key->heap);
     int i;
     int y;
+
+    WC_ALLOC_VAR_EX(eb, unsigned char, SAKKE_EB_BUF_SIZE, key->heap,
+                    DYNAMIC_TYPE_TMP_BUFFER, return MEMORY_E);
 
     /* Use table for values of b exponentiated. */
     (void)b;
 
-    (void)mp_to_unsigned_bin_len(e, eb, sizeof(eb));
+    (void)mp_to_unsigned_bin_len(e, eb, SAKKE_EB_BUF_SIZE);
 
     /* Set the working value to the base in PF_p[q] */
     err = mp_montgomery_calc_normalization(c->x, prime);
@@ -6058,6 +6061,7 @@ static int sakke_modexp_loop(SakkeKey* key, const mp_int* b, mp_int* e,
         }
     }
 
+    WC_FREE_VAR_EX(eb, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     return err;
 }
 #endif /* WOLFSSL_SAKKE_SMALL */

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -1354,16 +1354,21 @@ static int wc_Sha3Copy(wc_Sha3* src, wc_Sha3* dst)
 static int wc_Sha3GetHash(wc_Sha3* sha3, byte* hash, byte p, byte len)
 {
     int ret;
-    wc_Sha3 tmpSha3;
+    WC_DECLARE_VAR(tmpSha3, wc_Sha3, 1, sha3 ? sha3->heap : NULL);
 
     if (sha3 == NULL || hash == NULL)
         return BAD_FUNC_ARG;
 
-    XMEMSET(&tmpSha3, 0, sizeof(tmpSha3));
-    ret = wc_Sha3Copy(sha3, &tmpSha3);
+    WC_ALLOC_VAR_EX(tmpSha3, wc_Sha3, 1, sha3->heap, DYNAMIC_TYPE_TMP_BUFFER,
+                    return MEMORY_E);
+
+    XMEMSET(tmpSha3, 0, sizeof(*tmpSha3));
+    ret = wc_Sha3Copy(sha3, tmpSha3);
     if (ret == 0) {
-        ret = wc_Sha3Final(&tmpSha3, hash, p, len);
+        ret = wc_Sha3Final(tmpSha3, hash, p, len);
     }
+
+    WC_FREE_VAR_EX(tmpSha3, sha3->heap, DYNAMIC_TYPE_TMP_BUFFER);
     return ret;
 }
 

--- a/wolfssl/wolfcrypt/sakke.h
+++ b/wolfssl/wolfcrypt/sakke.h
@@ -40,6 +40,7 @@
 #define WOLFCRYPT_SAKKE_CLIENT
 
 #define SAKKE_ID_MAX_SIZE       128
+#define SAKKE_EB_BUF_SIZE       128
 
 /* Maximum number of loops of attempting to generate a key. */
 #ifndef SAKKE_MAX_GEN_COUNT


### PR DESCRIPTION
Make sure buffers larger than around 100 bytes are allocated on the heap when `WOLFSSL_SMALL_STACK` is defined. 

Follow-up for zd#21610, fixes zd#21642.