### PR TITLE
Fix include for errno in Microchip port settings

### DIFF
--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -205,7 +205,7 @@
             extern "C" {
         #endif
     #elif defined(MICROCHIP_PIC32)
-        #include <sys/errno.h>
+        #include <errno.h>
     #elif defined(HAVE_NETX)
         #include "nx_api.h"
         #include "errno.h"


### PR DESCRIPTION
# Description

Fix include for errno in Microchip port settings

Fixes zd21713

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
