### PR TITLE
fix: reorder wc_curve25519_make_pub/generic to input-before-output

### DIFF
--- a/doc/dox_comments/header_files/curve25519.h
+++ b/doc/dox_comments/header_files/curve25519.h
@@ -780,10 +780,10 @@ int wc_curve25519_size(curve25519_key* key);
     \return ECC_BAD_ARG_E If the key sizes are invalid
     \return BAD_FUNC_ARG If any input parameters are NULL
 
-    \param public_size Size of the public key buffer (must be 32)
-    \param pub Pointer to buffer to store the public key
     \param private_size Size of the private key (must be 32)
     \param priv Pointer to buffer containing the private key
+    \param public_size Size of the public key buffer (must be 32)
+    \param pub Pointer to buffer to store the public key
 
     _Example_
     \code
@@ -791,8 +791,8 @@ int wc_curve25519_size(curve25519_key* key);
     byte pub[CURVE25519_KEYSIZE];
 
     // initialize priv with private key
-    int ret = wc_curve25519_make_pub(sizeof(pub), pub, sizeof(priv),
-                                     priv);
+    int ret = wc_curve25519_make_pub(sizeof(priv), priv, sizeof(pub),
+                                     pub);
     if (ret != 0) {
         // error generating public key
     }
@@ -801,8 +801,8 @@ int wc_curve25519_size(curve25519_key* key);
     \sa wc_curve25519_make_key
     \sa wc_curve25519_make_pub_blind
 */
-int wc_curve25519_make_pub(int public_size, byte* pub, int private_size,
-                           const byte* priv);
+int wc_curve25519_make_pub(int private_size, const byte* priv,
+                           int public_size, byte* pub);
 
 /*!
     \ingroup Curve25519
@@ -814,10 +814,10 @@ int wc_curve25519_make_pub(int public_size, byte* pub, int private_size,
     \return ECC_BAD_ARG_E If the key sizes are invalid
     \return BAD_FUNC_ARG If any input parameters are NULL
 
-    \param public_size Size of the public key buffer (must be 32)
-    \param pub Pointer to buffer to store the public key
     \param private_size Size of the private key (must be 32)
     \param priv Pointer to buffer containing the private key
+    \param public_size Size of the public key buffer (must be 32)
+    \param pub Pointer to buffer to store the public key
     \param rng Pointer to initialized RNG for blinding
 
     _Example_
@@ -828,8 +828,8 @@ int wc_curve25519_make_pub(int public_size, byte* pub, int private_size,
 
     wc_InitRng(&rng);
     // initialize priv with private key
-    int ret = wc_curve25519_make_pub_blind(sizeof(pub), pub,
-                                           sizeof(priv), priv, &rng);
+    int ret = wc_curve25519_make_pub_blind(sizeof(priv), priv,
+                                           sizeof(pub), pub, &rng);
     if (ret != 0) {
         // error generating public key
     }
@@ -838,8 +838,8 @@ int wc_curve25519_make_pub(int public_size, byte* pub, int private_size,
     \sa wc_curve25519_make_pub
     \sa wc_curve25519_generic_blind
 */
-int wc_curve25519_make_pub_blind(int public_size, byte* pub,
-                                 int private_size, const byte* priv,
+int wc_curve25519_make_pub_blind(int private_size, const byte* priv,
+                                 int public_size, byte* pub,
                                  WC_RNG* rng);
 
 /*!
@@ -853,10 +853,10 @@ int wc_curve25519_make_pub_blind(int public_size, byte* pub,
     \return ECC_BAD_ARG_E If the sizes are invalid
     \return BAD_FUNC_ARG If any input parameters are NULL
 
-    \param public_size Size of the output buffer (must be 32)
-    \param pub Pointer to buffer to store the result
     \param private_size Size of the scalar (must be 32)
     \param priv Pointer to buffer containing the scalar
+    \param public_size Size of the output buffer (must be 32)
+    \param pub Pointer to buffer to store the result
     \param basepoint_size Size of the basepoint (must be 32)
     \param basepoint Pointer to buffer containing the basepoint
 
@@ -867,8 +867,8 @@ int wc_curve25519_make_pub_blind(int public_size, byte* pub,
     byte result[CURVE25519_KEYSIZE];
 
     // initialize scalar and basepoint
-    int ret = wc_curve25519_generic(sizeof(result), result,
-                                    sizeof(scalar), scalar,
+    int ret = wc_curve25519_generic(sizeof(scalar), scalar,
+                                    sizeof(result), result,
                                     sizeof(basepoint), basepoint);
     if (ret != 0) {
         // error computing result
@@ -878,9 +878,9 @@ int wc_curve25519_make_pub_blind(int public_size, byte* pub,
     \sa wc_curve25519_shared_secret
     \sa wc_curve25519_generic_blind
 */
-int wc_curve25519_generic(int public_size, byte* pub, int private_size,
-                         const byte* priv, int basepoint_size,
-                         const byte* basepoint);
+int wc_curve25519_generic(int private_size, const byte* priv,
+                         int public_size, byte* pub,
+                         int basepoint_size, const byte* basepoint);
 
 /*!
     \ingroup Curve25519
@@ -892,10 +892,10 @@ int wc_curve25519_generic(int public_size, byte* pub, int private_size,
     \return ECC_BAD_ARG_E If the sizes are invalid
     \return BAD_FUNC_ARG If any input parameters are NULL
 
-    \param public_size Size of the output buffer (must be 32)
-    \param pub Pointer to buffer to store the result
     \param private_size Size of the scalar (must be 32)
     \param priv Pointer to buffer containing the scalar
+    \param public_size Size of the output buffer (must be 32)
+    \param pub Pointer to buffer to store the result
     \param basepoint_size Size of the basepoint (must be 32)
     \param basepoint Pointer to buffer containing the basepoint
     \param rng Pointer to initialized RNG for blinding
@@ -909,8 +909,8 @@ int wc_curve25519_generic(int public_size, byte* pub, int private_size,
 
     wc_InitRng(&rng);
     // initialize scalar and basepoint
-    int ret = wc_curve25519_generic_blind(sizeof(result), result,
-                                          sizeof(scalar), scalar,
+    int ret = wc_curve25519_generic_blind(sizeof(scalar), scalar,
+                                          sizeof(result), result,
                                           sizeof(basepoint), basepoint,
                                           &rng);
     \endcode
@@ -918,8 +918,8 @@ int wc_curve25519_generic(int public_size, byte* pub, int private_size,
     \sa wc_curve25519_generic
     \sa wc_curve25519_make_pub_blind
 */
-int wc_curve25519_generic_blind(int public_size, byte* pub,
-                                int private_size, const byte* priv,
+int wc_curve25519_generic_blind(int private_size, const byte* priv,
+                                int public_size, byte* pub,
                                 int basepoint_size, const byte* basepoint,
                                 WC_RNG* rng);
 

--- a/tests/api/test_curve25519.c
+++ b/tests/api/test_curve25519.c
@@ -370,25 +370,25 @@ int test_wc_curve25519_make_pub(void)
     ExpectIntEQ(wc_InitRng(&rng), 0);
     ExpectIntEQ(wc_curve25519_make_key(&rng, CURVE25519_KEYSIZE, &key), 0);
 
-    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof(out), out,
-        (int)sizeof(key.k), key.k), 0);
+    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof(key.k), key.k,
+        (int)sizeof(out), out), 0);
     /* test bad cases */
     ExpectIntEQ(wc_curve25519_make_pub((int)sizeof(key.k) - 1, key.k,
-        (int)sizeof out, out), WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
-    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof out, out, (int)sizeof(key.k),
-        NULL), WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
-    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof out - 1, out,
-        (int)sizeof(key.k), key.k), WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
-    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof out, NULL,
-        (int)sizeof(key.k), key.k), WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
+        (int)sizeof(out), out), WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
+    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof(key.k), NULL,
+        (int)sizeof(out), out), WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
+    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof(key.k), key.k,
+        (int)sizeof(out) - 1, out), WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
+    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof(key.k), key.k,
+        (int)sizeof(out), NULL), WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
     /* verify clamping test */
     key.k[0] |= ~248;
-    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof out, out, (int)sizeof(key.k),
-        key.k), WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
+    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof(key.k), key.k,
+        (int)sizeof(out), out), WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
     key.k[0] &= 248;
     /* repeat the expected-to-succeed test. */
-    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof out, out, (int)sizeof(key.k),
-        key.k), 0);
+    ExpectIntEQ(wc_curve25519_make_pub((int)sizeof(key.k), key.k,
+        (int)sizeof(out), out), 0);
 
     DoExpectIntEQ(wc_FreeRng(&rng), 0);
     wc_curve25519_free(&key);

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -137,8 +137,8 @@ static WC_INLINE void curve25519_copy_point(byte* out, const byte* point,
  * return value is propagated from curve25519() (0 on success), or
  * ECC_BAD_ARG_E, and the byte vectors are little endian.
  */
-int wc_curve25519_make_pub(int public_size, byte* pub, int private_size,
-                           const byte* priv)
+int wc_curve25519_make_pub(int private_size, const byte* priv,
+                           int public_size, byte* pub)
 {
     int ret;
 #ifdef FREESCALE_LTC_ECC
@@ -204,8 +204,8 @@ int wc_curve25519_make_pub(int public_size, byte* pub, int private_size,
 
         ret = wc_InitRng(&rng);
         if (ret == 0) {
-            ret = wc_curve25519_make_pub_blind(public_size, pub, private_size,
-                priv, &rng);
+            ret = wc_curve25519_make_pub_blind(private_size, priv, public_size,
+                pub, &rng);
 
             wc_FreeRng(&rng);
         }
@@ -283,8 +283,8 @@ static int curve25519_smul_blind(byte* rp, const byte* n, const byte* p,
 }
 #endif
 
-int wc_curve25519_make_pub_blind(int public_size, byte* pub, int private_size,
-                                 const byte* priv, WC_RNG* rng)
+int wc_curve25519_make_pub_blind(int private_size, const byte* priv,
+                                 int public_size, byte* pub, WC_RNG* rng)
 {
     int ret;
 #ifdef FREESCALE_LTC_ECC
@@ -333,8 +333,8 @@ int wc_curve25519_make_pub_blind(int public_size, byte* pub, int private_size,
  * return value is propagated from curve25519() (0 on success),
  * and the byte vectors are little endian.
  */
-int wc_curve25519_generic(int public_size, byte* pub,
-                          int private_size, const byte* priv,
+int wc_curve25519_generic(int private_size, const byte* priv,
+                          int public_size, byte* pub,
                           int basepoint_size, const byte* basepoint)
 {
 #ifdef FREESCALE_LTC_ECC
@@ -373,7 +373,7 @@ int wc_curve25519_generic(int public_size, byte* pub,
 
     ret = wc_InitRng(&rng);
     if (ret == 0) {
-        ret = wc_curve25519_generic_blind(public_size, pub, private_size, priv,
+        ret = wc_curve25519_generic_blind(private_size, priv, public_size, pub,
             basepoint_size, basepoint, &rng);
 
         wc_FreeRng(&rng);
@@ -391,8 +391,8 @@ int wc_curve25519_generic(int public_size, byte* pub,
  * return value is propagated from curve25519() (0 on success),
  * and the byte vectors are little endian.
  */
-int wc_curve25519_generic_blind(int public_size, byte* pub,
-                                int private_size, const byte* priv,
+int wc_curve25519_generic_blind(int private_size, const byte* priv,
+                                int public_size, byte* pub,
                                 int basepoint_size, const byte* basepoint,
                                 WC_RNG* rng)
 {
@@ -579,14 +579,14 @@ int wc_curve25519_make_key(WC_RNG* rng, int keysize, curve25519_key* key)
         if (ret == 0) {
             key->privSet = 1;
 #ifdef WOLFSSL_CURVE25519_BLINDING
-            ret = wc_curve25519_make_pub_blind((int)sizeof(key->p.point),
-                      key->p.point, (int)sizeof(key->k), key->k, rng);
+            ret = wc_curve25519_make_pub_blind((int)sizeof(key->k),
+                      key->k, (int)sizeof(key->p.point), key->p.point, rng);
             if (ret == 0) {
                 ret = wc_curve25519_set_rng(key, rng);
             }
 #else
-            ret = wc_curve25519_make_pub((int)sizeof(key->p.point),
-                      key->p.point, (int)sizeof(key->k), key->k);
+            ret = wc_curve25519_make_pub((int)sizeof(key->k),
+                      key->k, (int)sizeof(key->p.point), key->p.point);
 #endif
             key->pubSet = (ret == 0);
         }
@@ -805,12 +805,12 @@ int wc_curve25519_export_public_ex(curve25519_key* key, byte* out,
     /* calculate public if missing */
     if (!key->pubSet) {
 #ifdef WOLFSSL_CURVE25519_BLINDING
-        ret = wc_curve25519_make_pub_blind((int)sizeof(key->p.point),
-                                           key->p.point, (int)sizeof(key->k),
-                                           key->k, key->rng);
+        ret = wc_curve25519_make_pub_blind((int)sizeof(key->k),
+                                           key->k, (int)sizeof(key->p.point),
+                                           key->p.point, key->rng);
 #else
-        ret = wc_curve25519_make_pub((int)sizeof(key->p.point), key->p.point,
-                                     (int)sizeof(key->k), key->k);
+        ret = wc_curve25519_make_pub((int)sizeof(key->k), key->k,
+                                     (int)sizeof(key->p.point), key->p.point);
 #endif
         key->pubSet = (ret == 0);
     }

--- a/wolfssl/wolfcrypt/curve25519.h
+++ b/wolfssl/wolfcrypt/curve25519.h
@@ -155,22 +155,22 @@ enum {
 };
 
 WOLFSSL_API
-int wc_curve25519_make_pub(int public_size, byte* pub, int private_size,
-                           const byte* priv);
+int wc_curve25519_make_pub(int private_size, const byte* priv,
+                           int public_size, byte* pub);
 #ifdef WOLFSSL_CURVE25519_BLINDING
 WOLFSSL_API
-int wc_curve25519_make_pub_blind(int public_size, byte* pub, int private_size,
-                                 const byte* priv, WC_RNG* rng);
+int wc_curve25519_make_pub_blind(int private_size, const byte* priv,
+                                 int public_size, byte* pub, WC_RNG* rng);
 #endif
 
 WOLFSSL_API
-int wc_curve25519_generic(int public_size, byte* pub,
-                          int private_size, const byte* priv,
+int wc_curve25519_generic(int private_size, const byte* priv,
+                          int public_size, byte* pub,
                           int basepoint_size, const byte* basepoint);
 #ifdef WOLFSSL_CURVE25519_BLINDING
 WOLFSSL_API
-int wc_curve25519_generic_blind(int public_size, byte* pub,
-                                int private_size, const byte* priv,
+int wc_curve25519_generic_blind(int private_size, const byte* priv,
+                                int public_size, byte* pub,
                                 int basepoint_size, const byte* basepoint,
                                 WC_RNG* rng);
 #endif

--- a/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
@@ -330,8 +330,8 @@ impl Curve25519Key {
         let private_size = crate::buffer_len_to_i32(private.len())?;
         let public_size = crate::buffer_len_to_i32(public.len())?;
         let rc = unsafe {
-            sys::wc_curve25519_make_pub(public_size, public.as_mut_ptr(),
-                private_size, private.as_ptr())
+            sys::wc_curve25519_make_pub(private_size, private.as_ptr(),
+                public_size, public.as_mut_ptr())
         };
         if rc != 0 {
             return Err(rc);
@@ -357,8 +357,8 @@ impl Curve25519Key {
         let private_size = crate::buffer_len_to_i32(private.len())?;
         let public_size = crate::buffer_len_to_i32(public.len())?;
         let rc = unsafe {
-            sys::wc_curve25519_make_pub_blind(public_size, public.as_mut_ptr(),
-                private_size, private.as_ptr(), &mut rng.wc_rng)
+            sys::wc_curve25519_make_pub_blind(private_size, private.as_ptr(),
+                public_size, public.as_mut_ptr(), &mut rng.wc_rng)
         };
         if rc != 0 {
             return Err(rc);
@@ -384,8 +384,8 @@ impl Curve25519Key {
         let public_size = crate::buffer_len_to_i32(public.len())?;
         let basepoint_size = crate::buffer_len_to_i32(basepoint.len())?;
         let rc = unsafe {
-            sys::wc_curve25519_generic(public_size, public.as_mut_ptr(),
-                private_size, private.as_ptr(), basepoint_size, basepoint.as_ptr())
+            sys::wc_curve25519_generic(private_size, private.as_ptr(),
+                public_size, public.as_mut_ptr(), basepoint_size, basepoint.as_ptr())
         };
         if rc != 0 {
             return Err(rc);
@@ -413,8 +413,8 @@ impl Curve25519Key {
         let public_size = crate::buffer_len_to_i32(public.len())?;
         let basepoint_size = crate::buffer_len_to_i32(basepoint.len())?;
         let rc = unsafe {
-            sys::wc_curve25519_generic_blind(public_size, public.as_mut_ptr(),
-                private_size, private.as_ptr(), basepoint_size, basepoint.as_ptr(),
+            sys::wc_curve25519_generic_blind(private_size, private.as_ptr(),
+                public_size, public.as_mut_ptr(), basepoint_size, basepoint.as_ptr(),
                 &mut rng.wc_rng)
         };
         if rc != 0 {


### PR DESCRIPTION
Refs: ZD-21733

## The Problem

Four raw-bytes Curve25519 functions had output parameters before input parameters:

```c
// Before (wrong):
int wc_curve25519_make_pub(int public_size, byte* pub,
                           int private_size, const byte* priv);
```

Every other wolfCrypt raw-bytes function uses input-before-output ordering:

```c
wc_curve25519_import_private(const byte* priv, word32 privSz, curve25519_key* key)
wc_ed25519_make_public(ed25519_key* key, unsigned char* pubKey, word32 pubKeySz)
wc_curve25519_make_priv(WC_RNG* rng, int keysize, byte* priv)
```

The same wrong ordering was shared by all four related raw-bytes functions: `wc_curve25519_make_pub`, `wc_curve25519_make_pub_blind`, `wc_curve25519_generic`, and `wc_curve25519_generic_blind`.

## Why It Was Not Caught

Both size parameters are `int` and both must equal `CURVE25519_KEYSIZE` (32). Transposing the arguments compiles without warning and passes the runtime size check. The clamping check (RFC 7748 §5) provides a partial accidental guard — an arbitrary 32-byte buffer will usually fail — but is not reliable. There was no test that deliberately passed arguments in the wrong order to verify the error path.

Additionally, the original author got the argument order wrong in six places in the test suite when the function was first introduced (2020-08-05), then had to push a follow-up commit the next day titled *"fix order of args to wc_curve25519_make_pub()"*. The signature was not corrected at that point; only the test was patched.

## How Fixed

Reordered parameters to private-before-public on all four functions:

```c
// After (correct):
int wc_curve25519_make_pub(int private_size, const byte* priv,
                           int public_size, byte* pub);
```

Updated all five internal call sites in `wolfcrypt/src/curve25519.c`, the test suite, and the Doxygen doc comments and code examples.

## Risk to External Callers

This is a breaking API change for any external caller that uses these four functions directly. Mitigating factors:

- These are low-level raw-bytes functions; the typical application uses `wc_curve25519_make_key()` instead
- All in-tree callers (5 sites, all in `wolfcrypt/src/curve25519.c`) have been updated atomically
- External callers with the wrong argument order were producing wrong output silently; the fix makes their code fail to compile rather than fail silently

If desired, a deprecated wrapper preserving the old name and signature can be added alongside.