### PR TITLE
[Renesas RX72N] Fix SP_MATH and SP_MATH_ALL conflict in user_settings.h

### DIFF
--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
@@ -197,7 +197,6 @@
   #define ECC_TIMING_RESISTANT
 
   #define FP_MAX_BITS   4096
-  #define WOLFSSL_SP_MATH
   #define WOLFSSL_SP_MATH_ALL /* use SP math for all key sizes and curves */
   #define WOLFSSL_HAVE_SP_RSA
   #define WOLFSSL_HAVE_SP_DH


### PR DESCRIPTION
# Description

Fix a conflict in `user_settings.h` where both SP_MATH and SP_MATH_ALL were defined.

# Testing
Run wolfcrypt on the device

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
