### PR TITLE
20260613-linuxkm-fix-fips-random-seed

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -217,15 +217,17 @@
         #endif
     #endif
 
-    #if defined(HAVE_HASHDRBG) && defined(HAVE_FIPS) && \
+    #if defined(HAVE_FIPS) && FIPS_VERSION3_LT(5, 2, 4)
+        #if defined(HAVE_HASHDRBG) && \
             defined(HAVE_ENTROPY_MEMUSE) && \
             !defined(WC_LINUXKM_WOLFENTROPY_IN_GLUE_LAYER)
-        #define WC_LINUXKM_WOLFENTROPY_IN_GLUE_LAYER
-    #elif defined(HAVE_HASHDRBG) && defined(HAVE_FIPS) && \
-            (defined(HAVE_INTEL_RDSEED) || defined(HAVE_AMD_RDSEED)) && \
-            !defined(HAVE_ENTROPY_MEMUSE) && \
-            !defined(WC_LINUXKM_RDSEED_IN_GLUE_LAYER)
-        #define WC_LINUXKM_RDSEED_IN_GLUE_LAYER
+            #define WC_LINUXKM_WOLFENTROPY_IN_GLUE_LAYER
+        #elif defined(HAVE_HASHDRBG) && \
+              (defined(HAVE_INTEL_RDSEED) || defined(HAVE_AMD_RDSEED)) && \
+              !defined(HAVE_ENTROPY_MEMUSE) && \
+              !defined(WC_LINUXKM_RDSEED_IN_GLUE_LAYER)
+            #define WC_LINUXKM_RDSEED_IN_GLUE_LAYER
+        #endif
     #endif
     #if defined(WC_LINUXKM_WOLFENTROPY_IN_GLUE_LAYER)
         struct OS_Seed;


### PR DESCRIPTION
`linuxkm/linuxkm_wc_port.h`: fix entropy source setup for FIPS: use in-boundary `wc_GenerateSeed()` unless FIPS < 5.2.4 or explicit `WC_LINUXKM_WOLFENTROPY_IN_GLUE_LAYER` / `WC_LINUXKM_RDSEED_IN_GLUE_LAYER`.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
quantum-safe-wolfssl-all-crypto-only-intelasm-fips-dev-linuxkm-next-insmod-amdrdseed
linuxkm-fips-dev-dist-insmod-cust-kernel-2-amdrdseed
linuxkm-fips-v5-strict-dist-insmod-cust-kernel-2-amdrdseed
linuxkm-fips-v5-cert4718-insmod-wolfguard-cust-kernel-3
all-crypto-only-intelasm-fips-v6-linuxkm-next-insmod-optest
linuxkm-6.12-cryptonly-intelasm-fips-v6-dyn-hash-LKCAPI-insmod
linuxkm-fips-v6-dist-insmod-cust-kernel-1
linuxkm-fips-v6-dist-insmod-cust-kernel-5
quantum-safe-wolfssl-all-crypto-only-intelasm-fips-dev-WOLFENTROPY_IN_GLUE_LAYER-linuxkm-next-insmod
quantum-safe-wolfssl-all-crypto-only-intelasm-fips-dev-RDSEED_IN_GLUE_LAYER-linuxkm-next-insmod
```
