### PR TITLE
fix memory report and add path filter

### DIFF
--- a/.github/membrowse-targets.json
+++ b/.github/membrowse-targets.json
@@ -7,6 +7,7 @@
     "build_cmd": "test -f IDE/GCC-ARM/Header/user_settings.h && mkdir -p IDE/GCC-ARM/Header-gen && { cat IDE/GCC-ARM/Header/user_settings.h; printf '#define NO_CRYPT_TEST\\n#define NO_CRYPT_BENCHMARK\\n'; } > IDE/GCC-ARM/Header-gen/user_settings.h && cd IDE/GCC-ARM && make -f Makefile.test TOOLCHAIN=arm-none-eabi- FIPS=0 USER_SETTINGS_DIR=./Header-gen CFLAGS_EXTRA='-Wno-cpp -DWOLFCRYPT_ONLY -DWOLFSSL_NO_SOCK' LDFLAGS='-mcpu=cortex-m4 -mthumb -mabi=aapcs --specs=nosys.specs --specs=nano.specs -Wl,-Map=./Build/WolfCryptTest.map -Wl,-ereset_handler -flto -Wl,--defsym=__stack_process_end__=0x20010000'",
     "elf": "IDE/GCC-ARM/Build/WolfCryptTest.elf",
     "ld": "IDE/GCC-ARM/linker.ld",
+    "map_file": "IDE/GCC-ARM/Build/WolfCryptTest.map",
     "linker_vars": ""
   },
   {
@@ -17,6 +18,7 @@
     "build_cmd": "test -f examples/configs/user_settings_min_ecc.h && mkdir -p IDE/GCC-ARM/Header-gen && { cat examples/configs/user_settings_min_ecc.h; printf '#define WOLFSSL_GENERAL_ALIGNMENT 4\\n#define SINGLE_THREADED\\n#define WOLFSSL_SMALL_STACK\\n#define NO_FILESYSTEM\\n#define NO_WRITEV\\n#define NO_MAIN_DRIVER\\n#define NO_DEV_RANDOM\\n#define BENCH_EMBEDDED\\n#define USE_CERT_BUFFERS_256\\n#define WOLFSSL_IGNORE_FILE_WARN\\n#define USE_WOLF_ARM_STARTUP\\n#define WOLFSSL_USER_CURRTIME\\n#define WOLFSSL_GMTIME\\n#define USER_TICKS\\nextern unsigned long my_time(unsigned long* timer);\\n#define XTIME my_time\\n#define CUSTOM_RAND_TYPE unsigned int\\nextern unsigned int my_rng_seed_gen(void);\\n#undef CUSTOM_RAND_GENERATE\\n#define CUSTOM_RAND_GENERATE my_rng_seed_gen\\n#define HAVE_HASHDRBG\\n#define NO_CRYPT_TEST\\n#define NO_CRYPT_BENCHMARK\\n'; } > IDE/GCC-ARM/Header-gen/user_settings.h && cd IDE/GCC-ARM && make -f Makefile.test TOOLCHAIN=arm-none-eabi- FIPS=0 USER_SETTINGS_DIR=./Header-gen CFLAGS_EXTRA='-Wno-cpp -DWOLFSSL_NO_SOCK -DWOLFCRYPT_ONLY' LDFLAGS='-mcpu=cortex-m4 -mthumb -mabi=aapcs --specs=nosys.specs --specs=nano.specs -Wl,-Map=./Build/WolfCryptTest.map -Wl,-ereset_handler -flto -Wl,--defsym=__stack_process_end__=0x20010000'",
     "elf": "IDE/GCC-ARM/Build/WolfCryptTest.elf",
     "ld": "IDE/GCC-ARM/linker.ld",
+    "map_file": "IDE/GCC-ARM/Build/WolfCryptTest.map",
     "linker_vars": ""
   },
   {
@@ -27,6 +29,7 @@
     "build_cmd": "test -f examples/configs/user_settings_tls12.h && mkdir -p IDE/GCC-ARM/Header-gen && { cat examples/configs/user_settings_tls12.h; printf '#define WOLFSSL_GENERAL_ALIGNMENT 4\\n#define SINGLE_THREADED\\n#define WOLFSSL_SMALL_STACK\\n#define NO_FILESYSTEM\\n#define NO_WRITEV\\n#define NO_MAIN_DRIVER\\n#define NO_DEV_RANDOM\\n#define BENCH_EMBEDDED\\n#define USE_CERT_BUFFERS_256\\n#define USE_CERT_BUFFERS_2048\\n#define WOLFSSL_IGNORE_FILE_WARN\\n#define USE_WOLF_ARM_STARTUP\\n#define WOLFSSL_USER_CURRTIME\\n#define WOLFSSL_GMTIME\\n#define USER_TICKS\\nextern unsigned long my_time(unsigned long* timer);\\n#define XTIME my_time\\n#define CUSTOM_RAND_TYPE unsigned int\\nextern unsigned int my_rng_seed_gen(void);\\n#undef CUSTOM_RAND_GENERATE\\n#define CUSTOM_RAND_GENERATE my_rng_seed_gen\\n#define HAVE_HASHDRBG\\n#define NO_CRYPT_TEST\\n#define NO_CRYPT_BENCHMARK\\n'; } > IDE/GCC-ARM/Header-gen/user_settings.h && cd IDE/GCC-ARM && make -f Makefile.test TOOLCHAIN=arm-none-eabi- FIPS=0 USER_SETTINGS_DIR=./Header-gen CFLAGS_EXTRA='-Wno-cpp -DWOLFSSL_NO_SOCK' LDFLAGS='-mcpu=cortex-m4 -mthumb -mabi=aapcs --specs=nosys.specs --specs=nano.specs -Wl,-Map=./Build/WolfCryptTest.map -Wl,-ereset_handler -flto -Wl,--defsym=__stack_process_end__=0x20010000'",
     "elf": "IDE/GCC-ARM/Build/WolfCryptTest.elf",
     "ld": "IDE/GCC-ARM/linker.ld",
+    "map_file": "IDE/GCC-ARM/Build/WolfCryptTest.map",
     "linker_vars": ""
   },
   {
@@ -37,6 +40,7 @@
     "build_cmd": "test -f examples/configs/user_settings_baremetal.h && mkdir -p IDE/GCC-ARM/Header-gen && { cat examples/configs/user_settings_baremetal.h; printf '#define WOLFSSL_GENERAL_ALIGNMENT 4\\n#define SINGLE_THREADED\\n#define WOLFSSL_SMALL_STACK\\n#define NO_FILESYSTEM\\n#define NO_WRITEV\\n#define NO_MAIN_DRIVER\\n#define NO_DEV_RANDOM\\n#define BENCH_EMBEDDED\\n#define USE_CERT_BUFFERS_256\\n#define USE_CERT_BUFFERS_2048\\n#define WOLFSSL_IGNORE_FILE_WARN\\n#define USE_WOLF_ARM_STARTUP\\n#define WOLFSSL_USER_CURRTIME\\n#define WOLFSSL_GMTIME\\n#define USER_TICKS\\nextern unsigned long my_time(unsigned long* timer);\\n#define XTIME my_time\\n#define CUSTOM_RAND_TYPE unsigned int\\nextern unsigned int my_rng_seed_gen(void);\\n#undef CUSTOM_RAND_GENERATE\\n#define CUSTOM_RAND_GENERATE my_rng_seed_gen\\n#define HAVE_HASHDRBG\\n#define NO_CRYPT_TEST\\n#define NO_CRYPT_BENCHMARK\\n'; } > IDE/GCC-ARM/Header-gen/user_settings.h && cd IDE/GCC-ARM && make -f Makefile.test TOOLCHAIN=arm-none-eabi- FIPS=0 USER_SETTINGS_DIR=./Header-gen CFLAGS_EXTRA='-Wno-cpp -DWOLFSSL_NO_SOCK -DWOLFCRYPT_ONLY' LDFLAGS='-mcpu=cortex-m4 -mthumb -mabi=aapcs --specs=nosys.specs --specs=nano.specs -Wl,-Map=./Build/WolfCryptTest.map -Wl,-ereset_handler -flto -Wl,--defsym=__stack_process_end__=0x20010000'",
     "elf": "IDE/GCC-ARM/Build/WolfCryptTest.elf",
     "ld": "IDE/GCC-ARM/linker.ld",
+    "map_file": "IDE/GCC-ARM/Build/WolfCryptTest.map",
     "linker_vars": ""
   }
 ]

--- a/.github/workflows/membrowse-comment.yml
+++ b/.github/workflows/membrowse-comment.yml
@@ -1,0 +1,32 @@
+name: Membrowse Comment
+
+on:
+  workflow_run:
+    workflows: [Membrowse Memory Report]
+    types:
+      - completed
+
+jobs:
+  post-comment:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    # Run the comment job even if some of the builds fail
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Post Membrowse PR comment
+        if: ${{ env.MEMBROWSE_API_KEY != '' }}
+        uses: membrowse/membrowse-action/comment-action@v1
+        with:
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          commit: ${{ github.event.workflow_run.head_sha }}
+        env:
+          MEMBROWSE_API_KEY: ${{ secrets.MEMBROWSE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/membrowse-report.yml
+++ b/.github/workflows/membrowse-report.yml
@@ -1,20 +1,19 @@
 name: Membrowse Memory Report
 
-# Runs nightly instead of per-PR - the report is for trend tracking, not
-# gating individual PRs, and the build matrix is too heavy to run on every
-# push.  Use workflow_dispatch to trigger an ad-hoc run.
-
 on:
-  schedule:
-    - cron: '0 4 * * *'   # daily at 04:00 UTC
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [master]
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   load-targets:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
@@ -27,8 +26,45 @@ jobs:
         id: set-matrix
         run: echo "matrix=$(jq -c '.' .github/membrowse-targets.json)" >> $GITHUB_OUTPUT
 
+  check-changes:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      needs_build: ${{ steps.filter.outputs.code == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Detect binary-affecting changes
+        id: filter
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        uses: dorny/paths-filter@v4
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - '!**.md'
+              - '!**/README*'
+              - '!doc/**'
+              - '!AUTHORS'
+              - '!COPYING*'
+              - '!LICENSE*'
+              - '!LICENSING'
+              - '!INSTALL'
+              - '!ChangeLog*'
+              - '!SCRIPTS-LIST'
+              - '!.gitignore'
+              - '!.editorconfig'
+              - '!.codespellexcludelines'
+              - '!.cyignore'
+              - '!.wolfssl_known_macro_extras'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/PULL_REQUEST_TEMPLATE.md'
+
   analyze:
-    needs: load-targets
+    needs: [load-targets, check-changes]
+    if: github.event_name != 'pull_request' || needs.check-changes.outputs.needs_build == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
@@ -40,15 +76,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0
-          submodules: recursive
+          fetch-depth: 2
+          submodules: ${{ needs.check-changes.outputs.needs_build == 'true' && 'recursive' || 'false' }}
 
       - name: Install packages
+        if: needs.check-changes.outputs.needs_build == 'true'
         uses: ./.github/actions/install-apt-deps
         with:
           packages: ${{ matrix.apt_packages }}
 
       - name: Build firmware
+        if: needs.check-changes.outputs.needs_build == 'true'
         run: ${{ matrix.build_cmd }}
 
       - name: Run Membrowse PR Action
@@ -56,9 +94,11 @@ jobs:
         uses: membrowse/membrowse-action@v1
         with:
           target_name: ${{ matrix.target_name }}
-          elf: ${{ matrix.elf }}
-          ld: ${{ matrix.ld }}
+          elf: ${{ needs.check-changes.outputs.needs_build == 'true' && matrix.elf || '' }}
+          ld: ${{ needs.check-changes.outputs.needs_build == 'true' && matrix.ld || '' }}
+          map_file: ${{ needs.check-changes.outputs.needs_build == 'true' && matrix.map_file || '' }}
           linker_vars: ${{ matrix.linker_vars }}
           api_key: ${{ secrets.MEMBROWSE_API_KEY }}
           api_url: ${{ vars.MEMBROWSE_API_URL }}
+          identical: ${{ needs.check-changes.outputs.needs_build != 'true' }}
           verbose: INFO


### PR DESCRIPTION
# Description

Following a conversation with @dgarske:

Fix the MemBrowse report flow to support push to master and PR changes.

The following optimizations were made: 

1. The workflow is optimized to skip build and report generation in case of non operational changes.
2. The repo checkout is optimized to checkout just the last 2 commits instead of the whole history.

Also, added support for a new MemBrowse feature that includes library attribution.
Now, you can see how libraries contribute to the footprint.
<img width="1501" height="247" alt="image" src="https://github.com/user-attachments/assets/ebbf7849-4af1-4824-b1e6-ddaf0ac9fbfc" />


In case this will still be slow (which it shouldn't: the workflow takes around 90 seconds):
I would suggest the following steps:
1. Remove the trigger from the PRs and just keep the push to master trigger.
4. Reduce the targets amount that are being tracked.

# Testing

Tested on forked repo

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
