### PR TITLE
Add error when RPK is used with DANE stub

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -122,6 +122,20 @@ PR stands for Pull Request, and PR <NUMBER> references a GitHub pull request num
 
 * **BREAKING (FIPS 205 SLH-DSA)**: `wc_SlhDsaKey_SignHash`, `wc_SlhDsaKey_SignHashDeterministic`, `wc_SlhDsaKey_SignHashWithRandom`, and `wc_SlhDsaKey_VerifyHash` now take the **caller-pre-hashed message digest** via `hash`/`hashSz` parameters (renamed from `msg`/`msgSz`), aligned with ML-DSA's `wc_dilithium_sign_ctx_hash` / `wc_dilithium_verify_ctx_hash` semantics, and NIST ACVP `signatureInterface=external` / `preHash=preHash` test vectors. `hashSz` must equal `wc_HashGetDigestSize(hashType)` (32 bytes for SHAKE128, 64 bytes for SHAKE256 per FIPS 205 Section 10.2.2); otherwise `BAD_LENGTH_E` is returned. Migration: hash the message yourself before the call (callers using positional arguments are source-compatible; only the parameter names changed). Caveat: callers who today pass a raw message whose length happens to equal the digest size for the chosen `hashType` (e.g., signing a 32-byte handle/IV/seed with `WC_HASH_TYPE_SHA256`) will not trip `BAD_LENGTH_E`; the resulting signature is syntactically valid but is over the wrong bytes. The pre-existing `wc_SlhDsaKey_SignMsgDeterministic` and `wc_SlhDsaKey_SignMsgWithRandom` retain their M'-supplied-directly contract (FIPS 205 internal interface, Algorithm 19); their input validation is hardened with the same NULL/length/`MISSING_KEY` checks as the `*Hash*` family. `wc_SlhDsaKey_VerifyMsg` is unchanged. All three gain doxygen coverage. (PR 10450, PR 10465)
 
+* **Behavioral change (Raw Public Key fail-closed)**: With `HAVE_RPK`, a peer
+  that presents a Raw Public Key (RFC 7250) is no longer silently accepted while
+  it is being authenticated. Previously an RPK handshake always completed and
+  the application validated the key out of band afterward (e.g. via
+  `wolfSSL_get_verify_result()`); it now fails closed (with `RPK_UNTRUSTED_E`,
+  reported as `WOLFSSL_X509_V_ERR_RPK_UNTRUSTED`) whenever the peer is being
+  authenticated, i.e. any verify mode other than `WOLFSSL_VERIFY_NONE`. This
+  applies to all `HAVE_RPK` builds, including those without `OPENSSL_EXTRA` (no
+  prior untrusted-RPK handling) and `NO_SHA256` builds (no in-library pinning).
+  To establish trust, pin the expected key with the new
+  `wolfSSL_set_expected_rpk()` / `wolfSSL_CTX_set_expected_rpk()` APIs
+  (requires SHA-256), install a verify callback that accepts the key, or set
+  `WOLFSSL_VERIFY_NONE` to accept without authentication.
+
 * **Behavioral change (RSA-PSS trailerField enforcement)**: `DecodeRsaPssParams`
   (and its public wrapper `wc_DecodeRsaPssParams`) now enforces RFC 8017 A.2.3,
   which mandates `trailerField == trailerFieldBC(1)`.  In the default build

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -16096,6 +16096,78 @@ int wolfSSL_get_negotiated_client_cert_type(WOLFSSL* ssl, int* tp);
 int wolfSSL_get_negotiated_server_cert_type(WOLFSSL* ssl, int* tp);
 
 /*!
+ \ingroup Setup
+ \brief  Pin a DER-encoded SubjectPublicKeyInfo that the peer is expected to
+ present as a Raw Public Key (RFC 7250), establishing out-of-band trust on the
+ WOLFSSL_CTX object. An unauthenticated RPK peer is otherwise rejected: when the
+ peer is being authenticated (any verify mode other than WOLFSSL_VERIFY_NONE)
+ the handshake fails closed unless the presented key matches a pin (or a verify
+ callback accepts it). May be called more than once to pin several keys, up to
+ WOLFSSL_MAX_RPK_PINS. The key is stored as its SHA-256 digest, so this API
+ requires SHA-256. Pins are append-only for the lifetime of the CTX.
+
+ \return WOLFSSL_SUCCESS on success
+ \return BAD_FUNC_ARG if ctx or spki is NULL, or spkiSz is 0
+ \return BUFFER_E if the pin table is already full (WOLFSSL_MAX_RPK_PINS)
+ \return other negative error code on a hashing failure
+
+ \param ctx     WOLFSSL_CTX object pointer
+ \param spki    DER-encoded SubjectPublicKeyInfo the peer is expected to present
+ \param spkiSz  length of spki in bytes
+    _Example_
+ \code
+  int ret;
+  WOLFSSL_CTX* ctx;
+  const unsigned char* spki; /* DER SubjectPublicKeyInfo */
+  unsigned int spkiSz;
+  ...
+
+  ret = wolfSSL_CTX_set_expected_rpk(ctx, spki, spkiSz);
+ \endcode
+ \sa wolfSSL_set_expected_rpk
+ \sa wolfSSL_set_client_cert_type
+ \sa wolfSSL_set_server_cert_type
+ */
+int wolfSSL_CTX_set_expected_rpk(WOLFSSL_CTX* ctx, const unsigned char* spki,
+    unsigned int spkiSz);
+
+/*!
+ \ingroup Setup
+ \brief  Pin a DER-encoded SubjectPublicKeyInfo that the peer is expected to
+ present as a Raw Public Key (RFC 7250), establishing out-of-band trust on the
+ WOLFSSL object. An unauthenticated RPK peer is otherwise rejected: when the
+ peer is being authenticated (any verify mode other than WOLFSSL_VERIFY_NONE)
+ the handshake fails closed unless the presented key matches a pin (or a verify
+ callback accepts it). May be called more than once to pin several keys, up to
+ WOLFSSL_MAX_RPK_PINS. The key is stored as its SHA-256 digest, so this API
+ requires SHA-256. Pins are append-only for the lifetime of the object.
+
+ \return WOLFSSL_SUCCESS on success
+ \return BAD_FUNC_ARG if ssl or spki is NULL, or spkiSz is 0
+ \return BUFFER_E if the pin table is already full (WOLFSSL_MAX_RPK_PINS)
+ \return other negative error code on a hashing failure
+
+ \param ssl     WOLFSSL object pointer
+ \param spki    DER-encoded SubjectPublicKeyInfo the peer is expected to present
+ \param spkiSz  length of spki in bytes
+    _Example_
+ \code
+  int ret;
+  WOLFSSL* ssl;
+  const unsigned char* spki; /* DER SubjectPublicKeyInfo */
+  unsigned int spkiSz;
+  ...
+
+  ret = wolfSSL_set_expected_rpk(ssl, spki, spkiSz);
+ \endcode
+ \sa wolfSSL_CTX_set_expected_rpk
+ \sa wolfSSL_set_client_cert_type
+ \sa wolfSSL_set_server_cert_type
+ */
+int wolfSSL_set_expected_rpk(WOLFSSL* ssl, const unsigned char* spki,
+    unsigned int spkiSz);
+
+/*!
 
 \brief Enable use of ConnectionID extensions for the SSL object. See RFC 9146
 and RFC 9147

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -16104,7 +16104,8 @@ int wolfSSL_get_negotiated_server_cert_type(WOLFSSL* ssl, int* tp);
  the handshake fails closed unless the presented key matches a pin (or a verify
  callback accepts it). May be called more than once to pin several keys, up to
  WOLFSSL_MAX_RPK_PINS. The key is stored as its SHA-256 digest, so this API
- requires SHA-256. Pins are append-only for the lifetime of the CTX.
+ requires SHA-256. Pins are append-only - there is no per-entry remove, but
+ wolfSSL_CTX_clear_expected_rpk() empties the table so it can be repopulated.
 
  \return WOLFSSL_SUCCESS on success
  \return BAD_FUNC_ARG if ctx or spki is NULL, or spkiSz is 0
@@ -16118,13 +16119,14 @@ int wolfSSL_get_negotiated_server_cert_type(WOLFSSL* ssl, int* tp);
  \code
   int ret;
   WOLFSSL_CTX* ctx;
-  const unsigned char* spki; /* DER SubjectPublicKeyInfo */
+  const unsigned char* spki;
   unsigned int spkiSz;
   ...
 
   ret = wolfSSL_CTX_set_expected_rpk(ctx, spki, spkiSz);
  \endcode
  \sa wolfSSL_set_expected_rpk
+ \sa wolfSSL_CTX_clear_expected_rpk
  \sa wolfSSL_set_client_cert_type
  \sa wolfSSL_set_server_cert_type
  */
@@ -16140,7 +16142,8 @@ int wolfSSL_CTX_set_expected_rpk(WOLFSSL_CTX* ctx, const unsigned char* spki,
  the handshake fails closed unless the presented key matches a pin (or a verify
  callback accepts it). May be called more than once to pin several keys, up to
  WOLFSSL_MAX_RPK_PINS. The key is stored as its SHA-256 digest, so this API
- requires SHA-256. Pins are append-only for the lifetime of the object.
+ requires SHA-256. Pins are append-only - there is no per-entry remove, but
+ wolfSSL_clear_expected_rpk() empties the table so it can be repopulated.
 
  \return WOLFSSL_SUCCESS on success
  \return BAD_FUNC_ARG if ssl or spki is NULL, or spkiSz is 0
@@ -16154,18 +16157,66 @@ int wolfSSL_CTX_set_expected_rpk(WOLFSSL_CTX* ctx, const unsigned char* spki,
  \code
   int ret;
   WOLFSSL* ssl;
-  const unsigned char* spki; /* DER SubjectPublicKeyInfo */
+  const unsigned char* spki;
   unsigned int spkiSz;
   ...
 
   ret = wolfSSL_set_expected_rpk(ssl, spki, spkiSz);
  \endcode
  \sa wolfSSL_CTX_set_expected_rpk
+ \sa wolfSSL_clear_expected_rpk
  \sa wolfSSL_set_client_cert_type
  \sa wolfSSL_set_server_cert_type
  */
 int wolfSSL_set_expected_rpk(WOLFSSL* ssl, const unsigned char* spki,
     unsigned int spkiSz);
+
+/*!
+ \ingroup Setup
+ \brief  Remove all pinned expected peer Raw Public Keys (RFC 7250) from the
+ WOLFSSL_CTX object, emptying the table so it can be repopulated - for example
+ across a peer key rotation, since the pinning APIs are otherwise append-only.
+ Like other WOLFSSL_CTX setters this is not locked, so reconfigure the pins on a
+ shared CTX while no handshakes are in flight (a WOLFSSL created with
+ wolfSSL_new() copies the pin table by value at creation time).
+
+ \return WOLFSSL_SUCCESS on success
+ \return BAD_FUNC_ARG if ctx is NULL
+
+ \param ctx  WOLFSSL_CTX object pointer
+    _Example_
+ \code
+  WOLFSSL_CTX* ctx;
+  ...
+
+  wolfSSL_CTX_clear_expected_rpk(ctx);
+ \endcode
+ \sa wolfSSL_CTX_set_expected_rpk
+ \sa wolfSSL_clear_expected_rpk
+ */
+int wolfSSL_CTX_clear_expected_rpk(WOLFSSL_CTX* ctx);
+
+/*!
+ \ingroup Setup
+ \brief  Remove all pinned expected peer Raw Public Keys (RFC 7250) from the
+ WOLFSSL object, emptying the table so it can be repopulated - for example
+ across a peer key rotation, since the pinning APIs are otherwise append-only.
+
+ \return WOLFSSL_SUCCESS on success
+ \return BAD_FUNC_ARG if ssl is NULL
+
+ \param ssl  WOLFSSL object pointer
+    _Example_
+ \code
+  WOLFSSL* ssl;
+  ...
+
+  wolfSSL_clear_expected_rpk(ssl);
+ \endcode
+ \sa wolfSSL_set_expected_rpk
+ \sa wolfSSL_CTX_clear_expected_rpk
+ */
+int wolfSSL_clear_expected_rpk(WOLFSSL* ssl);
 
 /*!
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -15216,6 +15216,7 @@ void DoCertFatalAlert(WOLFSSL* ssl, int ret)
         alertWhy = certificate_expired;
     }
     else if (ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E) ||
+             ret == WC_NO_ERR_TRACE(RPK_UNTRUSTED_E) ||
              ret == WC_NO_ERR_TRACE(ASN_PATHLEN_INV_E) ||
              ret == WC_NO_ERR_TRACE(ASN_PATHLEN_SIZE_E)) {
         alertWhy = unknown_ca;
@@ -17815,16 +17816,18 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         if (!rpkTrusted && !ssl->options.verifyNone) {
                             WOLFSSL_MSG("Untrusted RPK and peer verification "
                                         "is on; failing handshake");
-                            /* ASN_NO_SIGNER_E ("no trusted signer/anchor") is
-                             * the closest existing error for an unpinned RPK.
-                             * It is set here in the parse-SUCCESS branch, so the
-                             * X.509 recovery that keys on this code (alternate
-                             * chains, CA hash-dir lookup, Apple native
-                             * validation) - all of which live in the
-                             * parse-FAILURE branch above - is not reachable for
-                             * RPK. The leaf verify callback is still invoked at
-                             * TLS_ASYNC_FINALIZE and may override. */
-                            ret = ASN_NO_SIGNER_E;
+                            /* Use a dedicated RPK error rather than an
+                             * X.509 one (e.g. ASN_NO_SIGNER_E) so the failure is
+                             * distinguishable: GetX509Error() maps it to
+                             * WOLFSSL_X509_V_ERR_RPK_UNTRUSTED, so a verify
+                             * callback that accepts X.509 issuer-lookup errors
+                             * (ASN_NO_SIGNER_E /
+                             * WOLFSSL_X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY)
+                             * cannot accidentally accept an unauthenticated RPK.
+                             * The leaf verify callback is still invoked at
+                             * TLS_ASYNC_FINALIZE and may deliberately override
+                             * this RPK-specific code. */
+                            ret = RPK_UNTRUSTED_E;
                             WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
@@ -29023,6 +29026,9 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
 
     case SEQUENCE_NUMBER_E:
         return "Record sequence number would wrap";
+
+    case RPK_UNTRUSTED_E:
+        return "RFC 7250 Raw Public Key not trusted";
     }
 
     return "unknown error number";

--- a/src/internal.c
+++ b/src/internal.c
@@ -16985,6 +16985,43 @@ static int ProcessPeerCertDecodeKey(WOLFSSL* ssl, ProcPeerCertArgs* args,
     return 0;
 }
 
+#if defined(HAVE_RPK)
+/* Determine whether a received Raw Public Key (RFC 7250) has been pinned as
+ * trusted out of band. The on-wire RPK is exactly the DER SubjectPublicKeyInfo,
+ * so its SHA-256 digest is compared against the application-supplied pins.
+ *
+ * @param [in] ssl     SSL/TLS object.
+ * @param [in] spki    DER SubjectPublicKeyInfo received from the peer.
+ * @param [in] spkiSz  Length of spki in bytes.
+ * @return  1 when the key matches a pin, 0 otherwise.
+ */
+static int RpkIsTrusted(WOLFSSL* ssl, const byte* spki, word32 spkiSz)
+{
+#ifndef NO_SHA256
+    RpkConfig* cfg = &ssl->options.rpkConfig;
+
+    if ((cfg->expectedRpkCnt > 0) && (spki != NULL) && (spkiSz > 0)) {
+        byte digest[WC_SHA256_DIGEST_SIZE];
+        int i;
+
+        if (wc_Sha256Hash(spki, spkiSz, digest) == 0) {
+            for (i = 0; i < (int)cfg->expectedRpkCnt; i++) {
+                if (XMEMCMP(digest, cfg->expectedRpk[i],
+                            WC_SHA256_DIGEST_SIZE) == 0) {
+                    return 1;
+                }
+            }
+        }
+    }
+#else
+    (void)ssl;
+    (void)spki;
+    (void)spkiSz;
+#endif /* !NO_SHA256 */
+    return 0;
+}
+#endif /* HAVE_RPK */
+
 int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                      word32 totalSz)
 {
@@ -17736,6 +17773,63 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     if (ssl->peerVerifyRet == 0) /* Return first cert error here */
                         ssl->peerVerifyRet = WOLFSSL_X509_V_OK;
                 #endif
+
+                #if defined(HAVE_RPK)
+                    /* A Raw Public Key cert (RFC 7250) has no issuer and no
+                     * signature, so ParseCertRelative performed no peer
+                     * authentication. The key is only authenticated if it was
+                     * pinned out of band (expected RPK). Applies to both peers
+                     * - client checking the server's RPK and server checking
+                     * the client's RPK. */
+                    if (args->dCert->isRPK) {
+                        int rpkTrusted = RpkIsTrusted(ssl,
+                                args->certs[args->certIdx].buffer,
+                                args->certs[args->certIdx].length);
+
+                    #if defined(OPENSSL_EXTRA) || \
+                        defined(OPENSSL_EXTRA_X509_SMALL)
+                        /* Report the status truthfully regardless of verify
+                         * mode, mirroring OpenSSL: get_verify_result() reflects
+                         * the actual key status even under WOLFSSL_VERIFY_NONE
+                         * rather than leaving it at WOLFSSL_X509_V_OK. */
+                        if (!rpkTrusted &&
+                                ssl->peerVerifyRet == WOLFSSL_X509_V_OK) {
+                            ssl->peerVerifyRet = (unsigned long)
+                                WOLFSSL_X509_V_ERR_RPK_UNTRUSTED;
+                        }
+                    #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+                        /* Fail closed when the peer is being authenticated: an
+                         * untrusted RPK must abort the handshake rather than
+                         * silently complete it.
+                         * The gate is !verifyNone, matching the X.509
+                         * authentication gate above (the VERIFY/NO_VERIFY
+                         * choice passed to ProcessPeerCertParse) - so a default
+                         * authenticating client (verifyPeer unset, verifyNone
+                         * unset) validating an RPK server is protected too, not
+                         * just the explicit WOLFSSL_VERIFY_PEER case. The verify
+                         * callback can still override, exactly as it can for an
+                         * X.509 chain error. WOLFSSL_VERIFY_NONE keeps the
+                         * "accept and let the application decide" behaviour per
+                         * RFC 7250. */
+                        if (!rpkTrusted && !ssl->options.verifyNone) {
+                            WOLFSSL_MSG("Untrusted RPK and peer verification "
+                                        "is on; failing handshake");
+                            /* ASN_NO_SIGNER_E ("no trusted signer/anchor") is
+                             * the closest existing error for an unpinned RPK.
+                             * It is set here in the parse-SUCCESS branch, so the
+                             * X.509 recovery that keys on this code (alternate
+                             * chains, CA hash-dir lookup, Apple native
+                             * validation) - all of which live in the
+                             * parse-FAILURE branch above - is not reachable for
+                             * RPK. The leaf verify callback is still invoked at
+                             * TLS_ASYNC_FINALIZE and may override. */
+                            ret = ASN_NO_SIGNER_E;
+                            WOLFSSL_ERROR_VERBOSE(ret);
+                        }
+                    }
+                #endif /* HAVE_RPK */
+
                 #if defined(SESSION_CERTS) && defined(WOLFSSL_ALT_CERT_CHAINS)
                     /* if using alternate chain, store the cert used */
                     if (ssl->options.usingAltCertChain) {
@@ -17754,17 +17848,10 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     if (ssl->options.side == WOLFSSL_SERVER_END) {
                 #if defined(HAVE_RPK)
                         if (args->dCert->isRPK) {
-                            /* to verify Raw Public Key cert, DANE(RFC6698)
-                             * should be introduced. Without DANE, no
-                             * authentication is performed.
-                             */
-                        #if defined(HAVE_DANE)
-                            if (ssl->useDANE) {
-                                /* DANE authentication should be added */
-                            }
-                        #endif /* HAVE_DANE */
+                            /* RPK certs carry no X.509 version; the RPK trust
+                             * check above already handled this cert. */
                         }
-                        else /* skip followingx509 version check */
+                        else /* skip following x509 version check */
                 #endif  /* HAVE_RPK */
                         if (args->dCert->version != WOLFSSL_X509_V3) {
                             WOLFSSL_MSG("Peers certificate was not version 3!");
@@ -28329,6 +28416,9 @@ static const char* wolfSSL_ERR_reason_error_string_OpenSSL(unsigned long e)
 
     case WOLFSSL_X509_V_ERR_IP_ADDRESS_MISMATCH:
         return "IP address mismatch";
+
+    case WOLFSSL_X509_V_ERR_RPK_UNTRUSTED:
+        return "raw public key not trusted";
 
     default:
         return NULL;

--- a/src/ssl_api_cert.c
+++ b/src/ssl_api_cert.c
@@ -505,6 +505,38 @@ int wolfSSL_set_expected_rpk(WOLFSSL* ssl, const unsigned char* spki,
     ret = rpk_add_expected(&ssl->options.rpkConfig, spki, spkiSz);
     return (ret == 0) ? WOLFSSL_SUCCESS : ret;
 }
+
+/* Remove all pinned expected peer Raw Public Keys from the SSL/TLS CTX object,
+ * so the table can be repopulated (e.g. across a peer key rotation).
+ *
+ * @param [in] ctx  SSL/TLS CTX object.
+ * @return  WOLFSSL_SUCCESS on success.
+ * @return  BAD_FUNC_ARG when ctx is NULL.
+ */
+int wolfSSL_CTX_clear_expected_rpk(WOLFSSL_CTX* ctx)
+{
+    if (ctx == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    ctx->rpkConfig.expectedRpkCnt = 0;
+    return WOLFSSL_SUCCESS;
+}
+
+/* Remove all pinned expected peer Raw Public Keys from the SSL/TLS object, so
+ * the table can be repopulated (e.g. across a peer key rotation).
+ *
+ * @param [in] ssl  SSL/TLS object.
+ * @return  WOLFSSL_SUCCESS on success.
+ * @return  BAD_FUNC_ARG when ssl is NULL.
+ */
+int wolfSSL_clear_expected_rpk(WOLFSSL* ssl)
+{
+    if (ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    ssl->options.rpkConfig.expectedRpkCnt = 0;
+    return WOLFSSL_SUCCESS;
+}
 #endif /* !NO_SHA256 */
 #endif /* HAVE_RPK */
 

--- a/src/ssl_api_cert.c
+++ b/src/ssl_api_cert.c
@@ -430,6 +430,82 @@ int wolfSSL_get_negotiated_server_cert_type(WOLFSSL* ssl, int* tp)
     }
     return ret;
 }
+
+#ifndef NO_SHA256
+/* Store the SHA-256 digest of a DER SubjectPublicKeyInfo as an expected Raw
+ * Public Key (RFC 7250) for out-of-band trust.
+ *
+ * @param [in] cfg     RPK configuration to add the pin to.
+ * @param [in] spki    DER-encoded SubjectPublicKeyInfo.
+ * @param [in] spkiSz  Length of spki in bytes.
+ * @return  0 on success.
+ * @return  BAD_FUNC_ARG when cfg or spki is NULL, or spkiSz is 0.
+ * @return  BUFFER_E when no more pins can be stored.
+ * @return  negative hashing error on failure.
+ */
+static int rpk_add_expected(RpkConfig* cfg, const unsigned char* spki,
+    unsigned int spkiSz)
+{
+    int ret;
+
+    if ((cfg == NULL) || (spki == NULL) || (spkiSz == 0)) {
+        return BAD_FUNC_ARG;
+    }
+    if (cfg->expectedRpkCnt >= WOLFSSL_MAX_RPK_PINS) {
+        return BUFFER_E;
+    }
+
+    ret = wc_Sha256Hash(spki, spkiSz, cfg->expectedRpk[cfg->expectedRpkCnt]);
+    if (ret == 0) {
+        cfg->expectedRpkCnt++;
+    }
+    return ret;
+}
+
+/* Pin an expected peer Raw Public Key on the SSL/TLS CTX object.
+ *
+ * @param [in] ctx     SSL/TLS CTX object.
+ * @param [in] spki    DER-encoded SubjectPublicKeyInfo the peer will present.
+ * @param [in] spkiSz  Length of spki in bytes.
+ * @return  WOLFSSL_SUCCESS on success.
+ * @return  BAD_FUNC_ARG when ctx or spki is NULL, or spkiSz is 0.
+ * @return  BUFFER_E when the pin table is full (WOLFSSL_MAX_RPK_PINS reached).
+ * @return  Other negative error code on hashing failure.
+ */
+int wolfSSL_CTX_set_expected_rpk(WOLFSSL_CTX* ctx, const unsigned char* spki,
+    unsigned int spkiSz)
+{
+    int ret;
+
+    if (ctx == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    ret = rpk_add_expected(&ctx->rpkConfig, spki, spkiSz);
+    return (ret == 0) ? WOLFSSL_SUCCESS : ret;
+}
+
+/* Pin an expected peer Raw Public Key on the SSL/TLS object.
+ *
+ * @param [in] ssl     SSL/TLS object.
+ * @param [in] spki    DER-encoded SubjectPublicKeyInfo the peer will present.
+ * @param [in] spkiSz  Length of spki in bytes.
+ * @return  WOLFSSL_SUCCESS on success.
+ * @return  BAD_FUNC_ARG when ssl or spki is NULL, or spkiSz is 0.
+ * @return  BUFFER_E when the pin table is full (WOLFSSL_MAX_RPK_PINS reached).
+ * @return  Other negative error code on hashing failure.
+ */
+int wolfSSL_set_expected_rpk(WOLFSSL* ssl, const unsigned char* spki,
+    unsigned int spkiSz)
+{
+    int ret;
+
+    if (ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    ret = rpk_add_expected(&ssl->options.rpkConfig, spki, spkiSz);
+    return (ret == 0) ? WOLFSSL_SUCCESS : ret;
+}
+#endif /* !NO_SHA256 */
 #endif /* HAVE_RPK */
 
 /* Certificate verification options. */

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -282,6 +282,12 @@ int GetX509Error(int e)
         case WC_NO_ERR_TRACE(ASN_NO_SIGNER_E):
             /* get issuer error if no CA found locally */
             return WOLFSSL_X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY;
+        case WC_NO_ERR_TRACE(RPK_UNTRUSTED_E):
+            /* RFC 7250 Raw Public Key not trusted out of band. Distinct from
+             * the X.509 issuer-lookup error above so verify callbacks that
+             * accept ASN_NO_SIGNER_E / UNABLE_TO_GET_ISSUER_CERT_LOCALLY do not
+             * accidentally accept an unauthenticated RPK. */
+            return WOLFSSL_X509_V_ERR_RPK_UNTRUSTED;
         case WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E):
             return WOLFSSL_X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT;
         case WC_NO_ERR_TRACE(ASN_PATHLEN_INV_E):

--- a/tests/api.c
+++ b/tests/api.c
@@ -28911,6 +28911,21 @@ static int error_test(void)
             }
         }
     }
+
+#if defined(OPENSSL_EXTRA)
+    /* WOLFSSL_X509_V_ERR_RPK_UNTRUSTED is >= WC_OSSL_V509_V_ERR_MAX, so it is
+     * intentionally outside the contiguous sweep above. Check its reason string
+     * explicitly so it cannot regress silently. error_test() is invoked as
+     * ExpectIntEQ(error_test(), 1), so any non-1 return registers as a failure;
+     * return TEST_FAIL (0) - also <= 0, so it remains correct even if this
+     * function were ever run directly by the harness. */
+    errStr = wolfSSL_ERR_reason_error_string(WOLFSSL_X509_V_ERR_RPK_UNTRUSTED);
+    ExpectIntNE(XSTRCMP(errStr, unknownStr), 0);
+    ExpectIntEQ(XSTRCMP(errStr, "raw public key not trusted"), 0);
+    if (EXPECT_FAIL()) {
+        return TEST_FAIL;
+    }
+#endif
 #endif
 
     return 1;

--- a/tests/api.c
+++ b/tests/api.c
@@ -28912,7 +28912,12 @@ static int error_test(void)
         }
     }
 
-#if defined(OPENSSL_EXTRA)
+    /* Guard matches the compilation condition of the OpenSSL-style reason
+     * strings (wolfSSL_ERR_reason_error_string_OpenSSL), so the RPK string is
+     * exercised in OPENSSL_EXTRA_X509_SMALL / webserver / memcached builds too,
+     * not only OPENSSL_EXTRA. */
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+    defined(HAVE_WEBSERVER) || defined(HAVE_MEMCACHED)
     /* WOLFSSL_X509_V_ERR_RPK_UNTRUSTED is >= WC_OSSL_V509_V_ERR_MAX, so it is
      * intentionally outside the contiguous sweep above. Check its reason string
      * explicitly so it cannot regress silently. error_test() is invoked as

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -3703,6 +3703,27 @@ static int test_rpk_accept_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
     (void)store;
     return 1;
 }
+
+/* Mimics a real-world X.509 verify callback that accepts ONLY the "issuer not
+ * found locally" errors (the pattern used elsewhere to allow an unchained or
+ * self-signed leaf). It must NOT rescue an untrusted RPK: because the RPK
+ * failure now reports WOLFSSL_X509_V_ERR_RPK_UNTRUSTED (not the X.509
+ * issuer-lookup codes), these checks no longer match and the RPK stays rejected.
+ * Returns 1 (accept) only for the X.509 issuer codes, otherwise rejects. */
+static int test_rpk_x509_issuer_accept_cb(int preverify,
+        WOLFSSL_X509_STORE_CTX* store)
+{
+    (void)preverify;
+    if ((store->error == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E))
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+        || (store->error ==
+                WOLFSSL_X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY)
+#endif
+        ) {
+        return 1; /* would wrongly accept an RPK that reused these codes */
+    }
+    return 0; /* reject everything else, including WOLFSSL_X509_V_ERR_RPK_* */
+}
 #endif /* HAVE_RPK && WOLFSSL_TLS13 && client && server && !NO_SHA256 */
 
 #if defined(HAVE_RPK) && \
@@ -3926,6 +3947,31 @@ int test_tls13_rpk_trust(void)
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_CTX_free(ctx_s);
 
+    /* --- a callback that accepts only X.509 issuer-lookup errors must NOT
+     * rescue an untrusted RPK: the RPK failure reports its own error code, so
+     * the callback's X.509 checks do not match and the handshake fails closed.
+     * (Would complete if the RPK reused ASN_NO_SIGNER_E / the issuer-lookup
+     * verify-result code.) --- */
+    ctx_c = ctx_s = NULL;
+    ssl_c = ssl_s = NULL;
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_rpk_nopin_setup(&test_ctx, &ctx_c, &ctx_s,
+                &ssl_c, &ssl_s, wolfTLSv1_3_client_method,
+                wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_PEER,
+                       test_rpk_x509_issuer_accept_cb);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_PEER,
+                       test_rpk_x509_issuer_accept_cb);
+    ExpectIntNE(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    ExpectIntEQ(wolfSSL_get_verify_result(ssl_c),
+                WOLFSSL_X509_V_ERR_RPK_UNTRUSTED);
+#endif
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+
     /* --- SSL-level pin via wolfSSL_set_expected_rpk() -> V_OK --- */
     ctx_c = ctx_s = NULL;
     ssl_c = ssl_s = NULL;
@@ -3995,7 +4041,35 @@ int test_tls13_rpk_trust(void)
     }
     ExpectIntEQ(wolfSSL_set_expected_rpk(ssl_c, svrSpki,
                 (unsigned int)svrSpkiSz), WC_NO_ERR_TRACE(BUFFER_E));
+    /* clear empties the (full) table so an add succeeds again */
+    ExpectIntEQ(wolfSSL_clear_expected_rpk(NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wolfSSL_clear_expected_rpk(ssl_c), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_set_expected_rpk(ssl_c, svrSpki,
+                (unsigned int)svrSpkiSz), WOLFSSL_SUCCESS);
     wolfSSL_free(ssl_c);
+    wolfSSL_CTX_free(ctx_c);
+
+    /* same argument/capacity errors for the CTX-level wrapper */
+    ctx_c = NULL;
+    ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectIntEQ(wolfSSL_CTX_set_expected_rpk(NULL, svrSpki,
+                (unsigned int)svrSpkiSz), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wolfSSL_CTX_set_expected_rpk(ctx_c, NULL,
+                (unsigned int)svrSpkiSz), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wolfSSL_CTX_set_expected_rpk(ctx_c, svrSpki, 0),
+                WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    for (i = 0; i < WOLFSSL_MAX_RPK_PINS; i++) {
+        ExpectIntEQ(wolfSSL_CTX_set_expected_rpk(ctx_c, svrSpki,
+                    (unsigned int)svrSpkiSz), WOLFSSL_SUCCESS);
+    }
+    ExpectIntEQ(wolfSSL_CTX_set_expected_rpk(ctx_c, svrSpki,
+                (unsigned int)svrSpkiSz), WC_NO_ERR_TRACE(BUFFER_E));
+    /* clear empties the (full) table so an add succeeds again */
+    ExpectIntEQ(wolfSSL_CTX_clear_expected_rpk(NULL),
+                WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wolfSSL_CTX_clear_expected_rpk(ctx_c), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_set_expected_rpk(ctx_c, svrSpki,
+                (unsigned int)svrSpkiSz), WOLFSSL_SUCCESS);
     wolfSSL_CTX_free(ctx_c);
 
     XFREE(svrSpki, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -2709,6 +2709,30 @@ static int MyRpkVerifyCb(int mode, WOLFSSL_X509_STORE_CTX* strctx)
 }
 #endif /* WOLFSSL_ALWAYS_VERIFY_CB && WOLFSSL_TLS13 */
 
+#if !defined(NO_SHA256)
+/* Pin the peer's Raw Public Key so it is authenticated out of band (RFC 7250).
+ * In this test the RPK cert files are DER SubjectPublicKeyInfo (passed as
+ * WOLFSSL_FILETYPE_ASN1), which is exactly what is sent on the wire, so the raw
+ * file bytes are the pin. PEM files are X.509 and are left unpinned. */
+static int test_rpk_pin_peer(WOLFSSL_CTX* ctx, const char* file, int fmt)
+{
+    byte* buf = NULL;
+    size_t sz = 0;
+    int ret = 0;
+
+    if (fmt != WOLFSSL_FILETYPE_ASN1)
+        return 0; /* not an RPK file - nothing to pin */
+    if (load_file(file, &buf, &sz) != 0)
+        return -1;
+    if (wolfSSL_CTX_set_expected_rpk(ctx, buf, (unsigned int)sz)
+            != WOLFSSL_SUCCESS) {
+        ret = -1;
+    }
+    XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    return ret;
+}
+#endif /* !NO_SHA256 */
+
 static WC_INLINE int test_rpk_memio_setup(
     struct test_memio_ctx *ctx,
     WOLFSSL_CTX **ctx_c,
@@ -2746,6 +2770,17 @@ static WC_INLINE int test_rpk_memio_setup(
         if (ret != WOLFSSL_SUCCESS) {
             return -1;
         }
+        /* This helper sets WOLFSSL_VERIFY_PEER on both ends, so the RPK
+         * handshake cases below rely on the peer key being pinned here to
+         * complete (otherwise they fail closed). Pinning needs SHA-256; the
+         * RPK + NO_SHA256 combination is not exercised because the unit test
+         * suite does not build under NO_SHA256 (e.g. test_random.c). */
+#if !defined(NO_SHA256)
+        /* client must trust the server's RPK (if the server presents one) */
+        if (test_rpk_pin_peer(*ctx_c, certfile_s, fmt_cs) != 0) {
+            return -1;
+        }
+#endif
     }
 
     if (ctx_s != NULL && *ctx_s == NULL) {
@@ -2768,6 +2803,12 @@ static WC_INLINE int test_rpk_memio_setup(
         if (ret != WOLFSSL_SUCCESS) {
             return -1;
         }
+#if !defined(NO_SHA256)
+        /* server must trust the client's RPK (if the client presents one) */
+        if (test_rpk_pin_peer(*ctx_s, certfile_c, fmt_cc) != 0) {
+            return -1;
+        }
+#endif
         wolfSSL_SetIORecv(*ctx_s, test_memio_read_cb);
         wolfSSL_SetIOSend(*ctx_s, test_memio_write_cb);
         if (ctx->s_ciphers != NULL) {
@@ -2938,6 +2979,14 @@ int test_tls13_rpk_handshake(void)
                                                         WOLFSSL_SUCCESS);
     ExpectIntEQ(tp, WOLFSSL_CERT_TYPE_UNKNOWN);
 
+    /* x509 handshake: peer cert was verified against a CA, so the verify
+     * result stays WOLFSSL_X509_V_OK. This is the contrast case for the
+     * RPK checks below. */
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    ExpectIntEQ(wolfSSL_get_verify_result(ssl_c), WOLFSSL_X509_V_OK);
+    ExpectIntEQ(wolfSSL_get_verify_result(ssl_s), WOLFSSL_X509_V_OK);
+#endif
+
     (void)typeCnt_c;
     (void)typeCnt_s;
 
@@ -3005,6 +3054,15 @@ int test_tls13_rpk_handshake(void)
     ExpectIntEQ(wolfSSL_get_negotiated_server_cert_type(ssl_s, &tp),
                                                         WOLFSSL_SUCCESS);
     ExpectIntEQ(tp, WOLFSSL_CERT_TYPE_RPK);
+
+    /* TLS1.3 RPK: an RPK cert (RFC 7250) has no issuer and no signature chain,
+     * so it is only authenticated by the out-of-band pin established in
+     * test_rpk_memio_setup(). Because the peer's key was pinned, the handshake
+     * completes and wolfSSL_get_verify_result() reports WOLFSSL_X509_V_OK. */
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    ExpectIntEQ(wolfSSL_get_verify_result(ssl_c), WOLFSSL_X509_V_OK);
+    ExpectIntEQ(wolfSSL_get_verify_result(ssl_s), WOLFSSL_X509_V_OK);
+#endif
 
     wolfSSL_free(ssl_c);
     wolfSSL_CTX_free(ctx_c);
@@ -3074,6 +3132,13 @@ int test_tls13_rpk_handshake(void)
     ExpectIntEQ(wolfSSL_get_negotiated_server_cert_type(ssl_s, &tp),
                                                         WOLFSSL_SUCCESS);
     ExpectIntEQ(tp, WOLFSSL_CERT_TYPE_RPK);
+
+    /* TLS1.2 RPK: same as the TLS1.3 case above - the peer's key was pinned
+     * out of band, so the verify result is WOLFSSL_X509_V_OK. */
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    ExpectIntEQ(wolfSSL_get_verify_result(ssl_c), WOLFSSL_X509_V_OK);
+    ExpectIntEQ(wolfSSL_get_verify_result(ssl_s), WOLFSSL_X509_V_OK);
+#endif
 
     wolfSSL_free(ssl_c);
     wolfSSL_CTX_free(ctx_c);
@@ -3623,6 +3688,311 @@ int test_tls13_pha(void)
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_CTX_free(ctx_s);
 #endif
+    return EXPECT_RESULT();
+}
+
+#if defined(HAVE_RPK) && defined(WOLFSSL_TLS13) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_SHA256)
+/* Verify callback that unconditionally accepts the peer (returns "ok"),
+ * overriding any error - used to exercise the documented RPK override path.
+ * Only used by test_tls13_rpk_trust(), which requires SHA-256. */
+static int test_rpk_accept_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
+{
+    (void)preverify;
+    (void)store;
+    return 1;
+}
+#endif /* HAVE_RPK && WOLFSSL_TLS13 && client && server && !NO_SHA256 */
+
+#if defined(HAVE_RPK) && \
+    (defined(WOLFSSL_TLS13) || !defined(WOLFSSL_NO_TLS12)) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
+/* Build a client/server pair (protocol chosen by the caller) that both present
+ * a Raw Public Key but pin NOTHING (unlike test_rpk_memio_setup, which pins the
+ * peer key). Verify mode is left at the CTX default; the caller sets it on the
+ * SSL objects before the handshake. Returns 0 on success. */
+static int test_rpk_nopin_setup(struct test_memio_ctx* tctx,
+    WOLFSSL_CTX** ctx_c, WOLFSSL_CTX** ctx_s,
+    WOLFSSL** ssl_c, WOLFSSL** ssl_s,
+    method_provider method_c, method_provider method_s)
+{
+    char certType[MAX_CLIENT_CERT_TYPE_CNT];
+
+    *ctx_c = wolfSSL_CTX_new(method_c());
+    *ctx_s = wolfSSL_CTX_new(method_s());
+    if ((*ctx_c == NULL) || (*ctx_s == NULL))
+        return -1;
+
+    if (wolfSSL_CTX_load_verify_locations(*ctx_c, caCertFile, 0)
+            != WOLFSSL_SUCCESS)
+        return -1;
+    if (wolfSSL_CTX_use_certificate_file(*ctx_c, clntRpkCertFile,
+            WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS)
+        return -1;
+    if (wolfSSL_CTX_use_PrivateKey_file(*ctx_c, cliKeyFile, CERT_FILETYPE)
+            != WOLFSSL_SUCCESS)
+        return -1;
+    wolfSSL_SetIORecv(*ctx_c, test_memio_read_cb);
+    wolfSSL_SetIOSend(*ctx_c, test_memio_write_cb);
+
+    if (wolfSSL_CTX_load_verify_locations(*ctx_s, cliCertFile, 0)
+            != WOLFSSL_SUCCESS)
+        return -1;
+    if (wolfSSL_CTX_use_PrivateKey_file(*ctx_s, svrKeyFile, CERT_FILETYPE)
+            != WOLFSSL_SUCCESS)
+        return -1;
+    if (wolfSSL_CTX_use_certificate_file(*ctx_s, svrRpkCertFile,
+            WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS)
+        return -1;
+    wolfSSL_SetIORecv(*ctx_s, test_memio_read_cb);
+    wolfSSL_SetIOSend(*ctx_s, test_memio_write_cb);
+
+    *ssl_c = wolfSSL_new(*ctx_c);
+    *ssl_s = wolfSSL_new(*ctx_s);
+    if ((*ssl_c == NULL) || (*ssl_s == NULL))
+        return -1;
+    wolfSSL_SetIOWriteCtx(*ssl_c, tctx);
+    wolfSSL_SetIOReadCtx(*ssl_c, tctx);
+    wolfSSL_SetIOWriteCtx(*ssl_s, tctx);
+    wolfSSL_SetIOReadCtx(*ssl_s, tctx);
+#if !defined(NO_DH)
+    SetDH(*ssl_s);
+#endif
+
+    /* let both sides negotiate RPK in either direction */
+    certType[0] = WOLFSSL_CERT_TYPE_RPK;
+    certType[1] = WOLFSSL_CERT_TYPE_X509;
+    if ((wolfSSL_set_client_cert_type(*ssl_c, certType, 2) != WOLFSSL_SUCCESS) ||
+        (wolfSSL_set_server_cert_type(*ssl_c, certType, 2) != WOLFSSL_SUCCESS) ||
+        (wolfSSL_set_client_cert_type(*ssl_s, certType, 2) != WOLFSSL_SUCCESS) ||
+        (wolfSSL_set_server_cert_type(*ssl_s, certType, 2) != WOLFSSL_SUCCESS))
+        return -1;
+
+    return 0;
+}
+#endif /* HAVE_RPK && (WOLFSSL_TLS13 || !WOLFSSL_NO_TLS12) && client && server */
+
+/* Regression test for the RPK fail-closed behaviour: a peer that presents a
+ * Raw Public Key (RFC 7250) without an out-of-band pin must NOT be silently
+ * accepted while it is being authenticated. Covers both an explicit
+ * WOLFSSL_VERIFY_PEER client and a default-verify client (verify mode never
+ * set), since RPK server
+ * authentication is gated on !verifyNone, matching the X.509 path. Runs for
+ * every available protocol version, since the fail-closed code in
+ * ProcessPeerCerts is shared between the TLS 1.2 and TLS 1.3 state machines. */
+int test_tls13_rpk_untrusted(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_RPK) && \
+    (defined(WOLFSSL_TLS13) || !defined(WOLFSSL_NO_TLS12)) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+    int explicitVerifyPeer;
+    size_t v;
+    struct {
+        method_provider c;
+        method_provider s;
+    } methods[2];
+    size_t methodCnt = 0;
+
+#ifdef WOLFSSL_TLS13
+    methods[methodCnt].c = wolfTLSv1_3_client_method;
+    methods[methodCnt].s = wolfTLSv1_3_server_method;
+    methodCnt++;
+#endif
+#ifndef WOLFSSL_NO_TLS12
+    methods[methodCnt].c = wolfTLSv1_2_client_method;
+    methods[methodCnt].s = wolfTLSv1_2_server_method;
+    methodCnt++;
+#endif
+
+    for (v = 0; v < methodCnt; v++) {
+        /* round 0: explicit WOLFSSL_VERIFY_PEER on both ends.
+         * round 1: default authenticating client - verifyNone=0 but verifyPeer
+         * never set. Both must fail closed against an unpinned RPK server. */
+        for (explicitVerifyPeer = 1; explicitVerifyPeer >= 0;
+                explicitVerifyPeer--) {
+            ctx_c = ctx_s = NULL;
+            ssl_c = ssl_s = NULL;
+            XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+
+            ExpectIntEQ(test_rpk_nopin_setup(&test_ctx, &ctx_c, &ctx_s,
+                        &ssl_c, &ssl_s, methods[v].c, methods[v].s), 0);
+            if (explicitVerifyPeer) {
+                /* explicit mutual WOLFSSL_VERIFY_PEER on both ends */
+                wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_PEER, NULL);
+                wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_PEER, NULL);
+            }
+            else {
+                /* Default authenticating client: verifyNone=0 with verifyPeer
+                 * NOT set. WOLFSSL_VERIFY_DEFAULT sets exactly that state, and
+                 * it is applied explicitly so the test is deterministic
+                 * regardless of OPENSSL_COMPATIBLE_DEFAULTS (which would
+                 * otherwise default the CTX to WOLFSSL_VERIFY_NONE and skip
+                 * authentication). The server is left non-requesting
+                 * (verifyPeer=0) so the only authentication is the client
+                 * validating the server's RPK - isolating the !verifyNone gate:
+                 * it must fail closed even though verifyPeer was never set. */
+                wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_DEFAULT, NULL);
+                wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_DEFAULT, NULL);
+            }
+
+            /* With no pin and the peer being authenticated the handshake must
+             * NOT complete. */
+            ExpectIntNE(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+            /* and the failure is specifically the untrusted RPK */
+            ExpectIntEQ(wolfSSL_get_verify_result(ssl_c),
+                        WOLFSSL_X509_V_ERR_RPK_UNTRUSTED);
+#endif
+
+            wolfSSL_free(ssl_c);
+            wolfSSL_free(ssl_s);
+            wolfSSL_CTX_free(ctx_c);
+            wolfSSL_CTX_free(ctx_s);
+        }
+    }
+#endif /* HAVE_RPK && (WOLFSSL_TLS13 || !WOLFSSL_NO_TLS12) && client&&server */
+    return EXPECT_RESULT();
+}
+
+/* Exercises the trust-establishment paths around the RPK fail-closed change:
+ *  - WOLFSSL_VERIFY_NONE: handshake completes, get_verify_result() still
+ *    reports the key as untrusted.
+ *  - verify callback override: an untrusted RPK is accepted because the
+ *    callback returns ok.
+ *  - SSL-level pin via wolfSSL_set_expected_rpk(): pinned key -> V_OK.
+ *  - pinning API argument and capacity errors. */
+int test_tls13_rpk_trust(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_RPK) && defined(WOLFSSL_TLS13) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_SHA256)
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+    byte* svrSpki = NULL;
+    byte* cliSpki = NULL;
+    size_t svrSpkiSz = 0;
+    size_t cliSpkiSz = 0;
+    int i;
+
+    ExpectIntEQ(load_file(svrRpkCertFile, &svrSpki, &svrSpkiSz), 0);
+    ExpectIntEQ(load_file(clntRpkCertFile, &cliSpki, &cliSpkiSz), 0);
+
+    /* --- WOLFSSL_VERIFY_NONE: completes, but reported as untrusted --- */
+    ctx_c = ctx_s = NULL;
+    ssl_c = ssl_s = NULL;
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_rpk_nopin_setup(&test_ctx, &ctx_c, &ctx_s,
+                &ssl_c, &ssl_s, wolfTLSv1_3_client_method,
+                wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, NULL);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    ExpectIntEQ(wolfSSL_get_verify_result(ssl_c),
+                WOLFSSL_X509_V_ERR_RPK_UNTRUSTED);
+#endif
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+
+    /* --- verify callback overrides the untrusted RPK -> completes --- */
+    ctx_c = ctx_s = NULL;
+    ssl_c = ssl_s = NULL;
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_rpk_nopin_setup(&test_ctx, &ctx_c, &ctx_s,
+                &ssl_c, &ssl_s, wolfTLSv1_3_client_method,
+                wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_PEER, test_rpk_accept_cb);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_PEER, test_rpk_accept_cb);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+
+    /* --- SSL-level pin via wolfSSL_set_expected_rpk() -> V_OK --- */
+    ctx_c = ctx_s = NULL;
+    ssl_c = ssl_s = NULL;
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_rpk_nopin_setup(&test_ctx, &ctx_c, &ctx_s,
+                &ssl_c, &ssl_s, wolfTLSv1_3_client_method,
+                wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_PEER, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_PEER, NULL);
+    /* client trusts the server's key, server trusts the client's key */
+    ExpectIntEQ(wolfSSL_set_expected_rpk(ssl_c, svrSpki,
+                (unsigned int)svrSpkiSz), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_set_expected_rpk(ssl_s, cliSpki,
+                (unsigned int)cliSpkiSz), WOLFSSL_SUCCESS);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    ExpectIntEQ(wolfSSL_get_verify_result(ssl_c), WOLFSSL_X509_V_OK);
+    ExpectIntEQ(wolfSSL_get_verify_result(ssl_s), WOLFSSL_X509_V_OK);
+#endif
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+
+    /* --- non-matching pin: table populated, but with the WRONG key ---
+     * The client pins the *client's* own key, which is not what the server
+     * presents (the server's key), so RpkIsTrusted's compare loop runs to
+     * completion and finds no match -> fail closed. Distinct from the no-pin
+     * case (empty table) above. */
+    ctx_c = ctx_s = NULL;
+    ssl_c = ssl_s = NULL;
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_rpk_nopin_setup(&test_ctx, &ctx_c, &ctx_s,
+                &ssl_c, &ssl_s, wolfTLSv1_3_client_method,
+                wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_PEER, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_PEER, NULL);
+    /* wrong key pinned on the client: it expects cliSpki but gets svrSpki */
+    ExpectIntEQ(wolfSSL_set_expected_rpk(ssl_c, cliSpki,
+                (unsigned int)cliSpkiSz), WOLFSSL_SUCCESS);
+    ExpectIntNE(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    ExpectIntEQ(wolfSSL_get_verify_result(ssl_c),
+                WOLFSSL_X509_V_ERR_RPK_UNTRUSTED);
+#endif
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+
+    /* --- pinning API argument and capacity errors --- */
+    ctx_c = NULL;
+    ssl_c = NULL;
+    ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ssl_c = wolfSSL_new(ctx_c));
+    /* NULL handle / NULL spki / zero length all report BAD_FUNC_ARG */
+    ExpectIntEQ(wolfSSL_set_expected_rpk(NULL, svrSpki,
+                (unsigned int)svrSpkiSz), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wolfSSL_set_expected_rpk(ssl_c, NULL,
+                (unsigned int)svrSpkiSz), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wolfSSL_set_expected_rpk(ssl_c, svrSpki, 0),
+                WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    /* fill the pin table, then the next add overflows with BUFFER_E */
+    for (i = 0; i < WOLFSSL_MAX_RPK_PINS; i++) {
+        ExpectIntEQ(wolfSSL_set_expected_rpk(ssl_c, svrSpki,
+                    (unsigned int)svrSpkiSz), WOLFSSL_SUCCESS);
+    }
+    ExpectIntEQ(wolfSSL_set_expected_rpk(ssl_c, svrSpki,
+                (unsigned int)svrSpkiSz), WC_NO_ERR_TRACE(BUFFER_E));
+    wolfSSL_free(ssl_c);
+    wolfSSL_CTX_free(ctx_c);
+
+    XFREE(svrSpki, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(cliSpki, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#endif /* HAVE_RPK && WOLFSSL_TLS13 && client && server && !NO_SHA256 */
     return EXPECT_RESULT();
 }
 

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -3883,6 +3883,14 @@ int test_tls13_rpk_trust(void)
 
     ExpectIntEQ(load_file(svrRpkCertFile, &svrSpki, &svrSpkiSz), 0);
     ExpectIntEQ(load_file(clntRpkCertFile, &cliSpki, &cliSpkiSz), 0);
+    /* If either pin failed to load, stop before feeding NULL/zero-length
+     * buffers into the pinning calls below (which would only produce
+     * misleading downstream failures). */
+    if (EXPECT_FAIL()) {
+        XFREE(svrSpki, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(cliSpki, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        return EXPECT_RESULT();
+    }
 
     /* --- WOLFSSL_VERIFY_NONE: completes, but reported as untrusted --- */
     ctx_c = ctx_s = NULL;

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -30,6 +30,8 @@ int test_tls13_bad_psk_binder(void);
 int test_tls13_rpk_handshake(void);
 int test_tls13_rpk_handshake_no_negotiation(void);
 int test_tls13_pha(void);
+int test_tls13_rpk_untrusted(void);
+int test_tls13_rpk_trust(void);
 int test_tls13_pq_groups(void);
 int test_tls13_multi_pqc_key_share(void);
 int test_tls13_early_data(void);
@@ -108,6 +110,8 @@ int test_tls13_pqc_hybrid_async_server(void);
     TEST_DECL_GROUP("tls13", test_tls13_rpk_handshake),         \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_handshake_no_negotiation), \
     TEST_DECL_GROUP("tls13", test_tls13_pha),                   \
+    TEST_DECL_GROUP("tls13", test_tls13_rpk_untrusted),         \
+    TEST_DECL_GROUP("tls13", test_tls13_rpk_trust),             \
     TEST_DECL_GROUP("tls13", test_tls13_pq_groups),             \
     TEST_DECL_GROUP("tls13", test_tls13_multi_pqc_key_share),   \
     TEST_DECL_GROUP("tls13", test_tls13_early_data),            \

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -247,7 +247,10 @@ enum wolfSSL_ErrorCodes {
 
     SEQUENCE_NUMBER_E            = -520,   /* Record sequence number would wrap */
 
-    WOLFSSL_LAST_E               = -520
+    RPK_UNTRUSTED_E              = -521,   /* RFC 7250 Raw Public Key not trusted
+                                           * out of band */
+
+    WOLFSSL_LAST_E               = -521
 
     /* codes -1000 to -1999 are reserved for wolfCrypt. */
 };

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5313,9 +5313,6 @@ struct Options {
 #ifdef WOLFSSL_SEND_HRR_COOKIE
     word16            cookieGood:1;
 #endif
-#if defined(HAVE_DANE)
-    word16            useDANE:1;
-#endif /* HAVE_DANE */
 #ifdef WOLFSSL_TLS13
 #ifdef WOLFSSL_SEND_HRR_COOKIE
     word16            hrrSentCookie:1;    /* HRR sent with cookie */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3097,6 +3097,14 @@ typedef enum {
  * https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#tls-extensiontype-values-3
  */
 #if defined(HAVE_RPK)
+/* WOLFSSL_MAX_RPK_PINS (default 4) is defined in the public header
+ * wolfssl/ssl.h, which this header includes, so applications can see and
+ * override it. The pin table is stored inline in RpkConfig (see below),
+ * costing WOLFSSL_MAX_RPK_PINS * WC_SHA256_DIGEST_SIZE bytes per WOLFSSL_CTX and
+ * WOLFSSL. Out-of-band RPK pinning needs SHA-256 (pins are stored as digests);
+ * under NO_SHA256 there is no in-library pinning and trust must be expressed
+ * through a verify callback instead. */
+
 typedef struct RpkConfig {
     /* user's preference */
     byte preferred_ClientCertTypeCnt;
@@ -3104,6 +3112,16 @@ typedef struct RpkConfig {
     byte preferred_ServerCertTypeCnt;
     byte preferred_ServerCertTypes[MAX_CLIENT_CERT_TYPE_CNT];
     /* reflect to client_certificate_type extension in xxxHello */
+#ifndef NO_SHA256
+    /* SHA-256 digests of the DER SubjectPublicKeyInfo(s) the peer is expected
+     * to present as a Raw Public Key (RFC 7250), pinned out of band via
+     * wolfSSL_set_expected_rpk()/wolfSSL_CTX_set_expected_rpk(). A received RPK
+     * whose SPKI digest matches one of these is treated as authenticated.
+     * Stored inline (not a pointer) so the by-value RpkConfig copy from CTX to
+     * SSL needs no deep-copy or free handling. */
+    byte expectedRpkCnt;
+    byte expectedRpk[WOLFSSL_MAX_RPK_PINS][WC_SHA256_DIGEST_SIZE];
+#endif /* !NO_SHA256 */
 } RpkConfig;
 
 typedef struct RpkState {

--- a/wolfssl/openssl/x509.h
+++ b/wolfssl/openssl/x509.h
@@ -210,6 +210,10 @@
 #define X509_V_ERR_CA_CERT_MISSING_KEY_USAGE           92
 #define X509_V_ERR_EXTENSIONS_REQUIRE_VERSION_3        93
 #define X509_V_ERR_EC_KEY_EXPLICIT_PARAMS              94
+/* wolfSSL-specific value: this header's numbering already diverges from
+ * OpenSSL's for the higher X509_V_ERR_* codes, so RPK-untrusted takes the next
+ * free wolfSSL slot (95) rather than any particular OpenSSL number. */
+#define X509_V_ERR_RPK_UNTRUSTED                       95
 #define X509_R_CERT_ALREADY_IN_HASH_TABLE              101
 #define X509_R_KEY_VALUES_MISMATCH                     WC_KEY_MISMATCH_E
 

--- a/wolfssl/openssl/x509.h
+++ b/wolfssl/openssl/x509.h
@@ -210,9 +210,8 @@
 #define X509_V_ERR_CA_CERT_MISSING_KEY_USAGE           92
 #define X509_V_ERR_EXTENSIONS_REQUIRE_VERSION_3        93
 #define X509_V_ERR_EC_KEY_EXPLICIT_PARAMS              94
-/* wolfSSL-specific value: this header's numbering already diverges from
- * OpenSSL's for the higher X509_V_ERR_* codes, so RPK-untrusted takes the next
- * free wolfSSL slot (95) rather than any particular OpenSSL number. */
+/* 95 matches OpenSSL's X509_V_ERR_RPK_UNTRUSTED (OpenSSL 3.2+) for source
+ * compatibility. */
 #define X509_V_ERR_RPK_UNTRUSTED                       95
 #define X509_R_CERT_ALREADY_IN_HASH_TABLE              101
 #define X509_R_KEY_VALUES_MISMATCH                     WC_KEY_MISMATCH_E

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2782,8 +2782,9 @@ enum {
     WOLFSSL_X509_V_ERR_IP_ADDRESS_MISMATCH               = 64,
     WOLFSSL_X509_V_ERR_INVALID_CA                        = 79,
     WC_OSSL_V509_V_ERR_MAX = 80,
-    /* Codes at or above WC_OSSL_V509_V_ERR_MAX are intentionally outside the
-     * contiguous range swept by the error-string test in tests/api.c. */
+    /* wolfSSL-specific verify-result codes are assigned at or above
+     * WC_OSSL_V509_V_ERR_MAX, intentionally outside the contiguous
+     * OpenSSL-compatible range below it. */
     WOLFSSL_X509_V_ERR_RPK_UNTRUSTED                     = 95,
 
 #ifdef HAVE_OCSP

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2782,9 +2782,9 @@ enum {
     WOLFSSL_X509_V_ERR_IP_ADDRESS_MISMATCH               = 64,
     WOLFSSL_X509_V_ERR_INVALID_CA                        = 79,
     WC_OSSL_V509_V_ERR_MAX = 80,
-    /* wolfSSL-specific verify-result codes are assigned at or above
-     * WC_OSSL_V509_V_ERR_MAX, intentionally outside the contiguous
-     * OpenSSL-compatible range below it. */
+    /* 95 matches OpenSSL's X509_V_ERR_RPK_UNTRUSTED (OpenSSL 3.2+). It is
+     * deliberately at or above WC_OSSL_V509_V_ERR_MAX, i.e. outside the
+     * contiguous block of verify-result codes below it. */
     WOLFSSL_X509_V_ERR_RPK_UNTRUSTED                     = 95,
 
 #ifdef HAVE_OCSP
@@ -6258,15 +6258,23 @@ WOLFSSL_API int wolfSSL_get_negotiated_server_cert_type(WOLFSSL* ssl, int* tp);
  * stored as its SHA-256 digest, so these APIs require SHA-256; without it,
  * express RPK trust through a verify callback. Returns WOLFSSL_SUCCESS, or a
  * negative error code (BAD_FUNC_ARG for a NULL argument or zero length, BUFFER_E
- * when the pin table is full). Pins are append-only for the lifetime of the
- * object/CTX; there is no clear/replace call, so a long-lived CTX that re-pins
- * across key rotations can exhaust the WOLFSSL_MAX_RPK_PINS-entry table. */
+ * when the pin table is full). Pins are append-only: there is no per-entry
+ * remove, but wolfSSL_clear_expected_rpk()/wolfSSL_CTX_clear_expected_rpk()
+ * empties the WOLFSSL_MAX_RPK_PINS-entry table so it can be repopulated (e.g.
+ * across a peer key rotation). */
 WOLFSSL_API int wolfSSL_CTX_set_expected_rpk(WOLFSSL_CTX* ctx,
                                           const unsigned char* spki,
                                           unsigned int spkiSz);
 WOLFSSL_API int wolfSSL_set_expected_rpk(WOLFSSL* ssl,
                                           const unsigned char* spki,
                                           unsigned int spkiSz);
+/* Remove all pinned expected peer Raw Public Keys, emptying the table so it can
+ * be repopulated. Returns WOLFSSL_SUCCESS, or BAD_FUNC_ARG when the handle is
+ * NULL. Like the set calls and other CTX setters these are unlocked, so
+ * reconfigure pins on a shared CTX while no handshakes are in flight (each
+ * WOLFSSL copies the pin table by value at wolfSSL_new()). */
+WOLFSSL_API int wolfSSL_CTX_clear_expected_rpk(WOLFSSL_CTX* ctx);
+WOLFSSL_API int wolfSSL_clear_expected_rpk(WOLFSSL* ssl);
 #endif /* !NO_SHA256 */
 #endif /* HAVE_RPK */
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2782,6 +2782,9 @@ enum {
     WOLFSSL_X509_V_ERR_IP_ADDRESS_MISMATCH               = 64,
     WOLFSSL_X509_V_ERR_INVALID_CA                        = 79,
     WC_OSSL_V509_V_ERR_MAX = 80,
+    /* Codes at or above WC_OSSL_V509_V_ERR_MAX are intentionally outside the
+     * contiguous range swept by the error-string test in tests/api.c. */
+    WOLFSSL_X509_V_ERR_RPK_UNTRUSTED                     = 95,
 
 #ifdef HAVE_OCSP
     /* OCSP Flags */
@@ -6199,6 +6202,41 @@ enum {
 #define MAX_CLIENT_CERT_TYPE_CNT 2
 #define MAX_SERVER_CERT_TYPE_CNT 2
 
+/* Maximum number of expected Raw Public Keys that can be pinned out of band
+ * with wolfSSL_set_expected_rpk()/wolfSSL_CTX_set_expected_rpk(). Defined here
+ * (the public header) so applications can both see and override the limit;
+ * each pin costs WC_SHA256_DIGEST_SIZE bytes inline in WOLFSSL_CTX and WOLFSSL
+ * whether or not pinning is used, so lower it to 1 to minimise footprint when
+ * only a single pin is needed. */
+#ifndef WOLFSSL_MAX_RPK_PINS
+#define WOLFSSL_MAX_RPK_PINS 4
+#endif
+/* The internal pin counter is a byte, so the table cannot exceed 255 entries;
+ * a value of 0 would also declare a zero-length array (invalid C). */
+#if (WOLFSSL_MAX_RPK_PINS < 1) || (WOLFSSL_MAX_RPK_PINS > 255)
+    #error "WOLFSSL_MAX_RPK_PINS must be between 1 and 255"
+#endif
+
+/* RPK fail-closed BEHAVIOUR CHANGE - applies to ALL HAVE_RPK builds, including
+ * NO_SHA256 and builds without OPENSSL_EXTRA (this note is deliberately outside
+ * those guards so it is always visible): an unauthenticated Raw Public Key
+ * (RFC 7250) peer is no longer silently accepted. Previously an RPK handshake
+ * always completed and the application validated the key afterwards (e.g. via
+ * wolfSSL_get_verify_result()); it now fails closed whenever the peer is being
+ * authenticated (any verify mode other than WOLFSSL_VERIFY_NONE). Builds
+ * without OPENSSL_EXTRA, which previously had no untrusted-RPK handling at all,
+ * now also fail closed; and under
+ * NO_SHA256 there is no in-library pinning (wolfSSL_set_expected_rpk() below is
+ * unavailable), so every RPK peer fails closed unless a verify callback accepts
+ * it. To handle an RPK peer, choose one of:
+ *   - pin the key with wolfSSL_set_expected_rpk()/wolfSSL_CTX_set_expected_rpk()
+ *     (recommended; requires SHA-256);
+ *   - install a verify callback (wolfSSL_set_verify) - it is still invoked for
+ *     the RPK and may accept the key, so it can keep the old "complete then
+ *     validate out of band" model while leaving X.509 verification strict on
+ *     the same object (unlike WOLFSSL_VERIFY_NONE, which disables both); or
+ *   - set WOLFSSL_VERIFY_NONE to accept without authentication. */
+
 WOLFSSL_API int wolfSSL_CTX_set_client_cert_type(WOLFSSL_CTX* ctx,
                                           const char* buf, int len);
 WOLFSSL_API int wolfSSL_CTX_set_server_cert_type(WOLFSSL_CTX* ctx,
@@ -6209,6 +6247,26 @@ WOLFSSL_API int wolfSSL_set_server_cert_type(WOLFSSL* ssl,
                                           const char* buf, int len);
 WOLFSSL_API int wolfSSL_get_negotiated_client_cert_type(WOLFSSL* ssl, int* tp);
 WOLFSSL_API int wolfSSL_get_negotiated_server_cert_type(WOLFSSL* ssl, int* tp);
+#ifndef NO_SHA256
+/* Pin a DER-encoded SubjectPublicKeyInfo that the peer is expected to present
+ * as a Raw Public Key (RFC 7250). Establishes out-of-band trust so that, when
+ * the peer is being authenticated (any verify mode other than
+ * WOLFSSL_VERIFY_NONE), the handshake completes for the pinned key instead of
+ * failing closed (see the RPK fail-closed behaviour note above). May be called
+ * more than once to pin several keys (up to WOLFSSL_MAX_RPK_PINS). The key is
+ * stored as its SHA-256 digest, so these APIs require SHA-256; without it,
+ * express RPK trust through a verify callback. Returns WOLFSSL_SUCCESS, or a
+ * negative error code (BAD_FUNC_ARG for a NULL argument or zero length, BUFFER_E
+ * when the pin table is full). Pins are append-only for the lifetime of the
+ * object/CTX; there is no clear/replace call, so a long-lived CTX that re-pins
+ * across key rotations can exhaust the WOLFSSL_MAX_RPK_PINS-entry table. */
+WOLFSSL_API int wolfSSL_CTX_set_expected_rpk(WOLFSSL_CTX* ctx,
+                                          const unsigned char* spki,
+                                          unsigned int spkiSz);
+WOLFSSL_API int wolfSSL_set_expected_rpk(WOLFSSL* ssl,
+                                          const unsigned char* spki,
+                                          unsigned int spkiSz);
+#endif /* !NO_SHA256 */
 #endif /* HAVE_RPK */
 
 


### PR DESCRIPTION
# Description

DANE support was stubbed for the compatibility layer. Ensure an actual connection errors if it is used.

Thanks to Peter Samarin for reporting the issue and reviewing the fix.

Fixes zd21825

# Testing

Added test cases in `test_tls13_rpk_handshake`

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
