### PR TITLE
Fix support on CHERI RISC-V architecture

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -2151,14 +2151,14 @@ static void XorTable_Multi(const word32* t, word32* t0, byte o0,
     word32 e1 = 0;
     word32 e2 = 0;
     word32 e3 = 0;
-    byte hi0 = o0 & 0xf0;
-    byte lo0 = o0 & 0x0f;
-    byte hi1 = o1 & 0xf0;
-    byte lo1 = o1 & 0x0f;
-    byte hi2 = o2 & 0xf0;
-    byte lo2 = o2 & 0x0f;
-    byte hi3 = o3 & 0xf0;
-    byte lo3 = o3 & 0x0f;
+    byte hi0 = o0 & WC_CACHE_LINE_MASK_HI;
+    byte lo0 = o0 & WC_CACHE_LINE_MASK_LO;
+    byte hi1 = o1 & WC_CACHE_LINE_MASK_HI;
+    byte lo1 = o1 & WC_CACHE_LINE_MASK_LO;
+    byte hi2 = o2 & WC_CACHE_LINE_MASK_HI;
+    byte lo2 = o2 & WC_CACHE_LINE_MASK_LO;
+    byte hi3 = o3 & WC_CACHE_LINE_MASK_HI;
+    byte lo3 = o3 & WC_CACHE_LINE_MASK_LO;
     int i;
 
     for (i = 0; i < 256; i += (1 << WC_CACHE_LINE_BITS)) {

--- a/wolfcrypt/src/sakke.c
+++ b/wolfcrypt/src/sakke.c
@@ -2649,12 +2649,19 @@ static int sakke_modexp_loop(SakkeKey* key, mp_int* b, mp_int* e, mp_proj* r,
             err = sakke_proj_mul_qx1(c[0], by, prime, mp, c[j^1], t1, t2);
 #else
             err = sakke_proj_mul_qx1(c[0], by, prime, mp, c[2], t1, t2);
+#ifdef WC_NO_PTR_INT_CAST
+            err = mp_cond_copy(c[2]->x, j,   c[0]->x);
+            err = mp_cond_copy(c[2]->x, j^1, c[1]->x);
+            err = mp_cond_copy(c[2]->y, j,   c[0]->y);
+            err = mp_cond_copy(c[2]->y, j^1, c[1]->y);
+#else
             mp_copy(c[2]->x,
             (mp_int*) ( ((wc_ptr_t)c[0]->x & wc_off_on_addr[j]) +
                         ((wc_ptr_t)c[1]->x & wc_off_on_addr[j^1]) ) );
             mp_copy(c[2]->y,
             (mp_int*) ( ((wc_ptr_t)c[0]->y & wc_off_on_addr[j]) +
                         ((wc_ptr_t)c[1]->y & wc_off_on_addr[j^1]) ) );
+#endif
 #endif
         }
     }

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -5115,12 +5115,28 @@ static WC_INLINE sp_int_digit sp_div_word(sp_int_digit hi, sp_int_digit lo,
     (defined(HAVE_ECC) && defined(HAVE_COMP_KEY)) || defined(OPENSSL_EXTRA) || \
     (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_PUBLIC_ONLY))
 #ifndef WC_NO_CACHE_RESISTANT
+#ifdef WC_NO_PTR_INT_CAST
+static void _sp_cond_copy(const sp_int* a, int copy, sp_int* r, sp_size_t used)
+{
+    sp_int_digit mask = (sp_int_digit)0 - (sp_int_digit)copy;
+    unsigned int i;
+
+    for (i = 0; i < (unsigned int)used; i++) {
+        r->dp[i] ^= (r->dp[i] ^ a->dp[i]) & mask;
+    }
+    r->used ^= (r->used ^ a->used) & (sp_size_t)mask;
+#ifdef WOLFSSL_SP_INT_NEGATIVE
+    r->sign ^= (r->sign ^ a->sign) & (sp_sign_t)mask;
+#endif
+}
+#else
     /* Mask of address for constant time operations. */
     const size_t sp_off_on_addr[2] =
     {
         (size_t) 0,
         (size_t)-1
     };
+#endif
 #endif
 #endif
 
@@ -13166,13 +13182,23 @@ static int _sp_exptmod_ex(const sp_int* b, const sp_int* e, int bits,
             }
 #else
             /* 4.1. t[s] = t[s] ^ 2 */
+#ifdef WC_NO_PTR_INT_CAST
+            _sp_cond_copy(t[0], s^1, t[2], m->used);
+            _sp_cond_copy(t[1], s,   t[2], m->used);
+#else
             _sp_copy((sp_int*)(((size_t)t[0] & sp_off_on_addr[s^1]) +
                                ((size_t)t[1] & sp_off_on_addr[s  ])),
                      t[2]);
+#endif
             err = sp_sqrmod(t[2], m, t[2]);
+#ifdef WC_NO_PTR_INT_CAST
+            _sp_cond_copy(t[2], s^1, t[0], m->used);
+            _sp_cond_copy(t[2], s,   t[1], m->used);
+#else
             _sp_copy(t[2],
                      (sp_int*)(((size_t)t[0] & sp_off_on_addr[s^1]) +
                                ((size_t)t[1] & sp_off_on_addr[s  ])));
+#endif
 
             if (err == MP_OKAY) {
                 /* 4.2. y = e[i] */
@@ -13183,13 +13209,23 @@ static int _sp_exptmod_ex(const sp_int* b, const sp_int* e, int bits,
                 /* 4.4  s = s | y */
                 s |= y;
                 /* 4.5. t[j] = t[j] * b */
+#ifdef WC_NO_PTR_INT_CAST
+                _sp_cond_copy(t[0], j^1, t[2], m->used);
+                _sp_cond_copy(t[1], j,   t[2], m->used);
+#else
                 _sp_copy((sp_int*)(((size_t)t[0] & sp_off_on_addr[j^1]) +
                                    ((size_t)t[1] & sp_off_on_addr[j  ])),
                          t[2]);
+#endif
                 err = _sp_mulmod(t[2], b, m, t[2]);
+#ifdef WC_NO_PTR_INT_CAST
+                _sp_cond_copy(t[2], j^1, t[0], m->used);
+                _sp_cond_copy(t[2], j,   t[1], m->used);
+#else
                 _sp_copy(t[2],
                          (sp_int*)(((size_t)t[0] & sp_off_on_addr[j^1]) +
                                    ((size_t)t[1] & sp_off_on_addr[j  ])));
+#endif
             }
 #endif
         }
@@ -13279,9 +13315,14 @@ static int _sp_exptmod_ex(const sp_int* b, const sp_int* e, int bits,
             err = sp_mulmod(t[0], t[1], m, t[2]);
             /* 3.3. t[3] = t[y] ^ 2 */
             if (err == MP_OKAY) {
+#ifdef WC_NO_PTR_INT_CAST
+                _sp_cond_copy(t[0], y^1, t[3], m->used);
+                _sp_cond_copy(t[1], y,   t[3], m->used);
+#else
                 _sp_copy((sp_int*)(((size_t)t[0] & sp_off_on_addr[y^1]) +
                                    ((size_t)t[1] & sp_off_on_addr[y  ])),
                          t[3]);
+#endif
                 err = sp_sqrmod(t[3], m, t[3]);
             }
             /* 3.4. t[y] = t[3], t[y^1] = t[2] */
@@ -13403,16 +13444,26 @@ static int _sp_exptmod_mont_ex(const sp_int* b, const sp_int* e, int bits,
         /* 6. For i in (bits-1)...0 */
         for (i = bits - 1; (err == MP_OKAY) && (i >= 0); i--) {
             /* 6.1. t[s] = t[s] ^ 2 */
+#ifdef WC_NO_PTR_INT_CAST
+            _sp_cond_copy(t[0], s^1, t[3], m->used);
+            _sp_cond_copy(t[1], s,   t[3], m->used);
+#else
             _sp_copy((sp_int*)(((size_t)t[0] & sp_off_on_addr[s^1]) +
                                ((size_t)t[1] & sp_off_on_addr[s  ])),
                      t[3]);
+#endif
             err = sp_sqr(t[3], t[3]);
             if (err == MP_OKAY) {
                 err = _sp_mont_red(t[3], m, mp, 0);
             }
+#ifdef WC_NO_PTR_INT_CAST
+            _sp_cond_copy(t[3], s^1, t[0], m->used);
+            _sp_cond_copy(t[3], s,   t[1], m->used);
+#else
             _sp_copy(t[3],
                      (sp_int*)(((size_t)t[0] & sp_off_on_addr[s^1]) +
                                ((size_t)t[1] & sp_off_on_addr[s  ])));
+#endif
 
             if (err == MP_OKAY) {
                 /* 6.2. y = e[i] */
@@ -13424,16 +13475,26 @@ static int _sp_exptmod_mont_ex(const sp_int* b, const sp_int* e, int bits,
                 s |= y;
 
                 /* 6.5. t[j] = t[j] * bm */
+#ifdef WC_NO_PTR_INT_CAST
+                _sp_cond_copy(t[0], j^1, t[3], m->used);
+                _sp_cond_copy(t[1], j,   t[3], m->used);
+#else
                 _sp_copy((sp_int*)(((size_t)t[0] & sp_off_on_addr[j^1]) +
                                    ((size_t)t[1] & sp_off_on_addr[j  ])),
                          t[3]);
+#endif
                 err = sp_mul(t[3], t[2], t[3]);
                 if (err == MP_OKAY) {
                     err = _sp_mont_red(t[3], m, mp, 0);
                 }
+#ifdef WC_NO_PTR_INT_CAST
+                _sp_cond_copy(t[3], j^1, t[0], m->used);
+                _sp_cond_copy(t[3], j,   t[1], m->used);
+#else
                 _sp_copy(t[3],
                          (sp_int*)(((size_t)t[0] & sp_off_on_addr[j^1]) +
                                    ((size_t)t[1] & sp_off_on_addr[j  ])));
+#endif
             }
         }
         if (err == MP_OKAY) {
@@ -13543,9 +13604,14 @@ static int _sp_exptmod_mont_ex(const sp_int* b, const sp_int* e, int bits,
             }
             /* 4.3. t[3] = t[y] ^ 2 */
             if (err == MP_OKAY) {
+#ifdef WC_NO_PTR_INT_CAST
+                _sp_cond_copy(t[0], y^1, t[3], m->used);
+                _sp_cond_copy(t[1], y,   t[3], m->used);
+#else
                 _sp_copy((sp_int*)(((size_t)t[0] & sp_off_on_addr[y^1]) +
                                    ((size_t)t[1] & sp_off_on_addr[y  ])),
                          t[3]);
+#endif
                 err = sp_sqr(t[3], t[3]);
             }
             if (err == MP_OKAY) {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5761,7 +5761,7 @@ typedef struct BuildMsgArgs {
 #endif
 
 #ifdef WOLFSSL_ASYNC_IO
-    #define MAX_ASYNC_ARGS 18
+    #define MAX_ASYNC_ARGS 24
     typedef void (*FreeArgsCb)(struct WOLFSSL* ssl, void* pArgs);
 
     struct WOLFSSL_ASYNC {
@@ -5769,7 +5769,11 @@ typedef struct BuildMsgArgs {
         BuildMsgArgs  buildArgs; /* holder for current BuildMessage args */
 #endif
         FreeArgsCb    freeArgs; /* function pointer to cleanup args */
+#ifdef WC_NO_PTR_INT_CAST
+        max_align_t args[MAX_ASYNC_ARGS * sizeof(word32) / sizeof(max_align_t)]; /* holder for current args */
+#else
         word32        args[MAX_ASYNC_ARGS]; /* holder for current args */
+#endif
     };
 #endif
 

--- a/wolfssl/openssl/md5.h
+++ b/wolfssl/openssl/md5.h
@@ -43,9 +43,17 @@
 typedef struct WOLFSSL_MD5_CTX {
     /* big enough to hold wolfcrypt md5, but check on init */
 #ifdef STM32_HASH
+#  ifdef WC_NO_PTR_INT_CAST
+    void* holder[(128 + WC_ASYNC_DEV_SIZE + sizeof(STM32_HASH_Context)) / sizeof(void*)];
+#  else
     void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(STM32_HASH_Context)) / sizeof(void*)];
+#  endif
 #else
+#  ifdef WC_NO_PTR_INT_CAST
+    void* holder[(128 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#  else
     void* holder[(112 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#  endif
 #endif
 } WOLFSSL_MD5_CTX;
 

--- a/wolfssl/openssl/rc4.h
+++ b/wolfssl/openssl/rc4.h
@@ -39,7 +39,11 @@
  * the size of RC4_KEY structures. */
 typedef struct WOLFSSL_RC4_KEY {
     /* big enough for Arc4 from wolfssl/wolfcrypt/arc4.h */
+#ifdef WC_NO_PTR_INT_CAST
+    void* holder[(288 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#else
     void* holder[(272 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#endif
 } WOLFSSL_RC4_KEY;
 
 WOLFSSL_API void wolfSSL_RC4_set_key(WOLFSSL_RC4_KEY* key, int len,

--- a/wolfssl/openssl/sha.h
+++ b/wolfssl/openssl/sha.h
@@ -52,7 +52,11 @@
 #ifndef NO_SHA
 typedef struct WOLFSSL_SHA_CTX {
     /* big enough to hold wolfcrypt Sha, but check on init */
+#ifdef WC_NO_PTR_INT_CAST
+    void* holder[(160 + WC_ASYNC_DEV_SIZE + CTX_SHA_HW_ADDER) / sizeof(void*)];
+#else
     void* holder[(112 + WC_ASYNC_DEV_SIZE + CTX_SHA_HW_ADDER) / sizeof(void*)];
+#endif
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -5142,6 +5142,10 @@ extern void uITRON4_free(void *p) ;
     #endif
 #endif
 
+#ifdef __CHERI_PURE_CAPABILITY__
+    #define WC_NO_PTR_INT_CAST
+#endif
+
 #ifdef __cplusplus
     }   /* extern "C" */
 #endif


### PR DESCRIPTION
# Description

Whilst integrating wolfssl into the meta-cheri yocto layer I encountered issues during compilation and at runtime.

This PR is made up of 3 commits:

Commit 1:
At runtime this was causing a CHERI bounds exception. It seem `XorTable_Multi` was using hardcoded masks `0xf0`/`0x0f` which assume 64-bit cache lines. This meant that it was attempting to stride beyond the 256-entry table.

Commit 2: 
I was get a CHERI tag violation fault. On CHERI when you cast a pointer to a `size_t` this removes the hardware validity tag. When it is cast back to a pointer its tag is no longer valid, and leads to a violation fault. My fix here needs input, as it invalidates constant-time, but I left it as is in the interest of getting it working on CHERI.
Update: A fix has now been put in place to handle this by conditionally copying the digit data vs the pointers

Commit 3: 
I tripped a static_assert `WOLFSSL_ASSERT_SIZEOF_GE(ssl->async->args, *args);`. On CHERI pointers are capabilities and are larger (16-bytes in this case). I made the buffer larger here to accommodate that. Also CHERI pointers need to be 16-byte aligned so swapped it from a `word32` to a `max_align_t`. 

Commit 4:
I switched to building with `--enable-all` and found more cases where things need to be made bigger.

Commit 5:
Similar issue to Commit 2. Although opted for using the existing mp_cond_copy function for CHERI purecap

# Testing

Built with `--enable-all --enable-dtls --enable-dtls13 --enable-dtlscid --enable-dtls-frag-ch`
Ran wolfcrypttest - no issues
Ran wolfssl-unittest - Got `Failed/Skipped/Passed/All: 0/103/1102/1205`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
