### PR TITLE
Fix FIPS v6 or older build with crypto callbacks and SHA512

### DIFF
--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -2033,10 +2033,20 @@ int wc_CryptoCb_Sha384Hash(wc_Sha384* sha384, const byte* in,
 
 #ifdef WOLFSSL_SHA512
 int wc_CryptoCb_Sha512Hash(wc_Sha512* sha512, const byte* in,
-    word32 inSz, byte* digest, size_t digestSz)
+    word32 inSz, byte* digest
+#if !(defined(HAVE_FIPS) && FIPS_VERSION_LT(7,0))
+    , size_t digestSz
+#endif
+    )
 {
     int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
+#if defined(HAVE_FIPS) && FIPS_VERSION_LT(7,0)
+    /* Older FIPS sha512.c snapshots call the 4-arg API (no digestSz). Treat as
+     * full-size SHA-512 with no variant dispatch, matching pre-digestSz
+     * behavior. */
+    size_t digestSz = WC_SHA512_DIGEST_SIZE;
+#endif
 
     /* locate registered callback */
     #ifndef NO_SHA2_CRYPTO_CB

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -871,7 +871,11 @@ WOLFSSL_LOCAL int wc_CryptoCb_Sha384Hash(wc_Sha384* sha384, const byte* in,
 #endif
 #ifdef WOLFSSL_SHA512
 WOLFSSL_LOCAL int wc_CryptoCb_Sha512Hash(wc_Sha512* sha512, const byte* in,
-    word32 inSz, byte* digest, size_t digestSz);
+    word32 inSz, byte* digest
+#if !(defined(HAVE_FIPS) && FIPS_VERSION_LT(7,0))
+    , size_t digestSz
+#endif
+    );
 #endif
 
 #ifdef WOLFSSL_SHA3


### PR DESCRIPTION
# Description

Commit 9cbc3f97 added a `size_t digestSz` parameter to
`wc_CryptoCb_Sha512Hash` (to dispatch SHA-512/224 and SHA-512/256 to
variant-specific provider callbacks). The live `sha512.c` was updated to the
5-arg call, but in a FIPS build `sha512.c` is a frozen snapshot pulled from a
tag by `fips-check.sh`, while `cryptocb.c`/`.h` live outside the FIPS boundary
and ship the latest signature. For FIPS v6 and earlier the snapshot still calls
the old 4-arg API, so the build fails with:

```
sha512.c: error: too few arguments to function 'wc_CryptoCb_Sha512Hash'
```

(reported on `--enable-fips=v5`, e.g. wolfTPM builds).

This conditionally drops the `digestSz` parameter from the declaration and
definition under `defined(HAVE_FIPS) && FIPS_VERSION_LT(7,0)`, with a shimmed
`digestSz = WC_SHA512_DIGEST_SIZE` local so the single shared body behaves
identically to the pre-9cbc3f97 4-arg function. No `sha512.c` change; the public
`wc_CryptoInfo.hash` struct is untouched, so callback providers (wolfTPM, HSMs)
need no changes.

Fixes ZD21902 and ZD21780

# Testing

`FIPS_VERSION_LT(7,0)` is the boundary, verified against the snapshot tags in
`fips-check.sh` and the version assignments in `configure.ac`:

| FIPS option | version | sha512.c source | API |
|-------------|---------|-----------------|-----|
| v5 / cert4718 | 5.2.1 | `v5.2.1-stable` (frozen) | 4-arg |
| v5-RC12 | 5.2.0.1 | `WCv5.0-RC12` (frozen) | 4-arg |
| v6 / wolfentropy | 6.0 | `WCv6.0.0-RC5` (frozen) | 4-arg |
| ready / dev | 8.0 | master (not overwritten) | 5-arg |
| v7 (future) | 7.0 | snapshot picks up new sha512.c | 5-arg |

The tagged `sha512.c` for v5.2.1, RC12, and v6.0.0-RC5 were each confirmed to
call the 4-arg form; `ready`/`dev` leave `sha512.c` as live master (5-arg) and
report version 8, so they fall on the new-API side without special handling.

- Non-FIPS `cryptocb.c` compiles clean with `WOLF_CRYPTO_CB` + `WOLFSSL_SHA512`.
- Preprocessor expansion verified: non-FIPS -> 5 args, FIPS v5/v6 -> 4 args,
  FIPS v7 / ready / dev -> 5 args.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
