### PR TITLE
fix: add const to wc_Ed448 DER export function key parameters

### DIFF
--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -2845,7 +2845,7 @@ int wc_Ed448PublicKeyDecode(const byte* input, word32* inOutIdx,
 
     \sa wc_Ed448PrivateKeyToDer
 */
-int wc_Ed448KeyToDer(ed448_key* key, byte* output, word32 inLen);
+int wc_Ed448KeyToDer(const ed448_key* key, byte* output, word32 inLen);
 
 /*!
     \ingroup Ed448
@@ -2868,7 +2868,7 @@ int wc_Ed448KeyToDer(ed448_key* key, byte* output, word32 inLen);
 
     \sa wc_Ed448PrivateKeyDecode
 */
-int wc_Ed448PrivateKeyToDer(ed448_key* key, byte* output,
+int wc_Ed448PrivateKeyToDer(const ed448_key* key, byte* output,
                              word32 inLen);
 
 /*!
@@ -2881,19 +2881,20 @@ int wc_Ed448PrivateKeyToDer(ed448_key* key, byte* output,
     \param key Ed448 key structure with public key
     \param output Buffer for DER encoded public key
     \param inLen Size of output buffer
+    \param withAlg 1 to include algorithm identifier, 0 for key data only
 
     _Example_
     \code
     ed448_key key;
     byte der[1024];
     int derSz = wc_Ed448PublicKeyToDer(&key, der,
-                                       sizeof(der));
+                                       sizeof(der), 1);
     \endcode
 
     \sa wc_Ed448PublicKeyDecode
 */
-int wc_Ed448PublicKeyToDer(ed448_key* key, byte* output,
-                            int inLen);
+int wc_Ed448PublicKeyToDer(const ed448_key* key, byte* output,
+                            word32 inLen, int withAlg);
 
 /*!
     \ingroup Curve448

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -12621,7 +12621,7 @@ int wc_Ed25519PublicKeyToDer(const ed25519_key* key, byte* output, word32 inLen,
  * @return  BAD_FUNC_ARG when key is NULL.
  * @return  MEMORY_E when dynamic memory allocation failed.
  */
-int wc_Ed448PublicKeyToDer(ed448_key* key, byte* output, word32 inLen,
+int wc_Ed448PublicKeyToDer(const ed448_key* key, byte* output, word32 inLen,
                            int withAlg)
 {
     int    ret;
@@ -32022,7 +32022,7 @@ int wc_Curve448PublicKeyDecode(const byte* input, word32* inOutIdx,
 #if defined(HAVE_ED448) && defined(HAVE_ED448_KEY_EXPORT)
 /* Write a Private ecc key, including public to DER format,
  * length on success else < 0 */
-int wc_Ed448KeyToDer(ed448_key* key, byte* output, word32 inLen)
+int wc_Ed448KeyToDer(const ed448_key* key, byte* output, word32 inLen)
 {
     if (key == NULL) {
         return BAD_FUNC_ARG;
@@ -32033,7 +32033,7 @@ int wc_Ed448KeyToDer(ed448_key* key, byte* output, word32 inLen)
 
 /* Write only private ecc key to DER format,
  * length on success else < 0 */
-int wc_Ed448PrivateKeyToDer(ed448_key* key, byte* output, word32 inLen)
+int wc_Ed448PrivateKeyToDer(const ed448_key* key, byte* output, word32 inLen)
 {
     if (key == NULL) {
         return BAD_FUNC_ARG;

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -851,11 +851,11 @@ WOLFSSL_API int wc_Ed448PublicKeyDecode(
     const byte* input, word32* inOutIdx, ed448_key* key, word32 inSz);
 #endif
 #ifdef HAVE_ED448_KEY_EXPORT
-WOLFSSL_API int wc_Ed448KeyToDer(ed448_key* key, byte* output, word32 inLen);
+WOLFSSL_API int wc_Ed448KeyToDer(const ed448_key* key, byte* output, word32 inLen);
 WOLFSSL_API int wc_Ed448PrivateKeyToDer(
-    ed448_key* key, byte* output, word32 inLen);
+    const ed448_key* key, byte* output, word32 inLen);
 WOLFSSL_API int wc_Ed448PublicKeyToDer(
-    ed448_key* key, byte* output, word32 inLen, int withAlg);
+    const ed448_key* key, byte* output, word32 inLen, int withAlg);
 #endif
 #endif /* HAVE_ED448 */
 


### PR DESCRIPTION
## ZD Reference

ZD #21745

## Problem

`wc_Ed448KeyToDer`, `wc_Ed448PrivateKeyToDer`, and `wc_Ed448PublicKeyToDer` take a non-const `ed448_key*` parameter, while the directly analogous Ed25519 functions (`wc_Ed25519KeyToDer`, `wc_Ed25519PrivateKeyToDer`, `wc_Ed25519PublicKeyToDer`) correctly take `const ed25519_key*`. None of the three Ed448 DER encoding operations modify the key.

Impact: any FFI wrapper (Rust, Python, Go) that holds a read-only key reference cannot call the Ed448 DER functions without an unsafe coercion, while the identical Ed25519 functions work cleanly. In Rust specifically, the standard pattern is `&self` (shared/immutable reference); obtaining `*mut ed448_key` from `&self` requires `unsafe { }` with no benefit.

## Why it was missed

Both Ed25519 and Ed448 DER functions were originally written without `const` and were symmetric. In October 2025, commit `7cbcd0b00` ("Rust wrapper: add wolfssl::wolfcrypt::ed25519 module") retrofitted `const` onto all three Ed25519 DER functions, driven by the requirements of the new Rust wrapper. That commit was scoped to Ed25519 — no Ed448 Rust module existed yet, so there was no signal to trigger a parallel update.

The C compiler does not warn about the asymmetry: C silently accepts passing `ed448_key*` where `const ed448_key*` is expected. The existing Ed448 DER tests in `tests/api/test_ed448.c` all pass locally-allocated (mutable) key pointers, so they compile and pass regardless of whether the parameter is `const`. There is no automated check enforcing parity between parallel API families.

## Fix

Added `const` to the `ed448_key*` key parameter in all three function declarations (`wolfssl/wolfcrypt/asn_public.h`) and definitions (`wolfcrypt/src/asn.c`). No implementation changes — the internal `SetAsymKeyDer` helper already takes `const byte*` for both `privKey` and `pubKey`, and `wc_ed448_export_public` already takes `const ed448_key*`.

## Verification

- Build with `--enable-ed448 --enable-keygen`: zero errors, zero new warnings
- `./wolfcrypt/test/testwolfcrypt`: passes
- `./tests/unit.test`: passes; `test_wc_Ed448PublicKeyToDer`, `test_wc_Ed448KeyToDer`, and `test_wc_Ed448PrivateKeyToDer` all run and pass