### PR TITLE
Allow custom time functions on STM32

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2286,8 +2286,10 @@ extern void uITRON4_free(void *p) ;
         #ifndef STM32_HAL_TIMEOUT
             #define STM32_HAL_TIMEOUT   0xFF
         #endif
-        /* bypass certificate date checking, due to lack of properly configured RTC source */
-        #ifndef HAL_RTC_MODULE_ENABLED
+        /* bypass certificate date checking, due to lack of properly
+         * configured RTC source */
+        #if !defined(HAL_RTC_MODULE_ENABLED) && !defined(XTIME) && \
+            !defined(USER_TIME)
             #define NO_ASN_TIME
         #endif
 


### PR DESCRIPTION
# Description

Don't force `NO_ASN_TIME` if `XTIME` is defined for STM32

Fixes zd#21638

# Testing

Customer confirmed fix

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
