### PR TITLE
fix: ChaCha20-Poly1305 and XChaCha20-Poly1305 one-shot APIs allow empty plaintext

### DIFF
--- a/wolfcrypt/src/chacha20_poly1305.c
+++ b/wolfcrypt/src/chacha20_poly1305.c
@@ -93,11 +93,13 @@ int wc_ChaCha20Poly1305_Decrypt(
     WC_DECLARE_VAR(aead, ChaChaPoly_Aead, 1, 0);
     byte calculatedAuthTag[CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE];
 
-    /* Validate function arguments */
+    /* Validate function arguments.
+     * outPlaintext may be NULL when inCiphertextLen is 0
+     * (authentication-only, no plaintext to decrypt). */
     if (!inKey || !inIV ||
         (inCiphertextLen > 0 && inCiphertext == NULL) ||
         !inAuthTag ||
-        !outPlaintext)
+        (inCiphertextLen > 0 && !outPlaintext))
     {
         return BAD_FUNC_ARG;
     }
@@ -119,7 +121,7 @@ int wc_ChaCha20Poly1305_Decrypt(
     if (ret == 0)
         ret = wc_ChaCha20Poly1305_CheckTag(inAuthTag, calculatedAuthTag);
 
-    if (ret != 0) {
+    if (ret != 0 && inCiphertextLen > 0) {
         /* zero plaintext on error */
         ForceZero(outPlaintext, inCiphertextLen);
     }
@@ -229,7 +231,8 @@ int wc_ChaCha20Poly1305_UpdateData(ChaChaPoly_Aead* aead,
 {
     int ret = 0;
 
-    if (aead == NULL || inData == NULL || outData == NULL) {
+    if (aead == NULL ||
+        (dataLen > 0 && (inData == NULL || outData == NULL))) {
         return BAD_FUNC_ARG;
     }
     if (aead->state != CHACHA20_POLY1305_STATE_READY &&
@@ -249,7 +252,7 @@ int wc_ChaCha20Poly1305_UpdateData(ChaChaPoly_Aead* aead,
     aead->state = CHACHA20_POLY1305_STATE_DATA;
 
     /* Perform ChaCha20 encrypt/decrypt and Poly1305 auth calc */
-    if (ret == 0) {
+    if (ret == 0 && dataLen > 0) {
         if (aead->isEncrypt) {
             ret = wc_Chacha_Process(&aead->chacha, outData, inData, dataLen);
             if (ret == 0)
@@ -401,7 +404,7 @@ static WC_INLINE int wc_XChaCha20Poly1305_crypt_oneshot(
         dst_len = src_len - (size_t)POLY1305_DIGEST_SIZE;
     }
 
-    if ((dst == NULL) || (src == NULL)) {
+    if ((dst_len > 0 && dst == NULL) || (src == NULL)) {
         ret = BAD_FUNC_ARG;
         goto out;
     }

--- a/wolfcrypt/src/chacha20_poly1305.c
+++ b/wolfcrypt/src/chacha20_poly1305.c
@@ -93,11 +93,13 @@ int wc_ChaCha20Poly1305_Decrypt(
     WC_DECLARE_VAR(aead, ChaChaPoly_Aead, 1, 0);
     byte calculatedAuthTag[CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE];
 
-    /* Validate function arguments */
+    /* Validate function arguments.
+     * outPlaintext may be NULL when inCiphertextLen is 0
+     * (authentication-only, no plaintext to decrypt). */
     if (!inKey || !inIV ||
         (inCiphertextLen > 0 && inCiphertext == NULL) ||
         !inAuthTag ||
-        !outPlaintext)
+        (inCiphertextLen > 0 && !outPlaintext))
     {
         return BAD_FUNC_ARG;
     }
@@ -119,7 +121,7 @@ int wc_ChaCha20Poly1305_Decrypt(
     if (ret == 0)
         ret = wc_ChaCha20Poly1305_CheckTag(inAuthTag, calculatedAuthTag);
 
-    if (ret != 0) {
+    if (ret != 0 && inCiphertextLen > 0) {
         /* zero plaintext on error */
         ForceZero(outPlaintext, inCiphertextLen);
     }
@@ -229,7 +231,8 @@ int wc_ChaCha20Poly1305_UpdateData(ChaChaPoly_Aead* aead,
 {
     int ret = 0;
 
-    if (aead == NULL || inData == NULL || outData == NULL) {
+    if (aead == NULL ||
+        (dataLen > 0 && (inData == NULL || outData == NULL))) {
         return BAD_FUNC_ARG;
     }
     if (aead->state != CHACHA20_POLY1305_STATE_READY &&
@@ -249,7 +252,7 @@ int wc_ChaCha20Poly1305_UpdateData(ChaChaPoly_Aead* aead,
     aead->state = CHACHA20_POLY1305_STATE_DATA;
 
     /* Perform ChaCha20 encrypt/decrypt and Poly1305 auth calc */
-    if (ret == 0) {
+    if (ret == 0 && dataLen > 0) {
         if (aead->isEncrypt) {
             ret = wc_Chacha_Process(&aead->chacha, outData, inData, dataLen);
             if (ret == 0)
@@ -401,7 +404,7 @@ static WC_INLINE int wc_XChaCha20Poly1305_crypt_oneshot(
         dst_len = src_len - (size_t)POLY1305_DIGEST_SIZE;
     }
 
-    if ((dst == NULL) || (src == NULL)) {
+    if ((dst_len > 0 && dst == NULL) || (src_len > 0 && src == NULL)) {
         ret = BAD_FUNC_ARG;
         goto out;
     }


### PR DESCRIPTION
## Summary

Three functions rejected zero-length plaintext with `BAD_FUNC_ARG`:

1. `wc_ChaCha20Poly1305_Decrypt` — required `outPlaintext != NULL` even when `inCiphertextLen` is 0. RFC 8439 §2.8 permits empty plaintext (authentication-only mode).
2. `wc_ChaCha20Poly1305_UpdateData` — required `inData`/`outData != NULL` unconditionally, and called `wc_Chacha_Process` with NULL when `dataLen` is 0.
3. `wc_XChaCha20Poly1305_crypt_oneshot` — required `dst != NULL` even when `dst_len` is 0.

Also guards the `ForceZero` error-cleanup path in the one-shot decrypt, which would pass NULL to `ForceZero` on error with zero-length plaintext.

Note: the streaming Final() fix was a separate commit; this covers the one-shot and UpdateData paths.

Found via Wycheproof test vectors.

## Test plan
- [ ] Wycheproof ChaCha20-Poly1305 vectors with empty plaintext pass
- [ ] Existing ChaCha20-Poly1305 tests unaffected

/cc @wolfSSL-Fenrir-bot please review