### PR TITLE
f5381 enforce trailerField==1 in DecodeRsaPssParams

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,17 @@
 
 ## Enhancements
 
+* **Behavioral change (RSA-PSS trailerField enforcement)**: `DecodeRsaPssParams`
+  (and its public wrapper `wc_DecodeRsaPssParams`) now enforces RFC 8017 A.2.3,
+  which mandates `trailerField == trailerFieldBC(1)`.  In the default build
+  (i.e., without `WOLFSSL_NO_ASN_STRICT`), any certificate or CMS/PKCS#7
+  structure whose RSA-PSS parameters contain a `trailerField` value other than 1
+  is now rejected with `ASN_PARSE_E`.  Previously, any positive integer value was
+  silently accepted.  This affects all call paths that decode RSA-PSS algorithm
+  parameters, including X.509 certificate parsing and PKCS#7 signature
+  verification.  Users who need to interoperate with non-conformant peers can
+  define `WOLFSSL_NO_ASN_STRICT` to restore the previous permissive behavior.
+
 * **BREAKING (FIPS 205 SLH-DSA)**: `wc_SlhDsaKey_SignHash`,
   `wc_SlhDsaKey_SignHashDeterministic`, `wc_SlhDsaKey_SignHashWithRandom`, and
   `wc_SlhDsaKey_VerifyHash` now take the **caller-pre-hashed message digest**

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -1097,6 +1097,47 @@ int test_wc_DecodeRsaPssParams(void)
             &hash, &mgf, &saltLen), WC_NO_ERR_TRACE(ASN_PARSE_E));
     }
 
+    /* --- Test 9: trailerField = 1 (trailerFieldBC) => valid in all modes --- */
+    /* SEQUENCE { [3] CONSTRUCTED { INTEGER 1 } } = 30 05 a3 03 02 01 01 */
+    {
+        static const byte trailerValid[] = {
+            0x30, 0x05, 0xa3, 0x03, 0x02, 0x01, 0x01
+        };
+        hash    = WC_HASH_TYPE_NONE;
+        mgf     = 0;
+        saltLen = 0;
+        ExpectIntEQ(wc_DecodeRsaPssParams(trailerValid,
+            (word32)sizeof(trailerValid), &hash, &mgf, &saltLen), 0);
+        ExpectIntEQ((int)hash, (int)WC_HASH_TYPE_SHA);
+        ExpectIntEQ(mgf, WC_MGF1SHA1);
+        ExpectIntEQ(saltLen, 20);
+    }
+
+#ifndef WOLFSSL_NO_ASN_STRICT
+    /* --- Test 10: trailerField = 2 => ASN_PARSE_E (strict mode) --- */
+    /* RFC 8017 A.2.3: trailerField SHALL be trailerFieldBC(1). */
+    /* SEQUENCE { [3] CONSTRUCTED { INTEGER 2 } } = 30 05 a3 03 02 01 02 */
+    {
+        static const byte trailerTwo[] = {
+            0x30, 0x05, 0xa3, 0x03, 0x02, 0x01, 0x02
+        };
+        ExpectIntEQ(wc_DecodeRsaPssParams(trailerTwo,
+            (word32)sizeof(trailerTwo), &hash, &mgf, &saltLen),
+            WC_NO_ERR_TRACE(ASN_PARSE_E));
+    }
+
+    /* --- Test 11: trailerField = 0 => ASN_PARSE_E (strict mode) --- */
+    /* SEQUENCE { [3] CONSTRUCTED { INTEGER 0 } } = 30 05 a3 03 02 01 00 */
+    {
+        static const byte trailerZero[] = {
+            0x30, 0x05, 0xa3, 0x03, 0x02, 0x01, 0x00
+        };
+        ExpectIntEQ(wc_DecodeRsaPssParams(trailerZero,
+            (word32)sizeof(trailerZero), &hash, &mgf, &saltLen),
+            WC_NO_ERR_TRACE(ASN_PARSE_E));
+    }
+#endif /* !WOLFSSL_NO_ASN_STRICT */
+
 #endif /* WC_RSA_PSS && !NO_RSA && !NO_ASN */
     return EXPECT_RESULT();
 }

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -1136,6 +1136,20 @@ int test_wc_DecodeRsaPssParams(void)
             (word32)sizeof(trailerZero), &hash, &mgf, &saltLen),
             WC_NO_ERR_TRACE(ASN_PARSE_E));
     }
+
+    /* --- Test 12: trailerField = 256 (multi-byte INTEGER) => ASN_PARSE_E ---
+     * Exercises the 2-byte integer branch in GetInteger16Bit (non-template)
+     * and the len==2 case of ASN_DATA_TYPE_WORD16 (template path).
+     * SEQUENCE { [3] CONSTRUCTED { INTEGER 256 } } = 30 06 a3 04 02 02 01 00
+     */
+    {
+        static const byte trailerMultiByte[] = {
+            0x30, 0x06, 0xa3, 0x04, 0x02, 0x02, 0x01, 0x00
+        };
+        ExpectIntEQ(wc_DecodeRsaPssParams(trailerMultiByte,
+            (word32)sizeof(trailerMultiByte), &hash, &mgf, &saltLen),
+            WC_NO_ERR_TRACE(ASN_PARSE_E));
+    }
 #endif /* !WOLFSSL_NO_ASN_STRICT */
 
 #endif /* WC_RSA_PSS && !NO_RSA && !NO_ASN */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8074,6 +8074,9 @@ static int DecodeRsaPssParams(const byte* params, word32 sz,
 {
     DECL_ASNGETDATA(dataASN, rsaPssParamsASN_Length);
     int ret = 0;
+#ifndef WOLFSSL_NO_ASN_STRICT
+    word16 trailerVal = 1;
+#endif
     word16 sLen = 20;
 
     /* Default values. */
@@ -8089,6 +8092,10 @@ static int DecodeRsaPssParams(const byte* params, word32 sz,
         GetASN_OID(&dataASN[RSAPSSPARAMSASN_IDX_MGFHOID], oidHashType);
         /* Place the salt length into 16-bit var sLen. */
         GetASN_Int16Bit(&dataASN[RSAPSSPARAMSASN_IDX_SALTLENINT], &sLen);
+#ifndef WOLFSSL_NO_ASN_STRICT
+        /* Capture trailerField value for RFC 8017 A.2.3 validation. */
+        GetASN_Int16Bit(&dataASN[RSAPSSPARAMSASN_IDX_TRAILERINT], &trailerVal);
+#endif
         /* Decode the algorithm identifier. */
         ret = GetASN_Items(rsaPssParamsASN, dataASN, rsaPssParamsASN_Length, 1,
             params, &inOutIdx, sz);
@@ -8105,6 +8112,15 @@ static int DecodeRsaPssParams(const byte* params, word32 sz,
         word32 oid = dataASN[RSAPSSPARAMSASN_IDX_MGFHOID].data.oid.sum;
         ret = RsaPssHashOidToMgf1(oid, mgf);
     }
+#ifndef WOLFSSL_NO_ASN_STRICT
+    /* RFC 8017 A.2.3: trailerField SHALL be trailerFieldBC(1). */
+    if ((ret == 0) && (dataASN[RSAPSSPARAMSASN_IDX_TRAILERINT].tag != 0)) {
+        if (trailerVal != 1) {
+            WOLFSSL_MSG("DecodeRsaPssParams: trailerField must be 1");
+            ret = ASN_PARSE_E;
+        }
+    }
+#endif
     if (ret == 0) {
         *saltLen = sLen;
     }
@@ -8251,12 +8267,24 @@ static int DecodeRsaPssParams(const byte* params, word32 sz,
             }
             if (ret == 0) {
                 ret = GetInteger16Bit(params, &idx, sz);
+#ifndef WOLFSSL_NO_ASN_STRICT
+                /* RFC 8017 A.2.3: trailerField SHALL be trailerFieldBC(1). */
+                if (ret == 1) {
+                    ret = 0;
+                }
+                else {
+                    WOLFSSL_MSG("DecodeRsaPssParams: trailerField must be 1");
+                    if (ret >= 0)
+                        ret = ASN_PARSE_E;
+                }
+#else
                 if (ret > 0) {
                     ret = 0;
                 }
                 else if (ret != 0) {
                     WOLFSSL_MSG("DecodeRsaPssParams: fail at trailer_value");
                 }
+#endif
             }
         }
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8272,10 +8272,12 @@ static int DecodeRsaPssParams(const byte* params, word32 sz,
                 if (ret == 1) {
                     ret = 0;
                 }
-                else {
+                else if (ret >= 0) {
                     WOLFSSL_MSG("DecodeRsaPssParams: trailerField must be 1");
-                    if (ret >= 0)
-                        ret = ASN_PARSE_E;
+                    ret = ASN_PARSE_E;
+                }
+                else {
+                    WOLFSSL_MSG("DecodeRsaPssParams: fail at trailer_value");
                 }
 #else
                 if (ret > 0) {


### PR DESCRIPTION
# asn: enforce trailerField == trailerFieldBC(1) in DecodeRsaPssParams

## Summary

- **Bug fix**: Validate that the `trailerField` parameter in RSASSA-PSS-params
  equals `trailerFieldBC(1)` as mandated by RFC 8017 §A.2.3, in both the ASN
  template and non-template paths of `DecodeRsaPssParams`.
- **Test**: Extend `test_wc_DecodeRsaPssParams` with three trailerField-specific
  cases covering the valid value and two invalid values.

## Problem

RFC 8017 §A.2.3 defines:

```
TrailerField ::= INTEGER { trailerFieldBC(1) }
```

and states:

> The value of the `trailerField` field **SHALL** be `trailerFieldBC(1)`.

`DecodeRsaPssParams` parsed the `trailerField` element syntactically but
never validated its integer value, so any value was silently accepted.

### Non-template path (`!WOLFSSL_ASN_TEMPLATE`)

```c
/* before */
ret = GetInteger16Bit(params, &idx, sz);
if (ret > 0) {      /* accepts 1, 2, 3, …, 65535 */
    ret = 0;
}
else if (ret != 0) {
    WOLFSSL_MSG("DecodeRsaPssParams: fail at trailer_value");
}
/* ret == 0 (value 0) also falls through silently */
```

### Template path (`WOLFSSL_ASN_TEMPLATE`)

`RSAPSSPARAMSASN_IDX_TRAILERINT` appeared in the enum but
`GetASN_Int16Bit` was never called for it, so `GetASN_Items` validated
only the ASN.1 type tag while the integer value went completely unread.

### Impact

- Any positive trailerField value (2, 3, …) and value 0 were accepted without
  error in both paths.
- PSS signature verification always assumes the standard 0xbc trailer
  regardless; a non-conformant `trailerField` in an AlgorithmIdentifier is
  therefore accepted by the parser while an RFC-compliant peer would reject it.
- This is a **conformance / input-validation defect**, not a signature-forgery
  vulnerability.

## Fix

Both paths now reject `trailerField != 1` with `ASN_PARSE_E` when
`WOLFSSL_NO_ASN_STRICT` is not defined (the default). When
`WOLFSSL_NO_ASN_STRICT` is defined the previous permissive behaviour is
preserved for backward compatibility.

### Template path (`wolfcrypt/src/asn.c`)

```c
#ifndef WOLFSSL_NO_ASN_STRICT
    word16 trailerVal = 1;
#endif
    ...
#ifndef WOLFSSL_NO_ASN_STRICT
    GetASN_Int16Bit(&dataASN[RSAPSSPARAMSASN_IDX_TRAILERINT], &trailerVal);
#endif
    ret = GetASN_Items(...);
    ...
#ifndef WOLFSSL_NO_ASN_STRICT
    /* RFC 8017 A.2.3: trailerField SHALL be trailerFieldBC(1). */
    if ((ret == 0) && (dataASN[RSAPSSPARAMSASN_IDX_TRAILERINT].tag != 0)) {
        if (trailerVal != 1) {
            WOLFSSL_MSG("DecodeRsaPssParams: trailerField must be 1");
            ret = ASN_PARSE_E;
        }
    }
#endif
```

### Non-template path (`wolfcrypt/src/asn.c`)

```c
ret = GetInteger16Bit(params, &idx, sz);
#ifndef WOLFSSL_NO_ASN_STRICT
    /* RFC 8017 A.2.3: trailerField SHALL be trailerFieldBC(1). */
    if (ret == 1) {
        ret = 0;
    }
    else {
        WOLFSSL_MSG("DecodeRsaPssParams: trailerField must be 1");
        if (ret >= 0)
            ret = ASN_PARSE_E;
    }
#else
    if (ret > 0) { ret = 0; }
    else if (ret != 0) { WOLFSSL_MSG("...fail at trailer_value"); }
#endif
```

## Test

Three cases added to `test_wc_DecodeRsaPssParams` in
`tests/api/test_asn.c`. All use a minimal DER-encoded RSASSA-PSS-params
containing only the `trailerField` component:
`SEQUENCE { [3] CONSTRUCTED { INTEGER <value> } }`.

| Test | DER (hex) | trailerField value | Guard | Expected |
|---|---|---|---|---|
| 9 | `30 05 a3 03 02 01 01` | 1 (trailerFieldBC) | none — all modes | `0` (success) |
| 10 | `30 05 a3 03 02 01 02` | 2 | `!WOLFSSL_NO_ASN_STRICT` | `ASN_PARSE_E` |
| 11 | `30 05 a3 03 02 01 00` | 0 | `!WOLFSSL_NO_ASN_STRICT` | `ASN_PARSE_E` |

Tests 10 and 11 exercise both the template and non-template paths with
the same DER input; the path is selected at build time.

### How to build and run

**Template path (default), strict mode — all three tests active:**

```bash
./configure --enable-rsapss --enable-all \
    CFLAGS="-DNO_WOLFSSL_CIPHER_SUITE_TEST"
git clean -dfx && make
./tests/unit.test --list | grep DecodeRsaPssParams
./tests/unit.test -<N>
```

**Non-template path, strict mode:**

```bash
./configure --enable-rsapss --enable-all --enable-asn=original \
    CFLAGS="-DNO_WOLFSSL_CIPHER_SUITE_TEST"
git clean -dfx && make
```

**Non-strict mode — only Test 9 active, Tests 10/11 compiled out:**

```bash
./configure --enable-rsapss --enable-all \
    CFLAGS="-DNO_WOLFSSL_CIPHER_SUITE_TEST -DWOLFSSL_NO_ASN_STRICT"
git clean -dfx && make
```

## Files changed

| File | Change |
|---|---|
| `wolfcrypt/src/asn.c` | Template path: capture and validate `trailerField` value; non-template path: enforce `trailerField == 1`; both guarded by `!WOLFSSL_NO_ASN_STRICT` |
| `tests/api/test_asn.c` | Add Tests 9–11 to `test_wc_DecodeRsaPssParams` |


# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
