### PR TITLE
settings.h: don't set WOLFSSL_GENSEED_FORTEST.

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1728,8 +1728,6 @@
         #endif
     #endif
 
-    #define WOLFSSL_GENSEED_FORTEST
-
     #define NO_WOLFSSL_DIR
     #define NO_WRITEV
     #define TFM_TIMING_RESISTANT


### PR DESCRIPTION
# Description

We should not set `WOLFSSL_GENSEED_FORTEST` in our `settings.h`.

It's fine for demo examples, but not in main code.

Fixes F-2623.