### PR TITLE
Avoid unused variable errors in aesgcm_non12iv_test

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -19521,10 +19521,9 @@ static wc_test_ret_t aesgcm_non12iv_test(Aes* enc, Aes* dec)
     XFREE(large_output, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(large_outdec, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
-#else
+#endif /* ENABLE_NON_12BYTE_IV_TEST */
     (void)enc;
     (void)dec;
-#endif /* ENABLE_NON_12BYTE_IV_TEST */
     return ret;
 }
 


### PR DESCRIPTION
# Description

Currently blocking wolfHSM CI with the error below:

```
cc  -std=c90 -Werror -Wall -Wextra -ffunction-sections -fdata-sections -ggdb -g3 -fsanitize=address -D_POSIX_C_SOURCE=200809L -DWOLFHSM_CFG -DWOLFSSL_USER_SETTINGS -DWOLFHSM_CFG_DEBUG -DWOLFHSM_CFG_DEBUG_VERBOSE -DWC_USE_DEVID=0x5748534D -DWOLFHSM_CFG_ENABLE_AUTHENTICATION -I. -I./config -I./../ -I../../../wolfssl -I../../../ -I../../..//port/posix -I../../..//examples/demo/client -c -o Build/wh_demo_client_wctest.o ../../..//examples/demo/client/wh_demo_client_wctest.c
../../../wolfssl/wolfcrypt/test/test.c: In function ‘aesgcm_non12iv_test’:
../../../wolfssl/wolfcrypt/test/test.c:19220:57: error: unused parameter ‘dec’ [-Werror=unused-parameter]
19220 | static wc_test_ret_t aesgcm_non12iv_test(Aes* enc, Aes* dec)
      |                                                    ~~~~~^~~
cc1: all warnings being treated as errors
```

Note: wolfHSM tests define `BENCH_EMBEDDED` which means `BENCH_AESGCM_LARGE` is undefined and `dec` is not used. 

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
