### PR TITLE
reject extensions in a TLS 1.3 Certificate message that were not offered in the prior ClientHello/CertificateRequest

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -17387,6 +17387,20 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
             break;
         }
 
+#ifdef WOLFSSL_TLS13
+        /* RFC 8446 4.4.2: extensions in a Certificate message MUST
+         * correspond to ones offered in our prior ClientHello (client) or
+         * CertificateRequest (server). Reject anything we did not offer. */
+        if (msgType == certificate &&
+            IsAtLeastTLSv1_3(ssl->version) &&
+            TLSX_Find(ssl->extensions, (TLSX_Type)type) == NULL) {
+            WOLFSSL_MSG("Cert-msg extension not offered in CH/CR");
+            SendAlert(ssl, alert_fatal, unsupported_extension);
+            WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_EXTENSION);
+            return UNSUPPORTED_EXTENSION;
+        }
+#endif
+
         switch (type) {
 #ifdef HAVE_SNI
             case TLSX_SERVER_NAME:


### PR DESCRIPTION
fixes https://github.com/wolfSSL/wolfssl/issues/10319

per RFC 8846 4.4.2 (https://www.rfc-editor.org/rfc/rfc8446.html#section-4.4.2)

"Extensions in the Certificate message from the client MUST correspond to extensions in the CertificateRequest message from the server."

added missing check in src/tls.c checking message type, tls version (must be tls 1.3) and call to find the extensions in the ssl object that were parsed in the previous clienthello and/or certificate requesst