### PR TITLE
zero-initialize DecodedCert immediately after allocation in wolfSSL_CertManagerCABufferType

### DIFF
--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -633,6 +633,7 @@ int wolfSSL_CertManagerLoadCABufferType(WOLFSSL_CERT_MANAGER* cm,
         if (dCert == NULL) {
             ret = WOLFSSL_FATAL_ERROR;
         } else {
+            XMEMSET(dCert, 0, sizeof(DecodedCert));
             if (format == WOLFSSL_FILETYPE_PEM) {
             #ifndef WOLFSSL_PEM_TO_DER
                 ret = NOT_COMPILED_IN;
@@ -651,7 +652,6 @@ int wolfSSL_CertManagerLoadCABufferType(WOLFSSL_CERT_MANAGER* cm,
             }
 
             if (ret == WOLFSSL_SUCCESS) {
-                XMEMSET(dCert, 0, sizeof(DecodedCert));
                 wc_InitDecodedCert(dCert, buff,
                                 (word32)sz, cm->heap);
                 ret = wc_ParseCert(dCert, CERT_TYPE, NO_VERIFY, NULL);


### PR DESCRIPTION
# Description

zero-initialize DecodedCert immediately after allocation in wolfSSL_CertManagerCABufferType to prevent cleanup on an uninitialized struct on the pem error path.

Fixes zd#21777

# Testing

Against reproducer from zd#21777 with:
./configure --enable-debug --enable-pkcs7=no --enable-opensslall=no --enable-opensslextra=no --enable-shared --enable-static
as configuration.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
