### PR TITLE
fix: validate ML-DSA s1/s2 coefficient bounds in wc_dilithium_check_key

### DIFF
--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -11456,6 +11456,23 @@ int wc_dilithium_check_key(dilithium_key* key)
         /* Get s1, s2 and t0 from private key. */
         dilithium_vec_decode_eta_bits(s1p, params->eta, s1, params->l);
         dilithium_vec_decode_eta_bits(s2p, params->eta, s2, params->k);
+        /* Validate s1 and s2 coefficients are within [-eta, eta]. */
+        {
+            sword32 eta = (sword32)params->eta;
+            word32 c;
+            for (c = 0; c < (word32)(params->l * DILITHIUM_N); c++) {
+                if (s1[c] < -eta || s1[c] > eta) {
+                    ret = PUBLIC_KEY_E;
+                    break;
+                }
+            }
+            for (c = 0; (ret == 0) && (c < (word32)(params->k * DILITHIUM_N)); c++) {
+                if (s2[c] < -eta || s2[c] > eta) {
+                    ret = PUBLIC_KEY_E;
+                    break;
+                }
+            }
+        }
         dilithium_vec_decode_t0(t0p, params->k, t0);
 
         /* Get t1 from public key. */

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -11473,39 +11473,41 @@ int wc_dilithium_check_key(dilithium_key* key)
                 }
             }
         }
-        dilithium_vec_decode_t0(t0p, params->k, t0);
+        if (ret == 0) {
+            dilithium_vec_decode_t0(t0p, params->k, t0);
 
-        /* Get t1 from public key. */
-        dilithium_vec_decode_t1(t1p, params->k, t1);
+            /* Get t1 from public key. */
+            dilithium_vec_decode_t1(t1p, params->k, t1);
 
-        /* Calcaluate t = NTT-1(A o NTT(s1)) + s2 */
-        dilithium_vec_ntt_small_full(s1, params->l);
-        dilithium_matrix_mul(t, a, s1, params->k, params->l);
-    #ifdef WOLFSSL_DILITHIUM_SMALL
-        dilithium_vec_red(t, params->k);
-    #endif
-        dilithium_vec_invntt_full(t, params->k);
-        dilithium_vec_add(t, s2, params->k);
-        /* Subtract t0 from t. */
-        dilithium_vec_sub(t, t0, params->k);
-        /* Make t positive to match t1. */
-        dilithium_vec_make_pos(t, params->k);
+            /* Calcaluate t = NTT-1(A o NTT(s1)) + s2 */
+            dilithium_vec_ntt_small_full(s1, params->l);
+            dilithium_matrix_mul(t, a, s1, params->k, params->l);
+        #ifdef WOLFSSL_DILITHIUM_SMALL
+            dilithium_vec_red(t, params->k);
+        #endif
+            dilithium_vec_invntt_full(t, params->k);
+            dilithium_vec_add(t, s2, params->k);
+            /* Subtract t0 from t. */
+            dilithium_vec_sub(t, t0, params->k);
+            /* Make t positive to match t1. */
+            dilithium_vec_make_pos(t, params->k);
 
-        /* Check t - t0 and t1 are the same. */
-        for (i = 0; i < params->k; i++) {
-            for (j = 0; j < DILITHIUM_N; j++) {
-                x |= tt[j] ^ t1[j];
+            /* Check t - t0 and t1 are the same. */
+            for (i = 0; i < params->k; i++) {
+                for (j = 0; j < DILITHIUM_N; j++) {
+                    x |= tt[j] ^ t1[j];
+                }
+                tt += DILITHIUM_N;
+                t1 += DILITHIUM_N;
             }
-            tt += DILITHIUM_N;
-            t1 += DILITHIUM_N;
-        }
-        /* Check the public seed is the same in private and public key. */
-        for (i = 0; i < DILITHIUM_PUB_SEED_SZ; i++) {
-            x |= key->p[i] ^ key->k[i];
-        }
+            /* Check the public seed is the same in private and public key. */
+            for (i = 0; i < DILITHIUM_PUB_SEED_SZ; i++) {
+                x |= key->p[i] ^ key->k[i];
+            }
 
-        if ((ret == 0) && (x != 0)) {
-            ret = PUBLIC_KEY_E;
+            if (x != 0) {
+                ret = PUBLIC_KEY_E;
+            }
         }
     }
 

--- a/wolfcrypt/src/wc_mldsa.c
+++ b/wolfcrypt/src/wc_mldsa.c
@@ -12462,39 +12462,58 @@ int wc_MlDsaKey_CheckKey(wc_MlDsaKey* key)
         /* Get s1, s2 and t0 from private key. */
         mldsa_vec_decode_eta_bits(s1p, params->eta, s1, params->l);
         mldsa_vec_decode_eta_bits(s2p, params->eta, s2, params->k);
-        mldsa_vec_decode_t0(t0p, params->k, t0);
-
-        /* Get t1 from public key. */
-        mldsa_vec_decode_t1(t1p, params->k, t1);
-
-        /* Calcaluate t = NTT-1(A o NTT(s1)) + s2 */
-        mldsa_vec_ntt_small_full(s1, params->l);
-        mldsa_matrix_mul(t, a, s1, params->k, params->l);
-    #ifdef WOLFSSL_MLDSA_SMALL
-        mldsa_vec_red(t, params->k);
-    #endif
-        mldsa_vec_invntt_full(t, params->k);
-        mldsa_vec_add(t, s2, params->k);
-        /* Subtract t0 from t. */
-        mldsa_vec_sub(t, t0, params->k);
-        /* Make t positive to match t1. */
-        mldsa_vec_make_pos(t, params->k);
-
-        /* Check t - t0 and t1 are the same. */
-        for (i = 0; i < params->k; i++) {
-            for (j = 0; j < MLDSA_N; j++) {
-                x |= tt[j] ^ t1[j];
+        /* Validate s1 and s2 coefficients are within [-eta, eta]. */
+        {
+            sword32 eta = (sword32)params->eta;
+            word32 c;
+            for (c = 0; c < (word32)(params->l * MLDSA_N); c++) {
+                if (s1[c] < -eta || s1[c] > eta) {
+                    ret = PUBLIC_KEY_E;
+                    break;
+                }
             }
-            tt += MLDSA_N;
-            t1 += MLDSA_N;
+            for (c = 0; (ret == 0) && (c < (word32)(params->k * MLDSA_N)); c++) {
+                if (s2[c] < -eta || s2[c] > eta) {
+                    ret = PUBLIC_KEY_E;
+                    break;
+                }
+            }
         }
-        /* Check the public seed is the same in private and public key. */
-        for (i = 0; i < MLDSA_PUB_SEED_SZ; i++) {
-            x |= key->p[i] ^ key->k[i];
-        }
+        if (ret == 0) {
+            mldsa_vec_decode_t0(t0p, params->k, t0);
 
-        if (x != 0) {
-            ret = PUBLIC_KEY_E;
+            /* Get t1 from public key. */
+            mldsa_vec_decode_t1(t1p, params->k, t1);
+
+            /* Calculate t = NTT-1(A o NTT(s1)) + s2 */
+            mldsa_vec_ntt_small_full(s1, params->l);
+            mldsa_matrix_mul(t, a, s1, params->k, params->l);
+        #ifdef WOLFSSL_MLDSA_SMALL
+            mldsa_vec_red(t, params->k);
+        #endif
+            mldsa_vec_invntt_full(t, params->k);
+            mldsa_vec_add(t, s2, params->k);
+            /* Subtract t0 from t. */
+            mldsa_vec_sub(t, t0, params->k);
+            /* Make t positive to match t1. */
+            mldsa_vec_make_pos(t, params->k);
+
+            /* Check t - t0 and t1 are the same. */
+            for (i = 0; i < params->k; i++) {
+                for (j = 0; j < MLDSA_N; j++) {
+                    x |= tt[j] ^ t1[j];
+                }
+                tt += MLDSA_N;
+                t1 += MLDSA_N;
+            }
+            /* Check the public seed is the same in private and public key. */
+            for (i = 0; i < MLDSA_PUB_SEED_SZ; i++) {
+                x |= key->p[i] ^ key->k[i];
+            }
+
+            if (x != 0) {
+                ret = PUBLIC_KEY_E;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`dilithium_vec_decode_eta_bits` performs no bounds checking — it decodes raw bit fields and applies the formula without rejecting out-of-range values. For eta=2, 3-bit fields 5/6/7 (valid range 0–4) produce coefficients outside [-2, +2]. For eta=4, 4-bit nibbles 9–15 (valid range 0–8) produce coefficients outside [-4, +4]. Both are out of spec per FIPS 204 §7.2.

`wc_dilithium_check_key` had no coefficient range validation after decode. The mathematical consistency check (`As1 + s2 = t` mod q) validates algebraic structure, not coefficient range — a malformed key with out-of-range s1/s2 can still pass it.

**Commit 1:** After decoding s1/s2, validate every coefficient is in `[-eta, +eta]`. Sets `ret = PUBLIC_KEY_E` on first violation.

**Commit 2:** Wrap the NTT/matrix-multiply pipeline in `if (ret == 0)` so invalid coefficients are never fed to the NTT after the bounds check has already failed.

Found via Wycheproof ML-DSA `mldsa_*_sign_noseed_test.json` `InvalidPrivateKey` vectors.

## Test plan
- [ ] Wycheproof ML-DSA InvalidPrivateKey vectors correctly rejected
- [ ] Existing ML-DSA key check tests unaffected

/cc @wolfSSL-Fenrir-bot please review