### PR TITLE
Rust wrapper: ensure memory safety for C RNG struct

### DIFF
--- a/wrapper/rust/wolfssl-wolfcrypt/Cargo.toml
+++ b/wrapper/rust/wolfssl-wolfcrypt/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "security", "api-bindings"]
 readme = "README.md"
 
 [features]
-std = []
+alloc = []
 rand_core = ["dep:rand_core"]
 aead = ["dep:aead"]
 cipher = ["dep:cipher"]

--- a/wrapper/rust/wolfssl-wolfcrypt/Makefile
+++ b/wrapper/rust/wolfssl-wolfcrypt/Makefile
@@ -1,4 +1,4 @@
-FEATURES := rand_core,aead,cipher,digest,mac,signature,password-hash,kem
+FEATURES := alloc,rand_core,aead,cipher,digest,mac,signature,password-hash,kem
 CARGO_FEATURE_FLAGS := --features $(FEATURES)
 
 .PHONY: all

--- a/wrapper/rust/wolfssl-wolfcrypt/README.md
+++ b/wrapper/rust/wolfssl-wolfcrypt/README.md
@@ -3,6 +3,8 @@
 The `wolfssl-wolfcrypt` crate is a Rust wrapper for the wolfCrypt cryptographic
 algorithms portion of the wolfSSL C library.
 
+This crate requires wolfSSL version 5.9.0 or newer.
+
 ## Installation
 
 The `wolfssl` C library must be installed to be used by the Rust crate.

--- a/wrapper/rust/wolfssl-wolfcrypt/build.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/build.rs
@@ -371,6 +371,9 @@ fn scan_cfg() -> Result<()> {
     check_cfg(&binding, "wc_Dh_ffdhe6144_Get", "dh_ffdhe_6144");
     check_cfg(&binding, "wc_Dh_ffdhe8192_Get", "dh_ffdhe_8192");
 
+    /* crypto callback */
+    check_cfg(&binding, "wc_CryptoCb_RegisterDevice", "wolf_crypto_cb");
+
     /* ecc */
     check_cfg(&binding, "wc_ecc_init", "ecc");
     check_cfg(&binding, "wc_ecc_export_point_der_compressed", "ecc_comp_key");

--- a/wrapper/rust/wolfssl-wolfcrypt/src/aes.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/aes.rs
@@ -33,13 +33,10 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use aead::{AeadCore, AeadInPlace, KeyInit, KeySizeUser};
 
 #[cfg(feature = "aead")]
-use aead::generic_array::typenum::{U0, U12, U16, U32};
+use aead::generic_array::typenum::{U0, U12, U16, U24, U32};
 
 #[cfg(all(feature = "cipher", not(feature = "aead")))]
-use cipher::typenum::consts::{U16, U32};
-
-#[cfg(feature = "cipher")]
-use cipher::typenum::consts::U24;
+use cipher::typenum::consts::{U16, U24, U32};
 
 #[cfg(feature = "cipher")]
 use cipher::{
@@ -535,6 +532,58 @@ impl KeyInit for Aes128Ccm {
 
 #[cfg(all(aes_ccm, feature = "aead"))]
 impl AeadInPlace for Aes128Ccm {
+    fn encrypt_in_place_detached(
+        &self,
+        nonce: &aead::Nonce<Self>,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<aead::Tag<Self>, aead::Error> {
+        let mut tag = aead::Tag::<Self>::default();
+        ccm_encrypt_in_place(&self.key, nonce.as_ref(), associated_data, buffer, tag.as_mut())?;
+        Ok(tag)
+    }
+
+    fn decrypt_in_place_detached(
+        &self,
+        nonce: &aead::Nonce<Self>,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+        tag: &aead::Tag<Self>,
+    ) -> Result<(), aead::Error> {
+        ccm_decrypt_in_place(&self.key, nonce.as_ref(), associated_data, buffer, tag.as_ref())
+    }
+}
+
+/// AES-192-CCM authenticated encryption (12-byte nonce, 16-byte tag).
+#[cfg(all(aes_ccm, feature = "aead"))]
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct Aes192Ccm {
+    key: [u8; 24],
+}
+
+#[cfg(all(aes_ccm, feature = "aead"))]
+impl KeySizeUser for Aes192Ccm {
+    type KeySize = U24;
+}
+
+#[cfg(all(aes_ccm, feature = "aead"))]
+impl AeadCore for Aes192Ccm {
+    type NonceSize = U12;
+    type TagSize = U16;
+    type CiphertextOverhead = U0;
+}
+
+#[cfg(all(aes_ccm, feature = "aead"))]
+impl KeyInit for Aes192Ccm {
+    fn new(key: &aead::Key<Self>) -> Self {
+        let mut k = [0u8; 24];
+        k.copy_from_slice(key.as_ref());
+        Aes192Ccm { key: k }
+    }
+}
+
+#[cfg(all(aes_ccm, feature = "aead"))]
+impl AeadInPlace for Aes192Ccm {
     fn encrypt_in_place_detached(
         &self,
         nonce: &aead::Nonce<Self>,
@@ -1691,6 +1740,58 @@ impl KeyInit for Aes128Gcm {
 
 #[cfg(all(aes_gcm, feature = "aead"))]
 impl AeadInPlace for Aes128Gcm {
+    fn encrypt_in_place_detached(
+        &self,
+        nonce: &aead::Nonce<Self>,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<aead::Tag<Self>, aead::Error> {
+        let mut tag = aead::Tag::<Self>::default();
+        gcm_encrypt_in_place(&self.key, nonce.as_ref(), associated_data, buffer, tag.as_mut())?;
+        Ok(tag)
+    }
+
+    fn decrypt_in_place_detached(
+        &self,
+        nonce: &aead::Nonce<Self>,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+        tag: &aead::Tag<Self>,
+    ) -> Result<(), aead::Error> {
+        gcm_decrypt_in_place(&self.key, nonce.as_ref(), associated_data, buffer, tag.as_ref())
+    }
+}
+
+/// AES-192-GCM authenticated encryption (12-byte nonce, 16-byte tag).
+#[cfg(all(aes_gcm, feature = "aead"))]
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct Aes192Gcm {
+    key: [u8; 24],
+}
+
+#[cfg(all(aes_gcm, feature = "aead"))]
+impl KeySizeUser for Aes192Gcm {
+    type KeySize = U24;
+}
+
+#[cfg(all(aes_gcm, feature = "aead"))]
+impl AeadCore for Aes192Gcm {
+    type NonceSize = U12;
+    type TagSize = U16;
+    type CiphertextOverhead = U0;
+}
+
+#[cfg(all(aes_gcm, feature = "aead"))]
+impl KeyInit for Aes192Gcm {
+    fn new(key: &aead::Key<Self>) -> Self {
+        let mut k = [0u8; 24];
+        k.copy_from_slice(key.as_ref());
+        Aes192Gcm { key: k }
+    }
+}
+
+#[cfg(all(aes_gcm, feature = "aead"))]
+impl AeadInPlace for Aes192Gcm {
     fn encrypt_in_place_detached(
         &self,
         nonce: &aead::Nonce<Self>,

--- a/wrapper/rust/wolfssl-wolfcrypt/src/blake2_digest.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/blake2_digest.rs
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/*!
+RustCrypto `digest` trait implementations for the wolfCrypt BLAKE2 hash
+types.
+
+Because BLAKE2b and BLAKE2s have variable digest sizes, this module exposes
+typed wrappers that pin the digest size of an underlying [`crate::blake2`]
+instance to a specific value, matching the typed aliases provided by the
+RustCrypto `blake2` crate (`Blake2b512`, `Blake2b256`, `Blake2s256`, etc.).
+
+Each typed wrapper implements the traits from the `digest` crate
+(`HashMarker`, `OutputSizeUser`, `BlockSizeUser`, `Update`, `Reset`,
+`FixedOutput`, and `FixedOutputReset`). With these implementations the
+`digest::Digest` trait becomes available via its blanket implementation,
+allowing these hashers to be used anywhere a RustCrypto `Digest` is
+accepted.
+
+Any failure returned by the underlying wolfCrypt call in a trait method
+will result in a panic, matching the infallible signatures required by the
+RustCrypto traits.
+*/
+
+use digest::consts::{U16, U24, U32, U48, U64, U128};
+
+macro_rules! impl_blake2_digest {
+    (
+        $(#[$attr:meta])*
+        $name:ident,
+        wc_ty = $wc_ty:path,
+        digest_size = $digest_size:literal,
+        out = $out_size:ty,
+        block = $block_size:ty
+    ) => {
+        $(#[$attr])*
+        pub struct $name {
+            blake2: $wc_ty,
+        }
+
+        $(#[$attr])*
+        impl Default for $name {
+            fn default() -> Self {
+                Self {
+                    blake2: <$wc_ty>::new($digest_size)
+                        .expect("wolfCrypt BLAKE2 init failed"),
+                }
+            }
+        }
+
+        $(#[$attr])*
+        impl digest::HashMarker for $name {}
+
+        $(#[$attr])*
+        impl digest::OutputSizeUser for $name {
+            type OutputSize = $out_size;
+        }
+
+        $(#[$attr])*
+        impl digest::block_api::BlockSizeUser for $name {
+            type BlockSize = $block_size;
+        }
+
+        $(#[$attr])*
+        impl digest::Update for $name {
+            fn update(&mut self, data: &[u8]) {
+                <$wc_ty>::update(&mut self.blake2, data)
+                    .expect("wolfCrypt BLAKE2 update failed");
+            }
+        }
+
+        $(#[$attr])*
+        impl digest::Reset for $name {
+            fn reset(&mut self) {
+                self.blake2 = <$wc_ty>::new($digest_size)
+                    .expect("wolfCrypt BLAKE2 init failed");
+            }
+        }
+
+        $(#[$attr])*
+        impl digest::FixedOutput for $name {
+            fn finalize_into(mut self, out: &mut digest::Output<Self>) {
+                <$wc_ty>::finalize(&mut self.blake2, out.as_mut_slice())
+                    .expect("wolfCrypt BLAKE2 finalize failed");
+            }
+        }
+
+        $(#[$attr])*
+        impl digest::FixedOutputReset for $name {
+            fn finalize_into_reset(&mut self, out: &mut digest::Output<Self>) {
+                <$wc_ty>::finalize(&mut self.blake2, out.as_mut_slice())
+                    .expect("wolfCrypt BLAKE2 finalize failed");
+                self.blake2 = <$wc_ty>::new($digest_size)
+                    .expect("wolfCrypt BLAKE2 init failed");
+            }
+        }
+    };
+}
+
+impl_blake2_digest! {
+    #[cfg(blake2b)]
+    Blake2b256,
+    wc_ty = crate::blake2::BLAKE2b,
+    digest_size = 32,
+    out = U32,
+    block = U128
+}
+
+impl_blake2_digest! {
+    #[cfg(blake2b)]
+    Blake2b384,
+    wc_ty = crate::blake2::BLAKE2b,
+    digest_size = 48,
+    out = U48,
+    block = U128
+}
+
+impl_blake2_digest! {
+    #[cfg(blake2b)]
+    Blake2b512,
+    wc_ty = crate::blake2::BLAKE2b,
+    digest_size = 64,
+    out = U64,
+    block = U128
+}
+
+impl_blake2_digest! {
+    #[cfg(blake2s)]
+    Blake2s128,
+    wc_ty = crate::blake2::BLAKE2s,
+    digest_size = 16,
+    out = U16,
+    block = U64
+}
+
+impl_blake2_digest! {
+    #[cfg(blake2s)]
+    Blake2s192,
+    wc_ty = crate::blake2::BLAKE2s,
+    digest_size = 24,
+    out = U24,
+    block = U64
+}
+
+impl_blake2_digest! {
+    #[cfg(blake2s)]
+    Blake2s256,
+    wc_ty = crate::blake2::BLAKE2s,
+    digest_size = 32,
+    out = U32,
+    block = U64
+}

--- a/wrapper/rust/wolfssl-wolfcrypt/src/blake2_mac.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/blake2_mac.rs
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/*!
+RustCrypto `digest::Mac` trait implementations for the wolfCrypt keyed
+BLAKE2 types.
+
+These wrappers cover keyed BLAKE2 (the construction exposed by RustCrypto's
+`blake2` crate as `Blake2bMac` / `Blake2sMac`), not the wolfCrypt-specific
+HMAC-BLAKE2 construction. With these implementations the `digest::Mac`
+trait becomes available via its blanket implementation, allowing these
+types to be used anywhere a RustCrypto `Mac` is accepted.
+
+Each typed wrapper pins the digest size and the maximum key size to a
+specific algorithm parameterization. The `Blake2sMac128`, `Blake2sMac192`,
+and `Blake2sMac256` wrappers all accept keys of any length up to 32 bytes
+(the BLAKE2s maximum), and the `Blake2bMac512` wrapper accepts keys of any
+length up to 64 bytes (the BLAKE2b maximum), matching the variable-length
+key behavior of the RustCrypto `blake2` crate's `Blake2sMac` / `Blake2bMac`
+types.
+
+Any failure returned by the underlying wolfCrypt call in a trait method
+will result in a panic, matching the infallible signatures required by the
+RustCrypto traits.
+*/
+
+use digest::consts::{U16, U24, U32, U48, U64};
+
+macro_rules! impl_blake2_mac {
+    (
+        $(#[$attr:meta])*
+        $name:ident,
+        wc_ty = $wc_ty:path,
+        digest_size = $digest_size:literal,
+        out = $out_size:ty,
+        key = $key_size:ty
+    ) => {
+        $(#[$attr])*
+        pub struct $name {
+            blake2: $wc_ty,
+        }
+
+        $(#[$attr])*
+        impl digest::MacMarker for $name {}
+
+        $(#[$attr])*
+        impl digest::OutputSizeUser for $name {
+            type OutputSize = $out_size;
+        }
+
+        $(#[$attr])*
+        impl digest::common::KeySizeUser for $name {
+            type KeySize = $key_size;
+        }
+
+        $(#[$attr])*
+        impl digest::KeyInit for $name {
+            fn new(key: &digest::Key<Self>) -> Self {
+                Self {
+                    blake2: <$wc_ty>::new_with_key($digest_size, key.as_slice())
+                        .expect("wolfCrypt BLAKE2 init failed"),
+                }
+            }
+
+            fn new_from_slice(key: &[u8]) -> Result<Self, digest::InvalidLength> {
+                if key.len() > <Self as digest::common::KeySizeUser>::key_size() {
+                    return Err(digest::InvalidLength);
+                }
+                Ok(Self {
+                    blake2: <$wc_ty>::new_with_key($digest_size, key)
+                        .map_err(|_| digest::InvalidLength)?,
+                })
+            }
+        }
+
+        $(#[$attr])*
+        impl digest::Update for $name {
+            fn update(&mut self, data: &[u8]) {
+                <$wc_ty>::update(&mut self.blake2, data)
+                    .expect("wolfCrypt BLAKE2 update failed");
+            }
+        }
+
+        $(#[$attr])*
+        impl digest::FixedOutput for $name {
+            fn finalize_into(mut self, out: &mut digest::Output<Self>) {
+                <$wc_ty>::finalize(&mut self.blake2, out.as_mut_slice())
+                    .expect("wolfCrypt BLAKE2 finalize failed");
+            }
+        }
+    };
+}
+
+impl_blake2_mac! {
+    #[cfg(blake2b)]
+    Blake2bMac256,
+    wc_ty = crate::blake2::BLAKE2b,
+    digest_size = 32,
+    out = U32,
+    key = U64
+}
+
+impl_blake2_mac! {
+    #[cfg(blake2b)]
+    Blake2bMac384,
+    wc_ty = crate::blake2::BLAKE2b,
+    digest_size = 48,
+    out = U48,
+    key = U64
+}
+
+impl_blake2_mac! {
+    #[cfg(blake2b)]
+    Blake2bMac512,
+    wc_ty = crate::blake2::BLAKE2b,
+    digest_size = 64,
+    out = U64,
+    key = U64
+}
+
+impl_blake2_mac! {
+    #[cfg(blake2s)]
+    Blake2sMac128,
+    wc_ty = crate::blake2::BLAKE2s,
+    digest_size = 16,
+    out = U16,
+    key = U32
+}
+
+impl_blake2_mac! {
+    #[cfg(blake2s)]
+    Blake2sMac192,
+    wc_ty = crate::blake2::BLAKE2s,
+    digest_size = 24,
+    out = U24,
+    key = U32
+}
+
+impl_blake2_mac! {
+    #[cfg(blake2s)]
+    Blake2sMac256,
+    wc_ty = crate::blake2::BLAKE2s,
+    digest_size = 32,
+    out = U32,
+    key = U32
+}

--- a/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
@@ -513,7 +513,7 @@ impl Curve25519Key {
     /// Bind a shared `RNG` to this key. Available when the `alloc` feature
     /// is enabled.
     #[cfg(all(curve25519_blinding, random, feature = "alloc"))]
-    pub fn set_shared_rng(&mut self, rng: alloc::sync::Arc<RNG>) -> Result<(), i32> {
+    pub fn set_shared_rng(&mut self, rng: alloc::rc::Rc<RNG>) -> Result<(), i32> {
         let wc_rng = rng.wc_rng;
         let rc = unsafe {
             sys::wc_curve25519_set_rng(&mut self.wc_key, wc_rng)

--- a/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
@@ -26,12 +26,15 @@ functionality.
 #![cfg(curve25519)]
 
 #[cfg(random)]
-use crate::random::RNG;
+use crate::random::{RNG, RngHandle};
 use crate::sys;
 use core::mem::MaybeUninit;
 
 pub struct Curve25519Key {
     wc_key: sys::curve25519_key,
+    /// RNG bound via `set_rng`, kept alive while the C struct holds its pointer.
+    #[cfg(random)]
+    rng: Option<RngHandle>,
 }
 
 impl Curve25519Key {
@@ -73,7 +76,7 @@ impl Curve25519Key {
     /// Returns either Ok(curve25519key) on success or Err(e) containing the
     /// wolfSSL library error code value.
     #[cfg(random)]
-    pub fn generate(rng: &mut RNG) -> Result<Self, i32> {
+    pub fn generate(rng: &RNG) -> Result<Self, i32> {
         let mut wc_key: MaybeUninit<sys::curve25519_key> = MaybeUninit::uninit();
         let rc = unsafe {
             sys::wc_curve25519_init(wc_key.as_mut_ptr())
@@ -82,9 +85,13 @@ impl Curve25519Key {
             return Err(rc);
         }
         let wc_key = unsafe { wc_key.assume_init() };
-        let mut curve25519key = Curve25519Key { wc_key };
+        let mut curve25519key = Curve25519Key {
+            wc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let rc = unsafe {
-            sys::wc_curve25519_make_key(&mut rng.wc_rng, Self::KEYSIZE as i32,
+            sys::wc_curve25519_make_key(rng.wc_rng, Self::KEYSIZE as i32,
                 &mut curve25519key.wc_key)
         };
         if rc != 0 {
@@ -104,12 +111,12 @@ impl Curve25519Key {
     /// Returns either Ok(()) on success or Err(e) containing the wolfSSL
     /// library error code value.
     #[cfg(random)]
-    pub fn generate_priv(rng: &mut RNG, out: &mut [u8]) -> Result<(), i32> {
+    pub fn generate_priv(rng: &RNG, out: &mut [u8]) -> Result<(), i32> {
         if out.len() != Self::KEYSIZE {
             return Err(sys::wolfCrypt_ErrorCodes_BUFFER_E);
         }
         let rc = unsafe {
-            sys::wc_curve25519_make_priv(&mut rng.wc_rng, Self::KEYSIZE as i32, out.as_mut_ptr())
+            sys::wc_curve25519_make_priv(rng.wc_rng, Self::KEYSIZE as i32, out.as_mut_ptr())
         };
         if rc != 0 {
             return Err(rc);
@@ -137,7 +144,11 @@ impl Curve25519Key {
             return Err(rc);
         }
         let wc_key = unsafe { wc_key.assume_init() };
-        let mut curve25519key = Curve25519Key { wc_key };
+        let mut curve25519key = Curve25519Key {
+            wc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let rc = unsafe {
             sys::wc_curve25519_import_private(private.as_ptr(), private_size,
                 &mut curve25519key.wc_key)
@@ -169,7 +180,11 @@ impl Curve25519Key {
             return Err(rc);
         }
         let wc_key = unsafe { wc_key.assume_init() };
-        let mut curve25519key = Curve25519Key { wc_key };
+        let mut curve25519key = Curve25519Key {
+            wc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let endian = if big_endian {sys::EC25519_BIG_ENDIAN} else {sys::EC25519_LITTLE_ENDIAN};
         let rc = unsafe {
             sys::wc_curve25519_import_private_ex(private.as_ptr(),
@@ -203,7 +218,11 @@ impl Curve25519Key {
             return Err(rc);
         }
         let wc_key = unsafe { wc_key.assume_init() };
-        let mut curve25519key = Curve25519Key { wc_key };
+        let mut curve25519key = Curve25519Key {
+            wc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let rc = unsafe {
             sys::wc_curve25519_import_private_raw(private.as_ptr(),
                 private_size, public.as_ptr(), public_size,
@@ -238,7 +257,11 @@ impl Curve25519Key {
             return Err(rc);
         }
         let wc_key = unsafe { wc_key.assume_init() };
-        let mut curve25519key = Curve25519Key { wc_key };
+        let mut curve25519key = Curve25519Key {
+            wc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let endian = if big_endian {sys::EC25519_BIG_ENDIAN} else {sys::EC25519_LITTLE_ENDIAN};
         let rc = unsafe {
             sys::wc_curve25519_import_private_raw_ex(private.as_ptr(),
@@ -271,7 +294,11 @@ impl Curve25519Key {
             return Err(rc);
         }
         let wc_key = unsafe { wc_key.assume_init() };
-        let mut curve25519key = Curve25519Key { wc_key };
+        let mut curve25519key = Curve25519Key {
+            wc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let rc = unsafe {
             sys::wc_curve25519_import_public(public.as_ptr(), public_size,
                 &mut curve25519key.wc_key)
@@ -303,7 +330,11 @@ impl Curve25519Key {
             return Err(rc);
         }
         let wc_key = unsafe { wc_key.assume_init() };
-        let mut curve25519key = Curve25519Key { wc_key };
+        let mut curve25519key = Curve25519Key {
+            wc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let endian = if big_endian {sys::EC25519_BIG_ENDIAN} else {sys::EC25519_LITTLE_ENDIAN};
         let rc = unsafe {
             sys::wc_curve25519_import_public_ex(public.as_ptr(), public_size,
@@ -353,12 +384,12 @@ impl Curve25519Key {
     /// Returns either Ok(()) on success or Err(e) containing the wolfSSL
     /// library error code value.
     #[cfg(all(curve25519_blinding, random))]
-    pub fn make_pub_blind(private: &[u8], public: &mut [u8], rng: &mut RNG) -> Result<(), i32> {
+    pub fn make_pub_blind(private: &[u8], public: &mut [u8], rng: &RNG) -> Result<(), i32> {
         let private_size = crate::buffer_len_to_i32(private.len())?;
         let public_size = crate::buffer_len_to_i32(public.len())?;
         let rc = unsafe {
             sys::wc_curve25519_make_pub_blind(public_size, public.as_mut_ptr(),
-                private_size, private.as_ptr(), &mut rng.wc_rng)
+                private_size, private.as_ptr(), rng.wc_rng)
         };
         if rc != 0 {
             return Err(rc);
@@ -408,14 +439,14 @@ impl Curve25519Key {
     /// Returns either Ok(()) on success or Err(e) containing the wolfSSL
     /// library error code value.
     #[cfg(all(curve25519_blinding, random))]
-    pub fn make_pub_generic_blind(private: &[u8], public: &mut [u8], basepoint: &[u8], rng: &mut RNG) -> Result<(), i32> {
+    pub fn make_pub_generic_blind(private: &[u8], public: &mut [u8], basepoint: &[u8], rng: &RNG) -> Result<(), i32> {
         let private_size = crate::buffer_len_to_i32(private.len())?;
         let public_size = crate::buffer_len_to_i32(public.len())?;
         let basepoint_size = crate::buffer_len_to_i32(basepoint.len())?;
         let rc = unsafe {
             sys::wc_curve25519_generic_blind(public_size, public.as_mut_ptr(),
                 private_size, private.as_ptr(), basepoint_size, basepoint.as_ptr(),
-                &mut rng.wc_rng)
+                rng.wc_rng)
         };
         if rc != 0 {
             return Err(rc);
@@ -454,25 +485,55 @@ impl Curve25519Key {
     /// This is necessary when generating a shared secret if wolfSSL is built
     /// with the `WOLFSSL_CURVE25519_BLINDING` build option enabled.
     ///
+    /// The key takes ownership of the RNG, so the underlying `WC_RNG` is
+    /// guaranteed to outlive this key.
+    ///
     /// # Parameters
     ///
     /// * `rng`: The `RNG` struct instance to associate with this
-    ///   `Curve25519Key` instance. The `RNG` struct should not be moved in
-    ///   memory after calling this method.
+    ///   `Curve25519Key` instance.
     ///
     /// # Returns
     ///
     /// Returns Ok(()) on success or Err(e) containing the wolfSSL library
     /// error code value.
     #[cfg(all(curve25519_blinding, random))]
-    pub fn set_rng(&mut self, rng: &mut RNG) -> Result<(), i32> {
+    pub fn set_rng(&mut self, rng: RNG) -> Result<(), i32> {
+        let wc_rng = rng.wc_rng;
         let rc = unsafe {
-            sys::wc_curve25519_set_rng(&mut self.wc_key, &mut rng.wc_rng)
+            sys::wc_curve25519_set_rng(&mut self.wc_key, wc_rng)
         };
         if rc != 0 {
             return Err(rc);
         }
+        self.rng = Some(RngHandle::Owned(rng));
         Ok(())
+    }
+
+    /// Bind a shared `RNG` to this key. Available when the `alloc` feature
+    /// is enabled.
+    #[cfg(all(curve25519_blinding, random, feature = "alloc"))]
+    pub fn set_shared_rng(&mut self, rng: alloc::sync::Arc<RNG>) -> Result<(), i32> {
+        let wc_rng = rng.wc_rng;
+        let rc = unsafe {
+            sys::wc_curve25519_set_rng(&mut self.wc_key, wc_rng)
+        };
+        if rc != 0 {
+            return Err(rc);
+        }
+        self.rng = Some(RngHandle::Shared(rng));
+        Ok(())
+    }
+
+    /// Borrow the RNG previously bound via `set_rng` or `set_shared_rng`.
+    #[cfg(random)]
+    pub fn rng(&self) -> Option<&RNG> {
+        match &self.rng {
+            Some(RngHandle::Owned(rng)) => Some(rng),
+            #[cfg(feature = "alloc")]
+            Some(RngHandle::Shared(rng)) => Some(rng),
+            None => None,
+        }
     }
 
     /// Compute a shared secret key given a secret private key and a received

--- a/wrapper/rust/wolfssl-wolfcrypt/src/dh.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/dh.rs
@@ -194,7 +194,7 @@ impl DH {
     /// }
     /// ```
     #[cfg(all(dh_keygen, random))]
-    pub fn generate(rng: &mut RNG, modulus_size: i32) -> Result<Self, i32> {
+    pub fn generate(rng: &RNG, modulus_size: i32) -> Result<Self, i32> {
         Self::generate_ex(rng, modulus_size, None, None)
     }
 
@@ -225,7 +225,7 @@ impl DH {
     /// }
     /// ```
     #[cfg(all(dh_keygen, random))]
-    pub fn generate_ex(rng: &mut RNG, modulus_size: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex(rng: &RNG, modulus_size: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_dhkey: MaybeUninit<sys::DhKey> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -242,7 +242,7 @@ impl DH {
         let wc_dhkey = unsafe { wc_dhkey.assume_init() };
         let mut dh = DH { wc_dhkey };
         let rc = unsafe {
-            sys::wc_DhGenerateParams(&mut rng.wc_rng, modulus_size, &mut dh.wc_dhkey)
+            sys::wc_DhGenerateParams(rng.wc_rng, modulus_size, &mut dh.wc_dhkey)
         };
         if rc != 0 {
             return Err(rc);
@@ -921,7 +921,7 @@ impl DH {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn new_from_pgq_with_check(p: &[u8], g: &[u8], q: &[u8], trusted: i32, rng: &mut RNG) -> Result<Self, i32> {
+    pub fn new_from_pgq_with_check(p: &[u8], g: &[u8], q: &[u8], trusted: i32, rng: &RNG) -> Result<Self, i32> {
         Self::new_from_pgq_with_check_ex(p, g, q, trusted, rng, None, None)
     }
 
@@ -1030,7 +1030,7 @@ impl DH {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn new_from_pgq_with_check_ex(p: &[u8], g: &[u8], q: &[u8], trusted: i32, rng: &mut RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn new_from_pgq_with_check_ex(p: &[u8], g: &[u8], q: &[u8], trusted: i32, rng: &RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let p_size = crate::buffer_len_to_u32(p.len())?;
         let g_size = crate::buffer_len_to_u32(g.len())?;
         let q_size = crate::buffer_len_to_u32(q.len())?;
@@ -1050,7 +1050,7 @@ impl DH {
         let wc_dhkey = unsafe { wc_dhkey.assume_init() };
         let mut dh = DH { wc_dhkey };
         let rc = unsafe {
-            sys::wc_DhSetCheckKey(&mut dh.wc_dhkey, p.as_ptr(), p_size, g.as_ptr(), g_size, q.as_ptr(), q_size, trusted, &mut rng.wc_rng)
+            sys::wc_DhSetCheckKey(&mut dh.wc_dhkey, p.as_ptr(), p_size, g.as_ptr(), g_size, q.as_ptr(), q_size, trusted, rng.wc_rng)
         };
         if rc != 0 {
             return Err(rc);
@@ -1509,13 +1509,13 @@ impl DH {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn generate_key_pair(&mut self, rng: &mut RNG,
+    pub fn generate_key_pair(&mut self, rng: &RNG,
             private: &mut [u8], private_size: &mut u32,
             public: &mut [u8], public_size: &mut u32) -> Result<(), i32> {
         *private_size = crate::buffer_len_to_u32(private.len())?;
         *public_size = crate::buffer_len_to_u32(public.len())?;
         let rc = unsafe {
-            sys::wc_DhGenerateKeyPair(&mut self.wc_dhkey, &mut rng.wc_rng,
+            sys::wc_DhGenerateKeyPair(&mut self.wc_dhkey, rng.wc_rng,
                 private.as_mut_ptr(), private_size,
                 public.as_mut_ptr(), public_size)
         };

--- a/wrapper/rust/wolfssl-wolfcrypt/src/dilithium.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/dilithium.rs
@@ -159,7 +159,7 @@ impl Dilithium {
     /// }
     /// ```
     #[cfg(all(dilithium_make_key, random))]
-    pub fn generate(level: u8, rng: &mut RNG) -> Result<Self, i32> {
+    pub fn generate(level: u8, rng: &RNG) -> Result<Self, i32> {
         Self::generate_ex(level, rng, None, None)
     }
 
@@ -193,7 +193,7 @@ impl Dilithium {
     #[cfg(all(dilithium_make_key, random))]
     pub fn generate_ex(
         level: u8,
-        rng: &mut RNG,
+        rng: &RNG,
         heap: Option<*mut core::ffi::c_void>,
         dev_id: Option<i32>,
     ) -> Result<Self, i32> {
@@ -202,7 +202,7 @@ impl Dilithium {
         if rc != 0 {
             return Err(rc);
         }
-        let rc = unsafe { sys::wc_dilithium_make_key(&mut key.ws_key, &mut rng.wc_rng) };
+        let rc = unsafe { sys::wc_dilithium_make_key(&mut key.ws_key, rng.wc_rng) };
         if rc != 0 {
             return Err(rc);
         }
@@ -859,7 +859,7 @@ impl Dilithium {
         &mut self,
         msg: &[u8],
         sig: &mut [u8],
-        rng: &mut RNG,
+        rng: &RNG,
     ) -> Result<usize, i32> {
         let msg_len = crate::buffer_len_to_u32(msg.len())?;
         let mut sig_len = crate::buffer_len_to_u32(sig.len())?;
@@ -869,7 +869,7 @@ impl Dilithium {
                 msg.as_ptr(), msg_len,
                 sig.as_mut_ptr(), &mut sig_len,
                 &mut self.ws_key,
-                &mut rng.wc_rng,
+                rng.wc_rng,
             )
         };
         if rc != 0 {
@@ -917,7 +917,7 @@ impl Dilithium {
         ctx: &[u8],
         msg: &[u8],
         sig: &mut [u8],
-        rng: &mut RNG,
+        rng: &RNG,
     ) -> Result<usize, i32> {
         if ctx.len() > 255 {
             return Err(sys::wolfCrypt_ErrorCodes_BUFFER_E);
@@ -931,7 +931,7 @@ impl Dilithium {
                 msg.as_ptr(), msg_len,
                 sig.as_mut_ptr(), &mut sig_len,
                 &mut self.ws_key,
-                &mut rng.wc_rng,
+                rng.wc_rng,
             )
         };
         if rc != 0 {
@@ -966,7 +966,7 @@ impl Dilithium {
         hash_alg: i32,
         hash: &[u8],
         sig: &mut [u8],
-        rng: &mut RNG,
+        rng: &RNG,
     ) -> Result<usize, i32> {
         if ctx.len() > 255 {
             return Err(sys::wolfCrypt_ErrorCodes_BUFFER_E);
@@ -981,7 +981,7 @@ impl Dilithium {
                 hash.as_ptr(), hash_len,
                 sig.as_mut_ptr(), &mut sig_len,
                 &mut self.ws_key,
-                &mut rng.wc_rng,
+                rng.wc_rng,
             )
         };
         if rc != 0 {

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -59,11 +59,11 @@ impl ECCPoint {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::{ECC,ECCPoint};
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let curve_id = ECC::SECP256R1;
     /// let curve_size = ECC::get_curve_size_from_id(curve_id).expect("Error with get_curve_size_from_id()");
-    /// let mut ecc = ECC::generate_ex(curve_size, &mut rng, curve_id, None, None).expect("Error with generate()");
-    /// let ecc_point = ecc.make_pub_to_point(Some(&mut rng), None).expect("Error with make_pub_to_point()");
+    /// let mut ecc = ECC::generate_ex(curve_size, &rng, curve_id, None, None).expect("Error with generate()");
+    /// let ecc_point = ecc.make_pub_to_point(Some(&rng), None).expect("Error with make_pub_to_point()");
     /// let mut der = [0u8; 128];
     /// let size = ecc_point.export_der(&mut der, curve_id).expect("Error with export_der()");
     /// ECCPoint::import_der(&der[0..size], curve_id, None).expect("Error with import_der()");
@@ -117,11 +117,11 @@ impl ECCPoint {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::{ECC,ECCPoint};
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let curve_id = ECC::SECP256R1;
     /// let curve_size = ECC::get_curve_size_from_id(curve_id).expect("Error with get_curve_size_from_id()");
-    /// let mut ecc = ECC::generate_ex(curve_size, &mut rng, curve_id, None, None).expect("Error with generate()");
-    /// let ecc_point = ecc.make_pub_to_point(Some(&mut rng), None).expect("Error with make_pub_to_point()");
+    /// let mut ecc = ECC::generate_ex(curve_size, &rng, curve_id, None, None).expect("Error with generate()");
+    /// let ecc_point = ecc.make_pub_to_point(Some(&rng), None).expect("Error with make_pub_to_point()");
     /// let mut der = [0u8; 128];
     /// let size = ecc_point.export_der(&mut der, curve_id).expect("Error with export_der()");
     /// ECCPoint::import_der_ex(&der[0..size], curve_id, 0, None).expect("Error with import_der_ex()");
@@ -172,11 +172,11 @@ impl ECCPoint {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::{ECC,ECCPoint};
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let curve_id = ECC::SECP256R1;
     /// let curve_size = ECC::get_curve_size_from_id(curve_id).expect("Error with get_curve_size_from_id()");
-    /// let mut ecc = ECC::generate_ex(curve_size, &mut rng, curve_id, None, None).expect("Error with generate()");
-    /// let ecc_point = ecc.make_pub_to_point(Some(&mut rng), None).expect("Error with make_pub_to_point()");
+    /// let mut ecc = ECC::generate_ex(curve_size, &rng, curve_id, None, None).expect("Error with generate()");
+    /// let ecc_point = ecc.make_pub_to_point(Some(&rng), None).expect("Error with make_pub_to_point()");
     /// let mut der = [0u8; 128];
     /// let size = ecc_point.export_der(&mut der, curve_id).expect("Error with export_der()");
     /// assert!(size > 0 && size <= der.len());
@@ -219,11 +219,11 @@ impl ECCPoint {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::{ECC,ECCPoint};
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let curve_id = ECC::SECP256R1;
     /// let curve_size = ECC::get_curve_size_from_id(curve_id).expect("Error with get_curve_size_from_id()");
-    /// let mut ecc = ECC::generate_ex(curve_size, &mut rng, curve_id, None, None).expect("Error with generate()");
-    /// let ecc_point = ecc.make_pub_to_point(Some(&mut rng), None).expect("Error with make_pub_to_point()");
+    /// let mut ecc = ECC::generate_ex(curve_size, &rng, curve_id, None, None).expect("Error with generate()");
+    /// let ecc_point = ecc.make_pub_to_point(Some(&rng), None).expect("Error with make_pub_to_point()");
     /// let mut der = [0u8; 128];
     /// let size = ecc_point.export_der_compressed(&mut der, curve_id).expect("Error with export_der_compressed()");
     /// }
@@ -255,9 +255,9 @@ impl ECCPoint {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
-    /// let mut ecc_point = ecc.make_pub_to_point(Some(&mut rng), None).expect("Error with make_pub_to_point()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
+    /// let mut ecc_point = ecc.make_pub_to_point(Some(&rng), None).expect("Error with make_pub_to_point()");
     /// ecc_point.forcezero();
     /// }
     /// ```
@@ -438,8 +438,8 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// ecc.check().expect("Error with check()");
     /// }
     /// ```
@@ -486,10 +486,10 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let curve_id = ECC::SECP256R1;
     /// let curve_size = ECC::get_curve_size_from_id(curve_id).expect("Error with get_curve_size_from_id()");
-    /// let mut ecc = ECC::generate_ex(curve_size, &mut rng, curve_id, None, None).expect("Error with generate_ex()");
+    /// let mut ecc = ECC::generate_ex(curve_size, &rng, curve_id, None, None).expect("Error with generate_ex()");
     /// ecc.check().expect("Error with check()");
     /// }
     /// ```
@@ -537,10 +537,10 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let curve_id = ECC::SECP256R1;
     /// let curve_size = ECC::get_curve_size_from_id(curve_id).expect("Error with get_curve_size_from_id()");
-    /// let mut ecc = ECC::generate_ex2(curve_size, &mut rng, curve_id, ECC::FLAG_COFACTOR, None, None).expect("Error with generate_ex2()");
+    /// let mut ecc = ECC::generate_ex2(curve_size, &rng, curve_id, ECC::FLAG_COFACTOR, None, None).expect("Error with generate_ex2()");
     /// ecc.check().expect("Error with check()");
     /// }
     /// ```
@@ -582,10 +582,10 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let curve_id = ECC::SECP256R1;
     /// let curve_size = ECC::get_curve_size_from_id(curve_id).expect("Error with get_curve_size_from_id()");
-    /// let mut ecc = ECC::generate_ex(curve_size, &mut rng, curve_id, None, None).expect("Error with generate()");
+    /// let mut ecc = ECC::generate_ex(curve_size, &rng, curve_id, None, None).expect("Error with generate()");
     /// ecc.check().expect("Error with check()");
     /// }
     /// ```
@@ -619,7 +619,7 @@ impl ECC {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
     /// use std::fs;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let key_path = "../../../certs/ecc-client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut ecc = ECC::import_der(&der, None, None).expect("Error with import_der()");
@@ -667,13 +667,13 @@ impl ECC {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
     /// use std::fs;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let key_path = "../../../certs/ecc-client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut ecc = ECC::import_der(&der, None, None).expect("Error with import_der()");
     /// let hash = [0x42u8; 32];
     /// let mut signature = [0u8; 128];
-    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &mut rng).expect("Error with sign_hash()");
+    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &rng).expect("Error with sign_hash()");
     /// assert!(signature_length > 0 && signature_length <= signature.len());
     /// let signature = &mut signature[0..signature_length];
     /// let key_path = "../../../certs/ecc-client-keyPub.der";
@@ -726,11 +726,11 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let hash = [0x42u8; 32];
     /// let mut signature = [0u8; 128];
-    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &mut rng).expect("Error with sign_hash()");
+    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &rng).expect("Error with sign_hash()");
     /// let signature = &signature[0..signature_length];
     /// let mut d = [0u8; 32];
     /// let d_size = ecc.export_private(&mut d).expect("Error with export_private()");
@@ -791,13 +791,13 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let curve_id = ECC::SECP256R1;
     /// let curve_size = ECC::get_curve_size_from_id(curve_id).expect("Error with get_curve_size_from_id()");
-    /// let mut ecc = ECC::generate_ex(curve_size, &mut rng, curve_id, None, None).expect("Error with generate_ex()");
+    /// let mut ecc = ECC::generate_ex(curve_size, &rng, curve_id, None, None).expect("Error with generate_ex()");
     /// let hash = [0x42u8; 32];
     /// let mut signature = [0u8; 128];
-    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &mut rng).expect("Error with sign_hash()");
+    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &rng).expect("Error with sign_hash()");
     /// let signature = &signature[0..signature_length];
     /// let mut d = [0u8; 32];
     /// let d_size = ecc.export_private(&mut d).expect("Error with export_private()");
@@ -969,10 +969,10 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let curve_id = ECC::SECP256R1;
     /// let curve_size = ECC::get_curve_size_from_id(curve_id).expect("Error with get_curve_size_from_id()");
-    /// let mut ecc = ECC::generate_ex(curve_size, &mut rng, curve_id, None, None).expect("Error with generate()");
+    /// let mut ecc = ECC::generate_ex(curve_size, &rng, curve_id, None, None).expect("Error with generate()");
     /// let mut qx = [0u8; 32];
     /// let mut qx_len = 0u32;
     /// let mut qy = [0u8; 32];
@@ -1026,8 +1026,8 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let mut x963 = [0u8; 128];
     /// let x963_size = ecc.export_x963(&mut x963).expect("Error with export_x963()");
     /// let x963 = &x963[0..x963_size];
@@ -1080,10 +1080,10 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let curve_id = ECC::SECP256R1;
     /// let curve_size = ECC::get_curve_size_from_id(curve_id).expect("Error with get_curve_size_from_id()");
-    /// let mut ecc = ECC::generate_ex(curve_size, &mut rng, curve_id, None, None).expect("Error with generate_ex()");
+    /// let mut ecc = ECC::generate_ex(curve_size, &rng, curve_id, None, None).expect("Error with generate_ex()");
     /// let mut x963 = [0u8; 128];
     /// let x963_size = ecc.export_x963(&mut x963).expect("Error with export_x963()");
     /// let x963 = &x963[0..x963_size];
@@ -1143,13 +1143,13 @@ impl ECC {
     ///     hex_string.push('\0');
     ///     hex_string
     /// }
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let key_path = "../../../certs/ecc-client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut ecc = ECC::import_der(&der, None, None).expect("Error with import_der()");
     /// let hash = [0x42u8; 32];
     /// let mut signature = [0u8; 128];
-    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &mut rng).expect("Error with sign_hash()");
+    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &rng).expect("Error with sign_hash()");
     /// let signature = &mut signature[0..signature_length];
     /// let mut r = [0u8; 32];
     /// let mut r_size = 0u32;
@@ -1205,13 +1205,13 @@ impl ECC {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let key_path = "../../../certs/ecc-client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut ecc = ECC::import_der(&der, None, None).expect("Error with import_der()");
     /// let hash = [0x42u8; 32];
     /// let mut signature = [0u8; 128];
-    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &mut rng).expect("Error with sign_hash()");
+    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &rng).expect("Error with sign_hash()");
     /// let signature = &mut signature[0..signature_length];
     /// let mut r = [0u8; 32];
     /// let mut r_size = 0u32;
@@ -1258,13 +1258,13 @@ impl ECC {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let key_path = "../../../certs/ecc-client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut ecc = ECC::import_der(&der, None, None).expect("Error with import_der()");
     /// let hash = [0x42u8; 32];
     /// let mut signature = [0u8; 128];
-    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &mut rng).expect("Error with sign_hash()");
+    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &rng).expect("Error with sign_hash()");
     /// let signature = &mut signature[0..signature_length];
     /// let mut r = [0u8; 32];
     /// let mut r_size = 0u32;
@@ -1307,8 +1307,8 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// ecc.check().expect("Error with check()");
     /// }
     /// ```
@@ -1343,8 +1343,8 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let mut qx = [0u8; 32];
     /// let mut qx_len = 0u32;
     /// let mut qy = [0u8; 32];
@@ -1398,8 +1398,8 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let mut qx = [0u8; 32];
     /// let mut qx_len = 0u32;
     /// let mut qy = [0u8; 32];
@@ -1454,8 +1454,8 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let mut d = [0u8; 32];
     /// let d_size = ecc.export_private(&mut d).expect("Error with export_private()");
     /// assert_eq!(d_size, 32);
@@ -1495,8 +1495,8 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let mut qx = [0u8; 32];
     /// let mut qx_len = 0u32;
     /// let mut qy = [0u8; 32];
@@ -1538,8 +1538,8 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let mut x963 = [0u8; 128];
     /// let _x963_size = ecc.export_x963(&mut x963).expect("Error with export_x963()");
     /// }
@@ -1574,8 +1574,8 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let mut x963 = [0u8; 128];
     /// let _x963_size = ecc.export_x963_compressed(&mut x963).expect("Error with export_x963_compressed()");
     /// }
@@ -1613,11 +1613,11 @@ impl ECC {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let key_path = "../../../certs/ecc-client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut ecc = ECC::import_der(&der, None, None).expect("Error with import_der()");
-    /// ecc.make_pub(Some(&mut rng)).expect("Error with make_pub()");
+    /// ecc.make_pub(Some(&rng)).expect("Error with make_pub()");
     /// }
     /// ```
     #[cfg(random)]
@@ -1657,11 +1657,11 @@ impl ECC {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
+    /// let rng = RNG::new().expect("Failed to create RNG");
     /// let key_path = "../../../certs/ecc-client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut ecc = ECC::import_der(&der, None, None).expect("Error with import_der()");
-    /// ecc.make_pub_to_point(Some(&mut rng), None).expect("Error with make_pub_to_point()");
+    /// ecc.make_pub_to_point(Some(&rng), None).expect("Error with make_pub_to_point()");
     /// }
     /// ```
     #[cfg(random)]
@@ -1876,11 +1876,11 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let hash = [0x42u8; 32];
     /// let mut signature = [0u8; 128];
-    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &mut rng).expect("Error with sign_hash()");
+    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &rng).expect("Error with sign_hash()");
     /// let signature = &mut signature[0..signature_length];
     /// let valid = ecc.verify_hash(&signature, &hash).expect("Error with verify_hash()");
     /// assert_eq!(valid, true);
@@ -1919,11 +1919,11 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let hash = [0x42u8; 32];
     /// let mut signature = [0u8; 128];
-    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &mut rng).expect("Error with sign_hash()");
+    /// let signature_length = ecc.sign_hash(&hash, &mut signature, &rng).expect("Error with sign_hash()");
     /// let signature = &mut signature[0..signature_length];
     /// let valid = ecc.verify_hash(&signature, &hash).expect("Error with verify_hash()");
     /// assert_eq!(valid, true);

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -858,6 +858,10 @@ impl ECC {
     /// ```
     #[cfg(ecc_import)]
     pub fn import_raw(qx: &[u8], qy: &[u8], d: &[u8], curve_name: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+        if qx.is_empty() || qy.is_empty() || d.is_empty() || curve_name.is_empty() ||
+            qx[qx.len() - 1] != 0 || qy[qy.len() - 1] != 0 || d[d.len() - 1] != 0 || curve_name[curve_name.len() - 1] != 0 {
+            return Err(sys::wolfCrypt_ErrorCodes_BAD_FUNC_ARG);
+        }
         let heap = heap.unwrap_or(core::ptr::null_mut());
         let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
         let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
@@ -911,6 +915,10 @@ impl ECC {
     /// ```
     #[cfg(ecc_import)]
     pub fn import_raw_ex(qx: &[u8], qy: &[u8], d: &[u8], curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+        if qx.is_empty() || qy.is_empty() || d.is_empty() ||
+            qx[qx.len() - 1] != 0 || qy[qy.len() - 1] != 0 || d[d.len() - 1] != 0 {
+            return Err(sys::wolfCrypt_ErrorCodes_BAD_FUNC_ARG);
+        }
         let heap = heap.unwrap_or(core::ptr::null_mut());
         let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
         let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -1733,7 +1733,7 @@ impl ECC {
     /// Bind a shared `RNG` to this key. Available when the `alloc` feature
     /// is enabled.
     #[cfg(all(random, feature = "alloc"))]
-    pub fn set_shared_rng(&mut self, rng: alloc::sync::Arc<RNG>) -> Result<(), i32> {
+    pub fn set_shared_rng(&mut self, rng: alloc::rc::Rc<RNG>) -> Result<(), i32> {
         let wc_rng = rng.wc_rng;
         let rc = unsafe {
             sys::wc_ecc_set_rng(self.wc_ecc_key, wc_rng)
@@ -1774,16 +1774,16 @@ impl ECC {
     /// ```rust
     /// #[cfg(all(ecc_dh, random, feature = "alloc"))]
     /// {
-    /// use std::sync::Arc;
+    /// use std::rc::Rc;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let rng = Arc::new(RNG::new().expect("Failed to create RNG"));
+    /// let rng = Rc::new(RNG::new().expect("Failed to create RNG"));
     /// let mut ecc0 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let mut ecc1 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let mut ss0 = [0u8; 128];
     /// let mut ss1 = [0u8; 128];
-    /// ecc0.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
-    /// ecc1.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// ecc0.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// ecc1.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let ss0_size = ecc0.shared_secret(&mut ecc1, &mut ss0).expect("Error with shared_secret()");
     /// let ss1_size = ecc1.shared_secret(&mut ecc0, &mut ss1).expect("Error with shared_secret()");
     /// assert_eq!(ss0_size, ss1_size);
@@ -1824,17 +1824,17 @@ impl ECC {
     /// ```rust
     /// #[cfg(all(ecc_dh, random, feature = "alloc"))]
     /// {
-    /// use std::sync::Arc;
+    /// use std::rc::Rc;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let rng = Arc::new(RNG::new().expect("Failed to create RNG"));
+    /// let rng = Rc::new(RNG::new().expect("Failed to create RNG"));
     /// let mut ecc0 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let mut ecc1 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let ecc1_point = ecc1.make_pub_to_point(None, None).expect("Error with make_pub_to_point()");
     /// let mut ss0 = [0u8; 128];
     /// let mut ss1 = [0u8; 128];
-    /// ecc0.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
-    /// ecc1.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// ecc0.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// ecc1.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let ss0_size = ecc0.shared_secret_ex(&ecc1_point, &mut ss0).expect("Error with shared_secret_ex()");
     /// let ss1_size = ecc1.shared_secret(&mut ecc0, &mut ss1).expect("Error with shared_secret()");
     /// assert_eq!(ss0_size, ss1_size);

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -30,7 +30,7 @@ wolfSSL `ecc_key` object. It ensures proper initialization and deallocation.
 
 use crate::sys;
 #[cfg(random)]
-use crate::random::RNG;
+use crate::random::{RNG, RngHandle};
 use core::mem::{MaybeUninit};
 
 /// Rust wrapper for wolfSSL `ecc_point` object.
@@ -297,6 +297,10 @@ impl Drop for ECCPoint {
 /// `import_raw()`, or `import_raw_ex()`.
 pub struct ECC {
     pub(crate) wc_ecc_key: sys::ecc_key,
+    /// RNG bound to this key via `set_rng`, kept alive for as long as the C
+    /// struct holds its pointer.
+    #[cfg(random)]
+    rng: Option<RngHandle>,
 }
 
 #[cfg(ecc_curve_ids)]
@@ -421,7 +425,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn generate(size: i32, rng: &mut RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate(size: i32, rng: &RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -436,9 +440,13 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let rc = unsafe {
-            sys::wc_ecc_make_key(&mut rng.wc_rng, size, &mut ecc.wc_ecc_key)
+            sys::wc_ecc_make_key(rng.wc_rng, size, &mut ecc.wc_ecc_key)
         };
         if rc != 0 {
             return Err(rc);
@@ -478,7 +486,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn generate_ex(size: i32, rng: &mut RNG, curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex(size: i32, rng: &RNG, curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -493,9 +501,13 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let rc = unsafe {
-            sys::wc_ecc_make_key_ex(&mut rng.wc_rng, size, &mut ecc.wc_ecc_key, curve_id)
+            sys::wc_ecc_make_key_ex(rng.wc_rng, size, &mut ecc.wc_ecc_key, curve_id)
         };
         if rc != 0 {
             return Err(rc);
@@ -536,7 +548,7 @@ impl ECC {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn generate_ex2(size: i32, rng: &mut RNG, curve_id: i32, flags: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex2(size: i32, rng: &RNG, curve_id: i32, flags: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -551,9 +563,13 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let rc = unsafe {
-            sys::wc_ecc_make_key_ex2(&mut rng.wc_rng, size, &mut ecc.wc_ecc_key, curve_id, flags)
+            sys::wc_ecc_make_key_ex2(rng.wc_rng, size, &mut ecc.wc_ecc_key, curve_id, flags)
         };
         if rc != 0 {
             return Err(rc);
@@ -638,7 +654,11 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let mut idx = 0u32;
         let der_size = crate::buffer_len_to_u32(der.len())?;
         let rc = unsafe {
@@ -701,7 +721,11 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let mut idx = 0u32;
         let der_size = crate::buffer_len_to_u32(der.len())?;
         let rc = unsafe {
@@ -770,7 +794,11 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let priv_size = crate::buffer_len_to_u32(priv_buf.len())?;
         let pub_ptr = if pub_buf.is_empty() {core::ptr::null()} else {pub_buf.as_ptr()};
         let pub_size = crate::buffer_len_to_u32(pub_buf.len())?;
@@ -844,7 +872,11 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let priv_size = crate::buffer_len_to_u32(priv_buf.len())?;
         let pub_ptr = if pub_buf.is_empty() {core::ptr::null()} else {pub_buf.as_ptr()};
         let pub_size = crate::buffer_len_to_u32(pub_buf.len())?;
@@ -903,7 +935,11 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let qx_ptr = qx.as_ptr() as *const core::ffi::c_char;
         let qy_ptr = qy.as_ptr() as *const core::ffi::c_char;
         let d_ptr = d.as_ptr() as *const core::ffi::c_char;
@@ -963,7 +999,11 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let qx_ptr = qx.as_ptr() as *const core::ffi::c_char;
         let qy_ptr = qy.as_ptr() as *const core::ffi::c_char;
         let d_ptr = d.as_ptr() as *const core::ffi::c_char;
@@ -1031,7 +1071,11 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let rc = unsafe {
             sys::wc_ecc_import_unsigned(&mut ecc.wc_ecc_key, qx.as_ptr(),
                 qy.as_ptr(), d.as_ptr(), curve_id)
@@ -1090,7 +1134,11 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let rc = unsafe {
             sys::wc_ecc_import_x963(din.as_ptr(), din_size, &mut ecc.wc_ecc_key)
         };
@@ -1153,7 +1201,11 @@ impl ECC {
             return Err(rc);
         }
         let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC { wc_ecc_key };
+        let mut ecc = ECC {
+            wc_ecc_key,
+            #[cfg(random)]
+            rng: None,
+        };
         let rc = unsafe {
             sys::wc_ecc_import_x963_ex(din.as_ptr(), din_size, &mut ecc.wc_ecc_key, curve_id)
         };
@@ -1674,9 +1726,9 @@ impl ECC {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn make_pub(&mut self, rng: Option<&mut RNG>) -> Result<(), i32> {
+    pub fn make_pub(&mut self, rng: Option<&RNG>) -> Result<(), i32> {
         let rng_ptr = match rng {
-            Some(rng) => &mut rng.wc_rng,
+            Some(rng) => rng.wc_rng,
             None => core::ptr::null_mut(),
         };
         let rc = unsafe {
@@ -1718,9 +1770,9 @@ impl ECC {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn make_pub_to_point(&mut self, rng: Option<&mut RNG>, heap: Option<*mut core::ffi::c_void>) -> Result<ECCPoint, i32> {
+    pub fn make_pub_to_point(&mut self, rng: Option<&RNG>, heap: Option<*mut core::ffi::c_void>) -> Result<ECCPoint, i32> {
         let rng_ptr = match rng {
-            Some(rng) => &mut rng.wc_rng,
+            Some(rng) => rng.wc_rng,
             None => core::ptr::null_mut(),
         };
         let heap = match heap {
@@ -1749,8 +1801,14 @@ impl ECC {
     /// # Parameters
     ///
     /// * `rng`: The `RNG` struct instance to associate with this `ECC`
-    ///   instance. The `RNG` struct should not be moved in memory after
-    ///   calling this method.
+    ///   instance.
+    ///
+    /// # Safety contract
+    ///
+    /// The caller must ensure that the `RNG` instance is not dropped before
+    /// this `ECC` instance. The `ECC` struct holds an internal pointer to the
+    /// `RNG`'s underlying `WC_RNG` context, and dropping the `RNG` first
+    /// would result in a dangling pointer.
     ///
     /// # Returns
     ///
@@ -1765,20 +1823,49 @@ impl ECC {
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
-    /// ecc.set_rng(&mut rng).expect("Error with set_rng()");
+    /// let blinding_rng = RNG::new().expect("Failed to create RNG");
+    /// let key_gen_rng = RNG::new().expect("Failed to create RNG");
+    /// let mut ecc = ECC::generate(32, &key_gen_rng, None, None).expect("Error with generate()");
+    /// ecc.set_rng(blinding_rng).expect("Error with set_rng()");
     /// }
     /// ```
     #[cfg(random)]
-    pub fn set_rng(&mut self, rng: &mut RNG) -> Result<(), i32> {
+    pub fn set_rng(&mut self, rng: RNG) -> Result<(), i32> {
+        let wc_rng = rng.wc_rng;
         let rc = unsafe {
-            sys::wc_ecc_set_rng(&mut self.wc_ecc_key, &mut rng.wc_rng)
+            sys::wc_ecc_set_rng(&mut self.wc_ecc_key, wc_rng)
         };
         if rc != 0 {
             return Err(rc);
         }
+        self.rng = Some(RngHandle::Owned(rng));
         Ok(())
+    }
+
+    /// Bind a shared `RNG` to this key. Available when the `alloc` feature
+    /// is enabled.
+    #[cfg(all(random, feature = "alloc"))]
+    pub fn set_shared_rng(&mut self, rng: alloc::sync::Arc<RNG>) -> Result<(), i32> {
+        let wc_rng = rng.wc_rng;
+        let rc = unsafe {
+            sys::wc_ecc_set_rng(&mut self.wc_ecc_key, wc_rng)
+        };
+        if rc != 0 {
+            return Err(rc);
+        }
+        self.rng = Some(RngHandle::Shared(rng));
+        Ok(())
+    }
+
+    /// Borrow the RNG previously bound via `set_rng` or `set_shared_rng`.
+    #[cfg(random)]
+    pub fn rng(&self) -> Option<&RNG> {
+        match &self.rng {
+            Some(RngHandle::Owned(rng)) => Some(rng),
+            #[cfg(feature = "alloc")]
+            Some(RngHandle::Shared(rng)) => Some(rng),
+            None => None,
+        }
     }
 
     /// Compute the ECDH shared secret using this key's private component
@@ -1797,17 +1884,18 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ecc_dh, random))]
+    /// #[cfg(all(ecc_dh, random, feature = "alloc"))]
     /// {
+    /// use std::sync::Arc;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc0 = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
-    /// let mut ecc1 = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = Arc::new(RNG::new().expect("Failed to create RNG"));
+    /// let mut ecc0 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
+    /// let mut ecc1 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let mut ss0 = [0u8; 128];
     /// let mut ss1 = [0u8; 128];
-    /// ecc0.set_rng(&mut rng).expect("Error with set_rng()");
-    /// ecc1.set_rng(&mut rng).expect("Error with set_rng()");
+    /// ecc0.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// ecc1.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let ss0_size = ecc0.shared_secret(&mut ecc1, &mut ss0).expect("Error with shared_secret()");
     /// let ss1_size = ecc1.shared_secret(&mut ecc0, &mut ss1).expect("Error with shared_secret()");
     /// assert_eq!(ss0_size, ss1_size);
@@ -1846,18 +1934,19 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ecc_dh, random))]
+    /// #[cfg(all(ecc_dh, random, feature = "alloc"))]
     /// {
+    /// use std::sync::Arc;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
-    /// let mut rng = RNG::new().expect("Failed to create RNG");
-    /// let mut ecc0 = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
-    /// let mut ecc1 = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    /// let rng = Arc::new(RNG::new().expect("Failed to create RNG"));
+    /// let mut ecc0 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
+    /// let mut ecc1 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     /// let ecc1_point = ecc1.make_pub_to_point(None, None).expect("Error with make_pub_to_point()");
     /// let mut ss0 = [0u8; 128];
     /// let mut ss1 = [0u8; 128];
-    /// ecc0.set_rng(&mut rng).expect("Error with set_rng()");
-    /// ecc1.set_rng(&mut rng).expect("Error with set_rng()");
+    /// ecc0.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// ecc1.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let ss0_size = ecc0.shared_secret_ex(&ecc1_point, &mut ss0).expect("Error with shared_secret_ex()");
     /// let ss1_size = ecc1.shared_secret(&mut ecc0, &mut ss1).expect("Error with shared_secret()");
     /// assert_eq!(ss0_size, ss1_size);
@@ -1910,12 +1999,12 @@ impl ECC {
     /// }
     /// ```
     #[cfg(all(ecc_sign, random))]
-    pub fn sign_hash(&mut self, din: &[u8], dout: &mut [u8], rng: &mut RNG) -> Result<usize, i32> {
+    pub fn sign_hash(&mut self, din: &[u8], dout: &mut [u8], rng: &RNG) -> Result<usize, i32> {
         let din_size = crate::buffer_len_to_u32(din.len())?;
         let mut dout_size = crate::buffer_len_to_u32(dout.len())?;
         let rc = unsafe {
             sys::wc_ecc_sign_hash(din.as_ptr(), din_size, dout.as_mut_ptr(),
-                &mut dout_size, &mut rng.wc_rng, &mut self.wc_ecc_key)
+                &mut dout_size, rng.wc_rng, &mut self.wc_ecc_key)
         };
         if rc != 0 {
             return Err(rc);

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -1685,13 +1685,6 @@ impl ECC {
     /// * `rng`: The `RNG` struct instance to associate with this `ECC`
     ///   instance.
     ///
-    /// # Safety contract
-    ///
-    /// The caller must ensure that the `RNG` instance is not dropped before
-    /// this `ECC` instance. The `ECC` struct holds an internal pointer to the
-    /// `RNG`'s underlying `WC_RNG` context, and dropping the `RNG` first
-    /// would result in a dangling pointer.
-    ///
     /// # Returns
     ///
     /// Returns Ok(()) on success or Err(e) containing the wolfSSL library

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -985,6 +985,10 @@ impl ECC {
     /// ```
     #[cfg(ecc_import)]
     pub fn import_unsigned(qx: &[u8], qy: &[u8], d: &[u8], curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+        let curve_size = Self::get_curve_size_from_id(curve_id)? as usize;
+        if qx.len() < curve_size || qy.len() < curve_size || d.len() < curve_size {
+            return Err(sys::wolfCrypt_ErrorCodes_BAD_FUNC_ARG);
+        }
         let heap = heap.unwrap_or(core::ptr::null_mut());
         let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
         let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -31,7 +31,6 @@ wolfSSL `ecc_key` object. It ensures proper initialization and deallocation.
 use crate::sys;
 #[cfg(random)]
 use crate::random::{RNG, RngHandle};
-use core::mem::{MaybeUninit};
 
 /// Rust wrapper for wolfSSL `ecc_point` object.
 pub struct ECCPoint {
@@ -290,13 +289,14 @@ impl Drop for ECCPoint {
 
 /// The `ECC` struct manages the lifecycle of a wolfSSL `ecc_key` object.
 ///
-/// It ensures proper initialization and deallocation.
+/// It ensures proper initialization and deallocation. The struct holds a
+/// pointer to a `sys::ecc_key` allocated on the C heap.
 ///
 /// An instance can be created with `generate()`, `import_x963()`,
 /// `import_x963_ex()`, `import_private_key()`, `import_private_key_ex()`,
 /// `import_raw()`, or `import_raw_ex()`.
 pub struct ECC {
-    pub(crate) wc_ecc_key: sys::ecc_key,
+    pub(crate) wc_ecc_key: *mut sys::ecc_key,
     /// RNG bound to this key via `set_rng`, kept alive for as long as the C
     /// struct holds its pointer.
     #[cfg(random)]
@@ -396,6 +396,20 @@ impl ECC {
     pub const FLAG_COFACTOR: i32 = sys::WC_ECC_FLAG_COFACTOR as i32;
     pub const FLAG_DEC_SIGN: i32 = sys::WC_ECC_FLAG_DEC_SIGN as i32;
 
+    /// Allocate and initialize a new `sys::ecc_key` on the C heap.
+    fn new_ecc_key(heap: *mut core::ffi::c_void, dev_id: i32) -> Result<*mut sys::ecc_key, i32> {
+        let key = unsafe { sys::wc_ecc_key_new(heap) };
+        if key.is_null() {
+            return Err(sys::wolfCrypt_ErrorCodes_MEMORY_E);
+        }
+        let rc = unsafe { sys::wc_ecc_init_ex(key, heap, dev_id) };
+        if rc != 0 {
+            unsafe { sys::wc_ecc_key_free(key); }
+            return Err(rc);
+        }
+        Ok(key)
+    }
+
     /// Generate a new ECC key with the given size.
     ///
     /// # Parameters
@@ -426,27 +440,16 @@ impl ECC {
     /// ```
     #[cfg(random)]
     pub fn generate(size: i32, rng: &RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
         };
         let rc = unsafe {
-            sys::wc_ecc_make_key(rng.wc_rng, size, &mut ecc.wc_ecc_key)
+            sys::wc_ecc_make_key(rng.wc_rng, size, ecc.wc_ecc_key)
         };
         if rc != 0 {
             return Err(rc);
@@ -487,27 +490,16 @@ impl ECC {
     /// ```
     #[cfg(random)]
     pub fn generate_ex(size: i32, rng: &RNG, curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
         };
         let rc = unsafe {
-            sys::wc_ecc_make_key_ex(rng.wc_rng, size, &mut ecc.wc_ecc_key, curve_id)
+            sys::wc_ecc_make_key_ex(rng.wc_rng, size, ecc.wc_ecc_key, curve_id)
         };
         if rc != 0 {
             return Err(rc);
@@ -549,27 +541,16 @@ impl ECC {
     /// ```
     #[cfg(random)]
     pub fn generate_ex2(size: i32, rng: &RNG, curve_id: i32, flags: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
         };
         let rc = unsafe {
-            sys::wc_ecc_make_key_ex2(rng.wc_rng, size, &mut ecc.wc_ecc_key, curve_id, flags)
+            sys::wc_ecc_make_key_ex2(rng.wc_rng, size, ecc.wc_ecc_key, curve_id, flags)
         };
         if rc != 0 {
             return Err(rc);
@@ -640,21 +621,10 @@ impl ECC {
     /// }
     /// ```
     pub fn import_der(der: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
@@ -662,7 +632,7 @@ impl ECC {
         let mut idx = 0u32;
         let der_size = crate::buffer_len_to_u32(der.len())?;
         let rc = unsafe {
-            sys::wc_EccPrivateKeyDecode(der.as_ptr(), &mut idx, &mut ecc.wc_ecc_key, der_size)
+            sys::wc_EccPrivateKeyDecode(der.as_ptr(), &mut idx, ecc.wc_ecc_key, der_size)
         };
         if rc != 0 {
             return Err(rc);
@@ -707,21 +677,10 @@ impl ECC {
     /// }
     /// ```
     pub fn import_public_der(der: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
@@ -729,7 +688,7 @@ impl ECC {
         let mut idx = 0u32;
         let der_size = crate::buffer_len_to_u32(der.len())?;
         let rc = unsafe {
-            sys::wc_EccPublicKeyDecode(der.as_ptr(), &mut idx, &mut ecc.wc_ecc_key, der_size)
+            sys::wc_EccPublicKeyDecode(der.as_ptr(), &mut idx, ecc.wc_ecc_key, der_size)
         };
         if rc != 0 {
             return Err(rc);
@@ -780,21 +739,10 @@ impl ECC {
     /// ```
     #[cfg(ecc_import)]
     pub fn import_private_key(priv_buf: &[u8], pub_buf: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
@@ -804,7 +752,7 @@ impl ECC {
         let pub_size = crate::buffer_len_to_u32(pub_buf.len())?;
         let rc = unsafe {
             sys::wc_ecc_import_private_key(priv_buf.as_ptr(), priv_size,
-                pub_ptr, pub_size, &mut ecc.wc_ecc_key)
+                pub_ptr, pub_size, ecc.wc_ecc_key)
         };
         if rc != 0 {
             return Err(rc);
@@ -858,21 +806,10 @@ impl ECC {
     /// ```
     #[cfg(ecc_import)]
     pub fn import_private_key_ex(priv_buf: &[u8], pub_buf: &[u8], curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
@@ -882,7 +819,7 @@ impl ECC {
         let pub_size = crate::buffer_len_to_u32(pub_buf.len())?;
         let rc = unsafe {
             sys::wc_ecc_import_private_key_ex(priv_buf.as_ptr(), priv_size,
-                pub_ptr, pub_size, &mut ecc.wc_ecc_key, curve_id)
+                pub_ptr, pub_size, ecc.wc_ecc_key, curve_id)
         };
         if rc != 0 {
             return Err(rc);
@@ -921,21 +858,10 @@ impl ECC {
     /// ```
     #[cfg(ecc_import)]
     pub fn import_raw(qx: &[u8], qy: &[u8], d: &[u8], curve_name: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
@@ -945,7 +871,7 @@ impl ECC {
         let d_ptr = d.as_ptr() as *const core::ffi::c_char;
         let curve_name_ptr = curve_name.as_ptr() as *const core::ffi::c_char;
         let rc = unsafe {
-            sys::wc_ecc_import_raw(&mut ecc.wc_ecc_key, qx_ptr, qy_ptr, d_ptr,
+            sys::wc_ecc_import_raw(ecc.wc_ecc_key, qx_ptr, qy_ptr, d_ptr,
                 curve_name_ptr)
         };
         if rc != 0 {
@@ -985,21 +911,10 @@ impl ECC {
     /// ```
     #[cfg(ecc_import)]
     pub fn import_raw_ex(qx: &[u8], qy: &[u8], d: &[u8], curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
@@ -1008,7 +923,7 @@ impl ECC {
         let qy_ptr = qy.as_ptr() as *const core::ffi::c_char;
         let d_ptr = d.as_ptr() as *const core::ffi::c_char;
         let rc = unsafe {
-            sys::wc_ecc_import_raw_ex(&mut ecc.wc_ecc_key, qx_ptr, qy_ptr,
+            sys::wc_ecc_import_raw_ex(ecc.wc_ecc_key, qx_ptr, qy_ptr,
                 d_ptr, curve_id)
         };
         if rc != 0 {
@@ -1057,27 +972,16 @@ impl ECC {
     /// ```
     #[cfg(ecc_import)]
     pub fn import_unsigned(qx: &[u8], qy: &[u8], d: &[u8], curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
         };
         let rc = unsafe {
-            sys::wc_ecc_import_unsigned(&mut ecc.wc_ecc_key, qx.as_ptr(),
+            sys::wc_ecc_import_unsigned(ecc.wc_ecc_key, qx.as_ptr(),
                 qy.as_ptr(), d.as_ptr(), curve_id)
         };
         if rc != 0 {
@@ -1120,27 +1024,16 @@ impl ECC {
     #[cfg(ecc_import)]
     pub fn import_x963(din: &[u8], heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<ECC, i32> {
         let din_size = crate::buffer_len_to_u32(din.len())?;
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
         };
         let rc = unsafe {
-            sys::wc_ecc_import_x963(din.as_ptr(), din_size, &mut ecc.wc_ecc_key)
+            sys::wc_ecc_import_x963(din.as_ptr(), din_size, ecc.wc_ecc_key)
         };
         if rc != 0 {
             return Err(rc);
@@ -1187,27 +1080,16 @@ impl ECC {
     #[cfg(ecc_import)]
     pub fn import_x963_ex(din: &[u8], curve_id: i32, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<ECC, i32> {
         let din_size = crate::buffer_len_to_u32(din.len())?;
-        let mut wc_ecc_key: MaybeUninit<sys::ecc_key> = MaybeUninit::uninit();
-        let heap = match heap {
-            Some(heap) => heap,
-            None => core::ptr::null_mut(),
-        };
-        let dev_id = match dev_id {
-            Some(dev_id) => dev_id,
-            None => sys::INVALID_DEVID,
-        };
-        let rc = unsafe { sys::wc_ecc_init_ex(wc_ecc_key.as_mut_ptr(), heap, dev_id) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        let wc_ecc_key = unsafe { wc_ecc_key.assume_init() };
-        let mut ecc = ECC {
+        let heap = heap.unwrap_or(core::ptr::null_mut());
+        let dev_id = dev_id.unwrap_or(sys::INVALID_DEVID);
+        let wc_ecc_key = Self::new_ecc_key(heap, dev_id)?;
+        let ecc = ECC {
             wc_ecc_key,
             #[cfg(random)]
             rng: None,
         };
         let rc = unsafe {
-            sys::wc_ecc_import_x963_ex(din.as_ptr(), din_size, &mut ecc.wc_ecc_key, curve_id)
+            sys::wc_ecc_import_x963_ex(din.as_ptr(), din_size, ecc.wc_ecc_key, curve_id)
         };
         if rc != 0 {
             return Err(rc);
@@ -1418,7 +1300,7 @@ impl ECC {
     /// }
     /// ```
     pub fn check(&mut self) -> Result<(), i32> {
-        let rc = unsafe { sys::wc_ecc_check_key(&mut self.wc_ecc_key) };
+        let rc = unsafe { sys::wc_ecc_check_key(self.wc_ecc_key) };
         if rc != 0 {
             return Err(rc);
         }
@@ -1466,7 +1348,7 @@ impl ECC {
         *qy_len = crate::buffer_len_to_u32(qy.len())?;
         *d_len = crate::buffer_len_to_u32(d.len())?;
         let rc = unsafe {
-            sys::wc_ecc_export_private_raw(&mut self.wc_ecc_key,
+            sys::wc_ecc_export_private_raw(self.wc_ecc_key,
                 qx.as_mut_ptr(), qx_len,
                 qy.as_mut_ptr(), qy_len,
                 d.as_mut_ptr(), d_len)
@@ -1529,7 +1411,7 @@ impl ECC {
                 sys::WC_TYPE_UNSIGNED_BIN as i32
             };
         let rc = unsafe {
-            sys::wc_ecc_export_ex(&mut self.wc_ecc_key,
+            sys::wc_ecc_export_ex(self.wc_ecc_key,
                 qx.as_mut_ptr(), qx_len,
                 qy.as_mut_ptr(), qy_len,
                 d.as_mut_ptr(), d_len,
@@ -1570,7 +1452,7 @@ impl ECC {
     pub fn export_private(&mut self, d: &mut [u8]) -> Result<usize, i32> {
         let mut d_size = crate::buffer_len_to_u32(d.len())?;
         let rc = unsafe {
-            sys::wc_ecc_export_private_only(&mut self.wc_ecc_key,
+            sys::wc_ecc_export_private_only(self.wc_ecc_key,
                 d.as_mut_ptr(), &mut d_size)
         };
         if rc != 0 {
@@ -1615,7 +1497,7 @@ impl ECC {
         *qx_len = crate::buffer_len_to_u32(qx.len())?;
         *qy_len = crate::buffer_len_to_u32(qy.len())?;
         let rc = unsafe {
-            sys::wc_ecc_export_public_raw(&mut self.wc_ecc_key,
+            sys::wc_ecc_export_public_raw(self.wc_ecc_key,
                 qx.as_mut_ptr(), qx_len,
                 qy.as_mut_ptr(), qy_len)
         };
@@ -1653,7 +1535,7 @@ impl ECC {
     pub fn export_x963(&mut self, dout: &mut [u8]) -> Result<usize, i32> {
         let mut out_len = crate::buffer_len_to_u32(dout.len())?;
         let rc = unsafe {
-            sys::wc_ecc_export_x963(&mut self.wc_ecc_key, dout.as_mut_ptr(), &mut out_len)
+            sys::wc_ecc_export_x963(self.wc_ecc_key, dout.as_mut_ptr(), &mut out_len)
         };
         if rc != 0 {
             return Err(rc);
@@ -1689,7 +1571,7 @@ impl ECC {
     pub fn export_x963_compressed(&mut self, dout: &mut [u8]) -> Result<usize, i32> {
         let mut out_len = crate::buffer_len_to_u32(dout.len())?;
         let rc = unsafe {
-            sys::wc_ecc_export_x963_ex(&mut self.wc_ecc_key, dout.as_mut_ptr(), &mut out_len, 1)
+            sys::wc_ecc_export_x963_ex(self.wc_ecc_key, dout.as_mut_ptr(), &mut out_len, 1)
         };
         if rc != 0 {
             return Err(rc);
@@ -1732,7 +1614,7 @@ impl ECC {
             None => core::ptr::null_mut(),
         };
         let rc = unsafe {
-            sys::wc_ecc_make_pub_ex(&mut self.wc_ecc_key, core::ptr::null_mut(), rng_ptr)
+            sys::wc_ecc_make_pub_ex(self.wc_ecc_key, core::ptr::null_mut(), rng_ptr)
         };
         if rc != 0 {
             return Err(rc);
@@ -1785,7 +1667,7 @@ impl ECC {
         }
         let ecc_point = ECCPoint { wc_ecc_point, heap };
         let rc = unsafe {
-            sys::wc_ecc_make_pub_ex(&mut self.wc_ecc_key, wc_ecc_point, rng_ptr)
+            sys::wc_ecc_make_pub_ex(self.wc_ecc_key, wc_ecc_point, rng_ptr)
         };
         if rc != 0 {
             return Err(rc);
@@ -1833,7 +1715,7 @@ impl ECC {
     pub fn set_rng(&mut self, rng: RNG) -> Result<(), i32> {
         let wc_rng = rng.wc_rng;
         let rc = unsafe {
-            sys::wc_ecc_set_rng(&mut self.wc_ecc_key, wc_rng)
+            sys::wc_ecc_set_rng(self.wc_ecc_key, wc_rng)
         };
         if rc != 0 {
             return Err(rc);
@@ -1848,7 +1730,7 @@ impl ECC {
     pub fn set_shared_rng(&mut self, rng: alloc::sync::Arc<RNG>) -> Result<(), i32> {
         let wc_rng = rng.wc_rng;
         let rc = unsafe {
-            sys::wc_ecc_set_rng(&mut self.wc_ecc_key, wc_rng)
+            sys::wc_ecc_set_rng(self.wc_ecc_key, wc_rng)
         };
         if rc != 0 {
             return Err(rc);
@@ -1908,8 +1790,8 @@ impl ECC {
     pub fn shared_secret(&mut self, peer_key: &mut ECC, dout: &mut [u8]) -> Result<usize, i32> {
         let mut out_len = crate::buffer_len_to_u32(dout.len())?;
         let rc = unsafe {
-            sys::wc_ecc_shared_secret(&mut self.wc_ecc_key,
-                &mut peer_key.wc_ecc_key, dout.as_mut_ptr(), &mut out_len)
+            sys::wc_ecc_shared_secret(self.wc_ecc_key,
+                peer_key.wc_ecc_key, dout.as_mut_ptr(), &mut out_len)
         };
         if rc != 0 {
             return Err(rc);
@@ -1959,7 +1841,7 @@ impl ECC {
     pub fn shared_secret_ex(&mut self, peer: &ECCPoint, dout: &mut [u8]) -> Result<usize, i32> {
         let mut out_len = crate::buffer_len_to_u32(dout.len())?;
         let rc = unsafe {
-            sys::wc_ecc_shared_secret_ex(&mut self.wc_ecc_key,
+            sys::wc_ecc_shared_secret_ex(self.wc_ecc_key,
                 peer.wc_ecc_point, dout.as_mut_ptr(), &mut out_len)
         };
         if rc != 0 {
@@ -2004,7 +1886,7 @@ impl ECC {
         let mut dout_size = crate::buffer_len_to_u32(dout.len())?;
         let rc = unsafe {
             sys::wc_ecc_sign_hash(din.as_ptr(), din_size, dout.as_mut_ptr(),
-                &mut dout_size, rng.wc_rng, &mut self.wc_ecc_key)
+                &mut dout_size, rng.wc_rng, self.wc_ecc_key)
         };
         if rc != 0 {
             return Err(rc);
@@ -2048,7 +1930,7 @@ impl ECC {
         let hash_len = crate::buffer_len_to_u32(hash.len())?;
         let rc = unsafe {
             sys::wc_ecc_verify_hash(sig.as_ptr(), sig_len,
-                hash.as_ptr(), hash_len, &mut res, &mut self.wc_ecc_key)
+                hash.as_ptr(), hash_len, &mut res, self.wc_ecc_key)
         };
         if rc != 0 {
             return Err(rc);
@@ -2057,22 +1939,16 @@ impl ECC {
     }
 }
 
-impl ECC {
-    fn zeroize(&mut self) {
-        unsafe { crate::zeroize_raw(&mut self.wc_ecc_key); }
-    }
-}
-
 impl Drop for ECC {
     /// Safely free the underlying wolfSSL ECC context.
     ///
-    /// This calls the `wc_ecc_key_free()` wolfssl library function.
+    /// This calls the `wc_ecc_key_free()` wolfssl library function, which
+    /// frees the C-heap-allocated `ecc_key` object.
     ///
     /// The Rust Drop trait guarantees that this method is called when the ECC
     /// struct goes out of scope, automatically cleaning up resources and
     /// preventing memory leaks.
     fn drop(&mut self) {
-        unsafe { sys::wc_ecc_free(&mut self.wc_ecc_key); }
-        self.zeroize();
+        unsafe { sys::wc_ecc_key_free(self.wc_ecc_key); }
     }
 }

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -402,11 +402,16 @@ impl ECC {
         if key.is_null() {
             return Err(sys::wolfCrypt_ErrorCodes_MEMORY_E);
         }
-        let rc = unsafe { sys::wc_ecc_init_ex(key, heap, dev_id) };
-        if rc != 0 {
-            unsafe { sys::wc_ecc_key_free(key); }
-            return Err(rc);
-        }
+        // wc_ecc_key_new() always initializes the key with INVALID_DEVID.
+        // Calling wc_ecc_init_ex() a second time to install the user's dev_id
+        // would re-run every initialization step (including allocations under
+        // some build configurations such as async crypto without WOLF_CRYPTO_CB)
+        // and orphan resources from the first init. Instead, just patch devId
+        // in place for WOLF_CRYPTO_CB builds.
+        #[cfg(wolf_crypto_cb)]
+        unsafe { (*key).devId = dev_id; }
+        #[cfg(not(wolf_crypto_cb))]
+        let _ = dev_id;
         Ok(key)
     }
 

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecdsa.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecdsa.rs
@@ -252,7 +252,7 @@ macro_rules! define_ecdsa_curve {
                         sys::wc_SignatureType_WC_SIGNATURE_TYPE_ECC,
                         msg.as_ptr(), msg_len,
                         der.as_mut_ptr(), &mut der_len,
-                        &mut self.inner.wc_ecc_key as *mut _ as *mut c_void,
+                        self.inner.wc_ecc_key as *mut c_void,
                         size_of::<sys::ecc_key>() as u32,
                         self.rng.wc_rng,
                     )
@@ -313,7 +313,7 @@ macro_rules! define_ecdsa_curve {
             fn verify(&self, msg: &[u8], sig: &$signature) -> Result<(), Error> {
                 let mut der = [0u8; $der_max];
                 let der_len = rs_to_der::<$field_size>(&sig.0, &mut der)?;
-                let mut key = ECC::import_x963_ex(&self.pub_bytes, $curve_id, None, None)
+                let key = ECC::import_x963_ex(&self.pub_bytes, $curve_id, None, None)
                     .map_err(|_| Error::new())?;
                 let msg_len: u32 = msg.len().try_into().map_err(|_| Error::new())?;
                 let rc = unsafe {
@@ -322,7 +322,7 @@ macro_rules! define_ecdsa_curve {
                         sys::wc_SignatureType_WC_SIGNATURE_TYPE_ECC,
                         msg.as_ptr(), msg_len,
                         der.as_ptr(), der_len as u32,
-                        &mut key.wc_ecc_key as *mut _ as *mut c_void,
+                        key.wc_ecc_key as *mut c_void,
                         size_of::<sys::ecc_key>() as u32,
                     )
                 };

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecdsa.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecdsa.rs
@@ -254,7 +254,7 @@ macro_rules! define_ecdsa_curve {
                         der.as_mut_ptr(), &mut der_len,
                         &mut self.inner.wc_ecc_key as *mut _ as *mut c_void,
                         size_of::<sys::ecc_key>() as u32,
-                        &mut self.rng.wc_rng,
+                        self.rng.wc_rng,
                     )
                 };
                 if rc != 0 {

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ed25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ed25519.rs
@@ -72,7 +72,7 @@ impl Ed25519 {
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed25519::generate(&mut rng).expect("Error with generate()");
     /// ```
-    pub fn generate(rng: &mut RNG) -> Result<Self, i32> {
+    pub fn generate(rng: &RNG) -> Result<Self, i32> {
         Self::generate_ex(rng, None, None)
     }
 
@@ -97,7 +97,7 @@ impl Ed25519 {
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed25519::generate_ex(&mut rng, None, None).expect("Error with generate_ex()");
     /// ```
-    pub fn generate_ex(rng: &mut RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex(rng: &RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut ws_key: MaybeUninit<sys::ed25519_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -114,7 +114,7 @@ impl Ed25519 {
         let ws_key = unsafe { ws_key.assume_init() };
         let mut ed25519 = Ed25519 { ws_key };
         let rc = unsafe {
-            sys::wc_ed25519_make_key(&mut rng.wc_rng,
+            sys::wc_ed25519_make_key(rng.wc_rng,
                 sys::ED25519_KEY_SIZE as i32, &mut ed25519.ws_key)
         };
         if rc != 0 {

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ed448.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ed448.rs
@@ -71,7 +71,7 @@ impl Ed448 {
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed448::generate(&mut rng).expect("Error with generate()");
     /// ```
-    pub fn generate(rng: &mut RNG) -> Result<Self, i32> {
+    pub fn generate(rng: &RNG) -> Result<Self, i32> {
         Self::generate_ex(rng, None, None)
     }
 
@@ -96,7 +96,7 @@ impl Ed448 {
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed448::generate_ex(&mut rng, None, None).expect("Error with generate_ex()");
     /// ```
-    pub fn generate_ex(rng: &mut RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex(rng: &RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut ws_key: MaybeUninit<sys::ed448_key> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -113,7 +113,7 @@ impl Ed448 {
         let ws_key = unsafe { ws_key.assume_init() };
         let mut ed448 = Ed448 { ws_key };
         let rc = unsafe {
-            sys::wc_ed448_make_key(&mut rng.wc_rng,
+            sys::wc_ed448_make_key(rng.wc_rng,
                 sys::ED448_KEY_SIZE as i32, &mut ed448.ws_key)
         };
         if rc != 0 {

--- a/wrapper/rust/wolfssl-wolfcrypt/src/hmac.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/hmac.rs
@@ -330,6 +330,24 @@ impl HMAC {
     }
 }
 
+impl Clone for HMAC {
+    /// Deep-copy the HMAC state via `wc_HmacCopy()`.
+    ///
+    /// Panics if the underlying wolfSSL copy fails.
+    fn clone(&self) -> Self {
+        let mut wc_hmac: MaybeUninit<sys::Hmac> = MaybeUninit::uninit();
+        let rc = unsafe {
+            sys::wc_HmacCopy(&self.wc_hmac as *const _ as *mut _,
+                wc_hmac.as_mut_ptr())
+        };
+        if rc != 0 {
+            panic!("wc_HmacCopy() failed: {}", rc);
+        }
+        let wc_hmac = unsafe { wc_hmac.assume_init() };
+        HMAC { wc_hmac }
+    }
+}
+
 impl Drop for HMAC {
     /// Safely free the underlying wolfSSL Hmac context.
     ///

--- a/wrapper/rust/wolfssl-wolfcrypt/src/hmac_mac.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/hmac_mac.rs
@@ -42,6 +42,7 @@ macro_rules! impl_hmac_mac {
         $name:ident, hmac_type = $hmac_type:expr, key = $key_size:ty, out = $out_size:ty
     ) => {
         $(#[$attr])*
+        #[derive(Clone)]
         pub struct $name {
             hmac: crate::hmac::HMAC,
         }

--- a/wrapper/rust/wolfssl-wolfcrypt/src/lib.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/lib.rs
@@ -20,6 +20,9 @@
 
 #![no_std]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 /* bindgen-generated bindings to the C library */
 pub mod sys;
 

--- a/wrapper/rust/wolfssl-wolfcrypt/src/lib.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/lib.rs
@@ -45,6 +45,8 @@ pub(crate) unsafe fn zeroize_raw<T>(val: &mut T) {
 
 pub mod aes;
 pub mod blake2;
+#[cfg(all(any(blake2b, blake2s), feature = "mac"))]
+pub mod blake2_mac;
 pub mod chacha20_poly1305;
 pub mod cmac;
 #[cfg(all(cmac, feature = "mac"))]

--- a/wrapper/rust/wolfssl-wolfcrypt/src/lib.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/lib.rs
@@ -45,6 +45,8 @@ pub(crate) unsafe fn zeroize_raw<T>(val: &mut T) {
 
 pub mod aes;
 pub mod blake2;
+#[cfg(all(any(blake2b, blake2s), feature = "digest"))]
+pub mod blake2_digest;
 #[cfg(all(any(blake2b, blake2s), feature = "mac"))]
 pub mod blake2_mac;
 pub mod chacha20_poly1305;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/lms.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/lms.rs
@@ -442,8 +442,8 @@ impl Lms {
     /// }
     /// ```
     #[cfg(all(lms_make_key, random))]
-    pub fn make_key(&mut self, rng: &mut RNG) -> Result<(), i32> {
-        let rc = unsafe { sys::wc_LmsKey_MakeKey(&mut self.ws_key, &mut rng.wc_rng) };
+    pub fn make_key(&mut self, rng: &RNG) -> Result<(), i32> {
+        let rc = unsafe { sys::wc_LmsKey_MakeKey(&mut self.ws_key, rng.wc_rng) };
         if rc != 0 {
             return Err(rc);
         }

--- a/wrapper/rust/wolfssl-wolfcrypt/src/mlkem.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/mlkem.rs
@@ -123,7 +123,7 @@ impl MlKem {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn generate(key_type: i32, rng: &mut RNG) -> Result<Self, i32> {
+    pub fn generate(key_type: i32, rng: &RNG) -> Result<Self, i32> {
         Self::generate_ex(key_type, rng, None, None)
     }
 
@@ -157,12 +157,12 @@ impl MlKem {
     #[cfg(random)]
     pub fn generate_ex(
         key_type: i32,
-        rng: &mut RNG,
+        rng: &RNG,
         heap: Option<*mut core::ffi::c_void>,
         dev_id: Option<i32>,
     ) -> Result<Self, i32> {
         let key = Self::new_ex(key_type, heap, dev_id)?;
-        let rc = unsafe { sys::wc_MlKemKey_MakeKey(key.ws_key, &mut rng.wc_rng) };
+        let rc = unsafe { sys::wc_MlKemKey_MakeKey(key.ws_key, rng.wc_rng) };
         if rc != 0 {
             return Err(rc);
         }
@@ -472,7 +472,7 @@ impl MlKem {
         &mut self,
         ct: &mut [u8],
         ss: &mut [u8],
-        rng: &mut RNG,
+        rng: &RNG,
     ) -> Result<(), i32> {
         // Verify the cipher text length is as expected based on the parameter
         // set (key type) in use.
@@ -489,7 +489,7 @@ impl MlKem {
                 self.ws_key,
                 ct.as_mut_ptr(),
                 ss.as_mut_ptr(),
-                &mut rng.wc_rng,
+                rng.wc_rng,
             )
         };
         if rc != 0 {

--- a/wrapper/rust/wolfssl-wolfcrypt/src/random.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/random.rs
@@ -71,8 +71,8 @@ unsafe impl Send for RNG {}
 
 // Note: `RNG` is intentionally not `Sync`. The underlying C `WC_RNG` state is
 // mutated by every call to a generation routine, with no internal locking.
-// Callers that need cross-thread sharing must wrap the RNG in a `Mutex`
-// (typically `Arc<Mutex<RNG>>`).
+// Callers that need cross-thread sharing of a single RNG struct must implement
+// their own locking.
 
 /// Storage for an RNG that a consumer (e.g. `RSA`, `ECC`) has been bound to
 /// via `set_rng`. The consumer keeps the `RngHandle` alive for as long as the
@@ -80,7 +80,7 @@ unsafe impl Send for RNG {}
 pub(crate) enum RngHandle {
     Owned(RNG),
     #[cfg(feature = "alloc")]
-    Shared(alloc::sync::Arc<RNG>),
+    Shared(alloc::rc::Rc<RNG>),
 }
 
 impl RNG {

--- a/wrapper/rust/wolfssl-wolfcrypt/src/random.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/random.rs
@@ -31,7 +31,7 @@ wolfSSL `WC_RNG` object. It ensures proper initialization and deallocation.
 use wolfssl_wolfcrypt::random::RNG;
 
 // Create a RNG instance.
-let mut rng = RNG::new().expect("Failed to create RNG");
+let rng = RNG::new().expect("Failed to create RNG");
 
 // Generate a single random byte value.
 let byte = rng.generate_byte().expect("Failed to generate a single byte");
@@ -45,18 +45,42 @@ rng.generate_block(&mut buffer).expect("Failed to generate a block");
 #![cfg(random)]
 
 use crate::sys;
-use core::mem::{size_of_val, MaybeUninit};
+use core::mem::size_of_val;
 use num_traits::PrimInt;
 
 /// A cryptographically secure random number generator based on the wolfSSL
 /// library.
 ///
-/// This struct wraps the wolfssl `WC_RNG` type, providing a high-level API
-/// for generating random bytes and blocks of data. The `Drop` implementation
-/// ensures that the underlying wolfSSL RNG context is correctly freed when the
-/// `RNG` struct goes out of scope, preventing memory leaks.
+/// This struct wraps a pointer to a wolfssl `WC_RNG` allocated on the C heap,
+/// providing a high-level API for generating random bytes and blocks of data.
+/// The `Drop` implementation ensures that the underlying wolfSSL RNG context is
+/// correctly freed when the `RNG` struct goes out of scope, preventing memory
+/// leaks.
+///
+/// All generation methods take `&self`. The actual mutation of the DRBG state
+/// happens through the raw pointer in the C library; the `RNG` struct itself
+/// is logically immutable after construction.
 pub struct RNG {
-    pub(crate) wc_rng: sys::WC_RNG,
+    pub(crate) wc_rng: *mut sys::WC_RNG,
+}
+
+// Safety: the only field of `RNG` is a non-null pointer to a `WC_RNG` that
+// lives on the C heap and is never reassigned after construction. Moving the
+// struct between threads is sound.
+unsafe impl Send for RNG {}
+
+// Note: `RNG` is intentionally not `Sync`. The underlying C `WC_RNG` state is
+// mutated by every call to a generation routine, with no internal locking.
+// Callers that need cross-thread sharing must wrap the RNG in a `Mutex`
+// (typically `Arc<Mutex<RNG>>`).
+
+/// Storage for an RNG that a consumer (e.g. `RSA`, `ECC`) has been bound to
+/// via `set_rng`. The consumer keeps the `RngHandle` alive for as long as the
+/// C struct holds its pointer, ensuring the `WC_RNG` outlives the consumer.
+pub(crate) enum RngHandle {
+    Owned(RNG),
+    #[cfg(feature = "alloc")]
+    Shared(alloc::sync::Arc<RNG>),
 }
 
 impl RNG {
@@ -97,7 +121,7 @@ impl RNG {
                 return Err(rc);
             }
         }
-        let mut wc_rng: MaybeUninit<sys::WC_RNG> = MaybeUninit::uninit();
+        let mut wc_rng: *mut sys::WC_RNG = core::ptr::null_mut();
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -107,12 +131,10 @@ impl RNG {
             None => sys::INVALID_DEVID,
         };
         let rc = unsafe {
-            sys::wc_InitRng_ex(wc_rng.as_mut_ptr(), heap, dev_id)
+            sys::wc_rng_new_ex(&mut wc_rng, core::ptr::null_mut(), 0, heap, dev_id)
         };
         if rc == 0 {
-            let wc_rng = unsafe { wc_rng.assume_init() };
-            let rng = RNG {wc_rng};
-            Ok(rng)
+            Ok(RNG {wc_rng})
         } else {
             Err(rc)
         }
@@ -159,7 +181,7 @@ impl RNG {
         }
         let ptr = nonce.as_mut_ptr() as *mut u8;
         let size = crate::buffer_len_to_u32(size_of_val(nonce))?;
-        let mut wc_rng: MaybeUninit<sys::WC_RNG> = MaybeUninit::uninit();
+        let mut wc_rng: *mut sys::WC_RNG = core::ptr::null_mut();
         let heap = match heap {
             Some(heap) => heap,
             None => core::ptr::null_mut(),
@@ -169,12 +191,10 @@ impl RNG {
             None => sys::INVALID_DEVID,
         };
         let rc = unsafe {
-            sys::wc_InitRngNonce_ex(wc_rng.as_mut_ptr(), ptr, size, heap, dev_id)
+            sys::wc_rng_new_ex(&mut wc_rng, ptr, size, heap, dev_id)
         };
         if rc == 0 {
-            let wc_rng = unsafe { wc_rng.assume_init() };
-            let rng = RNG {wc_rng};
-            Ok(rng)
+            Ok(RNG {wc_rng})
         } else {
             Err(rc)
         }
@@ -315,9 +335,9 @@ impl RNG {
     ///
     /// A `Result` which is `Ok(u8)` containing the random byte on success or
     /// an `Err` with the wolfssl library return code on failure.
-    pub fn generate_byte(&mut self) -> Result<u8, i32> {
+    pub fn generate_byte(&self) -> Result<u8, i32> {
         let mut b: u8 = 0;
-        let rc = unsafe { sys::wc_RNG_GenerateByte(&mut self.wc_rng, &mut b) };
+        let rc = unsafe { sys::wc_RNG_GenerateByte(self.wc_rng, &mut b) };
         if rc == 0 {
             Ok(b)
         } else {
@@ -339,10 +359,10 @@ impl RNG {
     ///
     /// A `Result` which is `Ok(())` on success or an `Err` with the wolfssl
     /// library return code on failure.
-    pub fn generate_block<T: PrimInt>(&mut self, buf: &mut [T]) -> Result<(), i32> {
+    pub fn generate_block<T: PrimInt>(&self, buf: &mut [T]) -> Result<(), i32> {
         let ptr = buf.as_mut_ptr() as *mut u8;
         let size = crate::buffer_len_to_u32(size_of_val(buf))?;
-        let rc = unsafe { sys::wc_RNG_GenerateBlock(&mut self.wc_rng, ptr, size) };
+        let rc = unsafe { sys::wc_RNG_GenerateBlock(self.wc_rng, ptr, size) };
         if rc == 0 {
             Ok(())
         } else {
@@ -371,10 +391,10 @@ impl RNG {
     /// rng.reseed(&seed).expect("Error with reseed()");
     /// ```
     #[cfg(random_hashdrbg)]
-    pub fn reseed(&mut self, seed: &[u8]) -> Result<(), i32> {
+    pub fn reseed(&self, seed: &[u8]) -> Result<(), i32> {
         let seed_size = crate::buffer_len_to_u32(seed.len())?;
         let rc = unsafe {
-            sys::wc_RNG_DRBG_Reseed(&mut self.wc_rng, seed.as_ptr(), seed_size)
+            sys::wc_RNG_DRBG_Reseed(self.wc_rng, seed.as_ptr(), seed_size)
         };
         if rc != 0 {
             return Err(rc);
@@ -411,22 +431,16 @@ impl rand_core::TryRng for RNG {
 #[cfg(feature = "rand_core")]
 impl rand_core::TryCryptoRng for RNG {}
 
-impl RNG {
-    fn zeroize(&mut self) {
-        unsafe { crate::zeroize_raw(&mut self.wc_rng); }
-    }
-}
-
 impl Drop for RNG {
     /// Safely free the underlying wolfSSL RNG context.
     ///
-    /// This calls the `wc_FreeRng` wolfssl library function.
+    /// This calls the `wc_rng_free` wolfssl library function, which frees the
+    /// C-heap-allocated `WC_RNG` object.
     ///
     /// The Rust Drop trait guarantees that this method is called when the RNG
     /// struct goes out of scope, automatically cleaning up resources and
     /// preventing memory leaks.
     fn drop(&mut self) {
-        unsafe { sys::wc_FreeRng(&mut self.wc_rng); }
-        self.zeroize();
+        unsafe { sys::wc_rng_free(self.wc_rng); }
     }
 }

--- a/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
@@ -1187,13 +1187,6 @@ impl RSA {
     /// * `rng`: The `RNG` struct instance to associate with this `RSA`
     ///   instance.
     ///
-    /// # Safety contract
-    ///
-    /// The caller must ensure that the `RNG` instance is not dropped before
-    /// this `RSA` instance. The `RSA` struct holds an internal pointer to the
-    /// `RNG`'s underlying `WC_RNG` context, and dropping the `RNG` first
-    /// would result in a dangling pointer.
-    ///
     /// # Returns
     ///
     /// Returns Ok(()) on success or Err(e) containing the wolfSSL library

--- a/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
@@ -1196,25 +1196,25 @@ impl RSA {
     ///
     /// ```rust
     /// # extern crate std;
-    /// #[cfg(all(random, feature = "alloc"))]
+    /// #[cfg(random)]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_rng(RNG::new().expect("Error creating RNG")).expect("Error with set_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
-    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
+    /// let enc_rng = RNG::new().expect("Error creating RNG");
+    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &enc_rng).expect("Error with public_encrypt()");
     /// assert!(enc_len > 0 && enc_len <= 512);
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_rng(RNG::new().expect("Error creating RNG")).expect("Error with set_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());

--- a/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
@@ -35,20 +35,20 @@ use std::fs;
 use wolfssl_wolfcrypt::random::RNG;
 use wolfssl_wolfcrypt::rsa::RSA;
 
-let mut rng = RNG::new().expect("Error creating RNG");
+let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
 let key_path = "../../../certs/client-keyPub.der";
 let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
 let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-rsa.set_rng(&mut rng).expect("Error with set_rng()");
+rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
 let plain: &[u8] = b"Test message";
 let mut enc: [u8; 512] = [0; 512];
-let enc_len = rsa.public_encrypt(plain, &mut enc, &mut rng).expect("Error with public_encrypt()");
+let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
 assert!(enc_len > 0 && enc_len <= 512);
 
 let key_path = "../../../certs/client-key.der";
 let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
 let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-rsa.set_rng(&mut rng).expect("Error with set_rng()");
+rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
 let mut plain_out: [u8; 512] = [0; 512];
 let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
 assert!(dec_len as usize == plain.len());
@@ -61,7 +61,7 @@ assert_eq!(plain_out[0..dec_len], *plain);
 
 use crate::sys;
 #[cfg(random)]
-use crate::random::RNG;
+use crate::random::{RNG, RngHandle};
 use core::mem::{MaybeUninit};
 
 /// The `RSA` struct manages the lifecycle of a wolfSSL `RsaKey` object.
@@ -72,6 +72,10 @@ use core::mem::{MaybeUninit};
 /// or `generate()`.
 pub struct RSA {
     pub(crate) wc_rsakey: sys::RsaKey,
+    /// RNG bound to this key via `set_rng`. Kept alive here so the C struct's
+    /// internal `WC_RNG` pointer remains valid for as long as the key exists.
+    #[cfg(random)]
+    rng: Option<RngHandle>,
 }
 
 impl RSA {
@@ -143,26 +147,26 @@ impl RSA {
     ///
     /// ```rust
     /// # extern crate std;
-    /// #[cfg(random)]
+    /// #[cfg(all(random, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
-    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &mut rng).expect("Error with public_encrypt()");
+    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
     /// assert!(enc_len > 0 && enc_len <= 512);
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -191,26 +195,26 @@ impl RSA {
     ///
     /// ```rust
     /// # extern crate std;
-    /// #[cfg(random)]
+    /// #[cfg(all(random, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
-    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &mut rng).expect("Error with public_encrypt()");
+    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
     /// assert!(enc_len > 0 && enc_len <= 512);
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der_ex(&der, None, None).expect("Error with new_from_der_ex()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -241,7 +245,11 @@ impl RSA {
             unsafe { sys::wc_FreeRsaKey(&mut wc_rsakey); }
             return Err(rc);
         }
-        let rsa = RSA { wc_rsakey };
+        let rsa = RSA {
+            wc_rsakey,
+            #[cfg(random)]
+            rng: None,
+        };
         Ok(rsa)
     }
 
@@ -260,26 +268,26 @@ impl RSA {
     ///
     /// ```rust
     /// # extern crate std;
-    /// #[cfg(random)]
+    /// #[cfg(all(random, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
-    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &mut rng).expect("Error with public_encrypt()");
+    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
     /// assert!(enc_len > 0 && enc_len <= 512);
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -308,26 +316,26 @@ impl RSA {
     ///
     /// ```rust
     /// # extern crate std;
-    /// #[cfg(random)]
+    /// #[cfg(all(random, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der_ex(&der, None, None).expect("Error with new_public_from_der_ex()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
-    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &mut rng).expect("Error with public_encrypt()");
+    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
     /// assert!(enc_len > 0 && enc_len <= 512);
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -358,7 +366,11 @@ impl RSA {
             unsafe { sys::wc_FreeRsaKey(&mut wc_rsakey); }
             return Err(rc);
         }
-        let rsa = RSA { wc_rsakey };
+        let rsa = RSA {
+            wc_rsakey,
+            #[cfg(random)]
+            rng: None,
+        };
         Ok(rsa)
     }
 
@@ -411,7 +423,11 @@ impl RSA {
             unsafe { sys::wc_FreeRsaKey(&mut wc_rsakey); }
             return Err(rc);
         }
-        Ok(RSA { wc_rsakey })
+        Ok(RSA {
+            wc_rsakey,
+            #[cfg(random)]
+            rng: None,
+        })
     }
 
     /// Generate a new RSA key using the given size and exponent.
@@ -446,15 +462,15 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
-    /// let mut rsa = RSA::generate(2048, 65537, &mut rng).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Error creating RNG");
+    /// let mut rsa = RSA::generate(2048, 65537, &rng).expect("Error with generate()");
     /// rsa.check().expect("Error with check()");
     /// let encrypt_size = rsa.get_encrypt_size().expect("Error with get_encrypt_size()");
     /// assert_eq!(encrypt_size, 256);
     /// }
     /// ```
     #[cfg(all(random, rsa_keygen))]
-    pub fn generate(size: i32, e: i32, rng: &mut RNG) -> Result<Self, i32> {
+    pub fn generate(size: i32, e: i32, rng: &RNG) -> Result<Self, i32> {
         Self::generate_ex(size, e, rng, None, None)
     }
 
@@ -493,15 +509,15 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
-    /// let mut rsa = RSA::generate_ex(2048, 65537, &mut rng, None, None).expect("Error with generate_ex()");
+    /// let rng = RNG::new().expect("Error creating RNG");
+    /// let mut rsa = RSA::generate_ex(2048, 65537, &rng, None, None).expect("Error with generate_ex()");
     /// rsa.check().expect("Error with check()");
     /// let encrypt_size = rsa.get_encrypt_size().expect("Error with get_encrypt_size()");
     /// assert_eq!(encrypt_size, 256);
     /// }
     /// ```
     #[cfg(all(random, rsa_keygen))]
-    pub fn generate_ex(size: i32, e: i32, rng: &mut RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
+    pub fn generate_ex(size: i32, e: i32, rng: &RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut wc_rsakey: MaybeUninit<sys::RsaKey> = MaybeUninit::uninit();
         let heap = match heap {
             Some(heap) => heap,
@@ -518,13 +534,17 @@ impl RSA {
         let mut wc_rsakey = unsafe { wc_rsakey.assume_init() };
         let e = e as core::ffi::c_long;
         let rc = unsafe {
-            sys::wc_MakeRsaKey(&mut wc_rsakey, size, e, &mut rng.wc_rng)
+            sys::wc_MakeRsaKey(&mut wc_rsakey, size, e, rng.wc_rng)
         };
         if rc != 0 {
             unsafe { sys::wc_FreeRsaKey(&mut wc_rsakey); }
             return Err(rc);
         }
-        let rsa = RSA { wc_rsakey };
+        let rsa = RSA {
+            wc_rsakey,
+            #[cfg(random)]
+            rng: None,
+        };
         Ok(rsa)
     }
 
@@ -556,8 +576,8 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
-    /// let mut rsa = RSA::generate(2048, 65537, &mut rng).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Error creating RNG");
+    /// let mut rsa = RSA::generate(2048, 65537, &rng).expect("Error with generate()");
     /// let mut e: [u8; 256] = [0; 256];
     /// let mut e_size: u32 = 0;
     /// let mut n: [u8; 256] = [0; 256];
@@ -624,8 +644,8 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
-    /// let mut rsa = RSA::generate(2048, 65537, &mut rng).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Error creating RNG");
+    /// let mut rsa = RSA::generate(2048, 65537, &rng).expect("Error with generate()");
     /// let mut e: [u8; 256] = [0; 256];
     /// let mut e_size: u32 = 0;
     /// let mut n: [u8; 256] = [0; 256];
@@ -667,8 +687,8 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
-    /// let mut rsa = RSA::generate(2048, 65537, &mut rng).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Error creating RNG");
+    /// let mut rsa = RSA::generate(2048, 65537, &rng).expect("Error with generate()");
     /// let encrypt_size = rsa.get_encrypt_size().expect("Error with get_encrypt_size()");
     /// assert_eq!(encrypt_size, 256);
     /// }
@@ -696,8 +716,8 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
-    /// let mut rsa = RSA::generate(2048, 65537, &mut rng).expect("Error with generate()");
+    /// let rng = RNG::new().expect("Error creating RNG");
+    /// let mut rsa = RSA::generate(2048, 65537, &rng).expect("Error with generate()");
     /// rsa.check().expect("Error with check()");
     /// }
     /// ```
@@ -729,26 +749,26 @@ impl RSA {
     ///
     /// ```rust
     /// # extern crate std;
-    /// #[cfg(random)]
+    /// #[cfg(all(random, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
-    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &mut rng).expect("Error with public_encrypt()");
+    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
     /// assert!(enc_len > 0 && enc_len <= 512);
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -756,13 +776,13 @@ impl RSA {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn public_encrypt(&mut self, din: &[u8], dout: &mut [u8], rng: &mut RNG) -> Result<usize, i32> {
+    pub fn public_encrypt(&mut self, din: &[u8], dout: &mut [u8], rng: &RNG) -> Result<usize, i32> {
         let din_size = crate::buffer_len_to_u32(din.len())?;
         let dout_size = crate::buffer_len_to_u32(dout.len())?;
         let rc = unsafe {
             sys::wc_RsaPublicEncrypt(din.as_ptr(), din_size,
                 dout.as_mut_ptr(), dout_size, &mut self.wc_rsakey,
-                &mut rng.wc_rng)
+                rng.wc_rng)
         };
         if rc < 0 {
             return Err(rc);
@@ -788,26 +808,26 @@ impl RSA {
     ///
     /// ```rust
     /// # extern crate std;
-    /// #[cfg(random)]
+    /// #[cfg(all(random, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
-    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &mut rng).expect("Error with public_encrypt()");
+    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
     /// assert!(enc_len > 0 && enc_len <= 512);
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -855,20 +875,20 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
     /// let msg: &[u8] = b"This is the string to be signed!";
     /// let mut signature: [u8; 512] = [0; 512];
-    /// let sig_len = rsa.pss_sign(msg, &mut signature, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256, &mut rng).expect("Error with pss_sign()");
+    /// let sig_len = rsa.pss_sign(msg, &mut signature, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256, &rng).expect("Error with pss_sign()");
     /// assert!(sig_len > 0 && sig_len <= 512);
     ///
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.pss_verify(signature, &mut verify_out, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256).expect("Error with pss_verify()");
@@ -880,12 +900,12 @@ impl RSA {
     /// }
     /// ```
     #[cfg(all(random, rsa_pss))]
-    pub fn pss_sign(&mut self, din: &[u8], dout: &mut [u8], hash_algo: u32, mgf: i32, rng: &mut RNG) -> Result<usize, i32> {
+    pub fn pss_sign(&mut self, din: &[u8], dout: &mut [u8], hash_algo: u32, mgf: i32, rng: &RNG) -> Result<usize, i32> {
         let din_size = crate::buffer_len_to_u32(din.len())?;
         let dout_size = crate::buffer_len_to_u32(dout.len())?;
         let rc = unsafe {
             sys::wc_RsaPSS_Sign(din.as_ptr(), din_size, dout.as_mut_ptr(), dout_size,
-                hash_algo, mgf, &mut self.wc_rsakey, &mut rng.wc_rng)
+                hash_algo, mgf, &mut self.wc_rsakey, rng.wc_rng)
         };
         if rc < 0 {
             return Err(rc);
@@ -918,20 +938,20 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
     /// let msg: &[u8] = b"This is the string to be signed!";
     /// let mut signature: [u8; 512] = [0; 512];
-    /// let sig_len = rsa.pss_sign(msg, &mut signature, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256, &mut rng).expect("Error with pss_sign()");
+    /// let sig_len = rsa.pss_sign(msg, &mut signature, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256, &rng).expect("Error with pss_sign()");
     /// assert!(sig_len > 0 && sig_len <= 512);
     ///
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.pss_verify(signature, &mut verify_out, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256).expect("Error with pss_verify()");
@@ -984,20 +1004,20 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
     /// let msg: &[u8] = b"This is the string to be signed!";
     /// let mut signature: [u8; 512] = [0; 512];
-    /// let sig_len = rsa.pss_sign(msg, &mut signature, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256, &mut rng).expect("Error with pss_sign()");
+    /// let sig_len = rsa.pss_sign(msg, &mut signature, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256, &rng).expect("Error with pss_sign()");
     /// assert!(sig_len > 0 && sig_len <= 512);
     ///
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.pss_verify(signature, &mut verify_out, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256).expect("Error with pss_verify()");
@@ -1055,20 +1075,20 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
     /// let msg: &[u8] = b"This is the string to be signed!";
     /// let mut signature: [u8; 512] = [0; 512];
-    /// let sig_len = rsa.pss_sign(msg, &mut signature, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256, &mut rng).expect("Error with pss_sign()");
+    /// let sig_len = rsa.pss_sign(msg, &mut signature, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256, &rng).expect("Error with pss_sign()");
     /// assert!(sig_len > 0 && sig_len <= 512);
     ///
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.pss_verify(signature, &mut verify_out, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256).expect("Error with pss_verify()");
@@ -1125,7 +1145,7 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = RNG::new().expect("Error creating RNG");
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
@@ -1134,22 +1154,22 @@ impl RSA {
     /// let mut plain = [0u8; 256];
     /// plain[..msg.len()].copy_from_slice(msg);
     /// let mut enc = [0u8; 256];
-    /// let enc_len = rsa.rsa_direct(&plain, &mut enc, RSA::PRIVATE_ENCRYPT, &mut rng).expect("Error with rsa_direct()");
+    /// let enc_len = rsa.rsa_direct(&plain, &mut enc, RSA::PRIVATE_ENCRYPT, &rng).expect("Error with rsa_direct()");
     /// assert_eq!(enc_len, 256);
     /// let mut plain_out = [0u8; 256];
-    /// let dec_len = rsa.rsa_direct(&enc, &mut plain_out, RSA::PUBLIC_DECRYPT, &mut rng).expect("Error with rsa_direct()");
+    /// let dec_len = rsa.rsa_direct(&enc, &mut plain_out, RSA::PUBLIC_DECRYPT, &rng).expect("Error with rsa_direct()");
     /// assert_eq!(dec_len, 256);
     /// assert_eq!(plain_out, plain);
     /// }
     /// ```
     #[cfg(all(rsa_direct, rsa_const_api))]
-    pub fn rsa_direct(&mut self, din: &[u8], dout: &mut [u8], typ: i32, rng: &mut RNG) -> Result<usize, i32> {
+    pub fn rsa_direct(&mut self, din: &[u8], dout: &mut [u8], typ: i32, rng: &RNG) -> Result<usize, i32> {
         let din_size = crate::buffer_len_to_u32(din.len())?;
         let mut dout_size = crate::buffer_len_to_u32(dout.len())?;
         let rc = unsafe {
             sys::wc_RsaDirect(din.as_ptr(), din_size,
                 dout.as_mut_ptr(), &mut dout_size,
-                &mut self.wc_rsakey, typ, &mut rng.wc_rng)
+                &mut self.wc_rsakey, typ, rng.wc_rng)
         };
         if rc < 0 {
             return Err(rc);
@@ -1165,8 +1185,14 @@ impl RSA {
     /// # Parameters
     ///
     /// * `rng`: The `RNG` struct instance to associate with this `RSA`
-    ///   instance. The `RNG` struct should not be moved in memory after
-    ///   calling this method.
+    ///   instance.
+    ///
+    /// # Safety contract
+    ///
+    /// The caller must ensure that the `RNG` instance is not dropped before
+    /// this `RSA` instance. The `RSA` struct holds an internal pointer to the
+    /// `RNG`'s underlying `WC_RNG` context, and dropping the `RNG` first
+    /// would result in a dangling pointer.
     ///
     /// # Returns
     ///
@@ -1177,25 +1203,25 @@ impl RSA {
     ///
     /// ```rust
     /// # extern crate std;
-    /// #[cfg(random)]
+    /// #[cfg(all(random, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
-    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &mut rng).expect("Error with public_encrypt()");
+    /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
     /// assert!(enc_len > 0 && enc_len <= 512);
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -1203,14 +1229,45 @@ impl RSA {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn set_rng(&mut self, rng: &mut RNG) -> Result<(), i32> {
+    pub fn set_rng(&mut self, rng: RNG) -> Result<(), i32> {
+        let wc_rng = rng.wc_rng;
         let rc = unsafe {
-            sys::wc_RsaSetRNG(&mut self.wc_rsakey, &mut rng.wc_rng)
+            sys::wc_RsaSetRNG(&mut self.wc_rsakey, wc_rng)
         };
         if rc != 0 {
             return Err(rc);
         }
+        self.rng = Some(RngHandle::Owned(rng));
         Ok(())
+    }
+
+    /// Bind a shared `RNG` to this key for blinding during private operations.
+    ///
+    /// Like `set_rng`, but takes an `Arc<RNG>` so the same RNG can be shared
+    /// among multiple consumers and used directly by the caller. Available
+    /// when the `alloc` feature is enabled.
+    #[cfg(all(random, feature = "alloc"))]
+    pub fn set_shared_rng(&mut self, rng: alloc::sync::Arc<RNG>) -> Result<(), i32> {
+        let wc_rng = rng.wc_rng;
+        let rc = unsafe {
+            sys::wc_RsaSetRNG(&mut self.wc_rsakey, wc_rng)
+        };
+        if rc != 0 {
+            return Err(rc);
+        }
+        self.rng = Some(RngHandle::Shared(rng));
+        Ok(())
+    }
+
+    /// Borrow the RNG previously bound via `set_rng` or `set_shared_rng`.
+    #[cfg(random)]
+    pub fn rng(&self) -> Option<&RNG> {
+        match &self.rng {
+            Some(RngHandle::Owned(rng)) => Some(rng),
+            #[cfg(feature = "alloc")]
+            Some(RngHandle::Shared(rng)) => Some(rng),
+            None => None,
+        }
     }
 
     /// Sign the provided data with the private key.
@@ -1233,26 +1290,26 @@ impl RSA {
     ///
     /// ```rust
     /// # extern crate std;
-    /// #[cfg(random)]
+    /// #[cfg(all(random, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
     /// let msg: &[u8] = b"This is the string to be signed!";
     /// let mut signature: [u8; 512] = [0; 512];
-    /// let sig_len = rsa.ssl_sign(msg, &mut signature, &mut rng).expect("Error with ssl_sign()");
+    /// let sig_len = rsa.ssl_sign(msg, &mut signature, &rng).expect("Error with ssl_sign()");
     /// assert!(sig_len > 0 && sig_len <= 512);
     ///
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.ssl_verify(signature, &mut verify_out).expect("Error with ssl_verify()");
@@ -1260,13 +1317,13 @@ impl RSA {
     /// }
     /// ```
     #[cfg(random)]
-    pub fn ssl_sign(&mut self, din: &[u8], dout: &mut [u8], rng: &mut RNG) -> Result<usize, i32> {
+    pub fn ssl_sign(&mut self, din: &[u8], dout: &mut [u8], rng: &RNG) -> Result<usize, i32> {
         let din_size = crate::buffer_len_to_u32(din.len())?;
         let dout_size = crate::buffer_len_to_u32(dout.len())?;
         let rc = unsafe {
             sys::wc_RsaSSL_Sign(din.as_ptr(), din_size,
                 dout.as_mut_ptr(), dout_size,
-                &mut self.wc_rsakey, &mut rng.wc_rng)
+                &mut self.wc_rsakey, rng.wc_rng)
         };
         if rc < 0 {
             return Err(rc);
@@ -1295,26 +1352,26 @@ impl RSA {
     ///
     /// ```rust
     /// # extern crate std;
-    /// #[cfg(random)]
+    /// #[cfg(all(random, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let mut rng = RNG::new().expect("Error creating RNG");
+    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
     /// let msg: &[u8] = b"This is the string to be signed!";
     /// let mut signature: [u8; 512] = [0; 512];
-    /// let sig_len = rsa.ssl_sign(msg, &mut signature, &mut rng).expect("Error with ssl_sign()");
+    /// let sig_len = rsa.ssl_sign(msg, &mut signature, &rng).expect("Error with ssl_sign()");
     /// assert!(sig_len > 0 && sig_len <= 512);
     ///
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.ssl_verify(signature, &mut verify_out).expect("Error with ssl_verify()");

--- a/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
@@ -29,7 +29,7 @@ wolfSSL `RsaKey` object. It ensures proper initialization and deallocation.
 
 ```rust
 # extern crate std;
-#[cfg(random)]
+#[cfg(all(random, feature = "alloc"))]
 {
 use std::fs;
 use wolfssl_wolfcrypt::random::RNG;
@@ -869,7 +869,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(random, rsa_pss))]
+    /// #[cfg(all(random, rsa_pss, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
@@ -932,7 +932,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(random, rsa_pss, rsa_const_api))]
+    /// #[cfg(all(random, rsa_pss, rsa_const_api, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
@@ -998,7 +998,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(random, rsa_pss, rsa_const_api))]
+    /// #[cfg(all(random, rsa_pss, rsa_const_api, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;
@@ -1069,7 +1069,7 @@ impl RSA {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(random, rsa_pss, rsa_const_api))]
+    /// #[cfg(all(random, rsa_pss, rsa_const_api, feature = "alloc"))]
     /// {
     /// use std::fs;
     /// use wolfssl_wolfcrypt::random::RNG;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
@@ -35,11 +35,11 @@ use std::fs;
 use wolfssl_wolfcrypt::random::RNG;
 use wolfssl_wolfcrypt::rsa::RSA;
 
-let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
 let key_path = "../../../certs/client-keyPub.der";
 let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
 let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
 let plain: &[u8] = b"Test message";
 let mut enc: [u8; 512] = [0; 512];
 let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
@@ -48,7 +48,7 @@ assert!(enc_len > 0 && enc_len <= 512);
 let key_path = "../../../certs/client-key.der";
 let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
 let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
 let mut plain_out: [u8; 512] = [0; 512];
 let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
 assert!(dec_len as usize == plain.len());
@@ -153,11 +153,11 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
     /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
@@ -166,7 +166,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -201,11 +201,11 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
     /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
@@ -214,7 +214,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der_ex(&der, None, None).expect("Error with new_from_der_ex()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -274,11 +274,11 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
     /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
@@ -287,7 +287,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -322,11 +322,11 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der_ex(&der, None, None).expect("Error with new_public_from_der_ex()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
     /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
@@ -335,7 +335,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -755,11 +755,11 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
     /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
@@ -768,7 +768,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -814,11 +814,11 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let plain: &[u8] = b"Test message";
     /// let mut enc: [u8; 512] = [0; 512];
     /// let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
@@ -827,7 +827,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let mut plain_out: [u8; 512] = [0; 512];
     /// let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     /// assert!(dec_len as usize == plain.len());
@@ -875,7 +875,7 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
@@ -888,7 +888,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.pss_verify(signature, &mut verify_out, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256).expect("Error with pss_verify()");
@@ -938,7 +938,7 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
@@ -951,7 +951,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.pss_verify(signature, &mut verify_out, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256).expect("Error with pss_verify()");
@@ -1004,7 +1004,7 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
@@ -1017,7 +1017,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.pss_verify(signature, &mut verify_out, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256).expect("Error with pss_verify()");
@@ -1075,7 +1075,7 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
@@ -1088,7 +1088,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.pss_verify(signature, &mut verify_out, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256).expect("Error with pss_verify()");
@@ -1236,11 +1236,11 @@ impl RSA {
 
     /// Bind a shared `RNG` to this key for blinding during private operations.
     ///
-    /// Like `set_rng`, but takes an `Arc<RNG>` so the same RNG can be shared
+    /// Like `set_rng`, but takes an `Rc<RNG>` so the same RNG can be shared
     /// among multiple consumers and used directly by the caller. Available
     /// when the `alloc` feature is enabled.
     #[cfg(all(random, feature = "alloc"))]
-    pub fn set_shared_rng(&mut self, rng: alloc::sync::Arc<RNG>) -> Result<(), i32> {
+    pub fn set_shared_rng(&mut self, rng: alloc::rc::Rc<RNG>) -> Result<(), i32> {
         let wc_rng = rng.wc_rng;
         let rc = unsafe {
             sys::wc_RsaSetRNG(&mut self.wc_rsakey, wc_rng)
@@ -1289,7 +1289,7 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
@@ -1302,7 +1302,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.ssl_verify(signature, &mut verify_out).expect("Error with ssl_verify()");
@@ -1351,7 +1351,7 @@ impl RSA {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::rsa::RSA;
     ///
-    /// let rng = std::sync::Arc::new(RNG::new().expect("Error creating RNG"));
+    /// let rng = std::rc::Rc::new(RNG::new().expect("Error creating RNG"));
     ///
     /// let key_path = "../../../certs/client-key.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
@@ -1364,7 +1364,7 @@ impl RSA {
     /// let key_path = "../../../certs/client-keyPub.der";
     /// let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     /// let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    /// rsa.set_shared_rng(std::sync::Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    /// rsa.set_shared_rng(std::rc::Rc::clone(&rng)).expect("Error with set_shared_rng()");
     /// let signature = &signature[0..sig_len];
     /// let mut verify_out: [u8; 512] = [0; 512];
     /// let verify_out_size = rsa.ssl_verify(signature, &mut verify_out).expect("Error with ssl_verify()");

--- a/wrapper/rust/wolfssl-wolfcrypt/src/rsa_pkcs1v15.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/rsa_pkcs1v15.rs
@@ -149,9 +149,9 @@ pub struct SigningKey<H: Hash, const N: usize> {
 impl<H: Hash, const N: usize> SigningKey<H, N> {
     /// Generate a fresh `N * 8`-bit RSA key with public exponent 65537.
     #[cfg(rsa_keygen)]
-    pub fn generate(mut rng: RNG) -> Result<Self, i32> {
+    pub fn generate(rng: RNG) -> Result<Self, i32> {
         let bits: i32 = (N * 8).try_into().map_err(|_| sys::wolfCrypt_ErrorCodes_BAD_FUNC_ARG)?;
-        let rsa = RSA::generate(bits, 65537, &mut rng)?;
+        let rsa = RSA::generate(bits, 65537, &rng)?;
         Ok(Self { inner: rsa, rng, _hash: PhantomData })
     }
 
@@ -186,7 +186,7 @@ impl<H: Hash, const N: usize> SignerMut<Signature<N>> for SigningKey<H, N> {
                 sig.as_mut_ptr(), &mut sig_len,
                 &mut self.inner.wc_rsakey as *mut _ as *mut c_void,
                 size_of::<sys::RsaKey>() as u32,
-                &mut self.rng.wc_rng,
+                self.rng.wc_rng,
             )
         };
         if rc != 0 || sig_len as usize != N {

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_aes.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_aes.rs
@@ -1030,6 +1030,29 @@ fn test_aes256gcm_nist_tc14_encrypt() {
     assert_eq!(&tag[..], &expected_tag);
 }
 
+/// Roundtrip test for AES-192-GCM using `aead::Aead`.
+#[test]
+#[cfg(all(feature = "aead", aes_gcm))]
+fn test_aes192gcm_aead_roundtrip() {
+    let key = [0x77u8; 24];
+    let nonce_bytes = [0x88u8; 12];
+    let aad = b"aes-192-gcm test";
+    let plaintext = b"AES-192-GCM roundtrip test";
+
+    let cipher = Aes192Gcm::new_from_slice(&key).unwrap();
+    let nonce: aead::Nonce<Aes192Gcm> = nonce_bytes.into();
+
+    let ciphertext = cipher
+        .encrypt(&nonce, Payload { msg: plaintext, aad })
+        .expect("AES-192-GCM encrypt failed");
+
+    let recovered = cipher
+        .decrypt(&nonce, Payload { msg: &ciphertext, aad })
+        .expect("AES-192-GCM decrypt failed");
+
+    assert_eq!(recovered, plaintext);
+}
+
 /// Roundtrip test for AES-256-GCM using `aead::Aead`.
 #[test]
 #[cfg(all(feature = "aead", aes_gcm))]
@@ -1090,6 +1113,29 @@ fn test_aes128ccm_reject_tampered() {
     let mut ct = cipher.encrypt(&nonce, plaintext.as_ref()).expect("encrypt failed");
     ct[0] ^= 0x01;
     assert!(cipher.decrypt(&nonce, ct.as_slice()).is_err());
+}
+
+/// Roundtrip test for AES-192-CCM using `aead::Aead`.
+#[test]
+#[cfg(all(feature = "aead", aes_ccm))]
+fn test_aes192ccm_aead_roundtrip() {
+    let key = [0x33u8; 24];
+    let nonce_bytes = [0x44u8; 12];
+    let aad = b"aes-192-ccm test";
+    let plaintext = b"AES-192-CCM plaintext data";
+
+    let cipher = Aes192Ccm::new_from_slice(&key).unwrap();
+    let nonce: aead::Nonce<Aes192Ccm> = nonce_bytes.into();
+
+    let ciphertext = cipher
+        .encrypt(&nonce, Payload { msg: plaintext, aad })
+        .expect("AES-192-CCM encrypt failed");
+
+    let recovered = cipher
+        .decrypt(&nonce, Payload { msg: &ciphertext, aad })
+        .expect("AES-192-CCM decrypt failed");
+
+    assert_eq!(recovered, plaintext);
 }
 
 /// Roundtrip test for AES-256-CCM using `aead::Aead`.

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_blake2_digest.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_blake2_digest.rs
@@ -1,0 +1,126 @@
+#![cfg(all(any(blake2b, blake2s), feature = "digest"))]
+
+use digest::{Digest, FixedOutputReset};
+use digest::block_api::BlockSizeUser;
+
+mod common;
+
+fn check_digest<D: Digest + BlockSizeUser + FixedOutputReset + Default>(
+    input: &[u8],
+    expected: &[u8],
+    expected_block_size: usize,
+) {
+    assert_eq!(<D as Digest>::output_size(), expected.len());
+    assert_eq!(<D as BlockSizeUser>::block_size(), expected_block_size);
+
+    /* One-shot digest via associated function. */
+    let out = D::digest(input);
+    assert_eq!(out.as_slice(), expected);
+
+    /* Streaming via Digest::update and finalize. */
+    let mut hasher = D::new();
+    Digest::update(&mut hasher, input);
+    let out = hasher.finalize();
+    assert_eq!(out.as_slice(), expected);
+
+    /* Split update via Default + Update + FixedOutputReset::finalize_reset. */
+    let mut hasher = D::default();
+    if input.len() >= 2 {
+        let mid = input.len() / 2;
+        Digest::update(&mut hasher, &input[..mid]);
+        Digest::update(&mut hasher, &input[mid..]);
+    } else {
+        Digest::update(&mut hasher, input);
+    }
+    let out = hasher.finalize_reset();
+    assert_eq!(out.as_slice(), expected);
+
+    /* After reset, the same hasher should produce the same result. */
+    Digest::update(&mut hasher, input);
+    let out = hasher.finalize();
+    assert_eq!(out.as_slice(), expected);
+}
+
+#[test]
+#[cfg(blake2b)]
+fn test_digest_blake2b_512() {
+    use wolfssl_wolfcrypt::blake2_digest::Blake2b512;
+    common::setup();
+    check_digest::<Blake2b512>(
+        b"abc",
+        b"\xBA\x80\xA5\x3F\x98\x1C\x4D\x0D\x6A\x27\x97\xB6\x9F\x12\xF6\xE9\x4C\x21\x2F\x14\x68\x5A\xC4\xB7\x4B\x12\xBB\x6F\xDB\xFF\xA2\xD1\x7D\x87\xC5\x39\x2A\xAB\x79\x2D\xC2\x52\xD5\xDE\x45\x33\xCC\x95\x18\xD3\x8A\xA8\xDB\xF1\x92\x5A\xB9\x23\x86\xED\xD4\x00\x99\x23",
+        128,
+    );
+}
+
+#[test]
+#[cfg(blake2b)]
+fn test_digest_blake2b_384() {
+    use wolfssl_wolfcrypt::blake2::BLAKE2b;
+    use wolfssl_wolfcrypt::blake2_digest::Blake2b384;
+    common::setup();
+
+    let mut reference = BLAKE2b::new(48).expect("Error with new()");
+    reference.update(b"abc").expect("Error with update()");
+    let mut expected = [0u8; 48];
+    reference.finalize(&mut expected).expect("Error with finalize()");
+
+    check_digest::<Blake2b384>(b"abc", &expected, 128);
+}
+
+#[test]
+#[cfg(blake2b)]
+fn test_digest_blake2b_256() {
+    use wolfssl_wolfcrypt::blake2::BLAKE2b;
+    use wolfssl_wolfcrypt::blake2_digest::Blake2b256;
+    common::setup();
+
+    let mut reference = BLAKE2b::new(32).expect("Error with new()");
+    reference.update(b"abc").expect("Error with update()");
+    let mut expected = [0u8; 32];
+    reference.finalize(&mut expected).expect("Error with finalize()");
+
+    check_digest::<Blake2b256>(b"abc", &expected, 128);
+}
+
+#[test]
+#[cfg(blake2s)]
+fn test_digest_blake2s_256() {
+    use wolfssl_wolfcrypt::blake2_digest::Blake2s256;
+    common::setup();
+    check_digest::<Blake2s256>(
+        b"abc",
+        b"\x50\x8C\x5E\x8C\x32\x7C\x14\xE2\xE1\xA7\x2B\xA3\x4E\xEB\x45\x2F\x37\x45\x8B\x20\x9E\xD6\x3A\x29\x4D\x99\x9B\x4C\x86\x67\x59\x82",
+        64,
+    );
+}
+
+#[test]
+#[cfg(blake2s)]
+fn test_digest_blake2s_192() {
+    use wolfssl_wolfcrypt::blake2::BLAKE2s;
+    use wolfssl_wolfcrypt::blake2_digest::Blake2s192;
+    common::setup();
+
+    let mut reference = BLAKE2s::new(24).expect("Error with new()");
+    reference.update(b"abc").expect("Error with update()");
+    let mut expected = [0u8; 24];
+    reference.finalize(&mut expected).expect("Error with finalize()");
+
+    check_digest::<Blake2s192>(b"abc", &expected, 64);
+}
+
+#[test]
+#[cfg(blake2s)]
+fn test_digest_blake2s_128() {
+    use wolfssl_wolfcrypt::blake2::BLAKE2s;
+    use wolfssl_wolfcrypt::blake2_digest::Blake2s128;
+    common::setup();
+
+    let mut reference = BLAKE2s::new(16).expect("Error with new()");
+    reference.update(b"abc").expect("Error with update()");
+    let mut expected = [0u8; 16];
+    reference.finalize(&mut expected).expect("Error with finalize()");
+
+    check_digest::<Blake2s128>(b"abc", &expected, 64);
+}

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_blake2_mac.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_blake2_mac.rs
@@ -1,0 +1,181 @@
+#![cfg(all(any(blake2b, blake2s), feature = "mac"))]
+
+use digest::{KeyInit, Mac};
+
+#[test]
+#[cfg(blake2b)]
+fn test_blake2b_mac_512() {
+    use wolfssl_wolfcrypt::blake2::BLAKE2b;
+    use wolfssl_wolfcrypt::blake2_mac::Blake2bMac512;
+
+    let key = [0x42u8; 64];
+    let input = b"The quick brown fox jumps over the lazy dog";
+
+    let mut reference = BLAKE2b::new_with_key(64, &key)
+        .expect("Error with new_with_key()");
+    reference.update(input).expect("Error with update()");
+    let mut expected = [0u8; 64];
+    reference.finalize(&mut expected)
+        .expect("Error with finalize()");
+
+    let mut mac = Blake2bMac512::new_from_slice(&key)
+        .expect("Blake2bMac512 init failed");
+    mac.update(input);
+    let tag = mac.finalize();
+    assert_eq!(tag.into_bytes().as_slice(), &expected);
+}
+
+#[test]
+#[cfg(blake2b)]
+fn test_blake2b_mac_256() {
+    use wolfssl_wolfcrypt::blake2::BLAKE2b;
+    use wolfssl_wolfcrypt::blake2_mac::Blake2bMac256;
+
+    let key = [0x33u8; 64];
+    let input = b"libsodium crypto_generichash analog";
+
+    let mut reference = BLAKE2b::new_with_key(32, &key)
+        .expect("Error with new_with_key()");
+    reference.update(input).expect("Error with update()");
+    let mut expected = [0u8; 32];
+    reference.finalize(&mut expected)
+        .expect("Error with finalize()");
+
+    let mut mac = Blake2bMac256::new_from_slice(&key)
+        .expect("Blake2bMac256 init failed");
+    mac.update(input);
+    let tag = mac.finalize();
+    assert_eq!(tag.into_bytes().as_slice(), &expected);
+}
+
+#[test]
+#[cfg(blake2b)]
+fn test_blake2b_mac_384() {
+    use wolfssl_wolfcrypt::blake2::BLAKE2b;
+    use wolfssl_wolfcrypt::blake2_mac::Blake2bMac384;
+
+    let key = [0x77u8; 64];
+    let input = b"sha-384 sized blake2b mac";
+
+    let mut reference = BLAKE2b::new_with_key(48, &key)
+        .expect("Error with new_with_key()");
+    reference.update(input).expect("Error with update()");
+    let mut expected = [0u8; 48];
+    reference.finalize(&mut expected)
+        .expect("Error with finalize()");
+
+    let mut mac = Blake2bMac384::new_from_slice(&key)
+        .expect("Blake2bMac384 init failed");
+    mac.update(input);
+    let tag = mac.finalize();
+    assert_eq!(tag.into_bytes().as_slice(), &expected);
+}
+
+#[test]
+#[cfg(blake2b)]
+fn test_blake2b_mac_512_chunked() {
+    use wolfssl_wolfcrypt::blake2::BLAKE2b;
+    use wolfssl_wolfcrypt::blake2_mac::Blake2bMac512;
+
+    let key = [0xA5u8; 64];
+    let input: Vec<u8> = (0u8..200).collect();
+
+    let mut reference = BLAKE2b::new_with_key(64, &key)
+        .expect("Error with new_with_key()");
+    reference.update(&input).expect("Error with update()");
+    let mut expected = [0u8; 64];
+    reference.finalize(&mut expected)
+        .expect("Error with finalize()");
+
+    let mut mac = Blake2bMac512::new_from_slice(&key)
+        .expect("Blake2bMac512 init failed");
+    for chunk in input.chunks(17) {
+        mac.update(chunk);
+    }
+    mac.verify_slice(&expected)
+        .expect("Blake2bMac512 verify failed");
+}
+
+#[test]
+#[cfg(blake2s)]
+fn test_blake2s_mac_128() {
+    use wolfssl_wolfcrypt::blake2::BLAKE2s;
+    use wolfssl_wolfcrypt::blake2_mac::Blake2sMac128;
+
+    let key = [0x55u8; 32];
+    let input = b"short blake2s mac";
+
+    let mut reference = BLAKE2s::new_with_key(16, &key)
+        .expect("Error with new_with_key()");
+    reference.update(input).expect("Error with update()");
+    let mut expected = [0u8; 16];
+    reference.finalize(&mut expected)
+        .expect("Error with finalize()");
+
+    let mut mac = Blake2sMac128::new_from_slice(&key)
+        .expect("Blake2sMac128 init failed");
+    mac.update(input);
+    let tag = mac.finalize();
+    assert_eq!(tag.into_bytes().as_slice(), &expected);
+}
+
+#[test]
+#[cfg(blake2s)]
+fn test_blake2s_mac_192() {
+    use wolfssl_wolfcrypt::blake2::BLAKE2s;
+    use wolfssl_wolfcrypt::blake2_mac::Blake2sMac192;
+
+    let key = [0x99u8; 32];
+    let input = b"medium blake2s mac";
+
+    let mut reference = BLAKE2s::new_with_key(24, &key)
+        .expect("Error with new_with_key()");
+    reference.update(input).expect("Error with update()");
+    let mut expected = [0u8; 24];
+    reference.finalize(&mut expected)
+        .expect("Error with finalize()");
+
+    let mut mac = Blake2sMac192::new_from_slice(&key)
+        .expect("Blake2sMac192 init failed");
+    mac.update(input);
+    let tag = mac.finalize();
+    assert_eq!(tag.into_bytes().as_slice(), &expected);
+}
+
+#[test]
+#[cfg(blake2s)]
+fn test_blake2s_mac_256() {
+    use wolfssl_wolfcrypt::blake2::BLAKE2s;
+    use wolfssl_wolfcrypt::blake2_mac::Blake2sMac256;
+
+    let key = [0x42u8; 32];
+    let input = b"The quick brown fox jumps over the lazy dog";
+
+    let mut reference = BLAKE2s::new_with_key(32, &key)
+        .expect("Error with new_with_key()");
+    reference.update(input).expect("Error with update()");
+    let mut expected = [0u8; 32];
+    reference.finalize(&mut expected)
+        .expect("Error with finalize()");
+
+    let mut mac = Blake2sMac256::new_from_slice(&key)
+        .expect("Blake2sMac256 init failed");
+    mac.update(input);
+    let tag = mac.finalize();
+    assert_eq!(tag.into_bytes().as_slice(), &expected);
+}
+
+#[test]
+#[cfg(blake2s)]
+fn test_blake2s_mac_256_verify_fail() {
+    use wolfssl_wolfcrypt::blake2_mac::Blake2sMac256;
+
+    let key = [0x0Bu8; 32];
+    let input = b"hello";
+    let wrong_tag = [0u8; 32];
+
+    let mut mac = Blake2sMac256::new_from_slice(&key)
+        .expect("Blake2sMac256 init failed");
+    mac.update(input);
+    assert!(mac.verify_slice(&wrong_tag).is_err());
+}

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_curve25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_curve25519.rs
@@ -1,7 +1,7 @@
 #![cfg(all(curve25519, random))]
 
 #[cfg(curve25519_blinding)]
-use std::sync::Arc;
+use std::rc::Rc;
 use wolfssl_wolfcrypt::curve25519::*;
 use wolfssl_wolfcrypt::random::RNG;
 
@@ -100,16 +100,16 @@ fn test_make_pub_blind() {
 #[test]
 fn test_shared_secret() {
     #[cfg(curve25519_blinding)]
-    let rng = Arc::new(RNG::new().expect("Error with new()"));
+    let rng = Rc::new(RNG::new().expect("Error with new()"));
     #[cfg(not(curve25519_blinding))]
     let rng = RNG::new().expect("Error with new()");
     let mut key1 = Curve25519Key::generate(&rng).expect("Error with generate()");
     let mut key2 = Curve25519Key::generate(&rng).expect("Error with generate()");
 
     #[cfg(curve25519_blinding)]
-    key1.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    key1.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
     #[cfg(curve25519_blinding)]
-    key2.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    key2.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
 
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     key1.export_public(&mut public_buffer).expect("Error with export_public()");
@@ -128,16 +128,16 @@ fn test_shared_secret() {
 #[test]
 fn test_shared_secret_ex() {
     #[cfg(curve25519_blinding)]
-    let rng = Arc::new(RNG::new().expect("Error with new()"));
+    let rng = Rc::new(RNG::new().expect("Error with new()"));
     #[cfg(not(curve25519_blinding))]
     let rng = RNG::new().expect("Error with new()");
     let mut key1 = Curve25519Key::generate(&rng).expect("Error with generate()");
     let mut key2 = Curve25519Key::generate(&rng).expect("Error with generate()");
 
     #[cfg(curve25519_blinding)]
-    key1.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    key1.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
     #[cfg(curve25519_blinding)]
-    key2.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    key2.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
 
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     key1.export_public(&mut public_buffer).expect("Error with export_public()");

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_curve25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_curve25519.rs
@@ -1,5 +1,7 @@
 #![cfg(all(curve25519, random))]
 
+#[cfg(curve25519_blinding)]
+use std::sync::Arc;
 use wolfssl_wolfcrypt::curve25519::*;
 use wolfssl_wolfcrypt::random::RNG;
 
@@ -97,14 +99,17 @@ fn test_make_pub_blind() {
 
 #[test]
 fn test_shared_secret() {
-    let mut rng = RNG::new().expect("Error with new()");
-    let mut key1 = Curve25519Key::generate(&mut rng).expect("Error with generate()");
-    let mut key2 = Curve25519Key::generate(&mut rng).expect("Error with generate()");
+    #[cfg(curve25519_blinding)]
+    let rng = Arc::new(RNG::new().expect("Error with new()"));
+    #[cfg(not(curve25519_blinding))]
+    let rng = RNG::new().expect("Error with new()");
+    let mut key1 = Curve25519Key::generate(&rng).expect("Error with generate()");
+    let mut key2 = Curve25519Key::generate(&rng).expect("Error with generate()");
 
     #[cfg(curve25519_blinding)]
-    key1.set_rng(&mut rng).expect("Error with set_rng()");
+    key1.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
     #[cfg(curve25519_blinding)]
-    key2.set_rng(&mut rng).expect("Error with set_rng()");
+    key2.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
 
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     key1.export_public(&mut public_buffer).expect("Error with export_public()");
@@ -122,14 +127,17 @@ fn test_shared_secret() {
 
 #[test]
 fn test_shared_secret_ex() {
-    let mut rng = RNG::new().expect("Error with new()");
-    let mut key1 = Curve25519Key::generate(&mut rng).expect("Error with generate()");
-    let mut key2 = Curve25519Key::generate(&mut rng).expect("Error with generate()");
+    #[cfg(curve25519_blinding)]
+    let rng = Arc::new(RNG::new().expect("Error with new()"));
+    #[cfg(not(curve25519_blinding))]
+    let rng = RNG::new().expect("Error with new()");
+    let mut key1 = Curve25519Key::generate(&rng).expect("Error with generate()");
+    let mut key2 = Curve25519Key::generate(&rng).expect("Error with generate()");
 
     #[cfg(curve25519_blinding)]
-    key1.set_rng(&mut rng).expect("Error with set_rng()");
+    key1.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
     #[cfg(curve25519_blinding)]
-    key2.set_rng(&mut rng).expect("Error with set_rng()");
+    key2.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
 
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     key1.export_public(&mut public_buffer).expect("Error with export_public()");

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
@@ -368,6 +368,34 @@ fn test_ecc_import() {
 }
 
 #[test]
+#[cfg(ecc_import)]
+fn test_ecc_import_raw_not_null_terminated() {
+    common::setup();
+
+    let qx = b"7a4e287890a1a47ad3457e52f2f76a83ce46cbc947616d0cbaa82323818a793d\0";
+    let qy = b"eec4084f5b29ebf29c44cce3b3059610922f8b30ea6e8811742ac7238fe87308\0";
+    let d  = b"8c14b793cb19137e323a6d2e2a870bca2e7a493ec1153b3a95feb8a4873f8d08\0";
+    let qx_no_nul: &[u8] = &qx[..qx.len() - 1];
+    let qy_no_nul: &[u8] = &qy[..qy.len() - 1];
+    let d_no_nul:  &[u8] = &d[..d.len() - 1];
+    let curve_name = b"SECP256R1\0";
+    let curve_name_no_nul: &[u8] = b"SECP256R1";
+    let empty: &[u8] = b"";
+
+    assert!(ECC::import_raw(qx_no_nul, qy, d, curve_name, None, None).is_err());
+    assert!(ECC::import_raw(qx, qy_no_nul, d, curve_name, None, None).is_err());
+    assert!(ECC::import_raw(qx, qy, d_no_nul, curve_name, None, None).is_err());
+    assert!(ECC::import_raw(qx, qy, d, curve_name_no_nul, None, None).is_err());
+    assert!(ECC::import_raw(empty, qy, d, curve_name, None, None).is_err());
+    assert!(ECC::import_raw(qx, qy, d, empty, None, None).is_err());
+
+    assert!(ECC::import_raw_ex(qx_no_nul, qy, d, ECC::SECP256R1, None, None).is_err());
+    assert!(ECC::import_raw_ex(qx, qy_no_nul, d, ECC::SECP256R1, None, None).is_err());
+    assert!(ECC::import_raw_ex(qx, qy, d_no_nul, ECC::SECP256R1, None, None).is_err());
+    assert!(ECC::import_raw_ex(qx, qy, empty, ECC::SECP256R1, None, None).is_err());
+}
+
+#[test]
 fn test_ecc_rs_hex_to_sig_not_null_terminated() {
     common::setup();
 

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
@@ -5,7 +5,7 @@ mod common;
 #[cfg(any(all(ecc_import, ecc_export, ecc_sign, ecc_verify, random), random))]
 use std::fs;
 #[cfg(all(ecc_dh, random))]
-use std::sync::Arc;
+use std::rc::Rc;
 use wolfssl_wolfcrypt::ecc::*;
 #[cfg(random)]
 use wolfssl_wolfcrypt::random::RNG;
@@ -144,13 +144,13 @@ fn test_ecc_import_export_sign_verify() {
 fn test_ecc_shared_secret() {
     common::setup();
 
-    let rng = Arc::new(RNG::new().expect("Failed to create RNG"));
+    let rng = Rc::new(RNG::new().expect("Failed to create RNG"));
     let mut ecc0 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     let mut ecc1 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     let mut ss0 = [0u8; 128];
     let mut ss1 = [0u8; 128];
-    ecc0.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
-    ecc1.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    ecc0.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
+    ecc1.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
     let ss0_size = ecc0.shared_secret(&mut ecc1, &mut ss0).expect("Error with shared_secret()");
     let ss1_size = ecc1.shared_secret(&mut ecc0, &mut ss1).expect("Error with shared_secret()");
     assert_eq!(ss0_size, ss1_size);

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
@@ -4,6 +4,8 @@ mod common;
 
 #[cfg(any(all(ecc_import, ecc_export, ecc_sign, ecc_verify, random), random))]
 use std::fs;
+#[cfg(all(ecc_dh, random))]
+use std::sync::Arc;
 use wolfssl_wolfcrypt::ecc::*;
 #[cfg(random)]
 use wolfssl_wolfcrypt::random::RNG;
@@ -134,7 +136,7 @@ fn test_ecc_import_export_sign_verify() {
     let valid = ecc.verify_hash(&signature, &hash).expect("Error with verify_hash()");
     assert_eq!(valid, false);
 
-    ecc.set_rng(&mut rng).expect("Error with set_rng()");
+    ecc.set_rng(rng).expect("Error with set_rng()");
 }
 
 #[test]
@@ -142,13 +144,13 @@ fn test_ecc_import_export_sign_verify() {
 fn test_ecc_shared_secret() {
     common::setup();
 
-    let mut rng = RNG::new().expect("Failed to create RNG");
-    let mut ecc0 = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
-    let mut ecc1 = ECC::generate(32, &mut rng, None, None).expect("Error with generate()");
+    let rng = Arc::new(RNG::new().expect("Failed to create RNG"));
+    let mut ecc0 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
+    let mut ecc1 = ECC::generate(32, &rng, None, None).expect("Error with generate()");
     let mut ss0 = [0u8; 128];
     let mut ss1 = [0u8; 128];
-    ecc0.set_rng(&mut rng).expect("Error with set_rng()");
-    ecc1.set_rng(&mut rng).expect("Error with set_rng()");
+    ecc0.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    ecc1.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
     let ss0_size = ecc0.shared_secret(&mut ecc1, &mut ss0).expect("Error with shared_secret()");
     let ss1_size = ecc1.shared_secret(&mut ecc0, &mut ss1).expect("Error with shared_secret()");
     assert_eq!(ss0_size, ss1_size);

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
@@ -9,6 +9,8 @@ use std::rc::Rc;
 use wolfssl_wolfcrypt::ecc::*;
 #[cfg(random)]
 use wolfssl_wolfcrypt::random::RNG;
+#[cfg(ecc_import)]
+use wolfssl_wolfcrypt::sys;
 
 #[test]
 #[cfg(random)]
@@ -290,6 +292,33 @@ fn test_ecc_import_unsigned() {
     let signature = &signature[0..signature_length];
     let valid = ecc2.verify_hash(signature, &hash).expect("Error with verify_hash()");
     assert_eq!(valid, true);
+}
+
+#[test]
+#[cfg(ecc_import)]
+fn test_ecc_import_unsigned_short_slices() {
+    common::setup();
+
+    let curve_id = ECC::SECP256R1;
+    let qx = [0u8; 32];
+    let qy = [0u8; 32];
+    let d = [0u8; 32];
+    let empty: [u8; 0] = [];
+
+    let cases: [(&[u8], &[u8], &[u8]); 6] = [
+        (&qx[..31], &qy,        &d       ),
+        (&qx,       &qy[..31],  &d       ),
+        (&qx,       &qy,        &d[..31] ),
+        (&empty,    &qy,        &d       ),
+        (&qx,       &empty,     &d       ),
+        (&qx,       &qy,        &empty   ),
+    ];
+    for (qx, qy, d) in cases {
+        match ECC::import_unsigned(qx, qy, d, curve_id, None, None) {
+            Ok(_) => panic!("import_unsigned() should fail with short slice"),
+            Err(rc) => assert_eq!(rc, sys::wolfCrypt_ErrorCodes_BAD_FUNC_ARG),
+        }
+    }
 }
 
 #[test]

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_ecc.rs
@@ -387,11 +387,15 @@ fn test_ecc_import_raw_not_null_terminated() {
     assert!(ECC::import_raw(qx, qy, d_no_nul, curve_name, None, None).is_err());
     assert!(ECC::import_raw(qx, qy, d, curve_name_no_nul, None, None).is_err());
     assert!(ECC::import_raw(empty, qy, d, curve_name, None, None).is_err());
+    assert!(ECC::import_raw(qx, empty, d, curve_name, None, None).is_err());
+    assert!(ECC::import_raw(qx, qy, empty, curve_name, None, None).is_err());
     assert!(ECC::import_raw(qx, qy, d, empty, None, None).is_err());
 
     assert!(ECC::import_raw_ex(qx_no_nul, qy, d, ECC::SECP256R1, None, None).is_err());
     assert!(ECC::import_raw_ex(qx, qy_no_nul, d, ECC::SECP256R1, None, None).is_err());
     assert!(ECC::import_raw_ex(qx, qy, d_no_nul, ECC::SECP256R1, None, None).is_err());
+    assert!(ECC::import_raw_ex(empty, qy, d, ECC::SECP256R1, None, None).is_err());
+    assert!(ECC::import_raw_ex(qx, empty, d, ECC::SECP256R1, None, None).is_err());
     assert!(ECC::import_raw_ex(qx, qy, empty, ECC::SECP256R1, None, None).is_err());
 }
 

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_hmac_mac.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_hmac_mac.rs
@@ -41,6 +41,27 @@ fn test_hmac_sha256_mac_finalize() {
 }
 
 #[test]
+fn test_hmac_sha256_mac_clone() {
+    let key = b"\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b";
+    let prefix = b"Hi ";
+    let suffix = b"There";
+    let expected = b"\xb0\x34\x4c\x61\xd8\xdb\x38\x53\x5c\xa8\xaf\xce\xaf\x0b\xf1\x2b\x88\x1d\xc2\x00\xc9\x83\x3d\xa7\x26\xe9\x37\x6c\x2e\x32\xcf\xf7";
+
+    let mut mac = HmacSha256::new_from_slice(key)
+        .expect("HMAC init failed");
+    mac.update(prefix);
+
+    let mut forked = mac.clone();
+    forked.update(suffix);
+    let forked_tag = forked.finalize();
+    assert_eq!(forked_tag.as_bytes().as_slice(), expected);
+
+    mac.update(suffix);
+    let original_tag = mac.finalize();
+    assert_eq!(original_tag.as_bytes().as_slice(), expected);
+}
+
+#[test]
 fn test_hmac_sha256_mac_verify_fail() {
     let key = b"\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b";
     let input = b"Hi There";

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_random.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_random.rs
@@ -52,7 +52,7 @@ fn test_test_seed() {
 fn test_rng_generate_byte() {
     // Since a single 0x00 or 0xFF could occur occasionally, we'll combine four
     // bytes into a u32 and make sure they aren't all 0x00 or all 0xFF.
-    let mut rng = RNG::new().expect("Failed to create RNG");
+    let rng = RNG::new().expect("Failed to create RNG");
     let mut v: u32 = 0;
     for _i in 0..4 {
         let byte = rng.generate_byte().expect("Failed to generate a single byte");
@@ -65,7 +65,7 @@ fn test_rng_generate_byte() {
 // Test that generate_block works for a slice of u8.
 #[test]
 fn test_rng_generate_block_u8() {
-    let mut rng = RNG::new().expect("Failed to create RNG");
+    let rng = RNG::new().expect("Failed to create RNG");
     let mut buffer = [0u8; 32];
     rng.generate_block(&mut buffer).expect("Failed to generate a block of bytes");
 
@@ -77,7 +77,7 @@ fn test_rng_generate_block_u8() {
 // Test that generate_block works for a slice of u32.
 #[test]
 fn test_rng_generate_block_u32() {
-    let mut rng = RNG::new().expect("Failed to create RNG");
+    let rng = RNG::new().expect("Failed to create RNG");
     let mut buffer = [0u32; 8];
     rng.generate_block(&mut buffer).expect("Failed to generate a block of u32");
 
@@ -93,7 +93,7 @@ fn test_rng_generate_block_u32() {
 #[test]
 #[cfg(random_hashdrbg)]
 fn test_rng_reseed() {
-    let mut rng = RNG::new().expect("Failed to create RNG");
+    let rng = RNG::new().expect("Failed to create RNG");
     let seed = [1u8, 2, 3, 4];
     rng.reseed(&seed).expect("Error with reseed()");
 }

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_rsa.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_rsa.rs
@@ -5,7 +5,7 @@ mod common;
 #[cfg(any(all(sha256, random, rsa_pss), random, rsa_direct))]
 use std::fs;
 #[cfg(random)]
-use std::sync::Arc;
+use std::rc::Rc;
 #[cfg(random)]
 use wolfssl_wolfcrypt::random::RNG;
 #[cfg(any(random, rsa_direct, rsa_keygen))]
@@ -60,11 +60,11 @@ fn test_rsa_generate() {
 #[test]
 #[cfg(random)]
 fn test_rsa_encrypt_decrypt() {
-    let rng = Arc::new(RNG::new().expect("Error creating RNG"));
+    let rng = Rc::new(RNG::new().expect("Error creating RNG"));
     let key_path = "../../../certs/client-keyPub.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    rsa.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    rsa.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
     let plain: &[u8] = b"Test message";
     let mut enc: [u8; 512] = [0; 512];
     let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
@@ -73,7 +73,7 @@ fn test_rsa_encrypt_decrypt() {
     let key_path = "../../../certs/client-key.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    rsa.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    rsa.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
     let mut plain_out: [u8; 512] = [0; 512];
     let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     assert!(dec_len as usize == plain.len());
@@ -83,7 +83,7 @@ fn test_rsa_encrypt_decrypt() {
 #[test]
 #[cfg(all(sha256, random, rsa_pss))]
 fn test_rsa_pss() {
-    let rng = Arc::new(RNG::new().expect("Error creating RNG"));
+    let rng = Rc::new(RNG::new().expect("Error creating RNG"));
 
     let key_path = "../../../certs/client-key.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
@@ -96,7 +96,7 @@ fn test_rsa_pss() {
     let key_path = "../../../certs/client-keyPub.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    rsa.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    rsa.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
     let signature = &signature[0..sig_len];
     let mut verify_out: [u8; 512] = [0; 512];
     let verify_out_size = rsa.pss_verify(signature, &mut verify_out, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256).expect("Error with pss_verify()");
@@ -130,7 +130,7 @@ fn test_rsa_direct() {
 #[test]
 #[cfg(random)]
 fn test_rsa_ssl() {
-    let rng = Arc::new(RNG::new().expect("Error creating RNG"));
+    let rng = Rc::new(RNG::new().expect("Error creating RNG"));
 
     let key_path = "../../../certs/client-key.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
@@ -143,7 +143,7 @@ fn test_rsa_ssl() {
     let key_path = "../../../certs/client-keyPub.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    rsa.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
+    rsa.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
     let signature = &signature[0..sig_len];
     let mut verify_out: [u8; 512] = [0; 512];
     let verify_out_size = rsa.ssl_verify(signature, &mut verify_out).expect("Error with ssl_verify()");

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_rsa.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_rsa.rs
@@ -5,6 +5,8 @@ mod common;
 #[cfg(any(all(sha256, random, rsa_pss), random, rsa_direct))]
 use std::fs;
 #[cfg(random)]
+use std::sync::Arc;
+#[cfg(random)]
 use wolfssl_wolfcrypt::random::RNG;
 #[cfg(any(random, rsa_direct, rsa_keygen))]
 use wolfssl_wolfcrypt::rsa::*;
@@ -14,8 +16,8 @@ use wolfssl_wolfcrypt::rsa::*;
 fn test_rsa_generate() {
     common::setup();
 
-    let mut rng = RNG::new().expect("Error creating RNG");
-    let mut rsa = RSA::generate(2048, 65537, &mut rng).expect("Error with generate()");
+    let rng = RNG::new().expect("Error creating RNG");
+    let mut rsa = RSA::generate(2048, 65537, &rng).expect("Error with generate()");
     rsa.check().expect("Error with check()");
 
     let encrypt_size = rsa.get_encrypt_size().expect("Error with get_encrypt_size()");
@@ -58,20 +60,20 @@ fn test_rsa_generate() {
 #[test]
 #[cfg(random)]
 fn test_rsa_encrypt_decrypt() {
-    let mut rng = RNG::new().expect("Error creating RNG");
+    let rng = Arc::new(RNG::new().expect("Error creating RNG"));
     let key_path = "../../../certs/client-keyPub.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    rsa.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
     let plain: &[u8] = b"Test message";
     let mut enc: [u8; 512] = [0; 512];
-    let enc_len = rsa.public_encrypt(plain, &mut enc, &mut rng).expect("Error with public_encrypt()");
+    let enc_len = rsa.public_encrypt(plain, &mut enc, &rng).expect("Error with public_encrypt()");
     assert!(enc_len > 0 && enc_len <= 512);
 
     let key_path = "../../../certs/client-key.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
-    rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    rsa.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
     let mut plain_out: [u8; 512] = [0; 512];
     let dec_len = rsa.private_decrypt(&enc[0..enc_len], &mut plain_out).expect("Error with private_decrypt()");
     assert!(dec_len as usize == plain.len());
@@ -81,20 +83,20 @@ fn test_rsa_encrypt_decrypt() {
 #[test]
 #[cfg(all(sha256, random, rsa_pss))]
 fn test_rsa_pss() {
-    let mut rng = RNG::new().expect("Error creating RNG");
+    let rng = Arc::new(RNG::new().expect("Error creating RNG"));
 
     let key_path = "../../../certs/client-key.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
     let msg: &[u8] = b"This is the string to be signed!";
     let mut signature: [u8; 512] = [0; 512];
-    let sig_len = rsa.pss_sign(msg, &mut signature, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256, &mut rng).expect("Error with pss_sign()");
+    let sig_len = rsa.pss_sign(msg, &mut signature, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256, &rng).expect("Error with pss_sign()");
     assert!(sig_len > 0 && sig_len <= 512);
 
     let key_path = "../../../certs/client-keyPub.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    rsa.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
     let signature = &signature[0..sig_len];
     let mut verify_out: [u8; 512] = [0; 512];
     let verify_out_size = rsa.pss_verify(signature, &mut verify_out, RSA::HASH_TYPE_SHA256, RSA::MGF1SHA256).expect("Error with pss_verify()");
@@ -108,7 +110,7 @@ fn test_rsa_pss() {
 #[test]
 #[cfg(rsa_direct)]
 fn test_rsa_direct() {
-    let mut rng = RNG::new().expect("Error creating RNG");
+    let rng = RNG::new().expect("Error creating RNG");
 
     let key_path = "../../../certs/client-key.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
@@ -117,10 +119,10 @@ fn test_rsa_direct() {
     let mut plain = [0u8; 256];
     plain[..msg.len()].copy_from_slice(msg);
     let mut enc = [0u8; 256];
-    let enc_len = rsa.rsa_direct(&plain, &mut enc, RSA::PRIVATE_ENCRYPT, &mut rng).expect("Error with rsa_direct()");
+    let enc_len = rsa.rsa_direct(&plain, &mut enc, RSA::PRIVATE_ENCRYPT, &rng).expect("Error with rsa_direct()");
     assert_eq!(enc_len, 256);
     let mut plain_out = [0u8; 256];
-    let dec_len = rsa.rsa_direct(&enc, &mut plain_out, RSA::PUBLIC_DECRYPT, &mut rng).expect("Error with rsa_direct()");
+    let dec_len = rsa.rsa_direct(&enc, &mut plain_out, RSA::PUBLIC_DECRYPT, &rng).expect("Error with rsa_direct()");
     assert_eq!(dec_len, 256);
     assert_eq!(plain_out, plain);
 }
@@ -128,20 +130,20 @@ fn test_rsa_direct() {
 #[test]
 #[cfg(random)]
 fn test_rsa_ssl() {
-    let mut rng = RNG::new().expect("Error creating RNG");
+    let rng = Arc::new(RNG::new().expect("Error creating RNG"));
 
     let key_path = "../../../certs/client-key.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     let mut rsa = RSA::new_from_der(&der).expect("Error with new_from_der()");
     let msg: &[u8] = b"This is the string to be signed!";
     let mut signature: [u8; 512] = [0; 512];
-    let sig_len = rsa.ssl_sign(msg, &mut signature, &mut rng).expect("Error with ssl_sign()");
+    let sig_len = rsa.ssl_sign(msg, &mut signature, &rng).expect("Error with ssl_sign()");
     assert!(sig_len > 0 && sig_len <= 512);
 
     let key_path = "../../../certs/client-keyPub.der";
     let der: Vec<u8> = fs::read(key_path).expect("Error reading key file");
     let mut rsa = RSA::new_public_from_der(&der).expect("Error with new_public_from_der()");
-    rsa.set_rng(&mut rng).expect("Error with set_rng()");
+    rsa.set_shared_rng(Arc::clone(&rng)).expect("Error with set_shared_rng()");
     let signature = &signature[0..sig_len];
     let mut verify_out: [u8; 512] = [0; 512];
     let verify_out_size = rsa.ssl_verify(signature, &mut verify_out).expect("Error with ssl_verify()");


### PR DESCRIPTION
# Description

This PR includes several Fenrir fixes and some new functionality I found missing during my integration tests with boringtun.

See the commits for individual descriptions of each change.

# Testing

Unit/CI tests.

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation

# Change Log

```
Rust wrapper: gate RSA doc tests that use set_shared_rng() on alloc feature
Rust wrapper: check slice lengths in ECC::import_unsigned
Rust wrapper: test more empty slices in test_ecc
Rust wrapper: use Rc instead of Arc for RNG references
Rust wrapper: fix RSA::set_rng() doc test to actually call set_rng()
Rust wrapper: drop mut from rng in ecc doc tests
Rust wrapper: avoid double wc_ecc_init_ex() call
Rust wrapper: test for null-terminated C-style strings in ECC import_raw APIs
Rust wrapper: document wolfSSL version requirement
Rust wrapper: remove outdated set_rng safety contract comments
Rust wrapper: add blake2_digest module
Rust wrapper: add blake2_mac module
Rust wrapper: implement Clone for HMAC types
Rust wrapper: add Aes192Ccm and Aes192Gcm
Rust wrapper: store pointer to C ECC key struct instead of instance
Rust wrapper: ensure memory safety for C RNG struct
```