### PR TITLE
 Fix potential mismatch in size between DECL_MP_INT_SIZE_DYN and NEW_MP_INT_SIZE, fix unused variable warning in random.c.

### DIFF
--- a/tests/api/test_rsa.c
+++ b/tests/api/test_rsa.c
@@ -1212,6 +1212,56 @@ int test_wc_RsaDecrypt_BoundsCheck(void)
 } /* END test_wc_RsaDecryptBoundsCheck */
 
 /*
+ * Oversized RSA modulus (mp_bitsused(n) > RSA_MAX_SIZE) must not overflow the
+ * static stack buffer used by RsaFunctionCheckIn (DECL_MP_INT_SIZE_DYN).
+ */
+int test_wc_RsaFunctionCheckIn_OversizedModulus(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_RSA) && defined(WC_RSA_NO_PADDING) && defined(WC_RSA_DIRECT) && \
+    defined(WOLFSSL_PUBLIC_MP) && !defined(NO_RSA_BOUNDS_CHECK) && \
+    (defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
+    !defined(WOLFSSL_SMALL_STACK) && \
+    (defined(USE_CERT_BUFFERS_1024) || defined(USE_CERT_BUFFERS_2048))
+    WC_RNG rng;
+    RsaKey key;
+    const byte* derKey;
+    word32 derKeySz;
+    word32 idx = 0;
+    byte flatC[256];
+    word32 flatCSz;
+    byte out[256];
+    word32 outSz = sizeof(out);
+
+    #ifdef USE_CERT_BUFFERS_1024
+        derKey = server_key_der_1024;
+        derKeySz = (word32)sizeof_server_key_der_1024;
+        flatCSz = 128;
+    #else
+        derKey = server_key_der_2048;
+        derKeySz = (word32)sizeof_server_key_der_2048;
+        flatCSz = 256;
+    #endif
+
+    XMEMSET(&key, 0, sizeof(RsaKey));
+    XMEMSET(&rng, 0, sizeof(WC_RNG));
+
+    ExpectIntEQ(wc_InitRsaKey(&key, HEAP_HINT), 0);
+    ExpectIntEQ(wc_InitRng(&rng), 0);
+    ExpectIntEQ(wc_RsaPrivateKeyDecode(derKey, &idx, &key, derKeySz), 0);
+    /* Force modulus bit count above RSA_MAX_SIZE. */
+    ExpectIntEQ(mp_set_bit(&key.n, RSA_MAX_SIZE), 0);
+    XMEMSET(flatC, 0, flatCSz);
+    ExpectIntEQ(wc_RsaDirect(flatC, flatCSz, out, &outSz, &key,
+        RSA_PRIVATE_DECRYPT, &rng), WC_NO_ERR_TRACE(WC_KEY_SIZE_E));
+
+    DoExpectIntEQ(wc_FreeRsaKey(&key), 0);
+    DoExpectIntEQ(wc_FreeRng(&rng), 0);
+#endif
+    return EXPECT_RESULT();
+} /* END test_wc_RsaFunctionCheckIn_OversizedModulus */
+
+/*
  * Test wc_RsaKeyToDer with an mp_int large enough to wrap size calculations.
  */
 int test_wc_RsaKeyToDer_SizeOverflow(void)

--- a/tests/api/test_rsa.c
+++ b/tests/api/test_rsa.c
@@ -1214,33 +1214,43 @@ int test_wc_RsaDecrypt_BoundsCheck(void)
 /*
  * Oversized RSA modulus (mp_bitsused(n) > RSA_MAX_SIZE) must not overflow the
  * static stack buffer used by RsaFunctionCheckIn (DECL_MP_INT_SIZE_DYN).
+ *
+ * The buffer is sized for RSA_MAX_SIZE digits, and NEW_MP_INT_SIZE would zero
+ * mp_bitsused(&key->n) digits of it -- so an oversized modulus must be
+ * caught by MP_BITS_OVER_MAX *before* NEW_MP_INT_SIZE is reached.  We feed
+ * wc_RsaDirect() an input/output buffer matching the oversized modulus byte
+ * size so we get past wc_RsaDirect()'s inLen sanity check and reach the
+ * RsaFunctionCheckIn() guard inside wc_RsaFunction_ex().
  */
 int test_wc_RsaFunctionCheckIn_OversizedModulus(void)
 {
     EXPECT_DECLS;
 #if !defined(NO_RSA) && defined(WC_RSA_NO_PADDING) && defined(WC_RSA_DIRECT) && \
     defined(WOLFSSL_PUBLIC_MP) && !defined(NO_RSA_BOUNDS_CHECK) && \
+    !defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(TEST_UNPAD_CONSTANT_TIME) && \
     (defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
     !defined(WOLFSSL_SMALL_STACK) && \
     (defined(USE_CERT_BUFFERS_1024) || defined(USE_CERT_BUFFERS_2048))
+    /* Setting bit RSA_MAX_SIZE makes the modulus RSA_MAX_SIZE+1 bits, i.e.
+     * (RSA_MAX_SIZE/8 + 1) bytes -- size buffers accordingly with slack. */
+    #define WC_RSA_OVERSIZED_BUF_LEN ((RSA_MAX_SIZE / 8) + 8)
     WC_RNG rng;
     RsaKey key;
     const byte* derKey;
     word32 derKeySz;
     word32 idx = 0;
-    byte flatC[256];
+    byte flatC[WC_RSA_OVERSIZED_BUF_LEN];
     word32 flatCSz;
-    byte out[256];
+    byte out[WC_RSA_OVERSIZED_BUF_LEN];
     word32 outSz = sizeof(out);
+    int    encSz;
 
     #ifdef USE_CERT_BUFFERS_1024
         derKey = server_key_der_1024;
         derKeySz = (word32)sizeof_server_key_der_1024;
-        flatCSz = 128;
     #else
         derKey = server_key_der_2048;
         derKeySz = (word32)sizeof_server_key_der_2048;
-        flatCSz = 256;
     #endif
 
     XMEMSET(&key, 0, sizeof(RsaKey));
@@ -1251,12 +1261,22 @@ int test_wc_RsaFunctionCheckIn_OversizedModulus(void)
     ExpectIntEQ(wc_RsaPrivateKeyDecode(derKey, &idx, &key, derKeySz), 0);
     /* Force modulus bit count above RSA_MAX_SIZE. */
     ExpectIntEQ(mp_set_bit(&key.n, RSA_MAX_SIZE), 0);
-    XMEMSET(flatC, 0, flatCSz);
-    ExpectIntEQ(wc_RsaDirect(flatC, flatCSz, out, &outSz, &key,
-        RSA_PRIVATE_DECRYPT, &rng), WC_NO_ERR_TRACE(WC_KEY_SIZE_E));
+
+    /* Match wc_RsaDirect()'s inLen check so we actually reach
+     * RsaFunctionCheckIn() (where the MP_BITS_OVER_MAX guard lives). */
+    encSz = wc_RsaEncryptSize(&key);
+    ExpectIntGT(encSz, 0);
+    ExpectIntLE(encSz, (int)sizeof(flatC));
+    if (encSz > 0 && (size_t)encSz <= sizeof(flatC)) {
+        flatCSz = (word32)encSz;
+        XMEMSET(flatC, 0, flatCSz);
+        ExpectIntEQ(wc_RsaDirect(flatC, flatCSz, out, &outSz, &key,
+            RSA_PRIVATE_DECRYPT, &rng), WC_NO_ERR_TRACE(WC_KEY_SIZE_E));
+    }
 
     DoExpectIntEQ(wc_FreeRsaKey(&key), 0);
     DoExpectIntEQ(wc_FreeRng(&rng), 0);
+    #undef WC_RSA_OVERSIZED_BUF_LEN
 #endif
     return EXPECT_RESULT();
 } /* END test_wc_RsaFunctionCheckIn_OversizedModulus */

--- a/tests/api/test_rsa.h
+++ b/tests/api/test_rsa.h
@@ -43,6 +43,7 @@ int test_wc_RsaEncryptSize(void);
 int test_wc_RsaSSL_SignVerify(void);
 int test_wc_RsaFlattenPublicKey(void);
 int test_wc_RsaDecrypt_BoundsCheck(void);
+int test_wc_RsaFunctionCheckIn_OversizedModulus(void);
 int test_wc_RsaKeyToDer_SizeOverflow(void);
 
 #define TEST_RSA_DECLS                                          \
@@ -65,6 +66,7 @@ int test_wc_RsaKeyToDer_SizeOverflow(void);
     TEST_DECL_GROUP("rsa", test_wc_RsaSSL_SignVerify),          \
     TEST_DECL_GROUP("rsa", test_wc_RsaFlattenPublicKey),        \
     TEST_DECL_GROUP("rsa", test_wc_RsaDecrypt_BoundsCheck),             \
+    TEST_DECL_GROUP("rsa", test_wc_RsaFunctionCheckIn_OversizedModulus), \
     TEST_DECL_GROUP("rsa", test_wc_RsaKeyToDer_SizeOverflow)
 
 #endif /* WOLFCRYPT_TEST_RSA_H */

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -327,6 +327,14 @@ ECC Curve Sizes:
 #define MAX_ECC_BITS_USE    MAX_ECC_BITS_NEEDED
 #endif
 
+#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
+#define ECC_DECL_MP_OVER_MAX(bits) \
+    (MP_BITS_CNT(bits) > MP_BITS_CNT(MAX_ECC_BITS_USE))
+#else
+#define ECC_DECL_MP_OVER_MAX(bits) \
+    ((bits) > MAX_ECC_BITS_USE)
+#endif
+
 #if !defined(WOLFSSL_CUSTOM_CURVES) && (ECC_MIN_KEY_SZ > 160) && \
     (!defined(HAVE_ECC_KOBLITZ) || (ECC_MIN_KEY_SZ > 224))
 
@@ -2012,7 +2020,7 @@ static int _ecc_projective_add_point(ecc_point* P, ecc_point* Q, ecc_point* R,
    mp_int  *x, *y, *z;
    int     err;
 
-   if (mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+   if (ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
        return WC_KEY_SIZE_E;
    }
 
@@ -2416,7 +2424,7 @@ static int _ecc_projective_dbl_point(ecc_point *P, ecc_point *R, mp_int* a,
    mp_int *x, *y, *z;
    int    err;
 
-   if (mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+   if (ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
        return WC_KEY_SIZE_E;
    }
 
@@ -2770,7 +2778,7 @@ int ecc_map_ex(ecc_point* P, mp_int* modulus, mp_digit mp, int ct)
         #endif
         mp_int *x, *y, *z;
 
-        if (mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+        if (ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
             return WC_KEY_SIZE_E;
         }
 
@@ -3595,7 +3603,7 @@ static int ecc_point_to_mont(ecc_point* p, ecc_point* r, mp_int* modulus,
 
    DECL_MP_INT_SIZE_DYN(mu, mp_bitsused(modulus), MAX_ECC_BITS_USE);
 
-   if (mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+   if (ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
        return WC_KEY_SIZE_E;
    }
 
@@ -3903,8 +3911,8 @@ static int ecc_check_order_minus_1(const mp_int* k, ecc_point* tG, ecc_point* R,
     int err;
     DECL_MP_INT_SIZE_DYN(t, mp_bitsused(order), MAX_ECC_BITS_USE);
 
-    if (mp_bitsused(order) > MAX_ECC_BITS_USE ||
-            mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+    if (ECC_DECL_MP_OVER_MAX(mp_bitsused(order)) ||
+            ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
         return WC_KEY_SIZE_E;
     }
 
@@ -6858,7 +6866,7 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     word32 keySz;
 #endif
 
-    if (ECC_KEY_MAX_BITS(key) > MAX_ECC_BITS_USE) {
+    if (ECC_DECL_MP_OVER_MAX(ECC_KEY_MAX_BITS(key))) {
         return WC_KEY_SIZE_E;
     }
 
@@ -7063,7 +7071,7 @@ static int ecc_sign_hash_sw(ecc_key* key, ecc_key* pubkey, WC_RNG* rng,
 
     DECL_MP_INT_SIZE_DYN(b, ECC_KEY_MAX_BITS_NONULLCHECK(key), MAX_ECC_BITS_USE);
 
-    if (ECC_KEY_MAX_BITS_NONULLCHECK(key) > MAX_ECC_BITS_USE) {
+    if (ECC_DECL_MP_OVER_MAX(ECC_KEY_MAX_BITS_NONULLCHECK(key))) {
         return WC_KEY_SIZE_E;
     }
 
@@ -7394,7 +7402,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 #else
    DECLARE_CURVE_SPECS(1);
 #endif
-   if (ECC_KEY_MAX_BITS(key) > MAX_ECC_BITS_USE) {
+   if (ECC_DECL_MP_OVER_MAX(ECC_KEY_MAX_BITS(key))) {
        return WC_KEY_SIZE_E;
    }
 #endif /* !WOLFSSL_SP_MATH */
@@ -8317,7 +8325,7 @@ static int ecc_mont_norm_points(ecc_point* A, ecc_point* Am, ecc_point* B,
 
     DECL_MP_INT_SIZE_DYN(mu, mp_bitsused(modulus), MAX_ECC_BITS_USE);
 
-    if (mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+    if (ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
         return WC_KEY_SIZE_E;
     }
 
@@ -8707,7 +8715,7 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     word32 keySz;
 #endif
 
-    if (ECC_KEY_MAX_BITS(key) > MAX_ECC_BITS_USE) {
+    if (ECC_DECL_MP_OVER_MAX(ECC_KEY_MAX_BITS(key))) {
         return WC_KEY_SIZE_E;
     }
 
@@ -9095,7 +9103,7 @@ static int ecc_verify_hash(mp_int *r, mp_int *s, const byte* hash,
    mp_int*    u1 = NULL;     /* Will be e. */
    mp_int*    u2 = NULL;     /* Will be w. */
 
-   if (ECC_KEY_MAX_BITS_NONULLCHECK(key) > MAX_ECC_BITS_USE) {
+   if (ECC_DECL_MP_OVER_MAX(ECC_KEY_MAX_BITS_NONULLCHECK(key))) {
        return WC_KEY_SIZE_E;
    }
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2012,6 +2012,10 @@ static int _ecc_projective_add_point(ecc_point* P, ecc_point* Q, ecc_point* R,
    mp_int  *x, *y, *z;
    int     err;
 
+   if (mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+       return WC_KEY_SIZE_E;
+   }
+
    /* if Q == R then swap P and Q, so we don't require a local x,y,z */
    if (Q == R) {
       ecc_point* tPt  = P;
@@ -2412,6 +2416,10 @@ static int _ecc_projective_dbl_point(ecc_point *P, ecc_point *R, mp_int* a,
    mp_int *x, *y, *z;
    int    err;
 
+   if (mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+       return WC_KEY_SIZE_E;
+   }
+
 #ifdef WOLFSSL_SMALL_STACK
 #ifdef WOLFSSL_SMALL_STACK_CACHE
    if (R->key != NULL) {
@@ -2761,6 +2769,10 @@ int ecc_map_ex(ecc_point* P, mp_int* modulus, mp_digit mp, int ct)
         DECL_MP_INT_SIZE_DYN(rz, mp_bitsused(modulus), MAX_ECC_BITS_USE);
         #endif
         mp_int *x, *y, *z;
+
+        if (mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+            return WC_KEY_SIZE_E;
+        }
 
         /* special case for point at infinity */
         if (mp_cmp_d(P->z, 0) == MP_EQ) {
@@ -3580,7 +3592,12 @@ static int ecc_point_to_mont(ecc_point* p, ecc_point* r, mp_int* modulus,
                              void* heap)
 {
    int err = MP_OKAY;
+
    DECL_MP_INT_SIZE_DYN(mu, mp_bitsused(modulus), MAX_ECC_BITS_USE);
+
+   if (mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+       return WC_KEY_SIZE_E;
+   }
 
    (void)heap;
 
@@ -3885,6 +3902,11 @@ static int ecc_check_order_minus_1(const mp_int* k, ecc_point* tG, ecc_point* R,
 {
     int err;
     DECL_MP_INT_SIZE_DYN(t, mp_bitsused(order), MAX_ECC_BITS_USE);
+
+    if (mp_bitsused(order) > MAX_ECC_BITS_USE ||
+            mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+        return WC_KEY_SIZE_E;
+    }
 
     NEW_MP_INT_SIZE(t, mp_bitsused(modulus), NULL, DYNAMIC_TYPE_ECC);
 #ifdef MP_INT_SIZE_CHECK_NULL
@@ -6836,6 +6858,10 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     word32 keySz;
 #endif
 
+    if (ECC_KEY_MAX_BITS(key) > MAX_ECC_BITS_USE) {
+        return WC_KEY_SIZE_E;
+    }
+
     if (in == NULL || out == NULL || outlen == NULL || key == NULL) {
         return ECC_BAD_ARG_E;
     }
@@ -7034,7 +7060,12 @@ static int ecc_sign_hash_sw(ecc_key* key, ecc_key* pubkey, WC_RNG* rng,
 {
     int err = MP_OKAY;
     int loop_check = 0;
+
     DECL_MP_INT_SIZE_DYN(b, ECC_KEY_MAX_BITS_NONULLCHECK(key), MAX_ECC_BITS_USE);
+
+    if (ECC_KEY_MAX_BITS_NONULLCHECK(key) > MAX_ECC_BITS_USE) {
+        return WC_KEY_SIZE_E;
+    }
 
     NEW_MP_INT_SIZE(b, ECC_KEY_MAX_BITS_NONULLCHECK(key), key->heap, DYNAMIC_TYPE_ECC);
 #ifdef MP_INT_SIZE_CHECK_NULL
@@ -7363,6 +7394,9 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 #else
    DECLARE_CURVE_SPECS(1);
 #endif
+   if (ECC_KEY_MAX_BITS(key) > MAX_ECC_BITS_USE) {
+       return WC_KEY_SIZE_E;
+   }
 #endif /* !WOLFSSL_SP_MATH */
 
    if (in == NULL || r == NULL || s == NULL || key == NULL || rng == NULL) {
@@ -8280,7 +8314,12 @@ static int ecc_mont_norm_points(ecc_point* A, ecc_point* Am, ecc_point* B,
     ecc_point* Bm, mp_int* modulus, void* heap)
 {
     int err = MP_OKAY;
+
     DECL_MP_INT_SIZE_DYN(mu, mp_bitsused(modulus), MAX_ECC_BITS_USE);
+
+    if (mp_bitsused(modulus) > MAX_ECC_BITS_USE) {
+        return WC_KEY_SIZE_E;
+    }
 
     (void)heap;
 
@@ -8668,6 +8707,10 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     word32 keySz;
 #endif
 
+    if (ECC_KEY_MAX_BITS(key) > MAX_ECC_BITS_USE) {
+        return WC_KEY_SIZE_E;
+    }
+
     if (sig == NULL || hash == NULL || res == NULL || key == NULL) {
         return ECC_BAD_ARG_E;
     }
@@ -9038,6 +9081,7 @@ static int ecc_verify_hash(mp_int *r, mp_int *s, const byte* hash,
    ecc_point  lcl_mG;
    ecc_point  lcl_mQ;
 #endif
+
    DECL_MP_INT_SIZE_DYN(w, ECC_KEY_MAX_BITS_NONULLCHECK(key), MAX_ECC_BITS_USE);
 #if !defined(WOLFSSL_ASYNC_CRYPT) || !defined(HAVE_CAVIUM_V)
    DECL_MP_INT_SIZE_DYN(e_lcl, ECC_KEY_MAX_BITS_NONULLCHECK(key), MAX_ECC_BITS_USE);
@@ -9050,6 +9094,11 @@ static int ecc_verify_hash(mp_int *r, mp_int *s, const byte* hash,
 #endif
    mp_int*    u1 = NULL;     /* Will be e. */
    mp_int*    u2 = NULL;     /* Will be w. */
+
+   if (ECC_KEY_MAX_BITS_NONULLCHECK(key) > MAX_ECC_BITS_USE) {
+       return WC_KEY_SIZE_E;
+   }
+
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM_V)
    err = wc_ecc_alloc_mpint(key, &key->e);
    if (err != 0) {

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -327,14 +327,6 @@ ECC Curve Sizes:
 #define MAX_ECC_BITS_USE    MAX_ECC_BITS_NEEDED
 #endif
 
-#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
-#define ECC_DECL_MP_OVER_MAX(bits) \
-    (MP_BITS_CNT(bits) > MP_BITS_CNT(MAX_ECC_BITS_USE))
-#else
-#define ECC_DECL_MP_OVER_MAX(bits) \
-    ((bits) > MAX_ECC_BITS_USE)
-#endif
-
 #if !defined(WOLFSSL_CUSTOM_CURVES) && (ECC_MIN_KEY_SZ > 160) && \
     (!defined(HAVE_ECC_KOBLITZ) || (ECC_MIN_KEY_SZ > 224))
 
@@ -2020,7 +2012,7 @@ static int _ecc_projective_add_point(ecc_point* P, ecc_point* Q, ecc_point* R,
    mp_int  *x, *y, *z;
    int     err;
 
-   if (ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
+   if (MP_BITS_OVER_MAX(mp_bitsused(modulus), MAX_ECC_BITS_USE)) {
        return WC_KEY_SIZE_E;
    }
 
@@ -2424,7 +2416,7 @@ static int _ecc_projective_dbl_point(ecc_point *P, ecc_point *R, mp_int* a,
    mp_int *x, *y, *z;
    int    err;
 
-   if (ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
+   if (MP_BITS_OVER_MAX(mp_bitsused(modulus), MAX_ECC_BITS_USE)) {
        return WC_KEY_SIZE_E;
    }
 
@@ -2778,7 +2770,7 @@ int ecc_map_ex(ecc_point* P, mp_int* modulus, mp_digit mp, int ct)
         #endif
         mp_int *x, *y, *z;
 
-        if (ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
+        if (MP_BITS_OVER_MAX(mp_bitsused(modulus), MAX_ECC_BITS_USE)) {
             return WC_KEY_SIZE_E;
         }
 
@@ -3603,7 +3595,7 @@ static int ecc_point_to_mont(ecc_point* p, ecc_point* r, mp_int* modulus,
 
    DECL_MP_INT_SIZE_DYN(mu, mp_bitsused(modulus), MAX_ECC_BITS_USE);
 
-   if (ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
+   if (MP_BITS_OVER_MAX(mp_bitsused(modulus), MAX_ECC_BITS_USE)) {
        return WC_KEY_SIZE_E;
    }
 
@@ -3911,8 +3903,8 @@ static int ecc_check_order_minus_1(const mp_int* k, ecc_point* tG, ecc_point* R,
     int err;
     DECL_MP_INT_SIZE_DYN(t, mp_bitsused(order), MAX_ECC_BITS_USE);
 
-    if (ECC_DECL_MP_OVER_MAX(mp_bitsused(order)) ||
-            ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
+    if (MP_BITS_OVER_MAX(mp_bitsused(order), MAX_ECC_BITS_USE) ||
+            MP_BITS_OVER_MAX(mp_bitsused(modulus), MAX_ECC_BITS_USE)) {
         return WC_KEY_SIZE_E;
     }
 
@@ -6866,7 +6858,7 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     word32 keySz;
 #endif
 
-    if (ECC_DECL_MP_OVER_MAX(ECC_KEY_MAX_BITS(key))) {
+    if (MP_BITS_OVER_MAX(ECC_KEY_MAX_BITS(key), MAX_ECC_BITS_USE)) {
         return WC_KEY_SIZE_E;
     }
 
@@ -7071,7 +7063,7 @@ static int ecc_sign_hash_sw(ecc_key* key, ecc_key* pubkey, WC_RNG* rng,
 
     DECL_MP_INT_SIZE_DYN(b, ECC_KEY_MAX_BITS_NONULLCHECK(key), MAX_ECC_BITS_USE);
 
-    if (ECC_DECL_MP_OVER_MAX(ECC_KEY_MAX_BITS_NONULLCHECK(key))) {
+    if (MP_BITS_OVER_MAX(ECC_KEY_MAX_BITS_NONULLCHECK(key), MAX_ECC_BITS_USE)) {
         return WC_KEY_SIZE_E;
     }
 
@@ -7402,7 +7394,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 #else
    DECLARE_CURVE_SPECS(1);
 #endif
-   if (ECC_DECL_MP_OVER_MAX(ECC_KEY_MAX_BITS(key))) {
+   if (MP_BITS_OVER_MAX(ECC_KEY_MAX_BITS(key), MAX_ECC_BITS_USE)) {
        return WC_KEY_SIZE_E;
    }
 #endif /* !WOLFSSL_SP_MATH */
@@ -8325,7 +8317,7 @@ static int ecc_mont_norm_points(ecc_point* A, ecc_point* Am, ecc_point* B,
 
     DECL_MP_INT_SIZE_DYN(mu, mp_bitsused(modulus), MAX_ECC_BITS_USE);
 
-    if (ECC_DECL_MP_OVER_MAX(mp_bitsused(modulus))) {
+    if (MP_BITS_OVER_MAX(mp_bitsused(modulus), MAX_ECC_BITS_USE)) {
         return WC_KEY_SIZE_E;
     }
 
@@ -8715,7 +8707,7 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     word32 keySz;
 #endif
 
-    if (ECC_DECL_MP_OVER_MAX(ECC_KEY_MAX_BITS(key))) {
+    if (MP_BITS_OVER_MAX(ECC_KEY_MAX_BITS(key), MAX_ECC_BITS_USE)) {
         return WC_KEY_SIZE_E;
     }
 
@@ -9103,7 +9095,7 @@ static int ecc_verify_hash(mp_int *r, mp_int *s, const byte* hash,
    mp_int*    u1 = NULL;     /* Will be e. */
    mp_int*    u2 = NULL;     /* Will be w. */
 
-   if (ECC_DECL_MP_OVER_MAX(ECC_KEY_MAX_BITS_NONULLCHECK(key))) {
+   if (MP_BITS_OVER_MAX(ECC_KEY_MAX_BITS_NONULLCHECK(key), MAX_ECC_BITS_USE)) {
        return WC_KEY_SIZE_E;
    }
 

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1715,7 +1715,7 @@ static int _InitRng(WC_RNG* rng, byte* nonce, word32 nonceSz,
                     void* heap, int devId)
 {
     int ret = 0;
-#ifdef HAVE_HASHDRBG
+#if defined(HAVE_HASHDRBG) && !defined(CUSTOM_RAND_GENERATE_BLOCK)
 #if !defined(HAVE_FIPS) && defined(WOLFSSL_RNG_USE_FULL_SEED)
     word32 seedSz = SEED_SZ;
 #else

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -839,6 +839,10 @@ int wc_CheckRsaKey(RsaKey* key)
     }
 #endif
 
+    if (mp_bitsused(&key->n) > RSA_MAX_SIZE) {
+        return WC_KEY_SIZE_E;
+    }
+
     NEW_MP_INT_SIZE(tmp, mp_bitsused(&key->n), NULL, DYNAMIC_TYPE_RSA);
 #ifdef MP_INT_SIZE_CHECK_NULL
     if (tmp == NULL) {
@@ -2875,6 +2879,10 @@ static int RsaFunctionPrivate(mp_int* tmp, RsaKey* key, WC_RNG* rng)
     DECL_MP_INT_SIZE_DYN(rndi, mp_bitsused(&key->n), RSA_MAX_SIZE);
 #endif /* WC_RSA_BLINDING && !WC_NO_RNG */
 
+    if (mp_bitsused(&key->n) > RSA_MAX_SIZE) {
+        return WC_KEY_SIZE_E;
+    }
+
     (void)rng;
 
 #if defined(WC_RSA_BLINDING) && !defined(WC_NO_RNG)
@@ -3053,6 +3061,10 @@ static int RsaFunctionSync(const byte* in, word32 inLen, byte* out,
 {
     DECL_MP_INT_SIZE_DYN(tmp, mp_bitsused(&key->n), RSA_MAX_SIZE);
     int    ret = 0;
+
+    if (mp_bitsused(&key->n) > RSA_MAX_SIZE) {
+        return WC_KEY_SIZE_E;
+    }
 
     (void)rng;
 
@@ -3316,7 +3328,7 @@ int wc_RsaDirect(const byte* in, word32 inLen, byte* out, word32* outSz,
     }
 
     if ((ret = wc_RsaEncryptSize(key)) < 0) {
-        return BAD_FUNC_ARG;
+        return ret;
     }
 
     if (inLen != (word32)ret) {
@@ -3481,7 +3493,12 @@ int RsaFunctionCheckIn(const byte* in, word32 inLen, RsaKey* key,
     int checkSmallCt)
 {
     int ret = 0;
+
     DECL_MP_INT_SIZE_DYN(c, mp_bitsused(&key->n), RSA_MAX_SIZE);
+
+    if (mp_bitsused(&key->n) > RSA_MAX_SIZE) {
+        return WC_KEY_SIZE_E;
+    }
 
     NEW_MP_INT_SIZE(c, mp_bitsused(&key->n), key->heap, DYNAMIC_TYPE_RSA);
 #ifdef MP_INT_SIZE_CHECK_NULL
@@ -4821,6 +4838,10 @@ int wc_RsaEncryptSize(const RsaKey* key)
 
     if (key == NULL) {
         return BAD_FUNC_ARG;
+    }
+
+    if (mp_bitsused(&key->n) > RSA_MAX_SIZE) {
+        return WC_KEY_SIZE_E;
     }
 
     ret = mp_unsigned_bin_size(&key->n);

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -44,14 +44,6 @@ RSA keys can be used to encrypt, decrypt, sign and verify data.
 #include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/logging.h>
 
-#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
-#define RSA_DECL_MP_OVER_MAX(bits) \
-    (MP_BITS_CNT(bits) > MP_BITS_CNT(RSA_MAX_SIZE))
-#else
-#define RSA_DECL_MP_OVER_MAX(bits) \
-    ((bits) > RSA_MAX_SIZE)
-#endif
-
 #ifdef WOLFSSL_AFALG_XILINX_RSA
 #include <wolfssl/wolfcrypt/port/af_alg/wc_afalg.h>
 #endif
@@ -847,7 +839,7 @@ int wc_CheckRsaKey(RsaKey* key)
     }
 #endif
 
-    if (RSA_DECL_MP_OVER_MAX(mp_bitsused(&key->n))) {
+    if (MP_BITS_OVER_MAX(mp_bitsused(&key->n), RSA_MAX_SIZE)) {
         return WC_KEY_SIZE_E;
     }
 
@@ -2887,7 +2879,7 @@ static int RsaFunctionPrivate(mp_int* tmp, RsaKey* key, WC_RNG* rng)
     DECL_MP_INT_SIZE_DYN(rndi, mp_bitsused(&key->n), RSA_MAX_SIZE);
 #endif /* WC_RSA_BLINDING && !WC_NO_RNG */
 
-    if (RSA_DECL_MP_OVER_MAX(mp_bitsused(&key->n))) {
+    if (MP_BITS_OVER_MAX(mp_bitsused(&key->n), RSA_MAX_SIZE)) {
         return WC_KEY_SIZE_E;
     }
 
@@ -3070,7 +3062,7 @@ static int RsaFunctionSync(const byte* in, word32 inLen, byte* out,
     DECL_MP_INT_SIZE_DYN(tmp, mp_bitsused(&key->n), RSA_MAX_SIZE);
     int    ret = 0;
 
-    if (RSA_DECL_MP_OVER_MAX(mp_bitsused(&key->n))) {
+    if (MP_BITS_OVER_MAX(mp_bitsused(&key->n), RSA_MAX_SIZE)) {
         return WC_KEY_SIZE_E;
     }
 
@@ -3504,7 +3496,7 @@ int RsaFunctionCheckIn(const byte* in, word32 inLen, RsaKey* key,
 
     DECL_MP_INT_SIZE_DYN(c, mp_bitsused(&key->n), RSA_MAX_SIZE);
 
-    if (RSA_DECL_MP_OVER_MAX(mp_bitsused(&key->n))) {
+    if (MP_BITS_OVER_MAX(mp_bitsused(&key->n), RSA_MAX_SIZE)) {
         return WC_KEY_SIZE_E;
     }
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -44,6 +44,14 @@ RSA keys can be used to encrypt, decrypt, sign and verify data.
 #include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/logging.h>
 
+#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
+#define RSA_DECL_MP_OVER_MAX(bits) \
+    (MP_BITS_CNT(bits) > MP_BITS_CNT(RSA_MAX_SIZE))
+#else
+#define RSA_DECL_MP_OVER_MAX(bits) \
+    ((bits) > RSA_MAX_SIZE)
+#endif
+
 #ifdef WOLFSSL_AFALG_XILINX_RSA
 #include <wolfssl/wolfcrypt/port/af_alg/wc_afalg.h>
 #endif
@@ -839,7 +847,7 @@ int wc_CheckRsaKey(RsaKey* key)
     }
 #endif
 
-    if (mp_bitsused(&key->n) > RSA_MAX_SIZE) {
+    if (RSA_DECL_MP_OVER_MAX(mp_bitsused(&key->n))) {
         return WC_KEY_SIZE_E;
     }
 
@@ -2879,7 +2887,7 @@ static int RsaFunctionPrivate(mp_int* tmp, RsaKey* key, WC_RNG* rng)
     DECL_MP_INT_SIZE_DYN(rndi, mp_bitsused(&key->n), RSA_MAX_SIZE);
 #endif /* WC_RSA_BLINDING && !WC_NO_RNG */
 
-    if (mp_bitsused(&key->n) > RSA_MAX_SIZE) {
+    if (RSA_DECL_MP_OVER_MAX(mp_bitsused(&key->n))) {
         return WC_KEY_SIZE_E;
     }
 
@@ -3062,7 +3070,7 @@ static int RsaFunctionSync(const byte* in, word32 inLen, byte* out,
     DECL_MP_INT_SIZE_DYN(tmp, mp_bitsused(&key->n), RSA_MAX_SIZE);
     int    ret = 0;
 
-    if (mp_bitsused(&key->n) > RSA_MAX_SIZE) {
+    if (RSA_DECL_MP_OVER_MAX(mp_bitsused(&key->n))) {
         return WC_KEY_SIZE_E;
     }
 
@@ -3496,7 +3504,7 @@ int RsaFunctionCheckIn(const byte* in, word32 inLen, RsaKey* key,
 
     DECL_MP_INT_SIZE_DYN(c, mp_bitsused(&key->n), RSA_MAX_SIZE);
 
-    if (mp_bitsused(&key->n) > RSA_MAX_SIZE) {
+    if (RSA_DECL_MP_OVER_MAX(mp_bitsused(&key->n))) {
         return WC_KEY_SIZE_E;
     }
 
@@ -4838,10 +4846,6 @@ int wc_RsaEncryptSize(const RsaKey* key)
 
     if (key == NULL) {
         return BAD_FUNC_ARG;
-    }
-
-    if (mp_bitsused(&key->n) > RSA_MAX_SIZE) {
-        return WC_KEY_SIZE_E;
     }
 
     ret = mp_unsigned_bin_size(&key->n);

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -213,6 +213,10 @@ typedef int           mp_err;
 /* Type to cast to when using size marcos. */
 #define MP_INT_SIZE     mp_int
 
+/* integer.h allocates full-sized mp_int buffers, so DECL_MP_INT_SIZE_DYN
+ * cannot be undersized for any 'bits' value -- no check is needed. */
+#define MP_BITS_OVER_MAX(bits, max) 0
+
 #ifdef HAVE_WOLF_BIGINT
     /* raw big integer */
     typedef struct WC_BIGINT {

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -895,11 +895,13 @@ while (0)
 #define DECL_MP_INT_SIZE(name, bits)                               \
     sp_int_digit name##d[MP_INT_SIZEOF_DIGITS(MP_BITS_CNT(bits))]; \
     sp_int* (name) = (sp_int*)name##d
-/* Zero out mp_int of minimal size.
- * Use the declared digit array size, not bits, so memset cannot exceed the
- * buffer allocated by DECL_MP_INT_SIZE_DYN(..., bits, max). */
+/* Bytes to zero for a static mp_int: min(requested bits size, declared buffer). */
+#define MP_INT_ZERO_SIZE(name, bits)                                          \
+    ((sizeof(name##d) < MP_INT_SIZEOF(MP_BITS_CNT(bits))) ?                  \
+        sizeof(name##d) : MP_INT_SIZEOF(MP_BITS_CNT(bits)))
+/* Zero out mp_int without clearing more than the declared digit buffer. */
 #define NEW_MP_INT_SIZE(name, bits, heap, type) \
-    XMEMSET(name, 0, sizeof(name##d))
+    XMEMSET((name), 0, MP_INT_ZERO_SIZE(name, bits))
 /* Dispose of static mp_int. */
 #define FREE_MP_INT_SIZE(name, heap, type) WC_DO_NOTHING
 /* Type to force compiler to not complain about size. */

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -838,6 +838,17 @@ typedef struct sp_dh_ctx {
 #define MP_BITS_CNT(bits)                                       \
         ((unsigned int)(((((bits) + SP_WORD_SIZE - 1) / SP_WORD_SIZE) * 2 + 1)))
 
+/* True when 'bits' would require more digit storage than 'max'.
+ *
+ * Pairs with DECL_MP_INT_SIZE_DYN(name, bits, max) to guard against the
+ * static buffer (sized for 'max' digits) being undersized for 'bits' when
+ * the caller's 'bits' value can carry digit/byte alignment slack
+ * (e.g. mp_bitsused() returns used*SP_WORD_SIZE; dp->size*8 rounds up to a
+ * full byte).  Compare digit-rounded counts so curves like P-521 (521 bits,
+ * 17 32-bit digits) are not falsely rejected when max == 521. */
+#define MP_BITS_OVER_MAX(bits, max) \
+    (MP_BITS_CNT(bits) > MP_BITS_CNT(max))
+
 #if !defined(WOLFSSL_SP_NO_DYN_STACK) && defined(__STDC_VERSION__) && \
              (__STDC_VERSION__ >= 199901L) &&                         \
     (defined(WOLFSSL_SP_NO_MALLOC) ||                                 \

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -895,9 +895,11 @@ while (0)
 #define DECL_MP_INT_SIZE(name, bits)                               \
     sp_int_digit name##d[MP_INT_SIZEOF_DIGITS(MP_BITS_CNT(bits))]; \
     sp_int* (name) = (sp_int*)name##d
-/* Zero out mp_int of minimal size. */
+/* Zero out mp_int of minimal size.
+ * Use the declared digit array size, not bits, so memset cannot exceed the
+ * buffer allocated by DECL_MP_INT_SIZE_DYN(..., bits, max). */
 #define NEW_MP_INT_SIZE(name, bits, heap, type) \
-    XMEMSET(name, 0, MP_INT_SIZEOF(MP_BITS_CNT(bits)))
+    XMEMSET(name, 0, sizeof(name##d))
 /* Dispose of static mp_int. */
 #define FREE_MP_INT_SIZE(name, heap, type) WC_DO_NOTHING
 /* Type to force compiler to not complain about size. */

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -371,6 +371,10 @@ while (0)
 /* Type to cast to when using size macros. */
 #define MP_INT_SIZE     mp_int
 
+/* tfm.h allocates full-sized mp_int buffers, so DECL_MP_INT_SIZE_DYN cannot
+ * be undersized for any 'bits' value -- no check is needed. */
+#define MP_BITS_OVER_MAX(bits, max) 0
+
 
 #ifdef HAVE_WOLF_BIGINT
     /* raw big integer */


### PR DESCRIPTION
# Description

Fixes zd#21858, #10499 

# Testing

Built in tests

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
