### PR TITLE
asn: fix GetShortInt for asn original.

### DIFF
--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -753,7 +753,20 @@ int test_GetSetShortInt(void)
         ExpectIntEQ(GetShortInt(valDer, &idx, &value, 6),
                 WC_NO_ERR_TRACE(ASN_EXPECT_0_E));
     }
-#endif
+
+    #if (!defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)) || \
+        (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2))
+    /* zero length value. should return ASN_PARSE_E */
+    {
+        word32 idx = 0;
+        int value = 0;
+        valDer[0] = ASN_INTEGER;
+        valDer[1] = 0x00;
+        ExpectIntEQ(GetShortInt(valDer, &idx, &value, 2),
+                WC_NO_ERR_TRACE(ASN_PARSE_E));
+    }
+    #endif /* */
+#endif /* !NO_PWDBASED || WOLFSSL_ASN_EXTRA */
 #endif
 
     return EXPECT_RESULT();

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3465,6 +3465,13 @@ int GetShortInt(const byte* input, word32* inOutIdx, int* number, word32 maxIdx)
     if (len > 4)
         return ASN_PARSE_E;
 
+    /* to be consistent with GetASN_Integer */
+    #if (!defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)) || \
+        (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2))
+    if (len == 0)
+        return ASN_PARSE_E;
+    #endif
+
     if (len + idx > maxIdx)
         return ASN_PARSE_E;
 


### PR DESCRIPTION
# Description

Fix `GetShortInt()` to return ASN_PARSE_E for zero length with asn=original.

Fixes zd#21783.

# Testing

```
./configure --enable-asn=original && make && ./tests/unit.test
```

```
./configure --enable-asn=yes && make && ./tests/unit.test
```