### PR TITLE
wc_port: guard fcntl behind WOLFSSL_KERNEL_MODE.

### DIFF
--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -5178,7 +5178,7 @@ char* wolfSSL_strnstr(const char* s1, const char* s2, size_t n)
 #endif /* not SINGLE_THREADED */
 
 #if (defined(__unix__) || defined(__APPLE__)) && \
-    !defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_ZEPHYR) && \
+    !defined(WOLFSSL_KERNEL_MODE) && !defined(WOLFSSL_ZEPHYR) && \
     !defined(WOLFSSL_SGX)
 
 #include <fcntl.h>
@@ -5248,7 +5248,7 @@ int wc_accept_cloexec(int sockfd, void* addr, void* addrlen)
     return fd;
 }
 
-#endif /* (__unix__ || __APPLE__) && !WOLFSSL_LINUXKM && !WOLFSSL_ZEPHYR &&
+#endif /* (__unix__ || __APPLE__) && !WOLFSSL_KERNEL_MODE && !WOLFSSL_ZEPHYR &&
         * !WOLFSSL_SGX */
 
 #if defined(WOLFSSL_LINUXKM) && defined(CONFIG_ARM64) && \

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1864,7 +1864,7 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 #endif
 
 #if (defined(__unix__) || defined(__APPLE__)) && \
-    !defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_ZEPHYR) && \
+    !defined(WOLFSSL_KERNEL_MODE) && !defined(WOLFSSL_ZEPHYR) && \
     !defined(WOLFSSL_SGX)
     WOLFSSL_LOCAL void wc_set_cloexec(int fd);
     WOLFSSL_LOCAL int wc_open_cloexec(const char* path, int flags);
@@ -1872,8 +1872,8 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     WOLFSSL_LOCAL int wc_accept_cloexec(int sockfd, void* addr, void* addrlen);
 #else
     /* Platforms without POSIX close-on-exec semantics (Windows, OS/2 OW,
-     * Linux kernel module, Zephyr, etc.): pass through to plain syscalls
-     * where the underlying headers are available in the caller. */
+     * FreeBSD/Linux kernel module, Zephyr, etc.): pass through to plain
+     * syscalls where the underlying headers are available in the caller. */
     #define wc_set_cloexec(fd) ((void)(fd))
     #define wc_open_cloexec(path, flags) open((path), (flags))
     #define wc_socket_cloexec(domain, type, protocol) \


### PR DESCRIPTION
# Description

Guard userspace filesystem code with `!defined(WOLFSSL_KERNEL_MODE)` instead of `!defined(WOLFSSL_LINUXKM)`.
