### PR TITLE
harden falcon key handling

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9530,8 +9530,8 @@ int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID, word32* oidSz,
             return MEMORY_E;
 
         if (wc_falcon_init(falcon) == 0) {
-            tmpIdx = 0;
-            if (wc_falcon_set_level(falcon, 1) == 0) {
+            if ((*algoID == 0) && (wc_falcon_set_level(falcon, 1) == 0)) {
+                tmpIdx = 0;
                 if (wc_Falcon_PrivateKeyDecode(key, &tmpIdx, falcon, keySz)
                     == 0) {
                     *algoID = FALCON_LEVEL1k;
@@ -9540,7 +9540,8 @@ int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID, word32* oidSz,
                     WOLFSSL_MSG("Not Falcon Level 1 DER key");
                 }
             }
-            else if (wc_falcon_set_level(falcon, 5) == 0) {
+            if ((*algoID == 0) && (wc_falcon_set_level(falcon, 5) == 0)) {
+                tmpIdx = 0;
                 if (wc_Falcon_PrivateKeyDecode(key, &tmpIdx, falcon, keySz)
                     == 0) {
                     *algoID = FALCON_LEVEL5k;
@@ -9549,8 +9550,8 @@ int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID, word32* oidSz,
                     WOLFSSL_MSG("Not Falcon Level 5 DER key");
                 }
             }
-            else {
-                WOLFSSL_MSG("GetKeyOID falcon initialization failed");
+            if (*algoID == 0) {
+                WOLFSSL_MSG("GetKeyOID could not match Falcon DER key");
             }
             wc_falcon_free(falcon);
         }

--- a/wolfcrypt/src/falcon.c
+++ b/wolfcrypt/src/falcon.c
@@ -700,6 +700,14 @@ int wc_falcon_check_key(falcon_key* key)
         return BAD_FUNC_ARG;
     }
 
+    if ((key->level != 1) && (key->level != 5)) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (!key->pubKeySet || !key->prvKeySet) {
+        return PUBLIC_KEY_E;
+    }
+
     /* The public key is also decoded and stored within the private key buffer
      * behind the private key. Hence, we can compare both stored public keys. */
     if (key->level == 1) {


### PR DESCRIPTION
Fixes ~F-3316~, F-3317, F-3320, ~F-3321~.

- ~wc_sphincs_check_key: actually validate level/optim/keySet flags and compare embedded PK against key->p (was always returning 0)~
- wc_falcon_check_key: reject unset level and partially-populated keys before comparison (was passing on default-init key)
- GetKeyOID falcon: replace dead else-if chain so level 5 keys are detected (was only ever trying level 1)
- ~GetKeyOID sphincs: replace dead else-if chain so all six variants are detected (was only ever trying fast-L1)~