### PR TITLE
fix: EVP_DigestSignUpdate/VerifyUpdate accept size_t, not unsigned int

### DIFF
--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -3793,3 +3793,78 @@ int test_wolfSSL_d2i_PrivateKey_reuse_resets_state(void)
 #endif
     return EXPECT_RESULT();
 }
+
+/*
+ * Regression test: EVP_DigestSignUpdate and EVP_DigestVerifyUpdate must both
+ * accept size_t for the byte count.
+ *
+ * Before the fix:
+ *   - DigestSignUpdate declared unsigned int (not size_t), breaking FFI parity.
+ *   - DigestVerifyUpdate declared size_t but immediately cast to unsigned int
+ *     internally, silently truncating any count > (word32)-1.
+ *
+ * Test vector: RFC 4231 Section 4.2 HMAC-SHA256 (independent oracle).
+ *   Key  : "Jefe"
+ *   Data : "what do ya want for nothing?" (28 bytes)
+ *   HMAC : 5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843
+ */
+int test_wolfSSL_EVP_DigestSign_size_t_cnt(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_EXTRA) && !defined(NO_HMAC) && !defined(NO_SHA256)
+    static const byte kKey[] = "Jefe";
+    static const byte kMsg[] = "what do ya want for nothing?";
+    static const byte kExpected[] = {
+        0x5b, 0xdc, 0xc1, 0x46, 0xbf, 0x60, 0x75, 0x4e,
+        0x6a, 0x04, 0x24, 0x26, 0x08, 0x95, 0x75, 0xc7,
+        0x5a, 0x00, 0x3f, 0x08, 0x9d, 0x27, 0x39, 0x83,
+        0x9d, 0xec, 0x58, 0xb9, 0x64, 0xec, 0x38, 0x43
+    };
+    WOLFSSL_EVP_PKEY  *key = NULL;
+    WOLFSSL_EVP_MD_CTX mdCtx;
+    unsigned char      sig[WC_MAX_DIGEST_SIZE];
+    size_t             sigSz = sizeof(sig);
+    /* Deliberately size_t -- not unsigned int -- to verify both APIs accept it
+     * without a cast.  This was the type mismatch caught by ZD-21734. */
+    size_t             msgSz = sizeof(kMsg) - 1;
+
+    ExpectNotNull(key = wolfSSL_EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL,
+                                                     kKey,
+                                                     (int)sizeof(kKey) - 1));
+    wolfSSL_EVP_MD_CTX_init(&mdCtx);
+
+    /* Sign: passes size_t count directly -- regression for unsigned int decl */
+    ExpectIntEQ(wolfSSL_EVP_DigestSignInit(&mdCtx, NULL, EVP_sha256(),
+                                           NULL, key), 1);
+    ExpectIntEQ(wolfSSL_EVP_DigestSignUpdate(&mdCtx, kMsg, msgSz), 1);
+    ExpectIntEQ(wolfSSL_EVP_DigestSignFinal(&mdCtx, sig, &sigSz), 1);
+    ExpectIntEQ((int)sigSz, (int)sizeof(kExpected));
+    ExpectIntEQ(XMEMCMP(sig, kExpected, sizeof(kExpected)), 0);
+    ExpectIntEQ(wolfSSL_EVP_MD_CTX_cleanup(&mdCtx), 1);
+
+    /* Verify: passes size_t count directly -- regression for silent truncation */
+    wolfSSL_EVP_MD_CTX_init(&mdCtx);
+    ExpectIntEQ(wolfSSL_EVP_DigestVerifyInit(&mdCtx, NULL, EVP_sha256(),
+                                             NULL, key), 1);
+    ExpectIntEQ(wolfSSL_EVP_DigestVerifyUpdate(&mdCtx, kMsg, msgSz), 1);
+    ExpectIntEQ(wolfSSL_EVP_DigestVerifyFinal(&mdCtx, kExpected,
+                                              sizeof(kExpected)), 1);
+    ExpectIntEQ(wolfSSL_EVP_MD_CTX_cleanup(&mdCtx), 1);
+
+    /* Overflow guard: cnt > (word32)-1 must fail, not silently truncate.
+     * Only reachable on 64-bit platforms where size_t exceeds word32. */
+    if (sizeof(size_t) > sizeof(word32)) {
+        size_t oversized = (size_t)(word32)-1 + 1; /* (word32)-1 + 1 */
+        wolfSSL_EVP_MD_CTX_init(&mdCtx);
+        ExpectIntEQ(wolfSSL_EVP_DigestSignInit(&mdCtx, NULL, EVP_sha256(),
+                                               NULL, key), 1);
+        ExpectIntEQ(wolfSSL_EVP_DigestSignUpdate(&mdCtx, kMsg, oversized),
+                    WOLFSSL_FAILURE);
+        ExpectIntEQ(wolfSSL_EVP_MD_CTX_cleanup(&mdCtx), 1);
+    }
+
+    wolfSSL_EVP_PKEY_free(key);
+#endif
+    return EXPECT_RESULT();
+} /* END test_wolfSSL_EVP_DigestSign_size_t_cnt */
+

--- a/tests/api/test_evp_pkey.h
+++ b/tests/api/test_evp_pkey.h
@@ -76,6 +76,7 @@ int test_wolfSSL_d2i_PrivateKey_mldsa(void);
 int test_wolfSSL_EVP_PKEY_x25519(void);
 int test_wolfSSL_EVP_PKEY_x448(void);
 int test_wolfSSL_EVP_PKEY_encoded_public_key(void);
+int test_wolfSSL_EVP_DigestSign_size_t_cnt(void);
 int test_wolfSSL_d2i_PrivateKey_reuse_resets_state(void);
 
 #define TEST_EVP_PKEY_DECLS                                                    \
@@ -132,6 +133,7 @@ int test_wolfSSL_d2i_PrivateKey_reuse_resets_state(void);
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_x25519),                 \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_x448),                   \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_encoded_public_key),     \
+    TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_DigestSign_size_t_cnt),       \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_d2i_PrivateKey_reuse_resets_state)
 
 #endif /* WOLFCRYPT_TEST_EVP_PKEY_H */

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -4899,10 +4899,12 @@ static int wolfSSL_evp_digest_pk_init(WOLFSSL_EVP_MD_CTX *ctx,
  * Update a digest for RSA and ECC keys, or HMAC for HMAC key.
  */
 static int wolfssl_evp_digest_pk_update(WOLFSSL_EVP_MD_CTX *ctx,
-                                        const void *d, unsigned int cnt)
+                                        const void *d, size_t cnt)
 {
     if (ctx->isHMAC) {
-        if (wc_HmacUpdate(&ctx->hash.hmac, (const byte *)d, cnt) != 0)
+        if (cnt > (word32)-1)
+            return WOLFSSL_FAILURE;
+        if (wc_HmacUpdate(&ctx->hash.hmac, (const byte *)d, (word32)cnt) != 0)
             return WOLFSSL_FAILURE;
 
         return WOLFSSL_SUCCESS;
@@ -5053,7 +5055,7 @@ int wolfSSL_EVP_DigestSignInit(WOLFSSL_EVP_MD_CTX *ctx,
 
 
 int wolfSSL_EVP_DigestSignUpdate(WOLFSSL_EVP_MD_CTX *ctx, const void *d,
-                                 unsigned int cnt)
+                                 size_t cnt)
 {
     WOLFSSL_ENTER("EVP_DigestSignUpdate");
 
@@ -5209,7 +5211,7 @@ int wolfSSL_EVP_DigestVerifyUpdate(WOLFSSL_EVP_MD_CTX *ctx, const void *d,
     if (ctx == NULL || d == NULL)
         return WOLFSSL_FAILURE;
 
-    return wolfssl_evp_digest_pk_update(ctx, d, (unsigned int)cnt);
+    return wolfssl_evp_digest_pk_update(ctx, d, cnt);
 }
 
 

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -865,7 +865,7 @@ WOLFSSL_API int wolfSSL_EVP_DigestFinal_ex(WOLFSSL_EVP_MD_CTX* ctx,
 WOLFSSL_API int wolfSSL_EVP_DigestFinalXOF(WOLFSSL_EVP_MD_CTX* ctx,
                                             unsigned char* md, size_t sz);
 WOLFSSL_API int wolfSSL_EVP_DigestSignUpdate(WOLFSSL_EVP_MD_CTX *ctx,
-                                             const void *d, unsigned int cnt);
+                                             const void *d, size_t cnt);
 WOLFSSL_API int wolfSSL_EVP_DigestSignFinal(WOLFSSL_EVP_MD_CTX *ctx,
                                             unsigned char *sig, size_t *siglen);
 WOLFSSL_API int wolfSSL_EVP_DigestSign(WOLFSSL_EVP_MD_CTX *ctx,


### PR DESCRIPTION
## Root Cause

Three defects, all in `wolfcrypt/src/evp.c` and `wolfssl/openssl/evp.h`:

1. `wolfSSL_EVP_DigestSignUpdate` was **declared** with `unsigned int cnt` — unlike OpenSSL's `size_t cnt`, breaking source-level API compatibility and FFI bindings that pass `size_t`.
2. `wolfSSL_EVP_DigestVerifyUpdate` had the right `size_t cnt` declaration but the implementation cast it to `unsigned int` before calling the internal helper, **silently truncating** any count larger than `UINT_MAX` on 64-bit platforms.
3. The internal helper `wolfssl_evp_digest_pk_update` accepted `unsigned int`, which forced the truncating cast in #2.

## Why It Was Missed

`DigestSignUpdate` and `DigestVerifyUpdate` were added at different times. The `Verify` side was updated to match OpenSSL's `size_t` in the public declaration but the internal helper (which served both) was never updated, leaving the cast in place. The `Sign` side declaration was never updated at all. Because both functions compile without warning (implicit narrowing is legal in C), the type mismatch survived code review and CI undetected.

## Fix

- `wolfssl_evp_digest_pk_update`: `unsigned int` → `size_t`; add overflow guard before narrowing to `word32` for `wc_HmacUpdate`
- `wolfSSL_EVP_DigestSignUpdate` declaration (`evp.h`) and definition: `unsigned int` → `size_t`
- `wolfSSL_EVP_DigestVerifyUpdate` implementation: remove the `(unsigned int)` cast

## Test

New test `test_wolfSSL_EVP_DigestSign_size_t_cnt` in `tests/api/test_evp_pkey.c`:
- Passes `size_t msgSz` (not `unsigned int`) to both `DigestSignUpdate` and `DigestVerifyUpdate`
- Verifies output against RFC 4231 §4.2 HMAC-SHA256 test vector (independent oracle)
- On 64-bit platforms, verifies that `cnt > UINT_MAX` returns `WOLFSSL_FAILURE` instead of truncating

Refs: ZD-21734