### PR TITLE
Enhancement: Stand out less with ECH or GREASE ECH

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -13840,7 +13840,9 @@ static int TLSX_ECH_Write(WOLFSSL_ECH* ech, byte msgType, byte* writeBuf,
         *writeBuf_p = ech->configId;
         writeBuf_p += sizeof(ech->configId);
         /* encLen */
-        if (ech->hpkeContext == NULL) {
+        if (ech->hpkeContext == NULL || ech->state == ECH_WRITE_GREASE) {
+            /* GREASE always writes a fresh enc, even when a prior hpkeContext
+             * exists from a real CH1 that was rejected */
             c16toa(ech->encLen, writeBuf_p);
         }
         else {
@@ -16460,9 +16462,7 @@ static int TLSX_EchChangeSNI(WOLFSSL* ssl, TLSX** pEchX,
 
     /* if type is outer change sni to public name */
     if (echX != NULL &&
-        ((WOLFSSL_ECH*)echX->data)->type == ECH_TYPE_OUTER &&
-        (ssl->options.echAccepted ||
-        ((WOLFSSL_ECH*)echX->data)->innerCount == 0)) {
+        ((WOLFSSL_ECH*)echX->data)->type == ECH_TYPE_OUTER) {
         if (ssl->extensions) {
             serverNameX = TLSX_Find(ssl->extensions, TLSX_SERVER_NAME);
 
@@ -16656,12 +16656,6 @@ static int TLSX_GetSizeWithEch(WOLFSSL* ssl, byte* semaphore, byte msgType,
 
     if (echX != NULL)
         ech = (WOLFSSL_ECH*)echX->data;
-
-    /* If ECH won't be written exclude it from the size calculation */
-    if (r == 0 && !ssl->options.echAccepted && ech != NULL &&
-            ech->innerCount != 0) {
-        TURN_ON(semaphore, TLSX_ToSemaphore(echX->type));
-    }
 
     /* if encoding, then count encoded form of inner ClientHello.
      * `semaphore` is in/out so encodable extensions will later be ignored */
@@ -16869,14 +16863,10 @@ static int TLSX_WriteWithEch(WOLFSSL* ssl, byte* output, byte* semaphore,
                          msgType, pOffset);
     }
 
-    /* only write ECH if there is a shot at acceptance */
-    if (ret == 0 && echX != NULL &&
-        (ssl->options.echAccepted ||
-        ((WOLFSSL_ECH*)echX->data)->innerCount == 0)) {
-        if (echX != NULL) {
-            /* turn off and write it last */
-            TURN_OFF(semaphore, TLSX_ToSemaphore(echX->type));
-        }
+    /* write ECH last */
+    if (ret == 0 && echX != NULL) {
+        /* turn off and write it last */
+        TURN_OFF(semaphore, TLSX_ToSemaphore(echX->type));
 
         if (ret == 0 && ssl->extensions) {
             ret = TLSX_Write(ssl->extensions, output + *pOffset, semaphore,

--- a/src/tls.c
+++ b/src/tls.c
@@ -13645,10 +13645,15 @@ void TLSX_Remove(TLSX** list, TLSX_Type type, void* heap)
 static int TLSX_GreaseECH_Use(TLSX** extensions, void* heap, WC_RNG* rng)
 {
     int ret = 0;
+    TLSX* echX;
     WOLFSSL_ECH* ech;
 
     if (extensions == NULL)
         return BAD_FUNC_ARG;
+    /* skip if we already have an ech extension, we will for hrr */
+    echX = TLSX_Find(*extensions, TLSX_ECH);
+    if (echX != NULL)
+        return 0;
 
     ech = (WOLFSSL_ECH*)XMALLOC(sizeof(WOLFSSL_ECH), heap,
         DYNAMIC_TYPE_TMP_BUFFER);
@@ -13840,9 +13845,7 @@ static int TLSX_ECH_Write(WOLFSSL_ECH* ech, byte msgType, byte* writeBuf,
         *writeBuf_p = ech->configId;
         writeBuf_p += sizeof(ech->configId);
         /* encLen */
-        if (ech->hpkeContext == NULL || ech->state == ECH_WRITE_GREASE) {
-            /* GREASE always writes a fresh enc, even when a prior hpkeContext
-             * exists from a real CH1 that was rejected */
+        if (ech->innerCount == 0) {
             c16toa(ech->encLen, writeBuf_p);
         }
         else {
@@ -13851,50 +13854,59 @@ static int TLSX_ECH_Write(WOLFSSL_ECH* ech, byte msgType, byte* writeBuf,
         }
         writeBuf_p += 2;
         if (ech->state == ECH_WRITE_GREASE) {
-            WC_ALLOC_VAR_EX(hpke, Hpke, 1, NULL, DYNAMIC_TYPE_TMP_BUFFER, ret = MEMORY_E);
-            WC_ALLOC_VAR_EX(rng, WC_RNG, 1, NULL, DYNAMIC_TYPE_RNG, ret = MEMORY_E);
-            /* hpke init */
-            if (ret == 0) {
-                ret = wc_HpkeInit(hpke, ech->kemId, ech->cipherSuite.kdfId,
-                    ech->cipherSuite.aeadId, NULL);
-            }
+            word32 size;
+            WC_ALLOC_VAR_EX(rng, WC_RNG, 1, NULL, DYNAMIC_TYPE_RNG,
+                ret = MEMORY_E);
+
             if (ret == 0)
                 rngRet = ret = wc_InitRng(rng);
-            /* create the ephemeralKey */
-            if (ret == 0)
-                ret = wc_HpkeGenerateKeyPair(hpke, &ephemeralKey, rng);
-            /* enc */
-            if (ret == 0) {
-                ret = wc_HpkeSerializePublicKey(hpke, ephemeralKey, writeBuf_p,
-                    &ech->encLen);
-                writeBuf_p += ech->encLen;
-            }
-            if (ret == 0) {
-                /* innerClientHelloLen */
-                c16toa(GREASE_ECH_SIZE + ((writeBuf_p + 2 - writeBuf) % 32),
-                    writeBuf_p);
-                writeBuf_p += 2;
+            if (ret == 0 && ech->innerCount == 0) {
+                WC_ALLOC_VAR_EX(hpke, Hpke, 1, NULL, DYNAMIC_TYPE_TMP_BUFFER,
+                    ret = MEMORY_E);
 
-                /* innerClientHello */
-                ret = wc_RNG_GenerateBlock(rng, writeBuf_p, GREASE_ECH_SIZE +
-                    ((writeBuf_p - writeBuf) % 32));
-                writeBuf_p += GREASE_ECH_SIZE + ((writeBuf_p - writeBuf) % 32);
+                /* hpke init */
+                if (ret == 0)
+                    ret = wc_HpkeInit(hpke, ech->kemId, ech->cipherSuite.kdfId,
+                        ech->cipherSuite.aeadId, NULL);
+                /* create the ephemeralKey */
+                if (ret == 0)
+                    ret = wc_HpkeGenerateKeyPair(hpke, &ephemeralKey, rng);
+                /* enc */
+                if (ret == 0) {
+                    ret = wc_HpkeSerializePublicKey(hpke, ephemeralKey,
+                        writeBuf_p, &ech->encLen);
+                    writeBuf_p += ech->encLen;
+                }
+
+                if (ephemeralKey != NULL)
+                    wc_HpkeFreeKey(hpke, hpke->kem, ephemeralKey, hpke->heap);
+                WC_FREE_VAR_EX(hpke, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             }
+
+            if (ret == 0) {
+                size = GREASE_ECH_SIZE + (ech->configId / 4);
+                size += ECH_PADDING_TO_32(size) + WC_AES_BLOCK_SIZE;
+
+                /* innerClientHelloLen */
+                c16toa((word16)size, writeBuf_p);
+                writeBuf_p += 2;
+                /* innerClientHello */
+                ret = wc_RNG_GenerateBlock(rng, writeBuf_p, size);
+                writeBuf_p += size;
+            }
+
             if (rngRet == 0)
                 wc_FreeRng(rng);
-            if (ephemeralKey != NULL)
-                wc_HpkeFreeKey(hpke, hpke->kem, ephemeralKey, hpke->heap);
-            WC_FREE_VAR_EX(hpke, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             WC_FREE_VAR_EX(rng, NULL, DYNAMIC_TYPE_RNG);
         }
         else {
-            /* only write enc if this is our first ech, no hpke context */
-            if (ech->hpkeContext == NULL) {
+            if (ech->innerCount == 0) {
                 /* write enc to writeBuf_p */
                 ret = wc_HpkeSerializePublicKey(ech->hpke, ech->ephemeralKey,
                     writeBuf_p, &ech->encLen);
                 writeBuf_p += ech->encLen;
             }
+
             /* innerClientHelloLen */
             c16toa((word16)ech->innerClientHelloLen, writeBuf_p);
             writeBuf_p += 2;
@@ -13917,11 +13929,19 @@ static int TLSX_ECH_GetSize(WOLFSSL_ECH* ech, byte msgType)
     word32 size = 0;
 
     if (ech->state == ECH_WRITE_GREASE) {
+        word32 payload;
         size = sizeof(ech->type) + sizeof(ech->cipherSuite) +
-            sizeof(ech->configId) + sizeof(word16) + ech->encLen +
-            sizeof(word16);
-
-        size += GREASE_ECH_SIZE + (size % 32);
+            sizeof(ech->configId) + sizeof(word16) + sizeof(word16);
+        /* enc only printed on CH1 */
+        if (ech->innerCount == 0)
+            size += ech->encLen;
+        /* GREASE payload mimics the regular sealed inner:
+         *   plaintext length divisible by 32 and the AEAD tag
+         *   configId is used to randomize the GREASE length
+         *     (divide by 4 to save space) */
+        payload = GREASE_ECH_SIZE + (ech->configId / 4);
+        payload += ECH_PADDING_TO_32(payload) + WC_AES_BLOCK_SIZE;
+        size += payload;
     }
     else if (msgType == hello_retry_request) {
         size = ECH_ACCEPT_CONFIRMATION_SZ;
@@ -13946,8 +13966,8 @@ static int TLSX_ECH_GetSize(WOLFSSL_ECH* ech, byte msgType)
         size = sizeof(ech->type) + sizeof(ech->cipherSuite) +
             sizeof(ech->configId) + sizeof(word16) + sizeof(word16) +
             ech->innerClientHelloLen;
-        /* only set encLen if this is inner hello 1 */
-        if (ech->hpkeContext == NULL)
+        /* enc only printed on CH1 */
+        if (ech->innerCount == 0)
             size += ech->encLen;
     }
 
@@ -16460,8 +16480,8 @@ static int TLSX_EchChangeSNI(WOLFSSL* ssl, TLSX** pEchX,
         /* if not NULL the semaphore will stop it from being counted */
         echX = TLSX_Find(ssl->ctx->extensions, TLSX_ECH);
 
-    /* if type is outer change sni to public name */
-    if (echX != NULL &&
+    /* if type is outer and this is a real ECH then change sni to public name */
+    if (echX != NULL && ssl->echConfigs != NULL &&
         ((WOLFSSL_ECH*)echX->data)->type == ECH_TYPE_OUTER) {
         if (ssl->extensions) {
             serverNameX = TLSX_Find(ssl->extensions, TLSX_SERVER_NAME);
@@ -16754,8 +16774,7 @@ int TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType, word32* pLength)
     }
     #endif
 #if defined(HAVE_ECH)
-    if (ssl->echConfigs != NULL && !ssl->options.disableECH
-            && msgType == client_hello) {
+    if (!ssl->options.disableECH && msgType == client_hello) {
         ret = TLSX_GetSizeWithEch(ssl, semaphore, msgType, &length);
         if (ret != 0)
             return ret;
@@ -16977,10 +16996,8 @@ int TLSX_WriteRequest(WOLFSSL* ssl, byte* output, byte msgType, word32* pOffset)
     #endif
 #endif
 #if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
-    if (ssl->echConfigs != NULL && !ssl->options.disableECH
-            && msgType == client_hello) {
-        ret = TLSX_WriteWithEch(ssl, output, semaphore,
-                         msgType, &offset);
+    if (!ssl->options.disableECH && msgType == client_hello) {
+        ret = TLSX_WriteWithEch(ssl, output, semaphore, msgType, &offset);
         if (ret != 0)
             return ret;
     }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4781,7 +4781,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
 
     /* find length of outer and inner */
 #if defined(HAVE_ECH)
-    if (ssl->echConfigs != NULL && !ssl->options.disableECH) {
+    if (!ssl->options.disableECH) {
         TLSX* echX = TLSX_Find(ssl->extensions, TLSX_ECH);
         if (echX == NULL)
             return WOLFSSL_FATAL_ERROR;
@@ -4790,8 +4790,17 @@ int SendTls13ClientHello(WOLFSSL* ssl)
         if (args->ech == NULL)
             return WOLFSSL_FATAL_ERROR;
 
-        /* only prepare if we have a chance at acceptance */
-        if (ssl->options.echAccepted || args->ech->innerCount == 0) {
+        /* if ECH was rejected by the HRR then the server MUST stop
+         * decrypting ECH, so send a GREASE ECH for the follow-up CH */
+        if (ssl->echConfigs != NULL && !ssl->options.echAccepted &&
+                ssl->options.serverState ==
+                    SERVER_HELLO_RETRY_REQUEST_COMPLETE) {
+            args->ech->state = ECH_WRITE_GREASE;
+        }
+
+        /* only prepare if we have a chance at acceptance (real ECH only) */
+        if (ssl->echConfigs != NULL &&
+                (ssl->options.echAccepted || args->ech->innerCount == 0)) {
             word32 encodedLen;
             byte downgrade;
 
@@ -4845,8 +4854,8 @@ int SendTls13ClientHello(WOLFSSL* ssl)
 
             /* innerClientHelloLen and padding are based on the
              * encoded (sealed) inner */
-            args->ech->paddingLen += 31 -
-                ((encodedLen + args->ech->paddingLen - 1) % 32);
+            args->ech->paddingLen +=
+                ECH_PADDING_TO_32(encodedLen + args->ech->paddingLen);
             args->ech->innerClientHelloLen = encodedLen +
                 args->ech->paddingLen + args->ech->hpke->Nt;
 
@@ -5103,10 +5112,10 @@ int SendTls13ClientHello(WOLFSSL* ssl)
 
         if (ret != 0)
             return ret;
-
-        /* innerCount gates HRR re-prep and the server's copyRandom logic. */
-        args->ech->innerCount = 1;
     }
+    /* Mark CH1 done for any ECH extension (real or GREASE) */
+    if (args->ech != NULL)
+        args->ech->innerCount = 1;
 #endif
 
 #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
@@ -5854,11 +5863,9 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
         if (args->extMsgType == hello_retry_request &&
                 ((WOLFSSL_ECH*)args->echX->data)->confBuf == NULL) {
-            /* server rejected ECH, fallback to outer.  Swap ECH to GREASE so
-             * CH2 still carries an ECH extension */
+            /* server rejected ECH, fall back to outer */
             Free_HS_Hashes(ssl->hsHashesEch, ssl->heap);
             ssl->hsHashesEch = NULL;
-            ((WOLFSSL_ECH*)args->echX->data)->state = ECH_WRITE_GREASE;
         }
         else {
             /* account for hrr extension instead of server random */
@@ -5880,12 +5887,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
             if (ret != 0)
                 return ret;
-            /* When rejected on HRR, swap ECH to GREASE so CH2 still carries an
-             * ECH extension */
-            if (args->extMsgType == hello_retry_request &&
-                    !ssl->options.echAccepted) {
-                ((WOLFSSL_ECH*)args->echX->data)->state = ECH_WRITE_GREASE;
-            }
             /* use the inner random for client random */
             if (args->extMsgType != hello_retry_request) {
                 XMEMCPY(ssl->arrays->clientRandom,

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5854,9 +5854,11 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
         if (args->extMsgType == hello_retry_request &&
                 ((WOLFSSL_ECH*)args->echX->data)->confBuf == NULL) {
-            /* server rejected ECH, fallback to outer */
+            /* server rejected ECH, fallback to outer.  Swap ECH to GREASE so
+             * CH2 still carries an ECH extension */
             Free_HS_Hashes(ssl->hsHashesEch, ssl->heap);
             ssl->hsHashesEch = NULL;
+            ((WOLFSSL_ECH*)args->echX->data)->state = ECH_WRITE_GREASE;
         }
         else {
             /* account for hrr extension instead of server random */
@@ -5878,6 +5880,12 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
             if (ret != 0)
                 return ret;
+            /* When rejected on HRR, swap ECH to GREASE so CH2 still carries an
+             * ECH extension */
+            if (args->extMsgType == hello_retry_request &&
+                    !ssl->options.echAccepted) {
+                ((WOLFSSL_ECH*)args->echX->data)->state = ECH_WRITE_GREASE;
+            }
             /* use the inner random for client random */
             if (args->extMsgType != hello_retry_request) {
                 XMEMCPY(ssl->arrays->clientRandom,

--- a/tests/api.c
+++ b/tests/api.c
@@ -16087,7 +16087,6 @@ static int test_wolfSSL_Tls13_ECH_HRR_rejection(void)
 {
     EXPECT_DECLS;
     test_ssl_memio_ctx test_ctx;
-    word16 idx = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ;
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
 
@@ -16117,19 +16116,18 @@ static int test_wolfSSL_Tls13_ECH_HRR_rejection(void)
      * outer transcript */
     ExpectIntEQ(wolfSSL_NoKeyShares(test_ctx.c_ssl), WOLFSSL_SUCCESS);
 
-    /* One round: client sends CH1, server consumes it and writes HRR */
-    (void)test_ssl_memio_do_handshake(&test_ctx, 1, NULL);
-
-    ExpectIntEQ(ech_find_extension(test_ctx.s_buff, &idx, TLSXT_ECH), 0);
-
     if (EXPECT_SUCCESS()) {
-        idx = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ;
+        word16 idx = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ;
+
+        /* One round: client sends CH1, server consumes it and writes HRR */
+        (void)test_ssl_memio_do_handshake(&test_ctx, 1, NULL);
 
         /* Client reads HRR and writes CH2 into s_buff.
          * CH2 carries encrypted_client_hello so the connection doesn't
          * 'stick out' on the wire. */
         (void)wolfSSL_connect(test_ctx.c_ssl);
-        ExpectIntEQ(test_ctx.c_ssl->options.echAccepted, 0);
+        ExpectIntEQ(wolfSSL_GetEchStatus(test_ctx.c_ssl),
+            WOLFSSL_ECH_STATUS_REJECTED);
         /* hsHashesEch must have been freed by the HRR rejection code path */
         ExpectNull(test_ctx.c_ssl->hsHashesEch);
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -16081,11 +16081,13 @@ static int ech_find_extension(byte* buf, word16* idx_p, word16 extType)
 
 /* Test the HRR ECH rejection fallback path:
  * client offers ECH, HRR is triggered, server sends HRR without ECH extension,
- * client falls back to the outer transcript, then aborts with ech_required. */
+ * client falls back to the outer transcript, then aborts with ech_required.
+ * encrypted_client_hello should still be present in CH2 */
 static int test_wolfSSL_Tls13_ECH_HRR_rejection(void)
 {
     EXPECT_DECLS;
     test_ssl_memio_ctx test_ctx;
+    word16 idx = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ;
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
 
@@ -16115,7 +16117,26 @@ static int test_wolfSSL_Tls13_ECH_HRR_rejection(void)
      * outer transcript */
     ExpectIntEQ(wolfSSL_NoKeyShares(test_ctx.c_ssl), WOLFSSL_SUCCESS);
 
-    /* Handshake must fail: client aborts with ech_required */
+    /* One round: client sends CH1, server consumes it and writes HRR */
+    (void)test_ssl_memio_do_handshake(&test_ctx, 1, NULL);
+
+    ExpectIntEQ(ech_find_extension(test_ctx.s_buff, &idx, TLSXT_ECH), 0);
+
+    if (EXPECT_SUCCESS()) {
+        idx = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ;
+
+        /* Client reads HRR and writes CH2 into s_buff.
+         * CH2 carries encrypted_client_hello so the connection doesn't
+         * 'stick out' on the wire. */
+        (void)wolfSSL_connect(test_ctx.c_ssl);
+        ExpectIntEQ(test_ctx.c_ssl->options.echAccepted, 0);
+        /* hsHashesEch must have been freed by the HRR rejection code path */
+        ExpectNull(test_ctx.c_ssl->hsHashesEch);
+
+        ExpectIntEQ(ech_find_extension(test_ctx.s_buff, &idx, TLSXT_ECH), 0);
+    }
+
+    /* Finish handshake: client aborts with ech_required */
     ExpectIntNE(test_ssl_memio_do_handshake(&test_ctx, 10, NULL), TEST_SUCCESS);
     ExpectIntEQ(wolfSSL_GetEchStatus(test_ctx.c_ssl),
         WOLFSSL_ECH_STATUS_REJECTED);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3111,6 +3111,7 @@ typedef struct RpkState {
 
 #if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
 #define ECH_ACCEPT_CONFIRMATION_SZ 8
+#define ECH_PADDING_TO_32(length) (31 - (((length) - 1) % 32))
 
 typedef enum {
     ECH_TYPE_OUTER = 0,


### PR DESCRIPTION
# Description

When a server's HelloRetryRequest rejects a client's ECH, the client now sends a GREASE ECH on ClientHello2 instead of dropping ECH the second time. This prevents a rejected connection from standing out on the wire.

Changes have also been made to the GREASE ECH path to make it stand out less.

## Changes

  - **ClientHello2-on-reject**: Rejected connections are set to GREASE before writing. They are then funneled into the TLS Writer which has been refactored to manage both the GREASE and real ECH connections.
  - **GREASE written last**: Pure GREASE ECH connections would write ECH first. Because of the write refactor they are now written last like the real ECH connections. The `EchChangeSNI` public-name swap is gated to real ECH only.
  - **GREASE payload sizing**: The previous GREASE ECH size was constant before and did not follow the padding conventions of a real ECH connection. Used configId to randomize size and broke padding calculation out into a macro `ECH_PADDING_TO_32`.
  - **GREASE now preserved across HRR**: Added guard in `TLSX_GreaseECH_Use` so the configId remains constant across ClientHello's.
  - **ech.innerCount handling**: Changed innerCount to always be updated when ECH is enabled. This is then used to prevent a GREASE ECH from writing enc on ClientHello2.

# Testing

Modified `test_wolfSSL_Tls13_ECH_HRR_rejection` to check for the ECH extension in ClientHello2.

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
