### PR TITLE
Fix false positives in WOLFSSL_CIPHER_TEXT_CHECK for small records

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -20673,9 +20673,16 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
             }
 
         #ifdef WOLFSSL_CIPHER_TEXT_CHECK
-            if (ssl->specs.bulk_cipher_algorithm != wolfssl_cipher_null) {
+            /* The compare in CIPHER_STATE_END compares sz bytes of ciphertext
+             * against the saved plaintext. For very small records that makes
+             * the glitch check statistically unreliable (e.g. a 1-byte
+             * compare legitimately collides roughly 1/256 of the time). Only
+             * dothe check when there is a full sanityCheck buffer of
+             * plaintext to compare against. */
+            if (ssl->specs.bulk_cipher_algorithm != wolfssl_cipher_null &&
+                    sz >= sizeof(ssl->encrypt.sanityCheck)) {
                 XMEMCPY(ssl->encrypt.sanityCheck, input,
-                    min(sz, sizeof(ssl->encrypt.sanityCheck)));
+                    sizeof(ssl->encrypt.sanityCheck));
             }
         #endif
 
@@ -20761,9 +20768,12 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
         case CIPHER_STATE_END:
         {
         #ifdef WOLFSSL_CIPHER_TEXT_CHECK
+            /* Only compare when CIPHER_STATE_BEGIN prepared the check with a
+             * full sanityCheck buffer of plaintext (see rationale there). */
             if (ssl->specs.bulk_cipher_algorithm != wolfssl_cipher_null &&
+                    sz >= sizeof(ssl->encrypt.sanityCheck) &&
                 XMEMCMP(out, ssl->encrypt.sanityCheck,
-                    min(sz, sizeof(ssl->encrypt.sanityCheck))) == 0) {
+                    sizeof(ssl->encrypt.sanityCheck)) == 0) {
 
                 WOLFSSL_MSG("Encrypt sanity check failed! Glitch?");
                 WOLFSSL_ERROR_VERBOSE(ENCRYPT_ERROR);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2638,10 +2638,18 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
         #endif
 
         #ifdef WOLFSSL_CIPHER_TEXT_CHECK
+            /* The compare in CIPHER_STATE_END compares dataSz bytes of
+             * ciphertext against the saved plaintext. For very small AEAD
+             * records (e.g. a 1-byte empty TLS 1.3 app-data record, whose
+             * plaintext is just the content-type byte) that makes the glitch
+             * check statistically unreliable. With only 1 byte compared,
+             * legitimate encryption collides roughly 1/256 of the time. Only
+             * do the check when there is a full sanityCheck buffer of
+             * plaintext to compare against. */
             if (ssl->specs.bulk_cipher_algorithm != wolfssl_cipher_null &&
-                    dataSz > 0) {
+                    dataSz >= sizeof(ssl->encrypt.sanityCheck)) {
                 XMEMCPY(ssl->encrypt.sanityCheck, input,
-                    min(dataSz, sizeof(ssl->encrypt.sanityCheck)));
+                    sizeof(ssl->encrypt.sanityCheck));
             }
         #endif
 
@@ -2824,10 +2832,12 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
         #endif
 
         #ifdef WOLFSSL_CIPHER_TEXT_CHECK
+            /* Only compare when CIPHER_STATE_BEGIN prepared the check with a
+             * full sanityCheck buffer of plaintext (see rationale there). */
             if (ssl->specs.bulk_cipher_algorithm != wolfssl_cipher_null &&
-                    dataSz > 0 &&
+                    dataSz >= sizeof(ssl->encrypt.sanityCheck) &&
                 XMEMCMP(output, ssl->encrypt.sanityCheck,
-                    min(dataSz, sizeof(ssl->encrypt.sanityCheck))) == 0) {
+                    sizeof(ssl->encrypt.sanityCheck)) == 0) {
 
                 WOLFSSL_MSG("EncryptTls13 sanity check failed! Glitch?");
                 return ENCRYPT_ERROR;


### PR DESCRIPTION
## Problem

The glitch-detection check guarded by `WOLFSSL_CIPHER_TEXT_CHECK` (enabled by `--enable-maxstrength`) saves up to 8 bytes of plaintext before encryption and compares them to the start of the ciphertext afterward. If they match, it assumes the AEAD pass-through'd and returns `ENCRYPT_ERROR`. 

The copy and compare both used `min(dataSz, sizeof(sanityCheck))`, so when the plaintext is smaller than 8 bytes the check only compares that many bytes of ciphertext, which collides legitimately with random probability 1/256^dataSz. For a 1-byte plaintext (e.g. an empty TLS 1.3 application-data record, whose only plaintext is the content-type byte) that's ~1/256 per record.

This surfaced as sporadic failures of `test_tls13_empty_record_limit` introduced in #10187, which builds `WOLFSSL_MAX_EMPTY_RECORDS` such records in a row, resulting in a combined false-positive rate of ~8–9%.

## Fix

In both `EncryptTls13` (src/tls13.c) and `Encrypt` (src/internal.c), only arm the sanity check when there is a full `sizeof(sanityCheck)` (8) bytes of plaintext, and always compare the full 8 bytes. Shorter records skip the check entirely rather than running an unreliable version of it (a 1-byte glitch check isn't trustworthy anyway).