### PR TITLE
ML-DSA fixes: small vfy key object, small SHA-3, fix test

### DIFF
--- a/tests/api/test_mldsa.c
+++ b/tests/api/test_mldsa.c
@@ -24565,6 +24565,7 @@ int test_wc_dilithium_sign_mu_kats(void)
      * convention, so passing zeroSeed reproduces them byte-for-byte. */
     static const byte zeroSeed[DILITHIUM_RND_SZ] = { 0 };
 
+#ifndef WOLFSSL_NO_ML_DSA_44
     /* ML-DSA-44 externalMu: deterministic, tcId 91
      * Source: kh-fork-fips/wolfACVP/v7.0.0-known/
      *   ML-DSA-sigGen-request.json. Deterministic mode
@@ -25206,7 +25207,9 @@ int test_wc_dilithium_sign_mu_kats(void)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x12, 0x1f, 0x28, 0x39
     };
+#endif
 
+#ifndef WOLFSSL_NO_ML_DSA_65
     /* ML-DSA-65 externalMu: deterministic, tcId 121
      * Source: kh-fork-fips/wolfACVP/v7.0.0-known/
      *   ML-DSA-sigGen-request.json. Deterministic mode
@@ -26143,7 +26146,9 @@ int test_wc_dilithium_sign_mu_kats(void)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07,
         0x0c, 0x10, 0x18, 0x1c, 0x1f
     };
+#endif
 
+#ifndef WOLFSSL_NO_ML_DSA_87
     /* ML-DSA-87 externalMu: deterministic, tcId 151
      * Source: kh-fork-fips/wolfACVP/v7.0.0-known/
      *   ML-DSA-sigGen-request.json. Deterministic mode
@@ -27353,6 +27358,7 @@ int test_wc_dilithium_sign_mu_kats(void)
         0x00, 0x00, 0x00, 0x01, 0x08, 0x0e, 0x16, 0x1e,
         0x22, 0x2a, 0x30
     };
+#endif
 
 
     ExpectNotNull(key = (dilithium_key*)XMALLOC(sizeof(*key), NULL,
@@ -27423,6 +27429,7 @@ int test_wc_dilithium_verify_mu_kats(void)
     byte muBuf[DILITHIUM_MU_SZ];
     int res;
 
+#ifndef WOLFSSL_NO_ML_DSA_44
     /* ML-DSA-44 externalMu: deterministic, tcId 91
      * Source: kh-fork-fips/wolfACVP/v7.0.0-known/
      *   ML-DSA-sigGen-request.json. Deterministic mode
@@ -27908,7 +27915,9 @@ int test_wc_dilithium_verify_mu_kats(void)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x12, 0x1f, 0x28, 0x39
     };
+#endif
 
+#ifndef WOLFSSL_NO_ML_DSA_65
     /* ML-DSA-65 externalMu: deterministic, tcId 121
      * Source: kh-fork-fips/wolfACVP/v7.0.0-known/
      *   ML-DSA-sigGen-request.json. Deterministic mode
@@ -28585,7 +28594,9 @@ int test_wc_dilithium_verify_mu_kats(void)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07,
         0x0c, 0x10, 0x18, 0x1c, 0x1f
     };
+#endif
 
+#ifndef WOLFSSL_NO_ML_DSA_87
     /* ML-DSA-87 externalMu: deterministic, tcId 151
      * Source: kh-fork-fips/wolfACVP/v7.0.0-known/
      *   ML-DSA-sigGen-request.json. Deterministic mode
@@ -29507,7 +29518,7 @@ int test_wc_dilithium_verify_mu_kats(void)
         0x00, 0x00, 0x00, 0x01, 0x08, 0x0e, 0x16, 0x1e,
         0x22, 0x2a, 0x30
     };
-
+#endif
 
     ExpectNotNull(key = (dilithium_key*)XMALLOC(sizeof(*key), NULL,
         DYNAMIC_TYPE_TMP_BUFFER));

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -1113,6 +1113,8 @@ static int wc_InitSha3(wc_Sha3* sha3, void* heap, int devId)
     return ret;
 }
 
+#if !(defined(WOLFSSL_NOSHA3_224) && defined(WOLFSSL_NOSHA3_256) && \
+      defined(WOLFSSL_NOSHA3_384) && defined(WOLFSSL_NOSHA3_512))
 /* Update the SHA-3 hash state with message data.
  *
  * sha3  wc_Sha3 object holding state.
@@ -1243,6 +1245,7 @@ static int wc_Sha3Final(wc_Sha3* sha3, byte* hash, byte p, byte len)
     return InitSha3(sha3);  /* reset state */
 }
 #endif
+#endif
 
 /* Dispose of any dynamically allocated data from the SHA3-384 operation.
  * (Required for async ops.)
@@ -1342,6 +1345,8 @@ static int wc_Sha3Copy(wc_Sha3* src, wc_Sha3* dst)
     return ret;
 }
 
+#if !(defined(WOLFSSL_NOSHA3_224) && defined(WOLFSSL_NOSHA3_256) && \
+      defined(WOLFSSL_NOSHA3_384) && defined(WOLFSSL_NOSHA3_512))
 /* Calculate the SHA3-224 hash based on all the message data so far.
  * More message data can be added, after this operation, using the current
  * state.
@@ -1372,7 +1377,9 @@ static int wc_Sha3GetHash(wc_Sha3* sha3, byte* hash, byte p, byte len)
     WC_FREE_VAR_EX(tmpSha3, sha3->heap, DYNAMIC_TYPE_TMP_BUFFER);
     return ret;
 }
+#endif
 
+#ifndef WOLFSSL_NOSHA3_224
 /* Initialize the state for a SHA3-224 hash operation.
  *
  * sha3   wc_Sha3 object holding state.
@@ -1443,8 +1450,9 @@ int wc_Sha3_224_Copy(wc_Sha3* src, wc_Sha3* dst)
 {
     return wc_Sha3Copy(src, dst);
 }
+#endif
 
-
+#ifndef WOLFSSL_NOSHA3_256
 /* Initialize the state for a SHA3-256 hash operation.
  *
  * sha3   wc_Sha3 object holding state.
@@ -1515,8 +1523,9 @@ int wc_Sha3_256_Copy(wc_Sha3* src, wc_Sha3* dst)
 {
     return wc_Sha3Copy(src, dst);
 }
+#endif
 
-
+#ifndef WOLFSSL_NOSHA3_384
 /* Initialize the state for a SHA3-384 hash operation.
  *
  * sha3   wc_Sha3 object holding state.
@@ -1587,8 +1596,9 @@ int wc_Sha3_384_Copy(wc_Sha3* src, wc_Sha3* dst)
 {
     return wc_Sha3Copy(src, dst);
 }
+#endif
 
-
+#ifndef WOLFSSL_NOSHA3_512
 /* Initialize the state for a SHA3-512 hash operation.
  *
  * sha3   wc_Sha3 object holding state.
@@ -1659,6 +1669,7 @@ int wc_Sha3_512_Copy(wc_Sha3* src, wc_Sha3* dst)
 {
     return wc_Sha3Copy(src, dst);
 }
+#endif
 
 #ifdef WOLFSSL_HASH_FLAGS
 int wc_Sha3_SetFlags(wc_Sha3* sha3, word32 flags)

--- a/wolfssl/wolfcrypt/dilithium.h
+++ b/wolfssl/wolfcrypt/dilithium.h
@@ -638,10 +638,14 @@ struct dilithium_key {
 #elif !defined(WOLFSSL_DILITHIUM_ASSIGN_KEY)
 #ifdef USE_INTEL_SPEEDUP
     byte p[DILITHIUM_MAX_PUB_KEY_SIZE+8];
+#if !defined(WOLFSSL_DILITHIUM_VERIFY_ONLY)
     byte k[DILITHIUM_MAX_KEY_SIZE+8];
+#endif
 #else
     byte p[DILITHIUM_MAX_PUB_KEY_SIZE];
+#if !defined(WOLFSSL_DILITHIUM_VERIFY_ONLY)
     byte k[DILITHIUM_MAX_KEY_SIZE];
+#endif
 #endif
 #else
     const byte* p;


### PR DESCRIPTION
# Description

Only have the public key in the ML-DSA key object when verify-only.
Be able to leave out SHA-3 APIs when only needing SHAKE.
Fix ML-DSA testing to only have data for compiled in parameters.

# Testing

Various ML-DSA and SHA-3/SHAKE builds.
