### PR TITLE
13052026 Coverity Fixes

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10154,18 +10154,10 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     #endif
     #ifdef WOLFSSL_TLS13
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-        if (ssl->ctx != NULL) {
-            ssl->options.noPskDheKe = ssl->ctx->noPskDheKe;
-          #ifdef HAVE_SUPPORTED_CURVES
-            ssl->options.onlyPskDheKe = ssl->ctx->onlyPskDheKe;
-          #endif
-        }
-        else {
-            ssl->options.noPskDheKe = 0;
-          #ifdef HAVE_SUPPORTED_CURVES
-            ssl->options.onlyPskDheKe = 0;
-          #endif
-        }
+        ssl->options.noPskDheKe = ssl->ctx->noPskDheKe;
+        #ifdef HAVE_SUPPORTED_CURVES
+        ssl->options.onlyPskDheKe = ssl->ctx->onlyPskDheKe;
+        #endif
     #endif
     #endif
     #ifdef HAVE_SESSION_TICKET

--- a/tests/api.c
+++ b/tests/api.c
@@ -23967,21 +23967,23 @@ static int test_ParseSerial0FixtureMatrix(void)
         ExpectIntGE(derSz = wc_CertPemToDer(pemBuf, (int)pemSz, derBuf,
             (int)pemSz, CERT_TYPE), 0);
 
-        wc_InitDecodedCert(&dc, derBuf, (word32)derSz, NULL);
-        ret = wc_ParseCert(&dc, CERT_TYPE, NO_VERIFY, NULL);
-        if (cases[i].certTypeShouldPass)
-            ExpectIntEQ(ret, 0);
-        else
-            ExpectIntNE(ret, 0);
-        wc_FreeDecodedCert(&dc);
+        if (EXPECT_SUCCESS()) {
+            wc_InitDecodedCert(&dc, derBuf, (word32)derSz, NULL);
+            ret = wc_ParseCert(&dc, CERT_TYPE, NO_VERIFY, NULL);
+            if (cases[i].certTypeShouldPass)
+                ExpectIntEQ(ret, 0);
+            else
+                ExpectIntNE(ret, 0);
+            wc_FreeDecodedCert(&dc);
 
-        wc_InitDecodedCert(&dc, derBuf, (word32)derSz, NULL);
-        ret = wc_ParseCert(&dc, CA_TYPE, NO_VERIFY, NULL);
-        if (cases[i].caTypeShouldPass)
-            ExpectIntEQ(ret, 0);
-        else
-            ExpectIntNE(ret, 0);
-        wc_FreeDecodedCert(&dc);
+            wc_InitDecodedCert(&dc, derBuf, (word32)derSz, NULL);
+            ret = wc_ParseCert(&dc, CA_TYPE, NO_VERIFY, NULL);
+            if (cases[i].caTypeShouldPass)
+                ExpectIntEQ(ret, 0);
+            else
+                ExpectIntNE(ret, 0);
+            wc_FreeDecodedCert(&dc);
+        }
 
         XFREE(derBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         XFREE(pemBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/tests/api/api.h
+++ b/tests/api/api.h
@@ -268,9 +268,6 @@ static WC_INLINE int test_pkcs8_get_version_byte(const byte* der, word32 derSz)
     if (der[idx++] != 0x30) {
         return -1;
     }
-    if (idx >= derSz) {
-        return -1;
-    }
     if ((der[idx] & 0x80) == 0) {
         /* short-form length */
         idx += 1;

--- a/tests/api/test_camellia.c
+++ b/tests/api/test_camellia.c
@@ -126,6 +126,7 @@ int test_wc_CamelliaFree(void)
     byte zero[sizeof(camellia)];
 
     XMEMSET(zero, 0, sizeof(zero));
+    XMEMSET(&camellia, 0, sizeof(camellia));
 
     /* NULL is safe. */
     wc_CamelliaFree(NULL);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -31263,9 +31263,6 @@ static wc_test_ret_t openssl_aes_cbc_test(void)
             return WC_TEST_RET_ENC_NC;
         if (outlen != 16)
             return WC_TEST_RET_ENC_NC;
-        total += outlen;
-        if (total != 32)
-            return 3408;
 
         wolfSSL_EVP_CIPHER_CTX_cleanup(en);
 
@@ -31331,9 +31328,6 @@ static wc_test_ret_t openssl_aes_cbc_test(void)
         if (wolfSSL_EVP_CipherFinal(en, (byte*)&cipher[total], &outlen) == 0)
             return WC_TEST_RET_ENC_NC;
         if (outlen != 16)
-            return WC_TEST_RET_ENC_NC;
-        total += outlen;
-        if (total != 32)
             return WC_TEST_RET_ENC_NC;
 
         wolfSSL_EVP_CIPHER_CTX_cleanup(en);


### PR DESCRIPTION
# Description

CID 561133/560824: Logically dead code - removed dead code
CID 561132: Explicit null dereferenced - add check before using potentially null value
CID 560823: Uninitialized scalar variable - initialize camellia variable
CID 560822: Dereference after null check - refactored check, remove null check to prevent null dereference issue

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
