### PR TITLE
wc_port: guard stddef header include.

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3954,6 +3954,7 @@ extern void uITRON4_free(void *p) ;
     #undef HAVE_LIMITS_H
     #define NO_STRING_H
     #define NO_LIMITS_H
+    #define NO_STDDEF_H
     #define NO_STDLIB_H
     #define NO_STDINT_H
     #define NO_CTYPE_H

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1727,7 +1727,9 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 
 #if (!defined(WOLFSSL_LEANPSK) && !defined(STRING_USER)) || \
     defined(USE_WOLF_STRNSTR)
-    #include <stddef.h> /* for size_t */
+    #ifndef NO_STDDEF_H
+        #include <stddef.h> /* for size_t */
+    #endif /* NO_STDDEF_H */
     WOLFSSL_TEST_VIS char* wolfSSL_strnstr(const char* s1, const char* s2, size_t n);
 #endif
 


### PR DESCRIPTION
## Description

Guard `#include <stddef.h>`  behind `#ifndef NO_STDDEF_H`.

stddef header is not appropriate for FreeBSD kernel builds.

This is similar to existing pattern for `NO_STRING_H`, `NO_STDLIB_H`, etc.