### PR TITLE
wolfCrypt API hardening: input validation, key zeroization, hardware ports

### DIFF
--- a/tests/api/test_rc2.c
+++ b/tests/api/test_rc2.c
@@ -284,3 +284,28 @@ int test_wc_Rc2Cbc_MonteCarlo(void)
 #endif
     return EXPECT_RESULT();
 }
+
+/*
+ * Testing function for wc_Rc2Free().
+ */
+int test_wc_Rc2Free(void)
+{
+    EXPECT_DECLS;
+#ifdef WC_RC2
+    Rc2  rc2;
+    byte key[] = { 0x01, 0x02, 0x03, 0x04, 0x05 };
+    byte iv[]  = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    byte zero[sizeof(rc2)];
+
+    XMEMSET(&rc2, 0, sizeof(rc2));
+    XMEMSET(zero, 0, sizeof(zero));
+
+    wc_Rc2Free(NULL);
+
+    ExpectIntEQ(wc_Rc2SetKey(&rc2, key, (word32)sizeof(key), iv, 40), 0);
+    ExpectIntNE(XMEMCMP(&rc2, zero, sizeof(rc2)), 0);
+    wc_Rc2Free(&rc2);
+    ExpectIntEQ(XMEMCMP(&rc2, zero, sizeof(rc2)), 0);
+#endif
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_rc2.h
+++ b/tests/api/test_rc2.h
@@ -29,12 +29,14 @@ int test_wc_Rc2SetIV(void);
 int test_wc_Rc2EcbEncryptDecrypt(void);
 int test_wc_Rc2CbcEncryptDecrypt(void);
 int test_wc_Rc2Cbc_MonteCarlo(void);
+int test_wc_Rc2Free(void);
 
 #define TEST_RC2_DECLS                                      \
     TEST_DECL_GROUP("rc2", test_wc_Rc2SetKey),              \
     TEST_DECL_GROUP("rc2", test_wc_Rc2SetIV),               \
     TEST_DECL_GROUP("rc2", test_wc_Rc2EcbEncryptDecrypt),   \
     TEST_DECL_GROUP("rc2", test_wc_Rc2CbcEncryptDecrypt),   \
-    TEST_DECL_GROUP("rc2", test_wc_Rc2Cbc_MonteCarlo)
+    TEST_DECL_GROUP("rc2", test_wc_Rc2Cbc_MonteCarlo),      \
+    TEST_DECL_GROUP("rc2", test_wc_Rc2Free)
 
 #endif /* WOLFCRYPT_TEST_RC2_H */

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -309,6 +309,11 @@ int wc_curve25519_make_pub_blind(int public_size, byte* pub, int private_size,
     if ((pub == NULL) || (priv == NULL)) {
         return ECC_BAD_ARG_E;
     }
+#ifndef FREESCALE_LTC_ECC
+    if (rng == NULL) {
+        return ECC_BAD_ARG_E;
+    }
+#endif
 
     /* check clamping */
     ret = curve25519_priv_clamp_check(priv);
@@ -420,6 +425,9 @@ int wc_curve25519_generic_blind(int public_size, byte* pub,
     }
     if ((pub == NULL) || (priv == NULL) || (basepoint == NULL))
         return ECC_BAD_ARG_E;
+    if (rng == NULL) {
+        return ECC_BAD_ARG_E;
+    }
 
     /* check clamping */
     ret = curve25519_priv_clamp_check(priv);

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_rsa.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_rsa.c
@@ -251,7 +251,7 @@ static int tsip_RsakeyImport(TsipUserCtx* tuc)
  */
 int wc_tsip_RsaFunction(wc_CryptoInfo* info, TsipUserCtx* tuc)
 {
-    int ret;
+    int ret = CRYPTOCB_UNAVAILABLE;
     int keySize;
     int type;
     tsip_rsa_byte_data_t plain, cipher;
@@ -320,6 +320,9 @@ int wc_tsip_RsaFunction(wc_CryptoInfo* info, TsipUserCtx* tuc)
                 if (ret == 0) {
                     *(info->pk.rsa.outLen) = plain.data_length;
                 }
+            }
+            else {
+                ret = CRYPTOCB_UNAVAILABLE;
             }
             tsip_hw_unlock();
         }

--- a/wolfcrypt/src/port/nxp/casper_port.c
+++ b/wolfcrypt/src/port/nxp/casper_port.c
@@ -52,9 +52,15 @@ int casper_rsa_public_exptmod(
     int res;
     int sig_sz = inLen;
     int key_sz = mp_unsigned_bin_size(&key->n);
-    word32 exp = 0;
+    int exp_sz = mp_unsigned_bin_size(&key->e);
+    uint8_t exp_buf[sizeof(uint32_t)];
+    uint32_t exp = 0;
 
     if (inLen > CASPER_MAX_BUF_SZ || *outLen > CASPER_MAX_BUF_SZ)
+        return BAD_FUNC_ARG;
+
+    /* casper only accepts a 32-bit public exponent */
+    if (exp_sz <= 0 || exp_sz > (int)sizeof(exp_buf))
         return BAD_FUNC_ARG;
 
     /* casper requires little endian format for inputs/outputs */
@@ -65,8 +71,13 @@ int casper_rsa_public_exptmod(
         return res;
     mp_reverse(key_buf, key_sz);
 
-    if ((res = mp_to_unsigned_bin(&key->e, (uint8_t *)&exp)) != MP_OKAY)
+    XMEMSET(exp_buf, 0, sizeof(exp_buf));
+    if ((res = mp_to_unsigned_bin(&key->e,
+                                  exp_buf + sizeof(exp_buf) - exp_sz))
+        != MP_OKAY)
         return res;
+    exp = ((uint32_t)exp_buf[0] << 24) | ((uint32_t)exp_buf[1] << 16) |
+          ((uint32_t)exp_buf[2] <<  8) | ((uint32_t)exp_buf[3]);
 
     CASPER_ModExp(CASPER, (void *)sig_buf, (void *)key_buf,
             key_sz / sizeof(uint32_t), exp, out_buf);

--- a/wolfcrypt/src/rc2.c
+++ b/wolfcrypt/src/rc2.c
@@ -348,5 +348,13 @@ int wc_Rc2CbcDecrypt(Rc2* rc2, byte* out, const byte* in, word32 sz)
 }
 
 
+void wc_Rc2Free(Rc2* rc2)
+{
+    if (rc2 == NULL)
+        return;
+    ForceZero(rc2, sizeof(Rc2));
+}
+
+
 #endif /* WC_RC2 */
 

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -649,7 +649,7 @@ int wc_CryptKey(const char* password, int passwordSz, const byte* salt,
                     else
                         ret = wc_Rc2CbcDecrypt(&rc2, input, input, length);
                 }
-                ForceZero(&rc2, sizeof(Rc2));
+                wc_Rc2Free(&rc2);
                 break;
             }
     #endif

--- a/wolfcrypt/src/wolfentropy.c
+++ b/wolfcrypt/src/wolfentropy.c
@@ -495,6 +495,10 @@ int wc_Entropy_GetRawEntropy(unsigned char* raw, int cnt)
     int ret = 0;
     int locked = 0;
 
+    if (raw == NULL || cnt <= 0) {
+        return BAD_FUNC_ARG;
+    }
+
 #ifdef HAVE_FIPS
     if (!entropy_memuse_initialized) {
         ret = Entropy_Init();
@@ -809,10 +813,16 @@ static int Entropy_Condition(byte* output, word32 len, byte* noise,
 int wc_Entropy_Get(int bits, unsigned char* entropy, word32 len)
 {
     int ret = 0;
+    int noise_len;
+    static byte noise[MAX_NOISE_CNT];
+
+    if (bits <= 0 || (entropy == NULL && len > 0)) {
+        return BAD_FUNC_ARG;
+    }
+
     /* Noise length is the number of 8 byte samples required to get the bits of
      * entropy requested. */
-    int noise_len = (bits + ENTROPY_EXTRA) / ENTROPY_MIN;
-    static byte noise[MAX_NOISE_CNT];
+    noise_len = (bits + ENTROPY_EXTRA) / ENTROPY_MIN;
 
 #ifdef HAVE_FIPS
     /* FIPS KATs, e.g. EccPrimitiveZ_KnownAnswerTest(), call wc_Entropy_Get()

--- a/wolfssl/wolfcrypt/rc2.h
+++ b/wolfssl/wolfcrypt/rc2.h
@@ -60,6 +60,8 @@ WOLFSSL_API int wc_Rc2CbcEncrypt(Rc2* rc2, byte* out,
 WOLFSSL_API int wc_Rc2CbcDecrypt(Rc2* rc2, byte* out,
                                  const byte* in, word32 sz);
 
+WOLFSSL_API void wc_Rc2Free(Rc2* rc2);
+
 #ifdef __cplusplus
     } /* extern "C" */
 #endif


### PR DESCRIPTION
Fixes F-2214, F-3751, F-3752, F-3753, F-3754, F-3773, F-3782

- curve25519: reject NULL rng in wc_curve25519_make_pub_blind / generic_blind
- wolfentropy: reject NULL output and non-positive size in wc_Entropy_Get / GetRawEntropy
- rc2: add wc_Rc2Free to zero key schedule via ForceZero (plus test)
- TSIP RSA: initialize ret to CRYPTOCB_UNAVAILABLE on unsupported key / failed import
- casper RSA: bound exponent write to 4 bytes and assemble uint32_t portably