### PR TITLE
Static analysis fixes/improvements for SECO, devcrypto, ARIA, MD4, MD2

### DIFF
--- a/doc/dox_comments/header_files-ja/md2.h
+++ b/doc/dox_comments/header_files-ja/md2.h
@@ -4,6 +4,7 @@
     \brief この関数はmd2を初期化します。これはwc_Md2Hashによって自動的に呼び出されます。
 
     \return 0 初期化に成功した場合に返されます
+    \return BAD_FUNC_ARG md2がNULLの場合に返されます
 
     \param md2 暗号化に使用するmd2構造体へのポインタ
 
@@ -31,6 +32,7 @@ int wc_InitMd2(wc_Md2* md2);
     \brief 長さlenの提供されたバイト配列を継続的にハッシュするために呼び出すことができます。
 
     \return 0 ダイジェストへのデータ追加に成功した場合に返されます。
+    \return BAD_FUNC_ARG md2がNULLの場合、またはdataがNULLでlenが0でない場合に返されます
 
     \param md2 暗号化に使用するmd2構造体へのポインタ
     \param data ハッシュ化されるデータ
@@ -63,6 +65,7 @@ int wc_Md2Update(wc_Md2* md2, const byte* data, word32 len);
     \brief データのハッシュ化を完了します。結果はhashに格納されます。
 
     \return 0 完了に成功した場合に返されます。
+    \return BAD_FUNC_ARG md2またはhashがNULLの場合に返されます
 
     \param md2 暗号化に使用するmd2構造体へのポインタ
     \param hash ハッシュ値を保持するバイト配列。

--- a/doc/dox_comments/header_files-ja/md2.h
+++ b/doc/dox_comments/header_files-ja/md2.h
@@ -23,7 +23,7 @@
     \sa wc_Md2Update
     \sa wc_Md2Final
 */
-void wc_InitMd2(wc_Md2* md2);
+int wc_InitMd2(wc_Md2* md2);
 
 /*!
     \ingroup MD2
@@ -55,7 +55,7 @@ void wc_InitMd2(wc_Md2* md2);
     \sa wc_Md2Final
     \sa wc_InitMd2
 */
-void wc_Md2Update(wc_Md2* md2, const byte* data, word32 len);
+int wc_Md2Update(wc_Md2* md2, const byte* data, word32 len);
 
 /*!
     \ingroup MD2
@@ -86,7 +86,7 @@ void wc_Md2Update(wc_Md2* md2, const byte* data, word32 len);
     \sa wc_Md2Final
     \sa wc_InitMd2
 */
-void wc_Md2Final(wc_Md2* md2, byte* hash);
+int wc_Md2Final(wc_Md2* md2, byte* hash);
 
 /*!
     \ingroup MD2

--- a/doc/dox_comments/header_files-ja/md4.h
+++ b/doc/dox_comments/header_files-ja/md4.h
@@ -23,7 +23,7 @@
     \sa wc_Md4Update
     \sa wc_Md4Final
 */
-void wc_InitMd4(wc_Md4* md4);
+int wc_InitMd4(wc_Md4* md4);
 
 /*!
     \ingroup MD4
@@ -55,7 +55,7 @@ void wc_InitMd4(wc_Md4* md4);
     \sa wc_Md4Final
     \sa wc_InitMd4
 */
-void wc_Md4Update(wc_Md4* md4, const byte* data, word32 len);
+int wc_Md4Update(wc_Md4* md4, const byte* data, word32 len);
 
 /*!
     \ingroup MD4
@@ -83,4 +83,4 @@ void wc_Md4Update(wc_Md4* md4, const byte* data, word32 len);
     \sa wc_Md4Final
     \sa wc_InitMd4
 */
-void wc_Md4Final(wc_Md4* md4, byte* hash);
+int wc_Md4Final(wc_Md4* md4, byte* hash);

--- a/doc/dox_comments/header_files-ja/md4.h
+++ b/doc/dox_comments/header_files-ja/md4.h
@@ -4,6 +4,7 @@
     \brief この関数はmd4を初期化します。これはwc_Md4Hashによって自動的に呼び出されます。
 
     \return 0 初期化に成功した場合に返されます
+    \return BAD_FUNC_ARG md4がNULLの場合に返されます
 
     \param md4 暗号化に使用するmd4構造体へのポインタ
 
@@ -31,6 +32,7 @@ int wc_InitMd4(wc_Md4* md4);
     \brief 長さlenの提供されたバイト配列を継続的にハッシュするために呼び出すことができます。
 
     \return 0 ダイジェストへのデータ追加に成功した場合に返されます。
+    \return BAD_FUNC_ARG md4がNULLの場合、またはdataがNULLでlenが0でない場合に返されます
 
     \param md4 暗号化に使用するmd4構造体へのポインタ
     \param data ハッシュ化されるデータ
@@ -63,6 +65,7 @@ int wc_Md4Update(wc_Md4* md4, const byte* data, word32 len);
     \brief データのハッシュ化を完了します。結果はhashに格納されます。
 
     \return 0 完了に成功した場合に返されます。
+    \return BAD_FUNC_ARG md4またはhashがNULLの場合に返されます
 
     \param md4 暗号化に使用するmd4構造体へのポインタ
     \param hash ハッシュ値を保持するバイト配列。

--- a/doc/dox_comments/header_files/md2.h
+++ b/doc/dox_comments/header_files/md2.h
@@ -24,7 +24,7 @@
     \sa wc_Md2Update
     \sa wc_Md2Final
 */
-void wc_InitMd2(wc_Md2* md2);
+int wc_InitMd2(wc_Md2* md2);
 
 /*!
     \ingroup MD2
@@ -57,7 +57,7 @@ void wc_InitMd2(wc_Md2* md2);
     \sa wc_Md2Final
     \sa wc_InitMd2
 */
-void wc_Md2Update(wc_Md2* md2, const byte* data, word32 len);
+int wc_Md2Update(wc_Md2* md2, const byte* data, word32 len);
 
 /*!
     \ingroup MD2
@@ -88,7 +88,7 @@ void wc_Md2Update(wc_Md2* md2, const byte* data, word32 len);
     \sa wc_Md2Final
     \sa wc_InitMd2
 */
-void wc_Md2Final(wc_Md2* md2, byte* hash);
+int wc_Md2Final(wc_Md2* md2, byte* hash);
 
 /*!
     \ingroup MD2

--- a/doc/dox_comments/header_files/md2.h
+++ b/doc/dox_comments/header_files/md2.h
@@ -5,6 +5,7 @@
     called by wc_Md2Hash.
 
     \return 0 Returned upon successfully initializing
+    \return BAD_FUNC_ARG Returned if md2 is NULL
 
     \param md2 pointer to the md2 structure to use for encryption
 
@@ -33,6 +34,8 @@ int wc_InitMd2(wc_Md2* md2);
     array of length len.
 
     \return 0 Returned upon successfully adding the data to the digest.
+    \return BAD_FUNC_ARG Returned if md2 is NULL, or if data is NULL and
+    len is non-zero
 
     \param md2 pointer to the md2 structure to use for encryption
     \param data the data to be hashed
@@ -65,6 +68,7 @@ int wc_Md2Update(wc_Md2* md2, const byte* data, word32 len);
     \brief Finalizes hashing of data. Result is placed into hash.
 
     \return 0 Returned upon successfully finalizing.
+    \return BAD_FUNC_ARG Returned if md2 or hash is NULL
 
     \param md2 pointer to the md2 structure to use for encryption
     \param hash Byte array to hold hash value.

--- a/doc/dox_comments/header_files/md4.h
+++ b/doc/dox_comments/header_files/md4.h
@@ -5,6 +5,7 @@
     called by wc_Md4Hash.
 
     \return 0 Returned upon successfully initializing
+    \return BAD_FUNC_ARG Returned if md4 is NULL
 
     \param md4 pointer to the md4 structure to use for encryption
 
@@ -33,6 +34,8 @@ int wc_InitMd4(wc_Md4* md4);
     of length len.
 
     \return 0 Returned upon successfully adding the data to the digest.
+    \return BAD_FUNC_ARG Returned if md4 is NULL, or if data is NULL and
+    len is non-zero
 
     \param md4 pointer to the md4 structure to use for encryption
     \param data the data to be hashed
@@ -65,6 +68,7 @@ int wc_Md4Update(wc_Md4* md4, const byte* data, word32 len);
     \brief Finalizes hashing of data. Result is placed into hash.
 
     \return 0 Returned upon successfully finalizing.
+    \return BAD_FUNC_ARG Returned if md4 or hash is NULL
 
     \param md4 pointer to the md4 structure to use for encryption
     \param hash Byte array to hold hash value.

--- a/doc/dox_comments/header_files/md4.h
+++ b/doc/dox_comments/header_files/md4.h
@@ -24,7 +24,7 @@
     \sa wc_Md4Update
     \sa wc_Md4Final
 */
-void wc_InitMd4(wc_Md4* md4);
+int wc_InitMd4(wc_Md4* md4);
 
 /*!
     \ingroup MD4
@@ -57,7 +57,7 @@ void wc_InitMd4(wc_Md4* md4);
     \sa wc_Md4Final
     \sa wc_InitMd4
 */
-void wc_Md4Update(wc_Md4* md4, const byte* data, word32 len);
+int wc_Md4Update(wc_Md4* md4, const byte* data, word32 len);
 
 /*!
     \ingroup MD4
@@ -85,4 +85,4 @@ void wc_Md4Update(wc_Md4* md4, const byte* data, word32 len);
     \sa wc_Md4Final
     \sa wc_InitMd4
 */
-void wc_Md4Final(wc_Md4* md4, byte* hash);
+int wc_Md4Final(wc_Md4* md4, byte* hash);

--- a/tests/api/test_md2.c
+++ b/tests/api/test_md2.c
@@ -37,9 +37,12 @@
 /* Unit test for wc_InitMd2() and wc_InitMd2_ex() */
 int test_wc_InitMd2(void)
 {
-    EXPECT_SUCCESS_DECLS;
+    EXPECT_DECLS;
 #ifdef WOLFSSL_MD2
-    DIGEST_INIT_ONLY_TEST(wc_Md2, Md2);
+    wc_Md2 md2;
+
+    ExpectIntEQ(wc_InitMd2(NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_InitMd2(&md2), 0);
 #endif
     return EXPECT_RESULT();
 }
@@ -47,9 +50,19 @@ int test_wc_InitMd2(void)
 /* Unit test for wc_UpdateMd2() */
 int test_wc_Md2Update(void)
 {
-    EXPECT_SUCCESS_DECLS;
+    EXPECT_DECLS;
 #ifdef WOLFSSL_MD2
-    DIGEST_UPDATE_ONLY_TEST(wc_Md2, Md2);
+    wc_Md2 md2;
+
+    ExpectIntEQ(wc_InitMd2(&md2), 0);
+
+    ExpectIntEQ(wc_Md2Update(NULL, NULL, 1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_Md2Update(&md2, NULL, 1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_Md2Update(NULL, (byte*)"a", 1),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    ExpectIntEQ(wc_Md2Update(&md2, NULL, 0), 0);
+    ExpectIntEQ(wc_Md2Update(&md2, (byte*)"a", 1), 0);
 #endif
     return EXPECT_RESULT();
 }
@@ -57,9 +70,18 @@ int test_wc_Md2Update(void)
 /* Unit test for wc_Md2Final() */
 int test_wc_Md2Final(void)
 {
-    EXPECT_SUCCESS_DECLS;
+    EXPECT_DECLS;
 #ifdef WOLFSSL_MD2
-    DIGEST_FINAL_ONLY_TEST(wc_Md2, Md2, MD2);
+    wc_Md2 md2;
+    byte   hash[WC_MD2_DIGEST_SIZE];
+
+    ExpectIntEQ(wc_InitMd2(&md2), 0);
+
+    ExpectIntEQ(wc_Md2Final(NULL, NULL),  WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_Md2Final(&md2, NULL),  WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_Md2Final(NULL, hash),  WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    ExpectIntEQ(wc_Md2Final(&md2, hash), 0);
 #endif
     return EXPECT_RESULT();
 }
@@ -120,8 +142,20 @@ int test_wc_Md2Hash(void)
 {
     EXPECT_DECLS;
 #if defined(WOLFSSL_MD2)
-    DIGEST_HASH_ONLY_TEST(Md2, MD2);
+    byte data[WC_MD2_BLOCK_SIZE];
+    byte hash[WC_MD2_DIGEST_SIZE];
+
+    XMEMSET(data, 0xa5, sizeof(data));
+
+    /* Invalid parameters. */
+    ExpectIntEQ(wc_Md2Hash(NULL, sizeof(data), hash),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_Md2Hash(data, sizeof(data), NULL),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    /* Valid parameters. */
+    ExpectIntEQ(wc_Md2Hash(data, sizeof(data), hash), 0);
 #endif
     return EXPECT_RESULT();
-}  /* END test_wc_Sm3Hash */
+}
 

--- a/tests/api/test_md4.c
+++ b/tests/api/test_md4.c
@@ -37,9 +37,12 @@
 /* Unit test for wc_InitMd4() and wc_InitMd4_ex() */
 int test_wc_InitMd4(void)
 {
-    EXPECT_SUCCESS_DECLS;
+    EXPECT_DECLS;
 #ifndef NO_MD4
-    DIGEST_INIT_ONLY_TEST(wc_Md4, Md4);
+    wc_Md4 md4;
+
+    ExpectIntEQ(wc_InitMd4(NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_InitMd4(&md4), 0);
 #endif
     return EXPECT_RESULT();
 }
@@ -47,9 +50,19 @@ int test_wc_InitMd4(void)
 /* Unit test for wc_UpdateMd4() */
 int test_wc_Md4Update(void)
 {
-    EXPECT_SUCCESS_DECLS;
+    EXPECT_DECLS;
 #ifndef NO_MD4
-    DIGEST_UPDATE_ONLY_TEST(wc_Md4, Md4);
+    wc_Md4 md4;
+
+    ExpectIntEQ(wc_InitMd4(&md4), 0);
+
+    ExpectIntEQ(wc_Md4Update(NULL, NULL, 1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_Md4Update(&md4, NULL, 1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_Md4Update(NULL, (byte*)"a", 1),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    ExpectIntEQ(wc_Md4Update(&md4, NULL, 0), 0);
+    ExpectIntEQ(wc_Md4Update(&md4, (byte*)"a", 1), 0);
 #endif
     return EXPECT_RESULT();
 }
@@ -57,9 +70,18 @@ int test_wc_Md4Update(void)
 /* Unit test for wc_Md4Final() */
 int test_wc_Md4Final(void)
 {
-    EXPECT_SUCCESS_DECLS;
+    EXPECT_DECLS;
 #ifndef NO_MD4
-    DIGEST_FINAL_ONLY_TEST(wc_Md4, Md4, MD4);
+    wc_Md4 md4;
+    byte   hash[WC_MD4_DIGEST_SIZE];
+
+    ExpectIntEQ(wc_InitMd4(&md4), 0);
+
+    ExpectIntEQ(wc_Md4Final(NULL, NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_Md4Final(&md4, NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_Md4Final(NULL, hash), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    ExpectIntEQ(wc_Md4Final(&md4, hash), 0);
 #endif
     return EXPECT_RESULT();
 }

--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -52,7 +52,7 @@ Public domain.
 
     #define U32C(v) (v##U)
     #define U32V(v) ((word32)(v) & U32C(0xFFFFFFFF))
-    #define U8TO32_LITTLE(p) LITTLE32(((const word32*)(p))[0])
+    #define U8TO32_LITTLE(p) LITTLE32(readUnalignedWord32(p))
 
     #define ROTATE(v,c) rotlFixed(v, c)
     #define XOR(v,w)    ((v) ^ (w))

--- a/wolfcrypt/src/md2.c
+++ b/wolfcrypt/src/md2.c
@@ -33,19 +33,21 @@
 #endif
 
 
-void wc_InitMd2(wc_Md2* md2)
+int wc_InitMd2(wc_Md2* md2)
 {
     if (md2 == NULL)
-        return;
+        return BAD_FUNC_ARG;
 
     XMEMSET(md2->X, 0, WC_MD2_X_SIZE);
     XMEMSET(md2->C, 0, WC_MD2_BLOCK_SIZE);
     XMEMSET(md2->buffer, 0, WC_MD2_BLOCK_SIZE);
     md2->count = 0;
+
+    return 0;
 }
 
 
-void wc_Md2Update(wc_Md2* md2, const byte* data, word32 len)
+int wc_Md2Update(wc_Md2* md2, const byte* data, word32 len)
 {
     static const byte S[256] =
     {
@@ -70,7 +72,7 @@ void wc_Md2Update(wc_Md2* md2, const byte* data, word32 len)
     };
 
     if (md2 == NULL || (data == NULL && len != 0))
-        return;
+        return BAD_FUNC_ARG;
 
     while (len) {
         word32 L = (WC_MD2_PAD_SIZE - md2->count) < len ?
@@ -110,45 +112,55 @@ void wc_Md2Update(wc_Md2* md2, const byte* data, word32 len)
             }
         }
     }
+
+    return 0;
 }
 
 
-void wc_Md2Final(wc_Md2* md2, byte* hash)
+int wc_Md2Final(wc_Md2* md2, byte* hash)
 {
     byte   padding[WC_MD2_BLOCK_SIZE];
     word32 padLen;
     word32 i;
+    int    ret;
 
     if (md2 == NULL || hash == NULL)
-        return;
+        return BAD_FUNC_ARG;
 
     padLen = WC_MD2_PAD_SIZE - md2->count;
     for (i = 0; i < padLen; i++)
         padding[i] = (byte)padLen;
 
-    wc_Md2Update(md2, padding, padLen); /* cppcheck-suppress uninitvar */
-    wc_Md2Update(md2, md2->C, WC_MD2_BLOCK_SIZE);
+    /* cppcheck-suppress uninitvar */
+    ret = wc_Md2Update(md2, padding, padLen);
+    if (ret == 0)
+        ret = wc_Md2Update(md2, md2->C, WC_MD2_BLOCK_SIZE);
+    if (ret != 0)
+        return ret;
 
     XMEMCPY(hash, md2->X, WC_MD2_DIGEST_SIZE);
 
-    wc_InitMd2(md2);
+    return wc_InitMd2(md2);
 }
 
 
 int wc_Md2Hash(const byte* data, word32 len, byte* hash)
 {
+    int ret;
     WC_DECLARE_VAR(md2, wc_Md2, 1, 0);
 
     WC_ALLOC_VAR_EX(md2, wc_Md2, 1, NULL, DYNAMIC_TYPE_TMP_BUFFER,
         return MEMORY_E);
 
-    wc_InitMd2(md2);
-    wc_Md2Update(md2, data, len);
-    wc_Md2Final(md2, hash);
+    ret = wc_InitMd2(md2);
+    if (ret == 0)
+        ret = wc_Md2Update(md2, data, len);
+    if (ret == 0)
+        ret = wc_Md2Final(md2, hash);
 
     WC_FREE_VAR_EX(md2, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
-    return 0;
+    return ret;
 }
 
 

--- a/wolfcrypt/src/md4.c
+++ b/wolfcrypt/src/md4.c
@@ -32,10 +32,10 @@
 #endif
 
 
-void wc_InitMd4(wc_Md4* md4)
+int wc_InitMd4(wc_Md4* md4)
 {
     if (md4 == NULL)
-        return;
+        return BAD_FUNC_ARG;
 
     md4->digest[0] = 0x67452301L;
     md4->digest[1] = 0xefcdab89L;
@@ -45,6 +45,8 @@ void wc_InitMd4(wc_Md4* md4)
     md4->buffLen = 0;
     md4->loLen   = 0;
     md4->hiLen   = 0;
+
+    return 0;
 }
 
 
@@ -136,13 +138,13 @@ static WC_INLINE void AddLength(wc_Md4* md4, word32 len)
 }
 
 
-void wc_Md4Update(wc_Md4* md4, const byte* data, word32 len)
+int wc_Md4Update(wc_Md4* md4, const byte* data, word32 len)
 {
     /* do block size increments */
     byte* local;
 
     if (md4 == NULL || (data == NULL && len != 0))
-        return;
+        return BAD_FUNC_ARG;
 
     local = (byte*)md4->buffer;
     while (len) {
@@ -162,15 +164,17 @@ void wc_Md4Update(wc_Md4* md4, const byte* data, word32 len)
             md4->buffLen = 0;
         }
     }
+
+    return 0;
 }
 
 
-void wc_Md4Final(wc_Md4* md4, byte* hash)
+int wc_Md4Final(wc_Md4* md4, byte* hash)
 {
     byte* local;
 
     if (md4 == NULL || hash == NULL)
-        return;
+        return BAD_FUNC_ARG;
 
     local = (byte*)md4->buffer;
     AddLength(md4, md4->buffLen);               /* before adding pads */
@@ -209,7 +213,7 @@ void wc_Md4Final(wc_Md4* md4, byte* hash)
     #endif
     XMEMCPY(hash, md4->digest, WC_MD4_DIGEST_SIZE);
 
-    wc_InitMd4(md4);  /* reset state */
+    return wc_InitMd4(md4);  /* reset state */
 }
 
 

--- a/wolfcrypt/src/port/aria/aria-cryptocb.c
+++ b/wolfcrypt/src/port/aria/aria-cryptocb.c
@@ -241,6 +241,7 @@ int wc_AriaSign(byte* in, word32 inSz, byte* out, word32* outSz, ecc_key* key)
         rv = MC_Sign(hSession, in, inSz, out, outSz);
     WOLFSSL_MSG_EX("AriaSign Sign rv=%d",rv);
 
+    ForceZero(keyarr, sizeof(keyarr));
     wc_AriaFree(&hSession, &hPrikey);
     if (rv != MC_OK) {
         WOLFSSL_MSG(MC_GetErrorString(rv));
@@ -408,6 +409,7 @@ int wc_AriaDerive(ecc_key* private_key, ecc_key* public_key,
         rv = MC_DeriveKey(hSession, &mcAlg, hPrikey, out, outSz);
     WOLFSSL_MSG_EX("AriaDerive DeriveKey rv=%d",rv);
 
+    ForceZero(privAsn1, sizeof(privAsn1));
     wc_AriaFree(&hSession, &hPrikey);
     if (rv != MC_OK) {
         WOLFSSL_MSG(MC_GetErrorString(rv));

--- a/wolfcrypt/src/port/aria/aria-cryptocb.c
+++ b/wolfcrypt/src/port/aria/aria-cryptocb.c
@@ -39,6 +39,7 @@ size and a key size of 128, 192, or 256 bits.
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
+#include <wolfssl/wolfcrypt/misc.h>
 #include <wolfssl/wolfcrypt/port/aria/aria-cryptocb.h>
 
 int wc_AriaInit(void)

--- a/wolfcrypt/src/port/caam/wolfcaam_fsl_nxp.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_fsl_nxp.c
@@ -151,6 +151,9 @@ static int wc_CAAM_CommonHash(caam_handle_t* hndl, caam_hash_ctx_t *ctx,
             /* input not aligned */
             tmpIn = (byte*)XMALLOC(inSz + CAAM_BUFFER_ALIGN, NULL,
                 DYNAMIC_TYPE_TMP_BUFFER);
+            if (tmpIn == NULL) {
+                return MEMORY_E;
+            }
             alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -
                 ((wc_ptr_t)tmpIn % CAAM_BUFFER_ALIGN));
             XMEMCPY(alignedIn, in, inSz);
@@ -176,6 +179,9 @@ static int wc_CAAM_CommonHash(caam_handle_t* hndl, caam_hash_ctx_t *ctx,
             /* input not aligned */
             tmpOut = (byte*)XMALLOC(sz + CAAM_BUFFER_ALIGN, NULL,
                 DYNAMIC_TYPE_TMP_BUFFER);
+            if (tmpOut == NULL) {
+                return MEMORY_E;
+            }
             alignedOut = tmpOut + (CAAM_BUFFER_ALIGN -
                 ((wc_ptr_t)tmpOut % CAAM_BUFFER_ALIGN));
         }
@@ -308,6 +314,9 @@ static int DoAesCTR(unsigned int args[4], CAAM_BUFFER *buf, int sz)
         /* input not aligned */
         tmpIn = (byte*)XMALLOC(buf[2].Length + CAAM_BUFFER_ALIGN, NULL,
             DYNAMIC_TYPE_TMP_BUFFER);
+        if (tmpIn == NULL) {
+            return MEMORY_E;
+        }
         alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -
             ((wc_ptr_t)tmpIn % CAAM_BUFFER_ALIGN));
         XMEMCPY(alignedIn, (byte*)buf[2].TheAddress, buf[2].Length);
@@ -320,6 +329,10 @@ static int DoAesCTR(unsigned int args[4], CAAM_BUFFER *buf, int sz)
         /* output not aligned */
         tmpOut = (byte*)XMALLOC(buf[3].Length + CAAM_BUFFER_ALIGN, NULL,
             DYNAMIC_TYPE_TMP_BUFFER);
+        if (tmpOut == NULL) {
+            XFREE(tmpIn, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            return MEMORY_E;
+        }
         alignedOut = tmpOut + (CAAM_BUFFER_ALIGN -
             ((wc_ptr_t)tmpOut % CAAM_BUFFER_ALIGN));
     }
@@ -480,6 +493,10 @@ int wc_CAAM_EccSign(const byte* in, int inlen, byte* out, word32* outlen,
         /* input not aligned */
         tmpIn = (byte*)XMALLOC(inlen + CAAM_BUFFER_ALIGN, NULL,
             DYNAMIC_TYPE_TMP_BUFFER);
+        if (tmpIn == NULL) {
+            ForceZero(k, sizeof(k));
+            return MEMORY_E;
+        }
         alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -
             ((wc_ptr_t)tmpIn % CAAM_BUFFER_ALIGN));
         XMEMCPY(alignedIn, in, inlen);
@@ -594,6 +611,9 @@ static int wc_CAAM_EccVerify_ex(mp_int* r, mp_int *s, const byte* hash,
         /* input not aligned */
         tmpIn = (byte*)XMALLOC(hashlen + CAAM_BUFFER_ALIGN, NULL,
             DYNAMIC_TYPE_TMP_BUFFER);
+        if (tmpIn == NULL) {
+            return MEMORY_E;
+        }
         alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -
             ((wc_ptr_t)tmpIn % CAAM_BUFFER_ALIGN));
         XMEMCPY(alignedIn, hash, hashlen);

--- a/wolfcrypt/src/port/caam/wolfcaam_seco.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_seco.c
@@ -960,6 +960,10 @@ static hsm_err_t wc_SECO_AESCCM(unsigned int args[4], CAAM_BUFFER* buf, int sz)
     cipherAndTagSz = buf[4].Length + buf[2].Length;
     cipherAndTag   = (byte*)XMALLOC(cipherAndTagSz, NULL,
         DYNAMIC_TYPE_TMP_BUFFER);
+    if (cipherAndTag == NULL) {
+        return HSM_OUT_OF_MEMORY;
+    }
+
     dir = args[0] & 0xFFFF; /* get if doing enc or dec */
     if (dir == CAAM_ENC) {
         in = (uint8_t*)buf[2].TheAddress;
@@ -1012,6 +1016,11 @@ static hsm_err_t wc_SECO_AESGCM(unsigned int args[4], CAAM_BUFFER* buf, int sz)
         cipherAndTagSz = buf[4].Length + buf[2].Length;
         cipherAndTag   = (byte*)XMALLOC(cipherAndTagSz, NULL,
             DYNAMIC_TYPE_TMP_BUFFER);
+        if (cipherAndTag == NULL) {
+            (void)hsm_close_cipher_service(cipher_hdl);
+            return HSM_OUT_OF_MEMORY;
+        }
+
         if (dir == CAAM_ENC) {
             in = (uint8_t*)buf[2].TheAddress;
             inSz  = buf[2].Length;
@@ -1141,6 +1150,8 @@ word32 wc_SECO_WrapKey(word32 keyId, byte* in, word32 inSz, byte* iv,
                 WOLFSSL_MSG("error with AES-GCM set key");
             }
         }
+
+        ForceZero(KEK, sizeof(KEK));
 
         key_args.flags |= HSM_OP_MANAGE_KEY_FLAGS_PART_UNIQUE_ROOT_KEK;
         #if 0

--- a/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
@@ -253,13 +253,17 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     /* create key stream for later if needed */
     if (sz > 0) {
         Aes tmpAes;
-        if ((ret = wc_AesSetKey(&tmpAes, (byte*)aes->devKey, aes->keylen,
-                                (byte*)aes->reg, AES_ENCRYPTION)) != 0)
-            return ret;
-        if ((ret = wc_AesEncryptDirect(&tmpAes, (byte*)aes->tmp,
-                                       (const byte*)aes->reg)) != 0)
-            return ret;
+        ret = wc_AesSetKey(&tmpAes, (byte*)aes->devKey, aes->keylen,
+                           (byte*)aes->reg, AES_ENCRYPTION);
+        if (ret == 0) {
+            ret = wc_AesEncryptDirect(&tmpAes, (byte*)aes->tmp,
+                                      (const byte*)aes->reg);
+        }
         wc_AesFree(&tmpAes);
+        ForceZero(&tmpAes, sizeof(tmpAes));
+        if (ret != 0)
+            return ret;
+
         IncrementAesCounter((byte*)aes->reg);
 
         aes->left = WC_AES_BLOCK_SIZE - (sz % WC_AES_BLOCK_SIZE);

--- a/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
@@ -253,13 +253,16 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     /* create key stream for later if needed */
     if (sz > 0) {
         Aes tmpAes;
-        ret = wc_AesSetKey(&tmpAes, (byte*)aes->devKey, aes->keylen,
-                           (byte*)aes->reg, AES_ENCRYPTION);
+        ret = wc_AesInit(&tmpAes, NULL, INVALID_DEVID);
         if (ret == 0) {
-            ret = wc_AesEncryptDirect(&tmpAes, (byte*)aes->tmp,
-                                      (const byte*)aes->reg);
+            ret = wc_AesSetKey(&tmpAes, (byte*)aes->devKey, aes->keylen,
+                               (byte*)aes->reg, AES_ENCRYPTION);
+            if (ret == 0) {
+                ret = wc_AesEncryptDirect(&tmpAes, (byte*)aes->tmp,
+                                          (const byte*)aes->reg);
+            }
+            wc_AesFree(&tmpAes);
         }
-        wc_AesFree(&tmpAes);
         ForceZero(&tmpAes, sizeof(tmpAes));
         if (ret != 0)
             return ret;

--- a/wolfcrypt/src/port/devcrypto/devcrypto_rsa.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_rsa.c
@@ -175,7 +175,7 @@ static int _PrivateOperation(const byte* in, word32 inlen, byte* out,
     p = (byte*)XMALLOC(pSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     q = (byte*)XMALLOC(qSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     n = (byte*)XMALLOC(dSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (d == NULL || p == NULL || q == NULL) {
+    if (d == NULL || p == NULL || q == NULL || n == NULL) {
         ret = MEMORY_E;
     }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -4861,6 +4861,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t md5_test(void)
 
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t md4_test(void)
 {
+    wc_test_ret_t ret = 0;
     wc_Md4 md4;
     byte hash[WC_MD4_DIGEST_SIZE];
 
@@ -4921,11 +4922,18 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t md4_test(void)
     test_md4[5] = f;
     test_md4[6] = g;
 
-    wc_InitMd4(&md4);
+    ret = wc_InitMd4(&md4);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
 
     for (i = 0; i < times; ++i) {
-        wc_Md4Update(&md4, (byte*)test_md4[i].input, (word32)test_md4[i].inLen);
-        wc_Md4Final(&md4, hash);
+        ret = wc_Md4Update(&md4, (byte*)test_md4[i].input,
+                           (word32)test_md4[i].inLen);
+        if (ret != 0)
+            return WC_TEST_RET_ENC_I(i);
+        ret = wc_Md4Final(&md4, hash);
+        if (ret != 0)
+            return WC_TEST_RET_ENC_I(i);
 
         if (XMEMCMP(hash, test_md4[i].output, WC_MD4_DIGEST_SIZE) != 0)
             return WC_TEST_RET_ENC_I(i);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -4487,6 +4487,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t asn_test(void)
 #ifdef WOLFSSL_MD2
 static wc_test_ret_t md2_kat_test(void)
 {
+    wc_test_ret_t ret = 0;
     wc_Md2 md2;
     byte hash[WC_MD2_DIGEST_SIZE];
 
@@ -10814,6 +10815,45 @@ static wc_test_ret_t chacha_vector_test(ChaCha* enc, ChaCha* dec)
 
     if (XMEMCMP(plain + 64, sliver, 64))
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+    /* Test unaligned input buffer case */
+    {
+        ChaCha encAligned;
+        ChaCha encUnaligned;
+        byte   keyBuf[32 + 1];
+        byte   ivBuf[12 + 1];
+        byte   pt[64];
+        byte   ctAligned[64];
+        byte   ctUnaligned[64];
+
+        XMEMCPY(keyBuf + 1, keys[0], 32);
+        XMEMCPY(ivBuf + 1,  ivs[2],  12);
+        XMEMSET(pt, 0xa5, sizeof(pt));
+
+        ret = wc_Chacha_SetKey(&encAligned, keys[0], 32);
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        ret = wc_Chacha_SetKey(&encUnaligned, keyBuf + 1, 32);
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+        ret = wc_Chacha_SetIV(&encAligned, ivs[2], 0);
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        ret = wc_Chacha_SetIV(&encUnaligned, ivBuf + 1, 0);
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+        ret = wc_Chacha_Process(&encAligned, ctAligned, pt, sizeof(pt));
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        ret = wc_Chacha_Process(&encUnaligned, ctUnaligned, pt, sizeof(pt));
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+        if (XMEMCMP(ctAligned, ctUnaligned, sizeof(ctAligned)))
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+    }
 
 out:
     return ret;
@@ -23344,6 +23384,27 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t XChaCha_test(void) {
 
     if (XMEMCMP(buf2, Plaintext, sizeof Plaintext))
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+    /* Test unaligned input buffer case */
+    {
+        byte keyBuf[sizeof Key + 1];
+        byte ivBuf[sizeof IV + 1];
+
+        XMEMCPY(keyBuf + 1, Key, sizeof Key);
+        XMEMCPY(ivBuf + 1,  IV,  sizeof IV);
+
+        ret = wc_XChacha_SetKey(chacha, keyBuf + 1, sizeof Key,
+                                ivBuf + 1, sizeof IV, 0);
+        if (ret < 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+        ret = wc_Chacha_Process(chacha, buf2, Plaintext, sizeof Plaintext);
+        if (ret < 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+        if (XMEMCMP(buf2, Ciphertext, sizeof Plaintext))
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+    }
 
   out:
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -4546,11 +4546,18 @@ static wc_test_ret_t md2_kat_test(void)
     test_md2[5] = f;
     test_md2[6] = g;
 
-    wc_InitMd2(&md2);
+    ret = wc_InitMd2(&md2);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
 
     for (i = 0; i < times; ++i) {
-        wc_Md2Update(&md2, (byte*)test_md2[i].input, (word32)test_md2[i].inLen);
-        wc_Md2Final(&md2, hash);
+        ret = wc_Md2Update(&md2, (byte*)test_md2[i].input,
+                           (word32)test_md2[i].inLen);
+        if (ret != 0)
+            return WC_TEST_RET_ENC_I(i);
+        ret = wc_Md2Final(&md2, hash);
+        if (ret != 0)
+            return WC_TEST_RET_ENC_I(i);
 
         if (XMEMCMP(hash, test_md2[i].output, WC_MD2_DIGEST_SIZE) != 0)
             return WC_TEST_RET_ENC_I(i);

--- a/wolfssl/wolfcrypt/md2.h
+++ b/wolfssl/wolfcrypt/md2.h
@@ -51,10 +51,10 @@ typedef struct wc_Md2 {
 } wc_Md2;
 
 
-WOLFSSL_API void wc_InitMd2(wc_Md2* md2);
-WOLFSSL_API void wc_Md2Update(wc_Md2* md2, const byte* data, word32 len);
-WOLFSSL_API void wc_Md2Final(wc_Md2* md2, byte* hash);
-WOLFSSL_API int  wc_Md2Hash(const byte* data, word32 len, byte* hash);
+WOLFSSL_API int wc_InitMd2(wc_Md2* md2);
+WOLFSSL_API int wc_Md2Update(wc_Md2* md2, const byte* data, word32 len);
+WOLFSSL_API int wc_Md2Final(wc_Md2* md2, byte* hash);
+WOLFSSL_API int wc_Md2Hash(const byte* data, word32 len, byte* hash);
 
 #ifndef OPENSSL_COEXIST
 

--- a/wolfssl/wolfcrypt/md4.h
+++ b/wolfssl/wolfcrypt/md4.h
@@ -48,9 +48,9 @@ typedef struct wc_Md4 {
     word32  buffer[WC_MD4_BLOCK_SIZE  / sizeof(word32)];
 } wc_Md4;
 
-WOLFSSL_API void wc_InitMd4(wc_Md4* md4);
-WOLFSSL_API void wc_Md4Update(wc_Md4* md4, const byte* data, word32 len);
-WOLFSSL_API void wc_Md4Final(wc_Md4* md4, byte* hash);
+WOLFSSL_API int wc_InitMd4(wc_Md4* md4);
+WOLFSSL_API int wc_Md4Update(wc_Md4* md4, const byte* data, word32 len);
+WOLFSSL_API int wc_Md4Final(wc_Md4* md4, byte* hash);
 
 #ifndef OPENSSL_COEXIST
 


### PR DESCRIPTION
This breaks API compatibility for MD4 and MD2 switching the public API from returning void to returning int.