### PR TITLE
Various Fenrir fixes (F-2626, F-585, F-586, F-2638, F-1960, F-599)

### DIFF
--- a/wolfcrypt/src/port/intel/quickassist_sync.c
+++ b/wolfcrypt/src/port/intel/quickassist_sync.c
@@ -969,9 +969,7 @@ static int IntelQaSymCipher(IntelQaDev* dev, byte* out, const byte* in,
     flatBuffer = &dev->op.cipher.flatBuffer;
     metaBuf = XMALLOC(metaSize, dev->heap, DYNAMIC_TYPE_ASYNC_NUMA);
     dataBuf = XMALLOC(dataLen, dev->heap, DYNAMIC_TYPE_ASYNC_NUMA);
-    XMEMCPY(dataBuf, in, inOutSz);
     ivBuf = XMALLOC(WC_AES_BLOCK_SIZE, dev->heap, DYNAMIC_TYPE_ASYNC_NUMA);
-    XMEMCPY(ivBuf, iv, ivSz);
     authTagBuf = XMALLOC(authTagSz, dev->heap, DYNAMIC_TYPE_ASYNC_NUMA);
 
     /* check allocations */
@@ -979,6 +977,9 @@ static int IntelQaSymCipher(IntelQaDev* dev, byte* out, const byte* in,
         authTagBuf == NULL) {
         ret = MEMORY_E; goto exit;
     }
+
+    XMEMCPY(dataBuf, in, inOutSz);
+    XMEMCPY(ivBuf, iv, ivSz);
 
     /* AAD */
     if (authIn && authInSz > 0) {
@@ -990,10 +991,10 @@ static int IntelQaSymCipher(IntelQaDev* dev, byte* out, const byte* in,
 
         authInBuf = XMALLOC(authInSzAligned, dev->heap,
                 DYNAMIC_TYPE_ASYNC_NUMA);
-        XMEMCPY(authInBuf, authIn, authInSz);
         if (authInBuf == NULL) {
             ret = MEMORY_E; goto exit;
         }
+        XMEMCPY(authInBuf, authIn, authInSz);
         /* clear remainder */
         XMEMSET(authInBuf + authInSz, 0, authInSzAligned - authInSz);
     }

--- a/wolfcrypt/src/port/intel/quickassist_sync.c
+++ b/wolfcrypt/src/port/intel/quickassist_sync.c
@@ -1100,9 +1100,12 @@ exit:
     }
 
     /* Capture the inline decrypt into the output. */
-    XMEMCPY(out, dataBuf, inOutSz);
-    if (cipherDirection == CPA_CY_SYM_CIPHER_DIRECTION_ENCRYPT) {
-        if (authTag != NULL && authTagSz > 0) {
+    if (ret == 0 && dataBuf != NULL) {
+        XMEMCPY(out, dataBuf, inOutSz);
+    }
+    if (ret == 0 &&
+            cipherDirection == CPA_CY_SYM_CIPHER_DIRECTION_ENCRYPT) {
+        if (authTag != NULL && authTagSz > 0 && authTagBuf != NULL) {
             XMEMCPY(authTag, authTagBuf, authTagSz);
         }
     }

--- a/wolfcrypt/src/port/kcapi/kcapi_ecc.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_ecc.c
@@ -272,6 +272,7 @@ int KcapiEcc_SharedSecret(ecc_key* private_key, ecc_key* public_key, byte* out,
     }
 
     if (buf_aligned != NULL) {
+        ForceZero(buf_aligned, keySz * 2);
     #ifdef KCAPI_USE_XMALLOC
         XFREE(buf_aligned, private_key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     #else

--- a/wolfcrypt/src/port/nxp/se050_port.c
+++ b/wolfcrypt/src/port/nxp/se050_port.c
@@ -37,6 +37,13 @@
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/curve25519.h>
 
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+
 #include <wolfssl/wolfcrypt/port/nxp/se050_port.h>
 
 #ifdef WOLFSSL_SE050_INIT
@@ -3013,6 +3020,7 @@ int se050_ed25519_sign_msg(const byte* in, word32 inLen, byte* out,
                 status = sss_key_store_set_key(&host_keystore, &newKey, derBuf,
                                                 derSz, keySize * 8, NULL, 0);
             }
+            ForceZero(derBuf, sizeof(derBuf));
         }
         else {
             status = sss_key_object_get_handle(&newKey, keyId);

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -937,7 +937,7 @@ static int stm32_getabs_from_mp_int(uint8_t *dst, const mp_int *a, int sz,
     #if defined(USE_FAST_MATH) || defined(USE_INTEGER_HEAP_MATH) || \
         ((defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
             defined(WOLFSSL_SP_INT_NEGATIVE))
-        *abs_sign = x.sign;
+        *abs_sign = a->sign;
     #else
         *abs_sign = 1; /* default to negative */
     #endif

--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -51,6 +51,36 @@
     #endif
 #endif
 
+/* Minimum hash strength accepted by the wc_SignatureVerify/Generate
+ * convenience APIs. Default is SHA-256 to keep MD5 and SHA-1 (both with
+ * known collision attacks) out of new code. Define WC_SIG_MIN_HASH_TYPE
+ * to a weaker wc_HashType (e.g. WC_HASH_TYPE_SHA) to opt back into legacy
+ * behavior. The lower-level wc_SignatureVerifyHash/wc_SignatureGenerateHash
+ * APIs are unaffected. */
+#ifndef WC_SIG_MIN_HASH_TYPE
+    #define WC_SIG_MIN_HASH_TYPE WC_HASH_TYPE_SHA256
+#endif
+
+static int wc_SignatureCheckHashStrength(enum wc_HashType hash_type)
+{
+    int min_sz, this_sz;
+
+    min_sz = wc_HashGetDigestSize(WC_SIG_MIN_HASH_TYPE);
+    if (min_sz < 0) {
+        /* configured floor not compiled in - skip enforcement */
+        return 0;
+    }
+    this_sz = wc_HashGetDigestSize(hash_type);
+    if (this_sz < 0) {
+        return this_sz;
+    }
+    if (this_sz < min_sz) {
+        WOLFSSL_MSG("wc_Signature*: hash weaker than WC_SIG_MIN_HASH_TYPE");
+        return BAD_FUNC_ARG;
+    }
+    return 0;
+}
+
 
 #if !defined(NO_RSA) && defined(WOLFSSL_CRYPTOCELL)
     extern int cc310_RsaSSL_Verify(const byte* in, word32 inLen, byte* sig,
@@ -356,6 +386,12 @@ int wc_SignatureVerify(
     }
     hash_enc_len = hash_len = (word32)ret;
 
+    /* Reject hashes weaker than WC_SIG_MIN_HASH_TYPE (default SHA-256) */
+    ret = wc_SignatureCheckHashStrength(hash_type);
+    if (ret != 0) {
+        return ret;
+    }
+
 #ifndef NO_RSA
     if (sig_type == WC_SIGNATURE_TYPE_RSA_W_ENC) {
         /* For RSA with ASN.1 encoding include room */
@@ -554,6 +590,12 @@ int wc_SignatureGenerate_ex(
         return ret;
     }
     hash_enc_len = hash_len = (word32)ret;
+
+    /* Reject hashes weaker than WC_SIG_MIN_HASH_TYPE (default SHA-256) */
+    ret = wc_SignatureCheckHashStrength(hash_type);
+    if (ret != 0) {
+        return ret;
+    }
 
 #if !defined(NO_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)
     if (sig_type == WC_SIGNATURE_TYPE_RSA_W_ENC) {


### PR DESCRIPTION
# Description

* fix(signature): fenrir 2626 enforce min hash strength
* fix(qat): fenrir 585 null-check buffers before memcpy
* fix(qat): fenrir 586 guard exit memcpy on error path
* fix(se050): fenrir 2638 zero ed25519 der buffer   ← rewritten
* fix(kcapi): fenrir 1960 zero ecdh secret before free
* fix(stm32): fenrir 599 capture sign from input mp_int

# Testing


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
