### PR TITLE
Add negative-count and NULL checks to group-setting and shared-cipher APIs

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1274,10 +1274,12 @@ const char* wolfSSL_get_shared_ciphers(WOLFSSL* ssl, char* buf, int len)
 {
     const char* cipher;
 
-    if (ssl == NULL || len <= 0)
+    if (ssl == NULL || buf == NULL || len <= 0)
         return NULL;
 
     cipher = wolfSSL_get_cipher_name_iana(ssl);
+    if (cipher == NULL)
+        return NULL;
     len = (int)min((word32)len, (word32)(XSTRLEN(cipher) + 1));
     XMEMCPY(buf, cipher, (size_t)len);
     return buf;
@@ -3302,8 +3304,8 @@ int  wolfSSL_CTX_set1_groups(WOLFSSL_CTX* ctx, int* groups,
     int i;
     int _groups[WOLFSSL_MAX_GROUP_COUNT];
     WOLFSSL_ENTER("wolfSSL_CTX_set1_groups");
-    if (count == 0) {
-        WOLFSSL_MSG("Group count is zero");
+    if (groups == NULL || count <= 0) {
+        WOLFSSL_MSG("Group count is zero or negative");
         return WOLFSSL_FAILURE;
     }
     if (count > WOLFSSL_MAX_GROUP_COUNT) {
@@ -3341,8 +3343,8 @@ int  wolfSSL_set1_groups(WOLFSSL* ssl, int* groups, int count)
     int i;
     int _groups[WOLFSSL_MAX_GROUP_COUNT];
     WOLFSSL_ENTER("wolfSSL_CTX_set1_groups");
-    if (count == 0) {
-        WOLFSSL_MSG("Group count is zero");
+    if (groups == NULL || count <= 0) {
+        WOLFSSL_MSG("Group count is zero or negative");
         return WOLFSSL_FAILURE;
     }
     if (count > WOLFSSL_MAX_GROUP_COUNT) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3361,7 +3361,7 @@ int  wolfSSL_set1_groups(WOLFSSL* ssl, int* groups, int count)
 {
     int i;
     int _groups[WOLFSSL_MAX_GROUP_COUNT];
-    WOLFSSL_ENTER("wolfSSL_CTX_set1_groups");
+    WOLFSSL_ENTER("wolfSSL_set1_groups");
     if (groups == NULL || count <= 0) {
         WOLFSSL_MSG("Groups NULL or count not positive");
         return WOLFSSL_FAILURE;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1295,10 +1295,12 @@ const char* wolfSSL_get_shared_ciphers(WOLFSSL* ssl, char* buf, int len)
 {
     const char* cipher;
 
-    if (ssl == NULL || len <= 0)
+    if (ssl == NULL || buf == NULL || len <= 0)
         return NULL;
 
     cipher = wolfSSL_get_cipher_name_iana(ssl);
+    if (cipher == NULL)
+        return NULL;
     len = (int)min((word32)len, (word32)(XSTRLEN(cipher) + 1));
     XMEMCPY(buf, cipher, (size_t)len);
     return buf;
@@ -3321,8 +3323,8 @@ int  wolfSSL_CTX_set1_groups(WOLFSSL_CTX* ctx, int* groups,
     int i;
     int _groups[WOLFSSL_MAX_GROUP_COUNT];
     WOLFSSL_ENTER("wolfSSL_CTX_set1_groups");
-    if (count <= 0) {
-        WOLFSSL_MSG("Group count is not positive");
+    if (groups == NULL || count <= 0) {
+        WOLFSSL_MSG("Groups NULL or count not positive");
         return WOLFSSL_FAILURE;
     }
     if (count > WOLFSSL_MAX_GROUP_COUNT) {
@@ -3360,8 +3362,8 @@ int  wolfSSL_set1_groups(WOLFSSL* ssl, int* groups, int count)
     int i;
     int _groups[WOLFSSL_MAX_GROUP_COUNT];
     WOLFSSL_ENTER("wolfSSL_CTX_set1_groups");
-    if (count <= 0) {
-        WOLFSSL_MSG("Group count is not positive");
+    if (groups == NULL || count <= 0) {
+        WOLFSSL_MSG("Groups NULL or count not positive");
         return WOLFSSL_FAILURE;
     }
     if (count > WOLFSSL_MAX_GROUP_COUNT) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -405,7 +405,8 @@ int wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups, int count)
     int ret, i;
 
     WOLFSSL_ENTER("wolfSSL_CTX_set_groups");
-    if (ctx == NULL || groups == NULL || count > WOLFSSL_MAX_GROUP_COUNT)
+    if (ctx == NULL || groups == NULL || count < 0 ||
+            count > WOLFSSL_MAX_GROUP_COUNT)
         return BAD_FUNC_ARG;
     if (!IsTLS_ex(ctx->method->version))
         return BAD_FUNC_ARG;
@@ -450,7 +451,8 @@ int wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count)
     int ret, i;
 
     WOLFSSL_ENTER("wolfSSL_set_groups");
-    if (ssl == NULL || groups == NULL || count > WOLFSSL_MAX_GROUP_COUNT)
+    if (ssl == NULL || groups == NULL || count < 0 ||
+            count > WOLFSSL_MAX_GROUP_COUNT)
         return BAD_FUNC_ARG;
     if (!IsTLS_ex(ssl->version))
         return BAD_FUNC_ARG;

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -1357,25 +1357,25 @@ int test_wolfSSL_alert_type_string(void)
 int test_wolfSSL_get_shared_ciphers(void)
 {
     EXPECT_DECLS;
-#if !defined(WOLFSSL_NO_TLS12) && !defined(NO_TLS)
-#ifndef NO_WOLFSSL_CLIENT
+#if !defined(NO_TLS) && !defined(NO_WOLFSSL_CLIENT)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL*     ssl = NULL;
     char         buf[32];
 
-    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method()));
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
     ExpectNotNull(ssl = wolfSSL_new(ctx));
 
-    /* NULL ssl - pre-existing guard; pins the contract. */
     ExpectNull(wolfSSL_get_shared_ciphers(NULL, buf, sizeof(buf)));
-    /* NULL buf - primary regression case (pre-fix: XMEMCPY(NULL, ...) crash). */
     ExpectNull(wolfSSL_get_shared_ciphers(ssl, NULL, sizeof(buf)));
-    /* len == 0 - pre-existing guard; pins the contract. */
     ExpectNull(wolfSSL_get_shared_ciphers(ssl, buf, 0));
+#ifndef NO_ERROR_STRINGS
+    ExpectPtrEq(wolfSSL_get_shared_ciphers(ssl, buf, sizeof(buf)), buf);
+#else
+    ExpectNull(wolfSSL_get_shared_ciphers(ssl, buf, sizeof(buf)));
+#endif
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
-#endif /* NO_WOLFSSL_CLIENT */
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -1354,6 +1354,32 @@ int test_wolfSSL_alert_type_string(void)
     return EXPECT_RESULT();
 }
 
+int test_wolfSSL_get_shared_ciphers(void)
+{
+    EXPECT_DECLS;
+#if !defined(WOLFSSL_NO_TLS12) && !defined(NO_TLS)
+#ifndef NO_WOLFSSL_CLIENT
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL*     ssl = NULL;
+    char         buf[32];
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method()));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+
+    /* NULL ssl - pre-existing guard; pins the contract. */
+    ExpectNull(wolfSSL_get_shared_ciphers(NULL, buf, sizeof(buf)));
+    /* NULL buf - primary regression case (pre-fix: XMEMCPY(NULL, ...) crash). */
+    ExpectNull(wolfSSL_get_shared_ciphers(ssl, NULL, sizeof(buf)));
+    /* len == 0 - pre-existing guard; pins the contract. */
+    ExpectNull(wolfSSL_get_shared_ciphers(ssl, buf, 0));
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif /* NO_WOLFSSL_CLIENT */
+#endif
+    return EXPECT_RESULT();
+}
+
 /* Test the TLS 1.2 peerAuthGood fail-safe checks directly on both sides.
  * The client branch sets NO_PEER_VERIFY; the server branch returns a generic
  * fatal error from TICKET_SENT before sending its Finished. */

--- a/tests/api/test_tls.h
+++ b/tests/api/test_tls.h
@@ -43,6 +43,7 @@ int test_wolfSSL_alert_type_string(void);
 int test_wolfSSL_alert_desc_string(void);
 int test_record_size_matches_build_message(void);
 int test_record_size_cache_invalidated_on_renegotiation(void);
+int test_wolfSSL_get_shared_ciphers(void);
 
 #define TEST_TLS_DECLS                                                         \
         TEST_DECL_GROUP("tls", test_utils_memio_move_message),                 \
@@ -67,6 +68,7 @@ int test_record_size_cache_invalidated_on_renegotiation(void);
         TEST_DECL_GROUP("tls", test_tls12_peerauth_failsafe),                  \
         TEST_DECL_GROUP("tls", test_record_size_matches_build_message),        \
         TEST_DECL_GROUP("tls",                                                 \
-            test_record_size_cache_invalidated_on_renegotiation)
+            test_record_size_cache_invalidated_on_renegotiation),              \
+        TEST_DECL_GROUP("tls", test_wolfSSL_get_shared_ciphers)
 
 #endif /* TESTS_API_TEST_TLS_H */

--- a/tests/api/test_tls.h
+++ b/tests/api/test_tls.h
@@ -65,7 +65,6 @@ int test_wolfSSL_get_shared_ciphers(void);
         TEST_DECL_GROUP("tls", test_tls12_peerauth_failsafe),                  \
         TEST_DECL_GROUP("tls", test_wolfSSL_alert_type_string),                \
         TEST_DECL_GROUP("tls", test_wolfSSL_alert_desc_string),                \
-        TEST_DECL_GROUP("tls", test_tls12_peerauth_failsafe),                  \
         TEST_DECL_GROUP("tls", test_record_size_matches_build_message),        \
         TEST_DECL_GROUP("tls",                                                 \
             test_record_size_cache_invalidated_on_renegotiation),              \

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -590,10 +590,11 @@ int test_tls13_apis(void)
 #endif
     ExpectIntEQ(wolfSSL_CTX_set_groups(clientCtx, groups,
         WOLFSSL_MAX_GROUP_COUNT + 1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-    ExpectIntEQ(wolfSSL_CTX_set_groups(clientCtx, groups, -1),
-        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wolfSSL_CTX_set_groups(clientCtx, groups, numGroups),
         WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_set_groups(clientCtx, groups, -1),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(clientCtx->numGroups, numGroups);
     ExpectIntEQ(wolfSSL_CTX_set_groups(clientCtx, bad_groups, numGroups),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 #endif
@@ -619,10 +620,11 @@ int test_tls13_apis(void)
 #endif
     ExpectIntEQ(wolfSSL_set_groups(clientSsl, groups,
         WOLFSSL_MAX_GROUP_COUNT + 1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-    ExpectIntEQ(wolfSSL_set_groups(clientSsl, groups, -1),
-        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wolfSSL_set_groups(clientSsl, groups, numGroups),
         WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_set_groups(clientSsl, groups, -1),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(clientSsl->numGroups, numGroups);
     ExpectIntEQ(wolfSSL_set_groups(clientSsl, bad_groups, numGroups),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 #endif
@@ -656,6 +658,16 @@ int test_tls13_apis(void)
         WC_NO_ERR_TRACE(WOLFSSL_FAILURE));
     ExpectIntEQ(wolfSSL_set1_groups(clientSsl, NULL, 1),
         WC_NO_ERR_TRACE(WOLFSSL_FAILURE));
+    ExpectIntEQ(wolfSSL_CTX_set1_groups(clientCtx, groups, numGroups),
+        WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_set1_groups(clientCtx, groups, -1),
+        WC_NO_ERR_TRACE(WOLFSSL_FAILURE));
+    ExpectIntEQ(clientCtx->numGroups, numGroups);
+    ExpectIntEQ(wolfSSL_set1_groups(clientSsl, groups, numGroups),
+        WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_set1_groups(clientSsl, groups, -1),
+        WC_NO_ERR_TRACE(WOLFSSL_FAILURE));
+    ExpectIntEQ(clientSsl->numGroups, numGroups);
 #endif
 #ifndef NO_WOLFSSL_CLIENT
 #ifndef WOLFSSL_NO_TLS12

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -590,6 +590,8 @@ int test_tls13_apis(void)
 #endif
     ExpectIntEQ(wolfSSL_CTX_set_groups(clientCtx, groups,
         WOLFSSL_MAX_GROUP_COUNT + 1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wolfSSL_CTX_set_groups(clientCtx, groups, -1),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wolfSSL_CTX_set_groups(clientCtx, groups, numGroups),
         WOLFSSL_SUCCESS);
     ExpectIntEQ(wolfSSL_CTX_set_groups(clientCtx, bad_groups, numGroups),
@@ -617,6 +619,8 @@ int test_tls13_apis(void)
 #endif
     ExpectIntEQ(wolfSSL_set_groups(clientSsl, groups,
         WOLFSSL_MAX_GROUP_COUNT + 1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wolfSSL_set_groups(clientSsl, groups, -1),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wolfSSL_set_groups(clientSsl, groups, numGroups),
         WOLFSSL_SUCCESS);
     ExpectIntEQ(wolfSSL_set_groups(clientSsl, bad_groups, numGroups),
@@ -648,6 +652,10 @@ int test_tls13_apis(void)
         WOLFSSL_MAX_GROUP_COUNT + 1), WC_NO_ERR_TRACE(WOLFSSL_FAILURE));
     ExpectIntEQ(wolfSSL_set1_groups(clientSsl, too_many_groups,
         WOLFSSL_MAX_GROUP_COUNT + 1), WC_NO_ERR_TRACE(WOLFSSL_FAILURE));
+    ExpectIntEQ(wolfSSL_CTX_set1_groups(clientCtx, NULL, 1),
+        WC_NO_ERR_TRACE(WOLFSSL_FAILURE));
+    ExpectIntEQ(wolfSSL_set1_groups(clientSsl, NULL, 1),
+        WC_NO_ERR_TRACE(WOLFSSL_FAILURE));
 #endif
 #ifndef NO_WOLFSSL_CLIENT
 #ifndef WOLFSSL_NO_TLS12


### PR DESCRIPTION
- `wolfSSL_CTX_set_groups` / `wolfSSL_set_groups`: add `count < 0` to
  entry guard — negative count passes the upper-bound check and truncates
  to a garbage `numGroups` byte, causing OOB read during SSL init
- `wolfSSL_CTX_set1_groups` / `wolfSSL_set1_groups`: widen `count == 0`
  to `count <= 0` and add NULL `groups` check
- `wolfSSL_get_shared_ciphers`: add NULL checks for `buf` and
  `wolfSSL_get_cipher_name_iana` return value