### PR TITLE
Fix EncodedDottedForm to handle when first arc is 2

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -37073,6 +37073,10 @@ static int EncodedDottedForm(const byte* in, word32 inSz, word32* out,
         return BAD_FUNC_ARG;
     }
 
+    if (*outSz < 2) {
+        return BUFFER_E;
+    }
+
     /* decode bytes */
     while (inSz--) {
         t = (t << 7) | (in[x] & 0x7F);
@@ -37081,8 +37085,15 @@ static int EncodedDottedForm(const byte* in, word32 inSz, word32* out,
                 return BUFFER_E;
             }
             if (y == 0) {
-                out[0] = (word16)(t / 40);
-                out[1] = (word16)(t % 40);
+                /* Special case for when first arc is 2 */
+                if (t < 80) {
+                    out[0] = t / 40;
+                    out[1] = t % 40;
+                }
+                else {
+                    out[0] = 2;
+                    out[1] = t - 80;
+                }
                 y = 2;
             }
             else {


### PR DESCRIPTION
added case to handle when second arc of byte encoding is greater than 39 when first arc is 2

Description

Example oid: 2.100.6 each dot separated number is an arc.
In DER a byte sequence for endoing this is a SubIdentifier

When the first arc is either 0 or 1 the second arc is between 0-39. When OID
to DER encoding happens the first byte of the DER SI is arc1 * 40 + arc2. 
(this is a space saving trick devised in the 80's).
This number is less that 127 so it fits in the first byte (top byte is used to 
signal more bytes coming for a given SubIdentifier). Then we can do arc1 / 40 and 
arc1 % 40 to get the numbers back out.

When the first arc is 2 the second arc could be much larger than 128. In this
case 2 * 40 + arc2 does not fit in one byte so we make byte 1 base 128 and put 
the remainder in the second byte. This is why we do the t >= 80 branch. We need
to build up t to be t = (base128 value << 7) + second byte (done with bitwise &). Then we can say
for sure the first arc in OID is 2 and second arc is t - 80 ( 80 is how 2 was encoded).
Before the 2.100 would have been decoded as 4.20.

Reproduce: 

0x06, 0x03, 0x81, 0x34, 0x03
// tag=0x06 (OID), length=0x03, value=0x81 0x34 0x03

call wc_ASN1_PrintAll(..) with input DER file 0x06, 0x03, 0x81, 0x34, 0x03. The parser returns: 
   0: 2 +   3   (0) ─OBJECT ID       :(0x7ffc347e) 4.20.3. which is not 2.100.3.

after fix:
   0: 2 +   3   (0) ─OBJECT ID       :(0x7ffc347e) 2.100.3
Fixes #

Testing

There are tests in wolfCLU that exercise this code path. I have a regression test ready to go, but couldn't include it without producing a leftover tmp file as garbage that can't be cleaned up without the C standard library, so I left it out of this PR. If we need a test, I can add a new XTMPFILE or XREMOVE macro (with documentation changes) or add an fmemopen macro — lots of options for holding tmp data behind the FILE interface.

Checklist

- [ ] added tests
- [x] updated/added doxygen
- [ ] updated appropriate READMEs
- [ ] Updated manual and documentation
