### PR TITLE
20260615-linuxkm-fenrir-fixes

### DIFF
--- a/linuxkm/linuxkm_memory.c
+++ b/linuxkm/linuxkm_memory.c
@@ -197,7 +197,7 @@ ssize_t wc_reloc_normalize_segment(
         return i;
 
     WC_SANITIZE_DISABLE();
-    memcpy(seg_out, seg_in, *seg_in_out_len);
+    XMEMCPY(seg_out, seg_in, *seg_in_out_len);
     WC_SANITIZE_ENABLE();
 
     /* note, if there are no relocations in the src seg, the loop isn't entered

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -660,7 +660,7 @@
                 static inline int wc_lkm_refcount_to_int(atomic_t *refcount) {
                     _Pragma("GCC diagnostic push");
                     _Pragma("GCC diagnostic ignored \"-Wnested-externs\"");
-                    return atomic_read(&refcount);
+                    return atomic_read(refcount);
                     _Pragma("GCC diagnostic pop");
                 }
             #endif

--- a/linuxkm/lkcapi_aes_glue.c
+++ b/linuxkm/lkcapi_aes_glue.c
@@ -945,7 +945,7 @@ static struct skcipher_alg cfbAesAlg = {
 };
 static int cfbAesAlg_loaded = 0;
 
-#endif /* LINUXKM_LKCAPI_REGISTER_AESCBC */
+#endif /* LINUXKM_LKCAPI_REGISTER_AESCFB */
 
 #if defined(LINUXKM_LKCAPI_REGISTER_AESGCM) || \
     defined(LINUXKM_LKCAPI_REGISTER_AESGCM_RFC4106)
@@ -1016,7 +1016,7 @@ static int km_AesGcmSetKey_Rfc4106(struct crypto_aead *tfm, const u8 *in_key,
     if (key_len < 4)
         return -EINVAL;
     key_len -= 4;
-    memcpy(ctx->rfc4106_nonce, in_key + key_len, 4);
+    XMEMCPY(ctx->rfc4106_nonce, in_key + key_len, 4);
 
     err = wc_AesGcmSetKey(ctx->aes_encrypt, in_key, key_len);
 
@@ -1171,8 +1171,8 @@ static int AesGcmCrypt_1(struct aead_request *req, int decrypt_p, int rfc4106_p)
         }
         assoclen -= 8;
 
-        memcpy(rfc4106_iv, ctx->rfc4106_nonce, 4);
-        memcpy(rfc4106_iv + 4, walk.iv, 8);
+        XMEMCPY(rfc4106_iv, ctx->rfc4106_nonce, 4);
+        XMEMCPY(rfc4106_iv + 4, walk.iv, 8);
         err = wc_AesGcmInit(aes_copy, NULL /*key*/, 0 /*keylen*/, rfc4106_iv,
                             GCM_NONCE_MID_SZ);
     }
@@ -1396,8 +1396,8 @@ static int AesGcmCrypt_1(struct aead_request *req, int decrypt_p, int rfc4106_p)
         }
         assoclen -= 8;
 
-        memcpy(rfc4106_iv, ctx->rfc4106_nonce, 4);
-        memcpy(rfc4106_iv + 4, sk_walk.iv, 8);
+        XMEMCPY(rfc4106_iv, ctx->rfc4106_nonce, 4);
+        XMEMCPY(rfc4106_iv + 4, sk_walk.iv, 8);
     }
 #else
     (void)rfc4106_p;
@@ -1681,7 +1681,7 @@ static int km_AesCcmSetKey_Rfc4309(struct crypto_aead *tfm, const u8 *in_key,
     if (key_len < 3)
         return -EINVAL;
     key_len -= 3;
-    memcpy(ctx->rfc4309_nonce, in_key + key_len, 3);
+    XMEMCPY(ctx->rfc4309_nonce, in_key + key_len, 3);
 
     err = wc_AesCcmSetKey(ctx->aes_encrypt, in_key, key_len);
 
@@ -1878,8 +1878,8 @@ static int AesCcmCrypt_1(struct aead_request *req, int decrypt_p, int rfc4309_p)
         }
         assoclen -= 8;
 
-        memcpy(rfc4309_iv, ctx->rfc4309_nonce, 3);
-        memcpy(rfc4309_iv + 3, sk_walk.iv, 8);
+        XMEMCPY(rfc4309_iv, ctx->rfc4309_nonce, 3);
+        XMEMCPY(rfc4309_iv + 3, sk_walk.iv, 8);
         nonce   = rfc4309_iv;
         nonceSz = 11;
     }
@@ -3125,7 +3125,7 @@ static int linuxkm_test_aescbc(void)
         goto test_cbc_end;
     }
 
-    memcpy(dec2, p_vector, sizeof(p_vector));
+    XMEMCPY(dec2, p_vector, sizeof(p_vector));
 
     tfm = crypto_alloc_skcipher(WOLFKM_AESCBC_NAME, 0, 0);
     if (IS_ERR(tfm)) {
@@ -3181,7 +3181,7 @@ static int linuxkm_test_aescbc(void)
         goto test_cbc_end;
     }
 
-    memset(dec2, 0, sizeof(p_vector));
+    XMEMSET(dec2, 0, sizeof(p_vector));
     sg_init_one(&src, enc2, sizeof(p_vector));
     sg_init_one(&dst, dec2, sizeof(p_vector));
 
@@ -3338,7 +3338,7 @@ static int linuxkm_test_aescfb(void)
         goto test_cfb_end;
     }
 
-    memcpy(dec2, p_vector, sizeof(p_vector));
+    XMEMCPY(dec2, p_vector, sizeof(p_vector));
 
     tfm = crypto_alloc_skcipher(WOLFKM_AESCFB_NAME, 0, 0);
     if (IS_ERR(tfm)) {
@@ -3385,7 +3385,7 @@ static int linuxkm_test_aescfb(void)
         goto test_cfb_end;
     }
 
-    memset(dec2, 0, sizeof(p_vector));
+    XMEMSET(dec2, 0, sizeof(p_vector));
     sg_init_one(&src, enc2, sizeof(p_vector));
     sg_init_one(&dst, dec2, sizeof(p_vector));
 
@@ -3574,8 +3574,8 @@ static int linuxkm_test_aesgcm(void)
         ret = MEMORY_E;
         goto test_gcm_end;
     }
-    memset(assoc2, 0, sizeof(assoc));
-    memcpy(assoc2, assoc, sizeof(assoc));
+    XMEMSET(assoc2, 0, sizeof(assoc));
+    XMEMCPY(assoc2, assoc, sizeof(assoc));
 
     iv = malloc(WC_AES_BLOCK_SIZE);
     if (! iv) {
@@ -3583,8 +3583,8 @@ static int linuxkm_test_aesgcm(void)
         ret = MEMORY_E;
         goto test_gcm_end;
     }
-    memset(iv, 0, WC_AES_BLOCK_SIZE);
-    memcpy(iv, ivstr, GCM_NONCE_MID_SZ);
+    XMEMSET(iv, 0, WC_AES_BLOCK_SIZE);
+    XMEMCPY(iv, ivstr, GCM_NONCE_MID_SZ);
 
     enc2 = malloc(decryptLen);
     if (! enc2) {
@@ -3600,13 +3600,13 @@ static int linuxkm_test_aesgcm(void)
         goto test_gcm_end;
     }
 
-    memset(enc2, 0, decryptLen);
-    memset(dec2, 0, decryptLen);
-    memcpy(dec2, p_vector, sizeof(p_vector));
+    XMEMSET(enc2, 0, decryptLen);
+    XMEMSET(dec2, 0, decryptLen);
+    XMEMCPY(dec2, p_vector, sizeof(p_vector));
 
     tfm = crypto_alloc_aead(WOLFKM_AESGCM_NAME, 0, 0);
     if (IS_ERR(tfm)) {
-        pr_err("error: allocating AES skcipher algorithm %s failed: %ld\n",
+        pr_err("error: allocating AES aead algorithm %s failed: %ld\n",
                WOLFKM_AESGCM_DRIVER, PTR_ERR(tfm));
         tfm = NULL;
         goto test_gcm_end;
@@ -3632,7 +3632,7 @@ static int linuxkm_test_aesgcm(void)
     if (! req) {
         ret = -ENOMEM;
         pr_err("error: allocating AES aead request %s failed.\n",
-               WOLFKM_AESCBC_DRIVER);
+               WOLFKM_AESGCM_DRIVER);
         goto test_gcm_end;
     }
 
@@ -3684,7 +3684,7 @@ static int linuxkm_test_aesgcm(void)
     }
 
     /* Now decrypt crypto request. Reverse src and dst. */
-    memset(dec2, 0, decryptLen);
+    XMEMSET(dec2, 0, decryptLen);
     aead_request_set_ad(req, sizeof(assoc));
     aead_request_set_crypt(req, dst, src, decryptLen, iv);
 
@@ -4253,13 +4253,13 @@ static int aes_xts_128_test(void)
         goto test_xts_end;
     }
 
-    memcpy(dec2, p1, sizeof(p1));
-    memset(enc2, 0, sizeof(p1));
+    XMEMCPY(dec2, p1, sizeof(p1));
+    XMEMSET(enc2, 0, sizeof(p1));
 
     sg_init_one(src, dec2, sizeof(p1));
     sg_init_one(dst, enc2, sizeof(p1));
 
-    memcpy(stream.tweak_block, i1, sizeof(stream.tweak_block));
+    XMEMCPY(stream.tweak_block, i1, sizeof(stream.tweak_block));
     skcipher_request_set_crypt(req, src, dst, sizeof(p1), stream.tweak_block);
 
     ret = crypto_skcipher_encrypt(req);
@@ -4276,11 +4276,11 @@ static int aes_xts_128_test(void)
         goto test_xts_end;
     }
 
-    memset(dec2, 0, sizeof(p1));
+    XMEMSET(dec2, 0, sizeof(p1));
     sg_init_one(src, enc2, sizeof(p1));
     sg_init_one(dst, dec2, sizeof(p1));
 
-    memcpy(stream.tweak_block, i1, sizeof(stream.tweak_block));
+    XMEMCPY(stream.tweak_block, i1, sizeof(stream.tweak_block));
     skcipher_request_set_crypt(req, src, dst, sizeof(p1), stream.tweak_block);
 
     ret = crypto_skcipher_decrypt(req);
@@ -4297,13 +4297,13 @@ static int aes_xts_128_test(void)
         goto test_xts_end;
     }
 
-    memcpy(dec2, pp, sizeof(pp));
-    memset(enc2, 0, sizeof(pp));
+    XMEMCPY(dec2, pp, sizeof(pp));
+    XMEMSET(enc2, 0, sizeof(pp));
 
     sg_init_one(src, dec2, sizeof(pp));
     sg_init_one(dst, enc2, sizeof(pp));
 
-    memcpy(stream.tweak_block, i1, sizeof(stream.tweak_block));
+    XMEMCPY(stream.tweak_block, i1, sizeof(stream.tweak_block));
     skcipher_request_set_crypt(req, src, dst, sizeof(pp), stream.tweak_block);
 
     ret = crypto_skcipher_encrypt(req);
@@ -4320,11 +4320,11 @@ static int aes_xts_128_test(void)
         goto test_xts_end;
     }
 
-    memset(dec2, 0, sizeof(pp));
+    XMEMSET(dec2, 0, sizeof(pp));
     sg_init_one(src, enc2, sizeof(pp));
     sg_init_one(dst, dec2, sizeof(pp));
 
-    memcpy(stream.tweak_block, i1, sizeof(stream.tweak_block));
+    XMEMCPY(stream.tweak_block, i1, sizeof(stream.tweak_block));
     skcipher_request_set_crypt(req, src, dst, sizeof(pp), stream.tweak_block);
 
     ret = crypto_skcipher_decrypt(req);
@@ -4749,13 +4749,13 @@ static int aes_xts_256_test(void)
         goto test_xts_end;
     }
 
-    memcpy(dec2, p1, sizeof(p1));
-    memset(enc2, 0, sizeof(p1));
+    XMEMCPY(dec2, p1, sizeof(p1));
+    XMEMSET(enc2, 0, sizeof(p1));
 
     sg_init_one(src, dec2, sizeof(p1));
     sg_init_one(dst, enc2, sizeof(p1));
 
-    memcpy(stream.tweak_block, i1, sizeof(stream.tweak_block));
+    XMEMCPY(stream.tweak_block, i1, sizeof(stream.tweak_block));
     skcipher_request_set_crypt(req, src, dst, sizeof(p1), stream.tweak_block);
 
     ret = crypto_skcipher_encrypt(req);
@@ -4772,11 +4772,11 @@ static int aes_xts_256_test(void)
         goto test_xts_end;
     }
 
-    memset(dec2, 0, sizeof(p1));
+    XMEMSET(dec2, 0, sizeof(p1));
     sg_init_one(src, enc2, sizeof(p1));
     sg_init_one(dst, dec2, sizeof(p1));
 
-    memcpy(stream.tweak_block, i1, sizeof(stream.tweak_block));
+    XMEMCPY(stream.tweak_block, i1, sizeof(stream.tweak_block));
     skcipher_request_set_crypt(req, src, dst, sizeof(p1), stream.tweak_block);
 
     ret = crypto_skcipher_decrypt(req);
@@ -4793,13 +4793,13 @@ static int aes_xts_256_test(void)
         goto test_xts_end;
     }
 
-    memcpy(dec2, pp, sizeof(pp));
-    memset(enc2, 0, sizeof(pp));
+    XMEMCPY(dec2, pp, sizeof(pp));
+    XMEMSET(enc2, 0, sizeof(pp));
 
     sg_init_one(src, dec2, sizeof(pp));
     sg_init_one(dst, enc2, sizeof(pp));
 
-    memcpy(stream.tweak_block, i1, sizeof(stream.tweak_block));
+    XMEMCPY(stream.tweak_block, i1, sizeof(stream.tweak_block));
     skcipher_request_set_crypt(req, src, dst, sizeof(pp), stream.tweak_block);
 
     ret = crypto_skcipher_encrypt(req);
@@ -4816,11 +4816,11 @@ static int aes_xts_256_test(void)
         goto test_xts_end;
     }
 
-    memset(dec2, 0, sizeof(pp));
+    XMEMSET(dec2, 0, sizeof(pp));
     sg_init_one(src, enc2, sizeof(pp));
     sg_init_one(dst, dec2, sizeof(pp));
 
-    memcpy(stream.tweak_block, i1, sizeof(stream.tweak_block));
+    XMEMCPY(stream.tweak_block, i1, sizeof(stream.tweak_block));
     skcipher_request_set_crypt(req, src, dst, sizeof(pp), stream.tweak_block);
 
     ret = crypto_skcipher_decrypt(req);

--- a/linuxkm/lkcapi_dh_glue.c
+++ b/linuxkm/lkcapi_dh_glue.c
@@ -329,18 +329,18 @@ static int km_dh_decode_secret(const u8 * buf, unsigned int len,
 
     /* the type of secret should be the first byte. */
     ptr = buf;
-    memcpy(&secret, ptr, sizeof(secret));
+    XMEMCPY(&secret, ptr, sizeof(secret));
     ptr += sizeof(secret);
     if (secret.type != CRYPTO_KPP_SECRET_TYPE_DH) {
         return -EINVAL;
     }
 
     /* all three of these fields will be present */
-    memcpy(&params->key_size, ptr, sizeof(params->key_size));
+    XMEMCPY(&params->key_size, ptr, sizeof(params->key_size));
     ptr += sizeof(params->key_size);
-    memcpy(&params->p_size, ptr, sizeof(params->p_size));
+    XMEMCPY(&params->p_size, ptr, sizeof(params->p_size));
     ptr += sizeof(params->p_size);
-    memcpy(&params->g_size, ptr, sizeof(params->g_size));
+    XMEMCPY(&params->g_size, ptr, sizeof(params->g_size));
     ptr += sizeof(params->g_size);
 
     /* Calculate expected len based on provided 3 fields. Verify
@@ -411,7 +411,7 @@ static int km_dh_alloc_keys(struct km_dh_ctx * ctx)
         goto alloc_keys_end;
     }
 
-    memset(ctx->priv_key, 0, ctx->priv_len);
+    XMEMSET(ctx->priv_key, 0, ctx->priv_len);
 
     ctx->pub_key = malloc(ctx->pub_len);
     if (!ctx->pub_key) {
@@ -419,7 +419,7 @@ static int km_dh_alloc_keys(struct km_dh_ctx * ctx)
         goto alloc_keys_end;
     }
 
-    memset(ctx->pub_key, 0, ctx->pub_len);
+    XMEMSET(ctx->pub_key, 0, ctx->pub_len);
 
 alloc_keys_end:
     if (err) {
@@ -485,7 +485,7 @@ static int km_dh_set_secret(struct crypto_kpp *tfm, const void *buf,
     struct dh          params;
 
     ctx = kpp_tfm_ctx(tfm);
-    memset(&params, 0, sizeof(params));
+    XMEMSET(&params, 0, sizeof(params));
 
     if (km_dh_decode_secret(buf, len, &params) < 0) {
         #ifdef WOLFKM_DEBUG_DH
@@ -591,7 +591,7 @@ static int km_ffdhe_set_secret(struct crypto_kpp *tfm, const void *buf,
     struct dh          params;
 
     ctx = kpp_tfm_ctx(tfm);
-    memset(&params, 0, sizeof(params));
+    XMEMSET(&params, 0, sizeof(params));
 
     /* buf is optional for ffdhe */
     if (buf) {
@@ -659,7 +659,7 @@ static int km_ffdhe_set_secret(struct crypto_kpp *tfm, const void *buf,
             #endif
 
             memmove(ctx->pub_key + pad_len, ctx->pub_key, ctx->pub_len);
-            memset(ctx->pub_key, 0, pad_len);
+            XMEMSET(ctx->pub_key, 0, pad_len);
 
             ctx->pub_len += pad_len;
         }
@@ -760,7 +760,7 @@ static int km_ffdhe_init(struct crypto_kpp *tfm, int name, word32 nbits)
     int key_inited = 0;
 
     ctx = kpp_tfm_ctx(tfm);
-    memset(ctx, 0, sizeof(struct km_dh_ctx));
+    XMEMSET(ctx, 0, sizeof(struct km_dh_ctx));
     ctx->name = name;
     ctx->nbits = nbits;
 
@@ -885,7 +885,7 @@ static int km_dh_gen_pub(struct kpp_request *req)
     }
 
     if (ctx->has_pub_key == 0) {
-        memset(ctx->pub_key, 0, ctx->pub_len);
+        XMEMSET(ctx->pub_key, 0, ctx->pub_len);
 
         err = wc_DhGeneratePublic(ctx->key, ctx->priv_key, ctx->priv_len,
                                   ctx->pub_key, &ctx->pub_len);
@@ -965,7 +965,7 @@ static int km_dh_compute_shared_secret(struct kpp_request *req)
         goto dh_shared_secret_end;
     }
 
-    memset(pub, 0, pub_len);
+    XMEMSET(pub, 0, pub_len);
 
     /* copy req->src to pub */
     scatterwalk_map_and_copy(pub, req->src, 0, req->src_len, 0);
@@ -2941,7 +2941,7 @@ static int linuxkm_test_kpp_driver(const char * driver,
         goto test_kpp_end;
     }
 
-    memset(dst_buf, 0, dst_len);
+    XMEMSET(dst_buf, 0, dst_len);
 
     /* generate pub key from input, and verify matches expected. */
     kpp_request_set_input(req, NULL, 0);
@@ -2968,7 +2968,7 @@ static int linuxkm_test_kpp_driver(const char * driver,
         goto test_kpp_end;
     }
 
-    memcpy(src_buf, b_pub, pub_len);
+    XMEMCPY(src_buf, b_pub, pub_len);
 
     /* generate shared secret, verify matches expected value. */
     sg_init_one(&src, src_buf, src_len);

--- a/linuxkm/lkcapi_dh_glue.c
+++ b/linuxkm/lkcapi_dh_glue.c
@@ -970,7 +970,15 @@ static int km_dh_compute_shared_secret(struct kpp_request *req)
     /* copy req->src to pub */
     scatterwalk_map_and_copy(pub, req->src, 0, req->src_len, 0);
 
-    shared_secret_len = pub_len;
+    /* Note, shared_secret_len must use the canonical length of ctx->key, not
+     * the untrustworthy req->src_len, to prevent underallocation of
+     * shared_secret.
+     */
+    shared_secret_len = mp_unsigned_bin_size(&ctx->key->p);
+    if (shared_secret_len < req->src_len) {
+        err = -EINVAL;
+        goto dh_shared_secret_end;
+    }
     shared_secret = malloc(shared_secret_len);
     if (!shared_secret) {
         err = -ENOMEM;

--- a/linuxkm/lkcapi_ecdh_glue.c
+++ b/linuxkm/lkcapi_ecdh_glue.c
@@ -189,14 +189,14 @@ static int km_ecdh_decode_secret(const u8 * buf, unsigned int len,
 
     /* the type of secret should be the first byte. */
     ptr = buf;
-    memcpy(&secret, ptr, sizeof(secret));
+    XMEMCPY(&secret, ptr, sizeof(secret));
     ptr += sizeof(secret);
     if (secret.type != CRYPTO_KPP_SECRET_TYPE_ECDH) {
         return -EINVAL;
     }
 
     /* the key_size field will be present */
-    memcpy(&params->key_size, ptr, sizeof(params->key_size));
+    XMEMCPY(&params->key_size, ptr, sizeof(params->key_size));
     ptr += sizeof(params->key_size);
 
     /* Calculate expected len. Verify we got expected data. */
@@ -243,7 +243,7 @@ static int km_ecdh_set_secret(struct crypto_kpp *tfm, const void *buf,
     struct ecdh          params;
 
     ctx = kpp_tfm_ctx(tfm);
-    memset(&params, 0, sizeof(params));
+    XMEMSET(&params, 0, sizeof(params));
 
     switch (ctx->curve_len) {
     #if defined(LINUXKM_ECC192)
@@ -385,7 +385,7 @@ static int km_ecdh_init(struct crypto_kpp *tfm, int curve_id)
     int key_inited = 0;
 
     ctx = kpp_tfm_ctx(tfm);
-    memset(ctx, 0, sizeof(struct km_ecdh_ctx));
+    XMEMSET(ctx, 0, sizeof(struct km_ecdh_ctx));
     ctx->curve_id = curve_id;
     ctx->curve_len = 0;
 
@@ -525,7 +525,7 @@ static int km_ecdh_gen_pub(struct kpp_request *req)
         goto ecdh_gen_pub_end;
     }
 
-    memset(pub, 0, raw_pub_len);
+    XMEMSET(pub, 0, raw_pub_len);
 
     if (ctx->key->type == ECC_PRIVATEKEY_ONLY) {
         /* ecc key was imported as priv only.
@@ -959,7 +959,7 @@ static int linuxkm_test_ecdh_nist_driver(const char * driver,
         goto test_ecdh_nist_end;
     }
 
-    memset(dst_buf, 0, dst_len);
+    XMEMSET(dst_buf, 0, dst_len);
 
     /* generate pub key from input, and verify matches expected. */
     kpp_request_set_input(req, NULL, 0);
@@ -986,7 +986,7 @@ static int linuxkm_test_ecdh_nist_driver(const char * driver,
         goto test_ecdh_nist_end;
     }
 
-    memcpy(src_buf, b_pub, pub_len);
+    XMEMCPY(src_buf, b_pub, pub_len);
 
     /* generate shared secret, verify matches expected value. */
     sg_init_one(&src, src_buf, src_len);

--- a/linuxkm/lkcapi_ecdsa_glue.c
+++ b/linuxkm/lkcapi_ecdsa_glue.c
@@ -315,7 +315,7 @@ static int km_ecdsa_init(struct crypto_akcipher *tfm, int curve_id)
     int                   ret = 0;
 
     ctx = akcipher_tfm_ctx(tfm);
-    memset(ctx, 0, sizeof(struct km_ecdsa_ctx));
+    XMEMSET(ctx, 0, sizeof(struct km_ecdsa_ctx));
     ctx->curve_id = curve_id;
     ctx->curve_len = 0;
 
@@ -430,7 +430,7 @@ static int km_ecdsa_verify(struct akcipher_request *req)
 
     hash = sig + sig_len;
 
-    memset(sig, 0, sig_len + hash_len);
+    XMEMSET(sig, 0, sig_len + hash_len);
 
     /* copy sig and hash from req->src to sig and contiguous hash buffer. */
     scatterwalk_map_and_copy(sig, req->src, 0, sig_len + hash_len, 0);
@@ -731,9 +731,9 @@ static int linuxkm_test_ecdsa_nist_driver(const char * driver,
         test_rc = MEMORY_E;
         goto test_ecdsa_nist_end;
     }
-    memcpy(param_copy, sig, sig_len);
+    XMEMCPY(param_copy, sig, sig_len);
     sig = param_copy;
-    memcpy(param_copy + sig_len, hash, hash_len);
+    XMEMCPY(param_copy + sig_len, hash, hash_len);
     hash = param_copy + sig_len;
 
     /*
@@ -823,7 +823,7 @@ static int linuxkm_test_ecdsa_nist_driver(const char * driver,
         goto test_ecdsa_nist_end;
     }
 
-    memcpy(bad_sig, sig, sig_len);
+    XMEMCPY(bad_sig, sig, sig_len);
     bad_sig[sig_len/2] ^= 1;
 
     sg_init_table(src_tab, 2);

--- a/linuxkm/lkcapi_rsa_glue.c
+++ b/linuxkm/lkcapi_rsa_glue.c
@@ -554,7 +554,7 @@ static int km_rsa_ctx_init(struct km_rsa_ctx * ctx, int hash_oid)
 {
     int ret = 0;
 
-    memset(ctx, 0, sizeof(struct km_rsa_ctx));
+    XMEMSET(ctx, 0, sizeof(struct km_rsa_ctx));
 
     ctx->key = (RsaKey *)malloc(sizeof(RsaKey));
     if (!ctx->key) {
@@ -717,8 +717,8 @@ static int km_direct_rsa_enc(struct akcipher_request *req)
     }
 
     /* copy req->src to dec */
-    memset(dec, 0, req->src_len);
-    memset(enc, 0, req->dst_len);
+    XMEMSET(dec, 0, req->src_len);
+    XMEMSET(enc, 0, req->dst_len);
     scatterwalk_map_and_copy(dec, req->src, 0, req->src_len, 0);
 
     /* note: matching behavior of kernel rsa-generic. */
@@ -820,8 +820,8 @@ static int km_direct_rsa_dec(struct akcipher_request *req)
     }
 
     /* copy req->src to enc */
-    memset(enc, 0, req->src_len);
-    memset(dec, 0, req->dst_len);
+    XMEMSET(enc, 0, req->src_len);
+    XMEMSET(dec, 0, req->dst_len);
     scatterwalk_map_and_copy(enc, req->src, 0, req->src_len, 0);
 
     err = km_rsa_ctx_init_rng(ctx);
@@ -1145,7 +1145,7 @@ static int km_pkcs1pad_sign(struct akcipher_request *req)
         goto pkcs1pad_sign_out;
     }
 
-    memset(work_buffer, 0, 2 * ctx->key_len);
+    XMEMSET(work_buffer, 0, 2 * ctx->key_len);
     msg = work_buffer;
     sig = work_buffer + ctx->key_len;
 
@@ -1265,7 +1265,7 @@ static int km_pkcs1pad_verify(struct akcipher_request *req)
         goto pkcs1pad_verify_out;
     }
 
-    memset(work_buffer, 0, 2 * ctx->key_len);
+    XMEMSET(work_buffer, 0, 2 * ctx->key_len);
     msg = work_buffer;
     sig = work_buffer + ctx->key_len;
 
@@ -1284,7 +1284,7 @@ static int km_pkcs1pad_verify(struct akcipher_request *req)
     }
 
     /* reuse sig array for digest comparison */
-    memset(sig, 0, ctx->key_len);
+    XMEMSET(sig, 0, ctx->key_len);
     scatterwalk_map_and_copy(sig, req->src, sig_len, msg_len, 0);
 
     /* encode digest with hash oid. */
@@ -1396,9 +1396,9 @@ static int km_pkcs1_sign(struct crypto_sig *tfm,
     }
 
     /* copy src to msg, and clear buffers. */
-    memset(msg, 0, ctx->key_len);
-    memset(sig, 0, ctx->key_len);
-    memcpy(msg, src, slen);
+    XMEMSET(msg, 0, ctx->key_len);
+    XMEMSET(sig, 0, ctx->key_len);
+    XMEMCPY(msg, src, slen);
 
     /* encode message with hash oid. */
     enc_msg_len = wc_EncodeSignature(msg, msg, slen, ctx->hash_oid);
@@ -1519,7 +1519,7 @@ static int km_pkcs1_verify(struct crypto_sig *tfm,
         goto pkcs1_verify_out;
     }
 
-    memset(work_buffer, 0, 2 * ctx->key_len);
+    XMEMSET(work_buffer, 0, 2 * ctx->key_len);
     msg = work_buffer;
     enc_digest = work_buffer + ctx->key_len;
 
@@ -1534,7 +1534,7 @@ static int km_pkcs1_verify(struct crypto_sig *tfm,
         goto pkcs1_verify_out;
     }
 
-    memcpy(enc_digest, digest, msg_len);
+    XMEMCPY(enc_digest, digest, msg_len);
 
     /* encode digest with hash oid. */
     enc_msg_len = wc_EncodeSignature(enc_digest, enc_digest, msg_len,
@@ -1732,8 +1732,8 @@ static int km_pkcs1pad_enc(struct akcipher_request *req)
     }
 
     /* copy req->src to dec */
-    memset(dec, 0, req->src_len);
-    memset(enc, 0, req->dst_len);
+    XMEMSET(dec, 0, req->src_len);
+    XMEMSET(enc, 0, req->dst_len);
     scatterwalk_map_and_copy(dec, req->src, 0, req->src_len, 0);
 
     err = km_rsa_ctx_init_rng(ctx);
@@ -1816,8 +1816,8 @@ static int km_pkcs1pad_dec(struct akcipher_request *req)
     }
 
     /* copy req->src to enc */
-    memset(enc, 0, req->src_len);
-    memset(dec, 0, req->dst_len);
+    XMEMSET(enc, 0, req->src_len);
+    XMEMSET(dec, 0, req->dst_len);
     scatterwalk_map_and_copy(enc, req->src, 0, req->src_len, 0);
 
 #ifdef WC_RSA_BLINDING
@@ -2140,8 +2140,8 @@ static int linuxkm_test_rsa_driver(const char * driver, int nbits)
         goto test_rsa_end;
     }
 
-    memset(&rng, 0, sizeof(rng));
-    memset(key, 0, sizeof(RsaKey));
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(key, 0, sizeof(RsaKey));
 
     ret = LKCAPI_INITRNG(&rng);
 
@@ -2211,14 +2211,14 @@ static int linuxkm_test_rsa_driver(const char * driver, int nbits)
         goto test_rsa_end;
     }
 
-    memset(enc,  0, key_len);
-    memset(dec,  0, key_len + 1);
-    memset(plaintext, 0, key_len + 1);
+    XMEMSET(enc,  0, key_len);
+    XMEMSET(dec,  0, key_len + 1);
+    XMEMSET(plaintext, 0, key_len + 1);
 
     /* Fill up dec and plaintext with plaintext reference. */
     for (i = 0; i < key_len / sizeof(p_vector); ++i) {
-        memcpy(dec  + i * sizeof(p_vector), p_vector, sizeof(p_vector));
-        memcpy(plaintext + i * sizeof(p_vector), p_vector, sizeof(p_vector));
+        XMEMCPY(dec  + i * sizeof(p_vector), p_vector, sizeof(p_vector));
+        XMEMCPY(plaintext + i * sizeof(p_vector), p_vector, sizeof(p_vector));
     }
 
     /**
@@ -2233,7 +2233,7 @@ static int linuxkm_test_rsa_driver(const char * driver, int nbits)
         goto test_rsa_end;
     }
 
-    memset(dec, 0, key_len);
+    XMEMSET(dec, 0, key_len);
     dec_ret = wc_RsaDirect(enc, key_len, dec, &out_len, key,
                            RSA_PRIVATE_DECRYPT, &rng);
     if (dec_ret != key_len || key_len != (int)out_len) {
@@ -2263,7 +2263,7 @@ static int linuxkm_test_rsa_driver(const char * driver, int nbits)
         goto test_rsa_end;
     }
 
-    memset(priv, 0, priv_len);
+    XMEMSET(priv, 0, priv_len);
 
     priv_len = wc_RsaKeyToDer(key, priv, priv_len);
     if (priv_len <= 0) {
@@ -2284,7 +2284,7 @@ static int linuxkm_test_rsa_driver(const char * driver, int nbits)
         goto test_rsa_end;
     }
 
-    memset(pub, 0, pub_len);
+    XMEMSET(pub, 0, pub_len);
 
     pub_len = wc_RsaKeyToPublicDer(key, pub, pub_len);
     if (pub_len <= 0) {
@@ -2341,7 +2341,7 @@ static int linuxkm_test_rsa_driver(const char * driver, int nbits)
     }
 
     /* wolfcrypt private decrypt */
-    memset(dec, 0, key_len + 1);
+    XMEMSET(dec, 0, key_len + 1);
     dec_ret = wc_RsaDirect(enc, key_len, dec, &out_len, key,
                            RSA_PRIVATE_DECRYPT, &rng);
 
@@ -2387,7 +2387,7 @@ static int linuxkm_test_rsa_driver(const char * driver, int nbits)
 
     akcipher_request_set_crypt(req, &src, &dst, key_len, key_len);
 
-    memset(dec, 0, key_len);
+    XMEMSET(dec, 0, key_len);
     ret = crypto_akcipher_decrypt(req);
    #if defined(RHEL_RELEASE_CODE) && \
               (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 6))
@@ -2503,7 +2503,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(hash, 0, hash_len);
+    XMEMSET(hash, 0, hash_len);
 
     /* hash the test msg with hash algo. */
     ret = wc_Hash(wc_OidGetHash(hash_oid), p_vector, sizeof(p_vector),
@@ -2522,8 +2522,8 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(&rng, 0, sizeof(rng));
-    memset(key, 0, sizeof(RsaKey));
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(key, 0, sizeof(RsaKey));
 
     ret = LKCAPI_INITRNG(&rng);
     if (ret) {
@@ -2580,7 +2580,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         test_rc = MEMORY_E;
         goto test_pkcs1_end;
     }
-    memset(sig, 0, key_len);
+    XMEMSET(sig, 0, key_len);
 
     km_sig = (byte*)malloc(key_len);
     if (km_sig == NULL) {
@@ -2588,7 +2588,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         test_rc = MEMORY_E;
         goto test_pkcs1_end;
     }
-    memset(km_sig, 0, key_len);
+    XMEMSET(km_sig, 0, key_len);
     #endif /* !LINUXKM_AKCIPHER_NO_SIGNVERIFY */
 
     enc = (byte*)malloc(key_len);
@@ -2597,7 +2597,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         test_rc = MEMORY_E;
         goto test_pkcs1_end;
     }
-    memset(enc, 0, key_len);
+    XMEMSET(enc, 0, key_len);
 
     dec = (byte*)malloc(key_len + 1);
     if (dec == NULL) {
@@ -2605,7 +2605,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         test_rc = MEMORY_E;
         goto test_pkcs1_end;
     }
-    memset(dec, 0, key_len + 1);
+    XMEMSET(dec, 0, key_len + 1);
 
     enc2 = (byte*)malloc(key_len);
     if (enc2 == NULL) {
@@ -2613,7 +2613,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         test_rc = MEMORY_E;
         goto test_pkcs1_end;
     }
-    memset(enc2, 0, key_len);
+    XMEMSET(enc2, 0, key_len);
 
     dec2 = (byte*)malloc(key_len + 1);
     if (dec2 == NULL) {
@@ -2621,7 +2621,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         test_rc = MEMORY_E;
         goto test_pkcs1_end;
     }
-    memset(dec2, 0, key_len + 1);
+    XMEMSET(dec2, 0, key_len + 1);
 
     /**
      * Now export Rsa Der to pub and priv.
@@ -2640,7 +2640,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(priv, 0, priv_len);
+    XMEMSET(priv, 0, priv_len);
 
     priv_len = wc_RsaKeyToDer(key, priv, priv_len);
     if (priv_len <= 0) {
@@ -2664,7 +2664,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(pub, 0, pub_len);
+    XMEMSET(pub, 0, pub_len);
 
     pub_len = wc_RsaKeyToPublicDer(key, pub, pub_len);
     if (pub_len <= 0) {
@@ -2693,7 +2693,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(dec, 0, key_len + 1);
+    XMEMSET(dec, 0, key_len + 1);
     ret = wc_RsaSSL_Verify(sig, key_len, dec, enc_len, key);
     if (ret <= 0 || ret != (int) enc_len) {
         pr_err("error: wc_RsaSSL_Verify returned %d, expected %d\n" , ret,
@@ -2766,7 +2766,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
 
     sg_init_one(&src, hash, hash_len);
     sg_init_one(&dst, km_sig, key_len);
-    memset(km_sig, 0, key_len);
+    XMEMSET(km_sig, 0, key_len);
 
     akcipher_request_set_crypt(req, &src, &dst, hash_len, key_len);
 
@@ -2825,7 +2825,7 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(dec, 0, key_len + 1);
+    XMEMSET(dec, 0, key_len + 1);
     ret = wc_RsaSSL_Verify(km_sig, key_len, dec, key_len, key);
     if (ret <= 0) {
         pr_err("error: wc_RsaSSL_Verify returned: %d\n", ret);
@@ -2852,13 +2852,13 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
     /*
      * pkcs1 encrypt and ecrypt test
      */
-    memset(enc, 0, key_len);
-    memset(enc2, 0, key_len);
-    memset(dec, 0, key_len);
-    memset(dec2, 0, key_len);
+    XMEMSET(enc, 0, key_len);
+    XMEMSET(enc2, 0, key_len);
+    XMEMSET(dec, 0, key_len);
+    XMEMSET(dec2, 0, key_len);
 
-    memcpy(dec, p_vector, sizeof(p_vector));
-    memcpy(dec2, p_vector, sizeof(p_vector));
+    XMEMCPY(dec, p_vector, sizeof(p_vector));
+    XMEMCPY(dec2, p_vector, sizeof(p_vector));
 
     sg_init_one(&src, dec, sizeof(p_vector));
     sg_init_one(&dst, enc, key_len);
@@ -2889,8 +2889,8 @@ static int linuxkm_test_pkcs1pad_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(dec, 0, key_len);
-    memset(dec2, 0, key_len);
+    XMEMSET(dec, 0, key_len);
+    XMEMSET(dec2, 0, key_len);
 
     sg_init_one(&src, enc, key_len);
     sg_init_one(&dst, dec, sizeof(p_vector));
@@ -3032,7 +3032,7 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(hash, 0, hash_len);
+    XMEMSET(hash, 0, hash_len);
 
     /* hash the test msg with hash algo. */
     ret = wc_Hash(wc_OidGetHash(hash_oid), p_vector, sizeof(p_vector),
@@ -3050,8 +3050,8 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(&rng, 0, sizeof(rng));
-    memset(key, 0, sizeof(RsaKey));
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(key, 0, sizeof(RsaKey));
 
     ret = LKCAPI_INITRNG(&rng);
     if (ret) {
@@ -3107,7 +3107,7 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
         test_rc = MEMORY_E;
         goto test_pkcs1_end;
     }
-    memset(sig, 0, key_len);
+    XMEMSET(sig, 0, key_len);
 
     km_sig = (byte*)malloc(key_len);
     if (km_sig == NULL) {
@@ -3115,7 +3115,7 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
         test_rc = MEMORY_E;
         goto test_pkcs1_end;
     }
-    memset(km_sig, 0, key_len);
+    XMEMSET(km_sig, 0, key_len);
 
     /**
      * Now export Rsa Der to pub and priv.
@@ -3134,7 +3134,7 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(priv, 0, priv_len);
+    XMEMSET(priv, 0, priv_len);
 
     priv_len = wc_RsaKeyToDer(key, priv, priv_len);
     if (priv_len <= 0) {
@@ -3158,7 +3158,7 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(pub, 0, pub_len);
+    XMEMSET(pub, 0, pub_len);
 
     pub_len = wc_RsaKeyToPublicDer(key, pub, pub_len);
     if (pub_len <= 0) {
@@ -3173,7 +3173,7 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
         test_rc = MEMORY_E;
         goto test_pkcs1_end;
     }
-    memset(enc, 0, key_len);
+    XMEMSET(enc, 0, key_len);
 
     dec = (byte*)malloc(key_len + 1);
     if (dec == NULL) {
@@ -3181,7 +3181,7 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
         test_rc = MEMORY_E;
         goto test_pkcs1_end;
     }
-    memset(dec, 0, key_len + 1);
+    XMEMSET(dec, 0, key_len + 1);
 
     /**
      * Sanity test: first sign and verify with direct wolfcrypt API.
@@ -3202,7 +3202,7 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
         goto test_pkcs1_end;
     }
 
-    memset(dec, 0, key_len + 1);
+    XMEMSET(dec, 0, key_len + 1);
     ret = wc_RsaSSL_Verify(sig, key_len, dec, enc_len, key);
     if (ret <= 0 || ret != (int) enc_len) {
         pr_err("error: wc_RsaSSL_Verify returned %d, expected %d\n" , ret,

--- a/linuxkm/lkcapi_sha_glue.c
+++ b/linuxkm/lkcapi_sha_glue.c
@@ -1835,8 +1835,8 @@ static int wc_linuxkm_drbg_startup(void)
             u8 buf1[16], buf2[17];
             int i, j;
 
-            memset(buf1, 0, sizeof buf1);
-            memset(buf2, 0, sizeof buf2);
+            XMEMSET(buf1, 0, sizeof buf1);
+            XMEMSET(buf2, 0, sizeof buf2);
 
             ret = crypto_rng_generate(tfm, NULL, 0, buf1, (unsigned int)sizeof buf1);
             if (! ret)
@@ -1858,7 +1858,7 @@ static int wc_linuxkm_drbg_startup(void)
                  */
                 for (i = 1; i <= (int)sizeof buf2; ++i) {
                     for (j = 0; j < 20; ++j) {
-                        memset(buf2, 0, (size_t)i);
+                        XMEMSET(buf2, 0, (size_t)i);
                         ret = crypto_rng_generate(tfm, NULL, 0, buf2, (unsigned int)i);
                         if (ret)
                             break;

--- a/linuxkm/lkcapi_sha_glue.c
+++ b/linuxkm/lkcapi_sha_glue.c
@@ -1230,10 +1230,16 @@ static int wc_linuxkm_drbg_generate(struct wc_rng_bank *ctx,
         if (ret == 0)
             continue;
 
-        if (unlikely(ret == WC_NO_ERR_TRACE(RNG_FAILURE_E)) && (! retried)) {
-            if (slen > 0)
+        if (unlikely(ret == WC_NO_ERR_TRACE(RNG_FAILURE_E))) {
+            if (slen > 0) {
+                ret = -EINVAL;
                 break;
+            }
 
+            if (retried) {
+                ret = -EINVAL;
+                break;
+            }
             retried = 1;
 
             ret = wc_rng_bank_inst_reinit(ctx,

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -1368,7 +1368,7 @@ static int my_preempt_count(void) {
 }
 
 static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
-    memset(
+    XMEMSET(
         &wolfssl_linuxkm_pie_redirect_table,
         0,
         sizeof wolfssl_linuxkm_pie_redirect_table);
@@ -2059,7 +2059,7 @@ static ssize_t FIPS_optest_trig_handler(struct kobject *kobj, struct kobj_attrib
         corrected_count = count;
     if ((corrected_count < 1) || (corrected_count > 4))
         return -EINVAL;
-    memcpy(code_buf, buf, corrected_count);
+    XMEMCPY(code_buf, buf, corrected_count);
     code_buf[corrected_count] = 0;
 
     if (strspn(code_buf, "-0123456789") != corrected_count)

--- a/linuxkm/x86_vector_register_glue.c
+++ b/linuxkm/x86_vector_register_glue.c
@@ -76,7 +76,7 @@ WARN_UNUSED_RESULT int allocate_wolfcrypt_linuxkm_fpu_states(void)
         return MEMORY_E;
     }
 
-    memset(wc_linuxkm_fpu_states, 0, wc_linuxkm_fpu_states_n_tracked
+    XMEMSET(wc_linuxkm_fpu_states, 0, wc_linuxkm_fpu_states_n_tracked
            * sizeof(wc_linuxkm_fpu_states[0]));
 
     return 0;


### PR DESCRIPTION
fixes for F-5956 F-5957 F-5958 F-1236 F-3291 F-1431

tested with
```
wolfssl-multi-test.sh ...
check-source-text
quantum-safe-wolfssl-all-crypto-only-noasm-linuxkm-mainline-clang-tidy
quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-sp-linuxkm-mainline-clang-tidy
quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-fips-dev-linuxkm-next-clang-tidy
quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-sp-linuxkm-6.12-insmod
quantum-safe-wolfssl-all-crypto-only-intelasm-fips-dev-linuxkm-next-insmod
'.*cust-kernel-.*'
```
