### PR TITLE
Add EVP_PKEY encoded public key get/set compatibility functions

### DIFF
--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -2864,3 +2864,242 @@ int test_wolfSSL_EVP_PKEY_x448(void)
     return EXPECT_RESULT();
 }
 
+int test_wolfSSL_EVP_PKEY_encoded_public_key(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_EXTRA) && (defined(HAVE_ECC) || defined(HAVE_CURVE25519) || \
+    defined(HAVE_CURVE448))
+    /* Type-independent bad-argument handling. The deprecated tls_encodedpoint
+     * names are macro aliases of these, so exercising one covers both. */
+    {
+        unsigned char* p = NULL;
+        ExpectIntEQ((int)EVP_PKEY_get1_encoded_public_key(NULL, &p), 0);
+        ExpectIntEQ(EVP_PKEY_set1_encoded_public_key(NULL,
+            (const unsigned char*)"abc", 3), 0);
+    }
+
+#ifdef HAVE_ECC
+    {
+        EC_KEY* ec1 = NULL;
+        EC_KEY* ec2 = NULL;
+        EVP_PKEY* pkey1 = NULL;
+        EVP_PKEY* pkey2 = NULL;
+        unsigned char* enc = NULL;
+        unsigned char* enc2 = NULL;
+        unsigned char* encTls = NULL;
+        size_t encLen = 0;
+        size_t encLen2 = 0;
+        size_t encLenTls = 0;
+
+        /* EVP_PKEY holding a generated P-256 key. */
+        ExpectNotNull(ec1 = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
+        ExpectIntEQ(EC_KEY_generate_key(ec1), 1);
+        ExpectNotNull(pkey1 = EVP_PKEY_new());
+        ExpectIntEQ(EVP_PKEY_set1_EC_KEY(pkey1, ec1), 1);
+
+        /* Bad arguments with a valid key. */
+        ExpectIntEQ((int)EVP_PKEY_get1_encoded_public_key(pkey1, NULL), 0);
+        ExpectIntEQ(EVP_PKEY_set1_encoded_public_key(pkey1, NULL, 10), 0);
+        ExpectIntEQ(EVP_PKEY_set1_encoded_public_key(pkey1, enc, 0), 0);
+
+        /* get1 returns the uncompressed point: 0x04 || X || Y == 65 bytes. */
+        ExpectIntEQ((int)(encLen =
+            EVP_PKEY_get1_encoded_public_key(pkey1, &enc)), 65);
+        ExpectNotNull(enc);
+        if (enc != NULL) {
+            ExpectIntEQ(enc[0], 0x04);
+        }
+
+        /* Deprecated alias must produce identical output. */
+        ExpectIntEQ((int)(encLenTls =
+            EVP_PKEY_get1_tls_encodedpoint(pkey1, &encTls)), (int)encLen);
+        ExpectBufEQ(encTls, enc, encLen);
+
+        /* set1 into a second key with the same curve, then round-trip get1. */
+        ExpectNotNull(ec2 = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
+        ExpectIntEQ(EC_KEY_generate_key(ec2), 1);
+        ExpectNotNull(pkey2 = EVP_PKEY_new());
+        ExpectIntEQ(EVP_PKEY_set1_EC_KEY(pkey2, ec2), 1);
+        ExpectIntEQ(EVP_PKEY_set1_encoded_public_key(pkey2, enc, encLen), 1);
+        ExpectIntEQ((int)(encLen2 =
+            EVP_PKEY_get1_encoded_public_key(pkey2, &enc2)), (int)encLen);
+        ExpectBufEQ(enc2, enc, encLen);
+
+        OPENSSL_free(enc);
+        OPENSSL_free(enc2);
+        OPENSSL_free(encTls);
+        EC_KEY_free(ec1);
+        EC_KEY_free(ec2);
+        EVP_PKEY_free(pkey1);
+        EVP_PKEY_free(pkey2);
+    }
+
+    /* set1 must produce a peer key usable for ECDH, i.e. the internal wolfCrypt
+     * key (consumed by EVP_PKEY_derive) is synced, not just the wire bytes. */
+    {
+        EC_KEY* aKey = NULL;
+        EC_KEY* bKey = NULL;
+        EC_KEY* pKey = NULL;
+        EVP_PKEY* alice = NULL;
+        EVP_PKEY* bob = NULL;
+        EVP_PKEY* peer = NULL;
+        EVP_PKEY_CTX* ctx = NULL;
+        unsigned char* bobEnc = NULL;
+        size_t bobEncLen = 0;
+        unsigned char secretRef[80];
+        unsigned char secret[80];
+        size_t refLen = sizeof(secretRef);
+        size_t secLen = sizeof(secret);
+
+        ExpectNotNull(aKey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
+        ExpectIntEQ(EC_KEY_generate_key(aKey), 1);
+        ExpectNotNull(alice = EVP_PKEY_new());
+        ExpectIntEQ(EVP_PKEY_set1_EC_KEY(alice, aKey), 1);
+
+        ExpectNotNull(bKey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
+        ExpectIntEQ(EC_KEY_generate_key(bKey), 1);
+        ExpectNotNull(bob = EVP_PKEY_new());
+        ExpectIntEQ(EVP_PKEY_set1_EC_KEY(bob, bKey), 1);
+
+        /* Reference shared secret: alice + the real bob. */
+        ExpectNotNull(ctx = EVP_PKEY_CTX_new(alice, NULL));
+        ExpectIntEQ(EVP_PKEY_derive_init(ctx), 1);
+        ExpectIntEQ(EVP_PKEY_derive_set_peer(ctx, bob), 1);
+        ExpectIntEQ(EVP_PKEY_derive(ctx, secretRef, &refLen), 1);
+        EVP_PKEY_CTX_free(ctx);
+        ctx = NULL;
+
+        /* Load bob's public point into a fresh peer key (using the deprecated
+         * set name to also cover that alias). */
+        ExpectIntGT((int)(bobEncLen =
+            EVP_PKEY_get1_encoded_public_key(bob, &bobEnc)), 0);
+        ExpectNotNull(pKey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
+        ExpectIntEQ(EC_KEY_generate_key(pKey), 1);
+        ExpectNotNull(peer = EVP_PKEY_new());
+        ExpectIntEQ(EVP_PKEY_set1_EC_KEY(peer, pKey), 1);
+        ExpectIntEQ(EVP_PKEY_set1_tls_encodedpoint(peer, bobEnc, bobEncLen), 1);
+
+        /* Secret with the set1-loaded peer must match the reference. */
+        ExpectNotNull(ctx = EVP_PKEY_CTX_new(alice, NULL));
+        ExpectIntEQ(EVP_PKEY_derive_init(ctx), 1);
+        ExpectIntEQ(EVP_PKEY_derive_set_peer(ctx, peer), 1);
+        ExpectIntEQ(EVP_PKEY_derive(ctx, secret, &secLen), 1);
+        EVP_PKEY_CTX_free(ctx);
+        ctx = NULL;
+
+        ExpectIntEQ((int)secLen, (int)refLen);
+        ExpectBufEQ(secret, secretRef, refLen);
+
+        OPENSSL_free(bobEnc);
+        EC_KEY_free(aKey);
+        EC_KEY_free(bKey);
+        EC_KEY_free(pKey);
+        EVP_PKEY_free(alice);
+        EVP_PKEY_free(bob);
+        EVP_PKEY_free(peer);
+    }
+#endif /* HAVE_ECC */
+
+#ifdef HAVE_CURVE25519
+    {
+        EVP_PKEY_CTX* genCtx = NULL;
+        EVP_PKEY* pkey = NULL;
+        EVP_PKEY* peer = NULL;
+        unsigned char* enc = NULL;
+        unsigned char* enc2 = NULL;
+        unsigned char* encTls = NULL;
+        size_t encLen = 0;
+        size_t encLen2 = 0;
+        size_t encLenTls = 0;
+
+        ExpectNotNull(genCtx = EVP_PKEY_CTX_new_id(EVP_PKEY_X25519, NULL));
+        ExpectIntEQ(EVP_PKEY_keygen_init(genCtx), 1);
+        ExpectIntEQ(EVP_PKEY_keygen(genCtx, &pkey), 1);
+        ExpectIntEQ(EVP_PKEY_keygen(genCtx, &peer), 1);
+        EVP_PKEY_CTX_free(genCtx);
+        genCtx = NULL;
+
+        /* Raw X25519 public key is 32 bytes. */
+        ExpectIntEQ((int)(encLen =
+            EVP_PKEY_get1_encoded_public_key(pkey, &enc)), 32);
+        ExpectNotNull(enc);
+
+        /* Deprecated alias parity. */
+        ExpectIntEQ((int)(encLenTls =
+            EVP_PKEY_get1_tls_encodedpoint(pkey, &encTls)), (int)encLen);
+        ExpectBufEQ(encTls, enc, encLen);
+
+        /* set1 into the peer key and round-trip. */
+        ExpectIntEQ(EVP_PKEY_set1_encoded_public_key(peer, enc, encLen), 1);
+        ExpectIntEQ((int)(encLen2 =
+            EVP_PKEY_get1_encoded_public_key(peer, &enc2)), (int)encLen);
+        ExpectBufEQ(enc2, enc, encLen);
+
+        /* A failed set1 (wrong length) must leave the existing key intact. */
+        ExpectIntEQ(EVP_PKEY_set1_encoded_public_key(peer, enc, encLen - 1), 0);
+        {
+            unsigned char* enc3 = NULL;
+            size_t encLen3 = 0;
+            ExpectIntEQ((int)(encLen3 =
+                EVP_PKEY_get1_encoded_public_key(peer, &enc3)), (int)encLen);
+            ExpectBufEQ(enc3, enc, encLen);
+            OPENSSL_free(enc3);
+        }
+
+        OPENSSL_free(enc);
+        OPENSSL_free(enc2);
+        OPENSSL_free(encTls);
+        EVP_PKEY_free(pkey);
+        EVP_PKEY_free(peer);
+    }
+#endif /* HAVE_CURVE25519 */
+
+#ifdef HAVE_CURVE448
+    {
+        EVP_PKEY_CTX* genCtx = NULL;
+        EVP_PKEY* pkey = NULL;
+        EVP_PKEY* peer = NULL;
+        unsigned char* enc = NULL;
+        unsigned char* enc2 = NULL;
+        size_t encLen = 0;
+        size_t encLen2 = 0;
+
+        ExpectNotNull(genCtx = EVP_PKEY_CTX_new_id(EVP_PKEY_X448, NULL));
+        ExpectIntEQ(EVP_PKEY_keygen_init(genCtx), 1);
+        ExpectIntEQ(EVP_PKEY_keygen(genCtx, &pkey), 1);
+        ExpectIntEQ(EVP_PKEY_keygen(genCtx, &peer), 1);
+        EVP_PKEY_CTX_free(genCtx);
+        genCtx = NULL;
+
+        /* Raw X448 public key is 56 bytes. */
+        ExpectIntEQ((int)(encLen =
+            EVP_PKEY_get1_encoded_public_key(pkey, &enc)), 56);
+        ExpectNotNull(enc);
+
+        /* set1 into the peer key and round-trip. */
+        ExpectIntEQ(EVP_PKEY_set1_encoded_public_key(peer, enc, encLen), 1);
+        ExpectIntEQ((int)(encLen2 =
+            EVP_PKEY_get1_encoded_public_key(peer, &enc2)), (int)encLen);
+        ExpectBufEQ(enc2, enc, encLen);
+
+        /* A failed set1 (wrong length) must leave the existing key intact. */
+        ExpectIntEQ(EVP_PKEY_set1_encoded_public_key(peer, enc, encLen - 1), 0);
+        {
+            unsigned char* enc3 = NULL;
+            size_t encLen3 = 0;
+            ExpectIntEQ((int)(encLen3 =
+                EVP_PKEY_get1_encoded_public_key(peer, &enc3)), (int)encLen);
+            ExpectBufEQ(enc3, enc, encLen);
+            OPENSSL_free(enc3);
+        }
+
+        OPENSSL_free(enc);
+        OPENSSL_free(enc2);
+        EVP_PKEY_free(pkey);
+        EVP_PKEY_free(peer);
+    }
+#endif /* HAVE_CURVE448 */
+#endif /* OPENSSL_EXTRA && (HAVE_ECC || HAVE_CURVE25519 || HAVE_CURVE448) */
+    return EXPECT_RESULT();
+}
+

--- a/tests/api/test_evp_pkey.h
+++ b/tests/api/test_evp_pkey.h
@@ -68,6 +68,7 @@ int test_wolfSSL_CTX_use_PrivateKey_ed25519(void);
 int test_wolfSSL_EVP_PKEY_ed448(void);
 int test_wolfSSL_EVP_PKEY_x25519(void);
 int test_wolfSSL_EVP_PKEY_x448(void);
+int test_wolfSSL_EVP_PKEY_encoded_public_key(void);
 
 #define TEST_EVP_PKEY_DECLS                                                    \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_CTX_new_id),             \
@@ -114,6 +115,7 @@ int test_wolfSSL_EVP_PKEY_x448(void);
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_CTX_use_PrivateKey_ed25519),      \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_ed448),                  \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_x25519),                 \
-    TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_x448)
+    TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_x448),                   \
+    TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_encoded_public_key)
 
 #endif /* WOLFCRYPT_TEST_EVP_PKEY_H */

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -10051,7 +10051,7 @@ size_t wolfSSL_EVP_PKEY_get1_encoded_public_key(WOLFSSL_EVP_PKEY* pkey,
 int wolfSSL_EVP_PKEY_set1_encoded_public_key(WOLFSSL_EVP_PKEY* pkey,
     const unsigned char* pub, size_t publen)
 {
-    int ret = WOLFSSL_FAILURE;
+    int ret = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
 
     WOLFSSL_ENTER("wolfSSL_EVP_PKEY_set1_encoded_public_key");
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -9923,6 +9923,255 @@ int wolfSSL_EVP_PKEY_assign_EC_KEY(WOLFSSL_EVP_PKEY* pkey, WOLFSSL_EC_KEY* key)
 }
 #endif /* HAVE_ECC */
 
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+/* Get the public key from a key as an encoded point / raw octet string.
+ *
+ * This is the implementation behind both EVP_PKEY_get1_encoded_public_key()
+ * and the deprecated (but functionally identical) EVP_PKEY_get1_tls_encodedpoint().
+ *
+ * For EC keys the encoding is the uncompressed octet point (0x04 || X || Y).
+ * For X25519/X448 keys it is the raw little-endian public key (RFC 7748).
+ *
+ * The buffer returned through ppub is allocated here and must be released by
+ * the caller with OPENSSL_free().
+ *
+ * @param [in]  pkey  Key to encode the public part of.
+ * @param [out] ppub  Reference into which the allocated buffer is returned.
+ * @return  Length of the encoding in bytes on success.
+ * @return  0 on error.
+ */
+size_t wolfSSL_EVP_PKEY_get1_encoded_public_key(WOLFSSL_EVP_PKEY* pkey,
+    unsigned char** ppub)
+{
+    size_t ret = 0;
+
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_get1_encoded_public_key");
+
+    if ((pkey == NULL) || (ppub == NULL)) {
+        WOLFSSL_MSG("Bad parameter");
+        return 0;
+    }
+    /* Always initialize the output so the caller never uses or frees a stale
+     * pointer when this function returns 0. */
+    *ppub = NULL;
+
+    switch (pkey->type) {
+#if defined(HAVE_ECC) && defined(OPENSSL_EXTRA)
+        case WC_EVP_PKEY_EC: {
+            int len;
+            WOLFSSL_EC_KEY* ec = wolfSSL_EVP_PKEY_get1_EC_KEY(pkey);
+            if (ec == NULL) {
+                WOLFSSL_MSG("No EC key in EVP_PKEY");
+                break;
+            }
+            /* *ppub is NULL here, so i2o allocates the buffer for us. */
+            len = wolfSSL_i2o_ECPublicKey(ec, ppub);
+            wolfSSL_EC_KEY_free(ec);
+            if (len > 0) {
+                ret = (size_t)len;
+            }
+            break;
+        }
+#endif /* HAVE_ECC && OPENSSL_EXTRA */
+#ifdef HAVE_CURVE25519
+        case WC_EVP_PKEY_X25519: {
+            word32 len = CURVE25519_PUB_KEY_SIZE;
+            byte* buf;
+
+            if (pkey->curve25519 == NULL) {
+                WOLFSSL_MSG("No X25519 key in EVP_PKEY");
+                break;
+            }
+            buf = (byte*)XMALLOC(len, NULL, DYNAMIC_TYPE_OPENSSL);
+            if (buf == NULL) {
+                WOLFSSL_MSG("malloc failed");
+                break;
+            }
+            /* TLS wire format is little-endian (RFC 7748). */
+            if (wc_curve25519_export_public_ex(pkey->curve25519, buf, &len,
+                    EC25519_LITTLE_ENDIAN) != 0) {
+                WOLFSSL_MSG("wc_curve25519_export_public_ex error");
+                XFREE(buf, NULL, DYNAMIC_TYPE_OPENSSL);
+                break;
+            }
+            *ppub = buf;
+            ret = (size_t)len;
+            break;
+        }
+#endif /* HAVE_CURVE25519 */
+#ifdef HAVE_CURVE448
+        case WC_EVP_PKEY_X448: {
+            word32 len = CURVE448_PUB_KEY_SIZE;
+            byte* buf;
+
+            if (pkey->curve448 == NULL) {
+                WOLFSSL_MSG("No X448 key in EVP_PKEY");
+                break;
+            }
+            buf = (byte*)XMALLOC(len, NULL, DYNAMIC_TYPE_OPENSSL);
+            if (buf == NULL) {
+                WOLFSSL_MSG("malloc failed");
+                break;
+            }
+            /* TLS wire format is little-endian (RFC 7748). */
+            if (wc_curve448_export_public_ex(pkey->curve448, buf, &len,
+                    EC448_LITTLE_ENDIAN) != 0) {
+                WOLFSSL_MSG("wc_curve448_export_public_ex error");
+                XFREE(buf, NULL, DYNAMIC_TYPE_OPENSSL);
+                break;
+            }
+            *ppub = buf;
+            ret = (size_t)len;
+            break;
+        }
+#endif /* HAVE_CURVE448 */
+        default:
+            WOLFSSL_MSG("Unsupported key type");
+            break;
+    }
+
+    return ret;
+}
+
+/* Set the public key in a key from an encoded point / raw octet string.
+ *
+ * This is the implementation behind both EVP_PKEY_set1_encoded_public_key()
+ * and the deprecated (but functionally identical) EVP_PKEY_set1_tls_encodedpoint().
+ *
+ * For EC keys the EVP_PKEY must already hold the curve parameters; pub is
+ * decoded as an octet point. For X25519/X448 keys pkey->type must already be
+ * set; pub is the raw little-endian public key (RFC 7748).
+ *
+ * @param [in, out] pkey    Key to set the public part of.
+ * @param [in]      pub     Encoded public key.
+ * @param [in]      publen  Length of encoded public key in bytes.
+ * @return  WOLFSSL_SUCCESS on success.
+ * @return  WOLFSSL_FAILURE on error.
+ */
+int wolfSSL_EVP_PKEY_set1_encoded_public_key(WOLFSSL_EVP_PKEY* pkey,
+    const unsigned char* pub, size_t publen)
+{
+    int ret = WOLFSSL_FAILURE;
+
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_set1_encoded_public_key");
+
+    if ((pkey == NULL) || (pub == NULL) || (publen == 0) ||
+            (publen > INT_MAX)) {
+        WOLFSSL_MSG("Bad parameter");
+        return WOLFSSL_FAILURE;
+    }
+
+    switch (pkey->type) {
+#if defined(HAVE_ECC) && defined(OPENSSL_EXTRA)
+        case WC_EVP_PKEY_EC: {
+            const unsigned char* in = pub;
+            /* Need the EC key (with its group) to decode the point into. */
+            WOLFSSL_EC_KEY* ec = wolfSSL_EVP_PKEY_get1_EC_KEY(pkey);
+            if (ec == NULL) {
+                WOLFSSL_MSG("No EC parameters in EVP_PKEY");
+                break;
+            }
+            /* Decode the octet point into the external public key. */
+            if (wolfSSL_o2i_ECPublicKey(&ec, &in, (long)publen) == NULL) {
+                WOLFSSL_MSG("wolfSSL_o2i_ECPublicKey error");
+                wolfSSL_EC_KEY_free(ec);
+                break;
+            }
+            /* Push the new public point into the internal wolfCrypt key so
+             * that consumers such as EVP_PKEY_derive() can use it. */
+            ec->inSet = 0;
+            if (SetECKeyInternal(ec) != WOLFSSL_SUCCESS) {
+                WOLFSSL_MSG("SetECKeyInternal error");
+                wolfSSL_EC_KEY_free(ec);
+                break;
+            }
+            /* Refresh the cached DER representation in the EVP_PKEY. */
+            ret = ECC_populate_EVP_PKEY(pkey, ec);
+            wolfSSL_EC_KEY_free(ec);
+            break;
+        }
+#endif /* HAVE_ECC && OPENSSL_EXTRA */
+#ifdef HAVE_CURVE25519
+        case WC_EVP_PKEY_X25519: {
+            curve25519_key* key;
+
+            /* Build the replacement in a temporary first; only commit (and
+             * free the old key) once the import has succeeded, so a failure
+             * leaves the original EVP_PKEY intact. */
+            key = (curve25519_key*)XMALLOC(sizeof(curve25519_key), pkey->heap,
+                DYNAMIC_TYPE_CURVE25519);
+            if (key == NULL) {
+                WOLFSSL_MSG("malloc failed");
+                break;
+            }
+            if (wc_curve25519_init_ex(key, pkey->heap, INVALID_DEVID) != 0) {
+                XFREE(key, pkey->heap, DYNAMIC_TYPE_CURVE25519);
+                break;
+            }
+            /* Raw X25519 keys are little-endian (RFC 7748). */
+            if (wc_curve25519_import_public_ex(pub, (word32)publen, key,
+                    EC25519_LITTLE_ENDIAN) != 0) {
+                WOLFSSL_MSG("wc_curve25519_import_public_ex error");
+                wc_curve25519_free(key);
+                XFREE(key, pkey->heap, DYNAMIC_TYPE_CURVE25519);
+                break;
+            }
+            /* Import succeeded - replace any existing key. */
+            if ((pkey->curve25519 != NULL) && (pkey->ownCurve25519 == 1)) {
+                wc_curve25519_free(pkey->curve25519);
+                XFREE(pkey->curve25519, pkey->heap, DYNAMIC_TYPE_CURVE25519);
+            }
+            pkey->curve25519 = key;
+            pkey->ownCurve25519 = 1;
+            ret = WOLFSSL_SUCCESS;
+            break;
+        }
+#endif /* HAVE_CURVE25519 */
+#ifdef HAVE_CURVE448
+        case WC_EVP_PKEY_X448: {
+            curve448_key* key;
+
+            /* Build the replacement in a temporary first; only commit (and
+             * free the old key) once the import has succeeded, so a failure
+             * leaves the original EVP_PKEY intact. */
+            key = (curve448_key*)XMALLOC(sizeof(curve448_key), pkey->heap,
+                DYNAMIC_TYPE_CURVE448);
+            if (key == NULL) {
+                WOLFSSL_MSG("malloc failed");
+                break;
+            }
+            if (wc_curve448_init(key) != 0) {
+                XFREE(key, pkey->heap, DYNAMIC_TYPE_CURVE448);
+                break;
+            }
+            /* Raw X448 keys are little-endian (RFC 7748). */
+            if (wc_curve448_import_public_ex(pub, (word32)publen, key,
+                    EC448_LITTLE_ENDIAN) != 0) {
+                WOLFSSL_MSG("wc_curve448_import_public_ex error");
+                wc_curve448_free(key);
+                XFREE(key, pkey->heap, DYNAMIC_TYPE_CURVE448);
+                break;
+            }
+            /* Import succeeded - replace any existing key. */
+            if ((pkey->curve448 != NULL) && (pkey->ownCurve448 == 1)) {
+                wc_curve448_free(pkey->curve448);
+                XFREE(pkey->curve448, pkey->heap, DYNAMIC_TYPE_CURVE448);
+            }
+            pkey->curve448 = key;
+            pkey->ownCurve448 = 1;
+            ret = WOLFSSL_SUCCESS;
+            break;
+        }
+#endif /* HAVE_CURVE448 */
+        default:
+            WOLFSSL_MSG("Unsupported key type");
+            break;
+    }
+
+    return ret;
+}
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
 #ifndef NO_WOLFSSL_STUB
 const WOLFSSL_EVP_MD* wolfSSL_EVP_ripemd160(void)
 {

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -958,6 +958,10 @@ WOLFSSL_API int wolfSSL_EVP_PKEY_set1_RSA(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_RSA *k
 WOLFSSL_API int wolfSSL_EVP_PKEY_set1_DSA(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_DSA *key);
 WOLFSSL_API int wolfSSL_EVP_PKEY_set1_DH(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_DH *key);
 WOLFSSL_API int wolfSSL_EVP_PKEY_set1_EC_KEY(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_EC_KEY *key);
+WOLFSSL_API int wolfSSL_EVP_PKEY_set1_encoded_public_key(WOLFSSL_EVP_PKEY *pkey,
+    const unsigned char *pub, size_t publen);
+WOLFSSL_API size_t wolfSSL_EVP_PKEY_get1_encoded_public_key(WOLFSSL_EVP_PKEY *pkey,
+    unsigned char **ppub);
 WOLFSSL_API int wolfSSL_EVP_PKEY_assign(WOLFSSL_EVP_PKEY *pkey, int type, void *key);
 
 WOLFSSL_API const unsigned char* wolfSSL_EVP_PKEY_get0_hmac(const WOLFSSL_EVP_PKEY* pkey,
@@ -1392,6 +1396,12 @@ WOLFSSL_API int wolfSSL_EVP_SignInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
 #define EVP_PKEY_get0_DH               wolfSSL_EVP_PKEY_get0_DH
 #define EVP_PKEY_get1_DH               wolfSSL_EVP_PKEY_get1_DH
 #define EVP_PKEY_get0_EC_KEY           wolfSSL_EVP_PKEY_get0_EC_KEY
+/* New (OpenSSL 3.0+) names and the deprecated tls_encodedpoint names map to the
+ * same implementations. */
+#define EVP_PKEY_set1_encoded_public_key wolfSSL_EVP_PKEY_set1_encoded_public_key
+#define EVP_PKEY_get1_encoded_public_key wolfSSL_EVP_PKEY_get1_encoded_public_key
+#define EVP_PKEY_set1_tls_encodedpoint   wolfSSL_EVP_PKEY_set1_encoded_public_key
+#define EVP_PKEY_get1_tls_encodedpoint   wolfSSL_EVP_PKEY_get1_encoded_public_key
 #define EVP_PKEY_get0_hmac             wolfSSL_EVP_PKEY_get0_hmac
 #define EVP_PKEY_new_mac_key           wolfSSL_EVP_PKEY_new_mac_key
 #define EVP_PKEY_new_CMAC_key          wolfSSL_EVP_PKEY_new_CMAC_key


### PR DESCRIPTION
### Description

Adds the OpenSSL 3.0 encoded-public-key compatibility functions to the EVP layer and hardens the X25519/X448 setter against partial failure.

**`EVP_PKEY_set1_encoded_public_key` / `EVP_PKEY_get1_encoded_public_key`**

Implements both functions in the OpenSSL compatibility layer. The new OpenSSL 3.0 names and the deprecated `EVP_PKEY_{set1,get1}_tls_encodedpoint` names map to single shared implementations.

Supported key types:
- **EC**: uncompressed octet point (`0x04 || X || Y`), reusing `i2o_ECPublicKey` / `o2i_ECPublicKey`. `set1` also syncs the internal wolfCrypt key (`SetECKeyInternal`) so the key is usable by `EVP_PKEY_derive`, and refreshes the cached DER.
- **X25519 / X448**: raw little-endian public key (RFC 7748).

**Failure-atomicity fix for X25519/X448 `set1`**

The replacement curve25519/curve448 key is now built in a temporary and the existing key is only freed once the import succeeds, so a failed `set1` leaves the original `EVP_PKEY` intact (matching the EC branch).

### Testing

Adds `test_wolfSSL_EVP_PKEY_encoded_public_key` covering NULL handling, EC encode/decode round-trip and ECDH agreement, X25519/X448 round-trips, deprecated-name parity, and a wrong-length `set1` leaving the existing key usable (for both X25519 and X448).
