### PR TITLE
bsdkm: misc cleanup.

### DIFF
--- a/bsdkm/bsdkm_wc_port.h
+++ b/bsdkm/bsdkm_wc_port.h
@@ -36,6 +36,7 @@
 #ifndef CHAR_BIT
     #include <sys/limits.h>
 #endif /* !CHAR_BIT*/
+#include <sys/proc.h>
 
 #define NO_THREAD_LS
 #define NO_ATTRIBUTE_CONSTRUCTOR
@@ -80,20 +81,22 @@ extern struct malloc_type M_WOLFSSL[1];
 #if defined(WOLFSSL_BSDKM_MEMORY_DEBUG)
     #define XMALLOC(s, h, t) ({                                              \
         (void)(h); (void)(t);                                                \
-        void * _ptr = malloc(s, M_WOLFSSL, M_WAITOK | M_ZERO);               \
+        int _wait_flag = curthread->td_critnest == 0 ? M_WAITOK : M_NOWAIT;  \
+        void * _ptr = malloc((s), M_WOLFSSL, _wait_flag | M_ZERO);           \
         printf("info: malloc: %p, M_WOLFSSL, %zu\n", _ptr, (size_t) s);      \
         (void *)_ptr;                                                        \
     })
 
     #define XFREE(p, h, t) ({                                                \
         void* _xp; (void)(h); (void)(t); _xp = (p);                          \
-        printf("info: free: %p, M_WOLFSSL\n", p);                            \
+        printf("info: free: %p, M_WOLFSSL\n", _xp);                          \
         if(_xp) free(_xp, M_WOLFSSL);                                        \
     })
 #else
     #define XMALLOC(s, h, t) ({                                              \
         (void)(h); (void)(t);                                                \
-        void * _ptr = malloc(s, M_WOLFSSL, M_WAITOK | M_ZERO);               \
+        int _wait_flag = curthread->td_critnest == 0 ? M_WAITOK : M_NOWAIT;  \
+        void * _ptr = malloc((s), M_WOLFSSL, _wait_flag | M_ZERO);           \
         (void *)_ptr;                                                        \
     })
 

--- a/bsdkm/wolfkmod.c
+++ b/bsdkm/wolfkmod.c
@@ -249,15 +249,14 @@ static int wolfkmod_load(void)
 
     error = wolfkmod_init();
     if (error != 0) {
-        return (ECANCELED);
+        goto wolfkmod_load_out;
     }
 
     #ifndef NO_CRYPT_TEST
     error = wolfcrypt_test(NULL);
     if (error != 0) {
         printf("error: wolfcrypt test failed: %d\n", error);
-        (void)wolfkmod_cleanup();
-        return (ECANCELED);
+        goto wolfkmod_load_out;
     }
     printf("info: wolfCrypt self-test passed.\n");
     #endif /* NO_CRYPT_TEST */
@@ -266,15 +265,19 @@ static int wolfkmod_load(void)
     error = benchmark_test(NULL);
     if (error != 0) {
         printf("error: wolfcrypt benchmark failed: %d\n", error);
-        (void)wolfkmod_cleanup();
-        return (ECANCELED);
+        goto wolfkmod_load_out;
     }
     printf("info: wolfCrypt benchmark passed.\n");
     #endif /* WOLFSSL_KERNEL_BENCHMARKS */
-
     printf("info: libwolfssl loaded\n");
 
-    return (0);
+wolfkmod_load_out:
+    if (error != 0) {
+        (void)wolfkmod_cleanup();
+        error = ECANCELED;
+    }
+
+    return (error);
 }
 
 static int wolfkmod_unload(void)
@@ -435,7 +438,8 @@ static int wolfkdriv_attach(device_t dev)
 
     ret = wolfkmod_init();
     if (ret != 0) {
-        return (ECANCELED);
+        error = ECANCELED;
+        goto attach_out;
     }
 
     /**
@@ -452,7 +456,8 @@ static int wolfkdriv_attach(device_t dev)
     if (softc->crid < 0) {
         device_printf(dev, "error: crypto_get_driverid failed: %d\n",
                softc->crid);
-        return (ENXIO);
+        error = ENXIO;
+        goto attach_out;
     }
 
     /*
@@ -487,7 +492,7 @@ static int wolfkdriv_attach(device_t dev)
 attach_out:
     if (error) {
         wolfkdriv_unregister(softc);
-        error = ENXIO;
+        (void)wolfkmod_cleanup();
     }
 
     return (error);

--- a/bsdkm/x86_vecreg.c
+++ b/bsdkm/x86_vecreg.c
@@ -29,13 +29,13 @@
 #include <machine/pcb.h>
 
 struct wolfkmod_fpu_state_t {
-    volatile lwpid_t td_tid;
-    volatile u_int   nest;
+    volatile lwpid_t td_tid; /* the thread curently using fpu. */
+    volatile u_int   nest;   /* the fpu nesting level. */
 };
 
 typedef struct wolfkmod_fpu_state_t wolfkmod_fpu_state_t;
 
-/* fpu_states array tracks thread id and nesting level of save/restore
+/* The fpu_states array tracks thread id and nesting level of save/restore
  * and push/pop vector registers macro calls. It is indexed by raw cpu id,
  * and only accessed after the thread calls fpu_kern_enter(), and before
  * calling fpu_kern_leave(), and only indexed by the thread's PCPU_GET(cpuid).

--- a/bsdkm/x86_vecreg.c
+++ b/bsdkm/x86_vecreg.c
@@ -29,7 +29,7 @@
 #include <machine/pcb.h>
 
 struct wolfkmod_fpu_state_t {
-    volatile lwpid_t td_tid; /* the thread curently using fpu. */
+    volatile lwpid_t td_tid; /* the thread currently using fpu. */
     volatile u_int   nest;   /* the fpu nesting level. */
 };
 


### PR DESCRIPTION
## Description

Some bsdkm cleanup:
- Use `malloc()` `M_NOWAIT` in critical section, and `M_WAITOK` otherwise..
- Macro cleanup.
- Add better err handling cleanup (was not actually leaking on error, but this will make it more clear to analyzers).

Fixes several Fenrir issues.

