### PR TITLE
Fix double-free of she2 in she_test()

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -57626,6 +57626,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t she_test(void)
     ret = wc_SHE_Init(she2, HEAP_HINT, devId);
     if (ret != 0) {
         WC_FREE_VAR(she2, HEAP_HINT);
+    #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+        she2 = NULL;
+    #endif
         goto exit_SHE_Test;
     }
 
@@ -57639,6 +57642,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t she_test(void)
     if (ret != 0) {
         wc_SHE_Free(she2);
         WC_FREE_VAR(she2, HEAP_HINT);
+    #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+        she2 = NULL;
+    #endif
         goto exit_SHE_Test;
     }
 
@@ -57652,6 +57658,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t she_test(void)
 
     wc_SHE_Free(she2);
     WC_FREE_VAR(she2, HEAP_HINT);
+#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+    she2 = NULL;
+#endif
 
     if (ret != 0) {
         goto exit_SHE_Test;


### PR DESCRIPTION
## Summary

`she_test()` in `wolfcrypt/test/test.c` frees `she2` twice on several code paths. `WC_FREE_VAR` does not null its argument, so the exit-label cleanup at `exit_SHE_Test:` re-frees the same pointer that was already freed mid-test.

## Fix

Set `she2 = NULL` after every intermediate `WC_FREE_VAR(she2, HEAP_HINT)` so the subsequent free at `exit_SHE_Test:` sees `NULL` and becomes a no-op. Three sites updated.
