### PR TITLE
Fix Arduino CI test

### DIFF
--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -52,6 +52,7 @@ on:
     paths:
       # Specific to this Arduino CI Build (1 of 4)
       - '.github/workflows/arduino.yml'
+      - 'examples/configs/user_settings_arduino.h'
       - 'IDE/ARDUINO/**'
       - 'src/**'
       - 'wolfcrypt/**'
@@ -61,6 +62,7 @@ on:
     branches: [ '**' ]
     paths:
       - '.github/workflows/arduino.yml'
+      - 'examples/configs/user_settings_arduino.h'
       - 'IDE/ARDUINO/**'
       - 'src/**'
       - 'wolfcrypt/**'

--- a/examples/configs/user_settings_arduino.h
+++ b/examples/configs/user_settings_arduino.h
@@ -186,6 +186,11 @@
      * Use the smaller ECC-256 built-in cert set to keep the examples fitting.
      */
     #define USE_CERT_BUFFERS_256
+
+    /* ECC-256 certs alone no longer fit. Drop the error reason string
+     * tables to reclaim flash; only wolfSSL_ERR_*_string() text is lost,
+     * TLS/crypto and DEBUG_WOLFSSL traces are unchanged. */
+    #define NO_ERROR_STRINGS
 #elif defined (__AVR__) || defined(__AVR_ARCH__) || defined(__MEGAAVR__)
     /* Do not enable TLS on platforms without networking */
 


### PR DESCRIPTION
Reduce flash size for Arduino examples by removing error strings (debug messages are still present). This fixes the Flash overflow in the failing CI tests.