### PR TITLE
20260501 Coverity Fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -10621,7 +10621,8 @@ static int test_tls_ext_word16_overflow(void)
         ExpectIntEQ(TLSX_UseSessionTicket(&ssl->extensions, ticket, ssl->heap),
             WOLFSSL_SUCCESS);
         /* TLSX_UseSessionTicket takes ownership on success. */
-        ticket = NULL;
+        if (EXPECT_SUCCESS())
+            ticket = NULL;
     }
 
     /* TLSX_GetRequestSize must refuse to encode: 4-byte ext header +
@@ -10697,7 +10698,8 @@ static int test_tls_ext_word16_overflow(void)
         if (EXPECT_SUCCESS() && ticket2 != NULL) {
             ExpectIntEQ(TLSX_UseSessionTicket(&ssl2->extensions, ticket2,
                                               ssl2->heap), WOLFSSL_SUCCESS);
-            ticket2 = NULL;
+            if (EXPECT_SUCCESS())
+                ticket2 = NULL;
         }
 
         /* Exact boundary: internal sum == 0xFFFD must succeed, and the

--- a/tests/api/test_pkcs12.c
+++ b/tests/api/test_pkcs12.c
@@ -434,6 +434,7 @@ int test_wc_PKCS12_encrypted_content_bounds(void)
         word32 regPkeySz = 0;
         word32 regCertSz = 0;
 
+        XMEMSET(regCiphertext, 0, sizeof(regCiphertext));
         /* Derive AES-256 key with the same PBKDF2 that DecryptContent uses */
         ExpectIntEQ(wc_PBKDF2(regKey, (const byte*)regPassword,
             (int)XSTRLEN(regPassword), regSalt, (int)sizeof(regSalt),

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1154,39 +1154,31 @@ static int RsaMGF_SHAKE(enum wc_HashType shakeType, byte* seed, word32 seedSz,
         return MEMORY_E);
 
 #ifdef WOLFSSL_SHAKE128
-    if (shakeType == WC_HASH_TYPE_SHAKE128)
+    if (shakeType == WC_HASH_TYPE_SHAKE128) {
         ret = wc_InitShake128(shake, heap, INVALID_DEVID);
-    else
-#endif
-#ifdef WOLFSSL_SHAKE256
-    if (shakeType == WC_HASH_TYPE_SHAKE256)
-        ret = wc_InitShake256(shake, heap, INVALID_DEVID);
-    else
-#endif
-        ret = BAD_FUNC_ARG;
-
-    if (ret == 0) {
-#ifdef WOLFSSL_SHAKE128
-        if (shakeType == WC_HASH_TYPE_SHAKE128) {
+        if (ret == 0) {
             ret = wc_Shake128_Update(shake, seed, seedSz);
             if (ret == 0)
                 ret = wc_Shake128_Final(shake, out, outSz);
             wc_Shake128_Free(shake);
         }
-        else
+    }
+    else
 #endif
 #ifdef WOLFSSL_SHAKE256
-        if (shakeType == WC_HASH_TYPE_SHAKE256) {
+    if (shakeType == WC_HASH_TYPE_SHAKE256) {
+        ret = wc_InitShake256(shake, heap, INVALID_DEVID);
+        if (ret == 0) {
             ret = wc_Shake256_Update(shake, seed, seedSz);
             if (ret == 0)
                 ret = wc_Shake256_Final(shake, out, outSz);
             wc_Shake256_Free(shake);
         }
-        else
+    }
+    else
 #endif
-        {
-            ret = BAD_FUNC_ARG;
-        }
+    {
+        ret = BAD_FUNC_ARG;
     }
     WC_FREE_VAR_EX(shake, heap, DYNAMIC_TYPE_TMP_BUFFER);
     return ret;


### PR DESCRIPTION
# Description

Clears uninitialized variable, clean up dead code, fix unconditional NULL assignment.


# Testing

`./configure --enable-all && make check`

