### PR TITLE
Fix the error handling on wc_PKCS7_DecodeAuthEnvelopedData

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -15319,8 +15319,12 @@ authenv_atrbend:
                     encryptedContent, encryptedContentSz, encryptedContent,
                     pkcs7->devId, pkcs7->heap);
             if (ret != 0) {
-                XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
-                return ret;
+                /* Fall through to the shared error handler below, which
+                 * ForceZeros and frees encryptedContent, nulls
+                 * stream->bufferPt/key, and resets the stream. Returning
+                 * here would leave a dangling stream->bufferPt and risk a
+                 * use-after-free / double-free on streaming re-entry. */
+                break;
             }
 
             if (encodedAttribs != NULL) {


### PR DESCRIPTION
# Description

In the streaming path of wc_PKCS7_DecodeAuthEnvelopedData, state WC_PKCS7_AUTHENV_6 XFREEs encryptedContent on AES-GCM/CCM authentication tag failure then returns immediately without nulling pkcs7->stream->bufferPt and without calling wc_PKCS7_ResetStream. pkcs7->state remains WC_PKCS7_AUTHENV_6. 

Addressed by f_4637.

# Changes

Replaced it with a break (plus a comment) so control falls through to the existing shared error handler that already ForceZeros + frees encryptedContent, nulls bufferPt/key, and calls wc_PKCS7_ResetStream. This matches the other error breaks in the same switch and avoids the double-free that inlining the cleanup would have caused.

# Testing

- wolfcrypt/src/pkcs7.c compiles clean (--enable-all config).
- Full library + tests build clean.
- testwolfcrypt passes (exit 0); PKCS7authenveloped test passed! confirms no regression on the success path.
