### PR TITLE
fix membrowse report group

### DIFF
--- a/.github/workflows/membrowse-report.yml
+++ b/.github/workflows/membrowse-report.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   load-targets:


### PR DESCRIPTION
# Description

Fix membrowse-report.yml trigger so actions will not be cancelled by newer actions when pushed to master.
This will cause the commit chain to stay intact in the MemBrowse dashboard.

Fixes zd#

# Testing

Tested on fork repo

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
