### PR TITLE
tls.c: send missing_extension alert on TLS 1.3 SNI absence

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -2593,7 +2593,10 @@ static int TLSX_SNI_VerifyParse(WOLFSSL* ssl,  byte isRequest)
                         continue;
                 }
 
-                SendAlert(ssl, alert_fatal, handshake_failure);
+                SendAlert(ssl, alert_fatal,
+                          IsAtLeastTLSv1_3(ssl->version)
+                              ? missing_extension
+                              : handshake_failure);
                 WOLFSSL_ERROR_VERBOSE(SNI_ABSENT_ERROR);
                 return SNI_ABSENT_ERROR;
             }
@@ -2604,7 +2607,10 @@ static int TLSX_SNI_VerifyParse(WOLFSSL* ssl,  byte isRequest)
                 if (ssl_sni->status != WOLFSSL_SNI_NO_MATCH)
                     continue;
 
-                SendAlert(ssl, alert_fatal, handshake_failure);
+                SendAlert(ssl, alert_fatal,
+                          IsAtLeastTLSv1_3(ssl->version)
+                              ? missing_extension
+                              : handshake_failure);
                 WOLFSSL_ERROR_VERBOSE(SNI_ABSENT_ERROR);
                 return SNI_ABSENT_ERROR;
             }


### PR DESCRIPTION
This pull request updates the alert handling logic in the `TLSX_SNI_VerifyParse` function to improve compliance with TLS 1.3 requirements. Specifically, it changes the type of alert sent when the SNI (Server Name Indication) extension is absent or does not match, sending a `missing_extension` alert for TLS 1.3 and above, while maintaining the previous behavior for earlier versions.

Alert handling improvements for TLS 1.3:

* Updated `TLSX_SNI_VerifyParse` in `src/tls.c` to send a `missing_extension` alert instead of `handshake_failure` when the SNI extension is missing or has no match, but only for TLS 1.3 and above. For earlier versions, the function still sends `handshake_failure`. [[1]](diffhunk://#diff-bb132d62ad3f3a5eac6006e2a383ad909e30072360265a49a962ac765962be34L2598-R2601) [[2]](diffhunk://#diff-bb132d62ad3f3a5eac6006e2a383ad909e30072360265a49a962ac765962be34L2609-R2615)