### PR TITLE
Adjustment of CA pathlen check and glitch hardening

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -20682,9 +20682,10 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
             }
 
         #ifdef WOLFSSL_CIPHER_TEXT_CHECK
-            if (ssl->specs.bulk_cipher_algorithm != wolfssl_cipher_null) {
+            if (ssl->specs.bulk_cipher_algorithm != wolfssl_cipher_null &&
+                    sz >= sizeof(ssl->encrypt.sanityCheck)) {
                 XMEMCPY(ssl->encrypt.sanityCheck, input,
-                    min(sz, sizeof(ssl->encrypt.sanityCheck)));
+                    sizeof(ssl->encrypt.sanityCheck));
             }
         #endif
 
@@ -20771,8 +20772,9 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
         {
         #ifdef WOLFSSL_CIPHER_TEXT_CHECK
             if (ssl->specs.bulk_cipher_algorithm != wolfssl_cipher_null &&
+                    sz >= sizeof(ssl->encrypt.sanityCheck) &&
                 XMEMCMP(out, ssl->encrypt.sanityCheck,
-                    min(sz, sizeof(ssl->encrypt.sanityCheck))) == 0) {
+                    sizeof(ssl->encrypt.sanityCheck)) == 0) {
 
                 WOLFSSL_MSG("Encrypt sanity check failed! Glitch?");
                 WOLFSSL_ERROR_VERBOSE(ENCRYPT_ERROR);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2639,9 +2639,9 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
 
         #ifdef WOLFSSL_CIPHER_TEXT_CHECK
             if (ssl->specs.bulk_cipher_algorithm != wolfssl_cipher_null &&
-                    dataSz > 0) {
+                    dataSz >= sizeof(ssl->encrypt.sanityCheck)) {
                 XMEMCPY(ssl->encrypt.sanityCheck, input,
-                    min(dataSz, sizeof(ssl->encrypt.sanityCheck)));
+                    sizeof(ssl->encrypt.sanityCheck));
             }
         #endif
 
@@ -2825,9 +2825,9 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
 
         #ifdef WOLFSSL_CIPHER_TEXT_CHECK
             if (ssl->specs.bulk_cipher_algorithm != wolfssl_cipher_null &&
-                    dataSz > 0 &&
+                    dataSz >= sizeof(ssl->encrypt.sanityCheck) &&
                 XMEMCMP(output, ssl->encrypt.sanityCheck,
-                    min(dataSz, sizeof(ssl->encrypt.sanityCheck))) == 0) {
+                    sizeof(ssl->encrypt.sanityCheck)) == 0) {
 
                 WOLFSSL_MSG("EncryptTls13 sanity check failed! Glitch?");
                 return ENCRYPT_ERROR;

--- a/tests/api.c
+++ b/tests/api.c
@@ -21763,6 +21763,15 @@ static int test_PathLenSelfIssued(void)
         cm), WC_NO_ERR_TRACE(ASN_PATHLEN_INV_E));
     wc_FreeDecodedCert(&decodedCert);
 
+    /* Step 6: Parse the trust anchor itself as a chain cert.
+     * A peer is allowed to include the root in the chain it sends.
+     * Per RFC 5280 6.1 the trust anchor is not part of the prospective
+     * certification path, so its own pathLen=0 must not fire against
+     * itself. */
+    wc_InitDecodedCert(&decodedCert, rootDer, (word32)rootDerSz, NULL);
+    ExpectIntEQ(wc_ParseCert(&decodedCert, CHAIN_CERT_TYPE, VERIFY, cm), 0);
+    wc_FreeDecodedCert(&decodedCert);
+
     wolfSSL_CertManagerFree(cm);
     wc_ecc_free(&entityKey);
     wc_ecc_free(&icaKey);

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -4590,7 +4590,7 @@ int test_tls13_empty_record_limit(void)
     struct test_memio_ctx test_ctx;
     WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
     WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
-    int recSz;
+    int recSz = 0;
     /* Send exactly WOLFSSL_MAX_EMPTY_RECORDS to pin the boundary check.
      * The Nth record increments the counter to N, and `N >= N` triggers
      * the error. Sending one more would let a `>=` -> `>` mutation survive
@@ -4608,16 +4608,18 @@ int test_tls13_empty_record_limit(void)
 
     ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
 
-    /* Consume any post-handshake messages (e.g. NewSessionTicket). */
-    wolfSSL_read(ssl_c, buf, sizeof(buf));
-    test_memio_clear_buffer(&test_ctx, 0);
-    test_memio_clear_buffer(&test_ctx, 1);
+    if (EXPECT_SUCCESS()) {
+        /* Consume any post-handshake messages (e.g. NewSessionTicket). */
+        wolfSSL_read(ssl_c, buf, sizeof(buf));
+        test_memio_clear_buffer(&test_ctx, 0);
+        test_memio_clear_buffer(&test_ctx, 1);
 
-    /* Get the size of an encrypted zero-length app data record. */
-    recSz = BuildTls13Message(ssl_c, NULL, 0, NULL, 0,
-                              application_data, 0, 1, 0);
-    ExpectIntGT(recSz, 0);
-    ExpectIntLE(recSz, (int)sizeof(rec));
+        /* Get the size of an encrypted zero-length app data record. */
+        recSz = BuildTls13Message(ssl_c, NULL, 0, NULL, 0,
+                                  application_data, 0, 1, 0);
+        ExpectIntGT(recSz, 0);
+        ExpectIntLE(recSz, (int)sizeof(rec));
+    }
 
     /* Build all empty records into one contiguous buffer. */
     if (EXPECT_SUCCESS()) {
@@ -4664,15 +4666,17 @@ int test_tls13_empty_record_limit(void)
 
     ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
 
-    wolfSSL_read(ssl_c, buf, sizeof(buf));
-    test_memio_clear_buffer(&test_ctx, 0);
-    test_memio_clear_buffer(&test_ctx, 1);
+    if (EXPECT_SUCCESS()) {
+        wolfSSL_read(ssl_c, buf, sizeof(buf));
+        test_memio_clear_buffer(&test_ctx, 0);
+        test_memio_clear_buffer(&test_ctx, 1);
 
-    recSz = BuildTls13Message(ssl_c, NULL, 0, NULL, 0,
-                              application_data, 0, 1, 0);
-    ExpectIntGT(recSz, 0);
+        recSz = BuildTls13Message(ssl_c, NULL, 0, NULL, 0,
+                                  application_data, 0, 1, 0);
+        ExpectIntGT(recSz, 0);
+    }
 
-    {
+    if (EXPECT_SUCCESS()) {
         int emptyBefore = WOLFSSL_MAX_EMPTY_RECORDS - 1;
         int emptyAfter = WOLFSSL_MAX_EMPTY_RECORDS - 1;
         int dataRecSz;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -22527,7 +22527,22 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
                  * max_path_length, but the issuer's constraint still
                  * applies. A self-issued cert from a CA with maxPathLen=0
                  * cannot act as an intermediate CA. */
-                if (cert->ca->maxPathLen == 0) {
+                if (cert->publicKey != NULL &&
+                        cert->ca->publicKey != NULL &&
+                        cert->pubKeySize > 0 &&
+                        cert->pubKeySize == cert->ca->pubKeySize &&
+                        XMEMCMP(cert->publicKey, cert->ca->publicKey,
+                                cert->pubKeySize) == 0) {
+                    /* Exclude the trust anchor itself from step (l). Per
+                     * RFC 5280 6.1, when the trust anchor is supplied as a
+                     * self-signed certificate it "is not included as part
+                     * of the prospective certification path" */
+
+                    /* Trust anchor: honor issuer's constraint */
+                    cert->maxPathLen = (word16)min(cert->ca->maxPathLen,
+                                           cert->maxPathLen);
+                }
+                else if (cert->ca->maxPathLen == 0) {
                     cert->maxPathLen = 0;
                     if (verify != NO_VERIFY) {
                         WOLFSSL_MSG("\tSelf-issued cert, maxPathLen is 0");


### PR DESCRIPTION
Re-introducing some hostap CI tests (https://github.com/wolfSSL/wolfssl/pull/10058) exposed an edge case in current master branch with CA pathlen checking. This resolves handling when a trust anchor is being included as part of the certificate chain and adds a regression test.