### PR TITLE
Harden wolfCrypt input validation and zeroization 

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -10062,8 +10062,11 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     int ret;
 
     /* argument checks */
-    if (aes == NULL || authTagSz > WC_AES_BLOCK_SIZE || ivSz == 0 ||
-        ((authTagSz > 0) && (authTag == NULL)) ||
+    /* If sz is non-zero, both in and out must be set; if sz is 0, in and
+     * out are don't cares (GMAC case), matching wc_AesGcmDecrypt. */
+    if (aes == NULL || iv == NULL || ivSz == 0 ||
+        (sz != 0 && (in == NULL || out == NULL)) ||
+        authTag == NULL || authTagSz > WC_AES_BLOCK_SIZE ||
         ((authInSz > 0) && (authIn == NULL)))
     {
         return BAD_FUNC_ARG;
@@ -17140,7 +17143,8 @@ int wc_AesEaxEncryptFinal(AesEax* eax, byte* authTag, word32 authTagSz)
     int ret;
     word32 i;
 
-    if (eax == NULL || authTag == NULL || authTagSz > WC_AES_BLOCK_SIZE) {
+    if (eax == NULL || authTag == NULL || authTagSz == 0 ||
+            authTagSz > WC_AES_BLOCK_SIZE) {
         return BAD_FUNC_ARG;
     }
 
@@ -17197,7 +17201,8 @@ int wc_AesEaxDecryptFinal(AesEax* eax,
     byte authTag[WC_AES_BLOCK_SIZE];
 #endif
 
-    if (eax == NULL || authIn == NULL || authInSz > WC_AES_BLOCK_SIZE) {
+    if (eax == NULL || authIn == NULL || authInSz == 0 ||
+            authInSz > WC_AES_BLOCK_SIZE) {
         return BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/arc4.c
+++ b/wolfcrypt/src/arc4.c
@@ -25,6 +25,13 @@
 
 #include <wolfssl/wolfcrypt/arc4.h>
 
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+
 
 int wc_Arc4SetKey(Arc4* arc4, const byte* key, word32 length)
 {
@@ -137,6 +144,10 @@ void wc_Arc4Free(Arc4* arc4)
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ARC4)
     wolfAsync_DevCtxFree(&arc4->asyncDev, WOLFSSL_ASYNC_MARKER_ARC4);
 #endif /* WOLFSSL_ASYNC_CRYPT */
+
+    ForceZero(arc4->state, sizeof(arc4->state));
+    arc4->x = 0;
+    arc4->y = 0;
 }
 
 #endif /* NO_RC4 */

--- a/wolfcrypt/src/camellia.c
+++ b/wolfcrypt/src/camellia.c
@@ -1521,7 +1521,7 @@ int wc_CamelliaSetKey(wc_Camellia* cam, const byte* key, word32 len, const byte*
 {
     int ret = 0;
 
-    if (cam == NULL) return BAD_FUNC_ARG;
+    if (cam == NULL || key == NULL) return BAD_FUNC_ARG;
 
     XMEMSET(cam->key, 0, WC_CAMELLIA_TABLE_BYTE_LEN);
 

--- a/wolfcrypt/src/compress.c
+++ b/wolfcrypt/src/compress.c
@@ -81,6 +81,9 @@ int wc_Compress_ex(byte* out, word32 outSz, const byte* in, word32 inSz,
     z_stream stream;
     int result = 0;
 
+    if (out == NULL || in == NULL)
+        return BAD_FUNC_ARG;
+
     stream.next_in = (Bytef*)in;
     stream.avail_in = (uInt)inSz;
 #ifdef MAXSEG_64K
@@ -148,6 +151,9 @@ int wc_DeCompress_ex(byte* out, word32 outSz, const byte* in, word32 inSz,
 {
     z_stream stream;
     int result = 0;
+
+    if (out == NULL || in == NULL)
+        return BAD_FUNC_ARG;
 
     stream.next_in = (Bytef*)in;
     stream.avail_in = (uInt)inSz;

--- a/wolfcrypt/src/des3.c
+++ b/wolfcrypt/src/des3.c
@@ -2002,6 +2002,7 @@ void wc_Des3Free(Des3* des3)
         (defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_3DES))
     ForceZero(des3->devKey, sizeof(des3->devKey));
 #endif
+    ForceZero(des3, sizeof(Des3));
 #ifdef WOLFSSL_CHECK_MEM_ZERO
     wc_MemZero_Check(des3, sizeof(Des3));
 #endif

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -174,8 +174,8 @@ int wc_MakeDsaKey(WC_RNG *rng, DsaKey *dsa)
     SAVE_VECTOR_REGISTERS(;);
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-    if ((tmpQ = (mp_int *)XMALLOC(sizeof(*tmpQ), NULL,
-            DYNAMIC_TYPE_WOLF_BIGINT)) == NULL)
+    if ((tmpQ = (mp_int *)XMALLOC(sizeof(*tmpQ), dsa->heap,
+            DYNAMIC_TYPE_TMP_BUFFER)) == NULL)
         err = MEMORY_E;
     else
         err = MP_OKAY;

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -1395,7 +1395,7 @@ int  wc_HmacInit_Id(Hmac* hmac, unsigned char* id, int len, void* heap,
 
     if (ret == 0)
         ret = wc_HmacInit(hmac, heap, devId);
-    if (ret == 0) {
+    if (ret == 0 && id != NULL && len != 0) {
         XMEMCPY(hmac->id, id, (size_t)len);
         hmac->idLen = len;
     }

--- a/wolfcrypt/src/rng_bank.c
+++ b/wolfcrypt/src/rng_bank.c
@@ -52,7 +52,7 @@ WOLFSSL_API int wc_rng_bank_init(
 
 #ifdef WC_RNG_BANK_STATIC
     if (n_rngs > WC_RNG_BANK_STATIC_SIZE)
-        return BAD_LENGTH_E;
+        ret = BAD_LENGTH_E;
 #else
     ctx->rngs = (struct wc_rng_bank_inst *)
         XMALLOC(sizeof(*ctx->rngs) * (size_t)n_rngs,

--- a/wolfcrypt/src/wc_lms.c
+++ b/wolfcrypt/src/wc_lms.c
@@ -1159,7 +1159,8 @@ int wc_LmsKey_ExportPubRaw(const LmsKey* key, byte* out, word32* outLen)
     int ret = 0;
 
     /* Validate parameters. */
-    if ((key == NULL) || (out == NULL) || (outLen == NULL)) {
+    if ((key == NULL) || (out == NULL) || (outLen == NULL) ||
+            (key->params == NULL)) {
         ret = BAD_FUNC_ARG;
     }
     /* Check size of out is sufficient. */

--- a/wolfcrypt/src/wc_lms_impl.c
+++ b/wolfcrypt/src/wc_lms_impl.c
@@ -2855,6 +2855,7 @@ static int wc_hss_next_subtree_inc(LmsState* state, HssPrivKey* priv_key,
         q64_hi = cq64_hi;
     }
 
+    ForceZero(tmp_priv, sizeof(tmp_priv));
     return ret;
 }
 


### PR DESCRIPTION
Addresses F-3055, F-3056, F-1506, F-1373, F-2206, F-2655, F-1910, F-1912, F-2212, F-3059,  F-3060

  - Add NULL parameter validation to wc_HmacInit_Id, wc_LmsKey_ExportPubRaw, wc_CamelliaSetKey, and wc_Compress_ex/wc_DeCompress_ex.
 - wc_AesGcmEncrypt: add NULL checks for iv, in/out (when sz>0), and authTag to match wc_AesGcmDecrypt.                                                                          
 - wc_AesEaxEncryptFinal/DecryptFinal: reject zero-length auth tag — previously bypassed authentication via ConstantCompare(.., 0).                                                 
 - wc_Arc4Free and wc_Des3Free: ForceZero the key schedule before return.
 - wc_hss_next_subtree_inc: ForceZero the stack-resident LMS derived seed before return.    
 - wc_rng_bank_init: fall through to cleanup on size error so wolfSSL_RefInit state is released.                                                                                  
 - wc_MakeDsaKey: align tmpQ alloc/free heap hint and dynamic type to prevent static-memory free-list corruption. 