### PR TITLE
Ed448: check for public key presence on export

### DIFF
--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -2761,6 +2761,7 @@ int wc_Ed25519PrivateKeyToDer(const ed25519_key* key, byte* output,
     \param key Ed25519 key structure with public key
     \param output Buffer for DER encoded public key
     \param outLen Size of output buffer
+    \param withAlg Whether to use SubjectPublicKeyInfo format.
 
     _Example_
     \code
@@ -2773,7 +2774,7 @@ int wc_Ed25519PrivateKeyToDer(const ed25519_key* key, byte* output,
     \sa wc_Ed25519PublicKeyDecode
 */
 int wc_Ed25519PublicKeyToDer(const ed25519_key* key, byte* output,
-                              word32 outLen);
+        word32 outLen, int withAlg);
 
 /*!
     \ingroup Ed448

--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -1999,7 +1999,7 @@ int wc_DsaParamsDecode(const byte* input, word32* inOutIdx,
 
     \param key DSA key structure with parameters
     \param output Buffer for DER encoded parameters
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
 
     _Example_
     \code
@@ -2010,7 +2010,7 @@ int wc_DsaParamsDecode(const byte* input, word32* inOutIdx,
 
     \sa wc_DsaParamsDecode
 */
-int wc_DsaKeyToParamsDer(DsaKey* key, byte* output, word32 inLen);
+int wc_DsaKeyToParamsDer(DsaKey* key, byte* output, word32 outLen);
 
 /*!
     \ingroup DSA
@@ -2021,7 +2021,7 @@ int wc_DsaKeyToParamsDer(DsaKey* key, byte* output, word32 inLen);
 
     \param key DSA key structure with parameters
     \param output Buffer for DER encoded parameters
-    \param inLen Pointer to buffer size (in/out)
+    \param outLen Pointer to buffer size (in/out)
 
     _Example_
     \code
@@ -2034,7 +2034,7 @@ int wc_DsaKeyToParamsDer(DsaKey* key, byte* output, word32 inLen);
     \sa wc_DsaKeyToParamsDer
 */
 int wc_DsaKeyToParamsDer_ex(DsaKey* key, byte* output,
-                             word32* inLen);
+                             word32* outLen);
 
 /*!
     \ingroup DH
@@ -2174,7 +2174,7 @@ int wc_EccPrivateKeyDecode(const byte* input, word32* inOutIdx,
 
     \param key ECC key structure with private key
     \param output Buffer for DER encoded private key
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
 
     _Example_
     \code
@@ -2186,7 +2186,7 @@ int wc_EccPrivateKeyDecode(const byte* input, word32* inOutIdx,
     \sa wc_EccPrivateKeyDecode
 */
 int wc_EccPrivateKeyToDer(ecc_key* key, byte* output,
-                          word32 inLen);
+                          word32 outLen);
 
 /*!
     \ingroup ECC
@@ -2217,7 +2217,7 @@ int wc_EccKeyDerSize(ecc_key* key, int pub);
 
     \param key ECC key structure with private key
     \param output Buffer for PKCS#8 encoded key
-    \param inLen Pointer to buffer size (in/out)
+    \param outLen Pointer to buffer size (in/out)
 
     _Example_
     \code
@@ -2230,7 +2230,7 @@ int wc_EccKeyDerSize(ecc_key* key, int pub);
     \sa wc_EccPrivateKeyToDer
 */
 int wc_EccPrivateKeyToPKCS8(ecc_key* key, byte* output,
-                             word32* inLen);
+                             word32* outLen);
 
 /*!
     \ingroup ECC
@@ -2241,7 +2241,7 @@ int wc_EccPrivateKeyToPKCS8(ecc_key* key, byte* output,
 
     \param key ECC key structure with key pair
     \param output Buffer for PKCS#8 encoded key
-    \param inLen Pointer to buffer size (in/out)
+    \param outLen Pointer to buffer size (in/out)
 
     _Example_
     \code
@@ -2254,7 +2254,7 @@ int wc_EccPrivateKeyToPKCS8(ecc_key* key, byte* output,
     \sa wc_EccPrivateKeyToPKCS8
 */
 int wc_EccKeyToPKCS8(ecc_key* key, byte* output,
-                     word32* inLen);
+                     word32* outLen);
 
 /*!
     \ingroup ECC
@@ -2283,7 +2283,7 @@ int wc_EccPublicKeyDerSize(ecc_key* key, int with_AlgCurve);
 
     \return Success On successfully writing the ECC key to der format,
     returns the length written to the buffer
-    \return BAD_FUNC_ARG Returned if key or output is null, or inLen equals zero
+    \return BAD_FUNC_ARG Returned if key or output is null, or outLen equals zero
     \return MEMORY_E Returned if there is an error allocating memory
     with XMALLOC
     \return BUFFER_E Returned if the converted certificate is too large
@@ -2299,7 +2299,7 @@ int wc_EccPublicKeyDerSize(ecc_key* key, int with_AlgCurve);
 
     \param key pointer to the buffer containing the input ecc key
     \param output pointer to a buffer in which to store the der formatted key
-    \param inLen the length of the buffer in which to store the
+    \param outLen the length of the buffer in which to store the
     der formatted key
 
     _Example_
@@ -2318,7 +2318,7 @@ int wc_EccPublicKeyDerSize(ecc_key* key, int with_AlgCurve);
 
     \sa wc_RsaKeyToDer
 */
-int wc_EccKeyToDer(ecc_key* key, byte* output, word32 inLen);
+int wc_EccKeyToDer(ecc_key* key, byte* output, word32 outLen);
 
 /*!
     \ingroup ASN
@@ -2370,7 +2370,7 @@ int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
 
     \param key Pointer to ECC key
     \param output Pointer to output buffer to write to.
-    \param inLen Size of buffer.
+    \param outLen Size of buffer.
     \param with_AlgCurve a flag for when to include a header that has the
     Algorithm and Curve information.
 
@@ -2394,7 +2394,7 @@ int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
     \sa wc_EccPrivateKeyDecode
 */
 int wc_EccPublicKeyToDer(ecc_key* key, byte* output,
-                                         word32 inLen, int with_AlgCurve);
+                                         word32 outLen, int with_AlgCurve);
 
 /*!
     \ingroup ASN
@@ -2412,7 +2412,7 @@ int wc_EccPublicKeyToDer(ecc_key* key, byte* output,
 
     \param key Pointer to ECC key
     \param output Pointer to output buffer to write to.
-    \param inLen Size of buffer.
+    \param outLen Size of buffer.
     \param with_AlgCurve a flag for when to include a header that has the
     Algorithm and Curve information.
     \param comp If 1 (non-zero) the ECC public key will be written in
@@ -2439,7 +2439,7 @@ int wc_EccPublicKeyToDer(ecc_key* key, byte* output,
     \sa wc_EccPublicKeyDecode
 */
 int wc_EccPublicKeyToDer_ex(ecc_key* key, byte* output,
-                                     word32 inLen, int with_AlgCurve, int comp);
+                                     word32 outLen, int with_AlgCurve, int comp);
 
 
 /*!
@@ -2571,7 +2571,7 @@ int wc_Curve25519KeyDecode(const byte* input, word32* inOutIdx,
     \param key Pointer to curve25519_key structure containing private key to
     encode
     \param output Buffer to hold DER encoding
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
 
     \sa wc_Curve25519KeyToDer
     \sa wc_Curve25519PublicKeyToDer
@@ -2587,7 +2587,7 @@ int wc_Curve25519KeyDecode(const byte* input, word32* inOutIdx,
     \endcode
 */
 int wc_Curve25519PrivateKeyToDer(curve25519_key* key, byte* output,
-                                 word32 inLen);
+                                 word32 outLen);
 
 /*!
     \ingroup ASN
@@ -2603,7 +2603,7 @@ int wc_Curve25519PrivateKeyToDer(curve25519_key* key, byte* output,
     \param key Pointer to curve25519_key structure containing public key to
     encode
     \param output Buffer to hold DER encoding
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
     \param withAlg Whether to include algorithm identifier in the DER encoding
 
     \sa wc_Curve25519KeyToDer
@@ -2619,7 +2619,7 @@ int wc_Curve25519PrivateKeyToDer(curve25519_key* key, byte* output,
     wc_Curve25519PublicKeyToDer(&key, der, derSz, 1);
     \endcode
 */
-int wc_Curve25519PublicKeyToDer(curve25519_key* key, byte* output, word32 inLen,
+int wc_Curve25519PublicKeyToDer(curve25519_key* key, byte* output, word32 outLen,
                                 int withAlg);
 
 /*!
@@ -2635,7 +2635,7 @@ int wc_Curve25519PublicKeyToDer(curve25519_key* key, byte* output, word32 inLen,
 
     \param key Pointer to curve25519_key structure containing key to encode
     \param output Buffer to hold DER encoding
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
     \param withAlg Whether to include algorithm identifier in the DER encoding
 
     \sa wc_Curve25519PrivateKeyToDer
@@ -2651,7 +2651,7 @@ int wc_Curve25519PublicKeyToDer(curve25519_key* key, byte* output, word32 inLen,
     wc_Curve25519KeyToDer(&key, der, derSz, 1);
     \endcode
 */
-int wc_Curve25519KeyToDer(curve25519_key* key, byte* output, word32 inLen,
+int wc_Curve25519KeyToDer(curve25519_key* key, byte* output, word32 outLen,
                           int withAlg);
 
 /*!
@@ -2713,7 +2713,7 @@ int wc_Ed25519PublicKeyDecode(const byte* input, word32* inOutIdx,
 
     \param key Ed25519 key structure
     \param output Buffer for DER encoded key
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
 
     _Example_
     \code
@@ -2725,7 +2725,7 @@ int wc_Ed25519PublicKeyDecode(const byte* input, word32* inOutIdx,
     \sa wc_Ed25519PrivateKeyToDer
 */
 int wc_Ed25519KeyToDer(const ed25519_key* key, byte* output,
-                       word32 inLen);
+                       word32 outLen);
 
 /*!
     \ingroup Ed25519
@@ -2736,7 +2736,7 @@ int wc_Ed25519KeyToDer(const ed25519_key* key, byte* output,
 
     \param key Ed25519 key structure with private key
     \param output Buffer for DER encoded private key
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
 
     _Example_
     \code
@@ -2749,7 +2749,7 @@ int wc_Ed25519KeyToDer(const ed25519_key* key, byte* output,
     \sa wc_Ed25519PrivateKeyDecode
 */
 int wc_Ed25519PrivateKeyToDer(const ed25519_key* key, byte* output,
-                               word32 inLen);
+                               word32 outLen);
 
 /*!
     \ingroup Ed25519
@@ -2760,7 +2760,7 @@ int wc_Ed25519PrivateKeyToDer(const ed25519_key* key, byte* output,
 
     \param key Ed25519 key structure with public key
     \param output Buffer for DER encoded public key
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
 
     _Example_
     \code
@@ -2773,7 +2773,7 @@ int wc_Ed25519PrivateKeyToDer(const ed25519_key* key, byte* output,
     \sa wc_Ed25519PublicKeyDecode
 */
 int wc_Ed25519PublicKeyToDer(const ed25519_key* key, byte* output,
-                              int inLen);
+                              word32 outLen);
 
 /*!
     \ingroup Ed448
@@ -2834,7 +2834,7 @@ int wc_Ed448PublicKeyDecode(const byte* input, word32* inOutIdx,
 
     \param key Ed448 key structure
     \param output Buffer for DER encoded key
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
 
     _Example_
     \code
@@ -2845,7 +2845,7 @@ int wc_Ed448PublicKeyDecode(const byte* input, word32* inOutIdx,
 
     \sa wc_Ed448PrivateKeyToDer
 */
-int wc_Ed448KeyToDer(const ed448_key* key, byte* output, word32 inLen);
+int wc_Ed448KeyToDer(const ed448_key* key, byte* output, word32 outLen);
 
 /*!
     \ingroup Ed448
@@ -2856,7 +2856,7 @@ int wc_Ed448KeyToDer(const ed448_key* key, byte* output, word32 inLen);
 
     \param key Ed448 key structure with private key
     \param output Buffer for DER encoded private key
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
 
     _Example_
     \code
@@ -2869,7 +2869,7 @@ int wc_Ed448KeyToDer(const ed448_key* key, byte* output, word32 inLen);
     \sa wc_Ed448PrivateKeyDecode
 */
 int wc_Ed448PrivateKeyToDer(const ed448_key* key, byte* output,
-                             word32 inLen);
+                             word32 outLen);
 
 /*!
     \ingroup Ed448
@@ -2880,7 +2880,7 @@ int wc_Ed448PrivateKeyToDer(const ed448_key* key, byte* output,
 
     \param key Ed448 key structure with public key
     \param output Buffer for DER encoded public key
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
     \param withAlg 1 to include algorithm identifier, 0 for key data only
 
     _Example_
@@ -2894,7 +2894,7 @@ int wc_Ed448PrivateKeyToDer(const ed448_key* key, byte* output,
     \sa wc_Ed448PublicKeyDecode
 */
 int wc_Ed448PublicKeyToDer(const ed448_key* key, byte* output,
-                            word32 inLen, int withAlg);
+                            word32 outLen, int withAlg);
 
 /*!
     \ingroup Curve448
@@ -2955,7 +2955,7 @@ int wc_Curve448PublicKeyDecode(const byte* input, word32* inOutIdx,
 
     \param key Curve448 key structure with private key
     \param output Buffer for DER encoded private key
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
 
     _Example_
     \code
@@ -2968,7 +2968,7 @@ int wc_Curve448PublicKeyDecode(const byte* input, word32* inOutIdx,
     \sa wc_Curve448PrivateKeyDecode
 */
 int wc_Curve448PrivateKeyToDer(curve448_key* key, byte* output,
-                                word32 inLen);
+                                word32 outLen);
 
 /*!
     \ingroup Curve448
@@ -2979,7 +2979,7 @@ int wc_Curve448PrivateKeyToDer(curve448_key* key, byte* output,
 
     \param key Curve448 key structure with public key
     \param output Buffer for DER encoded public key
-    \param inLen Size of output buffer
+    \param outLen Size of output buffer
 
     _Example_
     \code
@@ -2992,7 +2992,7 @@ int wc_Curve448PrivateKeyToDer(curve448_key* key, byte* output,
     \sa wc_Curve448PublicKeyDecode
 */
 int wc_Curve448PublicKeyToDer(curve448_key* key, byte* output,
-                               word32 inLen);
+                               word32 outLen);
 
 /*!
     \ingroup ASN

--- a/doc/dox_comments/header_files/dsa.h
+++ b/doc/dox_comments/header_files/dsa.h
@@ -296,7 +296,7 @@ int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
 /*!
     \ingroup DSA
 
-    \brief Convert DsaKey key to DER format, write to output (inLen),
+    \brief Convert DsaKey key to DER format, write to output (outLen),
     return bytes written.
 
     \return outLen Success, number of bytes written
@@ -306,7 +306,7 @@ int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
 
     \param key Pointer to DsaKey structure to convert.
     \param output Pointer to output buffer for converted key.
-    \param inLen Length of key input.
+    \param outLen Length of output buffer.
 
     _Example_
     \code
@@ -326,7 +326,7 @@ int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
     \sa wc_FreeDsaKey
     \sa wc_MakeDsaKey
 */
-int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen);
+int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 outLen);
 
 /*!
     \ingroup DSA
@@ -496,7 +496,7 @@ int wc_SetDsaPublicKey(byte* output, DsaKey* key, int outLen,
 
     \param key DSA key
     \param output Output buffer
-    \param inLen Output buffer length
+    \param outLen Output buffer length
 
     _Example_
     \code
@@ -523,7 +523,7 @@ int wc_SetDsaPublicKey(byte* output, DsaKey* key, int outLen,
 
     \sa wc_SetDsaPublicKey
 */
-int wc_DsaKeyToPublicDer(DsaKey* key, byte* output, word32 inLen);
+int wc_DsaKeyToPublicDer(DsaKey* key, byte* output, word32 outLen);
 
 /*!
     \ingroup DSA

--- a/doc/dox_comments/header_files/ed25519.h
+++ b/doc/dox_comments/header_files/ed25519.h
@@ -904,6 +904,7 @@ int wc_ed25519_export_private(const ed25519_key* key, byte* out, word32* outLen)
     \return BAD_FUNC_ARG Returned if any of the input values evaluate to NULL.
     \return BUFFER_E Returned if the buffer provided is not large enough
     to store the key pair.
+    \return PUBLIC_KEY_E the given key only has a private key present.
 
     \param [in] key Pointer to an ed25519_key structure from which to export
     the key pair.

--- a/doc/dox_comments/header_files/ed448.h
+++ b/doc/dox_comments/header_files/ed448.h
@@ -665,6 +665,7 @@ int wc_ed448_import_private_key_ex(const byte* priv, word32 privSz,
     \return BUFFER_E Returned if the buffer provided is not large enough to
     store the private key. Upon returning this error, the function sets the
     size required in outLen.
+    \return PUBLIC_KEY_E the given key only has a private key present.
 
     \param [in] key Pointer to an ed448_key structure from which to export the
     public key.

--- a/doc/dox_comments/header_files/ed448.h
+++ b/doc/dox_comments/header_files/ed448.h
@@ -791,6 +791,7 @@ int wc_ed448_export_private(const ed448_key* key, byte* out, word32* outLen);
     \return ECC_BAD_ARG_E Returned if any of the input values evaluate to NULL.
     \return BUFFER_E Returned if the buffer provided is not large enough
     to store the key pair.
+    \return PUBLIC_KEY_E the given key only has a private key present.
 
     \param [in] key Pointer to an ed448_key structure from which to export
     the key pair.

--- a/doc/dox_comments/header_files/rsa.h
+++ b/doc/dox_comments/header_files/rsa.h
@@ -1163,12 +1163,12 @@ int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
 
     \return >0 Success, number of bytes written.
     \return BAD_FUNC_ARG Returned if key or output is null, or if key->type
-    is not RSA_PRIVATE, or if inLen isn't large enough for output buffer.
+    is not RSA_PRIVATE, or if outLen isn't large enough for output buffer.
     \return MEMORY_E Returned if there is an error allocating memory.
 
     \param key Initialized RsaKey structure.
     \param output Pointer to output buffer.
-    \param inLen Size of output buffer.
+    \param outLen Size of output buffer.
 
     _Example_
     \code
@@ -1193,7 +1193,7 @@ int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
     \sa wc_MakeRsaKey
     \sa wc_InitRng
 */
-int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen);
+int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 outLen);
 
 /*!
     \ingroup RSA
@@ -1408,7 +1408,7 @@ int  wc_RsaFlattenPublicKey(const RsaKey* key, byte* e, word32* eSz, byte* n,
 
     \param key The RSA key structure to convert.
     \param output Output buffer to hold DER. (if NULL will return length only)
-    \param inLen Length of buffer.
+    \param outLen Length of buffer.
 
     _Example_
     \code
@@ -1428,7 +1428,7 @@ int  wc_RsaFlattenPublicKey(const RsaKey* key, byte* e, word32* eSz, byte* n,
     \sa wc_RsaKeyToPublicDer_ex
     \sa wc_InitRsaKey
 */
-int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen);
+int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 outLen);
 
 /*!
     \ingroup RSA
@@ -1444,7 +1444,7 @@ int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen);
 
     \param key The RSA key structure to convert.
     \param output Output buffer to hold DER. (if NULL will return length only)
-    \param inLen Length of buffer.
+    \param outLen Length of buffer.
 
     _Example_
     \code
@@ -1464,7 +1464,7 @@ int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen);
     \sa wc_RsaKeyToPublicDer
     \sa wc_InitRsaKey
 */
-int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
+int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 outLen,
     int with_header);
 
 /*!

--- a/tests/api/test_ed25519.c
+++ b/tests/api/test_ed25519.c
@@ -557,7 +557,9 @@ int test_wc_Ed25519PublicKeyToDer(void)
     (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN))
     ed25519_key key;
     byte        derBuf[1024];
+    WC_RNG rng;
 
+    XMEMSET(&rng, 0, sizeof(WC_RNG));
     XMEMSET(&key, 0, sizeof(ed25519_key));
 
     /* Test bad args */
@@ -576,12 +578,15 @@ int test_wc_Ed25519PublicKeyToDer(void)
 #endif
     wc_ed25519_free(&key);
 
+    ExpectIntEQ(wc_ed25519_init(&key), 0);
+    ExpectIntEQ(wc_InitRng(&rng), 0);
+    ExpectIntEQ(wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key), 0);
+    ExpectIntEQ(wc_Ed25519PublicKeyToDer(&key, derBuf, 0, 0),
+        WC_NO_ERR_TRACE(BUFFER_E));
+    wc_ed25519_free(&key);
+
     /*  Test good args */
     if (EXPECT_SUCCESS()) {
-        WC_RNG rng;
-
-        XMEMSET(&rng, 0, sizeof(WC_RNG));
-
         ExpectIntEQ(wc_ed25519_init(&key), 0);
         ExpectIntEQ(wc_InitRng(&rng), 0);
         ExpectIntEQ(wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key), 0);

--- a/tests/api/test_ed25519.c
+++ b/tests/api/test_ed25519.c
@@ -583,6 +583,7 @@ int test_wc_Ed25519PublicKeyToDer(void)
     ExpectIntEQ(wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key), 0);
     ExpectIntEQ(wc_Ed25519PublicKeyToDer(&key, derBuf, 0, 0),
         WC_NO_ERR_TRACE(BUFFER_E));
+    DoExpectIntEQ(wc_FreeRng(&rng), 0);
     wc_ed25519_free(&key);
 
     /*  Test good args */

--- a/tests/api/test_ed448.c
+++ b/tests/api/test_ed448.c
@@ -501,8 +501,16 @@ int test_wc_Ed448PublicKeyToDer(void)
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
     ExpectIntEQ(wc_ed448_init(&key), 0);
+#if defined(HAVE_FIPS) && FIPS_VERSION3_LT(7,0,0)
+    if (EXPECT_SUCCESS()) {
+        int ret = wc_Ed448PublicKeyToDer(&key, derBuf, 0, 0);
+        ExpectTrue((ret == WC_NO_ERR_TRACE(BUFFER_E)) ||
+                   (ret == WC_NO_ERR_TRACE(PUBLIC_KEY_E)));
+    }
+#else
     ExpectIntEQ(wc_Ed448PublicKeyToDer(&key, derBuf, 0, 0),
         WC_NO_ERR_TRACE(PUBLIC_KEY_E));
+#endif
     wc_ed448_free(&key);
 
     ExpectIntEQ(wc_ed448_init(&key), 0);

--- a/tests/api/test_ed448.c
+++ b/tests/api/test_ed448.c
@@ -500,7 +500,7 @@ int test_wc_Ed448PublicKeyToDer(void)
 
     ExpectIntEQ(wc_ed448_init(&key), 0);
     ExpectIntEQ(wc_Ed448PublicKeyToDer(&key, derBuf, 0, 0),
-        WC_NO_ERR_TRACE(BUFFER_E));
+        WC_NO_ERR_TRACE(PUBLIC_KEY_E));
     wc_ed448_free(&key);
 
     /*  Test good args */

--- a/tests/api/test_ed448.c
+++ b/tests/api/test_ed448.c
@@ -510,6 +510,7 @@ int test_wc_Ed448PublicKeyToDer(void)
     ExpectIntEQ(wc_ed448_make_key(&rng, ED448_KEY_SIZE, &key), 0);
     ExpectIntEQ(wc_Ed448PublicKeyToDer(&key, derBuf, 0, 0),
         WC_NO_ERR_TRACE(BUFFER_E));
+    DoExpectIntEQ(wc_FreeRng(&rng), 0);
     wc_ed448_free(&key);
 
     /*  Test good args */

--- a/tests/api/test_ed448.c
+++ b/tests/api/test_ed448.c
@@ -491,7 +491,9 @@ int test_wc_Ed448PublicKeyToDer(void)
     (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN))
     ed448_key key;
     byte      derBuf[1024];
+    WC_RNG rng;
 
+    XMEMSET(&rng, 0, sizeof(WC_RNG));
     XMEMSET(&key, 0, sizeof(ed448_key));
 
     /* Test bad args */
@@ -503,12 +505,15 @@ int test_wc_Ed448PublicKeyToDer(void)
         WC_NO_ERR_TRACE(PUBLIC_KEY_E));
     wc_ed448_free(&key);
 
+    ExpectIntEQ(wc_ed448_init(&key), 0);
+    ExpectIntEQ(wc_InitRng(&rng), 0);
+    ExpectIntEQ(wc_ed448_make_key(&rng, ED448_KEY_SIZE, &key), 0);
+    ExpectIntEQ(wc_Ed448PublicKeyToDer(&key, derBuf, 0, 0),
+        WC_NO_ERR_TRACE(BUFFER_E));
+    wc_ed448_free(&key);
+
     /*  Test good args */
     if (EXPECT_SUCCESS()) {
-        WC_RNG rng;
-
-        XMEMSET(&rng, 0, sizeof(WC_RNG));
-
         ExpectIntEQ(wc_ed448_init(&key), 0);
         ExpectIntEQ(wc_InitRng(&rng), 0);
         ExpectIntEQ(wc_ed448_make_key(&rng, ED448_KEY_SIZE, &key), 0);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4361,7 +4361,7 @@ static int GetAlgoIdImpl(const byte* input, word32* inOutIdx, word32* oid, word3
 static int _RsaPrivateKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key, int* keySz, word32 inSz);
 #endif
 #ifndef NO_DSA
-static int DsaKeyIntsToDer(DsaKey* key, byte* output, word32* inLen, int ints, int includeVersion);
+static int DsaKeyIntsToDer(DsaKey* key, byte* output, word32* outLen, int ints, int includeVersion);
 #endif
 #if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT)
 static int SetEccPublicKey(byte* output, ecc_key* key, int outLen, int with_header, int comp);
@@ -12249,14 +12249,14 @@ int wc_SetDsaPublicKey(byte* output, DsaKey* key, int outLen, int with_header)
  *          encoding size.
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
-int wc_DsaKeyToPublicDer(DsaKey* key, byte* output, word32 inLen)
+int wc_DsaKeyToPublicDer(DsaKey* key, byte* output, word32 outLen)
 {
-    return wc_SetDsaPublicKey(output, key, (int)inLen, 1);
+    return wc_SetDsaPublicKey(output, key, (int)outLen, 1);
 }
 #endif /* !HAVE_SELFTEST && (WOLFSSL_KEY_GEN || WOLFSSL_CERT_GEN) */
 
 #ifdef WOLFSSL_ASN_TEMPLATE
-static int DsaKeyIntsToDer(DsaKey* key, byte* output, word32* inLen,
+static int DsaKeyIntsToDer(DsaKey* key, byte* output, word32* outLen,
                            int ints, int includeVersion)
 {
     DECL_ASNSETDATA(dataASN, dsaKeyASN_Length);
@@ -12265,7 +12265,7 @@ static int DsaKeyIntsToDer(DsaKey* key, byte* output, word32* inLen,
 
     (void)ints;
 
-    if ((key == NULL) || (inLen == NULL)) {
+    if ((key == NULL) || (outLen == NULL)) {
         ret = BAD_FUNC_ARG;
     }
     if ((ret == 0) && (ints > DSA_INTS)) {
@@ -12297,11 +12297,11 @@ static int DsaKeyIntsToDer(DsaKey* key, byte* output, word32* inLen,
         ret = SizeASN_Items(dsaKeyASN, dataASN, dsaKeyASN_Length, &sz);
     }
     if ((ret == 0) && (output == NULL)) {
-        *inLen = sz;
+        *outLen = sz;
         ret = WC_NO_ERR_TRACE(LENGTH_ONLY_E);
     }
     /* Check buffer is big enough for encoding. */
-    if ((ret == 0) && (sz > *inLen)) {
+    if ((ret == 0) && (sz > *outLen)) {
         ret = BAD_FUNC_ARG;
     }
     if (ret == 0) {
@@ -12319,13 +12319,13 @@ static int DsaKeyIntsToDer(DsaKey* key, byte* output, word32* inLen,
  *
  * @param [in]  key          DSA key object.
  * @param [out] output       Buffer to hold encoded data.
- * @param [out] inLen        Length of buffer.
+ * @param [out] outLen       Length of buffer.
  * @return  Size of encoded data in bytes on success.
  * @return  BAD_FUNC_ARG when key or output is NULL, or key is not a private key
  *          or, buffer size is smaller than encoding size.
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
-int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen)
+int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 outLen)
 {
     if (!key || !output)
         return BAD_FUNC_ARG;
@@ -12333,29 +12333,29 @@ int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen)
     if (key->type != DSA_PRIVATE)
         return BAD_FUNC_ARG;
 
-    return DsaKeyIntsToDer(key, output, &inLen, DSA_INTS, 1);
+    return DsaKeyIntsToDer(key, output, &outLen, DSA_INTS, 1);
 }
 
-/* Convert DsaKey parameters to DER format, write to output (inLen),
+/* Convert DsaKey parameters to DER format, write to output (outLen),
    return bytes written. Version is excluded to be compatible with
    OpenSSL d2i_DSAparams */
-int wc_DsaKeyToParamsDer(DsaKey* key, byte* output, word32 inLen)
+int wc_DsaKeyToParamsDer(DsaKey* key, byte* output, word32 outLen)
 {
     if (!key || !output)
         return BAD_FUNC_ARG;
 
-    return DsaKeyIntsToDer(key, output, &inLen, DSA_PARAM_INTS, 0);
+    return DsaKeyIntsToDer(key, output, &outLen, DSA_PARAM_INTS, 0);
 }
 
 /* This version of the function allows output to be NULL. In that case, the
    DsaKeyIntsToDer will return WC_NO_ERR_TRACE(LENGTH_ONLY_E) and the required
-   output buffer size will be pointed to by inLen. */
-int wc_DsaKeyToParamsDer_ex(DsaKey* key, byte* output, word32* inLen)
+   output buffer size will be pointed to by outLen. */
+int wc_DsaKeyToParamsDer_ex(DsaKey* key, byte* output, word32* outLen)
 {
-    if (!key || !inLen)
+    if (!key || !outLen)
         return BAD_FUNC_ARG;
 
-    return DsaKeyIntsToDer(key, output, inLen, DSA_PARAM_INTS, 0);
+    return DsaKeyIntsToDer(key, output, outLen, DSA_PARAM_INTS, 0);
 }
 
 #endif /* NO_DSA */
@@ -12887,23 +12887,23 @@ static int SetEccPublicKey(byte* output, ecc_key* key, int outLen,
  *
  * @param [in]  key            ECC key object.
  * @param [out] output         Buffer to hold DER encoding.
- * @param [in]  inLen          Size of buffer in bytes.
+ * @param [in]  outLen         Size of buffer in bytes.
  * @param [in]  with_AlgCurve  Whether to use SubjectPublicKeyInfo format.
  * @return  Size of encoded data in bytes on success.
  * @return  BAD_FUNC_ARG when key or key's parameters is NULL.
  * @return  MEMORY_E when dynamic memory allocation failed.
  */
 WOLFSSL_ABI
-int wc_EccPublicKeyToDer(ecc_key* key, byte* output, word32 inLen,
+int wc_EccPublicKeyToDer(ecc_key* key, byte* output, word32 outLen,
                                                               int with_AlgCurve)
 {
-    return SetEccPublicKey(output, key, (int)inLen, with_AlgCurve, 0);
+    return SetEccPublicKey(output, key, (int)outLen, with_AlgCurve, 0);
 }
 
-int wc_EccPublicKeyToDer_ex(ecc_key* key, byte* output, word32 inLen,
+int wc_EccPublicKeyToDer_ex(ecc_key* key, byte* output, word32 outLen,
                                                     int with_AlgCurve, int comp)
 {
-    return SetEccPublicKey(output, key, (int)inLen, with_AlgCurve, comp);
+    return SetEccPublicKey(output, key, (int)outLen, with_AlgCurve, comp);
 }
 
 int wc_EccPublicKeyDerSize(ecc_key* key, int with_AlgCurve)
@@ -13035,7 +13035,7 @@ int SetAsymKeyDerPublic(const byte* pubKey, word32 pubKeyLen,
  * @return  BAD_FUNC_ARG when key is NULL.
  * @return  MEMORY_E when dynamic memory allocation failed.
  */
-int wc_Ed25519PublicKeyToDer(const ed25519_key* key, byte* output, word32 inLen,
+int wc_Ed25519PublicKeyToDer(const ed25519_key* key, byte* output, word32 outLen,
                              int withAlg)
 {
     int    ret;
@@ -13052,7 +13052,7 @@ int wc_Ed25519PublicKeyToDer(const ed25519_key* key, byte* output, word32 inLen,
     ret = wc_ed25519_export_public(key, pubKey, &pubKeyLen);
     #endif
     if (ret == 0) {
-        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, inLen,
+        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, outLen,
             ED25519k, withAlg);
     }
     return ret;
@@ -13072,7 +13072,7 @@ int wc_Ed25519PublicKeyToDer(const ed25519_key* key, byte* output, word32 inLen,
  * @return  BAD_FUNC_ARG when key is NULL.
  * @return  MEMORY_E when dynamic memory allocation failed.
  */
-int wc_Ed448PublicKeyToDer(const ed448_key* key, byte* output, word32 inLen,
+int wc_Ed448PublicKeyToDer(const ed448_key* key, byte* output, word32 outLen,
                            int withAlg)
 {
     int    ret;
@@ -13089,7 +13089,7 @@ int wc_Ed448PublicKeyToDer(const ed448_key* key, byte* output, word32 inLen,
     ret = wc_ed448_export_public(key, pubKey, &pubKeyLen);
     #endif
     if (ret == 0) {
-        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, inLen,
+        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, outLen,
             ED448k, withAlg);
     }
     return ret;
@@ -13107,12 +13107,12 @@ int wc_Ed448PublicKeyToDer(const ed448_key* key, byte* output, word32 inLen,
  *
  * @param [in]  key       LMS key object.
  * @param [out] output    Buffer to put encoded data in.
- * @param [in]  inLen     Size of buffer in bytes.
+ * @param [in]  outLen    Size of buffer in bytes.
  * @param [in]  withAlg   Whether to use SubjectPublicKeyInfo format.
  * @return  Size of encoded data in bytes on success.
  * @return  BAD_FUNC_ARG when key is NULL.
  */
-int wc_LmsKey_PublicKeyToDer(const LmsKey* key, byte* output, word32 inLen,
+int wc_LmsKey_PublicKeyToDer(const LmsKey* key, byte* output, word32 outLen,
                              int withAlg)
 {
     int    ret;
@@ -13125,7 +13125,7 @@ int wc_LmsKey_PublicKeyToDer(const LmsKey* key, byte* output, word32 inLen,
 
     ret = wc_LmsKey_ExportPubRaw(key, pubKey, &pubKeyLen);
     if (ret == 0) {
-        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, inLen,
+        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, outLen,
             HSS_LMSk, withAlg);
     }
     return ret;
@@ -13143,12 +13143,12 @@ int wc_LmsKey_PublicKeyToDer(const LmsKey* key, byte* output, word32 inLen,
  *
  * @param [in]  key       XMSS key object.
  * @param [out] output    Buffer to put encoded data in.
- * @param [in]  inLen     Size of buffer in bytes.
+ * @param [in]  outLen    Size of buffer in bytes.
  * @param [in]  withAlg   Whether to use SubjectPublicKeyInfo format.
  * @return  Size of encoded data in bytes on success.
  * @return  BAD_FUNC_ARG when key is NULL.
  */
-int wc_XmssKey_PublicKeyToDer(const XmssKey* key, byte* output, word32 inLen,
+int wc_XmssKey_PublicKeyToDer(const XmssKey* key, byte* output, word32 outLen,
                               int withAlg)
 {
     int    ret;
@@ -13164,7 +13164,7 @@ int wc_XmssKey_PublicKeyToDer(const XmssKey* key, byte* output, word32 inLen,
 
     ret = wc_XmssKey_ExportPubRaw(key, pubKey, &pubKeyLen);
     if (ret == 0) {
-        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, inLen,
+        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, outLen,
             keyType, withAlg);
     }
     return ret;
@@ -26149,22 +26149,22 @@ int wc_RsaPublicKeyDerSize(RsaKey* key, int with_header)
  *
  * @param [in]  key     RSA key object.
  * @param [out] output  Buffer to put encoded data in.
- * @param [in]  inLen   Size of buffer in bytes.
+ * @param [in]  outLen  Size of buffer in bytes.
  * @return  Size of encoded data in bytes on success.
  * @return  BAD_FUNC_ARG when key or output is NULL.
  * @return  MEMORY_E when dynamic memory allocation failed.
  */
-int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen)
+int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 outLen)
 {
-    return SetRsaPublicKey(output, key, (int)inLen, 1);
+    return SetRsaPublicKey(output, key, (int)outLen, 1);
 }
 
 /* Returns public DER version of the RSA key. If with_header is 0 then only a
  * seq + n + e is returned in ASN.1 DER format */
-int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
+int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 outLen,
     int with_header)
 {
-    return SetRsaPublicKey(output, key, (int)inLen, with_header);
+    return SetRsaPublicKey(output, key, (int)outLen, with_header);
 }
 
 #endif /* !NO_RSA && WOLFSSL_KEY_TO_DER */
@@ -26178,13 +26178,13 @@ int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
  *
  * @param [in]  key     RSA key object.
  * @param [out] output  Buffer to put encoded data in.
- * @param [in]  inLen   Size of buffer in bytes.
+ * @param [in]  outLen  Size of buffer in bytes.
  * @return  Size of encoded data in bytes on success.
  * @return  BAD_FUNC_ARG when key is NULL or not a private key.
  * @return  MEMORY_E when dynamic memory allocation failed.
  */
 #ifdef WOLFSSL_ASN_TEMPLATE
-int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
+int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 outLen)
 {
     DECL_ASNSETDATA(dataASN, rsaKeyASN_Length);
     int i;
@@ -26210,7 +26210,7 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
         ret = SizeASN_Items(rsaKeyASN, dataASN, rsaKeyASN_Length, &sz);
     }
     /* Check output buffer has enough space for encoding. */
-    if ((ret == 0) && (output != NULL) && (sz > inLen)) {
+    if ((ret == 0) && (output != NULL) && (sz > outLen)) {
         ret = BAD_FUNC_ARG;
     }
     if ((ret == 0) && (output != NULL)) {
@@ -32356,7 +32356,7 @@ int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
 /* build DER formatted ECC key, include optional public key if requested,
  * return length on success, negative on error */
 #ifdef WOLFSSL_ASN_TEMPLATE
-int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
+int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *outLen,
                              int pubIn, int curveIn)
 {
     DECL_ASNSETDATA(dataASN, eccKeyASN_Length);
@@ -32367,7 +32367,7 @@ int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
     int curveIdSz = 0;
 
     /* Check validity of parameters. */
-    if ((key == NULL) || ((output == NULL) && (inLen == NULL))) {
+    if ((key == NULL) || ((output == NULL) && (outLen == NULL))) {
         ret = BAD_FUNC_ARG;
     }
 
@@ -32427,11 +32427,11 @@ int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
     }
     /* Return the size if no buffer. */
     if ((ret == 0) && (output == NULL)) {
-        *inLen = sz;
+        *outLen = sz;
         ret = WC_NO_ERR_TRACE(LENGTH_ONLY_E);
     }
     /* Check the buffer is big enough. */
-    if ((ret == 0) && (inLen != NULL) && (sz > *inLen)) {
+    if ((ret == 0) && (outLen != NULL) && (sz > *outLen)) {
         ret = BAD_FUNC_ARG;
     }
     if ((ret == 0) && (output != NULL)) {
@@ -32484,9 +32484,9 @@ int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
  * length on success else < 0 */
 /* Note: use wc_EccKeyDerSize to get length only */
 WOLFSSL_ABI
-int wc_EccKeyToDer(ecc_key* key, byte* output, word32 inLen)
+int wc_EccKeyToDer(ecc_key* key, byte* output, word32 outLen)
 {
-    return wc_BuildEccKeyDer(key, output, &inLen, 1, 1);
+    return wc_BuildEccKeyDer(key, output, &outLen, 1, 1);
 }
 
 /* Write only private ecc key to DER format,
@@ -32503,11 +32503,11 @@ int wc_EccKeyDerSize(ecc_key* key, int pub)
 
 /* Write only private ecc key to DER format,
  * length on success else < 0 */
-int wc_EccPrivateKeyToDer(ecc_key* key, byte* output, word32 inLen)
+int wc_EccPrivateKeyToDer(ecc_key* key, byte* output, word32 outLen)
 {
-    int ret = wc_BuildEccKeyDer(key, output, &inLen, 0, 1);
+    int ret = wc_BuildEccKeyDer(key, output, &outLen, 0, 1);
     if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
-        return (int)inLen;
+        return (int)outLen;
     }
     return ret;
 }
@@ -33333,24 +33333,24 @@ int SetAsymKeyDer(const byte* privKey, word32 privKeyLen,
 #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
 /* Write a Private ED25519 key, including public to DER format,
  * length on success else < 0 */
-int wc_Ed25519KeyToDer(const ed25519_key* key, byte* output, word32 inLen)
+int wc_Ed25519KeyToDer(const ed25519_key* key, byte* output, word32 outLen)
 {
     if (key == NULL) {
         return BAD_FUNC_ARG;
     }
     return SetAsymKeyDer(key->k, ED25519_KEY_SIZE,
-        key->p, ED25519_PUB_KEY_SIZE, output, inLen, ED25519k);
+        key->p, ED25519_PUB_KEY_SIZE, output, outLen, ED25519k);
 }
 
 /* Write only private ED25519 key to DER format,
  * length on success else < 0 */
-int wc_Ed25519PrivateKeyToDer(const ed25519_key* key, byte* output, word32 inLen)
+int wc_Ed25519PrivateKeyToDer(const ed25519_key* key, byte* output, word32 outLen)
 {
     if (key == NULL) {
         return BAD_FUNC_ARG;
     }
     return SetAsymKeyDer(key->k, ED25519_KEY_SIZE,
-        NULL, 0, output, inLen, ED25519k);
+        NULL, 0, output, outLen, ED25519k);
 }
 #endif /* HAVE_ED25519 && HAVE_ED25519_KEY_EXPORT */
 
@@ -33358,7 +33358,7 @@ int wc_Ed25519PrivateKeyToDer(const ed25519_key* key, byte* output, word32 inLen
 /* Write only private Curve25519 key to DER format,
  * length on success else < 0 */
 int wc_Curve25519PrivateKeyToDer(curve25519_key* key, byte* output,
-                                 word32 inLen)
+                                 word32 outLen)
 {
     int    ret;
     byte   privKey[CURVE25519_KEYSIZE];
@@ -33370,7 +33370,7 @@ int wc_Curve25519PrivateKeyToDer(curve25519_key* key, byte* output,
 
     ret = wc_curve25519_export_private_raw(key, privKey, &privKeyLen);
     if (ret == 0) {
-        ret = SetAsymKeyDer(privKey, privKeyLen, NULL, 0, output, inLen,
+        ret = SetAsymKeyDer(privKey, privKeyLen, NULL, 0, output, outLen,
             X25519k);
     }
     return ret;
@@ -33378,7 +33378,7 @@ int wc_Curve25519PrivateKeyToDer(curve25519_key* key, byte* output,
 
 /* Write a public Curve25519 key to DER format,
  * length on success else < 0 */
-int wc_Curve25519PublicKeyToDer(curve25519_key* key, byte* output, word32 inLen,
+int wc_Curve25519PublicKeyToDer(curve25519_key* key, byte* output, word32 outLen,
                              int withAlg)
 {
     int    ret;
@@ -33391,7 +33391,7 @@ int wc_Curve25519PublicKeyToDer(curve25519_key* key, byte* output, word32 inLen,
 
     ret = wc_curve25519_export_public(key, pubKey, &pubKeyLen);
     if (ret == 0) {
-        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, inLen,
+        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, outLen,
             X25519k, withAlg);
     }
     return ret;
@@ -33400,7 +33400,7 @@ int wc_Curve25519PublicKeyToDer(curve25519_key* key, byte* output, word32 inLen,
 /* Export Curve25519 key to DER format - handles private only, public only,
  * or private+public key pairs based on what's set in the key structure.
  * Returns length written on success, negative on error */
-int wc_Curve25519KeyToDer(curve25519_key* key, byte* output, word32 inLen,
+int wc_Curve25519KeyToDer(curve25519_key* key, byte* output, word32 outLen,
                           int withAlg)
 {
     int ret;
@@ -33430,13 +33430,13 @@ int wc_Curve25519KeyToDer(curve25519_key* key, byte* output, word32 inLen,
             /* Export both private and public */
             ret = SetAsymKeyDer(privKey, privKeyLen,
                                 pubKey, pubKeyLen,
-                                output, inLen, X25519k);
+                                output, outLen, X25519k);
         }
         else {
             /* Export private only */
             ret = SetAsymKeyDer(privKey, privKeyLen,
                                 NULL, 0,
-                                output, inLen, X25519k);
+                                output, outLen, X25519k);
         }
     }
     else if (key->pubSet) {
@@ -33444,7 +33444,7 @@ int wc_Curve25519KeyToDer(curve25519_key* key, byte* output, word32 inLen,
         ret = wc_curve25519_export_public(key, pubKey, &pubKeyLen);
         if (ret == 0) {
             ret = SetAsymKeyDerPublic(pubKey, pubKeyLen,
-                                      output, inLen, X25519k, withAlg);
+                                      output, outLen, X25519k, withAlg);
         }
     }
     else {
@@ -33549,24 +33549,24 @@ int wc_Curve448PublicKeyDecode(const byte* input, word32* inOutIdx,
 #if defined(HAVE_ED448) && defined(HAVE_ED448_KEY_EXPORT)
 /* Write a Private ecc key, including public to DER format,
  * length on success else < 0 */
-int wc_Ed448KeyToDer(const ed448_key* key, byte* output, word32 inLen)
+int wc_Ed448KeyToDer(const ed448_key* key, byte* output, word32 outLen)
 {
     if (key == NULL) {
         return BAD_FUNC_ARG;
     }
     return SetAsymKeyDer(key->k, ED448_KEY_SIZE,
-        key->p, ED448_KEY_SIZE, output, inLen, ED448k);
+        key->p, ED448_KEY_SIZE, output, outLen, ED448k);
 }
 
 /* Write only private ecc key to DER format,
  * length on success else < 0 */
-int wc_Ed448PrivateKeyToDer(const ed448_key* key, byte* output, word32 inLen)
+int wc_Ed448PrivateKeyToDer(const ed448_key* key, byte* output, word32 outLen)
 {
     if (key == NULL) {
         return BAD_FUNC_ARG;
     }
     return SetAsymKeyDer(key->k, ED448_KEY_SIZE,
-        NULL, 0, output, inLen, ED448k);
+        NULL, 0, output, outLen, ED448k);
 }
 
 #endif /* HAVE_ED448 && HAVE_ED448_KEY_EXPORT */
@@ -33574,7 +33574,7 @@ int wc_Ed448PrivateKeyToDer(const ed448_key* key, byte* output, word32 inLen)
 #if defined(HAVE_CURVE448) && defined(HAVE_CURVE448_KEY_EXPORT)
 /* Write private Curve448 key to DER format,
  * length on success else < 0 */
-int wc_Curve448PrivateKeyToDer(curve448_key* key, byte* output, word32 inLen)
+int wc_Curve448PrivateKeyToDer(curve448_key* key, byte* output, word32 outLen)
 {
     int    ret;
     byte   privKey[CURVE448_KEY_SIZE];
@@ -33586,14 +33586,14 @@ int wc_Curve448PrivateKeyToDer(curve448_key* key, byte* output, word32 inLen)
 
     ret = wc_curve448_export_private_raw(key, privKey, &privKeyLen);
     if (ret == 0) {
-        ret = SetAsymKeyDer(privKey, privKeyLen, NULL, 0, output, inLen,
+        ret = SetAsymKeyDer(privKey, privKeyLen, NULL, 0, output, outLen,
             X448k);
     }
     return ret;
 }
 /* Write a public Curve448 key to DER format,
  * length on success else < 0 */
-int wc_Curve448PublicKeyToDer(curve448_key* key, byte* output, word32 inLen,
+int wc_Curve448PublicKeyToDer(curve448_key* key, byte* output, word32 outLen,
                              int withAlg)
 {
     int    ret;
@@ -33606,7 +33606,7 @@ int wc_Curve448PublicKeyToDer(curve448_key* key, byte* output, word32 inLen,
 
     ret = wc_curve448_export_public(key, pubKey, &pubKeyLen);
     if (ret == 0) {
-        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, inLen,
+        ret = SetAsymKeyDerPublic(pubKey, pubKeyLen, output, outLen,
             X448k, withAlg);
     }
     return ret;

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -1528,13 +1528,10 @@ int wc_ed25519_export_key(const ed25519_key* key,
 
     /* export 'full' private part */
     ret = wc_ed25519_export_private(key, priv, privSz);
-    if (ret != 0)
-        return ret;
-
-    /* export public part */
-    ret = wc_ed25519_export_public(key, pub, pubSz);
-    if (ret == WC_NO_ERR_TRACE(PUBLIC_KEY_E))
-        ret = 0; /* ignore no public key */
+    if (ret == 0) {
+        /* export public part */
+        ret = wc_ed25519_export_public(key, pub, pubSz);
+    }
 
     return ret;
 }

--- a/wolfcrypt/src/ed448.c
+++ b/wolfcrypt/src/ed448.c
@@ -1112,7 +1112,8 @@ int wc_ed448_delete(ed448_key* key, ed448_key** key_p) {
  * out     [in]      Array to hold public key.
  * outLen  [in/out]  On in, the number of bytes in array.
  *                   On out, the number bytes put into array.
- * returns BAD_FUNC_ARG when a parameter is NULL,
+ * returns PUBLIC_KEY_E the given key only has a private key present,
+ *         BAD_FUNC_ARG when a parameter is NULL,
  *         ECC_BAD_ARG_E when outLen is less than ED448_PUB_KEY_SIZE,
  *         0 otherwise.
  */

--- a/wolfcrypt/src/ed448.c
+++ b/wolfcrypt/src/ed448.c
@@ -1130,6 +1130,10 @@ int wc_ed448_export_public(const ed448_key* key, byte* out, word32* outLen)
         ret = BUFFER_E;
     }
 
+    if ((ret == 0) && (!key->pubKeySet)) {
+        ret = PUBLIC_KEY_E;
+    }
+
     if (ret == 0) {
         *outLen = ED448_PUB_KEY_SIZE;
         XMEMCPY(out, key->p, ED448_PUB_KEY_SIZE);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -44860,6 +44860,62 @@ static wc_test_ret_t ed25519_test_check_key(void)
 }
 #endif
 
+#if defined(HAVE_ED25519_KEY_EXPORT) && defined(HAVE_ED25519_KEY_IMPORT)
+/* When only the private key is set, the public part is unavailable.
+ * wc_ed25519_export_public() must report PUBLIC_KEY_E, and
+ * wc_ed25519_export_key() must propagate that error rather than silently
+ * succeeding (matches wc_ed448_export_key()). */
+static wc_test_ret_t ed25519_export_key_no_pub_test(void)
+{
+    /* RFC 8032 section 7.1 test-vector secret key. */
+    WOLFSSL_SMALL_STACK_STATIC const byte privKey[] = {
+        0x9d,0x61,0xb1,0x9d,0xef,0xfd,0x5a,0x60,
+        0xba,0x84,0x4a,0xf4,0x92,0xec,0x2c,0xc4,
+        0x44,0x49,0xc5,0x69,0x7b,0x32,0x69,0x19,
+        0x70,0x3b,0xac,0x03,0x1c,0xae,0x7f,0x60
+    };
+    ed25519_key key;
+    byte    priv[ED25519_PRV_KEY_SIZE];
+    byte    pub[ED25519_PUB_KEY_SIZE];
+    word32  privSz = (word32)sizeof(priv);
+    word32  pubSz = (word32)sizeof(pub);
+    int     ret;
+    int     res = 0;
+
+    ret = wc_ed25519_init_ex(&key, HEAP_HINT, devId);
+    if (ret != 0) {
+        return WC_TEST_RET_ENC_NC;
+    }
+
+    /* Import the private key only; no public key is set. */
+    ret = wc_ed25519_import_private_only(privKey, (word32)sizeof(privKey),
+        &key);
+    if (ret != 0) {
+        res = WC_TEST_RET_ENC_NC;
+    }
+
+    /* With no public key, exporting the public part must fail. */
+    if (res == 0) {
+        ret = wc_ed25519_export_public(&key, pub, &pubSz);
+        if (ret != WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
+            res = WC_TEST_RET_ENC_NC;
+        }
+    }
+
+    /* wc_ed25519_export_key() must propagate the missing-public-key error. */
+    if (res == 0) {
+        ret = wc_ed25519_export_key(&key, priv, &privSz, pub, &pubSz);
+        if (ret != WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
+            res = WC_TEST_RET_ENC_NC;
+        }
+    }
+
+    wc_ed25519_free(&key);
+
+    return res;
+}
+#endif
+
 #if defined(HAVE_ED25519_SIGN) && defined(HAVE_ED25519_KEY_EXPORT) && \
     defined(HAVE_ED25519_KEY_IMPORT)
 static wc_test_ret_t ed25519ctx_test(void)
@@ -45902,6 +45958,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
     if (ret < 0)
         goto cleanup;
 #endif
+#if defined(HAVE_ED25519_KEY_EXPORT) && defined(HAVE_ED25519_KEY_IMPORT)
+    ret = ed25519_export_key_no_pub_test();
+    if (ret < 0)
+        goto cleanup;
+#endif
 #ifdef WOLFSSL_TEST_CERT
     ret = ed25519_test_cert();
     if (ret < 0)
@@ -46606,6 +46667,65 @@ static wc_test_ret_t ed448_test_check_key(void)
     }
 
     /* Dispose of key. */
+    wc_ed448_free(&key);
+
+    return res;
+}
+#endif
+
+#if defined(HAVE_ED448_KEY_EXPORT) && defined(HAVE_ED448_KEY_IMPORT)
+/* When only the private key is set, the public part is unavailable.
+ * wc_ed448_export_public() must report PUBLIC_KEY_E, and
+ * wc_ed448_export_key() must propagate that error rather than silently
+ * succeeding. */
+static wc_test_ret_t ed448_export_key_no_pub_test(void)
+{
+    /* RFC 8032 section 7.4 test-vector secret key. */
+    WOLFSSL_SMALL_STACK_STATIC const byte privKey[] = {
+        0x6c, 0x82, 0xa5, 0x62, 0xcb, 0x80, 0x8d, 0x10,
+        0xd6, 0x32, 0xbe, 0x89, 0xc8, 0x51, 0x3e, 0xbf,
+        0x6c, 0x92, 0x9f, 0x34, 0xdd, 0xfa, 0x8c, 0x9f,
+        0x63, 0xc9, 0x96, 0x0e, 0xf6, 0xe3, 0x48, 0xa3,
+        0x52, 0x8c, 0x8a, 0x3f, 0xcc, 0x2f, 0x04, 0x4e,
+        0x39, 0xa3, 0xfc, 0x5b, 0x94, 0x49, 0x2f, 0x8f,
+        0x03, 0x2e, 0x75, 0x49, 0xa2, 0x00, 0x98, 0xf9,
+        0x5b
+    };
+    ed448_key key;
+    byte    priv[ED448_PRV_KEY_SIZE];
+    byte    pub[ED448_PUB_KEY_SIZE];
+    word32  privSz = (word32)sizeof(priv);
+    word32  pubSz = (word32)sizeof(pub);
+    int     ret;
+    int     res = 0;
+
+    ret = wc_ed448_init_ex(&key, HEAP_HINT, devId);
+    if (ret != 0) {
+        return WC_TEST_RET_ENC_NC;
+    }
+
+    /* Import the private key only; no public key is set. */
+    ret = wc_ed448_import_private_only(privKey, (word32)sizeof(privKey), &key);
+    if (ret != 0) {
+        res = WC_TEST_RET_ENC_NC;
+    }
+
+    /* With no public key, exporting the public part must fail. */
+    if (res == 0) {
+        ret = wc_ed448_export_public(&key, pub, &pubSz);
+        if (ret != WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
+            res = WC_TEST_RET_ENC_NC;
+        }
+    }
+
+    /* wc_ed448_export_key() must propagate the missing-public-key error. */
+    if (res == 0) {
+        ret = wc_ed448_export_key(&key, priv, &privSz, pub, &pubSz);
+        if (ret != WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
+            res = WC_TEST_RET_ENC_NC;
+        }
+    }
+
     wc_ed448_free(&key);
 
     return res;
@@ -47668,6 +47788,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed448_test(void)
 
 #if defined(HAVE_ED448_KEY_IMPORT)
     ret = ed448_test_check_key();
+    if (ret < 0)
+        return ret;
+#endif
+#if defined(HAVE_ED448_KEY_EXPORT) && defined(HAVE_ED448_KEY_IMPORT)
+    ret = ed448_export_key_no_pub_test();
     if (ret < 0)
         return ret;
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -44867,6 +44867,9 @@ static wc_test_ret_t ed25519_test_check_key(void)
  * succeeding (matches wc_ed448_export_key()). */
 static wc_test_ret_t ed25519_export_key_no_pub_test(void)
 {
+    int res = 0;
+
+#if !(defined(HAVE_FIPS) && FIPS_VERSION3_LT(7,0,0))
     /* RFC 8032 section 7.1 test-vector secret key. */
     WOLFSSL_SMALL_STACK_STATIC const byte privKey[] = {
         0x9d,0x61,0xb1,0x9d,0xef,0xfd,0x5a,0x60,
@@ -44880,7 +44883,6 @@ static wc_test_ret_t ed25519_export_key_no_pub_test(void)
     word32  privSz = (word32)sizeof(priv);
     word32  pubSz = (word32)sizeof(pub);
     int     ret;
-    int     res = 0;
 
     ret = wc_ed25519_init_ex(&key, HEAP_HINT, devId);
     if (ret != 0) {
@@ -44911,6 +44913,7 @@ static wc_test_ret_t ed25519_export_key_no_pub_test(void)
     }
 
     wc_ed25519_free(&key);
+#endif
 
     return res;
 }
@@ -46680,6 +46683,9 @@ static wc_test_ret_t ed448_test_check_key(void)
  * succeeding. */
 static wc_test_ret_t ed448_export_key_no_pub_test(void)
 {
+    int res = 0;
+
+#if !(defined(HAVE_FIPS) && FIPS_VERSION3_LT(7,0,0))
     /* RFC 8032 section 7.4 test-vector secret key. */
     WOLFSSL_SMALL_STACK_STATIC const byte privKey[] = {
         0x6c, 0x82, 0xa5, 0x62, 0xcb, 0x80, 0x8d, 0x10,
@@ -46697,7 +46703,6 @@ static wc_test_ret_t ed448_export_key_no_pub_test(void)
     word32  privSz = (word32)sizeof(priv);
     word32  pubSz = (word32)sizeof(pub);
     int     ret;
-    int     res = 0;
 
     ret = wc_ed448_init_ex(&key, HEAP_HINT, devId);
     if (ret != 0) {
@@ -46727,6 +46732,7 @@ static wc_test_ret_t ed448_export_key_no_pub_test(void)
     }
 
     wc_ed448_free(&key);
+#endif
 
     return res;
 }

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -786,10 +786,10 @@ WOLFSSL_API word32 wc_PkcsPad(byte* buf, word32 sz, word32 blockSz);
          !defined(HAVE_FIPS_VERSION) || \
          ((HAVE_FIPS_VERSION > 2) && \
          (! ((HAVE_FIPS_VERSION == 5) && (HAVE_FIPS_VERSION_MINOR == 0)))))
-    WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen);
+    WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 outLen);
     #endif
     WOLFSSL_API int wc_RsaPublicKeyDerSize(RsaKey* key, int with_header);
-    WOLFSSL_API int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
+    WOLFSSL_API int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 outLen,
         int with_header);
 
     /* For FIPS v1/v2 and selftest rsa.h is replaced. */
@@ -805,9 +805,9 @@ WOLFSSL_API word32 wc_PkcsPad(byte* buf, word32 sz, word32 blockSz);
     WOLFSSL_API int wc_DsaParamsDecode(const byte* input, word32* inOutIdx, DsaKey* key,
                         word32 inSz);
     WOLFSSL_API int wc_DsaKeyToParamsDer(DsaKey* key, byte* output,
-        word32 inLen);
+        word32 outLen);
     WOLFSSL_API int wc_DsaKeyToParamsDer_ex(DsaKey* key, byte* output,
-        word32* inLen);
+        word32* outLen);
 #endif
 
 #if !defined(NO_DH) && defined(WOLFSSL_DH_EXTRA)
@@ -822,12 +822,12 @@ WOLFSSL_API int wc_DhPrivKeyToDer(DhKey* key, byte* out, word32* outSz);
     WOLFSSL_ABI
     WOLFSSL_API int wc_EccPrivateKeyDecode(const byte* input, word32* inOutIdx,
                                            ecc_key* key, word32 inSz);
-    WOLFSSL_LOCAL int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
+    WOLFSSL_LOCAL int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *outLen,
                                         int pubIn, int curveIn);
     WOLFSSL_ABI
-    WOLFSSL_API int wc_EccKeyToDer(ecc_key* key, byte* output, word32 inLen);
+    WOLFSSL_API int wc_EccKeyToDer(ecc_key* key, byte* output, word32 outLen);
     WOLFSSL_API int wc_EccPrivateKeyToDer(ecc_key* key, byte* output,
-                                          word32 inLen);
+                                          word32 outLen);
     WOLFSSL_API int wc_EccKeyDerSize(ecc_key* key, int pub);
     WOLFSSL_API int wc_EccPrivateKeyToPKCS8(ecc_key* key, byte* output,
                                             word32* outLen);
@@ -839,9 +839,9 @@ WOLFSSL_API int wc_DhPrivKeyToDer(DhKey* key, byte* out, word32* outSz);
     WOLFSSL_API int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
                           ecc_key* key, word32 inSz);
     WOLFSSL_ABI WOLFSSL_API int wc_EccPublicKeyToDer(ecc_key* key, byte* output,
-                                         word32 inLen, int with_AlgCurve);
+                                         word32 outLen, int with_AlgCurve);
     WOLFSSL_API int wc_EccPublicKeyToDer_ex(ecc_key* key, byte* output,
-                                         word32 inLen, int with_AlgCurve,
+                                         word32 outLen, int with_AlgCurve,
                                          int comp);
     WOLFSSL_API int wc_EccPublicKeyDerSize(ecc_key* key, int with_AlgCurve);
 #endif
@@ -855,11 +855,11 @@ WOLFSSL_API int wc_Ed25519PublicKeyDecode(const byte* input, word32* inOutIdx,
 #endif
 #ifdef HAVE_ED25519_KEY_EXPORT
 WOLFSSL_API int wc_Ed25519KeyToDer(const ed25519_key* key, byte* output,
-                                   word32 inLen);
+                                   word32 outLen);
 WOLFSSL_API int wc_Ed25519PrivateKeyToDer(const ed25519_key* key, byte* output,
-                                          word32 inLen);
+                                          word32 outLen);
 WOLFSSL_API int wc_Ed25519PublicKeyToDer(const ed25519_key* key, byte* output,
-                                         word32 inLen, int withAlg);
+                                         word32 outLen, int withAlg);
 #endif
 #endif /* HAVE_ED25519 */
 
@@ -874,11 +874,11 @@ WOLFSSL_API int wc_Curve25519KeyDecode(const byte *input, word32 *inOutIdx,
 #endif
 #ifdef HAVE_CURVE25519_KEY_EXPORT
 WOLFSSL_API int wc_Curve25519PrivateKeyToDer(
-    curve25519_key* key, byte* output, word32 inLen);
+    curve25519_key* key, byte* output, word32 outLen);
 WOLFSSL_API int wc_Curve25519PublicKeyToDer(
-    curve25519_key* key, byte* output, word32 inLen, int withAlg);
+    curve25519_key* key, byte* output, word32 outLen, int withAlg);
 WOLFSSL_API int wc_Curve25519KeyToDer(curve25519_key* key, byte* output,
-                                      word32 inLen, int withAlg);
+                                      word32 outLen, int withAlg);
 #endif
 #endif /* HAVE_CURVE25519 */
 
@@ -890,11 +890,11 @@ WOLFSSL_API int wc_Ed448PublicKeyDecode(
     const byte* input, word32* inOutIdx, ed448_key* key, word32 inSz);
 #endif
 #ifdef HAVE_ED448_KEY_EXPORT
-WOLFSSL_API int wc_Ed448KeyToDer(const ed448_key* key, byte* output, word32 inLen);
+WOLFSSL_API int wc_Ed448KeyToDer(const ed448_key* key, byte* output, word32 outLen);
 WOLFSSL_API int wc_Ed448PrivateKeyToDer(
-    const ed448_key* key, byte* output, word32 inLen);
+    const ed448_key* key, byte* output, word32 outLen);
 WOLFSSL_API int wc_Ed448PublicKeyToDer(
-    const ed448_key* key, byte* output, word32 inLen, int withAlg);
+    const ed448_key* key, byte* output, word32 outLen, int withAlg);
 #endif
 #endif /* HAVE_ED448 */
 
@@ -907,9 +907,9 @@ WOLFSSL_API int wc_Curve448PublicKeyDecode(const byte* input, word32* inOutIdx,
 #endif
 #ifdef HAVE_CURVE448_KEY_EXPORT
 WOLFSSL_API int wc_Curve448PrivateKeyToDer(curve448_key* key, byte* output,
-                                           word32 inLen);
+                                           word32 outLen);
 WOLFSSL_API int wc_Curve448PublicKeyToDer(curve448_key* key, byte* output,
-                                          word32 inLen, int withAlg);
+                                          word32 outLen, int withAlg);
 #endif
 #endif /* HAVE_CURVE448 */
 

--- a/wolfssl/wolfcrypt/dsa.h
+++ b/wolfssl/wolfcrypt/dsa.h
@@ -91,10 +91,10 @@ WOLFSSL_API int wc_DsaPublicKeyDecode(const byte* input, word32* inOutIdx,
                                       DsaKey* key, word32 inSz);
 WOLFSSL_API int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
                                        DsaKey* key, word32 inSz);
-WOLFSSL_API int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen);
+WOLFSSL_API int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 outLen);
 WOLFSSL_API int wc_SetDsaPublicKey(byte* output, DsaKey* key,
                                    int outLen, int with_header);
-WOLFSSL_API int wc_DsaKeyToPublicDer(DsaKey* key, byte* output, word32 inLen);
+WOLFSSL_API int wc_DsaKeyToPublicDer(DsaKey* key, byte* output, word32 outLen);
 WOLFSSL_API int wc_DsaCheckPubKey(DsaKey* key);
 
 #ifdef WOLFSSL_KEY_GEN

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -442,7 +442,7 @@ WOLFSSL_API int  wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx,
 WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
                                         const byte* e, word32 eSz, RsaKey* key);
 #ifdef WOLFSSL_KEY_TO_DER
-    WOLFSSL_API int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen);
+    WOLFSSL_API int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 outLen);
 #endif
 
 #ifndef WC_NO_RNG

--- a/wolfssl/wolfcrypt/wc_lms.h
+++ b/wolfssl/wolfcrypt/wc_lms.h
@@ -828,7 +828,7 @@ WOLFSSL_API int  wc_LmsKey_Sign(LmsKey* key, byte* sig, word32* sigSz,
     const byte* msg, int msgSz);
 WOLFSSL_API int  wc_LmsKey_SigsLeft(LmsKey* key);
 WOLFSSL_API int  wc_LmsKey_PublicKeyToDer(const LmsKey* key, byte* output,
-    word32 inLen, int withAlg);
+    word32 outLen, int withAlg);
 #endif /* ifndef WOLFSSL_LMS_VERIFY_ONLY */
 WOLFSSL_API void wc_LmsKey_Free(LmsKey* key);
 WOLFSSL_API int  wc_LmsKey_GetSigLen(const LmsKey* key, word32* len);

--- a/wolfssl/wolfcrypt/wc_xmss.h
+++ b/wolfssl/wolfcrypt/wc_xmss.h
@@ -452,7 +452,7 @@ WOLFSSL_API int  wc_XmssKey_Sign(XmssKey* key, byte* sig, word32* sigSz,
     const byte* msg, int msgSz);
 WOLFSSL_API int  wc_XmssKey_SigsLeft(XmssKey* key);
 WOLFSSL_API int  wc_XmssKey_PublicKeyToDer(const XmssKey* key, byte* output,
-    word32 inLen, int withAlg);
+    word32 outLen, int withAlg);
 #endif /* ifndef WOLFSSL_XMSS_VERIFY_ONLY */
 WOLFSSL_API void wc_XmssKey_Free(XmssKey* key);
 WOLFSSL_API int  wc_XmssKey_GetSigLen(const XmssKey* key, word32* len);


### PR DESCRIPTION
# Description

Ed448: check for public key presence on export

Return PUBLIC_KEY_E for wc_ed25519_export_key if public key is not present.
Return PUBLIC_KEY_E for wc_ed448_export_key if public key is not present.
Rename several inLen parameters to outLen for consistency.

Fix F-4427

# Testing

How did you test?

# Checklist

 - [X] added tests
 - [X] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
