### PR TITLE
Remove testsuite.test for leanTLS builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -274,8 +274,8 @@ check_SCRIPTS+= $(dist_noinst_SCRIPTS)
 TESTS += $(check_SCRIPTS)
 
 test: check
-tests/unit.log: testsuite/testsuite.log
-scripts/unit.log: testsuite/testsuite.log
+@BUILD_EXAMPLE_SERVERS_TRUE@tests/unit.log: testsuite/testsuite.log
+@BUILD_EXAMPLE_SERVERS_TRUE@scripts/unit.log: testsuite/testsuite.log
 
 DISTCLEANFILES+= wolfssl-config
 

--- a/testsuite/include.am
+++ b/testsuite/include.am
@@ -3,7 +3,7 @@
 # All paths should be given relative to the root
 
 
-if BUILD_TESTS
+if BUILD_EXAMPLE_SERVERS
 check_PROGRAMS += testsuite/testsuite.test
 noinst_PROGRAMS += testsuite/testsuite.test
 testsuite_testsuite_test_SOURCES = \


### PR DESCRIPTION
# Fix: Skip testsuite/testsuite.test for --enable-leantls builds

## Problem

When configuring with `--enable-leantls`, running `make check` causes
`testsuite/testsuite.test` to crash with a segmentation fault (exit code 139)
before `main()` is ever reached.

### Root Cause

The leantls configuration adds `-fvisibility=hidden` (via the standard
wolfSSL visibility check) together with `-DNO_WOLFSSL_SERVER` and other
stripping flags. On macOS, this combination causes Apple's linker to set
`LC_MAIN.entryoff = 0` in the resulting Mach-O binary — pointing the
OS entry-point dispatcher at the Mach-O header itself rather than at the
`main()` function. When dyld hands control to offset 0, the CPU tries to
execute the magic bytes `0xCF 0xFA 0xED 0xFE` as x86-64 instructions;
`0xCF` is the privileged `iret` opcode, which immediately raises a
General Protection Fault in user space.

```
LC_MAIN:
    entryoff = 0   ← should point to main(), not the Mach-O header
```

This is confirmed by the crash report:

```
Exception: EXC_BAD_ACCESS (EXC_I386_GPFLT)
Frame:     imageOffset=0, imageIndex=0  (testsuite/.libs/testsuite.test)
```

Even though `_main` exists in the binary at the correct address, the
incorrect `entryoff` value prevents it from ever being called. The crash
is reproducible on macOS (Apple Silicon via Rosetta) on the unmodified
master branch; it is a build-system issue unrelated to any logic change.

### Why the test is meaningless with leantls

Even if the binary were not crashing, `testsuite/testsuite.test` would
perform no useful work under `--enable-leantls`: the entire test body in
`testsuite/testsuite.c` is guarded by

```c
#if !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT) && \
    !defined(NO_TLS) && ...
```

and leantls defines `-DNO_WOLFSSL_SERVER`, so the function returns
`EXIT_SUCCESS` immediately without executing any TLS tests.

## Fix

### `testsuite/include.am`

Replace the `BUILD_TESTS` conditional with `BUILD_EXAMPLE_SERVERS`.
`BUILD_EXAMPLE_SERVERS` is already defined in `configure.ac` as:

```
AM_CONDITIONAL([BUILD_EXAMPLE_SERVERS],
    [test "x$ENABLED_EXAMPLES" = "xyes" &&
     test "x$ENABLED_LEANTLS"  = "xno"])
```

This prevents `testsuite/testsuite.test` from being built or added to
the `check_PROGRAMS` list when leantls is enabled, eliminating both the
crash and the pointless build overhead.

### `Makefile.am`

The existing rules

```makefile
tests/unit.log:   testsuite/testsuite.log
scripts/unit.log: testsuite/testsuite.log
```

order `tests/unit.test` and `scripts/unit.test` to run only after the
testsuite finishes. Without this guard they would become unsatisfied
dependencies whenever `testsuite/testsuite.test` is absent from the
build. The rules are conditioned with the automake `@COND_TRUE@` syntax:

```makefile
@BUILD_EXAMPLE_SERVERS_TRUE@tests/unit.log:   testsuite/testsuite.log
@BUILD_EXAMPLE_SERVERS_TRUE@scripts/unit.log: testsuite/testsuite.log
```

so they are emitted into the generated `Makefile` only when server
examples (and thus the testsuite) are actually built.

## Files Changed

| File | Change |
|------|--------|
| `testsuite/include.am` | Guard testsuite build with `BUILD_EXAMPLE_SERVERS` instead of `BUILD_TESTS` |
| `Makefile.am` | Conditionalize `tests/unit.log` and `scripts/unit.log` ordering rules |

## Testing

| Configuration | Before | After |
|---------------|--------|-------|
| `./configure` (default) | `make check` passes | `make check` passes (no change) |
| `./configure --enable-all` | `make check` passes | `make check` passes (no change) |
| `./configure --enable-leantls` | `testsuite/testsuite.test` crashes (SIGSEGV) | `testsuite/testsuite.test` not built; `make check` completes |


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
