### PR TITLE
20260602-FPKI-DecodeGeneralName-URI

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -10026,8 +10026,7 @@ static int test_wolfSSL_URI(void)
     wolfSSL_FreeX509(x509);
     x509 = NULL;
 
-#if !defined(IGNORE_NAME_CONSTRAINTS) && !defined(WOLFSSL_NO_ASN_STRICT) \
-    && !defined(WOLFSSL_FPKI)
+#if !defined(IGNORE_NAME_CONSTRAINTS) && !defined(WOLFSSL_NO_ASN_STRICT)
     ExpectNull(x509 = wolfSSL_X509_load_certificate_file(badUri,
         WOLFSSL_FILETYPE_PEM));
 #else

--- a/tests/api/test_certman.c
+++ b/tests/api/test_certman.c
@@ -2126,7 +2126,7 @@ int test_wolfSSL_X509_check_host_URI_SAN_not_DNS_match(void)
     WOLFSSL_X509_NAME* name = NULL;
     const char* server_cert = "./certs/test/server-goodcn.pem";
     const char hostName[] = "cnhost.local";
-    const char uriSan[] = "cnhost.local";
+    const char uriSan[] = "http://cnhost.local";
     byte    *pt;
     WOLFSSL_X509 *leafUri = NULL;
     WOLFSSL_X509 *leafUriDns = NULL;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -18644,7 +18644,7 @@ static int DecodeGeneralName(const byte* input, word32* inOutIdx, byte tag,
         }
         WOLFSSL_MSG("\tPutting URI into list but not using");
 
-    #if !defined(WOLFSSL_NO_ASN_STRICT) && !defined(WOLFSSL_FPKI)
+    #ifndef WOLFSSL_NO_ASN_STRICT
         /* Verify RFC 5280 Sec 4.2.1.6 rule:
             "The name MUST NOT be a relative URI"
             As per RFC 3986 Sec 4.3, an absolute URI is only required to contain
@@ -18660,9 +18660,8 @@ static int DecodeGeneralName(const byte* input, word32* inOutIdx, byte tag,
                     break;
                 }
                 if (input[idx + (word32)i] == '/') {
-                    i = len; /* error, found relative path since '/' was
-                              * encountered before ':'. Returning error
-                              * value in next if statement. */
+                    /* path is relative since '/' was encountered before ':'. */
+                    return ASN_ALT_NAME_E;
                 }
             }
 
@@ -37726,7 +37725,7 @@ static int DecodeAcertGeneralName(const byte* input, word32* inOutIdx,
     else if (tag == (ASN_CONTEXT_SPECIFIC | ASN_URI_TYPE)) {
         WOLFSSL_MSG("\tPutting URI into list but not using");
 
-    #if !defined(WOLFSSL_NO_ASN_STRICT) && !defined(WOLFSSL_FPKI)
+    #ifndef WOLFSSL_NO_ASN_STRICT
         /* Verify RFC 5280 Sec 4.2.1.6 rule:
            "The name MUST NOT be a relative URI"
            As per RFC 3986 Sec 4.3, an absolute URI is only required to contain
@@ -37742,9 +37741,8 @@ static int DecodeAcertGeneralName(const byte* input, word32* inOutIdx,
                     break;
                 }
                 if (input[idx + (word32)i] == '/') {
-                    i = len; /* error, found relative path since '/' was
-                              * encountered before ':'. Returning error
-                              * value in next if statement. */
+                    /* path is relative since '/' was encountered before ':'. */
+                    return ASN_ALT_NAME_E;
                 }
             }
 

--- a/wolfcrypt/src/asn_orig.c
+++ b/wolfcrypt/src/asn_orig.c
@@ -3420,7 +3420,7 @@ static int DecodeAltNames(const byte* input, word32 sz, DecodedCert* cert)
                 return ASN_PARSE_E;
             }
 
-        #if !defined(WOLFSSL_NO_ASN_STRICT) && !defined(WOLFSSL_FPKI)
+        #ifndef WOLFSSL_NO_ASN_STRICT
             /* Verify RFC 5280 Sec 4.2.1.6 rule:
                 "The name MUST NOT be a relative URI"
                 As per RFC 3986 Sec 4.3, an absolute URI is only required to contain


### PR DESCRIPTION
`wolfcrypt/src/asn.c`: don't disable URI validation in `DecodeGeneralName()` and `DecodeAcertGeneralName()` when `defined(WOLFSSL_FPKI)`.

`tests/api/test_certman.c`: fix `uriSan` in `test_wolfSSL_X509_check_host_URI_SAN_not_DNS_match()` (make it a URI).

`tests/api.c`: align gating in `test_wolfSSL_URI()` with new dynamics (URIs validated regardless of `defined(WOLFSSL_FPKI)`).

detected and tested with
```
wolfssl-multi-test.sh ...
old-valgrind-config-sanitizer
check-source-text
clang-tidy-all-sp-all
```
