### PR TITLE
.github: bump JavaScript actions to Node.js 24 runtimes

### DIFF
--- a/.github/actions/ccache-setup/action.yml
+++ b/.github/actions/ccache-setup/action.yml
@@ -42,7 +42,7 @@ runs:
         fi
 
     - name: Restore + save ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.ccache
         # Unique per run+attempt+config so each job persists its own

--- a/.github/actions/install-apt-deps/action.yml
+++ b/.github/actions/install-apt-deps/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: Restore apt cache
       if: inputs.cache == 'true'
       id: apt-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ~/apt-cache
         key: ${{ steps.cache-key.outputs.key }}
@@ -100,7 +100,7 @@ runs:
 
     - name: Save apt cache
       if: inputs.cache == 'true' && steps.apt-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ~/apt-cache
         key: ${{ steps.cache-key.outputs.key }}

--- a/.github/workflows/ada.yml
+++ b/.github/workflows/ada.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install alire
       uses: alire-project/setup-alire@v5

--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -142,7 +142,7 @@ jobs:
           df -h
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Arduino CLI
         run: |
@@ -271,7 +271,7 @@ jobs:
           echo "WOLFSSL_EXAMPLES_ROOT = $WOLFSSL_EXAMPLES_ROOT"
 
       - name: Cache Arduino Packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.arduino15

--- a/.github/workflows/async-examples.yml
+++ b/.github/workflows/async-examples.yml
@@ -26,7 +26,7 @@ jobs:
           - '-DWOLFSSL_STATIC_MEMORY'
     name: Async Examples (${{ matrix.async_mode }}, ${{ matrix.extra_cflags || 'default' }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Build async examples (no configure)

--- a/.github/workflows/async.yml
+++ b/.github/workflows/async.yml
@@ -28,7 +28,7 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: async-logs
           path: |

--- a/.github/workflows/atecc608-sim.yml
+++ b/.github/workflows/atecc608-sim.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout wolfSSL (PR source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: wolfssl-src
 
@@ -74,10 +74,10 @@ jobs:
           sed -i 's/--with-cryptoauthlib=\/usr \\/--enable-microchip=608 \\\n        --with-cryptoauthlib=\/usr \\/' Dockerfile.wolfcrypt
           grep -q -- '--enable-microchip=608' Dockerfile.wolfcrypt
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Build wolfCrypt-ATECC608 test image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: simulators/ATECC608Sim
           file: simulators/ATECC608Sim/Dockerfile.wolfcrypt

--- a/.github/workflows/bind.yml
+++ b/.github/workflows/bind.yml
@@ -34,7 +34,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-bind
           path: build-dir.tgz
@@ -54,13 +54,13 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-bind
 
@@ -73,14 +73,14 @@ jobs:
           packages: libuv1-dev libnghttp2-dev libcap-dev libcmocka-dev liburcu-dev
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout bind9
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: isc-projects/bind9
           path: bind

--- a/.github/workflows/check-headers.yml
+++ b/.github/workflows/check-headers.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         uses: ./.github/actions/install-apt-deps

--- a/.github/workflows/check-source-text.yml
+++ b/.github/workflows/check-source-text.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/cmake-autoconf.yml
+++ b/.github/workflows/cmake-autoconf.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
 # pull wolfSSL
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install cmake and autotools
       uses: ./.github/actions/install-apt-deps

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
 # pull wolfSSL
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install cmake
       uses: ./.github/actions/install-apt-deps

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: codespell-project/actions-codespell@v2.1
       with:

--- a/.github/workflows/coverity-scan-fixes.yml
+++ b/.github/workflows/coverity-scan-fixes.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         ref: master
 

--- a/.github/workflows/cryptocb-only.yml
+++ b/.github/workflows/cryptocb-only.yml
@@ -28,7 +28,7 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -225,7 +225,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cryptocb-only-logs
           path: |

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -32,7 +32,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-curl
           path: build-dir.tgz
@@ -51,7 +51,7 @@ jobs:
         curl_ref: [ 'master', 'curl-8_4_0' ]
     steps:
     - name: Checkout wolfSSL CI actions
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         sparse-checkout: .github/actions
         fetch-depth: 1
@@ -62,7 +62,7 @@ jobs:
         packages: nghttp2 libpsl5 libpsl-dev python3-impacket apache2 apache2-dev
 
     - name: Download lib
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: wolf-install-curl
 

--- a/.github/workflows/cyrus-sasl.yml
+++ b/.github/workflows/cyrus-sasl.yml
@@ -35,7 +35,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-sasl
           path: build-dir.tgz
@@ -55,7 +55,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -66,7 +66,7 @@ jobs:
           packages: krb5-kdc krb5-otp libkrb5-dev libsocket-wrapper libnss-wrapper krb5-admin-server libdb5.3-dev
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-sasl
 
@@ -74,14 +74,14 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout sasl
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: cyrusimap/cyrus-sasl
           ref: cyrus-sasl-${{ matrix.ref }}

--- a/.github/workflows/disable-pk-algs.yml
+++ b/.github/workflows/disable-pk-algs.yml
@@ -28,7 +28,7 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -133,7 +133,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: disable-pk-algs-logs
           path: |

--- a/.github/workflows/disabled/haproxy.yml
+++ b/.github/workflows/disabled/haproxy.yml
@@ -31,7 +31,7 @@ jobs:
           install: true
 
       - name: Checkout VTest
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: vtest/VTest
           path: VTest
@@ -42,7 +42,7 @@ jobs:
         run: make FLAGS='-O2 -s -Wall'
 
       - name: Checkout HaProxy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: haproxy/haproxy
           path: haproxy

--- a/.github/workflows/disabled/hitch.yml
+++ b/.github/workflows/disabled/hitch.yml
@@ -32,7 +32,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-hitch
           path: build-dir.tgz
@@ -55,7 +55,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-hitch
 
@@ -63,7 +63,7 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
@@ -75,7 +75,7 @@ jobs:
             sudo apt-get install -y libev-dev libssl-dev automake python3-docutils flex bison pkg-config make
 
       - name: Checkout hitch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: varnish/hitch
           ref: 1.7.3

--- a/.github/workflows/disabled/hostap.yml
+++ b/.github/workflows/disabled/hostap.yml
@@ -50,7 +50,7 @@ jobs:
           install: true
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.build_id }}
           path: build-dir
@@ -124,7 +124,7 @@ jobs:
           echo Our job run ID is $SHA_SUM
 
       - name: Checkout wolfSSL
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: wolfssl
 
@@ -151,7 +151,7 @@ jobs:
           echo "hostap_debug_flags=-d" >> $GITHUB_ENV
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ matrix.config.build_id }}
           path: build-dir
@@ -181,7 +181,7 @@ jobs:
           sudo rmmod mac80211_hwsim
 
       - name: Checkout hostap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: julek-wolfssl/hostap-mirror
           path: hostap
@@ -196,7 +196,7 @@ jobs:
 
       - if: ${{ matrix.config.osp_ref }}
         name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
@@ -286,7 +286,7 @@ jobs:
 
       - name: Upload failure logs
         if: ${{ failure() && steps.testing.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: hostap-logs-${{ env.our_job_run_id }}
           path: hostap/tests/hwsim/logs.zip

--- a/.github/workflows/docker-Espressif.yml
+++ b/.github/workflows/docker-Espressif.yml
@@ -24,7 +24,7 @@ jobs:
       image: espressif/idf:release-v5.5
       # image: espressif/idf:latest # The "latest" has breaking changes for ESP-IDF V6
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Initialize Espressif IDE and build examples
         run: cd /opt/esp/idf && . ./export.sh && cd $GITHUB_WORKSPACE; IDE/Espressif/ESP-IDF/compileAllExamples.sh
   espressif_v4_4:
@@ -34,7 +34,7 @@ jobs:
     container:
       image: espressif/idf:release-v4.4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Initialize Espressif IDE and build examples
         run: cd /opt/esp/idf && . ./export.sh && cd $GITHUB_WORKSPACE; IDE/Espressif/ESP-IDF/compileAllExamples.sh
   espressif_v5_0:
@@ -44,6 +44,6 @@ jobs:
     container:
       image: espressif/idf:release-v5.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Initialize Espressif IDE and build examples
         run: cd /opt/esp/idf && . ./export.sh && cd $GITHUB_WORKSPACE; IDE/Espressif/ESP-IDF/compileAllExamples.sh

--- a/.github/workflows/docker-OpenWrt.yml
+++ b/.github/workflows/docker-OpenWrt.yml
@@ -27,7 +27,7 @@ jobs:
         steps:
             - name: Install required tools
               run: apk add argp-standalone asciidoc bash bc binutils bzip2 cdrkit coreutils diffutils elfutils-dev findutils flex musl-fts-dev g++ gawk gcc gettext git grep intltool libxslt linux-headers make musl-libintl musl-obstack-dev ncurses-dev openssl-dev patch perl python3-dev rsync tar unzip util-linux wget zlib-dev autoconf automake libtool
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - name: Compile libwolfssl.so
               run: ./autogen.sh && ./configure --enable-all && make
               # 2024-08-05 - Something broke in the actions. They are no longer following links.
@@ -35,7 +35,7 @@ jobs:
               working-directory: src/.libs
               run: tar -zcf libwolfssl.tgz libwolfssl.so*
             - name: Upload libwolfssl.so
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                 name: openwrt-libwolfssl.so
                 path: src/.libs/libwolfssl.tgz
@@ -52,16 +52,16 @@ jobs:
             matrix:
                 release: [ "22.03.6", "21.02.7" ] # some other versions: 21.02.0 21.02.5 22.03.0 22.03.3 snapshot
         steps:
-            - uses: actions/checkout@v4
-            - uses: docker/setup-buildx-action@v3
-            - uses: actions/download-artifact@v4
+            - uses: actions/checkout@v5
+            - uses: docker/setup-buildx-action@v4
+            - uses: actions/download-artifact@v7
               with:
                 name: openwrt-libwolfssl.so
                 path: .
             - name: untar libwolfssl.so
               run: tar -xf libwolfssl.tgz -C Docker/OpenWrt
             - name: Build but dont push
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@v7
               with:
                   context: Docker/OpenWrt
                   platforms: linux/amd64

--- a/.github/workflows/emnet-nonblock.yml
+++ b/.github/workflows/emnet-nonblock.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout wolfSSL
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install build deps
         uses: ./.github/actions/install-apt-deps

--- a/.github/workflows/freertos-mem-track.yml
+++ b/.github/workflows/freertos-mem-track.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout wolfSSL
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run mem_track.h FreeRTOS reproducer
         run: sh tests/freertos-mem-track-repro/run.sh

--- a/.github/workflows/gencertbuf.yml
+++ b/.github/workflows/gencertbuf.yml
@@ -21,7 +21,7 @@ jobs:
     # This should be a safe limit for the tests to run.
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Test generate wolfssl/certs_test.h

--- a/.github/workflows/grpc.yml
+++ b/.github/workflows/grpc.yml
@@ -33,7 +33,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-grpc
           path: build-dir.tgz
@@ -64,7 +64,7 @@ jobs:
           ip addr list lo | grep 'inet6 '
 
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -75,7 +75,7 @@ jobs:
           packages: build-essential autoconf libtool pkg-config cmake clang libc++-dev
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-grpc
 
@@ -88,14 +88,14 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout grpc
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: grpc/grpc
           path: grpc

--- a/.github/workflows/haproxy.yml
+++ b/.github/workflows/haproxy.yml
@@ -32,7 +32,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-haproxy
           path: build-dir.tgz
@@ -51,7 +51,7 @@ jobs:
         haproxy_ref: [ 'v3.1.0', 'v3.2.0']
     steps:
     - name: Checkout wolfSSL CI actions
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         sparse-checkout: .github/actions
         fetch-depth: 1
@@ -62,7 +62,7 @@ jobs:
         packages: libpcre2-dev
 
     - name: Download lib
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: wolf-install-haproxy
 
@@ -71,7 +71,7 @@ jobs:
 
     # check cache for haproxy if not there then download it
     - name: Check haproxy cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: cache-haproxy
       with:
         path: build-dir/haproxy-${{matrix.haproxy_ref}}
@@ -79,7 +79,7 @@ jobs:
 
     - name: Download haproxy if needed
       if: steps.cache-haproxy.outputs.cache-hit != 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: haproxy/haproxy
         ref: ${{matrix.haproxy_ref}}

--- a/.github/workflows/hostap-vm.yml
+++ b/.github/workflows/hostap-vm.yml
@@ -58,7 +58,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.build_id }}
           path: build-dir.tgz
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checking if we have hostap in cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: hostap
@@ -86,7 +86,7 @@ jobs:
         run: tar -zcf hostap.tgz hostap
 
       - name: Upload hostap repo
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: hostap-repo
           path: hostap.tgz
@@ -101,7 +101,7 @@ jobs:
     needs: checkout_hostap
     steps:
       - name: Checking if we have kernel in cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: linux/linux
@@ -109,7 +109,7 @@ jobs:
 
       - name: Download hostap repo
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: hostap-repo
 
@@ -119,7 +119,7 @@ jobs:
 
       - name: Checkout linux
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: torvalds/linux
           path: linux
@@ -134,7 +134,7 @@ jobs:
           yes "" | ARCH=um make -j $(nproc)
 
       - name: Upload kernel binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: uml-linux-kernel
           path: linux/linux
@@ -189,7 +189,7 @@ jobs:
     needs: [build_wolfssl, build_uml_linux, checkout_hostap]
     steps:
       - name: Download kernel binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: uml-linux-kernel
           path: linux
@@ -214,12 +214,12 @@ jobs:
           echo Our job run ID is $SHA_SUM
 
       - name: Checkout wolfSSL
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: wolfssl
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ matrix.config.build_id }}
 
@@ -235,7 +235,7 @@ jobs:
         run: sudo pip install pycryptodome
 
       - name: Download hostap repo
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: hostap-repo
 
@@ -248,7 +248,7 @@ jobs:
 
       - if: ${{ matrix.config.osp_ref }}
         name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
@@ -401,7 +401,7 @@ jobs:
       #
       #- name: Upload failure logs
       #  if: ${{ failure() && steps.testing.outcome == 'failure' }}
-      #  uses: actions/upload-artifact@v4
+      #  uses: actions/upload-artifact@v6
       #  with:
       #    name: hostap-logs-${{ env.our_job_run_id }}
       #    path: hostap/tests/hwsim/logs.zip

--- a/.github/workflows/intelasm-c-fallback.yml
+++ b/.github/workflows/intelasm-c-fallback.yml
@@ -27,7 +27,7 @@ jobs:
     # This should be a safe limit for the tests to run.
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Test wolfSSL with WC_C_DYNAMIC_FALLBACK and DEBUG_VECTOR_REGISTER_ACCESS_FUZZING

--- a/.github/workflows/ipmitool.yml
+++ b/.github/workflows/ipmitool.yml
@@ -36,7 +36,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-ipmitool
           path: build-dir.tgz
@@ -53,7 +53,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -62,7 +62,7 @@ jobs:
         with:
           packages: libreadline-dev
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-ipmitool
 
@@ -70,7 +70,7 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp

--- a/.github/workflows/jwt-cpp.yml
+++ b/.github/workflows/jwt-cpp.yml
@@ -35,7 +35,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-jwt-cpp
           path: build-dir.tgz
@@ -56,7 +56,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -67,7 +67,7 @@ jobs:
           packages: libgtest-dev
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-jwt-cpp
 
@@ -80,14 +80,14 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout jwt-cpp
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: Thalhammer/jwt-cpp
           path: jwt-cpp

--- a/.github/workflows/krb5.yml
+++ b/.github/workflows/krb5.yml
@@ -37,7 +37,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-krb5
           path: build-dir.tgz
@@ -57,7 +57,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-krb5
 
@@ -65,14 +65,14 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout krb5
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: krb5/krb5
           ref: krb5-${{ matrix.ref }}-final

--- a/.github/workflows/libspdm.yml
+++ b/.github/workflows/libspdm.yml
@@ -34,7 +34,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-libspdm
           path: build-dir.tgz
@@ -55,7 +55,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-libspdm
 
@@ -63,14 +63,14 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout libspdm
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: DMTF/libspdm
           path: libspdm

--- a/.github/workflows/libssh2.yml
+++ b/.github/workflows/libssh2.yml
@@ -34,7 +34,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-libssh2
           path: build-dir.tgz
@@ -54,7 +54,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-libssh2
 
@@ -62,7 +62,7 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Clone libssh2
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: libssh2/libssh2
           ref: libssh2-${{ matrix.ref }}

--- a/.github/workflows/libvncserver.yml
+++ b/.github/workflows/libvncserver.yml
@@ -35,7 +35,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-libvncserver
           path: build-dir.tgz
@@ -52,7 +52,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-libvncserver
 
@@ -65,14 +65,14 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout libvncserver
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: LibVNC/libvncserver
           path: libvncserver

--- a/.github/workflows/linuxkm.yml
+++ b/.github/workflows/linuxkm.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install linux-headers

--- a/.github/workflows/mbedtls.yml
+++ b/.github/workflows/mbedtls.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checking if we have mbed in cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: mbedtls
@@ -34,7 +34,7 @@ jobs:
 
       - name: Checkout mbedtls
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: Mbed-TLS/mbedtls
           ref: ${{ env.MBED_REF }}
@@ -65,7 +65,7 @@ jobs:
         run: echo 1 | sudo tee /proc/sys/net/ipv6/conf/lo/disable_ipv6
 
       - name: Checking if we have mbed in cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: mbedtls
@@ -73,7 +73,7 @@ jobs:
 
       - name: Checkout mbedtls (fallback on cache miss)
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: Mbed-TLS/mbedtls
           ref: ${{ env.MBED_REF }}

--- a/.github/workflows/membrowse-zephyr.yml
+++ b/.github/workflows/membrowse-zephyr.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Download Zephyr build artifact
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: zephyr-artifacts/${{ matrix.target_name }}

--- a/.github/workflows/memcached.yml
+++ b/.github/workflows/memcached.yml
@@ -34,7 +34,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-memcached
           path: build-dir.tgz
@@ -53,13 +53,13 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-memcached
 
@@ -67,7 +67,7 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
@@ -79,7 +79,7 @@ jobs:
           packages: libevent-dev libevent-2.1-7 automake pkg-config make libio-socket-ssl-perl
 
       - name: Checkout memcached
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: memcached/memcached
           ref: 1.6.22

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
     - name: Checkout wolfSSL CI actions
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         sparse-checkout: .github/actions
         fetch-depth: 1

--- a/.github/workflows/mosquitto.yml
+++ b/.github/workflows/mosquitto.yml
@@ -33,7 +33,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-mosquitto
           path: build-dir.tgz
@@ -52,13 +52,13 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-mosquitto
 
@@ -66,7 +66,7 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
@@ -78,7 +78,7 @@ jobs:
           packages: build-essential libev-dev libssl-dev automake python3-docutils libcunit1 libcunit1-doc libcunit1-dev pkg-config make python3-psutil
 
       - name: Checkout mosquitto
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: eclipse/mosquitto
           ref: v${{ matrix.ref }}

--- a/.github/workflows/msmtp.yml
+++ b/.github/workflows/msmtp.yml
@@ -33,7 +33,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-msmtp
           path: build-dir.tgz
@@ -52,13 +52,13 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-msmtp
 
@@ -66,7 +66,7 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
@@ -78,7 +78,7 @@ jobs:
           packages: autoconf automake libtool pkg-config gettext libidn2-dev libsecret-1-dev autopoint
 
       - name: Checkout msmtp
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: marlam/msmtp
           ref: msmtp-${{ matrix.ref }}

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: msys2/setup-msys2@v2
         with:
           msystem: msys

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -26,7 +26,7 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -254,7 +254,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: multi-arch-logs
           path: |

--- a/.github/workflows/multi-compiler.yml
+++ b/.github/workflows/multi-compiler.yml
@@ -26,7 +26,7 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: multi-compiler-logs
           path: |

--- a/.github/workflows/net-snmp.yml
+++ b/.github/workflows/net-snmp.yml
@@ -33,7 +33,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-net-snmp
           path: build-dir.tgz
@@ -55,7 +55,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-net-snmp
 
@@ -63,7 +63,7 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -44,7 +44,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-nginx
           path: build-dir.tgz
@@ -154,7 +154,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-nginx
 
@@ -176,13 +176,13 @@ jobs:
           cpanm --notest Proc::Find Net::SSLeay@1.94 IO::Socket::SSL@2.090
 
       - name: Checkout wolfssl-nginx
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/wolfssl-nginx
           path: wolfssl-nginx
 
       - name: Checkout nginx
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: nginx/nginx
           path: nginx
@@ -198,7 +198,7 @@ jobs:
         run: patch -p1 < ../wolfssl-nginx/nginx-${{ matrix.ref }}-wolfssl-debug.patch
 
       - name: Checkout nginx-tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: nginx/nginx-tests
           path: nginx-tests

--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -26,7 +26,7 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: no-malloc-logs
           path: |

--- a/.github/workflows/nss.yml
+++ b/.github/workflows/nss.yml
@@ -27,13 +27,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
 
       - name: Checking if we have nss in cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: dist
@@ -48,7 +48,7 @@ jobs:
 
       - name: Checkout nss
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: nss-dev/nss
           ref: ${{ env.NSS_REF }}
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checking if we have nss in cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: dist
@@ -78,7 +78,7 @@ jobs:
 
       - name: Checkout wolfSSL CI actions (fallback on cache miss)
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -91,7 +91,7 @@ jobs:
 
       - name: Checkout nss (fallback on cache miss)
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: nss-dev/nss
           ref: ${{ env.NSS_REF }}

--- a/.github/workflows/ntp.yml
+++ b/.github/workflows/ntp.yml
@@ -34,7 +34,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-ntp
           path: build-dir.tgz
@@ -54,7 +54,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-ntp
 
@@ -62,7 +62,7 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
@@ -70,7 +70,7 @@ jobs:
 
       # Avoid DoS'ing ntp site so cache the tar.gz
       - name: Check if we have ntp
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: ntp-${{ matrix.ref }}.tar.gz

--- a/.github/workflows/ocsp.yml
+++ b/.github/workflows/ocsp.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout wolfSSL
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build wolfSSL
         run: autoreconf -ivf && ./configure --enable-ocsp --enable-ocspstapling && make

--- a/.github/workflows/openldap.yml
+++ b/.github/workflows/openldap.yml
@@ -34,7 +34,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-openldap
           path: build-dir.tgz
@@ -60,7 +60,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-openldap
 
@@ -68,14 +68,14 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout openldap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: openldap/openldap
           path: openldap

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -35,7 +35,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-openssh
           path: build-dir.tgz
@@ -86,7 +86,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-openssh
 
@@ -94,7 +94,7 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp

--- a/.github/workflows/openssl-ech.yml
+++ b/.github/workflows/openssl-ech.yml
@@ -48,7 +48,7 @@ jobs:
           tar -zcf build-dir.tgz build-dir
 
       - name: Upload built wolfSSL
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-openssl-ech
           path: build-dir.tgz
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout OpenSSL feature/ech branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: openssl/openssl
           ref: feature/ech
@@ -80,7 +80,7 @@ jobs:
         run: tar -zcf openssl-install.tgz openssl-install
 
       - name: Upload built OpenSSL
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: openssl-ech-install
           path: openssl-install.tgz
@@ -94,12 +94,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Download wolfSSL build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-openssl-ech
 
       - name: Download OpenSSL build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: openssl-ech-install
 

--- a/.github/workflows/opensslcoexist.yml
+++ b/.github/workflows/opensslcoexist.yml
@@ -28,7 +28,7 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: opensslcoexist-logs
           path: |

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -33,7 +33,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-openvpn
           path: build-dir.tgz
@@ -52,13 +52,13 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-openvpn
 

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -55,11 +55,11 @@ jobs:
     env:
       CCACHE_MAXSIZE: 500M
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # tlslite-ng is consumed by scripts/multi-msg-record.test (run from
       # `make check`); without it that test is SKIPped.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - run: pip install tlslite-ng
@@ -82,7 +82,7 @@ jobs:
         run: echo "CCACHE_DIR=$HOME/.cache/ccache" >> "$GITHUB_ENV"
 
       - name: Restore ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ccache
           # Per-shard cache lineage: each shard compiles a distinct config
@@ -390,7 +390,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: os-check-linux-logs-${{ matrix.shard }}
           path: |
@@ -419,11 +419,11 @@ jobs:
     # one-time setup, with headroom for a cold ccache.
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # tlslite-ng is consumed by scripts/multi-msg-record.test (run from
       # `make check`); without it that test is SKIPped.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - run: pip install tlslite-ng
@@ -488,7 +488,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: os-check-macos-logs
           path: |
@@ -516,10 +516,10 @@ jobs:
       # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
       BUILD_CONFIGURATION: Release
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
 
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout wolfSSL
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure wolfSSL
         run: |

--- a/.github/workflows/pam-ipmi.yml
+++ b/.github/workflows/pam-ipmi.yml
@@ -36,7 +36,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-pam-ipmi
           path: build-dir.tgz
@@ -53,7 +53,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -64,7 +64,7 @@ jobs:
           packages: libpam-dev ninja-build meson
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-pam-ipmi
 
@@ -72,14 +72,14 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout pam-ipmi
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: openbmc/pam-ipmi
           path: pam-ipmi

--- a/.github/workflows/pic32mz-sim.yml
+++ b/.github/workflows/pic32mz-sim.yml
@@ -58,17 +58,17 @@ jobs:
             cache_scope: pic32mz-harmony
     steps:
       - name: Checkout wolfSSL (PR source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: wolfssl
 
       - name: Clone PIC32MZ simulator
         run: git clone --depth 1 https://github.com/wolfSSL/simulators simulators
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Build ${{ matrix.image_tag }} image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: simulators/PIC32MZSim
           file: simulators/PIC32MZSim/${{ matrix.dockerfile }}

--- a/.github/workflows/pq-all.yml
+++ b/.github/workflows/pq-all.yml
@@ -32,7 +32,7 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -230,7 +230,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pq-all-logs-${{ matrix.shard }}
           path: |

--- a/.github/workflows/pr-commit-check.yml
+++ b/.github/workflows/pr-commit-check.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/psk.yml
+++ b/.github/workflows/psk.yml
@@ -28,7 +28,7 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: psk-logs
           path: |

--- a/.github/workflows/puf.yml
+++ b/.github/workflows/puf.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Build and test PUF

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,7 +34,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-python
           path: build-dir.tgz
@@ -100,7 +100,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -111,7 +111,7 @@ jobs:
           packages: build-essential autoconf automake autoconf-archive pkgconf libffi-dev libbz2-dev libreadline-dev libsqlite3-dev zlib1g-dev libncursesw5-dev libgdbm-dev libnss3-dev liblzma-dev uuid-dev pkg-config
 
       - name: Download wolfSSL
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-python
 
@@ -119,14 +119,14 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout CPython
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: python/cpython
           ref: v${{ matrix.python_ver }}

--- a/.github/workflows/retrigger-prb-on-ready.yml
+++ b/.github/workflows/retrigger-prb-on-ready.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post GHPRB trigger comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/rng-tools.yml
+++ b/.github/workflows/rng-tools.yml
@@ -34,7 +34,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-rng-tools
           path: build-dir.tgz
@@ -54,7 +54,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -65,7 +65,7 @@ jobs:
           packages: libcurl4-openssl-dev libjansson-dev libp11-dev librtlsdr-dev libcap-dev
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-rng-tools
 
@@ -73,14 +73,14 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout jitterentropy-library
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: smuellerDD/jitterentropy-library
           path: jitterentropy-library

--- a/.github/workflows/se050-sim.yml
+++ b/.github/workflows/se050-sim.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout wolfSSL (PR source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: wolfssl-src
 
@@ -53,10 +53,10 @@ jobs:
           grep -q '^COPY wolfssl /app/wolfssl$' Dockerfile.wolfcrypt
           ! grep -q 'git clone .*wolfssl\.git' Dockerfile.wolfcrypt
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Build wolfCrypt-SE050 test image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: simulators/SE050Sim
           file: simulators/SE050Sim/Dockerfile.wolfcrypt

--- a/.github/workflows/smallStackSize.yml
+++ b/.github/workflows/smallStackSize.yml
@@ -26,7 +26,7 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: smallstacksize-logs
           path: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -56,7 +56,7 @@ jobs:
       # For PRs we explicitly check out the PR head (not the auto-merge
       # ref) and do the merge ourselves below so we can fail fast on
       # conflicts. For push events we just check out the pushed SHA.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Restore ccache
         if: steps.merge_check.outputs.skip != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ccache
           key: smoke-ccache-${{ github.base_ref || github.ref_name }}-${{ github.sha }}
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure() && steps.merge_check.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: smoke-logs
           path: |

--- a/.github/workflows/socat.yml
+++ b/.github/workflows/socat.yml
@@ -31,7 +31,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-socat
           path: build-dir.tgz
@@ -54,7 +54,7 @@ jobs:
             expect_fail: "146,155,156,307,321,386,399,402,459,460,467,468,475,478,491,492,495,528,529"
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -65,7 +65,7 @@ jobs:
           packages: build-essential autoconf libtool pkg-config clang libc++-dev
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-socat
 
@@ -76,7 +76,7 @@ jobs:
         run: curl -O http://www.dest-unreach.org/socat/download/socat-${{ matrix.socat_version }}.tar.gz && tar xvf socat-${{ matrix.socat_version }}.tar.gz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp

--- a/.github/workflows/softhsm.yml
+++ b/.github/workflows/softhsm.yml
@@ -34,7 +34,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-softhsm
           path: build-dir.tgz
@@ -54,7 +54,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -65,7 +65,7 @@ jobs:
           packages: libcppunit-dev
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-softhsm
 
@@ -73,14 +73,14 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp
           fetch-depth: 1
 
       - name: Checkout SoftHSMv2
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: opendnssec/SoftHSMv2
           path: softhsm

--- a/.github/workflows/sssd.yml
+++ b/.github/workflows/sssd.yml
@@ -34,7 +34,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-sssd
           path: build-dir.tgz
@@ -58,7 +58,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -78,7 +78,7 @@ jobs:
           ln -s samba-4.0/ldb_version.h /usr/include/ldb_version.h
 
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-sssd
 
@@ -86,7 +86,7 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp

--- a/.github/workflows/stm32-sim.yml
+++ b/.github/workflows/stm32-sim.yml
@@ -48,7 +48,7 @@ jobs:
             script: run-wolfcrypt-mp135.sh
     steps:
       - name: Checkout wolfSSL (PR source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: wolfssl
 
@@ -72,10 +72,10 @@ jobs:
           grep -q '^#define WOLFSSL_SHAKE128$' user_settings.h
           grep -q '^#define WOLFSSL_SHAKE256$' user_settings.h
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Build stm32sim-wolfcrypt image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: simulators/STM32Sim
           file: simulators/STM32Sim/Dockerfile.wolfcrypt

--- a/.github/workflows/stsafe-a120-sim.yml
+++ b/.github/workflows/stsafe-a120-sim.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout wolfSSL (PR source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: wolfssl-src
 
@@ -80,10 +80,10 @@ jobs:
           grep -q -- '--enable-stsafe=a120' Dockerfile.wolfcrypt
           ! grep -q -- '-DWOLFSSL_STSAFEA120' Dockerfile.wolfcrypt
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Build wolfCrypt-STSAFE-A120 test image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: simulators/STSAFEA120Sim
           file: simulators/STSAFEA120Sim/Dockerfile.wolfcrypt

--- a/.github/workflows/stunnel.yml
+++ b/.github/workflows/stunnel.yml
@@ -33,7 +33,7 @@ jobs:
         run: tar -zcf build-dir.tgz build-dir
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolf-install-stunnel
           path: build-dir.tgz
@@ -53,7 +53,7 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wolf-install-stunnel
 
@@ -61,7 +61,7 @@ jobs:
         run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: wolfssl/osp
           path: osp

--- a/.github/workflows/symbol-prefixes.yml
+++ b/.github/workflows/symbol-prefixes.yml
@@ -26,7 +26,7 @@ jobs:
     # This should be a safe limit for the tests to run.
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Test --enable-opensslcoexist and TEST_OPENSSL_COEXIST

--- a/.github/workflows/threadx.yml
+++ b/.github/workflows/threadx.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - name: Cache NetXDuo bundle
       id: cache-netxduo
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ./v6.4.3_rel.tar.gz
         key: netxduo-bundle-v6.4.3_rel

--- a/.github/workflows/tls-anvil.yml
+++ b/.github/workflows/tls-anvil.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout wolfSSL
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install dependencies
         uses: ./.github/actions/install-apt-deps
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: tls-anvil-results-${{ matrix.test-name }}
           path: tls-anvil-results/

--- a/.github/workflows/trackmemory.yml
+++ b/.github/workflows/trackmemory.yml
@@ -30,7 +30,7 @@ jobs:
     # runner contention (a 20-min limit was hit with one config left).
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: trackmemory-logs
           path: |

--- a/.github/workflows/tropic01-sim.yml
+++ b/.github/workflows/tropic01-sim.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout wolfSSL (PR source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: wolfssl-src
 
@@ -72,10 +72,10 @@ jobs:
           sed -i '/^RUN sed -i .*ForceZero/,/tropic01\.c$/c\RUN true' Dockerfile.wolfcrypt
           ! grep -q 'sed -i .*ForceZero' Dockerfile.wolfcrypt
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Build wolfCrypt-TROPIC01 test image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: simulators/TROPIC01Sim
           file: simulators/TROPIC01Sim/Dockerfile.wolfcrypt

--- a/.github/workflows/watcomc.yml
+++ b/.github/workflows/watcomc.yml
@@ -60,7 +60,7 @@ jobs:
     name: ${{ matrix.platform.title }} (${{ matrix.thread.id }} ${{ matrix.library.id }})
     steps:
       - name: Setup Open Watcom ${{ matrix.platform.owimage }}
-        uses: open-watcom/setup-watcom@v0
+        uses: open-watcom/setup-watcom@v1
         with:
           version: ${{ matrix.platform.owimage }}
           # Currently fixed to a monthly build because of historical instability with daily releases.
@@ -69,7 +69,7 @@ jobs:
           tag: 2025-11-03-Build
 
       - name: Checkout wolfSSL
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: wolfssl
 
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload build errors
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.platform.id }}-${{ matrix.thread.id }}-${{ matrix.library.id }}
           path: |

--- a/.github/workflows/win-csharp-test.yml
+++ b/.github/workflows/win-csharp-test.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
         - name: Pull wolfssl
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
           with:
             repository: wolfssl/wolfssl
             path: wolfssl
@@ -42,7 +42,7 @@ jobs:
             echo $null >> wolfcrypt\src\wolfcrypt_last.c
 
         - name: Add MSBuild to PATH
-          uses: microsoft/setup-msbuild@v2
+          uses: microsoft/setup-msbuild@v3
 
         - name: Build
           working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/wolfCrypt-Wconversion.yml
+++ b/.github/workflows/wolfCrypt-Wconversion.yml
@@ -26,7 +26,7 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
       - name: Install dependencies
@@ -148,7 +148,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wconversion-logs
           path: |

--- a/.github/workflows/wolfboot-integration.yml
+++ b/.github/workflows/wolfboot-integration.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout wolfSSL
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Clone wolfBoot and stage tested wolfSSL
         run: |
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout wolfSSL
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Clone wolfBoot and stage tested wolfSSL
         run: |
@@ -202,7 +202,7 @@ jobs:
 
     steps:
       - name: Checkout wolfSSL
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Clone wolfBoot and stage tested wolfSSL
         run: |
@@ -225,7 +225,7 @@ jobs:
           test -f wolfboot/lib/wolfssl/wolfcrypt/src/asn.c
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -312,7 +312,7 @@ jobs:
 
       - name: Upload Output Dir
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: renode-multimem-smallstack-results
           path: wolfboot/test_results/
@@ -328,7 +328,7 @@ jobs:
 
     steps:
       - name: Checkout wolfSSL
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Clone wolfBoot and stage tested wolfSSL
         run: |
@@ -351,7 +351,7 @@ jobs:
           test -f wolfboot/lib/wolfssl/wolfcrypt/src/asn.c
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -420,7 +420,7 @@ jobs:
 
       - name: Upload Output Dir
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: renode-multimem-smallstack-fastmath-results
           path: wolfboot/test_results/
@@ -436,7 +436,7 @@ jobs:
 
     steps:
       - name: Checkout wolfSSL
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Clone wolfBoot and stage tested wolfSSL
         run: |
@@ -459,7 +459,7 @@ jobs:
           test -f wolfboot/lib/wolfssl/wolfcrypt/src/asn.c
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -528,7 +528,7 @@ jobs:
 
       - name: Upload Output Dir
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: renode-multimem-smallstack-noasm-results
           path: wolfboot/test_results/

--- a/.github/workflows/wolfsm.yml
+++ b/.github/workflows/wolfsm.yml
@@ -28,10 +28,10 @@ jobs:
     # Generous for a cold ccache; warm reruns finish in a fraction.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfSSL
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout wolfsm
         with:
           repository: wolfssl/wolfsm
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wolfsm-logs
           path: |

--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -63,7 +63,7 @@ jobs:
             sdk: appletvsimulator
             name: tvOS Simulator (ARM64, Release)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build wolfSSL with Xcode (${{ matrix.name }})
         working-directory: ./IDE/XCODE

--- a/.github/workflows/zephyr-4.x.yml
+++ b/.github/workflows/zephyr-4.x.yml
@@ -32,7 +32,7 @@ jobs:
             extra-conf: external_libc.conf
     steps:
       - name: Checkout test driver
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/scripts/zephyr-4.x
           fetch-depth: 1
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: zephyr-4.x-${{ matrix.zephyr-ref }}-${{ matrix.sample }}-${{ strategy.job-index }}
           path: .github/scripts/zephyr-4.x/logs/
@@ -91,7 +91,7 @@ jobs:
           matrix.zephyr-ref == 'v4.3.0' &&
           matrix.sample == 'wolfssl_test' &&
           matrix.extra-conf == ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: membrowse-zephyr-${{ matrix.board == 'native_sim' && 'native_sim' || 'frdm_rw612' }}
           path: |

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout wolfSSL CI actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .github/actions
           fetch-depth: 1
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload failure logs
         if: ${{ failure() && (steps.wolfssl-test.outcome == 'failure' || steps.wolfssl-tls-sock.outcome == 'failure' || steps.wolfssl-tls-thread.outcome == 'failure') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: zephyr-client-test-logs
           path: logs.zip


### PR DESCRIPTION
GitHub Actions now emits "Node.js 20 actions are deprecated" warnings: actions are forced to Node.js 24 by default starting 2026-06-16, and Node.js 20 is removed from the runners on 2026-09-16. This updates every JavaScript action referenced by the workflows and the local composite actions to the lowest release that runs on Node.js 24:

| Action | From | To | Note |
|--------|------|----|------|
| `actions/checkout` | v4 | v5 | |
| `actions/checkout` (SHA pin) | v4.1.7 | v5 | |
| `actions/upload-artifact` | v4 | v6 | v5 still Node.js 20 |
| `actions/download-artifact` | v4 | v7 | v5/v6 still Node.js 20 |
| `actions/cache[/restore\|/save]` | v4 | v5 | |
| `actions/setup-python` | v5 | v6 | |
| `actions/github-script` | v7 | v8 | |
| `docker/setup-buildx-action` | v3 | v4 | |
| `docker/build-push-action` | v5 | v7 | v6 still Node.js 20 |
| `docker/login-action` | v3 | v4 | |
| `microsoft/setup-msbuild` | v2 | v3 | |
| `open-watcom/setup-watcom` | v0 | v1 | |

Actions already running on Node.js 24 (`jwlawson/actions-setup-cmake`, `shogo82148/actions-setup-perl`, `msys2/setup-msys2`, `dorny/paths-filter`) are left unchanged.

These bumps are runtime-only; no workflow uses an input or output removed by the new majors, and v4-format artifacts remain compatible across the upload v6 / download v7 backends.
