### PR TITLE
Force-zero wc_AesSivDecrypt*() output buffer on authentication failure

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -17098,10 +17098,10 @@ static WARN_UNUSED_RESULT int AesSivCipher(
                 WOLFSSL_MSG("Computed SIV doesn't match received SIV.");
                 ret = AES_SIV_AUTH_E;
             }
+        }
 
-            if (ret != 0) {
-                ForceZero(out, dataSz);
-            }
+        if (ret != 0) {
+            ForceZero(out, dataSz);
         }
 
     #ifdef WOLFSSL_SMALL_STACK

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -17094,9 +17094,13 @@ static WARN_UNUSED_RESULT int AesSivCipher(
                 WOLFSSL_MSG("S2V failed.");
             }
 
-            if (ConstantCompare(siv, sivTmp, WC_AES_BLOCK_SIZE) != 0) {
+            if (ret == 0 && ConstantCompare(siv, sivTmp, WC_AES_BLOCK_SIZE) != 0) {
                 WOLFSSL_MSG("Computed SIV doesn't match received SIV.");
                 ret = AES_SIV_AUTH_E;
+            }
+
+            if (ret != 0) {
+                ForceZero(out, dataSz);
             }
         }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -74789,27 +74789,37 @@ static wc_test_ret_t aes_siv_negative_test(const AesSivTestVector* testVectors)
     byte computedCiphertext[82];
     byte computedPlaintext[82];
     byte siv[WC_AES_BLOCK_SIZE];
+    word32 j;
     wc_test_ret_t ret;
 
     /* Negative test: corrupted SIV must be rejected with AES_SIV_AUTH_E. */
-    ret = wc_AesSivEncrypt(testVectors[0].key, testVectors[0].keySz,
-                          testVectors[0].assoc1, testVectors[0].assoc1Sz,
-                          testVectors[0].nonce, testVectors[0].nonceSz,
-                          testVectors[0].plaintext,
-                          testVectors[0].plaintextSz, siv,
+    ret = wc_AesSivEncrypt(testVectors[5].key, testVectors[5].keySz,
+                          testVectors[5].assoc1, testVectors[5].assoc1Sz,
+                          testVectors[5].nonce, testVectors[5].nonceSz,
+                          testVectors[5].plaintext,
+                          testVectors[5].plaintextSz, siv,
                           computedCiphertext);
     if (ret != 0) {
         return WC_TEST_RET_ENC_EC(ret);
     }
+    XMEMSET(computedPlaintext, 0xFF, sizeof(computedPlaintext));
     /* Corrupt one byte of the SIV tag. */
     siv[0] ^= 0x01;
-    ret = wc_AesSivDecrypt(testVectors[0].key, testVectors[0].keySz,
-                          testVectors[0].assoc1, testVectors[0].assoc1Sz,
-                          testVectors[0].nonce, testVectors[0].nonceSz,
-                          computedCiphertext, testVectors[0].plaintextSz,
+    ret = wc_AesSivDecrypt(testVectors[5].key, testVectors[5].keySz,
+                          testVectors[5].assoc1, testVectors[5].assoc1Sz,
+                          testVectors[5].nonce, testVectors[5].nonceSz,
+                          computedCiphertext, testVectors[5].plaintextSz,
                           siv, computedPlaintext);
     if (ret != WC_NO_ERR_TRACE(AES_SIV_AUTH_E)) {
         return WC_TEST_RET_ENC_EC(ret);
+    }
+    if (testVectors[5].plaintextSz == 0U) {
+        return WC_TEST_RET_ENC_NC;
+    }
+    for (j = 0; j < testVectors[5].plaintextSz; ++j) {
+        if (computedPlaintext[j] != 0) {
+            return WC_TEST_RET_ENC_NC;
+        }
     }
     return 0;
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -74784,44 +74784,48 @@ static wc_test_ret_t aes_siv_oneassoc_test(const AesSivTestVector* testVectors,
     return 0;
 }
 
-static wc_test_ret_t aes_siv_negative_test(const AesSivTestVector* testVectors, size_t n_vectors)
+static wc_test_ret_t aes_siv_negative_test(const AesSivTestVector* testVectors,
+        int n_vectors)
 {
     byte computedCiphertext[82];
     byte computedPlaintext[82];
     byte siv[WC_AES_BLOCK_SIZE];
     word32 j;
     wc_test_ret_t ret;
-    size_t vector_idx;
+    int vector_idx;
 
     /* Find a test vector that has a non-empty plaintext size */
-    for (vector_idx = 0U; vector_idx < n_vectors; vector_idx++)
-    {
+    for (vector_idx = 0; vector_idx < n_vectors; vector_idx++) {
         if (testVectors[vector_idx].plaintextSz > 0U)
             break;
     }
-    if (vector_idx == n_vectors)
-    {
+    if (vector_idx == n_vectors) {
         return WC_TEST_RET_ENC_NC;
     }
 
     /* Negative test: corrupted SIV must be rejected with AES_SIV_AUTH_E. */
-    ret = wc_AesSivEncrypt(testVectors[vector_idx].key, testVectors[vector_idx].keySz,
-                          testVectors[vector_idx].assoc1, testVectors[vector_idx].assoc1Sz,
-                          testVectors[vector_idx].nonce, testVectors[vector_idx].nonceSz,
-                          testVectors[vector_idx].plaintext,
-                          testVectors[vector_idx].plaintextSz, siv,
-                          computedCiphertext);
+    ret = wc_AesSivEncrypt(
+            testVectors[vector_idx].key,
+            testVectors[vector_idx].keySz,
+            testVectors[vector_idx].assoc1,
+            testVectors[vector_idx].assoc1Sz,
+            testVectors[vector_idx].nonce,
+            testVectors[vector_idx].nonceSz,
+            testVectors[vector_idx].plaintext,
+            testVectors[vector_idx].plaintextSz,
+            siv, computedCiphertext);
     if (ret != 0) {
         return WC_TEST_RET_ENC_EC(ret);
     }
     XMEMSET(computedPlaintext, 0xFF, sizeof(computedPlaintext));
     /* Corrupt one byte of the SIV tag. */
     siv[0] ^= 0x01;
-    ret = wc_AesSivDecrypt(testVectors[vector_idx].key, testVectors[vector_idx].keySz,
-                          testVectors[vector_idx].assoc1, testVectors[vector_idx].assoc1Sz,
-                          testVectors[vector_idx].nonce, testVectors[vector_idx].nonceSz,
-                          computedCiphertext, testVectors[vector_idx].plaintextSz,
-                          siv, computedPlaintext);
+    ret = wc_AesSivDecrypt(
+            testVectors[vector_idx].key, testVectors[vector_idx].keySz,
+            testVectors[vector_idx].assoc1, testVectors[vector_idx].assoc1Sz,
+            testVectors[vector_idx].nonce, testVectors[vector_idx].nonceSz,
+            computedCiphertext, testVectors[vector_idx].plaintextSz,
+            siv, computedPlaintext);
     if (ret != WC_NO_ERR_TRACE(AES_SIV_AUTH_E)) {
         return WC_TEST_RET_ENC_EC(ret);
     }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -74784,20 +74784,32 @@ static wc_test_ret_t aes_siv_oneassoc_test(const AesSivTestVector* testVectors,
     return 0;
 }
 
-static wc_test_ret_t aes_siv_negative_test(const AesSivTestVector* testVectors)
+static wc_test_ret_t aes_siv_negative_test(const AesSivTestVector* testVectors, size_t n_vectors)
 {
     byte computedCiphertext[82];
     byte computedPlaintext[82];
     byte siv[WC_AES_BLOCK_SIZE];
     word32 j;
     wc_test_ret_t ret;
+    size_t vector_idx;
+
+    /* Find a test vector that has a non-empty plaintext size */
+    for (vector_idx = 0U; vector_idx < n_vectors; vector_idx++)
+    {
+        if (testVectors[vector_idx].plaintextSz > 0U)
+            break;
+    }
+    if (vector_idx == n_vectors)
+    {
+        return WC_TEST_RET_ENC_NC;
+    }
 
     /* Negative test: corrupted SIV must be rejected with AES_SIV_AUTH_E. */
-    ret = wc_AesSivEncrypt(testVectors[5].key, testVectors[5].keySz,
-                          testVectors[5].assoc1, testVectors[5].assoc1Sz,
-                          testVectors[5].nonce, testVectors[5].nonceSz,
-                          testVectors[5].plaintext,
-                          testVectors[5].plaintextSz, siv,
+    ret = wc_AesSivEncrypt(testVectors[vector_idx].key, testVectors[vector_idx].keySz,
+                          testVectors[vector_idx].assoc1, testVectors[vector_idx].assoc1Sz,
+                          testVectors[vector_idx].nonce, testVectors[vector_idx].nonceSz,
+                          testVectors[vector_idx].plaintext,
+                          testVectors[vector_idx].plaintextSz, siv,
                           computedCiphertext);
     if (ret != 0) {
         return WC_TEST_RET_ENC_EC(ret);
@@ -74805,18 +74817,15 @@ static wc_test_ret_t aes_siv_negative_test(const AesSivTestVector* testVectors)
     XMEMSET(computedPlaintext, 0xFF, sizeof(computedPlaintext));
     /* Corrupt one byte of the SIV tag. */
     siv[0] ^= 0x01;
-    ret = wc_AesSivDecrypt(testVectors[5].key, testVectors[5].keySz,
-                          testVectors[5].assoc1, testVectors[5].assoc1Sz,
-                          testVectors[5].nonce, testVectors[5].nonceSz,
-                          computedCiphertext, testVectors[5].plaintextSz,
+    ret = wc_AesSivDecrypt(testVectors[vector_idx].key, testVectors[vector_idx].keySz,
+                          testVectors[vector_idx].assoc1, testVectors[vector_idx].assoc1Sz,
+                          testVectors[vector_idx].nonce, testVectors[vector_idx].nonceSz,
+                          computedCiphertext, testVectors[vector_idx].plaintextSz,
                           siv, computedPlaintext);
     if (ret != WC_NO_ERR_TRACE(AES_SIV_AUTH_E)) {
         return WC_TEST_RET_ENC_EC(ret);
     }
-    if (testVectors[5].plaintextSz == 0U) {
-        return WC_TEST_RET_ENC_NC;
-    }
-    for (j = 0; j < testVectors[5].plaintextSz; ++j) {
+    for (j = 0; j < testVectors[vector_idx].plaintextSz; ++j) {
         if (computedPlaintext[j] != 0) {
             return WC_TEST_RET_ENC_NC;
         }
@@ -75012,7 +75021,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_siv_test(void)
     ret = aes_siv_multiassoc_test(testVectors, AES_SIV_TEST_VECTORS);
     if (ret != 0)
         return ret;
-    ret = aes_siv_negative_test(testVectors);
+    ret = aes_siv_negative_test(testVectors, AES_SIV_TEST_VECTORS);
     if (ret != 0)
         return ret;
     return 0;


### PR DESCRIPTION
# Description

Force-zero wc_AesSivDecrypt*() output buffer on authentication failure

Fixes F-5394

# Testing

How did you test?

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
