### PR TITLE
Fix flaky tcp bind on Windows test runs

### DIFF
--- a/examples/ocsp_responder/ocsp_responder.c
+++ b/examples/ocsp_responder/ocsp_responder.c
@@ -943,13 +943,6 @@ THREAD_RETURN WOLFSSL_THREAD ocsp_responder_test(void* args)
         }
     }
 
-#ifdef USE_WINDOWS_API
-    if (opts.port == 0) {
-        /* Generate random port for testing */
-        opts.port = GetRandomPort();
-    }
-#endif /* USE_WINDOWS_API */
-
     /* Create and listen on server socket */
     tcp_listen(&sockfd, &opts.port, 1, 0, 0);
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -3231,13 +3231,6 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     }
 #endif
 
-#ifdef USE_WINDOWS_API
-    if (port == 0) {
-        /* Generate random port for testing */
-        port = GetRandomPort();
-    }
-#endif /* USE_WINDOWS_API */
-
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfAsync_DevOpen(&devId);
     if (ret < 0) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -6050,11 +6050,6 @@ void test_wolfSSL_client_server_nofail_ex(callback_functions* client_cb,
     StartTCP();
     InitTcpReady(&ready);
 
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
-
     server_args.signal = &ready;
     server_args.callbacks = server_cb;
     client_args.signal = &ready;
@@ -6748,11 +6743,6 @@ static int test_wolfSSL_read_write(void)
     StartTCP();
     InitTcpReady(&ready);
 
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
-
     server_args.signal = &ready;
     client_args.signal = &ready;
 
@@ -6840,11 +6830,6 @@ static int test_wolfSSL_reuse_WOLFSSLobj(void)
 
     StartTCP();
     InitTcpReady(&ready);
-
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
 
     client_cbf.method = wolfTLSv1_2_client_method;
     server_cbf.method = wolfTLSv1_2_server_method;
@@ -8119,11 +8104,6 @@ static int test_wolfSSL_dtls_export(void)
 
     InitTcpReady(&ready);
 
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
-
     /* set using dtls */
     XMEMSET(&client_args, 0, sizeof(func_args));
     XMEMSET(&server_args, 0, sizeof(func_args));
@@ -8193,11 +8173,6 @@ static int test_wolfSSL_dtls_export(void)
 #endif
 
     InitTcpReady(&ready);
-
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
 
     /* set using dtls */
     XMEMSET(&server_args, 0, sizeof(func_args));
@@ -8675,11 +8650,6 @@ static int test_wolfSSL_tls_export_run(method_provider server_method,
 
     InitTcpReady(&ready);
 
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
-
     XMEMSET(&server_args, 0, sizeof(func_args));
     XMEMSET(&server_cbf, 0, sizeof(callback_functions));
     server_cbf.method = server_method;
@@ -8794,11 +8764,6 @@ static void test_wolfSSL_client_server(callback_functions* client_callbacks,
 
     /* RUN Server side */
     InitTcpReady(&ready);
-
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
 
     server_args.signal = &ready;
     client_args.signal = &ready;
@@ -18350,11 +18315,6 @@ static int test_wolfSSL_SESSION(void)
     StartTCP();
     InitTcpReady(&ready);
 
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
-
     server_args.signal = &ready;
     start_thread(test_server_nofail, &server_args, &serverThread);
     wait_tcp_ready(&server_args);
@@ -26887,11 +26847,6 @@ static int test_wolfSSL_read_detect_TCP_disconnect(void)
 #endif
     StartTCP();
     InitTcpReady(&ready);
-
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
 
     XMEMSET(&client_args, 0, sizeof(func_args));
     XMEMSET(&server_args, 0, sizeof(func_args));

--- a/tests/api/test_ossl_bio.c
+++ b/tests/api/test_ossl_bio.c
@@ -357,10 +357,6 @@ int test_wolfSSL_BIO_should_retry(void)
     StartTCP();
     InitTcpReady(&ready);
 
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
 
     server_args.signal = &ready;
     start_thread(test_server_nofail, &server_args, &serverThread);
@@ -465,10 +461,6 @@ int test_wolfSSL_BIO_connect(void)
     XMEMSET(&server_args, 0, sizeof(func_args));
     StartTCP();
     InitTcpReady(&ready);
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
     server_args.signal = &ready;
     start_thread(test_server_nofail, &server_args, &serverThread);
     wait_tcp_ready(&server_args);
@@ -512,10 +504,6 @@ int test_wolfSSL_BIO_connect(void)
     XMEMSET(&server_args, 0, sizeof(func_args));
     StartTCP();
     InitTcpReady(&ready);
-#if defined(USE_WINDOWS_API)
-    /* use RNG to get random port if using windows */
-    ready.port = GetRandomPort();
-#endif
     server_args.signal = &ready;
     start_thread(test_server_nofail, &server_args, &serverThread);
     wait_tcp_ready(&server_args);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1697,8 +1697,7 @@ static WC_INLINE void tcp_listen(SOCKET_T* sockfd, word16* port, int useAnyAddr,
         if (listen(*sockfd, SOCK_LISTEN_MAX_QUEUE) != 0)
                 err_sys_with_errno("tcp listen failed");
     }
-    #if !defined(USE_WINDOWS_API) && !defined(WOLFSSL_TIRTOS) \
-                                                     && !defined(WOLFSSL_ZEPHYR)
+    #if !defined(WOLFSSL_TIRTOS) && !defined(WOLFSSL_ZEPHYR)
         if (*port == 0) {
             socklen_t len = sizeof(addr);
             if (getsockname(*sockfd, (struct sockaddr*)&addr, &len) == 0) {
@@ -1770,8 +1769,7 @@ static WC_INLINE void udp_accept(SOCKET_T* sockfd, SOCKET_T* clientfd,
     if (bind(*sockfd, (const struct sockaddr*)&addr, sizeof(addr)) != 0)
         err_sys_with_errno("tcp bind failed");
 
-    #if !defined(USE_WINDOWS_API) && !defined(WOLFSSL_TIRTOS) && \
-           !defined(SINGLE_THREADED)
+    #if !defined(WOLFSSL_TIRTOS) && !defined(SINGLE_THREADED)
         if (port == 0) {
             socklen_t len = sizeof(addr);
             if (getsockname(*sockfd, (struct sockaddr*)&addr, &len) == 0) {


### PR DESCRIPTION
Windows test code pre-picked a random port via `GetRandomPort()` (returning a value in [49152, 65535]) before calling `bind()`, with no check that the port was free and no retry on collision. Under load this occasionally collided with an already-bound port and aborted the test with "tcp bind failed", producing intermittent Jenkins failures (e.g. PRB windows-test-v2 in the OCSP responder test).

The Unix path already does the right thing: bind to port 0 (OS-assigned ephemeral) and read the port back via `getsockname()`. The same primitives exist in Winsock 1.1, so drop the `USE_WINDOWS_API` guard around the `getsockname` block in `tcp_listen()`/`udp_accept()` and remove the per-caller `GetRandomPort()` workarounds in the OCSP responder, server example, and the api.c / test_ossl_bio.c test sites. `socklen_t` is already typedef'd as int on Windows in test.h.

`GetRandomPort()` itself is left in place since it is a static inline in a shipped public test header.
