### PR TITLE
OCSP_resp_find_status to require exact serial-length match

### DIFF
--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -776,7 +776,8 @@ int wolfSSL_OCSP_resp_find_status(WOLFSSL_OCSP_BASICRESP *bs,
     single = bs->single;
     while (single != NULL) {
         if (single->status != NULL && id->status != NULL &&
-            (XMEMCMP(single->status->serial, id->status->serial,
+            (single->status->serialSz == id->status->serialSz)
+         && (XMEMCMP(single->status->serial, id->status->serial,
                      (size_t)single->status->serialSz) == 0)
          && (XMEMCMP(single->issuerHash, id->issuerHash, OCSP_DIGEST_SIZE) == 0)
          && (XMEMCMP(single->issuerKeyHash, id->issuerKeyHash, OCSP_DIGEST_SIZE) == 0)) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -40934,6 +40934,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_ocsp_response_parsing),
     TEST_DECL(test_ocsp_certid_enc_dec),
     TEST_DECL(test_ocsp_certid_dup),
+    TEST_DECL(test_ocsp_resp_find_status_serial_prefix),
     TEST_DECL(test_ocsp_tls_cert_cb),
     TEST_DECL(test_ocsp_cert_unknown_crl_fallback),
     TEST_DECL(test_ocsp_cert_unknown_crl_fallback_nonleaf),

--- a/tests/api/test_ocsp.c
+++ b/tests/api/test_ocsp.c
@@ -765,6 +765,63 @@ int test_ocsp_certid_dup(void)
 }
 #endif
 
+int test_ocsp_resp_find_status_serial_prefix(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_OCSP) && defined(OPENSSL_EXTRA) && !defined(NO_SHA)
+    OcspResponse response;
+    OcspEntry    single;
+    CertStatus   responseStatus;
+    OcspEntry    requestedId;
+    CertStatus   requestedStatus;
+    int          status;
+
+    XMEMSET(&response, 0, sizeof(response));
+    XMEMSET(&single, 0, sizeof(single));
+    XMEMSET(&responseStatus, 0, sizeof(responseStatus));
+    XMEMSET(&requestedId, 0, sizeof(requestedId));
+    XMEMSET(&requestedStatus, 0, sizeof(requestedStatus));
+
+    single.status   = &responseStatus;
+    requestedId.status = &requestedStatus;
+    response.single  = &single;
+
+    /* Matching issuer name and key hashes on both sides. */
+    XMEMSET(single.issuerHash, 0x41, OCSP_DIGEST_SIZE);
+    XMEMSET(single.issuerKeyHash, 0x42, OCSP_DIGEST_SIZE);
+    XMEMCPY(requestedId.issuerHash, single.issuerHash, OCSP_DIGEST_SIZE);
+    XMEMCPY(requestedId.issuerKeyHash, single.issuerKeyHash, OCSP_DIGEST_SIZE);
+
+    /* Response carries a CERT_GOOD status for serial 01:02 (2 bytes). */
+    responseStatus.serial[0] = 0x01;
+    responseStatus.serial[1] = 0x02;
+    responseStatus.serialSz  = 2;
+    responseStatus.status    = CERT_GOOD;
+
+    /* Sanity check: an exact serial match must be found and report CERT_GOOD. */
+    requestedStatus.serial[0] = 0x01;
+    requestedStatus.serial[1] = 0x02;
+    requestedStatus.serialSz  = 2;
+    status = -1;
+    ExpectIntEQ(wolfSSL_OCSP_resp_find_status(&response, &requestedId, &status,
+                    NULL, NULL, NULL, NULL), WOLFSSL_SUCCESS);
+    ExpectIntEQ(status, CERT_GOOD);
+
+    /* Request serial 01:02:03 (3 bytes) shares the 01:02 prefix of the
+     * response serial.
+     * The lookup must not bind the good response to this longer and
+     * differing serial. */
+    requestedStatus.serial[0] = 0x01;
+    requestedStatus.serial[1] = 0x02;
+    requestedStatus.serial[2] = 0x03;
+    requestedStatus.serialSz  = 3;
+    status = -1;
+    ExpectIntEQ(wolfSSL_OCSP_resp_find_status(&response, &requestedId, &status,
+                    NULL, NULL, NULL, NULL), WOLFSSL_FAILURE);
+#endif
+    return EXPECT_RESULT();
+}
+
 #if defined(HAVE_OCSP) && defined(WOLFSSL_CERT_SETUP_CB) && \
     defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && !defined(NO_RSA) && \
     (defined(HAVE_CERTIFICATE_STATUS_REQUEST) || \

--- a/tests/api/test_ocsp.h
+++ b/tests/api/test_ocsp.h
@@ -24,6 +24,7 @@
 
 int test_ocsp_certid_enc_dec(void);
 int test_ocsp_certid_dup(void);
+int test_ocsp_resp_find_status_serial_prefix(void);
 int test_ocsp_status_callback(void);
 int test_ocsp_basic_verify(void);
 int test_ocsp_responder_keyhash_binding(void);


### PR DESCRIPTION
# Description

Require equal serial lengths before comparing serial bytes so a response serial that is only a prefix of the requested serial is not treated as a match.

Fixes zd#21903

# Testing

Added associated regression test.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
