### PR TITLE
20260610-ssl_api_ext-revert-ret-cascades

### DIFF
--- a/src/ssl_api_ext.c
+++ b/src/ssl_api_ext.c
@@ -45,16 +45,10 @@
 WOLFSSL_ABI
 int wolfSSL_UseSNI(WOLFSSL* ssl, byte type, const void* data, word16 size)
 {
-    int ret;
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ret = TLSX_UseSNI(&ssl->extensions, type, data, size, ssl->heap);
-    }
-
-    return ret;
+    return TLSX_UseSNI(&ssl->extensions, type, data, size, ssl->heap);
 }
 
 
@@ -70,18 +64,12 @@ int wolfSSL_UseSNI(WOLFSSL* ssl, byte type, const void* data, word16 size)
  */
 WOLFSSL_ABI
 int wolfSSL_CTX_UseSNI(WOLFSSL_CTX* ctx, byte type, const void* data,
-    word16 size)
+                                                                    word16 size)
 {
-    int ret;
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ret = TLSX_UseSNI(&ctx->extensions, type, data, size, ctx->heap);
-    }
-
-    return ret;
+    return TLSX_UseSNI(&ctx->extensions, type, data, size, ctx->heap);
 }
 
 #ifndef NO_WOLFSSL_SERVER
@@ -135,19 +123,13 @@ byte wolfSSL_SNI_Status(WOLFSSL* ssl, byte type)
  */
 word16 wolfSSL_SNI_GetRequest(WOLFSSL* ssl, byte type, void** data)
 {
-    word16 ret = 0;
-
-    /* Default the output to no request data. */
-    if (data != NULL) {
+    if (data)
         *data = NULL;
-    }
 
-    /* Only query when SNI extensions are present on the object. */
-    if ((ssl != NULL) && (ssl->extensions != NULL)) {
-        ret = TLSX_SNI_GetRequest(ssl->extensions, type, data, 0);
-    }
+    if (ssl && ssl->extensions)
+        return TLSX_SNI_GetRequest(ssl->extensions, type, data, 0);
 
-    return ret;
+    return 0;
 }
 
 
@@ -164,18 +146,10 @@ word16 wolfSSL_SNI_GetRequest(WOLFSSL* ssl, byte type, void** data)
 int wolfSSL_SNI_GetFromBuffer(const byte* clientHello, word32 helloSz,
                               byte type, byte* sni, word32* inOutSz)
 {
-    int ret;
+    if (clientHello && helloSz > 0 && sni && inOutSz && *inOutSz > 0)
+        return TLSX_SNI_GetFromBuffer(clientHello, helloSz, type, sni, inOutSz);
 
-    /* All arguments are required and the sizes must be non-zero. */
-    if ((clientHello == NULL) || (helloSz == 0) || (sni == NULL) ||
-            (inOutSz == NULL) || (*inOutSz == 0)) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ret = TLSX_SNI_GetFromBuffer(clientHello, helloSz, type, sni, inOutSz);
-    }
-
-    return ret;
+    return BAD_FUNC_ARG;
 }
 
 #endif /* !NO_WOLFSSL_SERVER */
@@ -198,44 +172,29 @@ int wolfSSL_SNI_GetFromBuffer(const byte* clientHello, word32 helloSz,
 int wolfSSL_UseTrustedCA(WOLFSSL* ssl, byte type,
     const byte* certId, word32 certIdSz)
 {
-    int ret = 0;
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
+    if (type == WOLFSSL_TRUSTED_CA_PRE_AGREED) {
+        if (certId != NULL || certIdSz != 0)
+            return BAD_FUNC_ARG;
     }
-    /* Pre-agreed type carries no identifier. */
-    else if (type == WOLFSSL_TRUSTED_CA_PRE_AGREED) {
-        if ((certId != NULL) || (certIdSz != 0)) {
-            ret = BAD_FUNC_ARG;
-        }
-    }
-    /* X.509 name type requires a non-empty identifier. */
     else if (type == WOLFSSL_TRUSTED_CA_X509_NAME) {
-        if ((certId == NULL) || (certIdSz == 0)) {
-            ret = BAD_FUNC_ARG;
-        }
+        if (certId == NULL || certIdSz == 0)
+            return BAD_FUNC_ARG;
     }
-#ifndef NO_SHA
-    /* SHA-1 hash types require a SHA-1 digest sized identifier. */
-    else if ((type == WOLFSSL_TRUSTED_CA_KEY_SHA1) ||
-            (type == WOLFSSL_TRUSTED_CA_CERT_SHA1)) {
-        if ((certId == NULL) || (certIdSz != WC_SHA_DIGEST_SIZE)) {
-            ret = BAD_FUNC_ARG;
-        }
+    #ifndef NO_SHA
+    else if (type == WOLFSSL_TRUSTED_CA_KEY_SHA1 ||
+            type == WOLFSSL_TRUSTED_CA_CERT_SHA1) {
+        if (certId == NULL || certIdSz != WC_SHA_DIGEST_SIZE)
+            return BAD_FUNC_ARG;
     }
-#endif
-    /* Any other identifier type is not supported. */
-    else {
-        ret = BAD_FUNC_ARG;
-    }
+    #endif
+    else
+        return BAD_FUNC_ARG;
 
-    /* Add the extension once the identifier has been validated. */
-    if (ret == 0) {
-        ret = TLSX_UseTrustedCA(&ssl->extensions, type, certId, certIdSz,
-            ssl->heap);
-    }
-
-    return ret;
+    return TLSX_UseTrustedCA(&ssl->extensions,
+            type, certId, certIdSz, ssl->heap);
 }
 
 #endif /* HAVE_TRUSTED_CA */
@@ -254,15 +213,13 @@ int wolfSSL_UseTrustedCA(WOLFSSL* ssl, byte type,
  */
 int wolfSSL_UseMaxFragment(WOLFSSL* ssl, byte mfl)
 {
-    int ret;
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
 #ifdef WOLFSSL_ALLOW_MAX_FRAGMENT_ADJUST
     /* The following is a non-standard way to reconfigure the max packet size
-     * post-handshake for wolfSSL_write/wolfSSL_read */
-    else if (ssl->options.handShakeState == HANDSHAKE_DONE) {
+        post-handshake for wolfSSL_write/wolfSSL_read */
+    if (ssl->options.handShakeState == HANDSHAKE_DONE) {
         switch (mfl) {
             case WOLFSSL_MFL_2_8 : ssl->max_fragment =  256; break;
             case WOLFSSL_MFL_2_9 : ssl->max_fragment =  512; break;
@@ -270,19 +227,16 @@ int wolfSSL_UseMaxFragment(WOLFSSL* ssl, byte mfl)
             case WOLFSSL_MFL_2_11: ssl->max_fragment = 2048; break;
             case WOLFSSL_MFL_2_12: ssl->max_fragment = 4096; break;
             case WOLFSSL_MFL_2_13: ssl->max_fragment = 8192; break;
-            default:               ssl->max_fragment = MAX_RECORD_SIZE; break;
+            default: ssl->max_fragment = MAX_RECORD_SIZE; break;
         }
-        ret = WOLFSSL_SUCCESS;
+        return WOLFSSL_SUCCESS;
     }
 #endif /* WOLFSSL_MAX_FRAGMENT_ADJUST */
-    else {
-        /* This call sets the max fragment TLS extension, which gets sent to
-         * server. The server_hello response is what sets the
-         * `ssl->max_fragment` in TLSX_MFL_Parse */
-        ret = TLSX_UseMaxFragment(&ssl->extensions, mfl, ssl->heap);
-    }
 
-    return ret;
+    /* This call sets the max fragment TLS extension, which gets sent to server.
+        The server_hello response is what sets the `ssl->max_fragment` in
+        TLSX_MFL_Parse */
+    return TLSX_UseMaxFragment(&ssl->extensions, mfl, ssl->heap);
 }
 
 
@@ -296,16 +250,10 @@ int wolfSSL_UseMaxFragment(WOLFSSL* ssl, byte mfl)
  */
 int wolfSSL_CTX_UseMaxFragment(WOLFSSL_CTX* ctx, byte mfl)
 {
-    int ret;
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ret = TLSX_UseMaxFragment(&ctx->extensions, mfl, ctx->heap);
-    }
-
-    return ret;
+    return TLSX_UseMaxFragment(&ctx->extensions, mfl, ctx->heap);
 }
 
 #endif /* NO_WOLFSSL_CLIENT */
@@ -323,16 +271,10 @@ int wolfSSL_CTX_UseMaxFragment(WOLFSSL_CTX* ctx, byte mfl)
  */
 int wolfSSL_UseTruncatedHMAC(WOLFSSL* ssl)
 {
-    int ret;
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ret = TLSX_UseTruncatedHMAC(&ssl->extensions, ssl->heap);
-    }
-
-    return ret;
+    return TLSX_UseTruncatedHMAC(&ssl->extensions, ssl->heap);
 }
 
 
@@ -345,16 +287,10 @@ int wolfSSL_UseTruncatedHMAC(WOLFSSL* ssl)
  */
 int wolfSSL_CTX_UseTruncatedHMAC(WOLFSSL_CTX* ctx)
 {
-    int ret;
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ret = TLSX_UseTruncatedHMAC(&ctx->extensions, ctx->heap);
-    }
-
-    return ret;
+    return TLSX_UseTruncatedHMAC(&ctx->extensions, ctx->heap);
 }
 
 #endif /* NO_WOLFSSL_CLIENT */
@@ -371,8 +307,6 @@ int wolfSSL_CTX_UseTruncatedHMAC(WOLFSSL_CTX* ctx)
  */
 static int isValidCurveGroup(word16 name)
 {
-    int ret;
-
     switch (name) {
         case WOLFSSL_ECC_SECP160K1:
         case WOLFSSL_ECC_SECP160R1:
@@ -433,16 +367,12 @@ static int isValidCurveGroup(word16 name)
         case WOLFSSL_X25519_KYBER_LEVEL3:
         case WOLFSSL_P256_KYBER_LEVEL3:
 #endif /* WOLFSSL_MLKEM_KYBER */
-#endif /*  WOLFSSL_HAVE_MLKEM*/
-            ret = 1;
-            break;
+#endif
+            return 1;
 
         default:
-            ret = 0;
-            break;
+            return 0;
     }
-
-    return ret;
 }
 
 /* Set a named group in the Supported Groups extension on the object.
@@ -455,22 +385,16 @@ static int isValidCurveGroup(word16 name)
  */
 int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name)
 {
-    int ret;
+    if (ssl == NULL || !isValidCurveGroup(name))
+        return BAD_FUNC_ARG;
 
-    if ((ssl == NULL) || (!isValidCurveGroup(name))) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ssl->options.userCurves = 1;
-    #if defined(NO_TLS)
-        ret = WOLFSSL_FAILURE;
-    #else
-        ret = TLSX_UseSupportedCurve(&ssl->extensions, name, ssl->heap,
-            ssl->options.side);
-    #endif /* NO_TLS */
-    }
-
-    return ret;
+    ssl->options.userCurves = 1;
+#if defined(NO_TLS)
+    return WOLFSSL_FAILURE;
+#else
+    return TLSX_UseSupportedCurve(&ssl->extensions, name, ssl->heap,
+                                  ssl->options.side);
+#endif /* NO_TLS */
 }
 
 
@@ -484,22 +408,16 @@ int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name)
  */
 int wolfSSL_CTX_UseSupportedCurve(WOLFSSL_CTX* ctx, word16 name)
 {
-    int ret;
+    if (ctx == NULL || !isValidCurveGroup(name))
+        return BAD_FUNC_ARG;
 
-    if ((ctx == NULL) || (!isValidCurveGroup(name))) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ctx->userCurves = 1;
-    #if defined(NO_TLS)
-        ret = WOLFSSL_FAILURE;
-    #else
-        ret = TLSX_UseSupportedCurve(&ctx->extensions, name, ctx->heap,
-            ctx->method->side);
-    #endif /* NO_TLS */
-    }
-
-    return ret;
+    ctx->userCurves = 1;
+#if defined(NO_TLS)
+    return WOLFSSL_FAILURE;
+#else
+    return TLSX_UseSupportedCurve(&ctx->extensions, name, ctx->heap,
+                                  ctx->method->side);
+#endif /* NO_TLS */
 }
 
 #if defined(OPENSSL_EXTRA)
@@ -656,28 +574,28 @@ int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
     WOLFSSL_ENTER("wolfSSL_UseALPN");
 
     if ((ssl == NULL) || (protocol_name_list == NULL)) {
-        ret = BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
     }
     else if (protocol_name_listSz > (WOLFSSL_MAX_ALPN_NUMBER *
              WOLFSSL_MAX_ALPN_PROTO_NAME_LEN + WOLFSSL_MAX_ALPN_NUMBER)) {
         WOLFSSL_MSG("Invalid arguments, protocol name list too long");
-        ret = BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
     }
     else if ((!(options & WOLFSSL_ALPN_CONTINUE_ON_MISMATCH)) &&
              (!(options & WOLFSSL_ALPN_FAILED_ON_MISMATCH))) {
         WOLFSSL_MSG("Invalid arguments, options not supported");
-        ret = BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
     }
-    if (ret == WOLFSSL_SUCCESS) {
-        list = (char *)XMALLOC(protocol_name_listSz + 1, ssl->heap,
-             DYNAMIC_TYPE_ALPN);
-        token = (char **)XMALLOC(sizeof(char*) * (WOLFSSL_MAX_ALPN_NUMBER + 1),
-            ssl->heap, DYNAMIC_TYPE_ALPN);
-        if ((list == NULL) || (token == NULL)) {
-            WOLFSSL_MSG("Memory failure");
-            ret = MEMORY_ERROR;
-        }
+
+    list = (char *)XMALLOC(protocol_name_listSz + 1, ssl->heap,
+                           DYNAMIC_TYPE_ALPN);
+    token = (char **)XMALLOC(sizeof(char*) * (WOLFSSL_MAX_ALPN_NUMBER + 1),
+                             ssl->heap, DYNAMIC_TYPE_ALPN);
+    if ((list == NULL) || (token == NULL)) {
+        WOLFSSL_MSG("Memory failure");
+        ret = MEMORY_ERROR;
     }
+
     if (ret == WOLFSSL_SUCCESS) {
         XMEMSET(token, 0, sizeof(char *) * (WOLFSSL_MAX_ALPN_NUMBER+1));
 
@@ -740,51 +658,43 @@ int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list, word16 *listSz)
     int i, len;
     char *p;
     byte *s;
-    int ret = WOLFSSL_SUCCESS;
 
-    if ((ssl == NULL) || (list == NULL) || (listSz == NULL)) {
-        ret = BAD_FUNC_ARG;
-    }
-    else if ((ssl->alpn_peer_requested == NULL) ||
-             (ssl->alpn_peer_requested_length == 0)) {
-        ret = BUFFER_ERROR;
-    }
-    if (ret == WOLFSSL_SUCCESS) {
-        /* ssl->alpn_peer_requested are the original bytes sent in a
-         * ClientHello, formatted as (len-byte chars+)+. To turn n protocols
-         * into a comma-separated C string, one needs (n-1) commas and a final
-         * 0 byte which has the same length as the original.
-         * The returned length is the strlen() of the C string, so -1 of
-         * that. */
-        *listSz = ssl->alpn_peer_requested_length-1;
-        *list = p = (char *)XMALLOC(ssl->alpn_peer_requested_length, ssl->heap,
-            DYNAMIC_TYPE_TLSX);
-        if (p == NULL) {
-            ret = MEMORY_ERROR;
-        }
-    }
-    if (ret == WOLFSSL_SUCCESS) {
-        s = ssl->alpn_peer_requested;
-        for (i = 0; i < ssl->alpn_peer_requested_length; p += len, i += len) {
-            if (i != 0) {
-                *p++ = ',';
-            }
-            len = s[i++];
-            /* Guard against bad length bytes. */
-            if ((i + len) > ssl->alpn_peer_requested_length) {
-                XFREE(*list, ssl->heap, DYNAMIC_TYPE_TLSX);
-                *list = NULL;
-                ret = WOLFSSL_FAILURE;
-                break;
-            }
-            XMEMCPY(p, s + i, (size_t)len);
-        }
-        if (ret == WOLFSSL_SUCCESS) {
-            *p = 0;
-        }
-    }
+    if (ssl == NULL || list == NULL || listSz == NULL)
+        return BAD_FUNC_ARG;
 
-    return ret;
+    if (ssl->alpn_peer_requested == NULL
+        || ssl->alpn_peer_requested_length == 0)
+        return BUFFER_ERROR;
+
+    /* ssl->alpn_peer_requested are the original bytes sent in a ClientHello,
+     * formatted as (len-byte chars+)+. To turn n protocols into a
+     * comma-separated C string, one needs (n-1) commas and a final 0 byte
+     * which has the same length as the original.
+     * The returned length is the strlen() of the C string, so -1 of that. */
+    *listSz = ssl->alpn_peer_requested_length-1;
+    *list = p = (char *)XMALLOC(ssl->alpn_peer_requested_length, ssl->heap,
+                                DYNAMIC_TYPE_TLSX);
+    if (p == NULL)
+        return MEMORY_ERROR;
+
+    for (i = 0, s = ssl->alpn_peer_requested;
+         i < ssl->alpn_peer_requested_length;
+         p += len, i += len)
+    {
+        if (i)
+            *p++ = ',';
+        len = s[i++];
+        /* guard against bad length bytes. */
+        if (i + len > ssl->alpn_peer_requested_length) {
+            XFREE(*list, ssl->heap, DYNAMIC_TYPE_TLSX);
+            *list = NULL;
+            return WOLFSSL_FAILURE;
+        }
+        XMEMCPY(p, s + i, (size_t)len);
+    }
+    *p = 0;
+
+    return WOLFSSL_SUCCESS;
 }
 
 
@@ -797,18 +707,14 @@ int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list, word16 *listSz)
  */
 int wolfSSL_ALPN_FreePeerProtocol(WOLFSSL* ssl, char **list)
 {
-    int ret;
-
     if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        XFREE(*list, ssl->heap, DYNAMIC_TYPE_TLSX);
-        *list = NULL;
-        ret = WOLFSSL_SUCCESS;
+        return BAD_FUNC_ARG;
     }
 
-    return ret;
+    XFREE(*list, ssl->heap, DYNAMIC_TYPE_TLSX);
+    *list = NULL;
+
+    return WOLFSSL_SUCCESS;
 }
 
 #endif /* HAVE_ALPN */
@@ -858,17 +764,11 @@ int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl)
  */
 int wolfSSL_CTX_UseSecureRenegotiation(WOLFSSL_CTX* ctx)
 {
-    int ret;
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ctx->useSecureReneg = 1;
-        ret = WOLFSSL_SUCCESS;
-    }
-
-    return ret;
+    ctx->useSecureReneg = 1;
+    return WOLFSSL_SUCCESS;
 }
 
 #ifdef HAVE_SECURE_RENEGOTIATION
@@ -886,61 +786,53 @@ static int _Rehandshake(WOLFSSL* ssl)
 {
     int ret;
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-        goto end;
-    }
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
     if (IsAtLeastTLSv1_3(ssl->version)) {
         WOLFSSL_MSG("Secure Renegotiation not supported in TLS 1.3");
-        ret = SECURE_RENEGOTIATION_E;
-        goto end;
+        return SECURE_RENEGOTIATION_E;
     }
 
     if (ssl->secure_renegotiation == NULL) {
         WOLFSSL_MSG("Secure Renegotiation not forced on by user");
-        ret = SECURE_RENEGOTIATION_E;
-        goto end;
+        return SECURE_RENEGOTIATION_E;
     }
 
     if (ssl->secure_renegotiation->enabled == 0) {
         WOLFSSL_MSG("Secure Renegotiation not enabled at extension level");
-        ret = SECURE_RENEGOTIATION_E;
-        goto end;
+        return SECURE_RENEGOTIATION_E;
     }
 
 #ifdef WOLFSSL_DTLS
-    if (ssl->options.dtls && (ssl->keys.dtls_epoch == 0xFFFF)) {
+    if (ssl->options.dtls && ssl->keys.dtls_epoch == 0xFFFF) {
         WOLFSSL_MSG("Secure Renegotiation not allowed. Epoch would wrap");
-        ret = SECURE_RENEGOTIATION_E;
-        goto end;
+        return SECURE_RENEGOTIATION_E;
     }
 #endif
 
     /* If the client started the renegotiation, the server will already
      * have processed the client's hello. */
-    if ((ssl->options.side != WOLFSSL_SERVER_END) ||
-        (ssl->options.acceptState != ACCEPT_FIRST_REPLY_DONE)) {
+    if (ssl->options.side != WOLFSSL_SERVER_END ||
+        ssl->options.acceptState != ACCEPT_FIRST_REPLY_DONE) {
 
         if (ssl->options.handShakeState != HANDSHAKE_DONE) {
             if (!ssl->options.handShakeDone) {
                 WOLFSSL_MSG("Can't renegotiate until initial "
                             "handshake complete");
-                ret = SECURE_RENEGOTIATION_E;
-                goto end;
+                return SECURE_RENEGOTIATION_E;
             }
             else {
                 WOLFSSL_MSG("Renegotiation already started. "
                             "Moving it forward.");
                 ret = wolfSSL_negotiate(ssl);
-                if (ret == WOLFSSL_SUCCESS) {
+                if (ret == WOLFSSL_SUCCESS)
                     ssl->secure_rene_count++;
-                }
-                goto end;
+                return ret;
             }
         }
 
-        /* Reset handshake states. */
+        /* reset handshake states */
         ssl->options.sendVerify = 0;
         ssl->options.serverState = NULL_STATE;
         ssl->options.clientState = NULL_STATE;
@@ -958,8 +850,7 @@ static int _Rehandshake(WOLFSSL* ssl)
             ret = SendHelloRequest(ssl);
             if (ret != 0) {
                 ssl->error = ret;
-                ret = WOLFSSL_FATAL_ERROR;
-                goto end;
+                return WOLFSSL_FATAL_ERROR;
             }
         }
 #endif /* !NO_WOLFSSL_SERVER && !WOLFSSL_NO_TLS12 */
@@ -967,16 +858,12 @@ static int _Rehandshake(WOLFSSL* ssl)
         ret = InitHandshakeHashes(ssl);
         if (ret != 0) {
             ssl->error = ret;
-            ret = WOLFSSL_FATAL_ERROR;
-            goto end;
+            return WOLFSSL_FATAL_ERROR;
         }
     }
     ret = wolfSSL_negotiate(ssl);
-    if (ret == WOLFSSL_SUCCESS) {
+    if (ret == WOLFSSL_SUCCESS)
         ssl->secure_rene_count++;
-    }
-
-end:
     return ret;
 }
 
@@ -993,42 +880,36 @@ end:
 int wolfSSL_Rehandshake(WOLFSSL* ssl)
 {
     int ret;
-
     WOLFSSL_ENTER("wolfSSL_Rehandshake");
 
-    if (ssl == NULL) {
-        ret = WOLFSSL_FAILURE;
+    if (ssl == NULL)
+        return WOLFSSL_FAILURE;
+
+#ifdef HAVE_SESSION_TICKET
+    ret = WOLFSSL_SUCCESS;
+#endif
+
+    if (ssl->options.side == WOLFSSL_SERVER_END) {
+        /* Reset option to send certificate verify. */
+        ssl->options.sendVerify = 0;
+        /* Reset resuming flag to do full secure handshake. */
+        ssl->options.resuming = 0;
     }
     else {
-#ifdef HAVE_SESSION_TICKET
-        ret = WOLFSSL_SUCCESS;
-#endif
-
-        if (ssl->options.side == WOLFSSL_SERVER_END) {
-            /* Reset option to send certificate verify. */
-            ssl->options.sendVerify = 0;
-            /* Reset resuming flag to do full secure handshake. */
-            ssl->options.resuming = 0;
-        }
-        else {
-            /* Reset resuming flag to do full secure handshake. */
-            ssl->options.resuming = 0;
-            #if defined(HAVE_SESSION_TICKET) && !defined(NO_WOLFSSL_CLIENT)
-                /* Clearing the ticket. */
-                ret = wolfSSL_UseSessionTicket(ssl);
-            #endif
-        }
-        /* CLIENT/SERVER: Reset peer authentication for full secure
-         * handshake. */
-        ssl->options.peerAuthGood = 0;
-
-#ifdef HAVE_SESSION_TICKET
-        if (ret == WOLFSSL_SUCCESS)
-#endif
-        {
-            ret = _Rehandshake(ssl);
-        }
+        /* Reset resuming flag to do full secure handshake. */
+        ssl->options.resuming = 0;
+        #if defined(HAVE_SESSION_TICKET) && !defined(NO_WOLFSSL_CLIENT)
+            /* Clearing the ticket. */
+            ret = wolfSSL_UseSessionTicket(ssl);
+        #endif
     }
+    /* CLIENT/SERVER: Reset peer authentication for full secure handshake. */
+    ssl->options.peerAuthGood = 0;
+
+#ifdef HAVE_SESSION_TICKET
+    if (ret == WOLFSSL_SUCCESS)
+#endif
+        ret = _Rehandshake(ssl);
 
     return ret;
 }
@@ -1047,22 +928,17 @@ int wolfSSL_Rehandshake(WOLFSSL* ssl)
  */
 int wolfSSL_SecureResume(WOLFSSL* ssl)
 {
-    int ret;
-
     WOLFSSL_ENTER("wolfSSL_SecureResume");
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else if (ssl->options.side == WOLFSSL_SERVER_END) {
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
+
+    if (ssl->options.side == WOLFSSL_SERVER_END) {
         ssl->error = SIDE_ERROR;
-        ret = WOLFSSL_FATAL_ERROR;
-    }
-    else {
-        ret = _Rehandshake(ssl);
+        return WOLFSSL_FATAL_ERROR;
     }
 
-    return ret;
+    return _Rehandshake(ssl);
 }
 
 #endif /* NO_WOLFSSL_CLIENT */
@@ -1097,7 +973,10 @@ WOLFSSL_API int wolfSSL_get_scr_check_enabled(const WOLFSSL* ssl)
 {
     WOLFSSL_ENTER("wolfSSL_get_scr_check_enabled");
 
-    return (ssl == NULL) ? BAD_FUNC_ARG : ssl->scr_check_enabled;
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
+
+    return ssl->scr_check_enabled;
 }
 
 /* Set whether the secure renegotiation check is enabled for the object.
@@ -1109,19 +988,13 @@ WOLFSSL_API int wolfSSL_get_scr_check_enabled(const WOLFSSL* ssl)
  */
 WOLFSSL_API int wolfSSL_set_scr_check_enabled(WOLFSSL* ssl, byte enabled)
 {
-    int ret;
-
     WOLFSSL_ENTER("wolfSSL_set_scr_check_enabled");
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ssl->scr_check_enabled = !!enabled;
-        ret = WOLFSSL_SUCCESS;
-    }
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
-    return ret;
+    ssl->scr_check_enabled = !!enabled;
+    return WOLFSSL_SUCCESS;
 }
 #endif
 
@@ -1137,17 +1010,12 @@ WOLFSSL_API int wolfSSL_set_scr_check_enabled(WOLFSSL* ssl, byte enabled)
  */
 int wolfSSL_CTX_NoTicketTLSv12(WOLFSSL_CTX* ctx)
 {
-    int ret;
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ctx->noTicketTls12 = 1;
-        ret = WOLFSSL_SUCCESS;
-    }
+    ctx->noTicketTls12 = 1;
 
-    return ret;
+    return WOLFSSL_SUCCESS;
 }
 
 /* Disable use of session tickets with TLS 1.2 on the object.
@@ -1158,17 +1026,12 @@ int wolfSSL_CTX_NoTicketTLSv12(WOLFSSL_CTX* ctx)
  */
 int wolfSSL_NoTicketTLSv12(WOLFSSL* ssl)
 {
-    int ret;
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ssl->options.noTicketTls12 = 1;
-        ret = WOLFSSL_SUCCESS;
-    }
+    ssl->options.noTicketTls12 = 1;
 
-    return ret;
+    return WOLFSSL_SUCCESS;
 }
 
 /* Set the session ticket encryption callback on the context.
@@ -1180,17 +1043,12 @@ int wolfSSL_NoTicketTLSv12(WOLFSSL* ssl)
  */
 int wolfSSL_CTX_set_TicketEncCb(WOLFSSL_CTX* ctx, SessionTicketEncCb cb)
 {
-    int ret;
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ctx->ticketEncCb = cb;
-        ret = WOLFSSL_SUCCESS;
-    }
+    ctx->ticketEncCb = cb;
 
-    return ret;
+    return WOLFSSL_SUCCESS;
 }
 
 /* Set the session ticket lifetime hint, in seconds, on the context.
@@ -1202,22 +1060,17 @@ int wolfSSL_CTX_set_TicketEncCb(WOLFSSL_CTX* ctx, SessionTicketEncCb cb)
  */
 int wolfSSL_CTX_set_TicketHint(WOLFSSL_CTX* ctx, int hint)
 {
-    int ret;
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
     /* RFC8446 Section 4.6.1: Servers MUST NOT use any value greater than
      * 604800 seconds (7 days). */
-    else if ((hint < 0) || (hint > 604800)) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ctx->ticketHint = hint;
-        ret = WOLFSSL_SUCCESS;
-    }
+    if (hint < 0 || hint > 604800)
+        return BAD_FUNC_ARG;
 
-    return ret;
+    ctx->ticketHint = hint;
+
+    return WOLFSSL_SUCCESS;
 }
 
 /* Set the user context passed to the session ticket encryption callback.
@@ -1229,17 +1082,12 @@ int wolfSSL_CTX_set_TicketHint(WOLFSSL_CTX* ctx, int hint)
  */
 int wolfSSL_CTX_set_TicketEncCtx(WOLFSSL_CTX* ctx, void* userCtx)
 {
-    int ret;
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ctx->ticketEncCtx = userCtx;
-        ret = WOLFSSL_SUCCESS;
-    }
+    ctx->ticketEncCtx = userCtx;
 
-    return ret;
+    return WOLFSSL_SUCCESS;
 }
 
 /* Get the user context passed to the session ticket encryption callback.
@@ -1250,16 +1098,10 @@ int wolfSSL_CTX_set_TicketEncCtx(WOLFSSL_CTX* ctx, void* userCtx)
  */
 void* wolfSSL_CTX_get_TicketEncCtx(WOLFSSL_CTX* ctx)
 {
-    void* ret;
+    if (ctx == NULL)
+        return NULL;
 
-    if (ctx == NULL) {
-        ret = NULL;
-    }
-    else {
-        ret = ctx->ticketEncCtx;
-    }
-
-    return ret;
+    return ctx->ticketEncCtx;
 }
 
 #ifdef WOLFSSL_TLS13
@@ -1272,17 +1114,11 @@ void* wolfSSL_CTX_get_TicketEncCtx(WOLFSSL_CTX* ctx)
  */
 int wolfSSL_CTX_set_num_tickets(WOLFSSL_CTX* ctx, size_t mxTickets)
 {
-    int ret;
+    if (ctx == NULL)
+        return WOLFSSL_FAILURE;
 
-    if (ctx == NULL) {
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        ctx->maxTicketTls13 = (unsigned int)mxTickets;
-        ret = WOLFSSL_SUCCESS;
-    }
-
-    return ret;
+    ctx->maxTicketTls13 = (unsigned int)mxTickets;
+    return WOLFSSL_SUCCESS;
 }
 
 /* Get the maximum number of TLS 1.3 session tickets to send.
@@ -1292,16 +1128,10 @@ int wolfSSL_CTX_set_num_tickets(WOLFSSL_CTX* ctx, size_t mxTickets)
  */
 size_t wolfSSL_CTX_get_num_tickets(WOLFSSL_CTX* ctx)
 {
-    size_t ret;
+    if (ctx == NULL)
+        return 0;
 
-    if (ctx == NULL) {
-        ret = 0;
-    }
-    else {
-        ret = (size_t)ctx->maxTicketTls13;
-    }
-
-    return ret;
+    return (size_t)ctx->maxTicketTls13;
 }
 #endif /* WOLFSSL_TLS13 */
 #endif /* !NO_WOLFSSL_SERVER */
@@ -1316,16 +1146,10 @@ size_t wolfSSL_CTX_get_num_tickets(WOLFSSL_CTX* ctx)
  */
 int wolfSSL_UseSessionTicket(WOLFSSL* ssl)
 {
-    int ret;
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ret = TLSX_UseSessionTicket(&ssl->extensions, NULL, ssl->heap);
-    }
-
-    return ret;
+    return TLSX_UseSessionTicket(&ssl->extensions, NULL, ssl->heap);
 }
 
 /* Enable use of the session ticket extension on the context.
@@ -1337,16 +1161,10 @@ int wolfSSL_UseSessionTicket(WOLFSSL* ssl)
  */
 int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx)
 {
-    int ret;
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ret = TLSX_UseSessionTicket(&ctx->extensions, NULL, ctx->heap);
-    }
-
-    return ret;
+    return TLSX_UseSessionTicket(&ctx->extensions, NULL, ctx->heap);
 }
 
 /* Get the session ticket stored on the object.
@@ -1362,32 +1180,25 @@ int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx)
  */
 int wolfSSL_get_SessionTicket(WOLFSSL* ssl, byte* buf, word32* bufSz)
 {
-    int ret;
+    if (ssl == NULL || bufSz == NULL)
+        return BAD_FUNC_ARG;
 
-    if ((ssl == NULL) || (bufSz == NULL)) {
-        ret = BAD_FUNC_ARG;
-    }
-    /* No buffer and zero size is a query for the required length. */
-    else if ((*bufSz == 0) && (buf == NULL)) {
+    if (*bufSz == 0 && buf == NULL) {
         *bufSz = ssl->session->ticketLen;
-        ret = LENGTH_ONLY_E;
-    }
-    else if (buf == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        /* Copy the ticket when it fits, otherwise report zero length. */
-        if (ssl->session->ticketLen <= *bufSz) {
-            XMEMCPY(buf, ssl->session->ticket, ssl->session->ticketLen);
-            *bufSz = ssl->session->ticketLen;
-        }
-        else {
-            *bufSz = 0;
-        }
-        ret = WOLFSSL_SUCCESS;
+        return LENGTH_ONLY_E;
     }
 
-    return ret;
+    if (buf == NULL)
+        return BAD_FUNC_ARG;
+
+    if (ssl->session->ticketLen <= *bufSz) {
+        XMEMCPY(buf, ssl->session->ticket, ssl->session->ticketLen);
+        *bufSz = ssl->session->ticketLen;
+    }
+    else
+        *bufSz = 0;
+
+    return WOLFSSL_SUCCESS;
 }
 
 /* Set the session ticket to use on the object.
@@ -1399,53 +1210,44 @@ int wolfSSL_get_SessionTicket(WOLFSSL* ssl, byte* buf, word32* bufSz)
  * @return  BAD_FUNC_ARG when ssl is NULL or buf is NULL with bufSz > 0.
  * @return  MEMORY_ERROR on allocation failure.
  */
-int wolfSSL_set_SessionTicket(WOLFSSL* ssl, const byte* buf, word32 bufSz)
+int wolfSSL_set_SessionTicket(WOLFSSL* ssl, const byte* buf,
+                                          word32 bufSz)
 {
-    int ret = WOLFSSL_SUCCESS;
+    if (ssl == NULL || (buf == NULL && bufSz > 0))
+        return BAD_FUNC_ARG;
 
-    if ((ssl == NULL) || ((buf == NULL) && (bufSz > 0))) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        if (bufSz > 0) {
-            /* Ticket will fit into the static ticket buffer. */
-            if (bufSz <= SESSION_TICKET_LEN) {
+    if (bufSz > 0) {
+        /* Ticket will fit into static ticket */
+        if (bufSz <= SESSION_TICKET_LEN) {
+            if (ssl->session->ticketLenAlloc > 0) {
+                XFREE(ssl->session->ticket, ssl->session->heap,
+                      DYNAMIC_TYPE_SESSION_TICK);
+                ssl->session->ticketLenAlloc = 0;
+                ssl->session->ticket = ssl->session->staticTicket;
+            }
+        }
+        else { /* Ticket requires dynamic ticket storage */
+            /* is dyn buffer big enough */
+            if (ssl->session->ticketLen < bufSz) {
                 if (ssl->session->ticketLenAlloc > 0) {
                     XFREE(ssl->session->ticket, ssl->session->heap,
                           DYNAMIC_TYPE_SESSION_TICK);
-                    ssl->session->ticketLenAlloc = 0;
+                }
+                ssl->session->ticket = (byte*)XMALLOC(bufSz, ssl->session->heap,
+                        DYNAMIC_TYPE_SESSION_TICK);
+                if(ssl->session->ticket == NULL) {
                     ssl->session->ticket = ssl->session->staticTicket;
+                    ssl->session->ticketLenAlloc = 0;
+                    return MEMORY_ERROR;
                 }
-            }
-            else { /* Ticket requires dynamic ticket storage */
-                /* Is the dynamic buffer big enough? */
-                if (ssl->session->ticketLen < bufSz) {
-                    if (ssl->session->ticketLenAlloc > 0) {
-                        XFREE(ssl->session->ticket, ssl->session->heap,
-                              DYNAMIC_TYPE_SESSION_TICK);
-                    }
-                    ssl->session->ticket = (byte*)XMALLOC(bufSz,
-                            ssl->session->heap, DYNAMIC_TYPE_SESSION_TICK);
-                    if (ssl->session->ticket == NULL) {
-                        ssl->session->ticket = ssl->session->staticTicket;
-                        ssl->session->ticketLenAlloc = 0;
-                        ret = MEMORY_ERROR;
-                    }
-                    else {
-                        ssl->session->ticketLenAlloc = (word16)bufSz;
-                    }
-                }
-            }
-            if (ret == WOLFSSL_SUCCESS) {
-                XMEMCPY(ssl->session->ticket, buf, bufSz);
+                ssl->session->ticketLenAlloc = (word16)bufSz;
             }
         }
-        if (ret == WOLFSSL_SUCCESS) {
-            ssl->session->ticketLen = (word16)bufSz;
-        }
+        XMEMCPY(ssl->session->ticket, buf, bufSz);
     }
+    ssl->session->ticketLen = (word16)bufSz;
 
-    return ret;
+    return WOLFSSL_SUCCESS;
 }
 
 
@@ -1457,21 +1259,16 @@ int wolfSSL_set_SessionTicket(WOLFSSL* ssl, const byte* buf, word32 bufSz)
  * @return  WOLFSSL_SUCCESS on success.
  * @return  BAD_FUNC_ARG when ssl is NULL.
  */
-int wolfSSL_set_SessionTicket_cb(WOLFSSL* ssl, CallbackSessionTicket cb,
-    void* ctx)
+int wolfSSL_set_SessionTicket_cb(WOLFSSL* ssl,
+                                 CallbackSessionTicket cb, void* ctx)
 {
-    int ret;
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ssl->session_ticket_cb = cb;
-        ssl->session_ticket_ctx = ctx;
-        ret = WOLFSSL_SUCCESS;
-    }
+    ssl->session_ticket_cb = cb;
+    ssl->session_ticket_ctx = ctx;
 
-    return ret;
+    return WOLFSSL_SUCCESS;
 }
 #endif /* !NO_WOLFSSL_CLIENT */
 
@@ -1489,17 +1286,12 @@ int wolfSSL_set_SessionTicket_cb(WOLFSSL* ssl, CallbackSessionTicket cb,
  */
 int wolfSSL_CTX_DisableExtendedMasterSecret(WOLFSSL_CTX* ctx)
 {
-    int ret;
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ctx->haveEMS = 0;
-        ret = WOLFSSL_SUCCESS;
-    }
+    ctx->haveEMS = 0;
 
-    return ret;
+    return WOLFSSL_SUCCESS;
 }
 
 
@@ -1511,17 +1303,12 @@ int wolfSSL_CTX_DisableExtendedMasterSecret(WOLFSSL_CTX* ctx)
  */
 int wolfSSL_DisableExtendedMasterSecret(WOLFSSL* ssl)
 {
-    int ret;
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ssl->options.haveEMS = 0;
-        ret = WOLFSSL_SUCCESS;
-    }
+    ssl->options.haveEMS = 0;
 
-    return ret;
+    return WOLFSSL_SUCCESS;
 }
 
 #endif
@@ -1542,17 +1329,12 @@ int wolfSSL_DisableExtendedMasterSecret(WOLFSSL* ssl)
  */
 long wolfSSL_set_tlsext_debug_arg(WOLFSSL* ssl, void *arg)
 {
-    long ret;
-
     if (ssl == NULL) {
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        ssl->loggingCtx = arg;
-        ret = WOLFSSL_SUCCESS;
+        return WOLFSSL_FAILURE;
     }
 
-    return ret;
+    ssl->loggingCtx = arg;
+    return WOLFSSL_SUCCESS;
 }
 #endif /* HAVE_PK_CALLBACKS */
 
@@ -1638,19 +1420,12 @@ long wolfSSL_set_tlsext_status_ids(WOLFSSL *s, void *arg)
  * @return  BAD_FUNC_ARG when c is NULL or mode is out of range.
  */
 int wolfSSL_CTX_set_tlsext_max_fragment_length(WOLFSSL_CTX *c,
-    unsigned char mode)
+                                               unsigned char mode)
 {
-    int ret;
+    if (c == NULL || (mode < WOLFSSL_MFL_2_9 || mode > WOLFSSL_MFL_2_12 ))
+        return BAD_FUNC_ARG;
 
-    if ((c == NULL) || ((mode < WOLFSSL_MFL_2_9) ||
-            (mode > WOLFSSL_MFL_2_12))) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ret = wolfSSL_CTX_UseMaxFragment(c, mode);
-    }
-
-    return ret;
+    return wolfSSL_CTX_UseMaxFragment(c, mode);
 }
 /* Set the Maximum Fragment Length extension on the object.
  *
@@ -1661,17 +1436,10 @@ int wolfSSL_CTX_set_tlsext_max_fragment_length(WOLFSSL_CTX *c,
  */
 int wolfSSL_set_tlsext_max_fragment_length(WOLFSSL *s, unsigned char mode)
 {
-    int ret;
+    if (s == NULL || (mode < WOLFSSL_MFL_2_9 || mode > WOLFSSL_MFL_2_12 ))
+        return BAD_FUNC_ARG;
 
-    if ((s == NULL) || ((mode < WOLFSSL_MFL_2_9) ||
-            (mode > WOLFSSL_MFL_2_12))) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        ret = wolfSSL_UseMaxFragment(s, mode);
-    }
-
-    return ret;
+    return wolfSSL_UseMaxFragment(s, mode);
 }
 #endif /* !NO_WOLFSSL_CLIENT && !NO_TLS */
 #endif /* HAVE_MAX_FRAGMENT */
@@ -1685,23 +1453,17 @@ int wolfSSL_set_tlsext_max_fragment_length(WOLFSSL *s, unsigned char mode)
  */
 int wolfSSL_CTX_set1_sigalgs_list(WOLFSSL_CTX* ctx, const char* list)
 {
-    int ret;
-
     WOLFSSL_MSG("wolfSSL_CTX_set1_sigalg_list");
 
-    if ((ctx == NULL) || (list == NULL)) {
+    if (ctx == NULL || list == NULL) {
         WOLFSSL_MSG("Bad function arguments");
-        ret = WOLFSSL_FAILURE;
-    }
-    /* Cipher suites must exist before the sig algs can be stored on them. */
-    else if (AllocateCtxSuites(ctx) != 0) {
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        ret = SetSuitesHashSigAlgo(ctx->suites, list);
+        return WOLFSSL_FAILURE;
     }
 
-    return ret;
+    if (AllocateCtxSuites(ctx) != 0)
+        return WOLFSSL_FAILURE;
+
+    return SetSuitesHashSigAlgo(ctx->suites, list);
 }
 
 /* Set the signature algorithms list on the object.
@@ -1713,23 +1475,17 @@ int wolfSSL_CTX_set1_sigalgs_list(WOLFSSL_CTX* ctx, const char* list)
  */
 int wolfSSL_set1_sigalgs_list(WOLFSSL* ssl, const char* list)
 {
-    int ret;
-
     WOLFSSL_MSG("wolfSSL_set1_sigalg_list");
 
-    if ((ssl == NULL) || (list == NULL)) {
+    if (ssl == NULL || list == NULL) {
         WOLFSSL_MSG("Bad function arguments");
-        ret = WOLFSSL_FAILURE;
-    }
-    /* Cipher suites must exist before the sig algs can be stored on them. */
-    else if (AllocateSuites(ssl) != 0) {
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        ret = SetSuitesHashSigAlgo(ssl->suites, list);
+        return WOLFSSL_FAILURE;
     }
 
-    return ret;
+    if (AllocateSuites(ssl) != 0)
+        return WOLFSSL_FAILURE;
+
+    return SetSuitesHashSigAlgo(ssl->suites, list);
 }
 
 #ifdef HAVE_ECC
@@ -1744,16 +1500,11 @@ int wolfSSL_set1_sigalgs_list(WOLFSSL* ssl, const char* list)
  */
 int wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, const char *list)
 {
-    int ret;
-
-    if ((ctx == NULL) || (list == NULL)) {
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        ret = set_curves_list(NULL, ctx, list, 0);
+    if (!ctx || !list) {
+        return WOLFSSL_FAILURE;
     }
 
-    return ret;
+    return set_curves_list(NULL, ctx, list, 0);
 }
 
 /* Set the supported groups list, by name, on the object.
@@ -1765,16 +1516,11 @@ int wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, const char *list)
  */
 int wolfSSL_set1_groups_list(WOLFSSL *ssl, const char *list)
 {
-    int ret;
-
-    if ((ssl == NULL) || (list == NULL)) {
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        ret = set_curves_list(ssl, NULL, list, 0);
+    if (!ssl || !list) {
+        return WOLFSSL_FAILURE;
     }
 
-    return ret;
+    return set_curves_list(ssl, NULL, list, 0);
 }
 #endif /* WOLFSSL_TLS13 */
 
@@ -1817,13 +1563,10 @@ int wolfSSL_set_tlsext_host_name(WOLFSSL* ssl, const char* host_name)
 const char * wolfSSL_get_servername(WOLFSSL* ssl, byte type)
 {
     void * serverName = NULL;
-
-    if (ssl != NULL) {
-        /* On a client request the name sent; on a server the name received. */
-        TLSX_SNI_GetRequest(ssl->extensions, type, &serverName,
-                !wolfSSL_is_server(ssl));
-    }
-
+    if (ssl == NULL)
+        return NULL;
+    TLSX_SNI_GetRequest(ssl->extensions, type, &serverName,
+            !wolfSSL_is_server(ssl));
     return (const char *)serverName;
 }
 #endif
@@ -1841,21 +1584,14 @@ const char * wolfSSL_get_servername(WOLFSSL* ssl, byte type)
  * @return  WOLFSSL_FAILURE when ctx is NULL.
  */
 int wolfSSL_CTX_set_tlsext_servername_callback(WOLFSSL_CTX* ctx,
-    CallbackSniRecv cb)
+                                               CallbackSniRecv cb)
 {
-    int ret;
-
     WOLFSSL_ENTER("wolfSSL_CTX_set_tlsext_servername_callback");
-
-    if (ctx == NULL) {
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
+    if (ctx) {
         ctx->sniRecvCb = cb;
-        ret = WOLFSSL_SUCCESS;
+        return WOLFSSL_SUCCESS;
     }
-
-    return ret;
+    return WOLFSSL_FAILURE;
 }
 
 #endif /* HAVE_SNI */
@@ -1888,19 +1624,12 @@ void wolfSSL_CTX_set_servername_callback(WOLFSSL_CTX* ctx, CallbackSniRecv cb)
  */
 int wolfSSL_CTX_set_servername_arg(WOLFSSL_CTX* ctx, void* arg)
 {
-    int ret;
-
     WOLFSSL_ENTER("wolfSSL_CTX_set_servername_arg");
-
-    if (ctx == NULL) {
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
+    if (ctx) {
         ctx->sniRecvCbArg = arg;
-        ret = WOLFSSL_SUCCESS;
+        return WOLFSSL_SUCCESS;
     }
-
-    return ret;
+    return WOLFSSL_FAILURE;
 }
 
 #endif /* HAVE_SNI */
@@ -2190,29 +1919,24 @@ int wolfSSL_CTX_set_tlsext_ticket_key_cb(WOLFSSL_CTX *ctx, ticketCompatCb cb)
 long wolfSSL_CTX_get_tlsext_ticket_keys(WOLFSSL_CTX *ctx,
      unsigned char *keys, int keylen)
 {
-    long ret = WOLFSSL_SUCCESS;
-
-    if ((ctx == NULL) || (keys == NULL)) {
-        ret = WOLFSSL_FAILURE;
+    if (ctx == NULL || keys == NULL) {
+        return WOLFSSL_FAILURE;
     }
-    else if (keylen != WOLFSSL_TICKET_KEYS_SZ) {
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        /* Serialize as: name | key[0] | key[1] | expiry[0] | expiry[1]. */
-        XMEMCPY(keys, ctx->ticketKeyCtx.name, WOLFSSL_TICKET_NAME_SZ);
-        keys += WOLFSSL_TICKET_NAME_SZ;
-        XMEMCPY(keys, ctx->ticketKeyCtx.key[0], WOLFSSL_TICKET_KEY_SZ);
-        keys += WOLFSSL_TICKET_KEY_SZ;
-        XMEMCPY(keys, ctx->ticketKeyCtx.key[1], WOLFSSL_TICKET_KEY_SZ);
-        keys += WOLFSSL_TICKET_KEY_SZ;
-        /* Expiry times are stored big-endian. */
-        c32toa(ctx->ticketKeyCtx.expirary[0], keys);
-        keys += OPAQUE32_LEN;
-        c32toa(ctx->ticketKeyCtx.expirary[1], keys);
+    if (keylen != WOLFSSL_TICKET_KEYS_SZ) {
+        return WOLFSSL_FAILURE;
     }
 
-    return ret;
+    XMEMCPY(keys, ctx->ticketKeyCtx.name, WOLFSSL_TICKET_NAME_SZ);
+    keys += WOLFSSL_TICKET_NAME_SZ;
+    XMEMCPY(keys, ctx->ticketKeyCtx.key[0], WOLFSSL_TICKET_KEY_SZ);
+    keys += WOLFSSL_TICKET_KEY_SZ;
+    XMEMCPY(keys, ctx->ticketKeyCtx.key[1], WOLFSSL_TICKET_KEY_SZ);
+    keys += WOLFSSL_TICKET_KEY_SZ;
+    c32toa(ctx->ticketKeyCtx.expirary[0], keys);
+    keys += OPAQUE32_LEN;
+    c32toa(ctx->ticketKeyCtx.expirary[1], keys);
+
+    return WOLFSSL_SUCCESS;
 }
 
 /* Deserialize the session ticket encryption keys.
@@ -2228,29 +1952,24 @@ long wolfSSL_CTX_set_tlsext_ticket_keys(WOLFSSL_CTX *ctx,
      const void *keys_vp, int keylen)
 {
     const byte* keys = (const byte*)keys_vp;
-    long ret = WOLFSSL_SUCCESS;
-
-    if ((ctx == NULL) || (keys == NULL)) {
-        ret = WOLFSSL_FAILURE;
+    if (ctx == NULL || keys == NULL) {
+        return WOLFSSL_FAILURE;
     }
-    else if (keylen != WOLFSSL_TICKET_KEYS_SZ) {
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        /* Parse as: name | key[0] | key[1] | expiry[0] | expiry[1]. */
-        XMEMCPY(ctx->ticketKeyCtx.name, keys, WOLFSSL_TICKET_NAME_SZ);
-        keys += WOLFSSL_TICKET_NAME_SZ;
-        XMEMCPY(ctx->ticketKeyCtx.key[0], keys, WOLFSSL_TICKET_KEY_SZ);
-        keys += WOLFSSL_TICKET_KEY_SZ;
-        XMEMCPY(ctx->ticketKeyCtx.key[1], keys, WOLFSSL_TICKET_KEY_SZ);
-        keys += WOLFSSL_TICKET_KEY_SZ;
-        /* Expiry times are stored big-endian. */
-        ato32(keys, &ctx->ticketKeyCtx.expirary[0]);
-        keys += OPAQUE32_LEN;
-        ato32(keys, &ctx->ticketKeyCtx.expirary[1]);
+    if (keylen != WOLFSSL_TICKET_KEYS_SZ) {
+        return WOLFSSL_FAILURE;
     }
 
-    return ret;
+    XMEMCPY(ctx->ticketKeyCtx.name, keys, WOLFSSL_TICKET_NAME_SZ);
+    keys += WOLFSSL_TICKET_NAME_SZ;
+    XMEMCPY(ctx->ticketKeyCtx.key[0], keys, WOLFSSL_TICKET_KEY_SZ);
+    keys += WOLFSSL_TICKET_KEY_SZ;
+    XMEMCPY(ctx->ticketKeyCtx.key[1], keys, WOLFSSL_TICKET_KEY_SZ);
+    keys += WOLFSSL_TICKET_KEY_SZ;
+    ato32(keys, &ctx->ticketKeyCtx.expirary[0]);
+    keys += OPAQUE32_LEN;
+    ato32(keys, &ctx->ticketKeyCtx.expirary[1]);
+
+    return WOLFSSL_SUCCESS;
 }
 #endif
 
@@ -2513,19 +2232,12 @@ int wolfSSL_curve_is_disabled(const WOLFSSL* ssl, word16 curve_id)
  */
 int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, const char* names)
 {
-    int ret;
-
     WOLFSSL_ENTER("wolfSSL_CTX_set1_curves_list");
-
-    if ((ctx == NULL) || (names == NULL)) {
+    if (ctx == NULL || names == NULL) {
         WOLFSSL_MSG("ctx or names was NULL");
-        ret = WOLFSSL_FAILURE;
+        return WOLFSSL_FAILURE;
     }
-    else {
-        ret = set_curves_list(NULL, ctx, names, 1);
-    }
-
-    return ret;
+    return set_curves_list(NULL, ctx, names, 1);
 }
 
 /* Set the supported curves list, by name, on the object.
@@ -2537,19 +2249,12 @@ int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, const char* names)
  */
 int wolfSSL_set1_curves_list(WOLFSSL* ssl, const char* names)
 {
-    int ret;
-
     WOLFSSL_ENTER("wolfSSL_set1_curves_list");
-
-    if ((ssl == NULL) || (names == NULL)) {
+    if (ssl == NULL || names == NULL) {
         WOLFSSL_MSG("ssl or names was NULL");
-        ret = WOLFSSL_FAILURE;
+        return WOLFSSL_FAILURE;
     }
-    else {
-        ret = set_curves_list(ssl, NULL, names, 1);
-    }
-
-    return ret;
+    return set_curves_list(ssl, NULL, names, 1);
 }
 
 #endif /* HAVE_ECC || HAVE_CURVE25519 || HAVE_CURVE448 */
@@ -2567,48 +2272,38 @@ int wolfSSL_set1_curves_list(WOLFSSL* ssl, const char* names)
  * @return  WOLFSSL_FAILURE (or 1 with WOLFSSL_ERROR_CODE_OPENSSL) on error.
  */
 int wolfSSL_CTX_set_alpn_protos(WOLFSSL_CTX *ctx, const unsigned char *p,
-    unsigned int p_len)
+                            unsigned int p_len)
 {
-    int ret;
-
     WOLFSSL_ENTER("wolfSSL_CTX_set_alpn_protos");
-
-    if ((ctx == NULL) || (p == NULL)) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        if (ctx->alpn_cli_protos != NULL) {
-            XFREE((void*)ctx->alpn_cli_protos, ctx->heap, DYNAMIC_TYPE_OPENSSL);
-        }
-
-        ctx->alpn_cli_protos = (const unsigned char*)XMALLOC(p_len,
-            ctx->heap, DYNAMIC_TYPE_OPENSSL);
-        if (ctx->alpn_cli_protos == NULL) {
-#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-            /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
-             * the function reverses the return value convention.
-             */
-            ret = 1;
-#else
-            ret = WOLFSSL_FAILURE;
-#endif
-        }
-        else {
-            XMEMCPY((void*)ctx->alpn_cli_protos, p, p_len);
-            ctx->alpn_cli_protos_len = p_len;
-
-#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-            /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
-             * the function reverses the return value convention.
-             */
-            ret = 0;
-#else
-            ret = WOLFSSL_SUCCESS;
-#endif
-        }
+    if (ctx == NULL || p == NULL)
+        return BAD_FUNC_ARG;
+    if (ctx->alpn_cli_protos != NULL) {
+        XFREE((void*)ctx->alpn_cli_protos, ctx->heap, DYNAMIC_TYPE_OPENSSL);
     }
 
-    return ret;
+    ctx->alpn_cli_protos = (const unsigned char*)XMALLOC(p_len,
+        ctx->heap, DYNAMIC_TYPE_OPENSSL);
+    if (ctx->alpn_cli_protos == NULL) {
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+        /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+         * the function reverses the return value convention.
+         */
+        return 1;
+#else
+        return WOLFSSL_FAILURE;
+#endif
+    }
+    XMEMCPY((void*)ctx->alpn_cli_protos, p, p_len);
+    ctx->alpn_cli_protos_len = p_len;
+
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+     * the function reverses the return value convention.
+     */
+    return 0;
+#else
+    return WOLFSSL_SUCCESS;
+#endif
 }
 
 

--- a/src/ssl_api_pk.c
+++ b/src/ssl_api_pk.c
@@ -1620,32 +1620,34 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
  */
 int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX* ctx, short keySz)
 {
-    int ret = WOLFSSL_SUCCESS;
+    short keySzBytes;
 
     WOLFSSL_ENTER("wolfSSL_CTX_SetMinEccKey_Sz");
-
-    if ((ctx == NULL) || (keySz < 0)) {
+    if (ctx == NULL || keySz < 0) {
         WOLFSSL_MSG("Key size must be positive value or ctx was null");
-        ret = BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
+    }
+
+    if (keySz % 8 == 0) {
+        keySzBytes = keySz / 8;
     }
     else {
-        short keySzBytes = (keySz + 7) / 8;
-
-    #if defined(WOLFSSL_SYS_CRYPTO_POLICY)
-        if (crypto_policy.enabled && (ctx->minEccKeySz > keySzBytes)) {
-            ret = CRYPTO_POLICY_FORBIDDEN;
-        }
-        else
-    #endif /* WOLFSSL_SYS_CRYPTO_POLICY */
-        {
-            ctx->minEccKeySz     = keySzBytes;
-        #ifndef NO_CERTS
-            ctx->cm->minEccKeySz = keySzBytes;
-        #endif
-        }
+        keySzBytes = (keySz / 8) + 1;
     }
 
-    return ret;
+#if defined(WOLFSSL_SYS_CRYPTO_POLICY)
+    if (crypto_policy.enabled) {
+        if (ctx->minEccKeySz > (keySzBytes)) {
+            return CRYPTO_POLICY_FORBIDDEN;
+        }
+    }
+#endif /* WOLFSSL_SYS_CRYPTO_POLICY */
+
+    ctx->minEccKeySz     = keySzBytes;
+#ifndef NO_CERTS
+    ctx->cm->minEccKeySz = keySzBytes;
+#endif
+    return WOLFSSL_SUCCESS;
 }
 
 
@@ -1659,29 +1661,31 @@ int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX* ctx, short keySz)
  */
 int wolfSSL_SetMinEccKey_Sz(WOLFSSL* ssl, short keySz)
 {
-    int ret = WOLFSSL_SUCCESS;
+    short keySzBytes;
 
     WOLFSSL_ENTER("wolfSSL_SetMinEccKey_Sz");
-
-    if ((ssl == NULL) || (keySz < 0)) {
+    if (ssl == NULL || keySz < 0) {
         WOLFSSL_MSG("Key size must be positive value or ctx was null");
-        ret = BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
+    }
+
+    if (keySz % 8 == 0) {
+        keySzBytes = keySz / 8;
     }
     else {
-        short keySzBytes = (keySz + 7) / 8;
-
-    #if defined(WOLFSSL_SYS_CRYPTO_POLICY)
-        if (crypto_policy.enabled && (ssl->options.minEccKeySz > keySzBytes)) {
-            ret = CRYPTO_POLICY_FORBIDDEN;
-        }
-        else
-    #endif /* WOLFSSL_SYS_CRYPTO_POLICY */
-        {
-            ssl->options.minEccKeySz = keySzBytes;
-        }
+        keySzBytes = (keySz / 8) + 1;
     }
 
-    return ret;
+#if defined(WOLFSSL_SYS_CRYPTO_POLICY)
+    if (crypto_policy.enabled) {
+        if (ssl->options.minEccKeySz > (keySzBytes)) {
+            return CRYPTO_POLICY_FORBIDDEN;
+        }
+    }
+#endif /* WOLFSSL_SYS_CRYPTO_POLICY */
+
+    ssl->options.minEccKeySz = keySzBytes;
+    return WOLFSSL_SUCCESS;
 }
 
 #endif /* HAVE_ECC */
@@ -1698,23 +1702,22 @@ int wolfSSL_SetMinEccKey_Sz(WOLFSSL* ssl, short keySz)
  */
 int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX* ctx, short keySz)
 {
-    int ret = WOLFSSL_SUCCESS;
-
-    if ((ctx == NULL) || (keySz < 0) || ((keySz % 8) != 0)) {
+    if (ctx == NULL || keySz < 0 || keySz % 8 != 0) {
         WOLFSSL_MSG("Key size must be divisible by 8 or ctx was null");
-        ret = BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
     }
+
 #if defined(WOLFSSL_SYS_CRYPTO_POLICY)
-    else if (crypto_policy.enabled && (ctx->minRsaKeySz > (keySz / 8))) {
-        ret = CRYPTO_POLICY_FORBIDDEN;
+    if (crypto_policy.enabled) {
+        if (ctx->minRsaKeySz > (keySz / 8)) {
+            return CRYPTO_POLICY_FORBIDDEN;
+        }
     }
 #endif /* WOLFSSL_SYS_CRYPTO_POLICY */
-    else {
-        ctx->minRsaKeySz     = keySz / 8;
-        ctx->cm->minRsaKeySz = keySz / 8;
-    }
 
-    return ret;
+    ctx->minRsaKeySz     = keySz / 8;
+    ctx->cm->minRsaKeySz = keySz / 8;
+    return WOLFSSL_SUCCESS;
 }
 
 
@@ -1729,22 +1732,21 @@ int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX* ctx, short keySz)
  */
 int wolfSSL_SetMinRsaKey_Sz(WOLFSSL* ssl, short keySz)
 {
-    int ret = WOLFSSL_SUCCESS;
-
-    if ((ssl == NULL) || (keySz < 0) || ((keySz % 8) != 0)) {
+    if (ssl == NULL || keySz < 0 || keySz % 8 != 0) {
         WOLFSSL_MSG("Key size must be divisible by 8 or ssl was null");
-        ret = BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
     }
+
 #if defined(WOLFSSL_SYS_CRYPTO_POLICY)
-    else if (crypto_policy.enabled && (ssl->options.minRsaKeySz > (keySz / 8))) {
-        ret = CRYPTO_POLICY_FORBIDDEN;
+    if (crypto_policy.enabled) {
+        if (ssl->options.minRsaKeySz > (keySz / 8)) {
+            return CRYPTO_POLICY_FORBIDDEN;
+        }
     }
 #endif /* WOLFSSL_SYS_CRYPTO_POLICY */
-    else {
-        ssl->options.minRsaKeySz = keySz / 8;
-    }
 
-    return ret;
+    ssl->options.minRsaKeySz = keySz / 8;
+    return WOLFSSL_SUCCESS;
 }
 #endif /* !NO_RSA */
 
@@ -1761,20 +1763,18 @@ int wolfSSL_SetMinRsaKey_Sz(WOLFSSL* ssl, short keySz)
  */
 int wolfSSL_SetEnableDhKeyTest(WOLFSSL* ssl, int enable)
 {
-    int ret = WOLFSSL_SUCCESS;
-
     WOLFSSL_ENTER("wolfSSL_SetEnableDhKeyTest");
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        /* Store the flag normalized to a boolean. */
-        ssl->options.dhDoKeyTest = (enable != 0);
-    }
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
-    WOLFSSL_LEAVE("wolfSSL_SetEnableDhKeyTest", ret);
-    return ret;
+    if (!enable)
+        ssl->options.dhDoKeyTest = 0;
+    else
+        ssl->options.dhDoKeyTest = 1;
+
+    WOLFSSL_LEAVE("wolfSSL_SetEnableDhKeyTest", WOLFSSL_SUCCESS);
+    return WOLFSSL_SUCCESS;
 }
 #endif
 
@@ -1789,21 +1789,19 @@ int wolfSSL_SetEnableDhKeyTest(WOLFSSL* ssl, int enable)
  */
 int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX* ctx, word16 keySz_bits)
 {
-    int ret = WOLFSSL_SUCCESS;
+    if (ctx == NULL || keySz_bits > 16000 || keySz_bits % 8 != 0)
+        return BAD_FUNC_ARG;
 
-    if ((ctx == NULL) || (keySz_bits > 16000) || ((keySz_bits % 8) != 0)) {
-        ret = BAD_FUNC_ARG;
-    }
 #if defined(WOLFSSL_SYS_CRYPTO_POLICY)
-    else if (crypto_policy.enabled && (ctx->minDhKeySz > (keySz_bits / 8))) {
-        ret = CRYPTO_POLICY_FORBIDDEN;
+    if (crypto_policy.enabled) {
+        if (ctx->minDhKeySz > (keySz_bits / 8)) {
+            return CRYPTO_POLICY_FORBIDDEN;
+        }
     }
 #endif /* WOLFSSL_SYS_CRYPTO_POLICY */
-    else {
-        ctx->minDhKeySz = keySz_bits / 8;
-    }
 
-    return ret;
+    ctx->minDhKeySz = keySz_bits / 8;
+    return WOLFSSL_SUCCESS;
 }
 
 
@@ -1818,22 +1816,19 @@ int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX* ctx, word16 keySz_bits)
  */
 int wolfSSL_SetMinDhKey_Sz(WOLFSSL* ssl, word16 keySz_bits)
 {
-    int ret = WOLFSSL_SUCCESS;
+    if (ssl == NULL || keySz_bits > 16000 || keySz_bits % 8 != 0)
+        return BAD_FUNC_ARG;
 
-    if ((ssl == NULL) || (keySz_bits > 16000) || ((keySz_bits % 8) != 0)) {
-        ret = BAD_FUNC_ARG;
-    }
 #if defined(WOLFSSL_SYS_CRYPTO_POLICY)
-    else if (crypto_policy.enabled &&
-             (ssl->options.minDhKeySz > (keySz_bits / 8))) {
-        ret = CRYPTO_POLICY_FORBIDDEN;
+    if (crypto_policy.enabled) {
+        if (ssl->options.minDhKeySz > (keySz_bits / 8)) {
+            return CRYPTO_POLICY_FORBIDDEN;
+        }
     }
 #endif /* WOLFSSL_SYS_CRYPTO_POLICY */
-    else {
-        ssl->options.minDhKeySz = keySz_bits / 8;
-    }
 
-    return ret;
+    ssl->options.minDhKeySz = keySz_bits / 8;
+    return WOLFSSL_SUCCESS;
 }
 
 
@@ -1847,21 +1842,19 @@ int wolfSSL_SetMinDhKey_Sz(WOLFSSL* ssl, word16 keySz_bits)
  */
 int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX* ctx, word16 keySz_bits)
 {
-    int ret = WOLFSSL_SUCCESS;
+    if (ctx == NULL || keySz_bits > 16000 || keySz_bits % 8 != 0)
+        return BAD_FUNC_ARG;
 
-    if ((ctx == NULL) || (keySz_bits > 16000) || (keySz_bits % 8 != 0)) {
-        ret = BAD_FUNC_ARG;
-    }
 #if defined(WOLFSSL_SYS_CRYPTO_POLICY)
-    else if (crypto_policy.enabled && (ctx->minDhKeySz > (keySz_bits / 8))) {
-        ret = CRYPTO_POLICY_FORBIDDEN;
+    if (crypto_policy.enabled) {
+        if (ctx->minDhKeySz > (keySz_bits / 8)) {
+            return CRYPTO_POLICY_FORBIDDEN;
+        }
     }
 #endif /* WOLFSSL_SYS_CRYPTO_POLICY */
-    else {
-        ctx->maxDhKeySz = keySz_bits / 8;
-    }
 
-    return ret;
+    ctx->maxDhKeySz = keySz_bits / 8;
+    return WOLFSSL_SUCCESS;
 }
 
 
@@ -1875,22 +1868,19 @@ int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX* ctx, word16 keySz_bits)
  */
 int wolfSSL_SetMaxDhKey_Sz(WOLFSSL* ssl, word16 keySz_bits)
 {
-    int ret = WOLFSSL_SUCCESS;
+    if (ssl == NULL || keySz_bits > 16000 || keySz_bits % 8 != 0)
+        return BAD_FUNC_ARG;
 
-    if ((ssl == NULL) || (keySz_bits > 16000) || ((keySz_bits % 8) != 0)) {
-        ret = BAD_FUNC_ARG;
-    }
 #if defined(WOLFSSL_SYS_CRYPTO_POLICY)
-    else if (crypto_policy.enabled &&
-             (ssl->options.minDhKeySz > (keySz_bits / 8))) {
-        ret = CRYPTO_POLICY_FORBIDDEN;
+    if (crypto_policy.enabled) {
+        if (ssl->options.minDhKeySz > (keySz_bits / 8)) {
+            return CRYPTO_POLICY_FORBIDDEN;
+        }
     }
 #endif /* WOLFSSL_SYS_CRYPTO_POLICY */
-    else {
-        ssl->options.maxDhKeySz = keySz_bits / 8;
-    }
 
-    return ret;
+    ssl->options.maxDhKeySz = keySz_bits / 8;
+    return WOLFSSL_SUCCESS;
 }
 
 
@@ -1902,17 +1892,10 @@ int wolfSSL_SetMaxDhKey_Sz(WOLFSSL* ssl, word16 keySz_bits)
  */
 int wolfSSL_GetDhKey_Sz(WOLFSSL* ssl)
 {
-    int ret;
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
-    if (ssl == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        /* Key size is stored in bytes; report it in bits. */
-        ret = ssl->options.dhKeySz * 8;
-    }
-
-    return ret;
+    return (ssl->options.dhKeySz * 8);
 }
 
 #endif /* !NO_DH */
@@ -2072,20 +2055,14 @@ static int SaToNid(byte sa, int* nid)
  */
 int wolfSSL_get_signature_nid(WOLFSSL *ssl, int* nid)
 {
-    int ret;
-
     WOLFSSL_MSG("wolfSSL_get_signature_nid");
 
-    if ((ssl == NULL) || (nid == NULL)) {
+    if (ssl == NULL || nid == NULL) {
         WOLFSSL_MSG("Bad function arguments");
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        /* Map this side's signing hash algorithm to its NID. */
-        ret = HashToNid(ssl->options.hashAlgo, nid);
+        return WOLFSSL_FAILURE;
     }
 
-    return ret;
+    return HashToNid(ssl->options.hashAlgo, nid);
 }
 
 /* Get the NID of the signature algorithm used for signing by this side.
@@ -2098,20 +2075,14 @@ int wolfSSL_get_signature_nid(WOLFSSL *ssl, int* nid)
  */
 int wolfSSL_get_signature_type_nid(const WOLFSSL* ssl, int* nid)
 {
-    int ret;
-
     WOLFSSL_MSG("wolfSSL_get_signature_type_nid");
 
-    if ((ssl == NULL) || (nid == NULL)) {
+    if (ssl == NULL || nid == NULL) {
         WOLFSSL_MSG("Bad function arguments");
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        /* Map this side's signature algorithm to its NID. */
-        ret = SaToNid(ssl->options.sigAlgo, nid);
+        return WOLFSSL_FAILURE;
     }
 
-    return ret;
+    return SaToNid(ssl->options.sigAlgo, nid);
 }
 
 /* Get the NID of the hash algorithm used for signing by the peer.
@@ -2124,20 +2095,14 @@ int wolfSSL_get_signature_type_nid(const WOLFSSL* ssl, int* nid)
  */
 int wolfSSL_get_peer_signature_nid(WOLFSSL* ssl, int* nid)
 {
-    int ret;
-
     WOLFSSL_MSG("wolfSSL_get_peer_signature_nid");
 
-    if ((ssl == NULL) || (nid == NULL)) {
+    if (ssl == NULL || nid == NULL) {
         WOLFSSL_MSG("Bad function arguments");
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        /* Map the peer's signing hash algorithm to its NID. */
-        ret = HashToNid(ssl->options.peerHashAlgo, nid);
+        return WOLFSSL_FAILURE;
     }
 
-    return ret;
+    return HashToNid(ssl->options.peerHashAlgo, nid);
 }
 
 /* Get the NID of the signature algorithm used for signing by the peer.
@@ -2150,20 +2115,14 @@ int wolfSSL_get_peer_signature_nid(WOLFSSL* ssl, int* nid)
  */
 int wolfSSL_get_peer_signature_type_nid(const WOLFSSL* ssl, int* nid)
 {
-    int ret;
-
     WOLFSSL_MSG("wolfSSL_get_peer_signature_type_nid");
 
-    if ((ssl == NULL) || (nid == NULL)) {
+    if (ssl == NULL || nid == NULL) {
         WOLFSSL_MSG("Bad function arguments");
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        /* Map the peer's signature algorithm to its NID. */
-        ret = SaToNid(ssl->options.peerSigAlgo, nid);
+        return WOLFSSL_FAILURE;
     }
 
-    return ret;
+    return SaToNid(ssl->options.peerSigAlgo, nid);
 }
 
 #endif /* OPENSSL_EXTRA */
@@ -2180,19 +2139,14 @@ int wolfSSL_get_peer_signature_type_nid(const WOLFSSL* ssl, int* nid)
  */
 int wolfSSL_SSL_CTX_set_tmp_ecdh(WOLFSSL_CTX *ctx, WOLFSSL_EC_KEY *ecdh)
 {
-    int ret = WOLFSSL_SUCCESS;
-
     WOLFSSL_ENTER("wolfSSL_SSL_CTX_set_tmp_ecdh");
 
-    if ((ctx == NULL) || (ecdh == NULL)) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        /* Only the curve of the EC key is used for ephemeral ECDH. */
-        ctx->ecdhCurveOID = (word32)ecdh->group->curve_oid;
-    }
+    if (ctx == NULL || ecdh == NULL)
+        return BAD_FUNC_ARG;
 
-    return ret;
+    ctx->ecdhCurveOID = (word32)ecdh->group->curve_oid;
+
+    return WOLFSSL_SUCCESS;
 }
 #endif
 
@@ -2213,97 +2167,95 @@ int wolfSSL_SSL_CTX_set_tmp_ecdh(WOLFSSL_CTX *ctx, WOLFSSL_EC_KEY *ecdh)
  */
 int wolfSSL_StaticEphemeralKeyLoad(WOLFSSL* ssl, int keyAlgo, void* keyPtr)
 {
-    int ret = 0;
+    int ret;
     word32 idx = 0;
     DerBuffer* der = NULL;
 
-    if ((ssl == NULL) || (ssl->ctx == NULL) || (keyPtr == NULL)) {
-        ret = BAD_FUNC_ARG;
+    if (ssl == NULL || ssl->ctx == NULL || keyPtr == NULL) {
+        return BAD_FUNC_ARG;
     }
+
 #ifndef SINGLE_THREADED
-    else if (!ssl->ctx->staticKELockInit) {
-        ret = BUFFER_E; /* no keys set */
+    if (!ssl->ctx->staticKELockInit) {
+        return BUFFER_E; /* no keys set */
     }
-    else {
-        ret = wc_LockMutex(&ssl->ctx->staticKELock);
+    ret = wc_LockMutex(&ssl->ctx->staticKELock);
+    if (ret != 0) {
+        return ret;
     }
 #endif
 
-    if (ret == 0) {
-        ret = BUFFER_E; /* set default error */
-        switch (keyAlgo) {
-        #ifndef NO_DH
-            case WC_PK_TYPE_DH:
-                if (ssl != NULL)
-                    der = ssl->staticKE.dhKey;
-                if (der == NULL)
-                    der = ssl->ctx->staticKE.dhKey;
-                if (der != NULL) {
-                    DhKey* key = (DhKey*)keyPtr;
-                    WOLFSSL_MSG("Using static DH key");
-                    ret = wc_DhKeyDecode(der->buffer, &idx, key, der->length);
-                }
-                break;
-        #endif
-        #ifdef HAVE_ECC
-            case WC_PK_TYPE_ECDH:
-                if (ssl != NULL)
-                    der = ssl->staticKE.ecKey;
-                if (der == NULL)
-                    der = ssl->ctx->staticKE.ecKey;
-                if (der != NULL) {
-                    ecc_key* key = (ecc_key*)keyPtr;
-                    WOLFSSL_MSG("Using static ECDH key");
-                    ret = wc_EccPrivateKeyDecode(der->buffer, &idx, key,
-                        der->length);
-                }
-                break;
-        #endif
-        #ifdef HAVE_CURVE25519
-            case WC_PK_TYPE_CURVE25519:
-                if (ssl != NULL)
-                    der = ssl->staticKE.x25519Key;
-                if (der == NULL)
-                    der = ssl->ctx->staticKE.x25519Key;
-                if (der != NULL) {
-                    curve25519_key* key = (curve25519_key*)keyPtr;
-                    WOLFSSL_MSG("Using static X25519 key");
-                #ifdef WOLFSSL_CURVE25519_BLINDING
-                    ret = wc_curve25519_set_rng(key, ssl->rng);
-                    if (ret == 0)
-                #endif
-                    {
-                        ret = wc_Curve25519PrivateKeyDecode(der->buffer, &idx,
-                            key, der->length);
-                    }
-                }
-                break;
-        #endif
-        #ifdef HAVE_CURVE448
-            case WC_PK_TYPE_CURVE448:
-                if (ssl != NULL)
-                    der = ssl->staticKE.x448Key;
-                if (der == NULL)
-                    der = ssl->ctx->staticKE.x448Key;
-                if (der != NULL) {
-                    curve448_key* key = (curve448_key*)keyPtr;
-                    WOLFSSL_MSG("Using static X448 key");
-                    ret = wc_Curve448PrivateKeyDecode(der->buffer, &idx, key,
-                        der->length);
-                }
-                break;
-        #endif
-            default:
-                /* Not supported. */
-                ret = NOT_COMPILED_IN;
-                break;
-        }
-
-    #ifndef SINGLE_THREADED
-        wc_UnLockMutex(&ssl->ctx->staticKELock);
+    ret = BUFFER_E; /* set default error */
+    switch (keyAlgo) {
+    #ifndef NO_DH
+        case WC_PK_TYPE_DH:
+            if (ssl != NULL)
+                der = ssl->staticKE.dhKey;
+            if (der == NULL)
+                der = ssl->ctx->staticKE.dhKey;
+            if (der != NULL) {
+                DhKey* key = (DhKey*)keyPtr;
+                WOLFSSL_MSG("Using static DH key");
+                ret = wc_DhKeyDecode(der->buffer, &idx, key, der->length);
+            }
+            break;
     #endif
+    #ifdef HAVE_ECC
+        case WC_PK_TYPE_ECDH:
+            if (ssl != NULL)
+                der = ssl->staticKE.ecKey;
+            if (der == NULL)
+                der = ssl->ctx->staticKE.ecKey;
+            if (der != NULL) {
+                ecc_key* key = (ecc_key*)keyPtr;
+                WOLFSSL_MSG("Using static ECDH key");
+                ret = wc_EccPrivateKeyDecode(der->buffer, &idx, key,
+                    der->length);
+            }
+            break;
+    #endif
+    #ifdef HAVE_CURVE25519
+        case WC_PK_TYPE_CURVE25519:
+            if (ssl != NULL)
+                der = ssl->staticKE.x25519Key;
+            if (der == NULL)
+                der = ssl->ctx->staticKE.x25519Key;
+            if (der != NULL) {
+                curve25519_key* key = (curve25519_key*)keyPtr;
+                WOLFSSL_MSG("Using static X25519 key");
+
+            #ifdef WOLFSSL_CURVE25519_BLINDING
+                ret = wc_curve25519_set_rng(key, ssl->rng);
+                if (ret == 0)
+            #endif
+                    ret = wc_Curve25519PrivateKeyDecode(der->buffer, &idx, key,
+                        der->length);
+            }
+            break;
+    #endif
+    #ifdef HAVE_CURVE448
+        case WC_PK_TYPE_CURVE448:
+            if (ssl != NULL)
+                der = ssl->staticKE.x448Key;
+            if (der == NULL)
+                der = ssl->ctx->staticKE.x448Key;
+            if (der != NULL) {
+                curve448_key* key = (curve448_key*)keyPtr;
+                WOLFSSL_MSG("Using static X448 key");
+                ret = wc_Curve448PrivateKeyDecode(der->buffer, &idx, key,
+                    der->length);
+            }
+            break;
+    #endif
+        default:
+            /* not supported */
+            ret = NOT_COMPILED_IN;
+            break;
     }
 
+#ifndef SINGLE_THREADED
+    wc_UnLockMutex(&ssl->ctx->staticKELock);
+#endif
     return ret;
 }
 
@@ -2598,18 +2550,11 @@ static int SetStaticEphemeralKey(WOLFSSL_CTX* ctx,
 int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo,
     const char* key, unsigned int keySz, int format)
 {
-    int ret;
-
     if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
     }
-    else {
-        /* Store into the context's static ephemeral key store. */
-        ret = SetStaticEphemeralKey(ctx, &ctx->staticKE, keyAlgo, key, keySz,
-            format, ctx->heap);
-    }
-
-    return ret;
+    return SetStaticEphemeralKey(ctx, &ctx->staticKE, keyAlgo,
+        key, keySz, format, ctx->heap);
 }
 /* Set the static ephemeral key on the object.
  *
@@ -2622,21 +2567,14 @@ int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo,
  * @return  BAD_FUNC_ARG when ssl or its context is NULL.
  * @return  Other negative value on error.
  */
-int wolfSSL_set_ephemeral_key(WOLFSSL* ssl, int keyAlgo, const char* key,
-    unsigned int keySz, int format)
+int wolfSSL_set_ephemeral_key(WOLFSSL* ssl, int keyAlgo,
+    const char* key, unsigned int keySz, int format)
 {
-    int ret;
-
-    if ((ssl == NULL) || (ssl->ctx == NULL)) {
-        ret = BAD_FUNC_ARG;
+    if (ssl == NULL || ssl->ctx == NULL) {
+        return BAD_FUNC_ARG;
     }
-    else {
-        /* Store into the object's own static ephemeral key store. */
-        ret = SetStaticEphemeralKey(ssl->ctx, &ssl->staticKE, keyAlgo, key,
-            keySz, format, ssl->heap);
-    }
-
-    return ret;
+    return SetStaticEphemeralKey(ssl->ctx, &ssl->staticKE, keyAlgo,
+        key, keySz, format, ssl->heap);
 }
 
 /* Get the loaded static ephemeral key as ASN.1 DER data.
@@ -2650,86 +2588,71 @@ int wolfSSL_set_ephemeral_key(WOLFSSL* ssl, int keyAlgo, const char* key,
  * @return  NOT_COMPILED_IN when the key algorithm is not supported.
  * @return  Other negative value on error.
  */
-static int GetStaticEphemeralKey(WOLFSSL_CTX* ctx, WOLFSSL* ssl, int keyAlgo,
-    const unsigned char** key, unsigned int* keySz)
+static int GetStaticEphemeralKey(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    int keyAlgo, const unsigned char** key, unsigned int* keySz)
 {
     int ret = 0;
     DerBuffer* der = NULL;
 
-    if (key != NULL) {
-        *key = NULL;
-    }
-    if (keySz != NULL) {
-        *keySz = 0;
-    }
+    if (key)   *key = NULL;
+    if (keySz) *keySz = 0;
 
 #ifndef SINGLE_THREADED
-    if (ctx->staticKELockInit) {
-        ret = wc_LockMutex(&ctx->staticKELock);
+    if (ctx->staticKELockInit &&
+        (ret = wc_LockMutex(&ctx->staticKELock)) != 0) {
+        return ret;
     }
 #endif
 
-    if (ret == 0) {
-        switch (keyAlgo) {
-        #ifndef NO_DH
-            case WC_PK_TYPE_DH:
-                if (ssl != NULL) {
-                    der = ssl->staticKE.dhKey;
-                }
-                if (der == NULL) {
-                    der = ctx->staticKE.dhKey;
-                }
-                break;
-        #endif
-        #ifdef HAVE_ECC
-            case WC_PK_TYPE_ECDH:
-                if (ssl != NULL) {
-                    der = ssl->staticKE.ecKey;
-                }
-                if (der == NULL) {
-                    der = ctx->staticKE.ecKey;
-                }
-                break;
-        #endif
-        #ifdef HAVE_CURVE25519
-            case WC_PK_TYPE_CURVE25519:
-                if (ssl != NULL) {
-                    der = ssl->staticKE.x25519Key;
-                }
-                if (der == NULL) {
-                    der = ctx->staticKE.x25519Key;
-                }
-                break;
-        #endif
-        #ifdef HAVE_CURVE448
-            case WC_PK_TYPE_CURVE448:
-                if (ssl != NULL) {
-                    der = ssl->staticKE.x448Key;
-                }
-                if (der == NULL) {
-                    der = ctx->staticKE.x448Key;
-                }
-                break;
-        #endif
-            default:
-                /* Not supported. */
-                ret = NOT_COMPILED_IN;
-                break;
-        }
-
-        if (der != NULL) {
-            if (key != NULL) {
-                *key = der->buffer;
-            }
-            if (keySz != NULL) {
-                *keySz = der->length;
-            }
-        }
-
-    #ifndef SINGLE_THREADED
-        wc_UnLockMutex(&ctx->staticKELock);
+    switch (keyAlgo) {
+    #ifndef NO_DH
+        case WC_PK_TYPE_DH:
+            if (ssl != NULL)
+                der = ssl->staticKE.dhKey;
+            if (der == NULL)
+                der = ctx->staticKE.dhKey;
+            break;
     #endif
+    #ifdef HAVE_ECC
+        case WC_PK_TYPE_ECDH:
+            if (ssl != NULL)
+                der = ssl->staticKE.ecKey;
+            if (der == NULL)
+                der = ctx->staticKE.ecKey;
+            break;
+    #endif
+    #ifdef HAVE_CURVE25519
+        case WC_PK_TYPE_CURVE25519:
+            if (ssl != NULL)
+                der = ssl->staticKE.x25519Key;
+            if (der == NULL)
+                der = ctx->staticKE.x25519Key;
+            break;
+    #endif
+    #ifdef HAVE_CURVE448
+        case WC_PK_TYPE_CURVE448:
+            if (ssl != NULL)
+                der = ssl->staticKE.x448Key;
+            if (der == NULL)
+                der = ctx->staticKE.x448Key;
+            break;
+    #endif
+        default:
+            /* not supported */
+            ret = NOT_COMPILED_IN;
+            break;
     }
+
+    if (der) {
+        if (key)
+            *key = der->buffer;
+        if (keySz)
+            *keySz = der->length;
+    }
+
+#ifndef SINGLE_THREADED
+    wc_UnLockMutex(&ctx->staticKELock);
+#endif
 
     return ret;
 }
@@ -2749,17 +2672,11 @@ static int GetStaticEphemeralKey(WOLFSSL_CTX* ctx, WOLFSSL* ssl, int keyAlgo,
 int wolfSSL_CTX_get_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo,
     const unsigned char** key, unsigned int* keySz)
 {
-    int ret;
-
     if (ctx == NULL) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        /* No object given, so look the key up on the context only. */
-        ret = GetStaticEphemeralKey(ctx, NULL, keyAlgo, key, keySz);
+        return BAD_FUNC_ARG;
     }
 
-    return ret;
+    return GetStaticEphemeralKey(ctx, NULL, keyAlgo, key, keySz);
 }
 /* Get the static ephemeral key in use by the object as ASN.1 DER data.
  *
@@ -2774,17 +2691,11 @@ int wolfSSL_CTX_get_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo,
 int wolfSSL_get_ephemeral_key(WOLFSSL* ssl, int keyAlgo,
     const unsigned char** key, unsigned int* keySz)
 {
-    int ret;
-
-    if ((ssl == NULL) || (ssl->ctx == NULL)) {
-        ret = BAD_FUNC_ARG;
-    }
-    else {
-        /* Prefer the object's key, falling back to the context's. */
-        ret = GetStaticEphemeralKey(ssl->ctx, ssl, keyAlgo, key, keySz);
+    if (ssl == NULL || ssl->ctx == NULL) {
+        return BAD_FUNC_ARG;
     }
 
-    return ret;
+    return GetStaticEphemeralKey(ssl->ctx, ssl, keyAlgo, key, keySz);
 }
 
 #endif /* WOLFSSL_STATIC_EPHEMERAL */

--- a/tests/api/test_ssl_cert.c
+++ b/tests/api/test_ssl_cert.c
@@ -41,7 +41,7 @@ int test_wolfSSL_get_verify_mode(void)
     EXPECT_DECLS;
 #if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || defined(HAVE_STUNNEL) || \
      defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(WOLFSSL_NGINX)) && \
-    !defined(NO_CERTS) && !defined(NO_WOLFSSL_CLIENT)
+    !defined(NO_CERTS) && !defined(NO_WOLFSSL_CLIENT) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
     int mode;
@@ -79,7 +79,7 @@ int test_wolfSSL_CTX_get_verify_mode(void)
     EXPECT_DECLS;
 #if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || defined(HAVE_STUNNEL) || \
      defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(WOLFSSL_NGINX)) && \
-    !defined(NO_CERTS) && !defined(NO_WOLFSSL_CLIENT)
+    !defined(NO_CERTS) && !defined(NO_WOLFSSL_CLIENT) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     int mode;
 
@@ -114,7 +114,8 @@ int test_wolfSSL_CTX_get_verify_mode(void)
     return EXPECT_RESULT();
 }
 
-#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && !defined(NO_WOLFSSL_CLIENT)
+#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && !defined(NO_WOLFSSL_CLIENT) \
+    && !defined(NO_TLS)
 static int test_cert_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
 {
     (void)store;
@@ -125,7 +126,8 @@ static int test_cert_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
 int test_wolfSSL_get_verify_callback(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && !defined(NO_WOLFSSL_CLIENT)
+#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && !defined(NO_WOLFSSL_CLIENT) \
+    && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
 
@@ -154,7 +156,7 @@ int test_wolfSSL_CTX_get_extra_chain_certs(void)
 #if (defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || \
      defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)) && \
     !defined(NO_CERTS) && !defined(NO_FILESYSTEM) && !defined(NO_RSA) && \
-    !defined(NO_WOLFSSL_SERVER)
+    !defined(NO_WOLFSSL_SERVER) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLF_STACK_OF(WOLFSSL_X509)* sk = NULL;
 
@@ -298,7 +300,7 @@ int test_wolfSSL_get_chain_cert_pem(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(SESSION_CERTS) && \
-    !defined(WOLFSSL_NO_TLS12) && !defined(NO_RSA)
+    !defined(WOLFSSL_NO_TLS12) && !defined(NO_RSA) && !defined(NO_TLS)
     WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
     WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
     struct test_memio_ctx test_ctx;
@@ -369,7 +371,8 @@ int test_wolfSSL_cmp_peer_cert_to_file(void)
     EXPECT_DECLS;
 #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(OPENSSL_EXTRA) && \
     defined(KEEP_PEER_CERT) && defined(HAVE_EX_DATA) && \
-    !defined(NO_FILESYSTEM) && !defined(WOLFSSL_NO_TLS12) && !defined(NO_RSA)
+    !defined(NO_FILESYSTEM) && !defined(WOLFSSL_NO_TLS12) && !defined(NO_RSA) \
+    && !defined(NO_TLS)
     WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
     WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
     struct test_memio_ctx test_ctx;

--- a/tests/api/test_ssl_ext.c
+++ b/tests/api/test_ssl_ext.c
@@ -41,7 +41,7 @@ int test_wolfSSL_NoTicketTLSv12_ext(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_SESSION_TICKET) && !defined(NO_WOLFSSL_SERVER) && \
-    (defined(NO_CERTS) || !defined(NO_RSA))
+    (defined(NO_CERTS) || !defined(NO_RSA)) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
 
@@ -71,7 +71,7 @@ int test_wolfSSL_NoTicketTLSv12_ext(void)
 int test_wolfSSL_CTX_UseMaxFragment_ext(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_MAX_FRAGMENT) && !defined(NO_WOLFSSL_CLIENT)
+#if defined(HAVE_MAX_FRAGMENT) && !defined(NO_WOLFSSL_CLIENT) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
 
     /* NULL context is rejected. */
@@ -113,7 +113,7 @@ int test_wolfSSL_set1_groups_ext(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && defined(HAVE_SUPPORTED_CURVES) && \
-    !defined(NO_WOLFSSL_CLIENT)
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
     int dummy[1];
@@ -175,7 +175,7 @@ int test_wolfSSL_set1_groups_list_ext(void)
 int test_wolfSSL_CTX_set_TicketHint_ext(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_SESSION_TICKET) && !defined(NO_WOLFSSL_SERVER)
+#if defined(HAVE_SESSION_TICKET) && !defined(NO_WOLFSSL_SERVER) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
 
     ExpectIntEQ(wolfSSL_CTX_set_TicketHint(NULL, 100),
@@ -199,7 +199,7 @@ int test_wolfSSL_tlsext_max_fragment_length_ext(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && defined(HAVE_MAX_FRAGMENT) && \
-    !defined(NO_WOLFSSL_CLIENT)
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
 
@@ -321,7 +321,7 @@ int test_wolfSSL_set_tlsext_debug_arg_ext(void)
 int test_wolfSSL_set_SessionTicket_cb_ext(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_SESSION_TICKET) && !defined(NO_WOLFSSL_CLIENT)
+#if defined(HAVE_SESSION_TICKET) && !defined(NO_WOLFSSL_CLIENT) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
 
@@ -344,7 +344,7 @@ int test_wolfSSL_set1_curves_list_ext(void)
     EXPECT_DECLS;
 #if (defined(OPENSSL_EXTRA) || defined(HAVE_CURL)) && \
     (defined(HAVE_ECC) || defined(HAVE_CURVE25519) || defined(HAVE_CURVE448)) \
-    && !defined(NO_WOLFSSL_CLIENT)
+    && !defined(NO_WOLFSSL_CLIENT) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
 
@@ -434,7 +434,7 @@ int test_wolfSSL_tlsext_status_exts_ids_ext(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_WOLFSSL_STUB) &&                     \
-    !defined(NO_WOLFSSL_CLIENT)
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
 

--- a/tests/api/test_ssl_pk.c
+++ b/tests/api/test_ssl_pk.c
@@ -343,7 +343,7 @@ int test_wolfSSL_get_signature_nid(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_WOLFSSL_SERVER) && \
-    (defined(NO_CERTS) || !defined(NO_RSA))
+    (defined(NO_CERTS) || !defined(NO_RSA)) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
     int nid = 0;
@@ -392,7 +392,7 @@ int test_wolfSSL_get_signature_type_nid(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_WOLFSSL_SERVER) && \
-    (defined(NO_CERTS) || !defined(NO_RSA))
+    (defined(NO_CERTS) || !defined(NO_RSA)) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
     int nid = 0;
@@ -461,7 +461,7 @@ int test_wolfSSL_get_peer_signature_nid(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_WOLFSSL_SERVER) && \
-    (defined(NO_CERTS) || !defined(NO_RSA))
+    (defined(NO_CERTS) || !defined(NO_RSA)) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
     int nid = 0;
@@ -493,7 +493,7 @@ int test_wolfSSL_get_peer_signature_type_nid(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_WOLFSSL_SERVER) && \
-    (defined(NO_CERTS) || !defined(NO_RSA))
+    (defined(NO_CERTS) || !defined(NO_RSA)) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
     int nid = 0;
@@ -527,7 +527,8 @@ int test_wolfSSL_get_peer_signature_type_nid(void)
 int test_wolfSSL_SSL_CTX_set_tmp_ecdh(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC) && !defined(NO_WOLFSSL_SERVER)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC) && !defined(NO_WOLFSSL_SERVER) \
+    && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL_EC_KEY* ecdh = NULL;
 
@@ -552,7 +553,7 @@ int test_wolfSSL_SSL_CTX_set_tmp_ecdh(void)
 int test_wolfSSL_CTX_set_dh_auto(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_EXTRA) && !defined(NO_WOLFSSL_SERVER)
+#if defined(OPENSSL_EXTRA) && !defined(NO_WOLFSSL_SERVER) && !defined(NO_TLS)
     WOLFSSL_CTX* ctx = NULL;
 
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1092,6 +1092,8 @@ typedef WOLFSSL_METHOD* (*wolfSSL_method_func)(void* heap);
 
 /* CTX Method Constructor Functions */
 
+#ifndef NO_TLS
+
 #ifndef NO_WOLFSSL_CLIENT
     WOLFSSL_API WOLFSSL_METHOD *wolfTLS_client_method_ex(void* heap);
     WOLFSSL_API WOLFSSL_METHOD *wolfTLS_client_method(void);
@@ -1243,6 +1245,8 @@ WOLFSSL_API WOLFSSL_METHOD *wolfSSLv23_method(void);
 #endif /* WOLFSSL_DTLS13 */
 
 #endif /* WOLFSSL_DTLS */
+
+#endif /* !NO_TLS */
 
 #if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
 WOLFSSL_API int wolfSSL_CTX_GenerateEchConfig(WOLFSSL_CTX* ctx,


### PR DESCRIPTION
The first commit in this PR just reverts semantically unchanged functions refactored by 359e688dc3, reverting them to their exact pre-refactor form as of the prior commit, 4f09916e7e.  Several whitespace changes in these functions are also reverted.  All substantive changes in 359e688dc3 are carried forward.

--

`src/ssl_api_ext.c` and `src/ssl_api_pk.c`: restore early `BAD_FUNC_ARG` returns that were refactored away in 359e688dc3, fixing null pointer deref regression in `wolfSSL_UseALPN()` (possibly others too).

`wolfssl/ssl.h`: add !`NO_TLS` gate around prototypes for `wolf*_{client,server}_method*()` to induce compile-time failures for TLS/SSL usage in `NO_TLS` configurations.

`tests/api/test_ssl_cert.c`, `tests/api/test_ssl_ext.c`, `tests/api/test_ssl_pk.c`: add missing gates on !`NO_TLS`.

--

fixes failures on `all-no-tls`, `lms-xmss-wolfssl-all-clang-sanitizer`, `sanitizer-clang-all-noasm`, and `sanitizer-clang-all-intelasm`.

--

tested with
```
wolfssl-multi-test.sh ...
pr-check
```
