### PR TITLE
f4429 Add missing upper-bound validation in wc_Entropy_Get()

### DIFF
--- a/tests/api/test_random.c
+++ b/tests/api/test_random.c
@@ -30,6 +30,9 @@
 
 #include <wolfssl/wolfcrypt/random.h>
 #include <wolfssl/wolfcrypt/types.h>
+#ifdef HAVE_ENTROPY_MEMUSE
+    #include <wolfssl/wolfcrypt/wolfentropy.h>
+#endif
 #include <tests/api/api.h>
 #include <tests/api/test_random.h>
 
@@ -739,3 +742,30 @@ int test_wc_RNG_HealthTest_SHA512(void)
     return EXPECT_RESULT();
 }
 
+int test_wc_Entropy_Get(void)
+{
+    EXPECT_DECLS;
+#ifdef HAVE_ENTROPY_MEMUSE
+    byte entropy[WC_SHA3_256_DIGEST_SIZE]; /* 32 bytes */
+
+    /* bits <= 0: must reject */
+    ExpectIntEQ(wc_Entropy_Get(0, entropy, sizeof(entropy)),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_Entropy_Get(-1, entropy, sizeof(entropy)),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    /* bits > MAX_ENTROPY_BITS: must reject (overflow guard) */
+    ExpectIntEQ(wc_Entropy_Get(MAX_ENTROPY_BITS + 1, entropy, sizeof(entropy)),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_Entropy_Get(2049, entropy, sizeof(entropy)),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    /* entropy == NULL with len > 0: must reject */
+    ExpectIntEQ(wc_Entropy_Get(MAX_ENTROPY_BITS, NULL, sizeof(entropy)),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    /* valid call: bits == MAX_ENTROPY_BITS */
+    ExpectIntEQ(wc_Entropy_Get(MAX_ENTROPY_BITS, entropy, sizeof(entropy)), 0);
+#endif /* HAVE_ENTROPY_MEMUSE */
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_random.c
+++ b/tests/api/test_random.c
@@ -757,7 +757,7 @@ int test_wc_Entropy_Get(void)
     /* bits > MAX_ENTROPY_BITS: must reject (overflow guard) */
     ExpectIntEQ(wc_Entropy_Get(MAX_ENTROPY_BITS + 1, entropy, sizeof(entropy)),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-    ExpectIntEQ(wc_Entropy_Get(2049, entropy, sizeof(entropy)),
+    ExpectIntEQ(wc_Entropy_Get(MAX_ENTROPY_BITS * 8 + 1, entropy, sizeof(entropy)),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
     /* entropy == NULL with len > 0: must reject */

--- a/tests/api/test_random.h
+++ b/tests/api/test_random.h
@@ -37,6 +37,7 @@ int test_wc_RNG_DRBG_Reseed(void);
 int test_wc_RNG_TestSeed(void);
 int test_wc_RNG_HealthTest(void);
 int test_wc_RNG_HealthTest_SHA512(void);
+int test_wc_Entropy_Get(void);
 
 #define TEST_RANDOM_DECLS                                           \
     TEST_DECL_GROUP("random", test_wc_InitRng),                     \
@@ -51,6 +52,7 @@ int test_wc_RNG_HealthTest_SHA512(void);
     TEST_DECL_GROUP("random", test_wc_RNG_DRBG_Reseed),             \
     TEST_DECL_GROUP("random", test_wc_RNG_TestSeed),                \
     TEST_DECL_GROUP("random", test_wc_RNG_HealthTest),              \
-    TEST_DECL_GROUP("random", test_wc_RNG_HealthTest_SHA512)
+    TEST_DECL_GROUP("random", test_wc_RNG_HealthTest_SHA512),       \
+    TEST_DECL_GROUP("random", test_wc_Entropy_Get)
 
 #endif /* WOLFCRYPT_TEST_RANDOM_H */

--- a/wolfcrypt/src/wolfentropy.c
+++ b/wolfcrypt/src/wolfentropy.c
@@ -816,7 +816,7 @@ int wc_Entropy_Get(int bits, unsigned char* entropy, word32 len)
     int noise_len;
     static byte noise[MAX_NOISE_CNT];
 
-    if (bits <= 0 || (entropy == NULL && len > 0)) {
+    if (bits <= 0 || bits > MAX_ENTROPY_BITS || (entropy == NULL && len > 0)) {
         return BAD_FUNC_ARG;
     }
 


### PR DESCRIPTION
# wolfentropy: enforce MAX_ENTROPY_BITS upper bound in wc_Entropy_Get()

## Summary

- **Bug fix**: Add missing upper-bound validation in `wc_Entropy_Get()` to prevent a static buffer overflow.
- **Test**: Add `test_wc_Entropy_Get()` to `tests/api/test_random.c` covering the new validation and the existing guards.

## Problem

`wc_Entropy_Get(int bits, ...)` is a public API declared `WOLFSSL_API` in
`wolfssl/wolfcrypt/wolfentropy.h`. Its documentation states 256 as the maximum
accepted value for `bits`, but the input validation at the top of the function
only rejected `bits <= 0`:

```c
/* before */
if (bits <= 0 || (entropy == NULL && len > 0)) {
    return BAD_FUNC_ARG;
}
```

The noise length is then computed as:

```c
noise_len = (bits + ENTROPY_EXTRA) / ENTROPY_MIN;
// ENTROPY_MIN == 1, ENTROPY_EXTRA == 64  →  noise_len = bits + 64
```

and passed directly to `Entropy_GetNoise(noise, noise_len)`, which writes
`noise_len` bytes into the function-scope static buffer:

```c
static byte noise[MAX_NOISE_CNT];
// MAX_NOISE_CNT = MAX_ENTROPY_BITS * 8 + ENTROPY_EXTRA = 256 * 8 + 64 = 2112
```

Any caller passing `bits >= 2049` produces `noise_len >= 2113`, which exceeds
`MAX_NOISE_CNT` (2112) and writes past the end of the static buffer.
`Entropy_GetNoise()` performs no independent bounds check.

All in-tree callers (`random.c` lines 4916, 4959, 5329 and
`linuxkm/module_hooks.c` line 403) pass `MAX_ENTROPY_BITS` (256), so the
defect is not reachable through internal code paths. However, the public API
gives no enforcement of the documented contract, making it reachable via direct
external use.

## Fix

Add `bits > MAX_ENTROPY_BITS` to the existing guard in `wc_Entropy_Get()`
(`wolfcrypt/src/wolfentropy.c`):

```c
/* after */
if (bits <= 0 || bits > MAX_ENTROPY_BITS || (entropy == NULL && len > 0)) {
    return BAD_FUNC_ARG;
}
```

This aligns the enforced contract with the documented maximum and eliminates
the overflow path with a single comparison.

## Test

`test_wc_Entropy_Get()` is added to `tests/api/test_random.c` and registered
in `TEST_RANDOM_DECLS`. It is compiled unconditionally but its body is gated on
`HAVE_ENTROPY_MEMUSE` (the same condition that compiles the implementation).

The test covers four invalid-argument cases and one valid call:

| Input | Expected result |
|---|---|
| `bits = 0` | `BAD_FUNC_ARG` |
| `bits = -1` | `BAD_FUNC_ARG` |
| `bits = MAX_ENTROPY_BITS + 1` | `BAD_FUNC_ARG` ← new check |
| `bits = 2049` | `BAD_FUNC_ARG` ← overflow boundary |
| `entropy = NULL, len > 0` | `BAD_FUNC_ARG` |
| `bits = MAX_ENTROPY_BITS` | `0` (success) |

### How to run

```bash
./configure --enable-wolfEntropy --enable-all \
    CFLAGS="-DNO_WOLFSSL_CIPHER_SUITE_TEST"
git clean -dfx   # required after configure option changes
make
./tests/unit.test --list | grep wc_Entropy_Get   # find test number
./tests/unit.test -<N>
```

## Files changed

| File | Change |
|---|---|
| `wolfcrypt/src/wolfentropy.c` | Add `bits > MAX_ENTROPY_BITS` guard |
| `tests/api/test_random.c` | Add `test_wc_Entropy_Get()` and include |
| `tests/api/test_random.h` | Add declaration and `TEST_RANDOM_DECLS` entry |


# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
