### PR TITLE
ecc: fix double-free in wc_ecc_import_point_der_ex on invalid format byte

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -10120,6 +10120,14 @@ int wc_ecc_import_point_der_ex(const byte* in, word32 inLen,
         return ECC_BAD_ARG_E;
     }
 
+    /* validate point format byte before any memory operations */
+    pointType = in[0];
+    if (pointType != ECC_POINT_UNCOMP &&
+            pointType != ECC_POINT_COMP_EVEN &&
+            pointType != ECC_POINT_COMP_ODD) {
+        return ASN_PARSE_E;
+    }
+
     /* clear if previously allocated */
     mp_clear(point->x);
     mp_clear(point->y);
@@ -10140,13 +10148,7 @@ int wc_ecc_import_point_der_ex(const byte* in, word32 inLen,
         return MEMORY_E;
 #endif
 
-    /* check for point type (4, 2, or 3) */
-    pointType = in[0];
-    if (pointType != ECC_POINT_UNCOMP && pointType != ECC_POINT_COMP_EVEN &&
-                                         pointType != ECC_POINT_COMP_ODD) {
-        err = ASN_PARSE_E;
-    }
-
+    /* pointType already validated above; check for compressed format */
     if (pointType == ECC_POINT_COMP_EVEN || pointType == ECC_POINT_COMP_ODD) {
 #ifdef HAVE_COMP_KEY
         compressed = 1;


### PR DESCRIPTION
## Summary

`wc_ecc_import_point_der_ex` crashes (double-free/SIGABRT) when given a full-length EC point blob with an invalid first byte (e.g. `0x01`, `0x05`, `0xFF`). The format byte check happened after `mp_clear(point->x/y)` and memory initialization, so on error the cleanup path freed already-freed memory.

## Fix

Move the format byte validation (`0x02`, `0x03`, or `0x04`) before any memory operations (`mp_clear`, `mp_init`). Return `ASN_PARSE_E` immediately on invalid format byte, before any state is touched.

## Reproducer

Call `wc_ecc_import_point_der_ex` with a buffer whose first byte is `0x05` (or any value other than `0x02`, `0x03`, `0x04`). Before this fix it crashes; after, it returns `ASN_PARSE_E`.

## Test Plan

- [ ] Invalid format byte (`0x01`, `0x05`, `0xFF`) returns `ASN_PARSE_E` without crash
- [ ] Valid uncompressed (`0x04`) and compressed (`0x02`, `0x03`) points still import correctly
- [ ] Run existing wolfSSL test suite