### PR TITLE
Fix CUDA with WOLFSSL_AES_SMALL_TABLES

### DIFF
--- a/wolfcrypt/src/port/cuda/aes-cuda.cu
+++ b/wolfcrypt/src/port/cuda/aes-cuda.cu
@@ -670,7 +670,7 @@ __global__ void AesEncrypt_C_CUDA(word32* rkBase, const byte* inBlockBase, byte*
     byte* outBlock = outBlockBase;
     word32* rk;
 
-    for (int i = index; i < sz; i += stride) {
+    for (int i = idx; i < sz; i += stride) {
         rk = rkBase;
         inBlock = inBlockBase + i * 4 * sizeof(s0);
         outBlock = outBlockBase + i * 4 * sizeof(s0);
@@ -842,7 +842,8 @@ __global__ void AesEncrypt_C_CUDA(word32* rkBase, const byte* inBlockBase, byte*
 #endif
 #else
 #ifndef WC_NO_CACHE_RESISTANT
-        s0 |= PreFetchSBox();
+        PreFetchSBox(sBox);
+        s0 |= sBox;
 #endif
 
         r *= 2;


### PR DESCRIPTION
# Description

Build error when enabling `WOLFSSL_AES_SMALL_TABLES` with CUDA port.

Fixes zd21744

# Testing

Customer confimed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
