### PR TITLE
rpm packaging: RHEL10 + LTO needs gcc-toolset-15

### DIFF
--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -13,6 +13,9 @@ BuildRequires: make
 BuildRequires: pkgconfig
 BuildRequires: sed
 BuildRequires: tar
+%if 0%{?rhel} == 10
+BuildRequires: gcc-toolset-15 gcc-toolset-15-gcc-plugin-annobin
+%endif
 URL: http://www.wolfssl.com/
 
 Packager: wolfSSL <support@wolfssl.com>
@@ -37,6 +40,9 @@ you will need to install %{name}-devel.
 %setup -q
 
 %build
+%if 0%{?rhel} == 10
+source /usr/lib/gcc-toolset/15-env.source
+%endif
 %configure @WOLFSSL_CONFIG_ARGS@
 %{__make} %{?_smp_mflags}
 if [ "@ENABLED_FIPS@" = "yes" ]


### PR DESCRIPTION
# Description

LTO builds on RHEL10 fail with the default GCC 14.3.1 and binutils 2.41. This PR makes RHEL10 use GCC 15.1.1 and binutils 2.44  from gcc-toolset-15 which has fixed the LTO build.

This is likely related to binutils 2.41 (and not GCC 14.3.1) - binutils 2.44 has a lot of improvements wrt LTO. This reproduces with gcc-toolset-14 on RHEL 9 (uses binutils 2.41).

# Testing
How did you test?

Before this PR:
```
/usr/bin/ld: /tmp/ccebgftR.ltrans9.ltrans.o:/builddir/rpmbuild/BUILD/wolfssl-5.9.1/wolfcrypt/src/eccsi.c:1458:(.text+0x6cfd): undefined reference to `ecc_map'
/usr/bin/ld: /tmp/ccebgftR.ltrans9.ltrans.o:/builddir/rpmbuild/BUILD/wolfssl-5.9.1/wolfcrypt/src/sakke.c:421:(.text+0x63c6): undefined reference to `ecc_map'
/usr/bin/ld: /tmp/ccebgftR.ltrans22.ltrans.o: in function `ec_point_convert_to_affine':
/builddir/rpmbuild/BUILD/wolfssl-5.9.1/src/pk_ec.c:1846:(.text+0x3402): undefined reference to `ecc_map'
/usr/bin/ld: /tmp/ccebgftR.ltrans22.ltrans.o: in function `wolfssl_ec_point_add':
/builddir/rpmbuild/BUILD/wolfssl-5.9.1/src/pk_ec.c:2144:(.text+0x3d55): undefined reference to `ecc_projective_add_point'
/usr/bin/ld: /builddir/rpmbuild/BUILD/wolfssl-5.9.1/src/pk_ec.c:2151:(.text+0x3d79): undefined reference to `ecc_map
```

```
sh autogen.sh
./configure --enable-distro --enable-pkcs11 EXTRA_CFLAGS="-DWOLF_CRYPTO_CB_RSA_PAD"
make dist
cp wolfssl-5.9.1.tar.gz ~/rpmbuild/SOURCES
rpmbuild -ba rpm/spec
```







# Checklist
n/a
 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
