### PR TITLE
fix: guard wc_Ed448PublicKeyToDer ed448_export_public call for FIPS<7

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -12931,7 +12931,11 @@ int wc_Ed448PublicKeyToDer(const ed448_key* key, byte* output, word32 inLen,
         return BAD_FUNC_ARG;
     }
 
+    #if defined(HAVE_FIPS) && FIPS_VERSION3_LT(7,0,0)
+    ret = wc_ed448_export_public((ed448_key *)key, pubKey, &pubKeyLen);
+    #else
     ret = wc_ed448_export_public(key, pubKey, &pubKeyLen);
+    #endif
     if (ret == 0) {
         ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, inLen,
             ED448k, withAlg);


### PR DESCRIPTION
This pull request introduces a conditional compilation change to the `wc_Ed448PublicKeyToDer` function in `asn.c` to improve compatibility with FIPS builds. Specifically, it adds a preprocessor check to handle the function call to `wc_ed448_export_public` differently based on the FIPS version.

Compatibility fix for FIPS builds:

* In `wolfcrypt/src/asn.c`, the call to `wc_ed448_export_public` is now conditionally compiled: for FIPS version 3 less than 7.0.0, the `key` parameter is explicitly cast to non-const, addressing compatibility or API differences in those builds.