### PR TITLE
wolfcrypt/src/wc_pkcs11.c: cache PKCS#11 session across multi-call HMAC

### DIFF
--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -6535,10 +6535,46 @@ int wc_Pkcs11_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
         }
         else if (info->algo_type == WC_ALGO_TYPE_HMAC) {
     #ifndef NO_HMAC
-            ret = Pkcs11OpenSession(token, &session, readWrite);
-            if (ret == 0) {
+            Hmac* hmac = info->hmac.hmac;
+
+            /* Sign ops are session-scoped; cache the session across
+             * multi-call HMAC dispatches. */
+            if (hmac != NULL && hmac->devCtx != NULL) {
+                session.func    = token->func;
+                session.slotId  = token->slotId;
+                session.version = token->version;
+                session.handle  =
+                    (CK_SESSION_HANDLE)(wc_ptr_t)hmac->devCtx;
                 ret = Pkcs11Hmac(&session, info);
-                Pkcs11CloseSession(token, &session);
+                if (ret != 0 ||
+                        hmac->innerHashKeyed
+                            != WC_HMAC_INNER_HASH_KEYED_DEV) {
+                    Pkcs11CloseSession(token, &session);
+                    hmac->devCtx = NULL;
+                    /* Don't leave stale DEV state past session close;
+                     * leave SW state (owned by software fallback). */
+                    if (hmac->innerHashKeyed
+                            == WC_HMAC_INNER_HASH_KEYED_DEV)
+                        hmac->innerHashKeyed = 0;
+                }
+            }
+            else {
+                ret = Pkcs11OpenSession(token, &session, readWrite);
+                if (ret == 0) {
+                    ret = Pkcs11Hmac(&session, info);
+                    if (ret == 0 && hmac != NULL &&
+                            hmac->innerHashKeyed
+                                == WC_HMAC_INNER_HASH_KEYED_DEV) {
+                        hmac->devCtx =
+                            (void*)(wc_ptr_t)session.handle;
+                    }
+                    else {
+                        Pkcs11CloseSession(token, &session);
+                        if (hmac != NULL && hmac->innerHashKeyed
+                                == WC_HMAC_INNER_HASH_KEYED_DEV)
+                            hmac->innerHashKeyed = 0;
+                    }
+                }
             }
     #else
             ret = NOT_COMPILED_IN;


### PR DESCRIPTION
The cryptocb dispatcher opened and closed a fresh PKCS#11 session around
each HMAC invocation. PKCS#11 sign operations are session-scoped, so a
multi-call HMAC (wc_HmacUpdate then wc_HmacFinal, which arrive as
separate cryptocb dispatches) had its C_SignFinal land on a session
that never saw a C_SignInit, returning CKR_OPERATION_NOT_INITIALIZED
and surfacing as WC_HW_E. This broke any code path that drives Update
and Final separately under PKCS#11 routing.

Cache the PKCS#11 session handle on Hmac.devCtx (cast through wc_ptr_t,
matching the existing pattern for cached PKCS#11 object handles) and
rebuild the Pkcs11Session on the stack. The session is opened on the
first dispatch when the operation enters
WC_HMAC_INNER_HASH_KEYED_DEV state and released when it leaves that
state (Final completed or hard error).
