### PR TITLE
Update RPM spec for changes in examples and cmake

### DIFF
--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -51,6 +51,7 @@ fi
 %{__make} install  DESTDIR="%{buildroot}" AM_INSTALL_PROGRAM_FLAGS=""
 %{__rm} -f %{buildroot}/%{_libdir}/libwolfssl@LIBSUFFIX@.la
 %{__rm} -f %{buildroot}/%{_libdir}/libwolfssl.a
+%{__cp} wolfssl/options.h %{buildroot}/%{_includedir}/%{name}/
 
 %check
 
@@ -66,8 +67,6 @@ fi
 %defattr(-,root,root,-)
 %doc AUTHORS ChangeLog.md COPYING README README.md
 %{_docdir}/wolfssl/taoCert.txt
-%{_docdir}/wolfssl/example/async_client.c
-%{_docdir}/wolfssl/example/async_server.c
 %{_docdir}/wolfssl/example/client.c
 %{_docdir}/wolfssl/example/server.c
 %{_docdir}/wolfssl/example/echoclient.c
@@ -77,6 +76,7 @@ fi
 %{_docdir}/wolfssl/example/sctp-client-dtls.c
 %{_docdir}/wolfssl/example/sctp-server-dtls.c
 %{_docdir}/wolfssl/example/tls_bench.c
+%{_docdir}/wolfssl/example/ocsp_responder.c
 %{_docdir}/wolfssl/README.txt
 %{_docdir}/wolfssl/QUIC.md
 %{_libdir}/libwolfssl@LIBSUFFIX@.so.*
@@ -90,6 +90,7 @@ fi
 %{_includedir}/wolfssl/openssl/*.h
 %{_libdir}/pkgconfig/wolfssl.pc
 %{_libdir}/libwolfssl@LIBSUFFIX@.so
+%{_libdir}/cmake/wolfssl
 
 %changelog
 * Mon Oct 17 2022 Juliusz Sosinowicz <juliusz@wolfssl.com>


### PR DESCRIPTION
# Description
Update RPM spec.in precursor:
- changes in example/ files
- copy wolfssl/options.h to the -devel package (tracks what Debian does in its libwolfssl-dev package)
- cmake artifact breadcrumbs

# Testing

On Fedora 44 (vanilla):
```
sh autogen.sh
./configure 
make dist
cp wolfssl-5.9.1.tar.gz ~/rpmbuild/SOURCES
rpmbuild -ba rpm/spec
```
On Fedora 44 (copy Debian flags; add PKCS#11 RSA padding ops):
```
sh autogen.sh
./configure --enable-distro --enable-ech --enable-hpke --enable-jni \
    --enable-jobserver=no --enable-memcached --enable-quic --enable-qt --enable-pkcs11 \
    --enable-writedup --disable-asm --disable-crl-monitor --disable-examples \
    --disable-silent-rules EXTRA_CFLAGS=-DWOLF_CRYPTO_CB_RSA_PAD

make dist
cp wolfssl-5.9.1.tar.gz ~/rpmbuild/SOURCES
rpmbuild -ba rpm/spec
```


# Checklist

N/A
 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
