### PR TITLE
CI: cache compiler output in os-check Ubuntu matrix

### DIFF
--- a/.github/actions/ccache-setup/action.yml
+++ b/.github/actions/ccache-setup/action.yml
@@ -1,0 +1,67 @@
+name: 'Set up ccache'
+description: >
+  Install ccache (on Ubuntu), restore the ccache directory from a previous
+  run, and prepend the ccache compiler-symlink dir to PATH. Subsequent
+  gcc/cc/g++/c++ invocations are transparently intercepted by ccache, so
+  no other workflow step needs to change. macOS is not supported yet.
+
+inputs:
+  workflow-id:
+    description: 'Cache namespace - typically the calling workflow name.'
+    required: true
+  config-hash:
+    description: >
+      Optional short string distinguishing matrix entries. Each unique
+      value gets its own primary cache key. Leave empty to share one
+      cache across all entries in the workflow.
+    required: false
+    default: 'shared'
+  max-size:
+    description: 'Per-job ccache max size (passed to ccache -M).'
+    required: false
+    default: '500M'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install ccache (Ubuntu)
+      shell: bash
+      run: |
+        if command -v ccache >/dev/null 2>&1; then
+          echo "ccache already installed: $(ccache --version | head -1)"
+        else
+          sudo apt-get update -q
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            --no-install-recommends ccache
+        fi
+
+    - name: Restore + save ccache
+      uses: actions/cache@v4
+      with:
+        path: ~/.ccache
+        # Unique per run+attempt+config so each job persists its own
+        # contribution; restore-keys falls back to the most recent
+        # cache for this workflow/os/config.
+        key: ccache-${{ inputs.workflow-id }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.config-hash }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          ccache-${{ inputs.workflow-id }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.config-hash }}-
+          ccache-${{ inputs.workflow-id }}-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Configure ccache and PATH
+      shell: bash
+      run: |
+        ccache -M "${{ inputs.max-size }}"
+        # base_dir lets ccache reuse hits across different workspace
+        # checkout paths (different runs use different /home/.../work/ dirs).
+        ccache --set-config=base_dir="$GITHUB_WORKSPACE"
+        ccache --set-config=hash_dir=false
+        ccache -z   # zero stats so the post-build summary is per-job
+        # /usr/lib/ccache contains gcc, g++, cc, c++ symlinks that resolve
+        # to ccache. Prepending to PATH makes the build transparently use
+        # ccache without changing any configure/make invocation.
+        echo "/usr/lib/ccache" >> "$GITHUB_PATH"
+        echo "CCACHE_DIR=$HOME/.ccache" >> "$GITHUB_ENV"
+
+    - name: Show ccache stats (initial)
+      shell: bash
+      run: ccache -s

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -139,6 +139,13 @@ jobs:
     # This should be a safe limit for the tests to run.
     timeout-minutes: 14
     steps:
+      # Local composite actions (./.github/actions/*) need the repo on
+      # disk before the runner can resolve them. The autotools-project
+      # step further down does its own checkout into the workspace, so
+      # this explicit checkout is only required for the ccache-setup
+      # composite below.
+      - uses: actions/checkout@v4
+
       # tlslite-ng is consumed by scripts/multi-msg-record.test (run from
       # `make check`); without it that test is SKIPped.
       - uses: actions/setup-python@v5
@@ -146,11 +153,23 @@ jobs:
           python-version: '3.x'
       - run: pip install tlslite-ng
 
+      # ccache cuts ~50% off rebuild time. /usr/lib/ccache is prepended to
+      # PATH so gcc/cc invocations from the autotools action are
+      # transparently intercepted - no other step needs to change.
+      - name: Set up ccache
+        uses: ./.github/actions/ccache-setup
+        with:
+          workflow-id: os-check-linux
+
       - name: Build and test wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           configure: CFLAGS="-pedantic -Wdeclaration-after-statement -Wnull-dereference -Wno-overlength-strings -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE" ${{ matrix.config }}
           check: true
+
+      - name: ccache stats (post-build)
+        if: always()
+        run: command -v ccache >/dev/null && ccache -s || echo "ccache not installed - composite likely skipped"
 
   # Curated macOS subset. Each config exists for a Darwin-specific reason;
   # do not add entries that only re-test platform-agnostic crypto already


### PR DESCRIPTION
# Description

- Add .github/actions/ccache-setup composite (ccache + PATH intercept).
- Wire into os-check.yml make_check_linux; macOS unchanged for now.
- Measured on master --enable-all: cold 11.6s -> warm 1.1s (~10x), 100% hit.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
