### PR TITLE
port/cavium: fix Octeon AES-GCM AAD GHASH bug

### DIFF
--- a/wolfcrypt/src/port/cavium/cavium_octeon_sync.c
+++ b/wolfcrypt/src/port/cavium/cavium_octeon_sync.c
@@ -558,13 +558,15 @@ static NOOPT int Octeon_AesGcm_SetAAD(Aes* aes, byte* aad, word32 aadSz)
         CVMX_MT_GFM_XORMUL1(p[1]);
     }
 
-    XMEMSET(aesBlock, 0, sizeof(aesBlock));
+    if (remainder > 0) {
+        XMEMSET(aesBlock, 0, sizeof(aesBlock));
 
-    for (i = 0; i < remainder; i++)
-        aesBlock[i] = aad[i];
+        for (i = 0; i < remainder; i++)
+            aesBlock[i] = aad[i];
 
-    CVMX_MT_GFM_XOR0(p[0]);
-    CVMX_MT_GFM_XORMUL1(p[1]);
+        CVMX_MT_GFM_XOR0(p[0]);
+        CVMX_MT_GFM_XORMUL1(p[1]);
+    }
 
     return 0;
 }


### PR DESCRIPTION
# Description

Octeon_AesGcm_SetAAD unconditionally ran XOR0/XORMUL1 on the partial-block buffer after the main loop, which processed an extra all-zero block when aadSz was a non-zero multiple of 16, corrupting the GCM tag. Guard the trailing XOR/MUL with `if (remainder > 0)`.

Issue: F-3335

# Testing

Visual inspection.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
