### PR TITLE
Support fixes - various reports

### DIFF
--- a/examples/sctp/sctp-client-dtls.c
+++ b/examples/sctp/sctp-client-dtls.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
            wolfSSL_CIPHER_get_name(wolfSSL_get_current_cipher(ssl)));
 
     wolfSSL_write(ssl, response, (int)strlen(response));
-    int got = wolfSSL_read(ssl, buffer, sizeof(buffer));
+    int got = wolfSSL_read(ssl, buffer, sizeof(buffer) - 1);
     if (got > 0) {
         buffer[got] = 0;
         printf("server said: %s\n", buffer);

--- a/examples/sctp/sctp-server-dtls.c
+++ b/examples/sctp/sctp-server-dtls.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
     printf("Cipher Suite is %s\n",
            wolfSSL_CIPHER_get_name(wolfSSL_get_current_cipher(ssl)));
 
-    int got = wolfSSL_read(ssl, buffer, sizeof(buffer));
+    int got = wolfSSL_read(ssl, buffer, sizeof(buffer) - 1);
     if (got > 0) {
         buffer[got] = 0;
         printf("client said: %s\n", buffer);

--- a/src/internal.c
+++ b/src/internal.c
@@ -24468,6 +24468,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         /* in buffer */
         ret |= wc_Md5Update(&md5, in, sz);
         if (ret != 0) {
+            wc_Md5Free(&md5);
             WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
@@ -24479,6 +24480,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
+            wc_Md5Free(&md5);
             WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
@@ -24488,6 +24490,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret |= wc_Md5Update(&md5, PAD2, padSz);
         ret |= wc_Md5Update(&md5, result, digestSz);
         if (ret != 0) {
+            wc_Md5Free(&md5);
             WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
@@ -24499,6 +24502,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
+            wc_Md5Free(&md5);
             WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
@@ -24518,6 +24522,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         /* in buffer */
         ret |= wc_ShaUpdate(&sha, in, sz);
         if (ret != 0) {
+            wc_ShaFree(&sha);
             WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
@@ -24529,6 +24534,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
+            wc_ShaFree(&sha);
             WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
@@ -24538,6 +24544,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret |= wc_ShaUpdate(&sha, PAD2, padSz);
         ret |= wc_ShaUpdate(&sha, result, digestSz);
         if (ret != 0) {
+            wc_ShaFree(&sha);
             WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
@@ -24549,6 +24556,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         }
     #endif
         if (ret != 0) {
+            wc_ShaFree(&sha);
             WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -9664,9 +9664,10 @@ int wc_ecc_import_point_der_ex(const byte* in, word32 inLen,
     alt_fp_init(point->z);
 #else
     err = mp_init_multi(point->x, point->y, point->z, NULL, NULL, NULL);
-#endif
+
     if (err != MP_OKAY)
         return MEMORY_E;
+#endif
 
     /* check for point type (4, 2, or 3) */
     pointType = in[0];
@@ -10935,9 +10936,10 @@ static int _ecc_import_x963_ex2(const byte* in, word32 inLen, ecc_key* key,
                                                                 key->kb, key->ku
     #endif
                             );
+
+        if (err != MP_OKAY)
+            return MEMORY_E;
     #endif
-    if (err != MP_OKAY)
-        return MEMORY_E;
 #ifdef WOLFSSL_ECC_BLIND_K
     mp_forcezero(key->kb);
 #endif
@@ -11999,9 +12001,10 @@ static int _ecc_import_raw_private(ecc_key* key, const char* qx,
                                                                 key->kb, key->ku
 #endif
                         );
-#endif
+
     if (err != MP_OKAY)
         return MEMORY_E;
+#endif
 #ifdef WOLFSSL_ECC_BLIND_K
     mp_forcezero(key->kb);
 #endif


### PR DESCRIPTION
# Description

Clean up dead `err` check in `ALT_ECC_SIZE #else` block. (zd#21969)
Fix off-by-one NUL write on full-length message. (zd#21992 - 50)
Free `MD5/SHA` before returning `VERIFY_MAC_ERROR` in `SSL_hmac()`. (F-3883)

# Testing

`./configure --enable-sslv3 && make check`
`./configure --enable-fastmath CFLAGS="-DALT_ECC_SIZE -DFP_MAX_BITS=16384" && make check`