### PR TITLE
fix: wc_SignatureVerify/Generate allow empty messages

### DIFF
--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -324,8 +324,10 @@ int wc_SignatureVerify(
     byte hash_data[MAX_DER_DIGEST_SZ];
 #endif
 
-    /* Check arguments */
-    if (data == NULL || data_len == 0 ||
+    /* Check arguments.
+     * data may be NULL when data_len is 0 (empty message is valid —
+     * the hash of an empty string is well-defined). */
+    if ((data == NULL && data_len > 0) ||
         sig == NULL || sig_len == 0 ||
         key == NULL || key_len == 0) {
         return BAD_FUNC_ARG;
@@ -523,8 +525,9 @@ int wc_SignatureGenerate_ex(
     byte hash_data[MAX_DER_DIGEST_SZ];
 #endif
 
-    /* Check arguments */
-    if (data == NULL || data_len == 0 ||
+    /* Check arguments.
+     * data may be NULL when data_len is 0 (signing an empty message). */
+    if ((data == NULL && data_len > 0) ||
         sig == NULL || sig_len == NULL || *sig_len == 0 ||
         key == NULL || key_len == 0) {
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -324,8 +324,10 @@ int wc_SignatureVerify(
     byte hash_data[MAX_DER_DIGEST_SZ];
 #endif
 
-    /* Check arguments */
-    if (data == NULL || data_len == 0 ||
+    /* Check arguments.
+     * data may be NULL when data_len is 0 (empty message is valid --
+     * the hash of an empty string is well-defined). */
+    if ((data == NULL && data_len > 0) ||
         sig == NULL || sig_len == 0 ||
         key == NULL || key_len == 0) {
         return BAD_FUNC_ARG;
@@ -523,8 +525,9 @@ int wc_SignatureGenerate_ex(
     byte hash_data[MAX_DER_DIGEST_SZ];
 #endif
 
-    /* Check arguments */
-    if (data == NULL || data_len == 0 ||
+    /* Check arguments.
+     * data may be NULL when data_len is 0 (signing an empty message). */
+    if ((data == NULL && data_len > 0) ||
         sig == NULL || sig_len == NULL || *sig_len == 0 ||
         key == NULL || key_len == 0) {
         return BAD_FUNC_ARG;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -23442,10 +23442,7 @@ static wc_test_ret_t rsa_sig_test(RsaKey* key, word32 keyLen, int modLen, WC_RNG
                                inLen, out, &sigSz, key, keyLen, rng);
     if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_sig);
-    ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
-                               0, out, &sigSz, key, keyLen, rng);
-    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_sig);
+    /* data_len==0 is valid (empty message); removed negative test */
     ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                                inLen, NULL, &sigSz, key, keyLen, rng);
     if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
@@ -23496,10 +23493,7 @@ static wc_test_ret_t rsa_sig_test(RsaKey* key, word32 keyLen, int modLen, WC_RNG
                              inLen, out, (word32)modLen, key, keyLen);
     if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_sig);
-    ret = wc_SignatureVerify(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
-                             0, out, (word32)modLen, key, keyLen);
-    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_sig);
+    /* data_len==0 is valid (empty message); removed negative test */
     ret = wc_SignatureVerify(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                              inLen, NULL, (word32)modLen, key, keyLen);
     if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))


### PR DESCRIPTION
## Summary

`wc_SignatureVerify` and `wc_SignatureGenerate_ex` rejected `data_len==0` with `BAD_FUNC_ARG`. Signing and verifying an empty message is valid — the hash of an empty string is well-defined for all supported hash algorithms, and PKCS#1 v1.5 / PSS impose no minimum message length.

`wc_Hash` already handles `NULL` data with `data_len==0` correctly (producing e.g. SHA-256 of `""`), so the only change needed is relaxing the argument check in the two wrapper functions.

Triggered by Wycheproof RSA PKCS#1 v1.5 test vectors where `tcId=1` in every file is a signature over an empty message.

## Test plan
- [ ] Wycheproof RSA PKCS#1 v1.5 `tcId=1` (empty message) vectors pass
- [ ] Existing signature verify/generate tests unaffected

/cc @wolfSSL-Fenrir-bot please review