### PR TITLE
Fix compilation with WOLFSSL_RNG_USE_FULL_SEED.  Fix benchmark compilation with MAIN_NO_ARGS.

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1298,9 +1298,6 @@ static const bench_alg bench_other_opt[] = {
 #endif
     { NULL, 0}
 };
-#endif /* MAIN_NO_ARGS */
-
-#endif /* !WOLFSSL_BENCHMARK_ALL && !NO_MAIN_DRIVER */
 
 #if defined(BENCH_PQ_STATEFUL_HBS)
 typedef struct bench_pq_hash_sig_alg {
@@ -1352,6 +1349,10 @@ static const bench_pq_hash_sig_alg bench_pq_hash_sig_opt[] = {
     { NULL, 0}
 };
 #endif /* BENCH_PQ_STATEFUL_HBS */
+
+#endif /* MAIN_NO_ARGS */
+
+#endif /* !WOLFSSL_BENCHMARK_ALL && !NO_MAIN_DRIVER */
 
 #if !defined(WOLFSSL_BENCHMARK_ALL) && !defined(MAIN_NO_ARGS)
 #if defined(WOLFSSL_HAVE_MLKEM) || defined(HAVE_FALCON) || \

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1720,10 +1720,10 @@ static int _InitRng(WC_RNG* rng, byte* nonce, word32 nonceSz,
     word32 seedSz = SEED_SZ;
 #else
     word32 seedSz = SEED_SZ + SEED_BLOCK_SZ;
+#endif
     WC_DECLARE_VAR(seed, byte, MAX_SEED_SZ, rng->heap);
 #ifdef WOLFSSL_SMALL_STACK_CACHE
     int drbg_scratch_instantiated = 0;
-#endif
 #endif
 #endif
 


### PR DESCRIPTION
# Description

Fixes zd#21907, zd#21874.

# Testing

Built in tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
