### PR TITLE
GH Actions: retrigger Jenkins PRB when draft PR is marked ready

### DIFF
--- a/.github/workflows/retrigger-prb-on-ready.yml
+++ b/.github/workflows/retrigger-prb-on-ready.yml
@@ -1,0 +1,35 @@
+name: Retrigger PRB on ready for review
+
+# When a draft PR is marked ready_for_review, GitHub fires a
+# 'ready_for_review' pull_request event but no 'synchronize' event, so
+# the Jenkins GHPRB plugin does not re-trigger the PRB-master-job. Post
+# the configured GHPRB trigger phrase as a PR comment to kick it off.
+#
+# pull_request_target (not pull_request) is required so GITHUB_TOKEN
+# gets write permissions on PRs from forks - this workflow only posts
+# a fixed comment string, so the usual pull_request_target risk
+# (executing untrusted PR code with elevated privileges) does not apply.
+
+on:
+  pull_request_target:
+    types: [ready_for_review]
+    branches: [master, main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  retrigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post GHPRB trigger comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'retest this please'
+            })


### PR DESCRIPTION
## Summary
- When a draft PR is marked ready_for_review, GitHub fires a `pull_request: ready_for_review` event but no `synchronize` event. The Jenkins GHPRB plugin only re-triggers on `opened`/`reopened`/`synchronize`, so PRB-master-job never runs for the ready transition and the PR is left without PRB coverage.
- This workflow posts the configured GHPRB trigger phrase ("retest this please") as a PR comment whenever a PR transitions to ready_for_review, which kicks off PRB-master-job.

## Implementation notes
- Uses `pull_request_target` (not `pull_request`) so `GITHUB_TOKEN` retains write permissions on PRs opened from forks. With `pull_request`, the token is read-only on fork PRs and `createComment` would 403 - exactly the case that matters for external contributors.
- Explicit `permissions: pull-requests: write` instead of relying on default token scope (which varies by org settings).
- The comment body is a fixed literal string with no PR-controlled inputs, so the usual `pull_request_target` concern (executing untrusted PR code with elevated privileges) does not apply here.
- Filtered to base branches `master` / `main` so it does not fire on release-branch PRs that do not use PRB.

## Test plan
- [ ] Open a draft PR against master, mark it ready_for_review, confirm a "retest this please" comment appears and PRB-master-job runs.
- [ ] Same flow from a fork PR (external contributor) - confirm the comment is still posted (validates `pull_request_target` write perms).