### PR TITLE
hostap CI tests: incorporate internal retries

### DIFF
--- a/.github/workflows/hostap-vm.yml
+++ b/.github/workflows/hostap-vm.yml
@@ -340,11 +340,27 @@ jobs:
             KVMARGS="-cpu host"
           EOF
           git config --global --add safe.directory $GITHUB_WORKSPACE/hostap
+          # parallel-vm.py exits non-zero whenever any test failed on its first
+          # attempt, even if hostap's own internal retry recovered. Treat
+          # "All failed cases passed on retry" as success so we don't churn the
+          # whole VM batch over a flaky test that already passed on retry.
+          run_hwsim() {
+            local log rc=0
+            log=$(mktemp)
+            ./vm/parallel-vm.py ${{ env.hostap_debug_flags }} --nocurses "$@" 2>&1 | tee "$log"
+            rc=${PIPESTATUS[0]}
+            if [ "$rc" -ne 0 ] && grep -q "All failed cases passed on retry" "$log"; then
+              echo "Treating run as success: hostap's internal retry recovered all failures"
+              rc=0
+            fi
+            rm -f "$log"
+            return $rc
+          }
           # Run tests in increments of 200 to not stall out the parallel-vm script
           while mapfile -t -n 200 ary && ((${#ary[@]})); do
             TESTS=$(printf '%s\n' "${ary[@]}" | tr '\n' ' ')
             HWSIM_RES=0 # Not set when command succeeds
-            ./vm/parallel-vm.py ${{ env.hostap_debug_flags }} --nocurses $(nproc) $TESTS  || HWSIM_RES=$?
+            run_hwsim $(nproc) $TESTS || HWSIM_RES=$?
             # Retry failing tests up to 2 times to mitigate flakiness in the
             # upstream hostap tests themselves.
             for i in 1 2; do
@@ -359,7 +375,7 @@ jobs:
                 printf 'failed tests (retry %d): %s\n' "$i" "$FAILED_TESTS"
                 rm -rf /tmp/hwsim-test-logs
                 HWSIM_RES=0
-                ./vm/parallel-vm.py ${{ env.hostap_debug_flags }} --nocurses $(nproc) $FAILED_TESTS || HWSIM_RES=$?
+                run_hwsim $(nproc) $FAILED_TESTS || HWSIM_RES=$?
               fi
             done
             if [ "$HWSIM_RES" -ne "0" ]; then


### PR DESCRIPTION
The hostap CI tests also have an internal retry mechanism that re-runs failed tests in addition to our retry mechanism in the script. However, we haven't properly obtained a successful internal retry and incorrectly triggered an outer retry. This resulted in spuriously flaky tests.

This PR fixes this by checking if an internal retry succeeded. 