### PR TITLE
20260601-fixes

### DIFF
--- a/tests/api/test_pkcs12.c
+++ b/tests/api/test_pkcs12.c
@@ -648,10 +648,12 @@ int test_wc_PKCS12_PBKDF(void)
     ExpectIntEQ(XMEMCMP(derived, verify2, 24), 0);
 
     /* iterations <= 0 must be rejected */
+    #if !defined(HAVE_FIPS) || FIPS_VERSION3_GE(7,0,0)
     ExpectIntEQ(wc_PKCS12_PBKDF(derived, passwd, (int)sizeof(passwd),
                     salt, (int)sizeof(salt), 0, 24, WC_SHA256, 1), BAD_FUNC_ARG);
     ExpectIntEQ(wc_PKCS12_PBKDF(derived, passwd, (int)sizeof(passwd),
                     salt, (int)sizeof(salt), -1, 24, WC_SHA256, 1), BAD_FUNC_ARG);
+    #endif /* !HAVE_FIPS || FIPS_VERSION3_GE(7,0,0) */
 #endif
     return EXPECT_RESULT();
 }
@@ -717,12 +719,14 @@ int test_wc_PKCS12_PBKDF_ex(void)
                     salt, (int)sizeof(salt), 1, 24, WC_SHA256, 3, NULL), 0);
 
     /* iterations <= 0 must be rejected */
+    #if !defined(HAVE_FIPS) || FIPS_VERSION3_GE(7,0,0)
     ExpectIntEQ(wc_PKCS12_PBKDF_ex(derived, passwd, (int)sizeof(passwd),
                     salt, (int)sizeof(salt), 0, 24, WC_SHA256, 1, NULL),
                 BAD_FUNC_ARG);
     ExpectIntEQ(wc_PKCS12_PBKDF_ex(derived, passwd, (int)sizeof(passwd),
                     salt, (int)sizeof(salt), -1, 24, WC_SHA256, 1, NULL),
                 BAD_FUNC_ARG);
+    #endif /* !HAVE_FIPS || FIPS_VERSION3_GE(7,0,0) */
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_pwdbased.c
+++ b/tests/api/test_pwdbased.c
@@ -29,7 +29,8 @@ int test_wc_PBKDF1_ex_iterations(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_PBKDF1) && !defined(NO_PWDBASED) && !defined(NO_SHA) && \
-    !defined(HAVE_SELFTEST)
+    !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || FIPS_VERSION3_GE(7,0,0))
+
     static const byte passwd[] = { 'p', 'a', 's', 's' };
     static const byte salt[]   = { 0x78, 0x57, 0x8E, 0x5a,
                                    0x5d, 0x63, 0xcb, 0x06 };

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -1893,7 +1893,7 @@ WOLFSSL_PKCS8_PRIV_KEY_INFO* wolfSSL_d2i_PKCS8_PKEY(
                 rawDer.buffer = pkcs8Der->buffer + inOutIdx;
                 rawDer.length = (word32)ret;
             }
-            if (ret >= 0) {
+            if (ret > 0) {
                 ret = 0; /* good DER */
             }
         }


### PR DESCRIPTION
`tests/api/test_pkcs12.c`, `tests/api/test_pwdbased.c`: add missing FIPS version gates to `test_wc_PKCS12_PBKDF()`, `test_wc_PKCS12_PBKDF_ex()`, and `test_wc_PBKDF1_ex_iterations()`;

`wolfcrypt/src/evp_pk.c`: fix `identicalInnerCondition` in `wolfSSL_d2i_PKCS8_PKEY()`.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
all-crypto-openssl-extra-coexist-fips-v6
```
