### PR TITLE
ci: switch direct apt usage to install-apt-deps action

### DIFF
--- a/.github/workflows/linuxkm.yml
+++ b/.github/workflows/linuxkm.yml
@@ -28,19 +28,13 @@ jobs:
       - uses: actions/checkout@v4
         name: Checkout wolfSSL
 
+      - name: Install linux-headers
+        uses: ./.github/actions/install-apt-deps
+        with:
+          packages: linux-headers-$(uname -r)
+
       - name: Prepare target kernel for module builds
         run: |
-          echo "updating linux-headers"
-          apt_ok=false
-          for i in 1 2 3; do
-            if sudo apt-get update && sudo apt-get install -y linux-headers-$(uname -r); then
-              apt_ok=true
-              break
-            fi
-            echo "::warning::apt-get failed (attempt $i/3), retrying..."
-            sleep $((5 * i))
-          done
-          if [ "$apt_ok" != true ]; then exit 2; fi
           echo "preparing target kernel $(uname -r)"
           pushd "/lib/modules/$(uname -r)/build" || $(exit 4)
           if [ -f /proc/config.gz ]; then gzip -dc /proc/config.gz > /tmp/.config && sudo mv /tmp/.config . || $(exit 5); elif [ -f "/boot/config-$(uname -r)" ]; then sudo cp -p "/boot/config-$(uname -r)" .config || $(exit 6); fi

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -56,11 +56,11 @@ jobs:
     # This should be a safe limit for the tests to run.
     timeout-minutes: 10
     steps:
-      - name: Install Compiler
-        run: |
-          sudo apt update
-          sudo apt install -y crossbuild-essential-${{ matrix.ARCH }} qemu-user
       - uses: actions/checkout@v4
+      - name: Install Compiler
+        uses: ./.github/actions/install-apt-deps
+        with:
+          packages: crossbuild-essential-${{ matrix.ARCH }} qemu-user
       - name: Build for ${{ matrix.ARCH }} with ${{ matrix.opts.name }}
         env:
             CC: ${{ matrix.CC }}


### PR DESCRIPTION
multi-arch.yml and linuxkm.yml were installing apt packages with inline
shell commands. Replace them with the install-apt-deps composite action
for consistent retry behavior and caching.
