### PR TITLE
Fix missing return code check in wc_PKCS12_parse_ex.

### DIFF
--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1546,8 +1546,13 @@ int wc_PKCS12_parse_ex(WC_PKCS12* pkcs12, const char* psw,
                             *pkeySz = (word32)size;
                         }
                         else {
-                            *pkeySz = (word32)ToTraditional_ex(*pkey,
+                            ret = ToTraditional_ex(*pkey,
                                 (word32)size, &algId);
+                            if (ret < 0) {
+                                goto exit_pk12par;
+                            } else {
+                                *pkeySz = (word32)ret;
+                            }
                         }
                     }
 


### PR DESCRIPTION
Thanks to Zou Dikai for the report.

# Description

Fixes zd#21657

# Testing

Built in tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
