### PR TITLE
Ada: bump 5.9.1 in alire.toml

### DIFF
--- a/wrapper/Ada/alire.toml
+++ b/wrapper/Ada/alire.toml
@@ -1,6 +1,6 @@
 name = "wolfssl"
 description = "WolfSSL encryption library and its Ada bindings"
-version = "5.8.0"
+version = "5.9.1"
 
 authors = ["WolfSSL Team <support@wolfssl.com>"]
 maintainers = ["Fernando Oleo Blanco <irvise@irvise.xyz>", "Manuel Gomez <mgrojo@gmail.com>"]


### PR DESCRIPTION
# Description

Bump the latest release in the Alire configuration, as first step for publishing the update in the Alire index.

# Testing
```
alr build
alr gnatprove --level=4
```
# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
