### PR TITLE
fix NO_VERIFY_OID build in GetOID

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -128,6 +128,8 @@ jobs:
             CPPFLAGS=''-DNO_WOLFSSL_SERVER -DWOLFSSL_NO_TLS12 -DNO_SESSION_CACHE
             -DWOLFSSL_AES_NO_UNROLL -DUSE_SLOW_SHA256 -DWOLFSSL_NO_ASYNC_IO
             -DWOLFSSL_DTLS_ONLY'' ',
+          'CPPFLAGS=-DNO_VERIFY_OID',
+          'CPPFLAGS="-DNO_VERIFY_OID -DWOLFSSL_FPKI"',
         ]
     name: make check linux
     if: github.repository_owner == 'wolfssl'

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7609,9 +7609,9 @@ static int GetOID(const byte* input, word32* inOutIdx, word32* oid,
 {
     int    ret = 0;
     word32 idx = *inOutIdx;
-#ifndef NO_VERIFY_OID
     word32 actualOidSz;
     const byte* actualOid;
+#ifndef NO_VERIFY_OID
     const byte* checkOid = NULL;
     word32 checkOidSz;
 #endif /* NO_VERIFY_OID */
@@ -7623,11 +7623,9 @@ static int GetOID(const byte* input, word32* inOutIdx, word32* oid,
     (void)oidType;
     *oid = 0;
 
-#if !defined(NO_VERIFY_OID) || defined(WOLFSSL_FPKI)
-    /* Keep references to OID data and length for check. */
+    /* Keep references to OID data and length for sum and (optional) check. */
     actualOid = &input[idx];
     actualOidSz = (word32)length;
-#endif /* NO_VERIFY_OID */
 
     *oid = wc_oid_sum(actualOid, (int)actualOidSz);
     idx += actualOidSz;


### PR DESCRIPTION
  # Description                                                                                                                                       
  Move `actualOid` and `actualOidSz` declarations out of the `#ifndef NO_VERIFY_OID` block in  `GetOID()` and drop the assignment guard. They're used unconditionally by `wc_oid_sum()` (added in 112351667), so gating the declarations on `NO_VERIFY_OID` broke compilation.       
  `NO_VERIFY_OID + WOLFSSL_FPKI` was broken for the same reason.  

  Fixes #10423

  # Credit

  Thanks to @cpsource for the proposed patch                         
   
  # Testing                                                                                                                                             
  Pre-patch with `-DNO_VERIFY_OID`: reproduces reporter's compile error.
  Post-patch with `-DNO_VERIFY_OID`, `-DNO_VERIFY_OID -DWOLFSSL_FPKI`, and default: all build clean. `make check` passes.  