### PR TITLE
F-5606: don't enforce DTLS 1.3 2^48-1 epoch cap on the receive side

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -12411,15 +12411,14 @@ static int DoTls13KeyUpdate(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 #ifdef WOLFSSL_DTLS13
     if (ssl->options.dtls) {
+        /* Increment on a local copy so ssl->dtls13PeerEpoch is left
+         * untouched when the check fails. */
         w64wrapper newEpoch = ssl->dtls13PeerEpoch;
         w64Increment(&newEpoch);
 
-        /* RFC 9147 Section 4.2.1: the epoch must not exceed 2^48-1. Reject a
-         * peer KeyUpdate that would advance the receiving epoch past the
-         * limit. Validate on a local copy so ssl->dtls13PeerEpoch is left
-         * untouched when the check fails. */
-        if (w64GT(newEpoch,
-                  w64From32(DTLS13_EPOCH_MAX_HI32, DTLS13_EPOCH_MAX_LO32)))
+        /* RFC 9147 Section 8: the 2^48-1 cap is sender-only; receivers MUST
+         * NOT enforce it. Guard only the wrap-to-zero (Section 4.2.1). */
+        if (w64IsZero(newEpoch))
             return BAD_STATE_E;
 
         ssl->dtls13PeerEpoch = newEpoch;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5950,8 +5950,10 @@ enum  {
     DTLS13_EPOCH_TRAFFIC0 = 3
 };
 
-/* RFC 9147 Section 4.2.1: the DTLS 1.3 epoch is a 48-bit value and must not
- * exceed 2^48-1. Expressed as the high/low 32-bit halves of a w64wrapper. */
+/* Sender-side DTLS 1.3 epoch ceiling: we MUST NOT advance our own epoch past
+ * 2^48-1 (RFC 9147 Section 4.2.1). This gates only the sending epoch; receivers
+ * MUST NOT enforce it on the peer epoch (RFC 9147 Section 8). Expressed as the
+ * high/low 32-bit halves of a w64wrapper. */
 #define DTLS13_EPOCH_MAX_HI32 0x0000FFFFU
 #define DTLS13_EPOCH_MAX_LO32 0xFFFFFFFFU
 


### PR DESCRIPTION
## Summary

Follow-up to F-5606 (#10575). RFC 9147 Section 8's `2^48-1` epoch ceiling is a sender-only rule; the same paragraph states that receiving implementations **MUST NOT** enforce it ("In order to allow this value to be changed later").

The KeyUpdate receive path in `DoTls13KeyUpdate` was rejecting a peer epoch that crossed `2^48-1`, which violates that requirement. This changes the receive-side guard to catch only the genuine wrap-to-zero (RFC 9147 Section 4.2.1) — which would alias epoch 0 and reuse keys — and otherwise lets the receiving (peer) epoch advance past `2^48-1`.

The sender-side gates that keep our own epoch at or below `2^48-1` (`SendTls13KeyUpdate`, `Dtls13KeyUpdateAckReceived`) are unchanged.

## Testing

- `./configure --enable-dtls13 --enable-dtls` and rebuild — compiles cleanly under `-Wall -Wextra`.

---

Depends on #10575, which introduces the F-5606 code this corrects. The other commits shown here belong to #10575 and will drop out of this diff once it merges to `master`.