### PR TITLE
20260527-fixes

### DIFF
--- a/tests/api/test_mldsa_legacy.c
+++ b/tests/api/test_mldsa_legacy.c
@@ -89,7 +89,7 @@ wc_static_assert(sizeof(wc_dilithium_params) == sizeof(wc_MlDsaParams));
  * DILITHIUM_LEVEL{2,3,5}_*, DILITHIUM_ML_DSA_{44,65,87}_*) lives in its own
  * `#define` line in <dilithium.h>, so each is checked separately. */
 #define MLDSA_LEGACY_SIZE_ASSERT(LEGACY, CANONICAL) \
-    wc_static_assert(LEGACY == CANONICAL)
+    wc_static_assert((LEGACY) == (CANONICAL))
 
 /* LEVEL2 = ML-DSA-44 */
 MLDSA_LEGACY_SIZE_ASSERT(ML_DSA_LEVEL2_KEY_SIZE,           WC_MLDSA_44_KEY_SIZE);

--- a/wolfssl/wolfcrypt/wc_mldsa.h
+++ b/wolfssl/wolfcrypt/wc_mldsa.h
@@ -54,6 +54,13 @@
     #include <wolfssl/wolfcrypt/cryptocb.h>
 #endif
 
+/* When WOLFSSL_MLDSA_FIPS204_DRAFT is enabled the legacy (pre-FIPS 204)
+ * no-context sign/verify API is required to handle draft-format signatures. */
+#if defined(WOLFSSL_MLDSA_FIPS204_DRAFT) && \
+    !defined(WOLFSSL_MLDSA_NO_CTX)
+    #define WOLFSSL_MLDSA_NO_CTX
+#endif
+
 /* TEMPORARY: pull in the legacy compatibility shim so its forward-arm
  * sub-config gate translation (legacy WOLFSSL_DILITHIUM_* /
  * WC_DILITHIUM_* -> canonical WOLFSSL_MLDSA_* / WC_MLDSA_*) and the
@@ -682,13 +689,6 @@ struct wc_MlDsaKey {
     typedef struct wc_MlDsaKey MlDsaKey;
     #define WC_MLDSAKEY_LEGACY_TYPE_DEFINED
 #endif
-#endif
-
-/* When WOLFSSL_MLDSA_FIPS204_DRAFT is enabled the legacy (pre-FIPS 204)
- * no-context sign/verify API is required to handle draft-format signatures. */
-#if defined(WOLFSSL_MLDSA_FIPS204_DRAFT) && \
-    !defined(WOLFSSL_MLDSA_NO_CTX)
-    #define WOLFSSL_MLDSA_NO_CTX
 #endif
 
 /* Functions */


### PR DESCRIPTION
`tests/api/test_mldsa_legacy.c`: fix `bugprone-macro-parentheses` in `MLDSA_LEGACY_SIZE_ASSERT()`.

`wolfssl/wolfcrypt/wc_mldsa.h`: move `WOLFSSL_MLDSA_NO_CTX` setup to precede legacy `dilithium.h` header, so that the `_NO_CTX` remap macros are properly gated in.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
clang-tidy-fips-140-3-dev-all
clang-tidy-fips-140-3-dev-all-crypto-no-sha-1
clang-tidy-fips-140-3-dev-defaults
clang-tidy-fips-140-3-dev-defaults-no-sha-1
linuxkm-defaults-all-quantum-safe-fips-dev-clang-tidy
linuxkm-defaults-all-quantum-safe-fips-dev-noasm-clang-tidy
quantum-safe-wolfssl-all-clang-tidy
quantum-safe-wolfssl-all-noasm-clang-tidy
quantum-safe-wolfssl-all-smallstack-clang-tidy
benchmark-wolfcrypt-intelasm-all-clang
quantum-safe-wolfssl-all-fips204-clang-tidy
quantum-safe-wolfssl-all-no-asm-clang-tidy
quantum-safe-wolfssl-all-linuxkm-defaults-clang-tidy
liboqs-all-clang-tidy
linuxkm-6.15-all-cryptonly-quantum-safe-fips-dev-intelasm-insmod-crypto-fuzzer-kmemleak
```
