### PR TITLE
remove openvpn master from CI test

### DIFF
--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ref: [ master, release/2.6, v2.6.19 ]
+        ref: [ release/2.6, v2.6.19 ]
     name: ${{ matrix.ref }}
     if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Testing against master branch of openvpn seems unstable for CI tests. Latest issues is:

```
ssl_openssl.c: In function ‘cert_verify_callback’:
ssl_openssl.c:321:5: warning: implicit declaration of function ‘X509_STORE_CTX_set0_crls’; did you mean ‘X509_STORE_CTX_get0_cert’? [-Wimplicit-function-declaration]
  321 |     X509_STORE_CTX_set0_crls(ctx, session->opt->ssl_ctx->crls);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
      |     X509_STORE_CTX_get0_cert
  CCLD     openvpn
/usr/bin/ld: ssl_openssl.o: in function `cert_verify_callback':
```