### PR TITLE
plumb caller heap into Cmac before cryptocb fires

### DIFF
--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -126,6 +126,13 @@ static int _InitCmac_common(Cmac* cmac, const byte* key, word32 keySz,
 #endif
     XMEMSET(cmac, 0, sizeof(Cmac));
 
+    /* Stash heap so the cryptocb can read it from the zeroed cmac. */
+#ifndef NO_AES
+    cmac->aes.heap = heap;
+#else
+    cmac->heap = heap;
+#endif
+
     /* Store id/label on the Cmac struct so the crypto callback can
      * inspect them to determine the hardware key slot. */
 #ifdef WOLF_PRIVATE_KEY_ID

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -63,6 +63,8 @@ struct Cmac {
     byte digest[WC_AES_BLOCK_SIZE]; /* running digest */
     byte k1[WC_AES_BLOCK_SIZE];
     byte k2[WC_AES_BLOCK_SIZE];
+#else
+    void* heap; /* fallback when no aes.heap is available */
 #endif
     word32 bufferSz;
     word32 totalSz;


### PR DESCRIPTION
`_InitCmac_` common `XMEMSET`s the Cmac struct then immediately invokes the cryptocb, so the heap arg passed to `wc_InitCmac_*` was lost before any hardware callback could read it. Stash heap in `cmac->aes.heap` (or a new `NO_AES` only `cmac->heap` fallback) right after the memset.
