### PR TITLE
Fix NameConstraints minimum/maximum parsing for values >= 128

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -19239,8 +19239,8 @@ static int DecodeSubtree(const byte* input, word32 sz, Base_entry** head,
 
     /* Process all subtrees. */
     while ((ret == 0) && (idx < (word32)sz)) {
-        byte minVal = 0;
-        byte maxVal = 0;
+        word16 minVal = 0;
+        word16 maxVal = 0;
         if (limit > 0) {
             cnt++;
             if (cnt > limit) {
@@ -19255,8 +19255,8 @@ static int DecodeSubtree(const byte* input, word32 sz, Base_entry** head,
          */
         XMEMSET(dataASN, 0, sizeof(*dataASN) * subTreeASN_Length);
         GetASN_Choice(&dataASN[SUBTREEASN_IDX_BASE], generalNameChoice);
-        GetASN_Int8Bit(&dataASN[SUBTREEASN_IDX_MIN], &minVal);
-        GetASN_Int8Bit(&dataASN[SUBTREEASN_IDX_MAX], &maxVal);
+        GetASN_Int16Bit(&dataASN[SUBTREEASN_IDX_MIN], &minVal);
+        GetASN_Int16Bit(&dataASN[SUBTREEASN_IDX_MAX], &maxVal);
         /* Parse GeneralSubtree. */
         ret = GetASN_Items(subTreeASN, dataASN, subTreeASN_Length, 0, input,
                            &idx, sz);


### PR DESCRIPTION
Closes #10659

`DecodeSubtree()` was using `GetASN_Int8Bit()` to decode the
GeneralSubtree minimum/maximum BaseDistance fields. That function
rejects any DER INTEGER longer than one byte, so values >= 128
(which need a two-byte encoding with leading zero sign octet)
caused `ASN_PARSE_E` and `d2i_X509()` to return NULL.

Switch to `GetASN_Int16Bit()` with `word16` storage — same pattern
already used for `BasicConstraints` pathLength elsewhere in this
file. Four lines changed, no behavioral change beyond fixing the
parse failure.

Tested:

| cert | before | after |
|------|--------|-------|
| NC minimum=1   | ACCEPT | ACCEPT |
| NC minimum=127 | ACCEPT | ACCEPT |
| NC minimum=128 | REJECT | ACCEPT |
| NC minimum=255 | REJECT | ACCEPT |
| NC maximum=128 | REJECT | ACCEPT |