### PR TITLE
Fix in IoTSafe RaspPi client example

### DIFF
--- a/IDE/iotsafe-raspberrypi/client-tls13.c
+++ b/IDE/iotsafe-raspberrypi/client-tls13.c
@@ -170,39 +170,31 @@ int client_loop(const char *peer_ip, const char *peer_name,
     char         randombytes[16] = {0};
 
     /* Construct HTTP POST */
-
-    /* Header */
-    strcat(buff, "POST /iot/device HTTP/1.1\r\n");
-    strcat(buff, "Content-Type: application/json\r\n");
-    strcat(buff, "Content-Length: 1000\r\n");
-    strcat(buff, "Accept: */*\r\n");
-    strcat(buff, "Host: ");
-    strcat(buff, peer_name);
-    strcat(buff, ":");
-    strcat(buff, peer_port);
-    strcat(buff, "\r\n");
-
-    /* Delimiter */
-    strcat(buff, "\r\n");
-
-    /* Body */
     srand(time(NULL));
-    int devid    = rand() % 100;
-    char snum[5] = {0};
-    snprintf(snum, sizeof(snum), "%d", devid);
+    int devid = rand() % 100;
 
-    strcat(buff, "{");
-    strcat(buff, "\"deviceId\": \"");
-    strcat(buff, snum);
-    strcat(buff, "\",");
-    strcat(buff, "\"sensorType\": \"Temperature\",");
-    strcat(buff, "\"sensorValue\": \"");
-    strcat(buff, temperature);
-    strcat(buff, "\",");
-    strcat(buff, "\"sensorUnit\": \"Celsius\",");
-    strcat(buff, "\"sensorTime\": 1582181510");
-    strcat(buff, "}");
-    strcat(buff, "\r\n");
+    int n = snprintf(buff, sizeof(buff),
+        "POST /iot/device HTTP/1.1\r\n"
+        "Content-Type: application/json\r\n"
+        "Content-Length: 1000\r\n"
+        "Accept: */*\r\n"
+        "Host: %s:%s\r\n"
+        "\r\n"
+        "{"
+        "\"deviceId\": \"%d\","
+        "\"sensorType\": \"Temperature\","
+        "\"sensorValue\": \"%s\","
+        "\"sensorUnit\": \"Celsius\","
+        "\"sensorTime\": 1582181510"
+        "}"
+        "\r\n",
+        peer_name, peer_port, devid, temperature);
+
+    if (n < 0 || n >= (int)sizeof(buff)) {
+        fprintf(stderr, "ERROR: HTTP request too large for buffer\n");
+        ret = -1;
+        goto exit;
+    }
 
     printf("\n\nPOST REQUEST\n\n%s\n\n", buff);
 

--- a/IDE/iotsafe-raspberrypi/main.c
+++ b/IDE/iotsafe-raspberrypi/main.c
@@ -203,27 +203,27 @@ int main(int argc, char** argv)
 
     if (argc == 11)
     {
-        if (strcmp(argv[1], "-ip") == 0)
-           strcpy((char*)&ip, argv[2]);
+        if (strcmp(argv[1], "-ip") == 0 && strlen(argv[2]) < sizeof(ip))
+            strcpy((char*)&ip, argv[2]);
         else
             show_usage(argv[0]);
 
-        if (strcmp(argv[3], "-h") == 0)
+        if (strcmp(argv[3], "-h") == 0 && strlen(argv[4]) < sizeof(name))
             strcpy((char*)&name, argv[4]);
         else
             show_usage(argv[0]);
 
-        if (strcmp(argv[5], "-p") == 0)
+        if (strcmp(argv[5], "-p") == 0 && strlen(argv[6]) < sizeof(port))
             strcpy((char*)&port, argv[6]);
         else
             show_usage(argv[0]);
 
-        if (strcmp(argv[7], "-t") == 0)
+        if (strcmp(argv[7], "-t") == 0 && strlen(argv[8]) < sizeof(temperature))
             strcpy((char*)&temperature, argv[8]);
         else
             show_usage(argv[0]);
 
-        if (strcmp(argv[9], "-d") == 0)
+        if (strcmp(argv[9], "-d") == 0 && strlen(argv[10]) < sizeof(device))
             strcpy((char*)&device, argv[10]);
         else
             show_usage(argv[0]);


### PR DESCRIPTION
# Description

Harden example application by avoiding `strcat`

Thanks to Ozidx(https://github.com/Ozidx) for reporting this issue.

Fixes zd21918

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
