### PR TITLE
Km fixes

### DIFF
--- a/bsdkm/wolfkmod.c
+++ b/bsdkm/wolfkmod.c
@@ -1020,7 +1020,8 @@ static int wolfkdriv_process(device_t dev, struct cryptop * crp, int hint)
                   csp->csp_mode, csp->csp_cipher_alg, error);
     #endif /* WOLFSSL_BSDKM_VERBOSE_DEBUG */
 
-    return (error);
+    /* opencrypto(9) contract: return 0 after crypto_done(); error is in crp_etype. */
+    return (0);
 }
 
 /*

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -450,6 +450,8 @@
         #define memset my_memset
 
         static inline void *my_memmove(void *dest, const void *src, size_t n) {
+            if (n == 0)
+                return dest;
             if (! (((uintptr_t)dest | (uintptr_t)src | (uintptr_t)n)
                    & (uintptr_t)(sizeof(uintptr_t) - 1)))
             {

--- a/linuxkm/x86_vector_register_glue.c
+++ b/linuxkm/x86_vector_register_glue.c
@@ -162,16 +162,22 @@ static struct wc_thread_fpu_count_ent *wc_linuxkm_fpu_state_assoc_unlikely(int c
             __atomic_store_n(&slot->pid, my_pid, __ATOMIC_RELEASE);
             return slot;
         } else {
+            struct pid *slot_pid_struct;
+
             /* if the slot is already occupied, that can be benign-ish due to a
              * unwanted migration, or due to a process crashing in kernel mode.
              * it will require fixup either here, or by the thread that owns the
              * slot, which will happen when it releases its lock.
              */
-            if (find_get_pid(slot_pid) == NULL) {
+            slot_pid_struct = find_get_pid(slot_pid);
+            if (slot_pid_struct == NULL) {
                 if (__atomic_compare_exchange_n(&slot->pid, &slot_pid, my_pid, 0, __ATOMIC_SEQ_CST, __ATOMIC_ACQUIRE)) {
                     pr_warn("WARNING: wc_linuxkm_fpu_state_assoc_unlikely fixed up orphaned slot on CPU %d owned by dead PID %d.\n", my_cpu, slot_pid);
                     return slot;
                 }
+            } else {
+                /* drop the refcount bumped by find_get_pid(). */
+                put_pid(slot_pid_struct);
             }
 
             {


### PR DESCRIPTION
# Description

Three minimal, independent fixes in the wolfSSL kernel ports:

1. **`bsdkm/wolfkmod.c`** — `wolfkdriv_process()` now returns `0` after `crypto_done()`, per `opencrypto(9)`. Errors continue to be reported via `crp->crp_etype`. Returning the operation error after completion could cause the framework to re-dispatch an already-completed request.

2. **`linuxkm/linuxkm_wc_port.h`** — `my_memmove()` early-returns when `n == 0`. The backward-copy branches compute `(n - 1)` as `size_t`, wrapping to `SIZE_MAX` for `n == 0`; with `src < dest` the loop walks backward through kernel memory and oopses. Reachable under `CONFIG_FORTIFY_SOURCE` from ASN.1/PKCS/TLS parsers via `XMEMMOVE`. Matches glibc, musl, and the kernel's own `memmove()`.

3. **`linuxkm/x86_vector_register_glue.c`** — Plug a `struct pid` refcount leak in `wc_linuxkm_fpu_state_assoc_unlikely()`: `find_get_pid()` bumps the refcount; the live-owner branch now releases it with `put_pid()`. Orphaned-slot branch unchanged.

Combined diff: 3 files, 11 insertions, 2 deletions.

# Testing

- `bsdkm` and `linuxkm` modules build and load; `wolfcrypt/test` passes.
- `my_memmove(dst, src, 0)` is now a no-op (was an oops with low/NULL `src`).
- No `struct pid` refcount growth under repeated contested-slot stress (previously monotonic).

# Checklist

 - [ ] added tests - N/A (kernel-mode correctness fixes)
 - [ ] updated/added doxygen - N/A (no API change)
 - [ ] updated appropriate READMEs - N/A
 - [ ] Updated manual and documentation - N/A