### PR TITLE
Fix CMAC verify error return value

### DIFF
--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -591,7 +591,7 @@ int wc_AesCmacVerify_ex(Cmac* cmac,
                                 devId);
     if (ret == 0) {
         compareRet = ConstantCompare(check, a, (int)min(checkSz, aSz));
-        ret = compareRet ? 1 : 0;
+        ret = compareRet ? MAC_CMP_FAILED_E : 0;
     }
 
     return ret;


### PR DESCRIPTION
Fixes F-1369.

Requires https://github.com/wolfSSL/fips/pull/389 (so CI failures are expected until it is merged).