### PR TITLE
zeroize sensitive memory and validate public API inputs

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -12119,6 +12119,19 @@ static int test_wc_PemToDer(void)
             XFREE(cert_buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
 #endif
+    /* NULL buff, zero size, and negative size must be rejected up front. The
+     * pre-fix code cast longSz to word32, so a negative value drove an
+     * over-read inside PemToDer. */
+    {
+        const byte stub[] = "x";
+        DerBuffer* badDer = NULL;
+        ExpectIntEQ(wc_PemToDer(NULL, 100, CERT_TYPE, &badDer, NULL, &info,
+            &eccKey), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(wc_PemToDer(stub, 0, CERT_TYPE, &badDer, NULL, &info,
+            &eccKey), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(wc_PemToDer(stub, -1, CERT_TYPE, &badDer, NULL, &info,
+            &eccKey), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    }
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_camellia.c
+++ b/tests/api/test_camellia.c
@@ -108,6 +108,38 @@ int test_wc_CamelliaSetIV(void)
 } /* END test_wc_CamelliaSetIV*/
 
 /*
+ * Test wc_CamelliaFree zeroes the key schedule and is NULL safe.
+ */
+int test_wc_CamelliaFree(void)
+{
+    EXPECT_DECLS;
+#ifdef HAVE_CAMELLIA
+    wc_Camellia camellia;
+    static const byte key[] = {
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+        0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10
+    };
+    static const byte iv[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+    };
+    byte zero[sizeof(camellia)];
+
+    XMEMSET(zero, 0, sizeof(zero));
+
+    /* NULL is safe. */
+    wc_CamelliaFree(NULL);
+
+    /* After SetKey the schedule is populated; Free must wipe it. */
+    ExpectIntEQ(wc_CamelliaSetKey(&camellia, key, (word32)sizeof(key), iv), 0);
+    ExpectIntNE(XMEMCMP(&camellia, zero, sizeof(camellia)), 0);
+    wc_CamelliaFree(&camellia);
+    ExpectIntEQ(XMEMCMP(&camellia, zero, sizeof(camellia)), 0);
+#endif
+    return EXPECT_RESULT();
+} /* END test_wc_CamelliaFree */
+
+/*
  * Test wc_CamelliaEncryptDirect and wc_CamelliaDecryptDirect
  */
 int test_wc_CamelliaEncryptDecryptDirect(void)

--- a/tests/api/test_camellia.h
+++ b/tests/api/test_camellia.h
@@ -26,6 +26,7 @@
 
 int test_wc_CamelliaSetKey(void);
 int test_wc_CamelliaSetIV(void);
+int test_wc_CamelliaFree(void);
 int test_wc_CamelliaEncryptDecryptDirect(void);
 int test_wc_CamelliaCbcEncryptDecrypt(void);
 int test_wc_CamelliaCbc_MonteCarlo(void);
@@ -33,6 +34,7 @@ int test_wc_CamelliaCbc_MonteCarlo(void);
 #define TEST_CAMELLIA_DECLS                                             \
     TEST_DECL_GROUP("camellia", test_wc_CamelliaSetKey),                \
     TEST_DECL_GROUP("camellia", test_wc_CamelliaSetIV),                 \
+    TEST_DECL_GROUP("camellia", test_wc_CamelliaFree),                  \
     TEST_DECL_GROUP("camellia", test_wc_CamelliaEncryptDecryptDirect),  \
     TEST_DECL_GROUP("camellia", test_wc_CamelliaCbcEncryptDecrypt),     \
     TEST_DECL_GROUP("camellia", test_wc_CamelliaCbc_MonteCarlo)

--- a/tests/api/test_pkcs7.c
+++ b/tests/api/test_pkcs7.c
@@ -5028,6 +5028,14 @@ int test_wc_PKCS7_DecodeCompressedData(void)
     ExpectNotNull(decompressed);
     ExpectIntEQ(XMEMCMP(decompressed, cert_buf, cert_sz), 0);
     XFREE(decompressed, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    decompressed = NULL;
+
+    /* inSz that would overflow on the initial 'tmpSz = inSz * 2' must be
+     * rejected up front rather than handed to XMALLOC. */
+    ExpectIntEQ(wc_DeCompressDynamic(&decompressed, -1, DYNAMIC_TYPE_TMP_BUFFER,
+        out, ((word32)INT_MAX / 2) + 1, 0, heap),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectNull(decompressed);
 
     if (cert_buf != NULL)
         XFREE(cert_buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -24880,7 +24880,14 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
 int wc_PemToDer(const unsigned char* buff, long longSz, int type,
               DerBuffer** pDer, void* heap, EncryptedInfo* info, int* keyFormat)
 {
-    int ret = PemToDer(buff, longSz, type, pDer, heap, info, keyFormat);
+    int ret;
+
+    if (buff == NULL || longSz <= 0) {
+        WOLFSSL_MSG("Bad pem der args");
+        return BAD_FUNC_ARG;
+    }
+
+    ret = PemToDer(buff, longSz, type, pDer, heap, info, keyFormat);
 #if defined(HAVE_PKCS8) || defined(HAVE_PKCS12)
     if (ret == 0 && type == PRIVATEKEY_TYPE) {
         DerBuffer* der = *pDer;

--- a/wolfcrypt/src/camellia.c
+++ b/wolfcrypt/src/camellia.c
@@ -1634,5 +1634,13 @@ int wc_CamelliaCbcDecrypt(wc_Camellia* cam, byte* out, const byte* in, word32 sz
 }
 
 
+void wc_CamelliaFree(wc_Camellia* cam)
+{
+    if (cam == NULL)
+        return;
+    ForceZero(cam, sizeof(wc_Camellia));
+}
+
+
 #endif /* HAVE_CAMELLIA */
 

--- a/wolfcrypt/src/compress.c
+++ b/wolfcrypt/src/compress.c
@@ -221,6 +221,11 @@ int wc_DeCompressDynamic(byte** out, int maxSz, int memoryType,
     if (out == NULL || in == NULL) {
         return BAD_FUNC_ARG;
     }
+    /* Cap input so the initial doubling and additive growth in the loop
+     * cannot overflow word32 or the int return type. */
+    if (inSz > (word32)(INT_MAX / 2)) {
+        return BAD_FUNC_ARG;
+    }
     i = (maxSz == 1)? 1 : 2; /* start with output buffer twice the size of input
                               * unless max was set to 1 */
 
@@ -229,7 +234,7 @@ int wc_DeCompressDynamic(byte** out, int maxSz, int memoryType,
     /* Check for source > 64K on 16-bit machine: */
     if ((uLong)stream.avail_in != inSz) return DECOMPRESS_INIT_E;
 
-    tmpSz = inSz * i;
+    tmpSz = inSz * (word32)i;
     tmp = (byte*)XMALLOC(tmpSz, heap, memoryType);
     if (tmp == NULL)
         return MEMORY_E;
@@ -278,6 +283,11 @@ int wc_DeCompressDynamic(byte** out, int maxSz, int memoryType,
             }
             i++;
 
+            if (tmpSz > (word32)INT_MAX - inSz) {
+                WOLFSSL_MSG("Decompress buffer would exceed INT_MAX");
+                result = DECOMPRESS_E;
+                break;
+            }
             newSz = tmpSz + inSz;
             newTmp = (byte*)XMALLOC(newSz, heap, memoryType);
             if (newTmp == NULL) {
@@ -295,13 +305,18 @@ int wc_DeCompressDynamic(byte** out, int maxSz, int memoryType,
     } while (result == Z_OK);
 
     if (result == Z_STREAM_END) {
-        result = (int)stream.total_out;
-        *out   = (byte*)XMALLOC(result, heap, memoryType);
-        if (*out != NULL) {
-            XMEMCPY(*out, tmp, result);
+        if (stream.total_out > (uLong)INT_MAX) {
+            result = DECOMPRESS_E;
         }
         else {
-            result = MEMORY_E;
+            result = (int)stream.total_out;
+            *out   = (byte*)XMALLOC(result, heap, memoryType);
+            if (*out != NULL) {
+                XMEMCPY(*out, tmp, result);
+            }
+            else {
+                result = MEMORY_E;
+            }
         }
     }
     else {

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -250,7 +250,7 @@ static int curve25519_smul_blind(byte* rp, const byte* n, const byte* p,
     for (cnt = 0; cnt < WOLFSSL_CURVE25519_BLINDING_RAND_CNT; cnt++) {
         ret = wc_RNG_GenerateBlock(rng, rz, sizeof(rz));
         if (ret < 0) {
-            return ret;
+            goto cleanup;
         }
         for (i = CURVE25519_KEYSIZE - 1; i >= 0; i--) {
             if (rz[i] != 0xff)
@@ -261,13 +261,14 @@ static int curve25519_smul_blind(byte* rp, const byte* n, const byte* p,
         }
     }
     if (cnt == WOLFSSL_CURVE25519_BLINDING_RAND_CNT) {
-        return RNG_FAILURE_E;
+        ret = RNG_FAILURE_E;
+        goto cleanup;
     }
 
     /* Generate 253 random bits. */
     ret = wc_RNG_GenerateBlock(rng, a, sizeof(a));
     if (ret != 0)
-        return ret;
+        goto cleanup;
     a[CURVE25519_KEYSIZE-1] &= 0x7f;
     /* k' = k ^ 2k ^ a */
     n_a[0] = n[0] ^ (byte)(n[0] << 1) ^ a[0];
@@ -280,6 +281,11 @@ static int curve25519_smul_blind(byte* rp, const byte* n, const byte* p,
     }
     /* Scalar multiple blinded scalar with blinding value. */
     ret = curve25519_blind(rp, n_a, a, p, rz);
+
+cleanup:
+    ForceZero(a, sizeof(a));
+    ForceZero(n_a, sizeof(n_a));
+    ForceZero(rz, sizeof(rz));
 
     RESTORE_VECTOR_REGISTERS();
 

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -548,6 +548,7 @@ int wc_ed25519_sign_msg_ex(const byte* in, word32 inLen, byte* out,
         }
         ret = ctMaskGT(c, 0) & SIG_VERIFY_E;
     }
+    ForceZero(orig_k, sizeof(orig_k));
 #endif
 
     return ret;

--- a/wolfcrypt/src/ed448.c
+++ b/wolfcrypt/src/ed448.c
@@ -505,6 +505,7 @@ int wc_ed448_sign_msg_ex(const byte* in, word32 inLen, byte* out,
         }
         ret = ctMaskGT(c, 0) & SIG_VERIFY_E;
     }
+    ForceZero(orig_k, sizeof(orig_k));
 #endif
 
     ForceZero(az, sizeof(az));

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -8860,7 +8860,7 @@ void wolfSSL_EVP_init(void)
 #endif
 #ifdef WOLFSSL_SM4_CTR
             case WC_SM4_CTR_TYPE :
-                WOLFSSL_MSG("AES CTR");
+                WOLFSSL_MSG("Sm4 CTR");
                 ret = wc_Sm4CtrEncrypt(&ctx->cipher.sm4, dst, src, len);
                 if (ret == 0)
                     ret = (int)len;

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3016,6 +3016,9 @@ int wolfSSL_EVP_PKEY_CTX_set1_hkdf_key(WOLFSSL_EVP_PKEY_CTX* ctx,
     }
 
     if (ret == WOLFSSL_SUCCESS) {
+        if (ctx->pkey->hkdfKey != NULL && ctx->pkey->hkdfKeySz > 0) {
+            ForceZero(ctx->pkey->hkdfKey, ctx->pkey->hkdfKeySz);
+        }
         XFREE(ctx->pkey->hkdfKey, NULL, DYNAMIC_TYPE_KEY);
         ctx->pkey->hkdfKey = (byte*)XMALLOC((size_t)keySz, NULL,
             DYNAMIC_TYPE_KEY);
@@ -11778,6 +11781,9 @@ void wolfSSL_EVP_PKEY_free(WOLFSSL_EVP_PKEY* key)
                 case WC_EVP_PKEY_HKDF:
                     XFREE(key->hkdfSalt, NULL, DYNAMIC_TYPE_SALT);
                     key->hkdfSalt = NULL;
+                    if (key->hkdfKey != NULL && key->hkdfKeySz > 0) {
+                        ForceZero(key->hkdfKey, key->hkdfKeySz);
+                    }
                     XFREE(key->hkdfKey, NULL, DYNAMIC_TYPE_KEY);
                     key->hkdfKey = NULL;
                     XFREE(key->hkdfInfo, NULL, DYNAMIC_TYPE_INFO);

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -10561,6 +10561,7 @@ int wc_PKCS7_EncodeEnvelopedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
         ret = wc_PKCS7_PadData(pkcs7->content, pkcs7->contentSz, plain,
                                (word32)encryptedOutSz, (word32)blockSz);
         if (ret < 0) {
+            ForceZero(plain, (word32)encryptedOutSz);
             XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
             wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
             return ret;
@@ -10575,6 +10576,8 @@ int wc_PKCS7_EncodeEnvelopedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
         encryptedContent = (byte*)XMALLOC((word32)encryptedOutSz, pkcs7->heap,
                                           DYNAMIC_TYPE_PKCS7);
         if (encryptedContent == NULL) {
+            if (plain != NULL)
+                ForceZero(plain, (word32)encryptedOutSz);
             XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
             wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
             return MEMORY_E;
@@ -10591,6 +10594,8 @@ int wc_PKCS7_EncodeEnvelopedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
 
     if (contentEncAlgoSz == 0) {
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+        if (plain != NULL)
+            ForceZero(plain, (word32)encryptedOutSz);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
         return BAD_FUNC_ARG;
@@ -10630,6 +10635,8 @@ int wc_PKCS7_EncodeEnvelopedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
             encryptedContent = (byte*)XMALLOC(streamSz, pkcs7->heap,
                                               DYNAMIC_TYPE_PKCS7);
             if (encryptedContent == NULL) {
+                if (plain != NULL)
+                    ForceZero(plain, (word32)encryptedOutSz);
                 XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
                 return MEMORY_E;
@@ -10676,6 +10683,8 @@ int wc_PKCS7_EncodeEnvelopedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
     ) {
         WOLFSSL_MSG("Pkcs7_encrypt output buffer too small");
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+        if (plain != NULL)
+            ForceZero(plain, (word32)encryptedOutSz);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
         wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
         return BUFFER_E;
@@ -10739,6 +10748,8 @@ int wc_PKCS7_EncodeEnvelopedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
     if (ret != 0) {
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 
+        if (plain != NULL)
+            ForceZero(plain, (word32)encryptedOutSz);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 
         wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
@@ -10785,6 +10796,8 @@ int wc_PKCS7_EncodeEnvelopedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
         idx += encryptedOutSz;
     }
 
+    if (plain != NULL)
+        ForceZero(plain, (word32)encryptedOutSz);
     XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 
     XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -14411,6 +14424,7 @@ int wc_PKCS7_EncodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* output,
     encryptedContent = (byte*)XMALLOC((word32)encryptedAllocSz, pkcs7->heap,
                                       DYNAMIC_TYPE_PKCS7);
     if (encryptedContent == NULL) {
+        ForceZero(plain, (word32)encryptedAllocSz);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
         XFREE(aadBuffer, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -14424,6 +14438,7 @@ int wc_PKCS7_EncodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* output,
             (int)pkcs7->cekSz, nonce, (int)nonceSz, aadBuffer, aadBufferSz,
             authTag, sizeof(authTag), plain, encryptedOutSz, encryptedContent);
 
+    ForceZero(plain, (word32)encryptedAllocSz);
     XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
     plain = NULL;
 
@@ -15461,6 +15476,7 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
     ret = wc_PKCS7_PadData(pkcs7->content, pkcs7->contentSz, plain,
                            (word32)encryptedOutSz, (word32)blockSz);
     if (ret < 0) {
+        ForceZero(plain, (word32)encryptedOutSz);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return ret;
     }
@@ -15468,6 +15484,7 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
     encryptedContent = (byte*)XMALLOC((word32)encryptedOutSz, pkcs7->heap,
                                       DYNAMIC_TYPE_PKCS7);
     if (encryptedContent == NULL) {
+        ForceZero(plain, (word32)encryptedOutSz);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return MEMORY_E;
     }
@@ -15481,6 +15498,7 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
                                  oidBlkType, ivOctetStringSz + blockSz);
     if (contentEncAlgoSz == 0) {
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+        ForceZero(plain, (word32)encryptedOutSz);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return BAD_FUNC_ARG;
     }
@@ -15490,6 +15508,7 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
     ret = wc_PKCS7_GenerateBlock(pkcs7, NULL, tmpIv, (word32)blockSz);
     if (ret != 0) {
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+        ForceZero(plain, (word32)encryptedOutSz);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return ret;
     }
@@ -15499,6 +15518,7 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
             NULL, 0, NULL, 0, plain, encryptedOutSz, encryptedContent);
     if (ret != 0) {
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+        ForceZero(plain, (word32)encryptedOutSz);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return ret;
     }
@@ -15516,6 +15536,7 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
 
         if (pkcs7->unprotectedAttribs == NULL) {
             XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+            ForceZero(plain, (word32)encryptedOutSz);
             XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
             return BAD_FUNC_ARG;
         }
@@ -15525,6 +15546,7 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
                 pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         if (attribs == NULL) {
             XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+            ForceZero(plain, (word32)encryptedOutSz);
             XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
             return MEMORY_E;
         }
@@ -15541,6 +15563,7 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
             if (flatAttribs == NULL) {
                 XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                ForceZero(plain, (word32)encryptedOutSz);
                 XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 return MEMORY_E;
             }
@@ -15550,6 +15573,7 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
             if (ret != 0) {
                 XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                ForceZero(plain, (word32)encryptedOutSz);
                 XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 XFREE(flatAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 return ret;
@@ -15590,6 +15614,7 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
         XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         XFREE(flatAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+        ForceZero(plain, (word32)encryptedOutSz);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return BUFFER_E;
     }
@@ -15631,6 +15656,7 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
     XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
     XFREE(flatAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
     XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+    ForceZero(plain, (word32)encryptedOutSz);
     XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 
     return idx;

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -584,7 +584,6 @@ static int Hash_DRBG_Reseed(DRBG_internal* drbg, const byte* seed, word32 seedSz
                 additional, additionalSz);
     if (ret == DRBG_SUCCESS) {
         XMEMCPY(drbg->V, newV, sizeof(drbg->V));
-        ForceZero(newV, DRBG_SEED_LEN);
 
         ret = Hash_df(drbg, drbg->C, sizeof(drbg->C), drbgInitC, drbg->V,
                                     sizeof(drbg->V), NULL, 0, NULL, 0);
@@ -592,6 +591,8 @@ static int Hash_DRBG_Reseed(DRBG_internal* drbg, const byte* seed, word32 seedSz
     if (ret == DRBG_SUCCESS) {
         drbg->reseedCtr = 1;
     }
+
+    ForceZero(newV, DRBG_SEED_LEN);
 
 #ifndef WOLFSSL_SMALL_STACK_CACHE
     WC_FREE_VAR_EX(newV, drbg->heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -1177,7 +1178,6 @@ static int Hash512_DRBG_Reseed(DRBG_SHA512_internal* drbg, const byte* seed,
                 additional, additionalSz);
     if (ret == DRBG_SUCCESS) {
         XMEMCPY(drbg->V, newV, sizeof(drbg->V));
-        ForceZero(newV, DRBG_SHA512_SEED_LEN);
 
         ret = Hash512_df(drbg, drbg->C, sizeof(drbg->C), drbgInitC, drbg->V,
                                     sizeof(drbg->V), NULL, 0,
@@ -1186,6 +1186,8 @@ static int Hash512_DRBG_Reseed(DRBG_SHA512_internal* drbg, const byte* seed,
     if (ret == DRBG_SUCCESS) {
         drbg->reseedCtr = 1;
     }
+
+    ForceZero(newV, DRBG_SHA512_SEED_LEN);
 
 #ifndef WOLFSSL_SMALL_STACK_CACHE
     WC_FREE_VAR_EX(newV, drbg->heap, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1398,6 +1398,7 @@ static int RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     /* generate random seed */
     if ((ret = wc_RNG_GenerateBlock(rng, seed, hLen)) != 0) {
             WC_FREE_VAR_EX(lHash, heap, DYNAMIC_TYPE_RSA_BUFFER);
+            ForceZero(seed, hLen);
             WC_FREE_VAR_EX(seed, heap, DYNAMIC_TYPE_RSA_BUFFER);
         return ret;
     }
@@ -1408,6 +1409,7 @@ static int RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     if (dbMask == NULL) {
 
             XFREE(lHash, heap, DYNAMIC_TYPE_RSA_BUFFER);
+            ForceZero(seed, hLen);
             XFREE(seed,  heap, DYNAMIC_TYPE_RSA_BUFFER);
         return MEMORY_E;
     }
@@ -1421,6 +1423,7 @@ static int RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     if (ret != 0) {
             WC_FREE_VAR_EX(dbMask, heap, DYNAMIC_TYPE_RSA);
             WC_FREE_VAR_EX(lHash, heap, DYNAMIC_TYPE_RSA_BUFFER);
+            ForceZero(seed, hLen);
             WC_FREE_VAR_EX(seed, heap, DYNAMIC_TYPE_RSA_BUFFER);
         return ret;
     }
@@ -1435,6 +1438,7 @@ static int RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     if ((ret = RsaMGF(mgf, pkcsBlock + hLen + 1, pkcsBlockLen - hLen - 1,
                                            pkcsBlock + 1, hLen, heap)) != 0) {
             WC_FREE_VAR_EX(lHash, heap, DYNAMIC_TYPE_RSA_BUFFER);
+            ForceZero(seed, hLen);
             WC_FREE_VAR_EX(seed, heap, DYNAMIC_TYPE_RSA_BUFFER);
         return ret;
     }

--- a/wolfcrypt/src/srp.c
+++ b/wolfcrypt/src/srp.c
@@ -498,7 +498,7 @@ int wc_SrpGetVerifier(Srp* srp, byte* verifier, word32* size)
     if (!r) r = mp_to_unsigned_bin(v, verifier);
     if (!r) *size = (word32)mp_unsigned_bin_size(v);
 
-    mp_clear(v);
+    mp_forcezero(v);
     WC_FREE_VAR_EX(v, srp->heap, DYNAMIC_TYPE_TMP_BUFFER);
 
     return r;
@@ -535,7 +535,7 @@ int wc_SrpSetPrivate(Srp* srp, const byte* priv, word32 size)
     if (!r) r = mp_mod(p, &srp->N, &srp->priv);
     if (!r) r = mp_iszero(&srp->priv) == MP_YES ? SRP_BAD_KEY_E : 0;
 
-    mp_clear(p);
+    mp_forcezero(p);
     WC_FREE_VAR_EX(p, srp->heap, DYNAMIC_TYPE_TMP_BUFFER);
 
     return r;
@@ -624,11 +624,11 @@ int wc_SrpGetPublic(Srp* srp, byte* pub, word32* size)
                 XFREE(i, srp->heap, DYNAMIC_TYPE_TMP_BUFFER);
             }
             if (j != NULL) {
-                mp_clear(j);
+                mp_forcezero(j);
                 XFREE(j, srp->heap, DYNAMIC_TYPE_TMP_BUFFER);
             }
 #else
-            mp_clear(i); mp_clear(j);
+            mp_clear(i); mp_forcezero(j);
 #endif
         }
     }
@@ -720,6 +720,7 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
     int digestSz;
     byte pad = 0;
     int r;
+    int hashInited = 0;
 
     /* validating params */
 
@@ -761,6 +762,7 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
 
     if ((r = SrpHashInit(hash, srp->type, srp->heap)) != 0)
         goto out;
+    hashInited = 1;
 
     digestSz = SrpHashSize(srp->type);
     if (digestSz < 0) {
@@ -805,6 +807,7 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
     if ((r = mp_read_unsigned_bin(u, digest, (word32)digestSz)))
         goto out;
     SrpHashFree(hash);
+    hashInited = 0;
 
     /* building s (secret) */
 
@@ -908,6 +911,9 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
         ForceZero(secret, secretSz);
         XFREE(secret, srp->heap, DYNAMIC_TYPE_SRP);
     }
+
+    if (hashInited)
+        SrpHashFree(hash);
 
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(hash, srp->heap, DYNAMIC_TYPE_SRP);

--- a/wolfcrypt/src/wc_slhdsa.c
+++ b/wolfcrypt/src/wc_slhdsa.c
@@ -7261,6 +7261,8 @@ int wc_SlhDsaKey_Sign(SlhDsaKey* key, const byte* ctx, byte ctxSz,
             sigSz, addRnd);
     }
 
+    ForceZero(addRnd, sizeof(addRnd));
+
     return ret;
 }
 
@@ -8055,6 +8057,8 @@ int wc_SlhDsaKey_SignHash(SlhDsaKey* key, const byte* ctx, byte ctxSz,
         ret = wc_SlhDsaKey_SignHashWithRandom(key, ctx, ctxSz, msg, msgSz,
             hashType, sig, sigSz, addRnd);
     }
+
+    ForceZero(addRnd, sizeof(addRnd));
 
     return ret;
 }

--- a/wolfssl/wolfcrypt/camellia.h
+++ b/wolfssl/wolfcrypt/camellia.h
@@ -90,6 +90,7 @@ WOLFSSL_API int wc_CamelliaCbcEncrypt(wc_Camellia* cam,
                                           byte* out, const byte* in, word32 sz);
 WOLFSSL_API int wc_CamelliaCbcDecrypt(wc_Camellia* cam,
                                           byte* out, const byte* in, word32 sz);
+WOLFSSL_API void wc_CamelliaFree(wc_Camellia* cam);
 
 #ifndef OPENSSL_COEXIST
 


### PR DESCRIPTION
Fixes F-1553, F-1554, F-1555, F-1917, F-2213, F-3095, F-3096, F-3351, F-3353, F-3555, F-3593, F-3594, F-3595, F-3596, F-3597, F-3598, F-3599, F-3600.

- srp: mp_forcezero on password verifier, private exponent, and verifier-derived intermediate; free hash on error path
- pkcs7: ForceZero plaintext payload before free in EncodeEnvelopedData / EncodeEncryptedData / EncodeAuthEnvelopedData
- eddsa: ForceZero orig_k after sign-time integrity check (ed25519, ed448)
- curve25519: ForceZero blinding state (a, n_a, rz) on every exit
- slhdsa: ForceZero addRnd after wc_SlhDsaKey_Sign / SignHash
- random: ForceZero DRBG newV on Hash_df failure (SHA-256 + SHA-512 reseed)
- rsa: ForceZero OAEP seed on padding error paths
- evp: ForceZero HKDF IKM in PKEY_CTX_set1_hkdf_key rotation and PKEY_free
- camellia: add wc_CamelliaFree to wipe key schedule
- evp: correct SM4-CTR debug message (was "AES CTR")
- compress: bound wc_DeCompressDynamic input/growth against INT_MAX
- asn: reject negative/zero size in wc_PemToDer
- tests: cover wc_PemToDer and wc_DeCompressDynamic input validation