### PR TITLE
Bugfix- wolf ssl add0 chain cert not incrementing certchain and causing TLS1.3 to fail

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -5230,6 +5230,7 @@ int wolfSSL_add0_chain_cert(WOLFSSL* ssl, WOLFSSL_X509* x509)
             ssl->buffers.weOwnCertChain, x509->derCert->buffer,
             x509->derCert->length, ssl->heap);
         if (ret == 1) {
+            ssl->buffers.certChainCnt++;
             /* We now own cert chain. */
             ssl->buffers.weOwnCertChain = 1;
             /* Create a stack to put certificate into. */

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -5230,9 +5230,10 @@ int wolfSSL_add0_chain_cert(WOLFSSL* ssl, WOLFSSL_X509* x509)
             ssl->buffers.weOwnCertChain, x509->derCert->buffer,
             x509->derCert->length, ssl->heap);
         if (ret == 1) {
-            ssl->buffers.certChainCnt++;
             /* We now own cert chain. */
             ssl->buffers.weOwnCertChain = 1;
+            /* Account for the certificate just added to the chain. */
+            ssl->buffers.certChainCnt++;
             /* Create a stack to put certificate into. */
             if (ssl->ourCertChain == NULL) {
                 ssl->ourCertChain = wolfSSL_sk_X509_new_null();

--- a/tests/api.c
+++ b/tests/api.c
@@ -3953,6 +3953,53 @@ static int test_wolfSSL_CTX_add1_chain_cert(void)
     return EXPECT_RESULT();
 }
 
+static int test_wolfSSL_add0_chain_cert_increments_count(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && defined(OPENSSL_EXTRA) && \
+    defined(KEEP_OUR_CERT) && !defined(NO_RSA) && !defined(NO_TLS) && \
+    !defined(NO_WOLFSSL_CLIENT)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL*     ssl = NULL;
+    const char*  chainCerts[] = {
+        "./certs/intermediate/ca-int2-cert.pem",
+        "./certs/intermediate/ca-int-cert.pem",
+        "./certs/ca-cert.pem",
+        NULL
+    };
+    const char** cert;
+    WOLFSSL_X509* x509 = NULL;
+    int expectedCnt = 0;
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+
+    ExpectNotNull(x509 = wolfSSL_X509_load_certificate_file(
+        "./certs/intermediate/client-int-cert.pem", WOLFSSL_FILETYPE_PEM));
+    ExpectIntEQ(SSL_add0_chain_cert(ssl, x509), 1);
+    /* Leaf -> ssl->buffers.certificate, not chain. certChainCnt unchanged. */
+    if (ssl != NULL) {
+        ExpectIntEQ(ssl->buffers.certChainCnt, 0);
+    }
+    x509 = NULL; 
+
+    for (cert = chainCerts; EXPECT_SUCCESS() && *cert != NULL; cert++) {
+        ExpectNotNull(x509 = wolfSSL_X509_load_certificate_file(*cert,
+            WOLFSSL_FILETYPE_PEM));
+        ExpectIntEQ(SSL_add0_chain_cert(ssl, x509), 1);
+        x509 = NULL; 
+        expectedCnt++;
+        if (ssl != NULL) {
+            ExpectIntEQ(ssl->buffers.certChainCnt, expectedCnt);
+        }
+    }
+
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 /* Test that wolfssl_add_to_chain rejects sizes that would overflow word32.
  * ZD #21241 */
 static int test_wolfSSL_add_to_chain_overflow(void)
@@ -38548,6 +38595,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_CTX_load_verify_buffer_ex),
     TEST_DECL(test_wolfSSL_CTX_load_verify_chain_buffer_format),
     TEST_DECL(test_wolfSSL_CTX_add1_chain_cert),
+    TEST_DECL(test_wolfSSL_add0_chain_cert_increments_count),
     TEST_DECL(test_wolfSSL_add_to_chain_overflow),
     TEST_DECL(test_wolfSSL_CTX_use_certificate_chain_buffer_format),
     TEST_DECL(test_wolfSSL_CTX_use_certificate_chain_buffer_max_depth),

--- a/tests/api.c
+++ b/tests/api.c
@@ -3953,7 +3953,7 @@ static int test_wolfSSL_CTX_add1_chain_cert(void)
     return EXPECT_RESULT();
 }
 
-static int test_wolfSSL_add0_chain_cert_increments_count(void)
+static int test_wolfSSL_add0_add1_chain_cert_increments_count(void)
 {
     EXPECT_DECLS;
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && defined(OPENSSL_EXTRA) && \
@@ -3970,28 +3970,62 @@ static int test_wolfSSL_add0_chain_cert_increments_count(void)
     const char** cert;
     WOLFSSL_X509* x509 = NULL;
     int expectedCnt = 0;
+    int refCnt = 0;
+    int added = 0;
 
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
     ExpectNotNull(ssl = wolfSSL_new(ctx));
 
     ExpectNotNull(x509 = wolfSSL_X509_load_certificate_file(
         "./certs/intermediate/client-int-cert.pem", WOLFSSL_FILETYPE_PEM));
-    ExpectIntEQ(SSL_add0_chain_cert(ssl, x509), 1);
+    ExpectIntEQ(added = SSL_add0_chain_cert(ssl, x509), 1);
+    /* add0 takes ownership only on success. */
+    if (added == 1) {
+        x509 = NULL;
+    }
+    wolfSSL_X509_free(x509);
+    x509 = NULL;
     /* Leaf -> ssl->buffers.certificate, not chain. certChainCnt unchanged. */
     if (ssl != NULL) {
         ExpectIntEQ(ssl->buffers.certChainCnt, 0);
     }
-    x509 = NULL;
     for (cert = chainCerts; EXPECT_SUCCESS() && *cert != NULL; cert++) {
+        added = 0;
         ExpectNotNull(x509 = wolfSSL_X509_load_certificate_file(*cert,
             WOLFSSL_FILETYPE_PEM));
-        ExpectIntEQ(SSL_add0_chain_cert(ssl, x509), 1);
+        ExpectIntEQ(added = SSL_add0_chain_cert(ssl, x509), 1);
+        if (added == 1) {
+            x509 = NULL;
+            expectedCnt++;
+        }
+        wolfSSL_X509_free(x509);
         x509 = NULL;
-        expectedCnt++;
         if (ssl != NULL) {
             ExpectIntEQ(ssl->buffers.certChainCnt, expectedCnt);
         }
     }
+
+    /* add1 funnels through add0 but takes its own reference: the caller keeps
+     * ownership of its X509 and must free it. */
+    ExpectNotNull(x509 = wolfSSL_X509_load_certificate_file(
+        "./certs/client-cert.pem", WOLFSSL_FILETYPE_PEM));
+    if (x509 != NULL) {
+        refCnt = (int)wolfSSL_RefCur(x509->ref);
+    }
+    ExpectIntEQ(added = SSL_add1_chain_cert(ssl, x509), 1);
+    if (added == 1) {
+        expectedCnt++;
+    }
+    if (x509 != NULL) {
+        ExpectIntEQ((int)wolfSSL_RefCur(x509->ref), refCnt + 1);
+    }
+    if (ssl != NULL) {
+        ExpectIntEQ(ssl->buffers.certChainCnt, expectedCnt);
+    }
+    /* Drop the caller's reference. SSL still owns one, so freeing the SSL
+     * below must not double free. */
+    wolfSSL_X509_free(x509);
+    x509 = NULL;
 
     SSL_free(ssl);
     SSL_CTX_free(ctx);
@@ -38594,7 +38628,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_CTX_load_verify_buffer_ex),
     TEST_DECL(test_wolfSSL_CTX_load_verify_chain_buffer_format),
     TEST_DECL(test_wolfSSL_CTX_add1_chain_cert),
-    TEST_DECL(test_wolfSSL_add0_chain_cert_increments_count),
+    TEST_DECL(test_wolfSSL_add0_add1_chain_cert_increments_count),
     TEST_DECL(test_wolfSSL_add_to_chain_overflow),
     TEST_DECL(test_wolfSSL_CTX_use_certificate_chain_buffer_format),
     TEST_DECL(test_wolfSSL_CTX_use_certificate_chain_buffer_max_depth),

--- a/tests/api.c
+++ b/tests/api.c
@@ -3981,13 +3981,12 @@ static int test_wolfSSL_add0_chain_cert_increments_count(void)
     if (ssl != NULL) {
         ExpectIntEQ(ssl->buffers.certChainCnt, 0);
     }
-    x509 = NULL; 
-
+    x509 = NULL;
     for (cert = chainCerts; EXPECT_SUCCESS() && *cert != NULL; cert++) {
         ExpectNotNull(x509 = wolfSSL_X509_load_certificate_file(*cert,
             WOLFSSL_FILETYPE_PEM));
         ExpectIntEQ(SSL_add0_chain_cert(ssl, x509), 1);
-        x509 = NULL; 
+        x509 = NULL;
         expectedCnt++;
         if (ssl != NULL) {
             ExpectIntEQ(ssl->buffers.certChainCnt, expectedCnt);


### PR DESCRIPTION
# Description
in TLS 1.3 handshake we're dependent on the cert chain cnt in SendTls13Certificate . not updating the chain count upon using `SSL_add0_chain_cert` made  TLS 1.3 to leave with leaf-only certificate and then peer rejected the chain and handshake failed.

# Testing
Tested it on my platform after encountering the handshake bug as part of migrating from openssl -> wolfssl + made a simple unitest for it

# Checklist

 - [* ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
