### PR TITLE
20260506 Coverity

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -14986,7 +14986,7 @@ static int TLSX_GetSize(TLSX* list, byte* semaphore, byte msgType,
             case TLSX_CERTIFICATE_AUTHORITIES: {
                 word16 canSz = CAN_GET_SIZE(extension->data);
                 /* 0 on non-empty list means 16-bit overflow. */
-                if (canSz == 0 && extension->data != NULL) {
+                if (canSz == 0) {
                     ret = LENGTH_ERROR;
                     break;
                 }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -14532,8 +14532,7 @@ int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group)
     if (WOLFSSL_NAMED_GROUP_IS_PQC(group) ||
         WOLFSSL_NAMED_GROUP_IS_PQC_HYBRID(group)) {
 
-        if (ssl->ctx != NULL && ssl->ctx->method != NULL &&
-            !IsAtLeastTLSv1_3(ssl->version)) {
+        if (!IsAtLeastTLSv1_3(ssl->version)) {
             return BAD_FUNC_ARG;
         }
 

--- a/tests/api/test_evp_digest.c
+++ b/tests/api/test_evp_digest.c
@@ -368,6 +368,22 @@ int test_wolfSSL_EVP_DigestFinalXOF(void)
     ExpectIntEQ(sz, 16);
     ExpectIntEQ(EVP_MD_CTX_cleanup(&mdCtx), WOLFSSL_SUCCESS);
     #endif
+
+    /* NULL size pointer on the non-XOF Final must not crash;
+     * defaults to 32 / 16 bytes for SHAKE256 / SHAKE128. */
+    wolfSSL_EVP_MD_CTX_init(&mdCtx);
+    ExpectIntEQ(EVP_DigestInit(&mdCtx, EVP_shake256()), WOLFSSL_SUCCESS);
+    ExpectIntEQ(EVP_DigestUpdate(&mdCtx, data, 1), WOLFSSL_SUCCESS);
+    ExpectIntEQ(EVP_DigestFinal(&mdCtx, shake, NULL), WOLFSSL_SUCCESS);
+    ExpectIntEQ(EVP_MD_CTX_cleanup(&mdCtx), WOLFSSL_SUCCESS);
+
+    #if defined(WOLFSSL_SHAKE128)
+    wolfSSL_EVP_MD_CTX_init(&mdCtx);
+    ExpectIntEQ(EVP_DigestInit(&mdCtx, EVP_shake128()), WOLFSSL_SUCCESS);
+    ExpectIntEQ(EVP_DigestUpdate(&mdCtx, data, 1), WOLFSSL_SUCCESS);
+    ExpectIntEQ(EVP_DigestFinal(&mdCtx, shake, NULL), WOLFSSL_SUCCESS);
+    ExpectIntEQ(EVP_MD_CTX_cleanup(&mdCtx), WOLFSSL_SUCCESS);
+    #endif
 #endif
     return EXPECT_RESULT();
 }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -868,9 +868,6 @@ int SizeASN_Items(const ASNItem* asn, ASNSetData *data, int count,
                     return ASN_PARSE_E;
                 }
                 length += mp_leading_bit(data[i].data.mp) ? 1 : 0;
-                if (length < 0) {
-                    return ASN_PARSE_E;
-                }
                 len = (word32)SizeASNHeader((word32)length) + (word32)length;
                 /* Check for overflow: header + length must not wrap word32. */
                 if (len < (word32)length) {

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -11317,6 +11317,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
                                unsigned int* s)
     {
         enum wc_HashType macType;
+    #if defined(WOLFSSL_SHA3) && (defined(WOLFSSL_SHAKE128) || \
+        defined(WOLFSSL_SHAKE256))
+        unsigned int defaultSz = 0;
+    #endif
 
         WOLFSSL_ENTER("wolfSSL_EVP_DigestFinal");
 
@@ -11345,18 +11349,21 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
 
             case WC_HASH_TYPE_SHAKE128:
         #if defined(WOLFSSL_SHA3) && defined(WOLFSSL_SHAKE128)
-                if (s != NULL)
-                    *s = 16; /* if mixing up XOF with plain digest 128 bit is
-                              * default for SHAKE128 */
+                if (s == NULL)
+                    s = &defaultSz;
+                *s = 16; /* if mixing up XOF with plain digest 128 bit is
+                            * default for SHAKE128 */
+
         #else
                 return WOLFSSL_FAILURE;
         #endif
                 break;
             case WC_HASH_TYPE_SHAKE256:
         #if defined(WOLFSSL_SHA3) && defined(WOLFSSL_SHAKE256)
-                if (s != NULL)
-                    *s = 32; /* if mixing up XOF with plain digest 256 bit is
-                              * default for SHAKE256 */
+                if (s == NULL)
+                    s = &defaultSz;
+                *s = 32; /* if mixing up XOF with plain digest 256 bit is
+                            * default for SHAKE256 */
         #else
                 return WOLFSSL_FAILURE;
         #endif

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -468,8 +468,8 @@ int wc_CryptKey(const char* password, int passwordSz, const byte* salt,
                 byte unicodePasswd[MAX_UNICODE_SZ];
 
                 if (passwordSz < 0 ||
-                    passwordSz >= (int)sizeof(unicodePasswd) ||
-                   (passwordSz * 2 + 2) > (int)sizeof(unicodePasswd)) {
+                    passwordSz >= MAX_UNICODE_SZ ||
+                   (passwordSz * 2 + 2) > MAX_UNICODE_SZ) {
                     ret = UNICODE_SIZE_E;
                     break;
                 }


### PR DESCRIPTION
# Description

560796: Dereference before null check - remove check as `extension->data` would not be NULL at this point
560760: Logically dead code - remove dead length check
560126: Dereference after null check - introduce `defaultSz` variable to handle `s == NULL`
560794: Dereference after null check - remove check as `ssl->ctx` and `ssl->ctx->method` would not be NULL in normal operation at this point

Also adds unit test for `NULL` parameters in `EVP_DigestFinal()` with SHAKE

# Testing

`./configure --enable-all && make check`

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
