### PR TITLE
fix: guard RsaUnPad_PSS masking when bits==0

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1882,8 +1882,15 @@ static int RsaUnPad_PSS(byte *pkcsBlock, unsigned int pkcsBlockLen,
         return ret;
     }
 
-    tmp[0] &= (byte)((1 << bits) - 1);
-    pkcsBlock[0] &= (byte)((1 << bits) - 1);
+    /* When bits==0 the key size is an exact multiple of 8 and pkcsBlock was
+     * already advanced past the leading 0x00 byte (see above); no masking is
+     * needed.  (1<<0)-1 == 0 would zero both bytes and corrupt the XOR
+     * separator check below.  RsaPad_PSS guards the same step with
+     * "if (hiBits)" for the same reason. */
+    if (bits) {
+        tmp[0] &= (byte)((1 << bits) - 1);
+        pkcsBlock[0] &= (byte)((1 << bits) - 1);
+    }
 #ifdef WOLFSSL_PSS_SALT_LEN_DISCOVER
     if (saltLen == RSA_PSS_SALT_LEN_DISCOVER) {
         for (i = 0; i < maskLen - 1; i++) {

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1977,8 +1977,16 @@ static int RsaUnPad_PSS(byte *pkcsBlock, unsigned int pkcsBlockLen,
         return ret;
     }
 
-    tmp[0] &= (byte)((1 << bits) - 1);
-    pkcsBlock[0] &= (byte)((1 << bits) - 1);
+    /* When bits==0, the modulus bit length is congruent to 1 mod 8, so
+     * the encoded block includes a leading 0x00 byte and pkcsBlock was
+     * already advanced past it (see above); no masking is needed.
+     * (1<<0)-1 == 0 would zero both bytes and corrupt the XOR separator
+     * check below.  RsaPad_PSS guards the same step with "if (hiBits)"
+     * for the same reason. */
+    if (bits) {
+        tmp[0] &= (byte)((1 << bits) - 1);
+        pkcsBlock[0] &= (byte)((1 << bits) - 1);
+    }
 #ifdef WOLFSSL_PSS_SALT_LEN_DISCOVER
     if (saltLen == RSA_PSS_SALT_LEN_DISCOVER) {
         for (i = 0; i < maskLen - 1; i++) {


### PR DESCRIPTION
## Summary

When `(mp_count_bits(n) - 1) & 0x7 == 0` (i.e. the modulus bit count is congruent to 1 mod 8 — e.g. a 2041-bit or 3073-bit key), `RsaUnPad_PSS` advances past the leading zero byte and then executes:

```c
tmp[0]       &= (byte)((1 << bits) - 1);   // bits == 0 → &= 0
pkcsBlock[0] &= (byte)((1 << bits) - 1);   // bits == 0 → &= 0
```

`(1 << 0) - 1 == 0` zeros both bytes, corrupting maskedDB[0] before the XOR separator comparison. `RsaPad_PSS` already guards the equivalent step with `if (hiBits)` for exactly this reason.

**Fix:** add `if (bits)` guard, mirroring `RsaPad_PSS`.

Standard power-of-two key sizes (1024, 2048, 4096-bit) are unaffected — their bit counts give `bits == 7` after the recomputation. The bug affects non-standard key sizes loaded from external DER where `mp_count_bits(n) % 8 == 1`. Cross-library PSS verification (verifying a Go/OpenSSL signature with wolfSSL) surfaces this asymmetry.

## Test plan
- [ ] PSS verify with a non-standard key (`mp_count_bits % 8 == 1`) against a signature from OpenSSL passes
- [ ] Existing RSA PSS verify tests unaffected

/cc @wolfSSL-Fenrir-bot please review