### PR TITLE
20260508-fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -38112,7 +38112,7 @@ static int rfc9802_verify_one_cert(const char* path, word32 expectedKeyOID,
      * its bytes lie between (certBegin + outerSeqHeader) and sigIndex.
      * Picking the midpoint ensures we're inside TBS regardless of the
      * fixture's DN / extensions layout. */
-    if (tampered != NULL && sigIndex > certBegin + 8u) {
+    if (tampered != NULL && sigIndex > certBegin + 8U) {
         word32 midTbs = certBegin + 8 + ((sigIndex - (certBegin + 8)) / 2);
         XMEMCPY(tampered, buf, (size_t)bytes);
         tampered[midTbs] ^= 0x01;

--- a/tests/api/test_mldsa.c
+++ b/tests/api/test_mldsa.c
@@ -3241,9 +3241,9 @@ static int dilithium_oneasymkey_version_check(int level)
     ExpectIntEQ(test_pkcs8_get_version_byte(ref, (word32)refSz), 1);
 
     idx = 0;
+    PRIVATE_KEY_UNLOCK();
     ExpectIntEQ(wc_Dilithium_PrivateKeyDecode(ref, &idx, &key2,
         (word32)refSz), 0);
-    PRIVATE_KEY_UNLOCK();
     ExpectIntEQ(rtSz = wc_Dilithium_KeyToDer(&key2, rt,
         DILITHIUM_MAX_DER_SIZE), refSz);
     PRIVATE_KEY_LOCK();

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -36887,6 +36887,7 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
     }
 
     x = ECC_SIG_SIZE;
+    XMEMSET(sig, 0, ECC_SIG_SIZE);
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
         ret = wc_AsyncWait(ret, &userA->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);


### PR DESCRIPTION
tests/api.c: fix readability-uppercase-literal-suffix in rfc9802_verify_one_cert();

tests/api/test_mldsa.c: fix misplaced PRIVATE_KEY_UNLOCK() in dilithium_oneasymkey_version_check();

wolfcrypt/test/test.c: fix valgrind-detected "Conditional jump or move depends on uninitialised value(s)" in ecc_test_curve_size() negative test on all-zeros digest.

detected & tested with `wolfssl-multi-test.sh` nightlies
