### PR TITLE
Zephyr 4.x workflow: stabilize CI for renamed forks and slashed branch names

### DIFF
--- a/.github/scripts/zephyr-4.x/zephyr-test.sh
+++ b/.github/scripts/zephyr-4.x/zephyr-test.sh
@@ -111,8 +111,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG_DIR="${SCRIPT_DIR}/logs"
 mkdir -p "${LOG_DIR}"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-ZVER="${ZEPHYR_VERSION#v}"
-LOG_FILE="${LOG_DIR}/${ZVER}_${WOLFSSL_BRANCH}_${BOARD_TARGET//\//-}_${TIMESTAMP}.log"
+LOG_FILE="${LOG_DIR}/${BOARD_SLUG}_${TIMESTAMP}.log"
 
 echo "==> wolfSSL repo:   ${WOLFSSL_REPO}"
 echo "==> wolfSSL branch: ${WOLFSSL_BRANCH}"
@@ -175,6 +174,7 @@ cd ..
 
 # --- 3. Update all modules (including wolfSSL) ---
 echo "==> [container] Running west update..."
+export GIT_TERMINAL_PROMPT=0
 west update -n -o=--depth=1
 
 # --- 3b. Checkout specific commit if requested ---

--- a/.github/workflows/zephyr-4.x.yml
+++ b/.github/workflows/zephyr-4.x.yml
@@ -47,8 +47,9 @@ jobs:
         id: src
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "repo=${{ github.event.pull_request.head.repo.clone_url }}" >> "$GITHUB_OUTPUT"
-            echo "branch=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+            # Fetch via upstream PR ref so renames, deletes, or visibility changes on the fork do not break us
+            echo "repo=https://github.com/${{ github.repository }}" >> "$GITHUB_OUTPUT"
+            echo "branch=refs/pull/${{ github.event.pull_request.number }}/head" >> "$GITHUB_OUTPUT"
           else
             echo "repo=https://github.com/${{ github.repository }}" >> "$GITHUB_OUTPUT"
             echo "branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The Zephyr 4.x CI workflow occasionally failed in two ways:
log file creation crashed when the branch name contained a `/` (e.g. `feat/sbom-bomsh` was interpreted as a subdirectory), and `west update` hung on a credential prompt when a PR's fork was renamed, deleted, or made private.

The workflow now fetches the wolfSSL revision via the upstream repo's `refs/pull/<N>/head` ref instead of `pull_request.head.repo.clone_url`.

The test script simplifies the log filename to `<board>_<timestamp>.log` so slashes in branch names can no longer break the path.

It also exports `GIT_TERMINAL_PROMPT=0` before `west update` so any future auth issue fails fast with a clear error instead of the cryptic "could not read Username" hang.