### PR TITLE
Fix SHAKE with STM32MP13 and add simulator

### DIFF
--- a/.github/workflows/stm32-sim.yml
+++ b/.github/workflows/stm32-sim.yml
@@ -14,12 +14,20 @@ concurrency:
 
 # Build the STM32 software simulator (https://github.com/wolfSSL/simulators,
 # STM32Sim/ subdirectory) and run the wolfCrypt test suite on emulated
-# STM32H753 (Cortex-M7) and STM32U585 (Cortex-M33) hardware. Replaces the
-# previous Renode-based STM32H753 workflow and adds U5/PKA coverage.
+# STM32H753 (Cortex-M7), STM32U585 (Cortex-M33), and STM32MP135 (Cortex-A7)
+# hardware. Replaces the previous Renode-based STM32H753 workflow and adds
+# U5/PKA + MP135 (SHA3/SHAKE on HASH1) coverage.
 #
 # Dockerfile.wolfcrypt reads wolfSSL from /opt/wolfssl at runtime via a
 # bind mount, so unlike se050-sim.yml / stsafe-a120-sim.yml no Dockerfile
 # patching is required - we just mount the PR checkout.
+#
+# The simulators repo is pinned via SIMULATORS_REF so the MP135 SHAKE-
+# enabling sed patch below has a known anchor in user_settings.h. Bump
+# the pin when simulators changes are needed.
+
+env:
+  SIMULATORS_REF: 840da2f4a28a9e3027c127da38d758ded902d926
 
 jobs:
   stm32_sim:
@@ -35,6 +43,8 @@ jobs:
             script: run-wolfcrypt-h7.sh
           - chip_label: U585
             script: run-wolfcrypt-u5.sh
+          - chip_label: MP135
+            script: run-wolfcrypt-mp135.sh
     steps:
       - name: Checkout wolfSSL (PR source)
         uses: actions/checkout@v4
@@ -42,7 +52,24 @@ jobs:
           path: wolfssl
 
       - name: Clone STM32 simulator
-        run: git clone --depth 1 https://github.com/wolfSSL/simulators simulators
+        run: |
+          git clone https://github.com/wolfSSL/simulators simulators
+          cd simulators && git checkout "$SIMULATORS_REF"
+
+      # The MP135 firmware in the simulators repo currently disables SHAKE
+      # in user_settings.h with a comment pointing at the wolfSSL build
+      # break that this PR resolves. Once the simulators repo refreshes
+      # that file, this patch step becomes a no-op (the grep below will
+      # still pass) - drop it then.
+      - name: Enable SHAKE in MP135 firmware user_settings.h
+        if: matrix.chip_label == 'MP135'
+        working-directory: simulators/STM32Sim/firmware/wolfcrypt-test-mp135
+        run: |
+          sed -i 's|^#define WOLFSSL_SHA3$|#define WOLFSSL_SHA3\n#define WOLFSSL_SHAKE128\n#define WOLFSSL_SHAKE256|' user_settings.h
+          # Fail fast if the anchor line drifted - better than silently
+          # building with SHAKE off and "passing" without exercising it.
+          grep -q '^#define WOLFSSL_SHAKE128$' user_settings.h
+          grep -q '^#define WOLFSSL_SHAKE256$' user_settings.h
 
       - uses: docker/setup-buildx-action@v3
 

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -76,6 +76,24 @@
     #include <wolfcrypt/src/misc.c>
 #endif
 
+/* Gates the non-WOLFSSL_SHA3_SMALL software Keccak primitives
+ * (hash_keccak_r, BlockSha3, InitSha3, Sha3Update, Sha3Final and the
+ * Load64* helpers). Compiled when:
+ *  - No HW SHA-3 backend is selected (the original baseline), OR
+ *  - STM32 HW SHA-3 is selected and SHAKE is enabled - SHAKE on STM32MP13
+ *    runs in software because the HASH peripheral's SHAKE support is
+ *    fixed-length and does not match wolfSSL's variable-length / iterative
+ *    SqueezeBlocks API. SHA-3 still uses the HASH peripheral.
+ *
+ * Note: the WOLFSSL_SHA3_SMALL branch earlier in this file defines its
+ * own hash_keccak_r and BlockSha3 unconditionally inside its #ifdef
+ * block, so this macro only controls the non-SMALL implementation. */
+#if (!defined(STM32_HASH_SHA3) && !defined(PSOC6_HASH_SHA3)) || \
+    (defined(STM32_HASH_SHA3) && \
+     (defined(WOLFSSL_SHAKE128) || defined(WOLFSSL_SHAKE256)))
+    #define WC_SHA3_SW_KECCAK
+#endif
+
 #if FIPS_VERSION3_GE(6,0,0)
     const unsigned int wolfCrypt_FIPS_sha3_ro_sanity[2] =
                                                      { 0x1a2b3c4d, 0x00000016 };
@@ -320,7 +338,7 @@ void BlockSha3(word64* s)
  */
 #define ROTL64(a, n)    (((a)<<(n))|((a)>>(64-(n))))
 
-#if !defined(STM32_HASH_SHA3) && !defined(PSOC6_HASH_SHA3)
+#ifdef WC_SHA3_SW_KECCAK
 /* An array of values to XOR for block operation. */
 static const word64 hash_keccak_r[24] =
 {
@@ -555,7 +573,7 @@ do {                                                      \
 while (0)
 #endif /* SHA3_BY_SPEC */
 
-#if !defined(STM32_HASH_SHA3) && !defined(PSOC6_HASH_SHA3)
+#ifdef WC_SHA3_SW_KECCAK
 /* The block operation performed on the state.
  *
  * s  The state.
@@ -581,11 +599,11 @@ void BlockSha3(word64* s)
         s[0] ^= hash_keccak_r[i+1];
     }
 }
-#endif /* WOLFSSL_SHA3_SMALL */
-#endif /* STM32_HASH_SHA3 */
+#endif /* WC_SHA3_SW_KECCAK */
+#endif /* !WOLFSSL_SHA3_SMALL */
 #endif /* !WOLFSSL_ARMASM && !WOLFSSL_RISCV_ASM */
 
-#if !defined(STM32_HASH_SHA3) && !defined(PSOC6_HASH_SHA3)
+#ifdef WC_SHA3_SW_KECCAK
 #if defined(BIG_ENDIAN_ORDER)
 static WC_INLINE word64 Load64Unaligned(const unsigned char *a)
 {
@@ -929,7 +947,7 @@ static int Sha3Final(wc_Sha3* sha3, byte padChar, byte* hash, byte p, word32 l)
 
     return 0;
 }
-#endif
+#endif /* WC_SHA3_SW_KECCAK */
 #if defined(STM32_HASH_SHA3)
 
 /* Supports CubeMX HAL or Standard Peripheral Library */


### PR DESCRIPTION
This fixes the fact that you can't compile SHAKE when SHA-3 hardware acceleration is enabled for STM32. It also adds the STM32MP13 emulator with hardware support from the simulators repo.