### PR TITLE
fix: correct sp_384/sp_521 div quotient when borrow hides in t1[0]

### DIFF
--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -31321,6 +31321,14 @@ static int sp_384_div_15(const sp_digit* a, const sp_digit* d,
             sp_384_norm_15(&t1[i + 1]);
         }
         sp_384_norm_15(t1);
+        /* Correction: at loop i=0, sp_384_norm_15(&t1[1]) skips t1[0], so a
+         * borrow there is invisible to the correction mask that checks t1[15].
+         * After the outer sp_384_norm_15(t1) the borrow lands in t1[14].
+         * Add sd back when t1[14] is negative. */
+        mask = (sp_digit)(t1[14] >> 31);
+        for (i = 0; i < 15; i++)
+            t1[i] += sd[i] & mask;
+        sp_384_norm_15(t1);
         sp_384_rshift_15(r, t1, 6);
     }
 
@@ -39031,6 +39039,14 @@ static int sp_521_div_21(const sp_digit* a, const sp_digit* d,
             sp_521_cond_sub_21(t1 + i, t1 + i, sd, mask);
             sp_521_norm_21(&t1[i + 1]);
         }
+        sp_521_norm_21(t1);
+        /* Correction: at loop i=0, sp_521_norm_21(&t1[1]) skips t1[0], so a
+         * borrow there is invisible to the correction mask that checks t1[21].
+         * After the outer sp_521_norm_21(t1) the borrow lands in t1[20].
+         * Add sd back when t1[20] is negative. */
+        mask = (sp_digit)(t1[20] >> 31);
+        for (i = 0; i < 21; i++)
+            t1[i] += sd[i] & mask;
         sp_521_norm_21(t1);
         sp_521_rshift_21(r, t1, 4);
     }

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -31191,6 +31191,14 @@ static int sp_384_div_7(const sp_digit* a, const sp_digit* d,
             sp_384_norm_7(&t1[i + 1]);
         }
         sp_384_norm_7(t1);
+        /* Correction: at loop i=0, sp_384_norm_7(&t1[1]) skips t1[0], so a
+         * borrow there is invisible to the correction mask that checks t1[7].
+         * After the outer sp_384_norm_7(t1) the borrow lands in t1[6].
+         * Add sd back when t1[6] is negative. */
+        mask = (sp_digit)(t1[6] >> 63);
+        for (i = 0; i < 7; i++)
+            t1[i] += sd[i] & mask;
+        sp_384_norm_7(t1);
         sp_384_rshift_7(r, t1, 1);
     }
 
@@ -38215,6 +38223,14 @@ static int sp_521_div_9(const sp_digit* a, const sp_digit* d,
             sp_521_cond_sub_9(t1 + i, t1 + i, sd, mask);
             sp_521_norm_9(&t1[i + 1]);
         }
+        sp_521_norm_9(t1);
+        /* Correction: at loop i=0, sp_521_norm_9(&t1[1]) skips t1[0], so a
+         * borrow there is invisible to the correction mask that checks t1[9].
+         * After the outer sp_521_norm_9(t1) the borrow lands in t1[8].
+         * Add sd back when t1[8] is negative. */
+        mask = (sp_digit)(t1[8] >> 63);
+        for (i = 0; i < 9; i++)
+            t1[i] += sd[i] & mask;
         sp_521_norm_9(t1);
         sp_521_rshift_9(r, t1, 1);
     }


### PR DESCRIPTION
## Summary

`sp_521_div_9` (sp_c64.c), `sp_521_div_21` (sp_c32.c), `sp_384_div_7` (sp_c64.c), and `sp_384_div_15` (sp_c32.c) all share the same quotient-correction loop structure. At iteration `i=0`, the loop calls `sp_N_norm_N(&t1[1])`, which normalises limbs `[1..N]` but skips `t1[0]`. A borrow that exists only in `t1[0]` after the subtraction is therefore invisible to the correction mask (which tests the sign of `t1[N]`). After the outer `sp_N_norm_N(t1)` at the end of the function, the hidden borrow resurfaces in the top limb, yielding a quotient one too small and a remainder that is one multiple of the divisor too large.

**Fix:** after the outer norm, test the sign of the top limb and add `sd` back once more when negative, then renormalise. `sp_256_div` uses a two-pass subtraction strategy and is unaffected.

**Reproducer:** Wycheproof secp521r1 ECDH `tcId 55` (EdgeCaseEphemeralKey, `x² ≡ -3 mod p`) returns the wrong shared secret without this fix.

## Test plan
- [ ] Wycheproof secp521r1 ECDH tcId 55 returns correct shared secret
- [ ] Wycheproof secp384r1 ECDH edge-case vectors pass
- [ ] Existing P-384 and P-521 ECDH/ECDSA tests unaffected

/cc @wolfSSL-Fenrir-bot please review