### PR TITLE
add sp_hex_iszero for catching edge case of negative zero value

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -18739,6 +18739,27 @@ int sp_read_radix(sp_int* a, const char* in, int radix)
 
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
     defined(WC_MP_TO_RADIX)
+/* Determine whether the magnitude of a is zero by scanning the digits.
+ *
+ * A non-normalized value (used >= 1 with all-zero digits, e.g. negative zero)
+ * is recognized as zero so that sp_radix_size() and sp_tohex() size and write
+ * the same canonical zero.
+ */
+static int sp_hex_iszero(const sp_int* a)
+{
+    int zero = 1;
+    unsigned int i;
+
+    for (i = 0; i < a->used; i++) {
+        if (a->dp[i] != 0) {
+            zero = 0;
+            break;
+        }
+    }
+
+    return zero;
+}
+
 /* Put the big-endian, hex string encoding of a into str.
  *
  * Assumes str is large enough for result.
@@ -18761,7 +18782,7 @@ int sp_tohex(const sp_int* a, char* str)
 
     if (err == MP_OKAY) {
         /* Quick out if number is zero. */
-        if (sp_iszero(a) == MP_YES) {
+        if (sp_hex_iszero(a)) {
         #ifndef WC_DISABLE_RADIX_ZERO_PAD
             /* Make string represent complete bytes. */
             *str++ = '0';
@@ -18983,7 +19004,8 @@ int sp_radix_size(const sp_int* a, int radix, int* size)
     }
     /* Handle base 16 if requested. */
     else if (radix == MP_RADIX_HEX) {
-        if (a->used == 0) {
+        /* Match sp_tohex() so a non-normalized zero is sized the same way. */
+        if (sp_hex_iszero(a)) {
         #ifndef WC_DISABLE_RADIX_ZERO_PAD
             /* 00 and '\0' */
             *size = 2 + 1;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -18763,6 +18763,27 @@ int sp_read_radix(sp_int* a, const char* in, int radix)
 
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
     defined(WC_MP_TO_RADIX)
+/* Determine whether the magnitude of a is zero by scanning the digits.
+ *
+ * A non-normalized value (used >= 1 with all-zero digits, e.g. negative zero)
+ * is recognized as zero so that sp_radix_size() and sp_tohex() size and write
+ * the same canonical zero.
+ */
+static int sp_hex_iszero(const sp_int* a)
+{
+    int zero = 1;
+    unsigned int i;
+
+    for (i = 0; i < a->used; i++) {
+        if (a->dp[i] != 0) {
+            zero = 0;
+            break;
+        }
+    }
+
+    return zero;
+}
+
 /* Put the big-endian, hex string encoding of a into str.
  *
  * Assumes str is large enough for result.
@@ -18785,7 +18806,7 @@ int sp_tohex(const sp_int* a, char* str)
 
     if (err == MP_OKAY) {
         /* Quick out if number is zero. */
-        if (sp_iszero(a) == MP_YES) {
+        if (sp_hex_iszero(a)) {
         #ifndef WC_DISABLE_RADIX_ZERO_PAD
             /* Make string represent complete bytes. */
             *str++ = '0';
@@ -19005,7 +19026,8 @@ int sp_radix_size(const sp_int* a, int radix, int* size)
     }
     /* Handle base 16 if requested. */
     else if (radix == MP_RADIX_HEX) {
-        if (a->used == 0) {
+        /* Match sp_tohex() so a non-normalized zero is sized the same way. */
+        if (sp_hex_iszero(a)) {
         #ifndef WC_DISABLE_RADIX_ZERO_PAD
             /* 00 and '\0' */
             *size = 2 + 1;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -18828,37 +18828,33 @@ int sp_tohex(const sp_int* a, char* str)
 
             /* Start at last digit - most significant digit. */
             i = (int)(a->used - 1);
+            /* Skip leading zero digits, there is at least one non-zero one. */
+            while ((i > 0) && (a->dp[i] == 0)) {
+                i--;
+            }
             d = a->dp[i];
         #ifndef WC_DISABLE_RADIX_ZERO_PAD
-            /* Find highest non-zero byte in most-significant word. */
-            for (j = SP_WORD_SIZE - 8; j >= 0 && i >= 0; j -= 8) {
+            /* Find highest non-zero byte in most-significant word.
+             * d is non-zero so a byte is always found. */
+            for (j = SP_WORD_SIZE - 8; j >= 0; j -= 8) {
                 /* When a byte at this index is not 0 break out to start
                  * writing.
                  */
                 if (((d >> j) & 0xff) != 0) {
                     break;
                 }
-                /* Skip this digit if it was 0. */
-                if (j == 0) {
-                    j = SP_WORD_SIZE - 8;
-                    d = a->dp[--i];
-                }
             }
             /* Start with high nibble of byte. */
             j += 4;
         #else
-            /* Find highest non-zero nibble in most-significant word. */
+            /* Find highest non-zero nibble in most-significant word.
+             * d is non-zero so a nibble is always found. */
             for (j = SP_WORD_SIZE - 4; j >= 0; j -= 4) {
                 /* When a nibble at this index is not 0 break out to start
                  * writing.
                  */
                 if (((d >> j) & 0xf) != 0) {
                     break;
-                }
-                /* Skip this digit if it was 0. */
-                if (j == 0) {
-                    j = SP_WORD_SIZE - 4;
-                    d = a->dp[--i];
                 }
             }
         #endif /* WC_DISABLE_RADIX_ZERO_PAD */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -75354,6 +75354,49 @@ static wc_test_ret_t mp_test_radix_16(mp_int* a, mp_int* r, WC_RNG* rng)
     if (!mp_iszero(r))
         return WC_TEST_RET_ENC_NC;
 
+#ifdef WOLFSSL_SP_MATH_ALL
+    /* Force a non-normalized zero (used > 0 with all-zero digits,
+     * e.g. a negative zero) to test with. */
+    mp_zero(a);
+    a->used = 2;
+    a->dp[0] = 0;
+    a->dp[1] = 0;
+#ifdef WOLFSSL_SP_INT_NEGATIVE
+    a->sign = MP_NEG;
+#endif
+    ret = mp_radix_size(a, MP_RADIX_HEX, &size);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+
+#ifndef WC_DISABLE_RADIX_ZERO_PAD
+    if (size != 3)
+        return WC_TEST_RET_ENC_NC;
+#else
+    if (size != 2)
+        return WC_TEST_RET_ENC_NC;
+#endif
+
+    XMEMSET(str, 0xff, sizeof(str));
+    ret = mp_tohex(a, str);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    if ((int)XSTRLEN(str) != size - 1)
+        return WC_TEST_RET_ENC_NC;
+
+#ifndef WC_DISABLE_RADIX_ZERO_PAD
+    if (XSTRCMP(str, "00") != 0)
+        return WC_TEST_RET_ENC_NC;
+#else
+    if (XSTRCMP(str, "0") != 0)
+        return WC_TEST_RET_ENC_NC;
+#endif
+
+    /* Nothing was written past the reported size. */
+    if ((unsigned char)str[size] != 0xff)
+        return WC_TEST_RET_ENC_NC;
+    mp_zero(a);
+#endif
+
 #ifdef WOLFSSL_SP_INT_NEGATIVE
     /* Negative values are written with a leading '-' and read back. */
     ret = mp_set(a, 0xABCD);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -75395,6 +75395,40 @@ static wc_test_ret_t mp_test_radix_16(mp_int* a, mp_int* r, WC_RNG* rng)
     if ((unsigned char)str[size] != 0xff)
         return WC_TEST_RET_ENC_NC;
     mp_zero(a);
+
+    /* Force a non-normalized non-zero value (zero most significant digit with
+     * only the top nibble of the next digit set) to check that leading zero
+     * digits are skipped without reading before dp[0]. */
+    mp_zero(a);
+    a->used = 2;
+    a->dp[0] = (sp_int_digit)1 << (SP_WORD_SIZE - 4);
+    a->dp[1] = 0;
+    ret = mp_radix_size(a, MP_RADIX_HEX, &size);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    /* "1" followed by the remaining nibbles of the digit and '\0'. */
+    if (size != (SP_WORD_SIZE / 4) + 1)
+        return WC_TEST_RET_ENC_NC;
+
+    XMEMSET(str, 0xff, sizeof(str));
+    ret = mp_tohex(a, str);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    if ((int)XSTRLEN(str) != size - 1)
+        return WC_TEST_RET_ENC_NC;
+    if (XSTRNCMP(str, "10", 2) != 0)
+        return WC_TEST_RET_ENC_NC;
+    /* Nothing was written past the reported size. */
+    if ((unsigned char)str[size] != 0xff)
+        return WC_TEST_RET_ENC_NC;
+
+    /* Reading the string back gives the normalized value. */
+    ret = mp_read_radix(r, str, MP_RADIX_HEX);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    if (r->used != 1 || r->dp[0] != ((sp_int_digit)1 << (SP_WORD_SIZE - 4)))
+        return WC_TEST_RET_ENC_NC;
+    mp_zero(a);
 #endif
 
 #ifdef WOLFSSL_SP_INT_NEGATIVE


### PR DESCRIPTION
Fix for oss-fuzz report when handling a sp_int that has 'used' greater than 0 but has a magnitude of 0.