### PR TITLE
Increase pq-all test timeout

### DIFF
--- a/.github/workflows/pq-all.yml
+++ b/.github/workflows/pq-all.yml
@@ -44,7 +44,7 @@ jobs:
     if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-24.04
     # This should be a safe limit for the tests to run.
-    timeout-minutes: 6
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         name: Checkout wolfSSL


### PR DESCRIPTION
Increase the timeout for PQC CI tests from 6 to 10 minutes. The new SLH-DSA tests take more time than the previous tests due to the slow signing. 

With the old timeout, some tests sometimes hit the timeout before finishing successfully.
