### PR TITLE
fix tls_bench DTLS mode failures

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -126,15 +126,10 @@ Or
 #endif
 
 #ifdef WOLFSSL_DTLS
-    #ifdef BENCH_EMBEDDED
-        /* WOLFSSL_MAX_MTU in internal.h */
-        #define TEST_DTLS_PACKET_SIZE   (1500)
-    #else
-        /* Must fit in one DTLS record: WOLFSSL_MAX_MTU (1400) - MAX_MSG_EXTRA (~102).
-         * Define WOLFSSL_DTLS_MTU and call wolfSSL_dtls_set_mtu() to use larger
-         * packets; or build with WOLFSSL_NO_DTLS_SIZE_CHECK to auto-fragment. */
-        #define TEST_DTLS_PACKET_SIZE   (1200)
-    #endif
+    /* Must fit in one DTLS record: WOLFSSL_MAX_MTU (1400) - MAX_MSG_EXTRA (~102).
+     * Define WOLFSSL_DTLS_MTU and call wolfSSL_dtls_set_mtu() to use larger
+     * packets; or build with WOLFSSL_NO_DTLS_SIZE_CHECK to auto-fragment. */
+    #define TEST_DTLS_PACKET_SIZE   (1200)
 #endif
 
 /* In memory transfer buffer maximum size */

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -130,8 +130,10 @@ Or
         /* WOLFSSL_MAX_MTU in internal.h */
         #define TEST_DTLS_PACKET_SIZE   (1500)
     #else
-        /* MAX_UDP_SIZE in interna.h */
-        #define TEST_DTLS_PACKET_SIZE   (8092)
+        /* Must fit in one DTLS record: WOLFSSL_MAX_MTU (1400) - MAX_MSG_EXTRA (~102).
+         * Define WOLFSSL_DTLS_MTU and call wolfSSL_dtls_set_mtu() to use larger
+         * packets; or build with WOLFSSL_NO_DTLS_SIZE_CHECK to auto-fragment. */
+        #define TEST_DTLS_PACKET_SIZE   (1200)
     #endif
 #endif
 
@@ -1304,25 +1306,29 @@ static int SetupSocketAndListen(int* listenFd, word32 port, int doDTLS)
             fprintf(stderr, "ERROR: failed to create the socket\n");
             return -1;
         }
-
-        /* allow reuse */
-        if (setsockopt(*listenFd, SOL_SOCKET, SO_REUSEADDR,
-                    &optval, sizeof(optval)) == -1) {
-            fprintf(stderr, "setsockopt SO_REUSEADDR failed\n");
-            return -1;
-        }
-
-        /* Listen for the client. */
-        if (bind(*listenFd, (struct sockaddr*)&servAddr,
-                                                    sizeof(servAddr)) == -1) {
-            fprintf(stderr, "ERROR: failed to bind\n");
-            return -1;
-        }
     }
 
-    if (listen(*listenFd, 5) != 0) {
-        fprintf(stderr, "ERROR: failed to listen\n");
+    /* allow reuse */
+    if (setsockopt(*listenFd, SOL_SOCKET, SO_REUSEADDR,
+                &optval, sizeof(optval)) == -1) {
+        fprintf(stderr, "setsockopt SO_REUSEADDR failed\n");
         return -1;
+    }
+
+    if (bind(*listenFd, (struct sockaddr*)&servAddr,
+                                                sizeof(servAddr)) == -1) {
+        fprintf(stderr, "ERROR: failed to bind\n");
+        return -1;
+    }
+
+#ifdef WOLFSSL_DTLS
+    if (!doDTLS)
+#endif
+    {
+        if (listen(*listenFd, 5) != 0) {
+            fprintf(stderr, "ERROR: failed to listen\n");
+            return -1;
+        }
     }
 
 #ifdef BENCH_USE_NONBLOCK
@@ -2119,7 +2125,11 @@ int bench_tls(void* args)
         }
     }
 #endif
-    fprintf(stderr, "Running TLS Benchmarks...\n");
+    if (doDTLS) {
+        fprintf(stderr, "Running DTLS Benchmarks...\n");
+    } else {
+        fprintf(stderr, "Running TLS Benchmarks...\n");
+    }
 
     /* parse by : */
     while ((cipher != NULL) && (cipher[0] != '\0')) {
@@ -2134,6 +2144,14 @@ int bench_tls(void* args)
         if (argShowVerbose) {
             fprintf(stderr, "Cipher: %s\n", cipher);
         }
+
+#if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_DTLS13)
+        if (doDTLS && XSTRNCMP(cipher, "TLS13", 5) == 0) {
+            /* DTLS 1.3 not compiled in; skip TLS 1.3 ciphers */
+            cipher = (next_cipher != NULL) ? (next_cipher + 1) : NULL;
+            continue;
+        }
+#endif
 
 #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
         for (group_index = 0; groups[group_index].name != NULL; group_index++) {

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -2125,9 +2125,12 @@ int bench_tls(void* args)
         }
     }
 #endif
+#ifdef WOLFSSL_DTLS
     if (doDTLS) {
         fprintf(stderr, "Running DTLS Benchmarks...\n");
-    } else {
+    } else
+#endif
+    {
         fprintf(stderr, "Running TLS Benchmarks...\n");
     }
 


### PR DESCRIPTION
# Fix tls_bench DTLS (`-u`) mode failures

## Summary

Running `tls_bench -u` (DTLS mode) failed immediately with the following errors:

```
Running TLS Benchmarks...
ERROR: failed to listen
error creating ctx
Client Error: -125 (out of memory error)
```

And after partial fixes, a third error appeared:

```
error on client write
Client Error: -439 (DTLS trying to send too much in single datagram error)
```

This PR fixes three independent bugs in `examples/benchmark/tls_bench.c`.

---

## Bug 1: `SetupSocketAndListen` called `listen()` on a UDP socket

### Root cause

When DTLS mode is active, `SetupSocketAndListen()` correctly created a `SOCK_DGRAM`
(UDP) socket instead of a `SOCK_STREAM` (TCP) socket. However, `setsockopt()`,
`bind()`, and `listen()` were all inside the TCP-only `else` branch, so:

- The UDP socket was never bound to the server address.
- `listen()` was called unconditionally after the socket-type branch, which always
  fails on a UDP socket (`EOPNOTSUPP`), producing `ERROR: failed to listen`.

### Fix

- Move `setsockopt(SO_REUSEADDR)` and `bind()` outside the TCP-only block so they
  apply to both TCP and UDP sockets.
- Guard the `listen()` call with `#ifdef WOLFSSL_DTLS if (!doDTLS)` so it is only
  called for TCP connections.

---

## Bug 2: `wolfSSL_CTX_new()` returned NULL for TLS 1.3 ciphers in DTLS mode (when `WOLFSSL_DTLS13` is not compiled in)

### Root cause

When iterating over the default cipher list in DTLS mode, TLS 1.3 cipher suites
(names starting with `"TLS13"`) were encountered. The client/server setup code
attempted to use `wolfDTLSv1_3_client/server_method()` inside an
`#ifdef WOLFSSL_DTLS13` guard. When `WOLFSSL_DTLS13` is not compiled in, no
method was assigned, leaving `ctx == NULL`. The subsequent NULL check returned
`MEMORY_E` (-125), producing:

```
error creating ctx
Client Error: -125 (out of memory error)
```

### Fix

Add an early-continue in the cipher iteration loop: when DTLS mode is active and
`WOLFSSL_DTLS13` is not compiled in, silently skip any TLS 1.3 cipher suite.

```c
#if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_DTLS13)
        if (doDTLS && XSTRNCMP(cipher, "TLS13", 5) == 0) {
            /* DTLS 1.3 not compiled in; skip TLS 1.3 ciphers */
            cipher = (next_cipher != NULL) ? (next_cipher + 1) : NULL;
            continue;
        }
#endif
```

---

## Bug 3: `TEST_DTLS_PACKET_SIZE` exceeded the default DTLS MTU

### Root cause

`TEST_DTLS_PACKET_SIZE` was defined as 8092 bytes (referencing `MAX_UDP_SIZE` in
`internal.h`). However, wolfSSL's `SendData()` checks that the total DTLS record
size fits within `MAX_MTU` (default: **1400 bytes**). Since 8092 bytes of payload
produces a record far larger than 1400 bytes, `SendData()` returned
`DTLS_SIZE_ERROR` (-439) on every write:

```
error on client write
Client Error: -439 (DTLS trying to send too much in single datagram error)
```

`MAX_UDP_SIZE` (8092) is the maximum UDP datagram size wolfSSL is prepared to
receive, not the send-side MTU limit. The two constants serve different purposes
and were conflated.

### Fix

Change `TEST_DTLS_PACKET_SIZE` for non-embedded builds from `8092` to `1200`,
which fits within `MAX_MTU (1400) - MAX_MSG_EXTRA (~102)`.  A comment documents
the two compile-time options that allow larger packets:

- `WOLFSSL_DTLS_MTU` + `wolfSSL_dtls_set_mtu()` — set a per-session MTU
- `WOLFSSL_NO_DTLS_SIZE_CHECK` — auto-fragment writes that exceed the MTU

The automatic fallback already present in tls_bench (`argTestPacketSize` is
reduced to `TEST_DTLS_PACKET_SIZE` when DTLS mode is detected and no `-p` flag
is given) now produces a value that actually works with the default MTU.

---

## Improvement: startup message now reflects the active protocol

The banner printed at the start of the run was always `"Running TLS Benchmarks..."`,
even when DTLS mode (`-u`) was selected.  It now reads `"Running DTLS Benchmarks..."`
when DTLS is active and `"Running TLS Benchmarks..."` otherwise.

---

## Files changed

- `examples/benchmark/tls_bench.c`

---

## Testing

Verified on Linux (x86-64) with a wolfSSL build that has `WOLFSSL_DTLS` and
`WOLFSSL_DTLS13` enabled.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
