### PR TITLE
Allow Zephyr build w/o having posix api enabled

### DIFF
--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -142,9 +142,8 @@ static memoryStats ourMemStats;
 WOLFSSL_API extern memoryStats *wc_MemStats_Ptr;
 
 #ifdef DO_MEM_LIST
-    #include <pthread.h>
     static memoryList ourMemList;
-    static pthread_mutex_t memLock = PTHREAD_MUTEX_INITIALIZER;
+    static wolfSSL_Mutex memLock WOLFSSL_MUTEX_INITIALIZER_CLAUSE(memLock);
 #endif
 
 #ifdef WOLFSSL_DEBUG_MEMORY
@@ -182,7 +181,7 @@ static WC_INLINE void* TrackMalloc(size_t sz)
 #endif
 #endif
 #if !defined(SINGLE_THREADED) && (defined(DO_MEM_LIST) || defined(DO_MEM_STATS))
-    if (pthread_mutex_lock(&memLock) == 0)
+    if (wc_LockMutex(&memLock) == 0)
     {
 #endif
 
@@ -228,7 +227,7 @@ static WC_INLINE void* TrackMalloc(size_t sz)
         ourMemList.count++;
 #endif
 #if !defined(SINGLE_THREADED) && (defined(DO_MEM_LIST) || defined(DO_MEM_STATS))
-        pthread_mutex_unlock(&memLock);
+        wc_UnLockMutex(&memLock);
     }
 #endif /* DO_MEM_LIST */
 
@@ -255,7 +254,7 @@ static WC_INLINE void TrackFree(void* ptr)
     sz = header->thisSize;
 
 #if !defined(SINGLE_THREADED) && (defined(DO_MEM_LIST) || defined(DO_MEM_STATS))
-    if (pthread_mutex_lock(&memLock) == 0)
+    if (wc_LockMutex(&memLock) == 0)
     {
 #endif
 
@@ -289,7 +288,7 @@ static WC_INLINE void TrackFree(void* ptr)
 #endif
 
 #if !defined(SINGLE_THREADED) && (defined(DO_MEM_LIST) || defined(DO_MEM_STATS))
-        pthread_mutex_unlock(&memLock);
+        wc_UnLockMutex(&memLock);
     }
 #endif
 
@@ -369,7 +368,10 @@ static WC_INLINE int InitMemoryTracker(void)
     }
 
 #ifdef DO_MEM_LIST
-    if (pthread_mutex_lock(&memLock) == 0)
+    #ifndef WOLFSSL_MUTEX_INITIALIZER
+    wc_InitMutex(&memLock);
+    #endif
+    if (wc_LockMutex(&memLock) == 0)
 #endif
     {
     #ifdef DO_MEM_STATS
@@ -388,7 +390,7 @@ static WC_INLINE int InitMemoryTracker(void)
         XMEMSET(&ourMemList, 0, sizeof(ourMemList));
         ourMemStats.memList = &ourMemList;
 
-        pthread_mutex_unlock(&memLock);
+        wc_UnLockMutex(&memLock);
     #endif
     }
 
@@ -400,7 +402,7 @@ static WC_INLINE int InitMemoryTracker(void)
 static WC_INLINE void ShowMemoryTracker(void)
 {
 #ifdef DO_MEM_LIST
-    if (pthread_mutex_lock(&memLock) == 0)
+    if (wc_LockMutex(&memLock) == 0)
 #endif
     {
     #ifdef DO_MEM_STATS
@@ -430,13 +432,16 @@ static WC_INLINE void ShowMemoryTracker(void)
             }
         }
 
-        pthread_mutex_unlock(&memLock);
+        wc_UnLockMutex(&memLock);
     #endif
     }
 }
 
 static WC_INLINE int CleanupMemoryTracker(void)
 {
+#ifndef WOLFSSL_MUTEX_INITIALIZER
+    wc_FreeMutex(&memLock);
+#endif
     wc_MemStats_Ptr = NULL;
     /* restore default allocators */
     return wolfSSL_SetAllocators(mfDefault, ffDefault, rfDefault);

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -314,16 +314,12 @@
      * before Zephyr's posix_types.h can define a conflicting timer_t */
     #include <sys/types.h>
     #ifndef SINGLE_THREADED
-        #if !defined(CONFIG_PTHREAD_IPC) && !defined(CONFIG_POSIX_THREADS)
-            #error "Threading needs CONFIG_PTHREAD_IPC / CONFIG_POSIX_THREADS"
-        #endif
         #if KERNEL_VERSION_NUMBER >= 0x30100
             #include <zephyr/kernel.h>
-            #ifndef CONFIG_ARCH_POSIX
-                #include <zephyr/posix/posix_types.h>
-                #include <zephyr/posix/pthread.h>
-            #endif
         #else
+            #if !defined(CONFIG_PTHREAD_IPC) && !defined(CONFIG_POSIX_THREADS)
+                #error "Threading needs CONFIG_PTHREAD_IPC / CONFIG_POSIX_THREADS"
+            #endif
             #include <kernel.h>
             #ifndef CONFIG_ARCH_POSIX
                 #include <posix/posix_types.h>
@@ -1557,12 +1553,12 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
         #include <posix/time.h>
     #endif
 
-    #ifndef CLOCK_REALTIME
-        #ifdef SYS_CLOCK_REALTIME
+    #ifdef SYS_CLOCK_REALTIME
+        #ifndef CLOCK_REALTIME
             #define CLOCK_REALTIME  SYS_CLOCK_REALTIME
-            #define clock_gettime   sys_clock_gettime
-            #define clock_settime   sys_clock_settime
         #endif
+        #define clock_gettime   sys_clock_gettime
+        #define clock_settime   sys_clock_settime
     #endif
 
     #if defined(CONFIG_RTC)


### PR DESCRIPTION
# Description

At the moment the Zephyr integration requires POSIX API (`CONFIG_POSIX_API`) to be enabled. However this causes build issues when picolib instead of newlib is enabled (at least for Zephyr 4.3). Luckily the POSIX API isn't really necessary anymore as nearly everything is updated to Zephyr core API already.
So the checks can be updated. One place where the POSIX API was still left was memory tracking (`WOLFSSL_TRACK_MEMORY`) which was easy to update to wolfSSL's own abstraction layer.

# Testing

Building a modified version of the tls_sock example and ran it directly on the target.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
