### PR TITLE
Fix FIPS v6 build: cast away const for ed448 export call

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1658,7 +1658,6 @@ AC_ARG_ENABLE([tailscale],
 if test "$ENABLED_TAILSCALE" = "yes"
 then
     enable_wolfguard=yes
-    test "x$enable_sp" = "x" && enable_sp="yes,256"
     enable_opensslall=yes
     enable_alpn=yes
     enable_sni=yes

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -12931,7 +12931,11 @@ int wc_Ed448PublicKeyToDer(const ed448_key* key, byte* output, word32 inLen,
         return BAD_FUNC_ARG;
     }
 
+    #if defined(HAVE_FIPS) && FIPS_VERSION3_LT(7,0,0)
+    ret = wc_ed448_export_public((ed448_key *)key, pubKey, &pubKeyLen);
+    #else
     ret = wc_ed448_export_public(key, pubKey, &pubKeyLen);
+    #endif
     if (ret == 0) {
         ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, inLen,
             ED448k, withAlg);


### PR DESCRIPTION
# Description

Mirror the FIPS-version-conditional cast pattern used for wc_ed25519_export_public in wc_Ed25519PublicKeyToDer. 

Latest ed448.h prototype recently added a const param causing the following error in FIPS v6:

```
make[2]: warning: -jN forced in submake: disabling jobserver mode.
  CC       wolfcrypt/src/src_libwolfssl_la-asn.lo
wolfcrypt/src/asn.c:12934:34: error: passing 'const ed448_key *' (aka 'const struct ed448_key *') to parameter of type 'ed448_key *' (aka 'struct ed448_key *') discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
 12934 |     ret = wc_ed448_export_public(key, pubKey, &pubKeyLen);
       |                                  ^~~
./wolfssl/wolfcrypt/ed448.h:186:39: note: passing argument to parameter 'key' here
  186 | int wc_ed448_export_public(ed448_key* key, byte* out, word32* outLen);
      |                                       ^
```

# Testing

./configure --enable-fips=v6 && make

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
