### PR TITLE
ci: add wycheproof vector test job

### DIFF
--- a/.github/workflows/wycheproof.yml
+++ b/.github/workflows/wycheproof.yml
@@ -1,0 +1,84 @@
+name: Wycheproof Vectors
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '**' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  wycheproof:
+    name: wycheproof vectors
+    if: github.repository_owner == 'wolfssl'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout wolfSSL
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            autoconf automake libtool cmake
+
+      - name: Build wolfSSL
+        run: |
+          autoreconf -i
+          ./configure \
+            --enable-cryptocb \
+            --enable-ecc \
+            --enable-aesgcm \
+            --enable-aesccm \
+            --enable-aeseax \
+            --enable-aessiv \
+            --enable-aesxts \
+            --enable-aeskeywrap \
+            --enable-siphash \
+            --enable-hkdf \
+            --enable-mldsa \
+            --enable-mlkem \
+            --enable-slhdsa \
+            --disable-examples
+          make -j$(nproc)
+
+      - name: Checkout wychcheck
+        uses: actions/checkout@v4
+        with:
+          repository: wolfSSL/wychcheck
+          ref: ${{ vars.WYCHCHECK_REF }}
+          path: wychcheck
+
+      - name: Init wycheproof vectors submodule
+        working-directory: wychcheck
+        run: git submodule update --init --depth 1 wycheproof
+
+      - name: Build wolfcrypt-check
+        working-directory: wychcheck
+        env:
+          WOLFSSL_DIR: ${{ github.workspace }}
+        run: |
+          cmake -B build
+          cmake --build build -j$(nproc)
+
+      - name: Run wycheproof tests
+        working-directory: wychcheck
+        run: |
+          ctest --test-dir build \
+            --output-on-failure \
+            --parallel $(nproc) \
+            --output-junit test-results.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wycheproof-results
+          path: wychcheck/test-results.xml


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/wycheproof.yml` which builds wolfSSL from the PR branch and runs it against the [wolfSSL/wychcheck](https://github.com/wolfSSL/wychcheck) test suite (340+ Wycheproof JSON test files, NIST ACVP vectors, and RFC vectors covering AES-GCM, AES-EAX, AES-SIV, ChaCha20-Poly1305, RSA-PSS, RSA-OAEP, ECDH/ECDSA over all curves, X25519, ML-DSA, ML-KEM, SLH-DSA, EdDSA)
- Guarded with `if: github.repository_owner == 'wolfssl'` per project convention
- Only inits the `wycheproof` submodule (not `acvp-server` which is 900 MB)
- Uploads JUnit XML results as a build artifact

## Relationship to wychcheck

`wolfSSL/wychcheck` already runs nightly against `wolfssl/wolfssl` master (Saturday 22:00 UTC). This job adds per-PR coverage so regressions are caught before merge rather than after.

## Test plan

- [ ] Verify job appears in PR checks
- [ ] Confirm `wolfcrypt-check` builds and ctest passes
- [ ] Confirm artifact upload contains `wycheproof-results/test-results.xml`