### PR TITLE
DTLS 1.3 client-only minimum: WOLFSSL_DTLS_ONLY + autoconf cascade

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -108,6 +108,18 @@ jobs:
           '--enable-lms=small,verify-only --enable-xmss=small,verify-only',
           '--enable-curve25519=nonblock --enable-ecc=nonblock --enable-sp=yes,nonblock CPPFLAGS="-DWOLFSSL_PUBLIC_MP -DWOLFSSL_DEBUG_NONBLOCK"',
           '--enable-certreq --enable-certext --enable-certgen --disable-secure-renegotiation-info CPPFLAGS="-DNO_TLS"',
+          # Minimal DTLS 1.3 client-only build. The SHA-224/384/512/3
+          # disables are deliberately omitted: --disable-sha384 alone
+          # trips a pre-existing wolfSSL bug in
+          # test_tls13_duplicate_extension (reproducible on clean master).
+          '--enable-dtls13 --disable-tlsv12 --disable-oldtls --disable-rsa --disable-dh
+            --disable-aescbc --disable-aesecb --disable-md5 --disable-chacha
+            --disable-poly1305 --disable-errorstrings --disable-asn-print
+            --disable-eccshamir --disable-base64encode --disable-coding --disable-sni
+            --enable-aesgcm=small --enable-sp-math --enable-sp=smallec256 --disable-sp-asm
+            CPPFLAGS=''-DNO_WOLFSSL_SERVER -DWOLFSSL_NO_TLS12 -DNO_SESSION_CACHE
+            -DWOLFSSL_AES_NO_UNROLL -DUSE_SLOW_SHA256 -DWOLFSSL_NO_ASYNC_IO
+            -DWOLFSSL_DTLS_ONLY'' ',
         ]
     name: make check linux
     if: github.repository_owner == 'wolfssl'

--- a/configure.ac
+++ b/configure.ac
@@ -5736,9 +5736,26 @@ AC_ARG_ENABLE([dtls13],
     )
 if test "x$ENABLED_DTLS13" = "xyes"
 then
-        if test "x$ENABLED_DTLS" != "xyes" || test "x$ENABLED_TLS13" != "xyes"
+        # DTLSv1.3 implies TLS 1.3 and DTLS; auto-enable, but don't
+        # override explicit --disable.
+        if test "x$enable_tls13" = "xno" || test "x$ENABLED_TLS13" = "xno"
         then
-                AC_MSG_ERROR([You need to enable both DTLS and TLSv1.3 to use DTLSv1.3])
+                AC_MSG_ERROR([--enable-dtls13 requires TLS 1.3, but TLS 1.3 is disabled])
+        fi
+        if test "x$ENABLED_TLS13" != "xyes"
+        then
+                AC_MSG_NOTICE([DTLSv1.3 is enabled, enabling TLS 1.3])
+                ENABLED_TLS13=yes
+        fi
+        if test "x$enable_dtls" = "xno"
+        then
+                AC_MSG_ERROR([--enable-dtls13 requires DTLS, but --disable-dtls was given])
+        fi
+        if test "x$ENABLED_DTLS" != "xyes"
+        then
+                AC_MSG_NOTICE([DTLSv1.3 is enabled, enabling DTLS])
+                AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DTLS"
+                ENABLED_DTLS=yes
         fi
         if test "x$ENABLED_SEND_HRR_COOKIE" = "xundefined"
         then
@@ -8346,6 +8363,11 @@ if test "x$ENABLED_PSK" = "xno" && test "x$ENABLED_ECC" = "xno" && \
 then
     # disable TLS 1.3
     ENABLED_TLS13=no
+fi
+# DTLSv1.3 cannot survive a downgrade of TLS 1.3.
+if test "x$ENABLED_DTLS13" = "xyes" && test "x$ENABLED_TLS13" = "xno"
+then
+    AC_MSG_ERROR([--enable-dtls13 requires TLS 1.3, but TLS 1.3 was disabled by an earlier prerequisite check (no key-exchange or signature algorithms reachable). Enable at least one of ECC, RSA+DH, Curve25519+Ed25519, Curve448+Ed448, PSK, or ML-KEM.])
 fi
 if test "$ENABLED_TLS13" = "yes" && (test "x$ENABLED_ECC" = "xyes" || \
     test "$ENABLED_DH" != "no")

--- a/src/internal.c
+++ b/src/internal.c
@@ -2703,8 +2703,10 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
         }
         #endif
     #else
-        ctx->CBIORecv = EmbedReceive;
-        ctx->CBIOSend = EmbedSend;
+        #ifndef WOLFSSL_DTLS_ONLY
+            ctx->CBIORecv = EmbedReceive;
+            ctx->CBIOSend = EmbedSend;
+        #endif
         #ifdef WOLFSSL_SESSION_EXPORT
             ctx->CBGetPeer = EmbedGetPeer;
             ctx->CBSetPeer = EmbedSetPeer;

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -402,6 +402,7 @@ int SslBioSend(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 
 #ifdef USE_WOLFSSL_IO
 
+#ifndef WOLFSSL_DTLS_ONLY
 /* The receive embedded callback
  *  return : nb bytes read, or error
  */
@@ -450,6 +451,7 @@ int EmbedSend(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 
     return sent;
 }
+#endif /* !WOLFSSL_DTLS_ONLY */
 
 
 #ifdef WOLFSSL_DTLS

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -1920,8 +1920,9 @@ static WARN_UNUSED_RESULT word32 col_mul(
     return GETBYTE(t, ia) ^ GETBYTE(t, ib) ^ t3 ^ tm;
 }
 
-#if defined(HAVE_AES_CBC) || defined(HAVE_AES_ECB) || \
-    defined(WOLFSSL_AES_DIRECT)
+#if defined(HAVE_AES_DECRYPT) && \
+    (defined(HAVE_AES_CBC) || defined(HAVE_AES_ECB) || \
+     defined(WOLFSSL_AES_DIRECT))
 static WARN_UNUSED_RESULT word32 inv_col_mul(
     word32 t, int i9, int ib, int id, int ie)
 {
@@ -1932,7 +1933,7 @@ static WARN_UNUSED_RESULT word32 inv_col_mul(
     byte t0 = t9 ^ tb ^ td;
     return t0 ^ AES_XTIME(AES_XTIME(AES_XTIME(t0 ^ te) ^ td ^ te) ^ tb ^ te);
 }
-#endif /* HAVE_AES_CBC || WOLFSSL_AES_DIRECT */
+#endif /* HAVE_AES_DECRYPT && (HAVE_AES_CBC || HAVE_AES_ECB || WOLFSSL_AES_DIRECT) */
 #endif /* WOLFSSL_AES_SMALL_TABLES */
 #endif
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -4687,6 +4687,10 @@ extern void uITRON4_free(void *p) ;
 #error "DTLS v1.3 requires both WOLFSSL_TLS13 and WOLFSSL_DTLS"
 #endif
 
+#if defined(WOLFSSL_DTLS_ONLY) && !defined(WOLFSSL_DTLS)
+#error "WOLFSSL_DTLS_ONLY requires WOLFSSL_DTLS"
+#endif
+
 #if defined(WOLFSSL_QUIC) && defined(WOLFSSL_CALLBACKS)
     #error WOLFSSL_QUIC is incompatible with WOLFSSL_CALLBACKS.
 #endif

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -674,8 +674,10 @@ WOLFSSL_LOCAL int SslBioReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
     /* default IO callbacks */
 
     #ifdef WOLFSSL_API_PREFIX_MAP
-        #define EmbedReceive wolfSSL_EmbedReceive
-        #define EmbedSend wolfSSL_EmbedSend
+        #ifndef WOLFSSL_DTLS_ONLY
+            #define EmbedReceive wolfSSL_EmbedReceive
+            #define EmbedSend wolfSSL_EmbedSend
+        #endif
         #ifdef WOLFSSL_DTLS
             #define EmbedReceiveFrom wolfSSL_EmbedReceiveFrom
             #define EmbedSendTo wolfSSL_EmbedSendTo
@@ -686,8 +688,10 @@ WOLFSSL_LOCAL int SslBioReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
         #endif /* WOLFSSL_DTLS */
     #endif /* WOLFSSL_API_PREFIX_MAP */
 
+    #ifndef WOLFSSL_DTLS_ONLY
     WOLFSSL_API int EmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
     WOLFSSL_API int EmbedSend(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+    #endif
 
     #ifdef WOLFSSL_DTLS
         #ifdef NUCLEUS_PLUS_2_3


### PR DESCRIPTION
* configure.ac: --enable-dtls13 auto-enables --enable-dtls and TLS 1.3,
  with a targeted error if either is explicitly --disabled.
* src/internal.c, src/wolfio.c, wolfssl/wolfio.h: new WOLFSSL_DTLS_ONLY
  compile-time flag elides EmbedReceive / EmbedSend default callbacks
  and the GetSEQIncrement helper.
* wolfcrypt/src/aes.c: add HAVE_AES_DECRYPT to the inv_col_mul
  definition gate to match its only caller; without it the function is
  emitted dead under WOLFSSL_AES_DIRECT && NO_AES_DECRYPT and
  -Werror=unused-function fails the build.
* .github/workflows/os-check.yml: matrix entry for a minimal DTLS 1.3
  client-only build.
