### PR TITLE
skip membrowse comment action on draft PRs

### DIFF
--- a/.github/workflows/membrowse-comment.yml
+++ b/.github/workflows/membrowse-comment.yml
@@ -13,7 +13,8 @@ jobs:
     # Run the comment job even if some of the builds fail
     if: >
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion != 'cancelled'
+      github.event.workflow_run.conclusion != 'cancelled' &&
+      github.event.workflow_run.conclusion != 'skipped'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
# Description

Skipping membrowse commit workflow in case the PR is set as draft.

Fixes zd#

# Testing

How did you test?
Tested on a forked repo

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
