### PR TITLE
20260512-fips-gating-fixes

### DIFF
--- a/tests/api/test_dtls.c
+++ b/tests/api/test_dtls.c
@@ -1932,8 +1932,9 @@ int test_dtls13_frag_ch2_with_ch1_rtx(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) &&                           \
-    defined(WOLFSSL_DTLS13) && defined(WOLFSSL_DTLS) &&                         \
-    defined(WOLFSSL_DTLS_MTU) && defined(WOLFSSL_DTLS_CH_FRAG)
+    defined(WOLFSSL_DTLS13) && defined(WOLFSSL_DTLS) &&                        \
+    defined(WOLFSSL_DTLS_MTU) && defined(WOLFSSL_DTLS_CH_FRAG) &&              \
+    (!defined(HAVE_FIPS) || FIPS_VERSION3_GE(7,0,0))
     WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
     WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
     struct test_memio_ctx test_ctx;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -34317,6 +34317,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pbkdf2_test(void)
     if (XMEMCMP(derived, verify, sizeof(verify)) != 0)
         return WC_TEST_RET_ENC_NC;
 
+#if !defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION3_GE(7,0,0))
     {
         int cur_pbkdf_limit = wc_PBKDF_max_iterations_set(iterations - 1);
         if (cur_pbkdf_limit <= 0)
@@ -34340,9 +34342,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pbkdf2_test(void)
             return WC_TEST_RET_ENC_EC(ret);
         ret = 0;
     }
+#endif /* !HAVE_SELFTEST) && (!HAVE_FIPS || FIPS_VERSION3_GE(7,0,0)) */
 
     return ret;
-
 }
 #endif /* HAVE_PBKDF2 && !NO_SHA256 && !NO_HMAC */
 
@@ -34397,7 +34399,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pwdbased_test(void)
         return ret;
 #endif
 #if defined(HAVE_PKCS12) && !defined(NO_ASN) && !defined(NO_PWDBASED) && \
-    !defined(NO_HMAC) && !defined(NO_CERTS) && !defined(WOLFSSL_NO_MALLOC)
+    !defined(NO_HMAC) && !defined(NO_CERTS) && !defined(WOLFSSL_NO_MALLOC) && \
+    !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0))
     /* Test that a crafted PKCS#12 with INT_MAX MAC iterations is rejected
      * immediately rather than hanging in DoPKCS12Hash(). */
     {
@@ -34445,7 +34448,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pwdbased_test(void)
             return ret;
     }
 #endif /* HAVE_PKCS12 && !NO_ASN && !NO_PWDBASED && !NO_HMAC && !NO_CERTS && */
-       /* !WOLFSSL_NO_MALLOC                                                 */
+       /* !WOLFSSL_NO_MALLOC &&                                              */
+       /* !HAVE_SELFTEST && (!HAVE_FIPS || FIPS_VERSION_GE(7,0))             */
 #ifdef HAVE_SCRYPT
     ret = scrypt_test();
 #endif
@@ -34543,6 +34547,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pkcs12_test(void)
         goto out;
     }
 
+#if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0))
     /* Test that a crafted PKCS#12 with INT_MAX MAC iterations is rejected
      * immediately rather than hanging in DoPKCS12Hash(). This is a 90-byte
      * minimal PKCS#12 with mac->itt = 0x7FFFFFFF (2,147,483,647). */
@@ -34587,6 +34592,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pkcs12_test(void)
             ret = 0;  /* rejection is the expected outcome */
         }
     }
+#endif /* !HAVE_SELFTEST && (!HAVE_FIPS || FIPS_VERSION_GE(7,0)) */
 
 out:
 
@@ -43255,6 +43261,8 @@ static wc_test_ret_t ecc_buffers_encrypt_test(ecc_key* cliKey, ecc_key* servKey,
     if (XMEMCMP(plain, in, inLen))
         return WC_TEST_RET_ENC_NC;
 
+#if !defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION3_GE(6,0,0))
     /* Negative test: corrupt HMAC tag in encrypted msg, expect
      * HASH_TYPE_E from wc_ecc_decrypt. */
     out[x - 1] ^= 0x01;
@@ -43262,6 +43270,7 @@ static wc_test_ret_t ecc_buffers_encrypt_test(ecc_key* cliKey, ecc_key* servKey,
     ret = wc_ecc_decrypt(servKey, tmpKey, out, x, plain, &y, NULL);
     if (ret != WC_NO_ERR_TRACE(HASH_TYPE_E))
         return WC_TEST_RET_ENC_EC(ret);
+#endif /* !HAVE_SELFTEST && (!HAVE_FIPS || FIPS_VERSION3_GE(6,0,0)) */
 
     (void)tmpKey;
     return 0;

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -552,7 +552,7 @@ WOLFSSL_LOCAL int wc_debug_CipherLifecycleFree(void **CipherLifecycleTag,
 
 #if defined(WOLFSSL_LINUXKM) || defined(WC_SYM_RELOC_TABLES) || \
     defined(WC_SYM_RELOC_TABLES_SUPPORT)
-    #include "linuxkm/linuxkm_memory.h"
+    #include "../../linuxkm/linuxkm_memory.h"
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
wolfcrypt/test/test.c:
* in pbkdf2_test(), pwdbased_test(), and pkcs12_test(), add missing FIPS v7+ gates around stanzas that use wc_PBKDF_max_iterations_set() and wc_PBKDF_max_iterations_get() or depend on erroring for excessive PBKDF iterations (fixes #10050);

* in ecc_test_buffers(), omit new corrupt HMAC tag test on FIPS <v6 (fixes 8f2a3f9563).

tests/api/test_dtls.c: add FIPS v7+ gate to test_dtls13_frag_ch2_with_ch1_rtx().

wolfssl/wolfcrypt/memory.h: #include "../../linuxkm/linuxkm_memory.h" rather than "linuxkm/linuxkm_memory.h", following pattern in wc_port.h.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
all-gcc-c99
all-crypto-openssl-extra-coexist-fips-v5-pilot
all-crypto-openssl-extra-coexist-fips-v6
all-crypto-openssl-extra-coexist-fips-dev
all-c89-clang-tidy
all-crypto-only-intelasm-fips-v5-linuxkm-next-insmod-optest
all-crypto-only-intelasm-fips-v6-linuxkm-next-insmod-optest
linuxkm-6.12-cryptonly-intelasm-fips-v6-dyn-hash-LKCAPI-insmod
linuxkm-next-fips-dev-insmod-wolfguard-compkey
linuxkm-fips-v5-vanilla-insmod-wolfguard-cust-kernel-3-compkey
linuxkm-fips-v6-insmod-wolfguard-cust-kernel-3
clang-tidy-all-intelasm
clang-tidy-all-async-quic
linuxkm-6.15-all-cryptonly-quantum-safe-intelasm-LKCAPI-insmod-crypto-fuzzer-kmemleak
linuxkm-6.15-all-cryptonly-quantum-safe-intelasm-LKCAPI-insmod-crypto-fuzzer-ksan
```
