### PR TITLE
fix: pem.test exit 1 on test failure

### DIFF
--- a/scripts/pem.test
+++ b/scripts/pem.test
@@ -457,3 +457,7 @@ fi
 # Cleanup temporaries
 do_cleanup
 
+if [ "$TEST_FAIL_CNT" != "0" ]; then
+    exit 1
+fi
+


### PR DESCRIPTION
## Summary

`scripts/pem.test` tracks `TEST_FAIL_CNT` and prints a `FAILURES` message when tests fail, but always exits 0 — making the script useless as an automated gate since test harnesses only see the exit code.

- Add `exit 1` after cleanup when `TEST_FAIL_CNT != 0`

## Test plan

- [ ] Run `scripts/pem.test` against a build where a test is expected to fail — confirm exit code is now 1
- [ ] Run `scripts/pem.test` against a clean passing build — confirm exit code is still 0

/cc @douzzer @SparkiDev for review