### PR TITLE
Fix Blake2 oversized key path

### DIFF
--- a/wolfcrypt/src/blake2b.c
+++ b/wolfcrypt/src/blake2b.c
@@ -501,6 +501,8 @@ int wc_Blake2bHmacInit(Blake2b* b2b, const byte* key, size_t key_len)
     if (key == NULL)
         return BAD_FUNC_ARG;
 
+    XMEMSET(x_key, 0, sizeof(x_key));
+
     if (key_len > BLAKE2B_BLOCKBYTES) {
         ret = wc_InitBlake2b(b2b, BLAKE2B_OUTBYTES);
         if (ret == 0)
@@ -509,9 +511,6 @@ int wc_Blake2bHmacInit(Blake2b* b2b, const byte* key, size_t key_len)
             ret = wc_Blake2bFinal(b2b, x_key, 0);
     } else {
         XMEMCPY(x_key, key, key_len);
-        if (key_len < BLAKE2B_BLOCKBYTES) {
-            XMEMSET(x_key + key_len, 0, BLAKE2B_BLOCKBYTES - key_len);
-        }
     }
 
     if (ret == 0) {
@@ -541,6 +540,7 @@ int wc_Blake2bHmacFinal(Blake2b* b2b, const byte* key, size_t key_len,
         byte* out, size_t out_len)
 {
     byte x_key[BLAKE2B_BLOCKBYTES];
+    Blake2b keyHash;
     int i;
     int ret = 0;
 
@@ -550,17 +550,17 @@ int wc_Blake2bHmacFinal(Blake2b* b2b, const byte* key, size_t key_len,
     if (out_len != BLAKE2B_OUTBYTES)
         return BUFFER_E;
 
+    XMEMSET(x_key, 0, sizeof(x_key));
+
     if (key_len > BLAKE2B_BLOCKBYTES) {
-        ret = wc_InitBlake2b(b2b, BLAKE2B_OUTBYTES);
+        ret = wc_InitBlake2b(&keyHash, BLAKE2B_OUTBYTES);
         if (ret == 0)
-            ret = wc_Blake2bUpdate(b2b, key, (word32)key_len);
+            ret = wc_Blake2bUpdate(&keyHash, key, (word32)key_len);
         if (ret == 0)
-            ret = wc_Blake2bFinal(b2b, x_key, 0);
+            ret = wc_Blake2bFinal(&keyHash, x_key, 0);
+        ForceZero(&keyHash, sizeof(keyHash));
     } else {
         XMEMCPY(x_key, key, key_len);
-        if (key_len < BLAKE2B_BLOCKBYTES) {
-            XMEMSET(x_key + key_len, 0, BLAKE2B_BLOCKBYTES - key_len);
-        }
     }
 
     if (ret == 0) {

--- a/wolfcrypt/src/blake2s.c
+++ b/wolfcrypt/src/blake2s.c
@@ -498,6 +498,8 @@ int wc_Blake2sHmacInit(Blake2s* b2s, const byte* key, size_t key_len)
     if (key == NULL)
         return BAD_FUNC_ARG;
 
+    XMEMSET(x_key, 0, sizeof(x_key));
+
     if (key_len > BLAKE2S_BLOCKBYTES) {
         ret = wc_InitBlake2s(b2s, BLAKE2S_OUTBYTES);
         if (ret == 0)
@@ -506,9 +508,6 @@ int wc_Blake2sHmacInit(Blake2s* b2s, const byte* key, size_t key_len)
             ret = wc_Blake2sFinal(b2s, x_key, 0);
     } else {
         XMEMCPY(x_key, key, key_len);
-        if (key_len < BLAKE2S_BLOCKBYTES) {
-            XMEMSET(x_key + key_len, 0, BLAKE2S_BLOCKBYTES - key_len);
-        }
     }
 
     if (ret == 0) {
@@ -538,6 +537,7 @@ int wc_Blake2sHmacFinal(Blake2s* b2s, const byte* key, size_t key_len,
         byte* out, size_t out_len)
 {
     byte x_key[BLAKE2S_BLOCKBYTES];
+    Blake2s keyHash;
     int i;
     int ret = 0;
 
@@ -547,17 +547,17 @@ int wc_Blake2sHmacFinal(Blake2s* b2s, const byte* key, size_t key_len,
     if (out_len != BLAKE2S_OUTBYTES)
         return BUFFER_E;
 
+    XMEMSET(x_key, 0, sizeof(x_key));
+
     if (key_len > BLAKE2S_BLOCKBYTES) {
-        ret = wc_InitBlake2s(b2s, BLAKE2S_OUTBYTES);
+        ret = wc_InitBlake2s(&keyHash, BLAKE2S_OUTBYTES);
         if (ret == 0)
-            ret = wc_Blake2sUpdate(b2s, key, (word32)key_len);
+            ret = wc_Blake2sUpdate(&keyHash, key, (word32)key_len);
         if (ret == 0)
-            ret = wc_Blake2sFinal(b2s, x_key, 0);
+            ret = wc_Blake2sFinal(&keyHash, x_key, 0);
+        ForceZero(&keyHash, sizeof(keyHash));
     } else {
         XMEMCPY(x_key, key, key_len);
-        if (key_len < BLAKE2S_BLOCKBYTES) {
-            XMEMSET(x_key + key_len, 0, BLAKE2S_BLOCKBYTES - key_len);
-        }
     }
 
     if (ret == 0) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5188,6 +5188,31 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t blake2b_hmac_test(void)
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
+    {
+        byte long_key[BLAKE2B_BLOCKBYTES + 72];
+        static const byte expected_long[] = {
+            0xb5, 0x17, 0xd2, 0x26, 0xcb, 0x6c, 0xa2, 0x09,
+            0xd2, 0x56, 0x30, 0xa2, 0x55, 0xe9, 0xfa, 0xfb,
+            0x1e, 0x0f, 0xbf, 0x60, 0x00, 0xbd, 0x44, 0x09,
+            0xb7, 0xf6, 0x25, 0x75, 0x90, 0x80, 0xb1, 0xde,
+            0x72, 0xa5, 0x8a, 0x15, 0x95, 0xd2, 0x49, 0x8d,
+            0x4c, 0xdc, 0xc8, 0x68, 0x68, 0xa5, 0x07, 0x62,
+            0x10, 0x64, 0x0b, 0x20, 0x0b, 0xe0, 0xb0, 0xb2,
+            0x13, 0xf4, 0x2d, 0x42, 0x15, 0x7a, 0x5c, 0xd6,
+        };
+        int i;
+
+        for (i = 0; i < (int)sizeof(long_key); ++i)
+            long_key[i] = (byte)i;
+
+        ret = wc_Blake2bHmac(message2, sizeof(message2),
+                long_key, sizeof(long_key), out, sizeof(out));
+        if (ret != 0)
+            return WC_TEST_RET_ENC_EC(ret);
+        if (XMEMCMP(out, expected_long, sizeof(out)) != 0)
+            return WC_TEST_RET_ENC_NC;
+    }
+
     return 0;
 }
 #endif /* HAVE_BLAKE2B */
@@ -5325,6 +5350,27 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t blake2s_hmac_test(void)
     ret = wc_Blake2sHmacFinal(&b2s, key2, sizeof(key2), out, sizeof(out));
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
+
+    {
+        byte long_key[BLAKE2S_BLOCKBYTES + 36];
+        static const byte expected_long[] = {
+            0x1a, 0xd0, 0x73, 0xd7, 0xba, 0xab, 0x55, 0x83,
+            0x26, 0xa8, 0xc2, 0x71, 0xf2, 0x1a, 0xdf, 0x3e,
+            0x28, 0x57, 0x14, 0x49, 0x3a, 0x26, 0x33, 0xe7,
+            0x7f, 0xf4, 0xca, 0x1a, 0xfd, 0xa3, 0xe0, 0xd9,
+        };
+        int i;
+
+        for (i = 0; i < (int)sizeof(long_key); ++i)
+            long_key[i] = (byte)i;
+
+        ret = wc_Blake2sHmac(message2, sizeof(message2),
+                long_key, sizeof(long_key), out, sizeof(out));
+        if (ret != 0)
+            return WC_TEST_RET_ENC_EC(ret);
+        if (XMEMCMP(out, expected_long, sizeof(out)) != 0)
+            return WC_TEST_RET_ENC_NC;
+    }
 
     return 0;
 }


### PR DESCRIPTION
# Description

- Reduce long keys in a separate state rather than reusing the state used for the HMAC inner hash.
- Pad the rest of the buffer with zeros as required by the spec.
- Add regression tests

Fixes zd#21783 (1, 3)

# Testing

```
./configure --enable-blake2 --enable-blake2s
make
make check
```