### PR TITLE
fix: EVP_CIPHER_iv_length returns 0 for AES-CFB128 and AES-OFB (ZD-21730)

### DIFF
--- a/tests/api/test_evp_cipher.c
+++ b/tests/api/test_evp_cipher.c
@@ -501,6 +501,28 @@ int test_wolfSSL_EVP_CIPHER_iv_length(void)
     #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
          NID_chacha20_poly1305,
     #endif
+    #ifdef WOLFSSL_AES_CFB
+    #ifdef WOLFSSL_AES_128
+        NID_aes_128_cfb128,
+    #endif
+    #ifdef WOLFSSL_AES_192
+        NID_aes_192_cfb128,
+    #endif
+    #ifdef WOLFSSL_AES_256
+        NID_aes_256_cfb128,
+    #endif
+    #endif /* WOLFSSL_AES_CFB */
+    #ifdef WOLFSSL_AES_OFB
+    #ifdef WOLFSSL_AES_128
+        NID_aes_128_ofb,
+    #endif
+    #ifdef WOLFSSL_AES_192
+        NID_aes_192_ofb,
+    #endif
+    #ifdef WOLFSSL_AES_256
+        NID_aes_256_ofb,
+    #endif
+    #endif /* WOLFSSL_AES_OFB */
     };
     int iv_lengths[] = {
     #if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_DIRECT)
@@ -546,6 +568,28 @@ int test_wolfSSL_EVP_CIPHER_iv_length(void)
     #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
             CHACHA20_POLY1305_AEAD_IV_SIZE,
     #endif
+    #ifdef WOLFSSL_AES_CFB
+    #ifdef WOLFSSL_AES_128
+            AES_BLOCK_SIZE,
+    #endif
+    #ifdef WOLFSSL_AES_192
+            AES_BLOCK_SIZE,
+    #endif
+    #ifdef WOLFSSL_AES_256
+            AES_BLOCK_SIZE,
+    #endif
+    #endif /* WOLFSSL_AES_CFB */
+    #ifdef WOLFSSL_AES_OFB
+    #ifdef WOLFSSL_AES_128
+            AES_BLOCK_SIZE,
+    #endif
+    #ifdef WOLFSSL_AES_192
+            AES_BLOCK_SIZE,
+    #endif
+    #ifdef WOLFSSL_AES_256
+            AES_BLOCK_SIZE,
+    #endif
+    #endif /* WOLFSSL_AES_OFB */
     };
     int i;
     int nidsLen = (sizeof(nids)/sizeof(int));

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -5674,6 +5674,34 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbynid(int id)
             return wolfSSL_EVP_aes_256_ccm();
         #endif
     #endif
+    #ifdef WOLFSSL_AES_OFB
+        #ifdef WOLFSSL_AES_128
+        case WC_NID_aes_128_ofb:
+            return wolfSSL_EVP_aes_128_ofb();
+        #endif
+        #ifdef WOLFSSL_AES_192
+        case WC_NID_aes_192_ofb:
+            return wolfSSL_EVP_aes_192_ofb();
+        #endif
+        #ifdef WOLFSSL_AES_256
+        case WC_NID_aes_256_ofb:
+            return wolfSSL_EVP_aes_256_ofb();
+        #endif
+    #endif /* WOLFSSL_AES_OFB */
+    #ifdef WOLFSSL_AES_CFB
+        #ifdef WOLFSSL_AES_128
+        case WC_NID_aes_128_cfb128:
+            return wolfSSL_EVP_aes_128_cfb128();
+        #endif
+        #ifdef WOLFSSL_AES_192
+        case WC_NID_aes_192_cfb128:
+            return wolfSSL_EVP_aes_192_cfb128();
+        #endif
+        #ifdef WOLFSSL_AES_256
+        case WC_NID_aes_256_cfb128:
+            return wolfSSL_EVP_aes_256_cfb128();
+        #endif
+    #endif /* WOLFSSL_AES_CFB */
 #endif
 
 #ifdef HAVE_ARIA

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -9960,6 +9960,61 @@ int wolfSSL_EVP_CIPHER_iv_length(const WOLFSSL_EVP_CIPHER* cipher)
     #endif /* WOLFSSL_AES_256 */
 #endif /* WOLFSSL_AES_XTS && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) */
 
+#ifdef WOLFSSL_AES_OFB
+    #ifdef WOLFSSL_AES_128
+    if (XSTRCMP(name, EVP_AES_128_OFB) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+    #ifdef WOLFSSL_AES_192
+    if (XSTRCMP(name, EVP_AES_192_OFB) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+    #ifdef WOLFSSL_AES_256
+    if (XSTRCMP(name, EVP_AES_256_OFB) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+#endif /* WOLFSSL_AES_OFB */
+#ifdef WOLFSSL_AES_CFB
+#ifndef WOLFSSL_NO_AES_CFB_1_8
+    #ifdef WOLFSSL_AES_128
+    if (XSTRCMP(name, EVP_AES_128_CFB1) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+    #ifdef WOLFSSL_AES_192
+    if (XSTRCMP(name, EVP_AES_192_CFB1) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+    #ifdef WOLFSSL_AES_256
+    if (XSTRCMP(name, EVP_AES_256_CFB1) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+    #ifdef WOLFSSL_AES_128
+    if (XSTRCMP(name, EVP_AES_128_CFB8) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+    #ifdef WOLFSSL_AES_192
+    if (XSTRCMP(name, EVP_AES_192_CFB8) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+    #ifdef WOLFSSL_AES_256
+    if (XSTRCMP(name, EVP_AES_256_CFB8) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+#endif /* !WOLFSSL_NO_AES_CFB_1_8 */
+    #ifdef WOLFSSL_AES_128
+    if (XSTRCMP(name, EVP_AES_128_CFB128) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+    #ifdef WOLFSSL_AES_192
+    if (XSTRCMP(name, EVP_AES_192_CFB128) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+    #ifdef WOLFSSL_AES_256
+    if (XSTRCMP(name, EVP_AES_256_CFB128) == 0)
+        return WC_AES_BLOCK_SIZE;
+    #endif
+#endif /* WOLFSSL_AES_CFB */
+
 #endif
 #ifdef HAVE_ARIA
     if (XSTRCMP(name, EVP_ARIA_128_GCM) == 0)


### PR DESCRIPTION
## Summary

`wolfSSL_EVP_CIPHER_iv_length` returns 0 for all CFB and OFB cipher descriptors (CFB1, CFB8, CFB128, OFB for all three key sizes). The correct IV length for these modes is 16 bytes (`AES_BLOCK_SIZE`). A 0 return causes callers that size their IV buffer from the descriptor to use a zero-length or uninitialized IV on every call — silent IV reuse that destroys semantic security.

Fixes Zendesk ticket ZD-21730.

---

## Root cause

`wolfSSL_EVP_CIPHER_iv_length` is a string-comparison chain mapping cipher descriptor names to IV lengths. It has entries for AES-CBC, AES-GCM, AES-CCM, AES-CTR, AES-XTS, DES, ChaCha20, and SM4 — but the entire CFB and OFB sections are absent. No comparison matches `"AES-128-CFB128"` (or any CFB/OFB variant), so the function falls through to `return 0`.

The companion function `wolfSSL_EVP_CIPHER_CTX_iv_length` (which dispatches by integer `cipherType` from an initialized context) correctly returns `WC_AES_BLOCK_SIZE` for all CFB and OFB variants. The bug is isolated to the string-comparison version.

---

## Why it was missed

1. **Two parallel implementations with no enforced parity.** CFB and OFB were added to the CTX-based function correctly but never added to the string-based function. No shared table or generated code links the two.

2. **CFB/OFB are later additions.** The string-comparison function was written when only CBC, GCM, CCM, and CTR existed. When CFB/OFB support was added later, the developer added cipher operations, string constants, and CTX dispatch — but did not audit the string-comparison function for completeness.

3. **Test coverage matched the bug exactly.** `test_wolfSSL_EVP_CIPHER_iv_length` covered only the modes present in the buggy function (CBC, GCM, CTR, DES, ChaCha20-Poly1305). No test ever called `EVP_CIPHER_iv_length(EVP_aes_128_cfb128())`.

4. **Silent failure.** Returning 0 is valid for stream ciphers (RC4), so no assertion fires. A caller must know independently that 0 is wrong for CFB128 to notice.

---

## How we fixed it

**`wolfcrypt/src/evp.c`** — Added 12 missing entries to `wolfSSL_EVP_CIPHER_iv_length` inside the existing `#ifndef NO_AES` block, after the XTS section. Gated by the same compile guards as the corresponding string constant declarations (`WOLFSSL_AES_CFB`, `WOLFSSL_NO_AES_CFB_1_8`, `WOLFSSL_AES_OFB`, and per-keysize `WOLFSSL_AES_128/192/256`):

- AES-128/192/256-OFB → `WC_AES_BLOCK_SIZE`
- AES-128/192/256-CFB1 → `WC_AES_BLOCK_SIZE` (gated `!WOLFSSL_NO_AES_CFB_1_8`)
- AES-128/192/256-CFB8 → `WC_AES_BLOCK_SIZE` (gated `!WOLFSSL_NO_AES_CFB_1_8`)
- AES-128/192/256-CFB128 → `WC_AES_BLOCK_SIZE`

**`tests/api/test_evp_cipher.c`** — Extended `test_wolfSSL_EVP_CIPHER_iv_length` to include CFB128 and OFB NIDs in the `nids[]` / `iv_lengths[]` parallel arrays. These returned 0 before the fix and 16 after. The independent oracle is NIST SP 800-38A, which specifies a 16-byte IV for all AES feedback modes.

## Test plan

- [ ] `./wolfcrypt/test/testwolfcrypt` passes
- [ ] `./tests/unit.test` passes (test 659 `test_wolfSSL_EVP_CIPHER_iv_length` passes and now covers CFB128 and OFB)
- [ ] `EVP_CIPHER_iv_length(EVP_aes_128_cfb128())` returns 16, not 0