### PR TITLE
Fix static / mem tracker build error

### DIFF
--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -525,7 +525,7 @@ void* wolfSSL_Realloc(void *ptr, size_t size)
     !defined(WOLFSSL_STATIC_MEMORY)
 #include <wolfssl/wolfcrypt/mem_track.h>
 WOLFSSL_API memoryStats *wc_MemStats_Ptr;
-#endif
+#endif /* WOLFSSL_TRACK_MEMORY && USE_WOLFSSL_MEMORY && !WOLFSSL_STATIC_MEMORY */
 
 #ifdef WOLFSSL_STATIC_MEMORY
 

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -521,7 +521,8 @@ void* wolfSSL_Realloc(void *ptr, size_t size)
 }
 #endif /* WOLFSSL_STATIC_MEMORY */
 
-#ifdef WOLFSSL_TRACK_MEMORY
+#if defined(WOLFSSL_TRACK_MEMORY) && defined(USE_WOLFSSL_MEMORY) && \
+    !defined(WOLFSSL_STATIC_MEMORY)
 #include <wolfssl/wolfcrypt/mem_track.h>
 WOLFSSL_API memoryStats *wc_MemStats_Ptr;
 #endif


### PR DESCRIPTION
# Description

Fix build error when configured with:
`./configure --enable-trackmemory --enable-staticmemory`

This is not a valid use case (static + memtracker), so not tests need to be added. Just fixing the build error.

Fixes zd21724

# Testing

Clean build with config

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
