### PR TITLE
20260430-ecc_test_vector_item-WC_MIN_DIGEST_SIZE

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -34832,20 +34832,22 @@ static wc_test_ret_t ecc_test_vector_item(const eccVector* vector)
 #endif /* !NO_ASN */
 
 #ifdef HAVE_ECC_VERIFY
-    do {
+    if (vector->msgLen >= WC_MIN_DIGEST_SIZE) {
+        do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, &userA->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+            ret = wc_AsyncWait(ret, &userA->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
-        if (ret == 0)
-            ret = wc_ecc_verify_hash(sig, sigSz, (byte*)vector->msg,
-                                               vector->msgLen, &verify, userA);
-    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
-    if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
-    TEST_SLEEP();
+            if (ret == 0)
+                ret = wc_ecc_verify_hash(sig, sigSz, (byte*)vector->msg,
+                                         vector->msgLen, &verify, userA);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+        TEST_SLEEP();
 
-    if (verify != 1)
-        ret = WC_TEST_RET_ENC_NC;
+        if (verify != 1)
+            ret = WC_TEST_RET_ENC_NC;
+    }
 #endif
 
 done:


### PR DESCRIPTION
`wolfcrypt/test/test.c`: in `ecc_test_vector_item()`, don't attempt `wc_ecc_verify_hash()` if the test vector's message (hash) is shorter than `WC_MIN_DIGEST_SIZE`.

discovered and tested with `all-crypto-only-intelasm-fips-v5-linuxkm-next-insmod-optest`, which unintentionally had `--disable-sha`, exposing the issue.
