### PR TITLE
fix: enforce pathlen constraint in X509 API verify path

### DIFF
--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -819,7 +819,7 @@ int CM_VerifyBuffer_ex(WOLFSSL_CERT_MANAGER* cm, const unsigned char* buff,
 
         /* Parse DER into decoded certificate fields and verify signature
          * against a known CA. */
-        ret = ParseCertRelative(cert, CERT_TYPE, VERIFY, cm, NULL);
+        ret = ParseCertRelative(cert, CHAIN_CERT_TYPE, VERIFY, cm, NULL);
      }
 
 #ifdef HAVE_CRL


### PR DESCRIPTION
## Summary

`wolfSSL_X509_verify_cert()` passes `CERT_TYPE` to `ParseCertRelative()`, but the pathlen enforcement guard in `asn.c` skips the check when `type == CERT_TYPE`:

```c
if (type != CERT_TYPE && cert->isCA && cert->ca && ...)
```

This means the standalone X.509 verification API (`wolfSSL_X509_verify_cert()`) never enforces `BasicConstraints.pathlen`, allowing unlimited intermediate CAs.

**The TLS handshake path is NOT affected** — it already uses `CHAIN_CERT_TYPE`.

## Fix

Change `ssl_certman.c` to use `CHAIN_CERT_TYPE`, consistent with the TLS path. One-line change:

```diff
-        ret = ParseCertRelative(cert, CERT_TYPE, VERIFY, cm, NULL);
+        ret = ParseCertRelative(cert, CHAIN_CERT_TYPE, VERIFY, cm, NULL);
```

## Reproduction

Create a 3-tier chain: Root → Intermediate (pathlen:0) → Sub-CA → Leaf. The Sub-CA violates the intermediate's `pathlen:0` constraint.

```
wolfSSL X509 API:  ACCEPT  ← BUG
OpenSSL 3.6.2:    REJECT
OpenSSL 1.1.1w:   REJECT
mbedTLS 3.6.6:    REJECT
LibreSSL 4.3.1:   REJECT
BearSSL 0.6:      REJECT
```

PoC available in the linked issue with full C source + pre-built DER certificates.

## Testing

- The TLS handshake path already uses `CHAIN_CERT_TYPE` and works correctly — no regression expected
- Only the `wolfSSL_X509_verify_cert()` / `wolfSSL_CertManagerVerifyBuffer()` standalone API path changes behavior
- Existing certman tests should pass; pathlen violation chains will now be correctly rejected

## Credit

Discovered through differential fuzzing of 6 X.509 implementations (PathDiff project).