### PR TITLE
Fix race condition in hostap CI tests

### DIFF
--- a/.github/workflows/hostap-vm.yml
+++ b/.github/workflows/hostap-vm.yml
@@ -76,11 +76,20 @@ jobs:
         with:
           path: hostap
           key: hostap-repo
-          lookup-only: true
 
       - name: Checkout hostap
         if: steps.cache.outputs.cache-hit != 'true'
         run: git clone https://w1.fi/hostap.git hostap
+
+      - name: tar hostap
+        run: tar -zcf hostap.tgz hostap
+
+      - name: Upload hostap repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: hostap-repo
+          path: hostap.tgz
+          retention-days: 1
 
   build_uml_linux:
     name: Build UML (UserMode Linux)
@@ -96,15 +105,16 @@ jobs:
         with:
           path: linux/linux
           key: hostap-linux-${{ env.LINUX_REF }}
-          lookup-only: true
 
-      - name: Checking if we have hostap in cache
+      - name: Download hostap repo
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@v4
+        uses: actions/download-artifact@v4
         with:
-          path: hostap
-          key: hostap-repo
-          fail-on-cache-miss: true
+          name: hostap-repo
+
+      - name: untar hostap
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: tar -xf hostap.tgz
 
       - name: Checkout linux
         if: steps.cache.outputs.cache-hit != 'true'
@@ -121,6 +131,13 @@ jobs:
           cp hostap/tests/hwsim/vm/kernel-config.uml linux/.config
           cd linux
           yes "" | ARCH=um make -j $(nproc)
+
+      - name: Upload kernel binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: uml-linux-kernel
+          path: linux/linux
+          retention-days: 1
 
   hostap_test:
     strategy:
@@ -170,13 +187,14 @@ jobs:
     timeout-minutes: 45
     needs: [build_wolfssl, build_uml_linux, checkout_hostap]
     steps:
-      - name: Checking if we have kernel in cache
-        uses: actions/cache/restore@v4
-        id: cache
+      - name: Download kernel binary
+        uses: actions/download-artifact@v4
         with:
-          path: linux/linux
-          key: hostap-linux-${{ env.LINUX_REF }}
-          fail-on-cache-miss: true
+          name: uml-linux-kernel
+          path: linux
+
+      - name: Restore kernel binary executable bit
+        run: chmod +x linux/linux
 
         # No way to view the full strategy in the browser (really weird)
       - name: Print strategy
@@ -215,12 +233,13 @@ jobs:
       - name: Install pip dependencies
         run: sudo pip install pycryptodome
 
-      - name: Checking if we have hostap in cache
-        uses: actions/cache/restore@v4
+      - name: Download hostap repo
+        uses: actions/download-artifact@v4
         with:
-          path: hostap
-          key: hostap-repo
-          fail-on-cache-miss: true
+          name: hostap-repo
+
+      - name: untar hostap
+        run: tar -xf hostap.tgz
 
       - name: Checkout correct ref
         working-directory: hostap


### PR DESCRIPTION
Fix flaky hostap-vm cache restore failures

The hwsim test jobs were intermittently failing at the kernel cache restore step with Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: hostap-linux-v6.12.

Root cause: the UML kernel binary was being passed from build_uml_linux to hostap_test via the GitHub Actions cache (hostap-linux-v6.12). When two PRs ran the workflow concurrently, both build_uml_linux jobs raced on the same cache key — the loser's post-step logged Unable to reserve cache with key hostap-linux-v6.12, another job may be creating this cache, and its hostap_test started a few seconds later before the winner had finished uploading, hitting a cache miss and erroring out due to fail-on-cache-miss: true.

Fix: hand the kernel between jobs as a workflow artifact (scoped to the run, no cross-run key contention) instead of via the cache. The cross-run hostap-linux-v6.12 cache is kept so repeat runs still skip the kernel rebuild; it just isn't the inter-job transport anymore. Artifact size is ~5 MB compressed with 1-day retention, so storage/bandwidth impact is negligible.