### PR TITLE
Change macro name to avoid suspicion of typo

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -327,7 +327,7 @@
         #define WC_16BIT_CPU
         #define WOLFSSL_OLD_OID_SUM
     #elif defined(__SAM3X8E__)
-        #define WOLFSSL_NO_ATOMIC
+        #define WOLFSSL_NO_STDATOMIC_FENCE
         #define WOLFSSL_NO_SOCK
         #define WOLFSSL_USER_IO
         #define NO_WRITEV

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1786,7 +1786,7 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
         /* use user-supplied XFENCE definition. */
     #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && \
           !defined(__STDC_NO_ATOMICS__) && !defined(NO_STDATOMIC_H)
-        #ifdef WOLFSSL_NO_ATOMIC
+        #ifdef WOLFSSL_NO_STDATOMIC_FENCE
             #define XFENCE() WC_DO_NOTHING
         #else
             #include <stdatomic.h>


### PR DESCRIPTION
Note that there is also a WOLFSSL_NO_ATOMICS so this gets rid of ambiguity. 

Fixes ZD21904