### PR TITLE
OIDs represented as word32 instead of word16

### DIFF
--- a/doc/dox_comments/header_files-ja/asn_public.h
+++ b/doc/dox_comments/header_files-ja/asn_public.h
@@ -1934,7 +1934,7 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
     \code
     int ret = 0;
     // 不明な拡張コールバックのプロトタイプ
-    int myUnknownExtCallback(const word16* oid, word32 oidSz, int crit,
+    int myUnknownExtCallback(const word32* oid, word32 oidSz, int crit,
                              const unsigned char* der, word32 derSz);
 
     // 登録する
@@ -1948,7 +1948,7 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
     // crit: 拡張が重要としてマークされたかどうか。
     // der: 拡張のコンテンツのderエンコーディング。
     // derSz: derエンコーディングのサイズ（バイト単位）。
-    int myCustomExtCallback(const word16* oid, word32 oidSz, int crit,
+    int myCustomExtCallback(const word32* oid, word32 oidSz, int crit,
                             const unsigned char* der, word32 derSz) {
 
         // 拡張を解析するロジックがここに入ります。

--- a/doc/dox_comments/header_files-ja/asn_public.h
+++ b/doc/dox_comments/header_files-ja/asn_public.h
@@ -1928,13 +1928,15 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
     \return Other 失敗時に負の値。
 
     \param cert このコールバックに関連付けられるDecodedCert構造体。
-    \param cb 時刻コールバックとして登録する関数。
+    \param cb 不明な拡張コールバックとして登録する関数。
+
+    \note 各OIDアークはword16としてコールバックに渡されるため、65535を超える値は切り捨てられます。新しいコードではwc_SetUnknownExtCallback32()を使用してください。同一のDecodedCertにword16とword32の両方のコールバックが登録されている場合、word32のコールバックのみが呼び出されます。
 
     _Example_
     \code
     int ret = 0;
     // 不明な拡張コールバックのプロトタイプ
-    int myUnknownExtCallback(const word32* oid, word32 oidSz, int crit,
+    int myUnknownExtCallback(const word16* oid, word32 oidSz, int crit,
                              const unsigned char* der, word32 derSz);
 
     // 登録する
@@ -1943,13 +1945,13 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
         // コールバックの設定失敗
     }
 
-    // oid: oidのドット区切り値である整数の配列。
+    // oid: oidのドット区切り値であるword16の配列。
     // oidSz: oid内の値の数。
     // crit: 拡張が重要としてマークされたかどうか。
     // der: 拡張のコンテンツのderエンコーディング。
     // derSz: derエンコーディングのサイズ（バイト単位）。
-    int myCustomExtCallback(const word32* oid, word32 oidSz, int crit,
-                            const unsigned char* der, word32 derSz) {
+    int myUnknownExtCallback(const word16* oid, word32 oidSz, int crit,
+                             const unsigned char* der, word32 derSz) {
 
         // 拡張を解析するロジックがここに入ります。
 
@@ -1966,6 +1968,7 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
 
     \sa ParseCert
     \sa wc_SetCustomExtension
+    \sa wc_SetUnknownExtCallback32
 */
 int wc_SetUnknownExtCallback(DecodedCert* cert,
                                              wc_UnknownExtCallback cb);

--- a/doc/dox_comments/header_files-ja/asn_public.h
+++ b/doc/dox_comments/header_files-ja/asn_public.h
@@ -1928,9 +1928,7 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
     \return Other 失敗時に負の値。
 
     \param cert このコールバックに関連付けられるDecodedCert構造体。
-    \param cb 不明な拡張コールバックとして登録する関数。
-
-    \note 各OIDアークはword16としてコールバックに渡されるため、65535を超える値は切り捨てられます。新しいコードではwc_SetUnknownExtCallback32()を使用してください。同一のDecodedCertにword16とword32の両方のコールバックが登録されている場合、word32のコールバックのみが呼び出されます。
+    \param cb 時刻コールバックとして登録する関数。
 
     _Example_
     \code
@@ -1945,13 +1943,13 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
         // コールバックの設定失敗
     }
 
-    // oid: oidのドット区切り値であるword16の配列。
+    // oid: oidのドット区切り値である整数の配列。
     // oidSz: oid内の値の数。
     // crit: 拡張が重要としてマークされたかどうか。
     // der: 拡張のコンテンツのderエンコーディング。
     // derSz: derエンコーディングのサイズ（バイト単位）。
-    int myUnknownExtCallback(const word16* oid, word32 oidSz, int crit,
-                             const unsigned char* der, word32 derSz) {
+    int myCustomExtCallback(const word16* oid, word32 oidSz, int crit,
+                            const unsigned char* der, word32 derSz) {
 
         // 拡張を解析するロジックがここに入ります。
 
@@ -1968,7 +1966,6 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
 
     \sa ParseCert
     \sa wc_SetCustomExtension
-    \sa wc_SetUnknownExtCallback32
 */
 int wc_SetUnknownExtCallback(DecodedCert* cert,
                                              wc_UnknownExtCallback cb);

--- a/doc/dox_comments/header_files/asn.h
+++ b/doc/dox_comments/header_files/asn.h
@@ -80,11 +80,16 @@ void FreeAltNames(DNS_entry* altNames, void* heap);
     \note This API is not public by default. Define WOLFSSL_PUBLIC_ASN to
     expose APIs marked WOLFSSL_ASN_API.
 
+    \note The oid argument passed to the callback is an array of word32
+    elements, one per OID arc, so that arcs > 65535 are represented without
+    truncation. Callbacks must declare their oid parameter as const word32*.
+    The same applies to wc_SetUnknownExtCallback.
+
     _Example_
     \code
     DecodedCert cert;
 
-    int UnknownExtCallback(const byte* oid, word32 oidSz, int crit,
+    int UnknownExtCallback(const word32* oid, word32 oidSz, int crit,
                           const byte* der, word32 derSz, void* ctx) {
         // handle unknown extension
         return 0;
@@ -140,16 +145,19 @@ int wc_CheckCertSignature(const byte* cert, word32 certSz, void* heap,
 
 /*!
     \ingroup ASN
-    \brief This function encodes an array of word16 values into an ASN.1
+    \brief This function encodes an array of word32 values into an ASN.1
     Object Identifier (OID) in DER format. OIDs are used to identify
     algorithms, extensions, and other objects in certificates and
     cryptographic protocols.
+
+    Each OID arc is a word32, so OIDs containing arcs with values > 65535 are
+    represented without truncation.
 
     \return 0 On success.
     \return BAD_FUNC_ARG If in, inSz, or outSz are invalid.
     \return BUFFER_E If out is not NULL and outSz is too small.
 
-    \param in pointer to array of word16 values representing OID components
+    \param in pointer to array of word32 values representing OID components
     \param inSz number of components in the OID
     \param out pointer to buffer to store encoded OID (can be NULL to
     calculate size)
@@ -157,11 +165,11 @@ int wc_CheckCertSignature(const byte* cert, word32 certSz, void* heap,
 
     _Example_
     \code
-    word16 oid[] = {1, 2, 840, 113549, 1, 1, 11}; // sha256WithRSAEncryption
+    word32 oid[] = {1, 2, 840, 113549, 1, 1, 11}; // sha256WithRSAEncryption
     byte encoded[32];
     word32 encodedSz = sizeof(encoded);
 
-    int ret = wc_EncodeObjectId(oid, sizeof(oid)/sizeof(word16),
+    int ret = wc_EncodeObjectId(oid, sizeof(oid)/sizeof(*oid),
                                 encoded, &encodedSz);
     if (ret == 0) {
         // encoded contains DER encoded OID
@@ -170,7 +178,7 @@ int wc_CheckCertSignature(const byte* cert, word32 certSz, void* heap,
 
     \sa wc_BerToDer
 */
-int wc_EncodeObjectId(const word16* in, word32 inSz, byte* out,
+int wc_EncodeObjectId(const word32* in, word32 inSz, byte* out,
                       word32* outSz);
 
 /*!

--- a/doc/dox_comments/header_files/asn.h
+++ b/doc/dox_comments/header_files/asn.h
@@ -77,8 +77,8 @@ void FreeAltNames(DNS_entry* altNames, void* heap);
     \param cb callback function to handle unknown extensions
     \param ctx context pointer passed to the callback
 
-    \note This API is not public by default. Define WOLFSSL_PUBLIC_ASN to
-    expose APIs marked WOLFSSL_ASN_API.
+    \note This API is available whenever the library is built with
+    WC_ASN_UNKNOWN_EXT_CB defined.
 
     \note The oid argument passed to the callback is an array of word16
     elements, one per OID arc, so arcs with values > 65535 are truncated.
@@ -128,8 +128,8 @@ int wc_SetUnknownExtCallbackEx(DecodedCert* cert,
     \param cb callback function to handle unknown extensions
     \param ctx context pointer passed to the callback
 
-    \note This API is not public by default. Define WOLFSSL_PUBLIC_ASN to
-    expose APIs marked WOLFSSL_ASN_API.
+    \note This API is available whenever the library is built with
+    WC_ASN_UNKNOWN_EXT_CB defined.
 
     \note A word32 callback takes precedence over a word16 one: when both
     wc_SetUnknownExtCallbackEx() and wc_SetUnknownExtCallback32Ex() (or their
@@ -225,7 +225,7 @@ int wc_CheckCertSignature(const byte* cert, word32 certSz, void* heap,
 
     _Example_
     \code
-    word16 oid[] = {1, 2, 840, 113549, 1, 1, 11}; // sha256WithRSAEncryption
+    word16 oid[] = {1, 3, 132, 0, 6}; // secp112r1
     byte encoded[32];
     word32 encodedSz = sizeof(encoded);
 

--- a/doc/dox_comments/header_files/asn.h
+++ b/doc/dox_comments/header_files/asn.h
@@ -80,16 +80,22 @@ void FreeAltNames(DNS_entry* altNames, void* heap);
     \note This API is not public by default. Define WOLFSSL_PUBLIC_ASN to
     expose APIs marked WOLFSSL_ASN_API.
 
-    \note The oid argument passed to the callback is an array of word32
-    elements, one per OID arc, so that arcs > 65535 are represented without
-    truncation. Callbacks must declare their oid parameter as const word32*.
-    The same applies to wc_SetUnknownExtCallback.
+    \note The oid argument passed to the callback is an array of word16
+    elements, one per OID arc, so arcs with values > 65535 are truncated.
+    Callbacks must declare their oid parameter as const word16*. Use
+    wc_SetUnknownExtCallback32Ex() in new code to receive untruncated word32
+    arcs. When both a word16 and a word32 callback are registered on the same
+    DecodedCert, only the word32 callback is invoked.
+
+    \note wc_SetUnknownExtCallbackEx() and wc_SetUnknownExtCallback32Ex()
+    share a single context slot on the DecodedCert. Registering one overwrites
+    the context registered by the other.
 
     _Example_
     \code
     DecodedCert cert;
 
-    int UnknownExtCallback(const word32* oid, word32 oidSz, int crit,
+    int UnknownExtCallback(const word16* oid, word32 oidSz, int crit,
                           const byte* der, word32 derSz, void* ctx) {
         // handle unknown extension
         return 0;
@@ -101,10 +107,60 @@ void FreeAltNames(DNS_entry* altNames, void* heap);
     \endcode
 
     \sa wc_SetUnknownExtCallback
+    \sa wc_SetUnknownExtCallback32Ex
     \sa wc_InitDecodedCert
 */
 int wc_SetUnknownExtCallbackEx(DecodedCert* cert,
                                wc_UnknownExtCallbackEx cb, void *ctx);
+
+/*!
+    \ingroup ASN
+    \brief This function sets an extended callback for handling unknown
+    certificate extensions during certificate parsing. It behaves exactly
+    like wc_SetUnknownExtCallbackEx() except that each OID arc is passed to
+    the callback as a word32, so arcs with values > 65535 are represented
+    without truncation.
+
+    \return 0 On success.
+    \return BAD_FUNC_ARG If cert is NULL.
+
+    \param cert pointer to the DecodedCert structure
+    \param cb callback function to handle unknown extensions
+    \param ctx context pointer passed to the callback
+
+    \note This API is not public by default. Define WOLFSSL_PUBLIC_ASN to
+    expose APIs marked WOLFSSL_ASN_API.
+
+    \note A word32 callback takes precedence over a word16 one: when both
+    wc_SetUnknownExtCallbackEx() and wc_SetUnknownExtCallback32Ex() (or their
+    non-Ex counterparts) have been called on the same DecodedCert, only the
+    word32 callback is invoked.
+
+    \note wc_SetUnknownExtCallbackEx() and wc_SetUnknownExtCallback32Ex()
+    share a single context slot on the DecodedCert. Registering one overwrites
+    the context registered by the other.
+
+    _Example_
+    \code
+    DecodedCert cert;
+
+    int UnknownExtCallback32(const word32* oid, word32 oidSz, int crit,
+                            const byte* der, word32 derSz, void* ctx) {
+        // handle unknown extension
+        return 0;
+    }
+
+    wc_InitDecodedCert(&cert, derCert, derCertSz, NULL);
+    wc_SetUnknownExtCallback32Ex(&cert, UnknownExtCallback32, myContext);
+    wc_ParseCert(&cert, CERT_TYPE, NO_VERIFY, NULL);
+    \endcode
+
+    \sa wc_SetUnknownExtCallback32
+    \sa wc_SetUnknownExtCallbackEx
+    \sa wc_InitDecodedCert
+*/
+int wc_SetUnknownExtCallback32Ex(DecodedCert* cert,
+                                 wc_UnknownExtCallback32Ex cb, void *ctx);
 
 /*!
     \ingroup ASN
@@ -154,7 +210,9 @@ int wc_CheckCertSignature(const byte* cert, word32 certSz, void* heap,
     represented. Use wc_EncodeObjectId32() in new code.
 
     \return 0 On success.
-    \return BAD_FUNC_ARG If in, inSz, or outSz are invalid.
+    \return BAD_FUNC_ARG If in or outSz is NULL, if inSz is less than 2, or
+    if the first arc in[0] is greater than 2. An OID must have at least two
+    arcs and, per X.690, its first arc must be 0, 1 or 2.
     \return BUFFER_E If out is not NULL and outSz is too small.
 
     \param in pointer to array of word16 values representing OID components
@@ -193,7 +251,10 @@ int wc_EncodeObjectId(const word16* in, word32 inSz, byte* out,
     represented without truncation.
 
     \return 0 On success.
-    \return BAD_FUNC_ARG If in, inSz, or outSz are invalid.
+    \return BAD_FUNC_ARG If in or outSz is NULL, if inSz is less than 2, if
+    the first arc in[0] is greater than 2, or if the combined first arc
+    (40 * in[0] + in[1]) would overflow a word32. An OID must have at least
+    two arcs and, per X.690, its first arc must be 0, 1 or 2.
     \return BUFFER_E If out is not NULL and outSz is too small.
 
     \param in pointer to array of word32 values representing OID components

--- a/doc/dox_comments/header_files/asn.h
+++ b/doc/dox_comments/header_files/asn.h
@@ -145,6 +145,45 @@ int wc_CheckCertSignature(const byte* cert, word32 certSz, void* heap,
 
 /*!
     \ingroup ASN
+    \brief This function encodes an array of word16 values into an ASN.1
+    Object Identifier (OID) in DER format. OIDs are used to identify
+    algorithms, extensions, and other objects in certificates and
+    cryptographic protocols.
+
+    Each OID arc is a word16, so arcs with values > 65535 cannot be
+    represented. Use wc_EncodeObjectId32() in new code.
+
+    \return 0 On success.
+    \return BAD_FUNC_ARG If in, inSz, or outSz are invalid.
+    \return BUFFER_E If out is not NULL and outSz is too small.
+
+    \param in pointer to array of word16 values representing OID components
+    \param inSz number of components in the OID
+    \param out pointer to buffer to store encoded OID (can be NULL to
+    calculate size)
+    \param outSz pointer to size of out buffer; updated with actual size
+
+    _Example_
+    \code
+    word16 oid[] = {1, 2, 840, 113549, 1, 1, 11}; // sha256WithRSAEncryption
+    byte encoded[32];
+    word32 encodedSz = sizeof(encoded);
+
+    int ret = wc_EncodeObjectId(oid, sizeof(oid)/sizeof(*oid),
+                                encoded, &encodedSz);
+    if (ret == 0) {
+        // encoded contains DER encoded OID
+    }
+    \endcode
+
+    \sa wc_EncodeObjectId32
+    \sa wc_BerToDer
+*/
+int wc_EncodeObjectId(const word16* in, word32 inSz, byte* out,
+                      word32* outSz);
+
+/*!
+    \ingroup ASN
     \brief This function encodes an array of word32 values into an ASN.1
     Object Identifier (OID) in DER format. OIDs are used to identify
     algorithms, extensions, and other objects in certificates and
@@ -169,17 +208,18 @@ int wc_CheckCertSignature(const byte* cert, word32 certSz, void* heap,
     byte encoded[32];
     word32 encodedSz = sizeof(encoded);
 
-    int ret = wc_EncodeObjectId(oid, sizeof(oid)/sizeof(*oid),
-                                encoded, &encodedSz);
+    int ret = wc_EncodeObjectId32(oid, sizeof(oid)/sizeof(*oid),
+                                  encoded, &encodedSz);
     if (ret == 0) {
         // encoded contains DER encoded OID
     }
     \endcode
 
+    \sa wc_EncodeObjectId
     \sa wc_BerToDer
 */
-int wc_EncodeObjectId(const word32* in, word32 inSz, byte* out,
-                      word32* outSz);
+int wc_EncodeObjectId32(const word32* in, word32 inSz, byte* out,
+                        word32* outSz);
 
 /*!
     \ingroup ASN

--- a/doc/dox_comments/header_files/asn.h
+++ b/doc/dox_comments/header_files/asn.h
@@ -210,9 +210,11 @@ int wc_CheckCertSignature(const byte* cert, word32 certSz, void* heap,
     represented. Use wc_EncodeObjectId32() in new code.
 
     \return 0 On success.
-    \return BAD_FUNC_ARG If in or outSz is NULL, if inSz is less than 2, or
-    if the first arc in[0] is greater than 2. An OID must have at least two
-    arcs and, per X.690, its first arc must be 0, 1 or 2.
+    \return BAD_FUNC_ARG If in or outSz is NULL, if inSz is less than 2, if
+    the first arc in[0] is greater than 2, or if in[0] is 0 or 1 and the
+    second arc in[1] is greater than 39. An OID must have at least two arcs
+    and, per X.690, its first arc must be 0, 1 or 2, with the second arc
+    limited to 0..39 unless the first arc is 2.
     \return BUFFER_E If out is not NULL and outSz is too small.
 
     \param in pointer to array of word16 values representing OID components
@@ -252,9 +254,11 @@ int wc_EncodeObjectId(const word16* in, word32 inSz, byte* out,
 
     \return 0 On success.
     \return BAD_FUNC_ARG If in or outSz is NULL, if inSz is less than 2, if
-    the first arc in[0] is greater than 2, or if the combined first arc
+    the first arc in[0] is greater than 2, if in[0] is 0 or 1 and the second
+    arc in[1] is greater than 39, or if the combined first arc
     (40 * in[0] + in[1]) would overflow a word32. An OID must have at least
-    two arcs and, per X.690, its first arc must be 0, 1 or 2.
+    two arcs and, per X.690, its first arc must be 0, 1 or 2, with the second
+    arc limited to 0..39 unless the first arc is 2.
     \return BUFFER_E If out is not NULL and outSz is too small.
 
     \param in pointer to array of word32 values representing OID components

--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -4178,13 +4178,18 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
 
     \param cert the DecodedCert struct that is to be associated with this
     callback.
-    \param cb function to register as the time callback.
+    \param cb function to register as the unknown extension callback.
+
+    \note Each OID arc is passed to the callback as a word16, so arcs with
+    values > 65535 are truncated. Use wc_SetUnknownExtCallback32() in new
+    code. When both a word16 and a word32 callback are registered on the same
+    DecodedCert, only the word32 callback is invoked.
 
     _Example_
     \code
     int ret = 0;
     // Unknown extension callback prototype
-    int myUnknownExtCallback(const word32* oid, word32 oidSz, int crit,
+    int myUnknownExtCallback(const word16* oid, word32 oidSz, int crit,
                              const unsigned char* der, word32 derSz);
 
     // Register it
@@ -4193,13 +4198,13 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
         // failed to set the callback
     }
 
-    // oid: Array of integers that are the dot separated values in an oid.
+    // oid: Array of word16 that are the dot separated values in an oid.
     // oidSz: Number of values in oid.
-    // crit: Whether the extension was mark critical.
+    // crit: Whether the extension was marked critical.
     // der: The der encoding of the content of the extension.
     // derSz: The size in bytes of the der encoding.
-    int myCustomExtCallback(const word32* oid, word32 oidSz, int crit,
-                            const unsigned char* der, word32 derSz) {
+    int myUnknownExtCallback(const word16* oid, word32 oidSz, int crit,
+                             const unsigned char* der, word32 derSz) {
 
         // Logic to parse extension goes here.
 
@@ -4216,9 +4221,71 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
 
     \sa ParseCert
     \sa wc_SetCustomExtension
+    \sa wc_SetUnknownExtCallback32
 */
 int wc_SetUnknownExtCallback(DecodedCert* cert,
                                              wc_UnknownExtCallback cb);
+
+/*!
+    \ingroup ASN
+
+    \brief This function registers a callback that will be used anytime
+    wolfSSL encounters an unknown X.509 extension in a certificate while
+    parsing a certificate. It behaves exactly like wc_SetUnknownExtCallback()
+    except that each OID arc is passed to the callback as a word32, so arcs
+    with values > 65535 are represented without truncation.
+
+    \return 0 Returned on success.
+    \return BAD_FUNC_ARG Returned if cert is NULL.
+
+    \param cert the DecodedCert struct that is to be associated with this
+    callback.
+    \param cb function to register as the unknown extension callback.
+
+    \note A word32 callback takes precedence over a word16 one: when both
+    wc_SetUnknownExtCallback() and wc_SetUnknownExtCallback32() have been
+    called on the same DecodedCert, only the word32 callback is invoked.
+
+    _Example_
+    \code
+    int ret = 0;
+    // Unknown extension callback prototype
+    int myUnknownExtCallback32(const word32* oid, word32 oidSz, int crit,
+                               const unsigned char* der, word32 derSz);
+
+    // Register it
+    ret = wc_SetUnknownExtCallback32(cert, myUnknownExtCallback32);
+    if (ret != 0) {
+        // failed to set the callback
+    }
+
+    // oid: Array of word32 that are the dot separated values in an oid.
+    // oidSz: Number of values in oid.
+    // crit: Whether the extension was marked critical.
+    // der: The der encoding of the content of the extension.
+    // derSz: The size in bytes of the der encoding.
+    int myUnknownExtCallback32(const word32* oid, word32 oidSz, int crit,
+                               const unsigned char* der, word32 derSz) {
+
+        // Logic to parse extension goes here.
+
+        // NOTE: by returning zero, we are accepting this extension and
+        // informing wolfSSL that it is acceptable. If you find an extension
+        // that you do not find acceptable, you should return an error. The
+        // standard behavior upon encountering an unknown extension with the
+        // critical flag set is to return ASN_CRIT_EXT_E.
+        return 0;
+    }
+    \endcode
+
+    \sa ParseCert
+    \sa wc_SetCustomExtension
+    \sa wc_SetUnknownExtCallback
+    \sa wc_SetUnknownExtCallback32Ex
+*/
+int wc_SetUnknownExtCallback32(DecodedCert* cert,
+                                             wc_UnknownExtCallback32 cb);
+
 /*!
     \ingroup ASN
 

--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -4184,7 +4184,7 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
     \code
     int ret = 0;
     // Unknown extension callback prototype
-    int myUnknownExtCallback(const word16* oid, word32 oidSz, int crit,
+    int myUnknownExtCallback(const word32* oid, word32 oidSz, int crit,
                              const unsigned char* der, word32 derSz);
 
     // Register it
@@ -4198,7 +4198,7 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
     // crit: Whether the extension was mark critical.
     // der: The der encoding of the content of the extension.
     // derSz: The size in bytes of the der encoding.
-    int myCustomExtCallback(const word16* oid, word32 oidSz, int crit,
+    int myCustomExtCallback(const word32* oid, word32 oidSz, int crit,
                             const unsigned char* der, word32 derSz) {
 
         // Logic to parse extension goes here.

--- a/doc/dox_comments/header_files/pkcs7.h
+++ b/doc/dox_comments/header_files/pkcs7.h
@@ -1252,10 +1252,16 @@ wc_PKCS7* wc_PKCS7_New(void* heap, int devId);
     \ingroup PKCS7
     \brief Sets unknown extension callback.
 
+    Each OID arc is passed to the callback as a word16, so arcs with values
+    > 65535 are truncated. Use wc_PKCS7_SetUnknownExtCallback32() in new code.
+
     \return none No returns
 
     \param pkcs7 PKCS7 structure
     \param cb Callback function
+
+    \note When both a word16 and a word32 callback are registered on the same
+    wc_PKCS7 structure, only the word32 callback is invoked.
 
     _Example_
     \code
@@ -1263,9 +1269,39 @@ wc_PKCS7* wc_PKCS7_New(void* heap, int devId);
     \endcode
 
     \sa wc_PKCS7_Init
+    \sa wc_PKCS7_SetUnknownExtCallback32
 */
 void wc_PKCS7_SetUnknownExtCallback(wc_PKCS7* pkcs7,
                                     wc_UnknownExtCallback cb);
+
+/*!
+    \ingroup PKCS7
+    \brief Sets unknown extension callback.
+
+    Behaves exactly like wc_PKCS7_SetUnknownExtCallback() except that each OID
+    arc is passed to the callback as a word32, so arcs with values > 65535 are
+    represented without truncation.
+
+    \return none No returns
+
+    \param pkcs7 PKCS7 structure
+    \param cb Callback function
+
+    \note A word32 callback takes precedence over a word16 one: when both
+    wc_PKCS7_SetUnknownExtCallback() and wc_PKCS7_SetUnknownExtCallback32()
+    have been called on the same wc_PKCS7 structure, only the word32 callback
+    is invoked.
+
+    _Example_
+    \code
+    wc_PKCS7_SetUnknownExtCallback32(pkcs7, myCallback32);
+    \endcode
+
+    \sa wc_PKCS7_Init
+    \sa wc_PKCS7_SetUnknownExtCallback
+*/
+void wc_PKCS7_SetUnknownExtCallback32(wc_PKCS7* pkcs7,
+                                      wc_UnknownExtCallback32 cb);
 
 /*!
     \ingroup PKCS7

--- a/src/crl.c
+++ b/src/crl.c
@@ -950,7 +950,9 @@ int BufferLoadCRL(WOLFSSL_CRL* crl, const byte* buff, long sz, int type,
 #ifdef WC_ASN_UNKNOWN_EXT_CB
     if (crl->cm != NULL) {
         dcrl->unknownExtCallback      = crl->cm->crlUnknownExtCallback;
+        dcrl->unknownExtCallback32    = crl->cm->crlUnknownExtCallback32;
         dcrl->unknownExtCallbackEx    = crl->cm->crlUnknownExtCallbackEx;
+        dcrl->unknownExtCallback32Ex  = crl->cm->crlUnknownExtCallback32Ex;
         dcrl->unknownExtCallbackExCtx = crl->cm->crlUnknownExtCallbackExCtx;
     }
 #endif
@@ -1282,7 +1284,9 @@ int GetCRLInfo(WOLFSSL_CRL* crl, CrlInfo* info, const byte* buff,
 #ifdef WC_ASN_UNKNOWN_EXT_CB
     if (crl->cm != NULL) {
         dcrl->unknownExtCallback      = crl->cm->crlUnknownExtCallback;
+        dcrl->unknownExtCallback32    = crl->cm->crlUnknownExtCallback32;
         dcrl->unknownExtCallbackEx    = crl->cm->crlUnknownExtCallbackEx;
+        dcrl->unknownExtCallback32Ex  = crl->cm->crlUnknownExtCallback32Ex;
         dcrl->unknownExtCallbackExCtx = crl->cm->crlUnknownExtCallbackExCtx;
     }
 #endif

--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -753,6 +753,15 @@ void wolfSSL_CertManagerSetUnknownExtCallback(WOLFSSL_CERT_MANAGER* cm,
 
 }
 
+void wolfSSL_CertManagerSetUnknownExtCallback32(WOLFSSL_CERT_MANAGER* cm,
+        wc_UnknownExtCallback32 cb)
+{
+    WOLFSSL_ENTER("wolfSSL_CertManagerSetUnknownExtCallback32");
+    if (cm != NULL) {
+        cm->unknownExtCallback32 = cb;
+    }
+}
+
 #ifdef HAVE_CRL
 int wolfSSL_CertManagerSetCRLUnknownExtCallback(WOLFSSL_CERT_MANAGER* cm,
         wc_UnknownExtCallback cb)
@@ -773,6 +782,30 @@ int wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(WOLFSSL_CERT_MANAGER* cm,
         return BAD_FUNC_ARG;
     }
     cm->crlUnknownExtCallbackEx = cb;
+    cm->crlUnknownExtCallbackExCtx = ctx;
+    return WOLFSSL_SUCCESS;
+}
+
+int wolfSSL_CertManagerSetCRLUnknownExtCallback32(WOLFSSL_CERT_MANAGER* cm,
+        wc_UnknownExtCallback32 cb)
+{
+    WOLFSSL_ENTER("wolfSSL_CertManagerSetCRLUnknownExtCallback32");
+    if (cm == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    cm->crlUnknownExtCallback32 = cb;
+    return WOLFSSL_SUCCESS;
+}
+
+int wolfSSL_CertManagerSetCRLUnknownExtCallback32Ex(WOLFSSL_CERT_MANAGER* cm,
+        wc_UnknownExtCallback32Ex cb,
+        void* ctx)
+{
+    WOLFSSL_ENTER("wolfSSL_CertManagerSetCRLUnknownExtCallback32Ex");
+    if (cm == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    cm->crlUnknownExtCallback32Ex  = cb;
     cm->crlUnknownExtCallbackExCtx = ctx;
     return WOLFSSL_SUCCESS;
 }
@@ -842,6 +875,8 @@ int CM_VerifyBuffer_ex(WOLFSSL_CERT_MANAGER* cm, const unsigned char* buff,
         InitDecodedCert(cert, buff, (word32)sz, cm->heap);
 
 #ifdef WC_ASN_UNKNOWN_EXT_CB
+        if (cm->unknownExtCallback32 != NULL)
+            wc_SetUnknownExtCallback32(cert, cm->unknownExtCallback32);
         if (cm->unknownExtCallback != NULL)
             wc_SetUnknownExtCallback(cert, cm->unknownExtCallback);
 #endif
@@ -3157,6 +3192,9 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
     InitDecodedCert(cert, der->buffer, der->length, cm->heap);
 
 #ifdef WC_ASN_UNKNOWN_EXT_CB
+    if (cm->unknownExtCallback32 != NULL) {
+        wc_SetUnknownExtCallback32(cert, cm->unknownExtCallback32);
+    }
     if (cm->unknownExtCallback != NULL) {
         wc_SetUnknownExtCallback(cert, cm->unknownExtCallback);
     }

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -2690,21 +2690,25 @@ int test_wc_DecodeObjectId_ex(void)
     (defined(HAVE_OID_DECODING) || defined(WOLFSSL_ASN_PRINT))
     {
         word32 i;
+
+        /* Tests multi byte encoding for arc 1 and 2
+         * (only possible when arc 1 is 2 and arc 2 is greater than 48) */
         static const word32 oid_dot_2[] = {
             2, 100, 4, 6
         };
 
+        /* Tests multi byte encoding for arc 1 and 2
+         * (only possible when arc 1 is 2 and arc 2 is greater than 48) */
         static const byte oid_start_with_2[] = {
             0x81, 0x34, 0x04, 0x06
         };
-
 
         /* OID 1.3.132.0.6 (secp112r1)
          * DER encoding: 2b 81 04 00 06
          * First byte 0x2b = 43 => arc0 = 43/40 = 1, arc1 = 43%40 = 3
          * Remaining arcs: 132 0 6
          */
-        static const byte oid_sha256rsa[] = {
+        static const byte oid_secp112r1[] = {
             0x2B, 0x81, 0x04, 0x00, 0x06
         };
 
@@ -2718,7 +2722,7 @@ int test_wc_DecodeObjectId_ex(void)
         word32 trueOutSz = sizeof(oid_dot_form) / sizeof(word32);
         /* Test 1: Normal decode */
         outSz = MAX_OID_SZ;
-        ExpectIntEQ(DecodeObjectId_ex(oid_sha256rsa, sizeof(oid_sha256rsa),
+        ExpectIntEQ(DecodeObjectId_ex(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, &outSz), 0);
         ExpectIntEQ((int)outSz, trueOutSz);
         for (i = 0; i < ((outSz <= trueOutSz) ? outSz : trueOutSz); i++) {
@@ -2727,22 +2731,22 @@ int test_wc_DecodeObjectId_ex(void)
 
         /* Test 2: NULL args */
         outSz = MAX_OID_SZ;
-        ExpectIntEQ(DecodeObjectId_ex(NULL, sizeof(oid_sha256rsa), out, &outSz),
+        ExpectIntEQ(DecodeObjectId_ex(NULL, sizeof(oid_secp112r1), out, &outSz),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-        ExpectIntEQ(DecodeObjectId_ex(oid_sha256rsa, sizeof(oid_sha256rsa),
+        ExpectIntEQ(DecodeObjectId_ex(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, NULL),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
         /* Test 3 (Bug 1): outSz=1 must return BUFFER_E, not OOB write.
          * The first OID byte decodes into two arcs, so outSz must be >= 2. */
         outSz = 1;
-        ExpectIntEQ(DecodeObjectId_ex(oid_sha256rsa, sizeof(oid_sha256rsa),
+        ExpectIntEQ(DecodeObjectId_ex(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
         /* Test 4: outSz=0 must also return BUFFER_E */
         outSz = 0;
-        ExpectIntEQ(DecodeObjectId_ex(oid_sha256rsa, sizeof(oid_sha256rsa),
+        ExpectIntEQ(DecodeObjectId_ex(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
@@ -2759,11 +2763,11 @@ int test_wc_DecodeObjectId_ex(void)
 
         /* Test 6: Buffer too small for later arcs */
         outSz = 3; /* only room for 3 arcs, but OID has 7 */
-        ExpectIntEQ(DecodeObjectId_ex(oid_sha256rsa, sizeof(oid_sha256rsa),
+        ExpectIntEQ(DecodeObjectId_ex(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
-    /* Test 7: first Arc is 2 */
+        /* Test 7: first Arc is 2 */
         {
             word32 trueOutSz2 = sizeof(oid_dot_2) / sizeof(word32);
             outSz = MAX_OID_SZ;
@@ -2777,8 +2781,7 @@ int test_wc_DecodeObjectId_ex(void)
             }
         }
 
-        /* Test 8: an OID with an arc that exceeds word16.
-         */
+        /* Test 8: an OID with an arc that exceeds word16. */
         {
             static const byte oid_large_arc[] = {
                 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b
@@ -2858,8 +2861,7 @@ int test_wc_EncodeObjectId(void)
         ExpectIntEQ(wc_EncodeObjectId(oid_small, oid_small_cnt, out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
-        /* Test 5 : arc greater that SHRT_MAX
-         */
+        /* Test 5 : arc greater that SHRT_MAX */
         {
             static const word32 oid_large[] = {
                 1U, 2U, 840U, 113549U, 1U, 1U, 11U

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -2682,7 +2682,7 @@ int test_wc_DecodeObjectId_FIPS16(void)
     return EXPECT_RESULT();
 }
 
-int test_wc_DecodeObjectId_ex(void)
+int test_wc_DecodeObjectId32(void)
 {
     EXPECT_DECLS;
 
@@ -2722,7 +2722,7 @@ int test_wc_DecodeObjectId_ex(void)
         word32 trueOutSz = sizeof(oid_dot_form) / sizeof(word32);
         /* Test 1: Normal decode */
         outSz = MAX_OID_SZ;
-        ExpectIntEQ(DecodeObjectId_ex(oid_secp112r1, sizeof(oid_secp112r1),
+        ExpectIntEQ(DecodeObjectId32(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, &outSz), 0);
         ExpectIntEQ((int)outSz, trueOutSz);
         for (i = 0; i < ((outSz <= trueOutSz) ? outSz : trueOutSz); i++) {
@@ -2731,22 +2731,22 @@ int test_wc_DecodeObjectId_ex(void)
 
         /* Test 2: NULL args */
         outSz = MAX_OID_SZ;
-        ExpectIntEQ(DecodeObjectId_ex(NULL, sizeof(oid_secp112r1), out, &outSz),
+        ExpectIntEQ(DecodeObjectId32(NULL, sizeof(oid_secp112r1), out, &outSz),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-        ExpectIntEQ(DecodeObjectId_ex(oid_secp112r1, sizeof(oid_secp112r1),
+        ExpectIntEQ(DecodeObjectId32(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, NULL),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
         /* Test 3 (Bug 1): outSz=1 must return BUFFER_E, not OOB write.
          * The first OID byte decodes into two arcs, so outSz must be >= 2. */
         outSz = 1;
-        ExpectIntEQ(DecodeObjectId_ex(oid_secp112r1, sizeof(oid_secp112r1),
+        ExpectIntEQ(DecodeObjectId32(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
         /* Test 4: outSz=0 must also return BUFFER_E */
         outSz = 0;
-        ExpectIntEQ(DecodeObjectId_ex(oid_secp112r1, sizeof(oid_secp112r1),
+        ExpectIntEQ(DecodeObjectId32(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
@@ -2754,7 +2754,7 @@ int test_wc_DecodeObjectId_ex(void)
         {
             static const byte oid_one_byte[] = { 0x2a }; /* 1.2 */
             outSz = 2;
-            ExpectIntEQ(DecodeObjectId_ex(oid_one_byte, sizeof(oid_one_byte),
+            ExpectIntEQ(DecodeObjectId32(oid_one_byte, sizeof(oid_one_byte),
                                        out, &outSz), 0);
             ExpectIntEQ((int)outSz, 2);
             ExpectIntEQ(out[0], 1);
@@ -2763,7 +2763,7 @@ int test_wc_DecodeObjectId_ex(void)
 
         /* Test 6: Buffer too small for later arcs */
         outSz = 3; /* only room for 3 arcs, but OID has 7 */
-        ExpectIntEQ(DecodeObjectId_ex(oid_secp112r1, sizeof(oid_secp112r1),
+        ExpectIntEQ(DecodeObjectId32(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
@@ -2771,7 +2771,7 @@ int test_wc_DecodeObjectId_ex(void)
         {
             word32 trueOutSz2 = sizeof(oid_dot_2) / sizeof(word32);
             outSz = MAX_OID_SZ;
-            ExpectIntEQ(DecodeObjectId_ex(oid_start_with_2,
+            ExpectIntEQ(DecodeObjectId32(oid_start_with_2,
                         sizeof(oid_start_with_2),
                         out, &outSz), 0);
             ExpectIntEQ((int)outSz, trueOutSz2);
@@ -2792,7 +2792,7 @@ int test_wc_DecodeObjectId_ex(void)
             word32 trueOutSz3 = sizeof(oid_dot_large_arc) / sizeof(word32);
 
             outSz = MAX_OID_SZ;
-            ExpectIntEQ(DecodeObjectId_ex(oid_large_arc, sizeof(oid_large_arc),
+            ExpectIntEQ(DecodeObjectId32(oid_large_arc, sizeof(oid_large_arc),
                                        out, &outSz), 0);
             ExpectIntEQ((int)outSz, (int)trueOutSz3);
             for (i = 0; i < ((outSz <= trueOutSz3) ? outSz : trueOutSz3); i++) {
@@ -2809,7 +2809,7 @@ int test_wc_DecodeObjectId_ex(void)
                 0x2a, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F
             };
             outSz = MAX_OID_SZ;
-            ExpectIntEQ(DecodeObjectId_ex(oid_overflow_arc,
+            ExpectIntEQ(DecodeObjectId32(oid_overflow_arc,
                         sizeof(oid_overflow_arc), out, &outSz),
                         WC_NO_ERR_TRACE(ASN_OBJECT_ID_E));
         }
@@ -2824,13 +2824,13 @@ int test_wc_EncodeObjectId(void)
     EXPECT_DECLS;
 #if defined(HAVE_OID_ENCODING) && !defined(NO_ASN)
     {
-        /* 1.3.132.0.6 (secp112r1) -- every arc fits in word16, so this
-         * encodes identically in both build configs. */
-        static const word32 oid_small[] = { 1U, 3U, 132U, 0U, 6U };
+        /* wc_EncodeObjectId() takes word16 arcs, so only OIDs whose arcs all
+         * fit in a word16 can be encoded with it. 1.3.132.0.6 (secp112r1). */
+        static const word16 oid_small[] = { 1U, 3U, 132U, 0U, 6U };
         static const byte oid_small_der[] = {
             0x2b, 0x81, 0x04, 0x00, 0x06
         };
-        const word32 oid_small_cnt = sizeof(oid_small) / sizeof(word32);
+        const word32 oid_small_cnt = sizeof(oid_small) / sizeof(word16);
         byte   out[MAX_OID_SZ];
         word32 outSz;
         word32 i;
@@ -2861,6 +2861,68 @@ int test_wc_EncodeObjectId(void)
         ExpectIntEQ(wc_EncodeObjectId(oid_small, oid_small_cnt, out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
+        /* Test 5: first arc greater than 2 is invalid (in[0] > 2) */
+        {
+            static const word16 oid_bad_first[] = { 3U, 1U };
+            outSz = sizeof(out);
+            ExpectIntEQ(wc_EncodeObjectId(oid_bad_first,
+                        sizeof(oid_bad_first) / sizeof(word16), out, &outSz),
+                        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        }
+
+        /* Test 6: fewer than two arcs is invalid (inSz < 2) */
+        outSz = sizeof(out);
+        ExpectIntEQ(wc_EncodeObjectId(oid_small, 1, out, &outSz),
+                    WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    }
+#endif /* HAVE_OID_ENCODING && !NO_ASN */
+
+    return EXPECT_RESULT();
+}
+
+int test_wc_EncodeObjectId32(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_OID_ENCODING) && !defined(NO_ASN)
+    {
+        /* 1.3.132.0.6 (secp112r1) -- every arc fits in word16, so this
+         * encodes identically in both build configs. */
+        static const word32 oid_small[] = { 1U, 3U, 132U, 0U, 6U };
+        static const byte oid_small_der[] = {
+            0x2b, 0x81, 0x04, 0x00, 0x06
+        };
+        const word32 oid_small_cnt = sizeof(oid_small) / sizeof(word32);
+        byte   out[MAX_OID_SZ];
+        word32 outSz;
+        word32 i;
+
+        /* Test 1: length-only query (out == NULL) */
+        outSz = 0;
+        ExpectIntEQ(wc_EncodeObjectId32(oid_small, oid_small_cnt, NULL, &outSz),
+                    0);
+        ExpectIntEQ((int)outSz, (int)sizeof(oid_small_der));
+
+        /* Test 2: normal encode matches expected DER */
+        outSz = sizeof(out);
+        ExpectIntEQ(wc_EncodeObjectId32(oid_small, oid_small_cnt, out, &outSz),
+                    0);
+        ExpectIntEQ((int)outSz, (int)sizeof(oid_small_der));
+        for (i = 0; i < outSz && i < sizeof(oid_small_der); i++) {
+            ExpectIntEQ(out[i], oid_small_der[i]);
+        }
+
+        /* Test 3: NULL args */
+        outSz = sizeof(out);
+        ExpectIntEQ(wc_EncodeObjectId32(NULL, oid_small_cnt, out, &outSz),
+                    WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(wc_EncodeObjectId32(oid_small, oid_small_cnt, out, NULL),
+                    WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+        /* Test 4: output buffer too small */
+        outSz = 1;
+        ExpectIntEQ(wc_EncodeObjectId32(oid_small, oid_small_cnt, out, &outSz),
+                    WC_NO_ERR_TRACE(BUFFER_E));
+
         /* Test 5 : arc greater that SHRT_MAX */
         {
             static const word32 oid_large[] = {
@@ -2872,8 +2934,8 @@ int test_wc_EncodeObjectId(void)
             const word32 oid_large_cnt = sizeof(oid_large) / sizeof(word32);
 
             outSz = sizeof(out);
-            ExpectIntEQ(wc_EncodeObjectId(oid_large, oid_large_cnt, out, &outSz),
-                        0);
+            ExpectIntEQ(wc_EncodeObjectId32(oid_large, oid_large_cnt, out,
+                        &outSz), 0);
             ExpectIntEQ((int)outSz, (int)sizeof(oid_large_der));
             for (i = 0; i < outSz && i < sizeof(oid_large_der); i++) {
                 ExpectIntEQ(out[i], oid_large_der[i]);
@@ -2883,7 +2945,7 @@ int test_wc_EncodeObjectId(void)
             {
                 word32 dec[MAX_OID_SZ];
                 word32 decSz = MAX_OID_SZ;
-                ExpectIntEQ(DecodeObjectId_ex(out, outSz, dec, &decSz), 0);
+                ExpectIntEQ(DecodeObjectId32(out, outSz, dec, &decSz), 0);
                 ExpectIntEQ((int)decSz, (int)oid_large_cnt);
                 for (i = 0; i < decSz && i < oid_large_cnt; i++) {
                     ExpectIntEQ(dec[i], oid_large[i]);
@@ -2896,15 +2958,24 @@ int test_wc_EncodeObjectId(void)
         {
             static const word32 oid_bad_first[] = { 3U, 1U };
             outSz = sizeof(out);
-            ExpectIntEQ(wc_EncodeObjectId(oid_bad_first,
+            ExpectIntEQ(wc_EncodeObjectId32(oid_bad_first,
                         sizeof(oid_bad_first) / sizeof(word32), out, &outSz),
                         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
         }
 
         /* Test 7: fewer than two arcs is invalid (inSz < 2) */
         outSz = sizeof(out);
-        ExpectIntEQ(wc_EncodeObjectId(oid_small, 1, out, &outSz),
+        ExpectIntEQ(wc_EncodeObjectId32(oid_small, 1, out, &outSz),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+        /* Test 8: (in[0] * 40) + in[1] must not overflow a word32 */
+        {
+            static const word32 oid_overflow[] = { 2U, 0xFFFFFFFFU, 1U };
+            outSz = sizeof(out);
+            ExpectIntEQ(wc_EncodeObjectId32(oid_overflow,
+                        sizeof(oid_overflow) / sizeof(word32), out, &outSz),
+                        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        }
     }
 #endif /* HAVE_OID_ENCODING && !NO_ASN */
 

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -2800,16 +2800,46 @@ int test_wc_DecodeObjectId32(void)
         }
 
         /* Test 9: an arc that does not fit in a word32 must be rejected by
-         * the overflow guard rather than silently wrapping. The first byte
-         * (0x2a) decodes to 1.2; the following five continuation bytes encode
-         * a single sub-identifier that needs more than 32 bits. */
+         * the overflow guard rather than silently wrapping. In each vector
+         * the first byte (0x2a) decodes to 1.2 and the remaining bytes encode
+         * a single sub-identifier. */
         {
+            /* Five continuation bytes: 35 significant bits. */
             static const byte oid_overflow_arc[] = {
                 0x2a, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F
             };
+            /* Six continuation bytes: more than the encoder ever emits. */
+            static const byte oid_overflow_arc_long[] = {
+                0x2a, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F
+            };
+            /* Exactly 2^32 - 1: the largest arc that does fit. */
+            static const byte oid_max_arc[] = {
+                0x2a, 0x8F, 0xFF, 0xFF, 0xFF, 0x7F
+            };
+            /* Exactly 2^32: one more than fits. */
+            static const byte oid_over_max_arc[] = {
+                0x2a, 0x90, 0x80, 0x80, 0x80, 0x00
+            };
+
             outSz = MAX_OID_SZ;
             ExpectIntEQ(DecodeObjectId32(oid_overflow_arc,
                         sizeof(oid_overflow_arc), out, &outSz),
+                        WC_NO_ERR_TRACE(ASN_OBJECT_ID_E));
+
+            outSz = MAX_OID_SZ;
+            ExpectIntEQ(DecodeObjectId32(oid_overflow_arc_long,
+                        sizeof(oid_overflow_arc_long), out, &outSz),
+                        WC_NO_ERR_TRACE(ASN_OBJECT_ID_E));
+
+            outSz = MAX_OID_SZ;
+            ExpectIntEQ(DecodeObjectId32(oid_max_arc, sizeof(oid_max_arc),
+                        out, &outSz), 0);
+            ExpectIntEQ((int)outSz, 3);
+            ExpectTrue(out[2] == 0xFFFFFFFFU);
+
+            outSz = MAX_OID_SZ;
+            ExpectIntEQ(DecodeObjectId32(oid_over_max_arc,
+                        sizeof(oid_over_max_arc), out, &outSz),
                         WC_NO_ERR_TRACE(ASN_OBJECT_ID_E));
         }
     }

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -2561,56 +2561,66 @@ int test_SerialNumber0_RootCA(void)
     return EXPECT_RESULT();
 }
 
-int test_wc_DecodeObjectId(void)
+
+/* Test for word16 FIPS version of function */
+int test_wc_DecodeObjectId_FIPS16(void)
 {
     EXPECT_DECLS;
 
 #if !defined(NO_ASN) && \
     (defined(HAVE_OID_DECODING) || defined(WOLFSSL_ASN_PRINT))
     {
-        /* OID 1.2.840.113549.1.1.11 (sha256WithRSAEncryption)
-         * DER encoding: 2a 86 48 86 f7 0d 01 01 0b
-         * First byte 0x2a = 42 => arc0 = 42/40 = 1, arc1 = 42%40 = 2
-         * Remaining arcs: 840, 113549, 1, 1, 11
-         */
-        static const byte oid_sha256rsa[] = {
-            0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b
+        word32 i;
+        static const word16 oid_dot_2[] = {
+            2, 100, 4, 6
         };
+
+        static const byte oid_start_with_2[] = {
+            0x81, 0x34, 0x04, 0x06
+        };
+
+
+        static const byte oid_sha256secp112r1[] = {
+            0x2B, 0x81, 0x04, 0x00, 0x06
+        };
+
+        static const word16 oid_dot_form[] = {
+            1U, 3U, 132U, 0U, 6U
+        };
+
         word16 out[MAX_OID_SZ];
         word32 outSz;
 
+        word32 trueOutSz = sizeof(oid_dot_form) / sizeof(*oid_dot_form);
         /* Test 1: Normal decode */
         outSz = MAX_OID_SZ;
-        ExpectIntEQ(DecodeObjectId(oid_sha256rsa, sizeof(oid_sha256rsa),
-                                   out, &outSz), 0);
-        ExpectIntEQ((int)outSz, 7);
-        ExpectIntEQ(out[0], 1);
-        ExpectIntEQ(out[1], 2);
-        ExpectIntEQ(out[2], 840);
-        ExpectIntEQ(out[3], (word16)113549); /* truncated to word16 */
-        ExpectIntEQ(out[4], 1);
-        ExpectIntEQ(out[5], 1);
-        ExpectIntEQ(out[6], 11);
+        ExpectIntEQ(DecodeObjectId(oid_sha256secp112r1,
+                    sizeof(oid_sha256secp112r1), out, &outSz), 0);
+        ExpectIntEQ((int)outSz, trueOutSz);
+        for (i = 0; i < ((outSz <= trueOutSz) ? outSz : trueOutSz); i++) {
+            ExpectIntEQ(out[i], oid_dot_form[i]);
+        }
 
         /* Test 2: NULL args */
         outSz = MAX_OID_SZ;
-        ExpectIntEQ(DecodeObjectId(NULL, sizeof(oid_sha256rsa), out, &outSz),
+        ExpectIntEQ(DecodeObjectId(NULL, sizeof(oid_sha256secp112r1),
+                    out, &outSz),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-        ExpectIntEQ(DecodeObjectId(oid_sha256rsa, sizeof(oid_sha256rsa),
-                                   out, NULL),
+        ExpectIntEQ(DecodeObjectId(oid_sha256secp112r1,
+                    sizeof(oid_sha256secp112r1), out, NULL),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
         /* Test 3 (Bug 1): outSz=1 must return BUFFER_E, not OOB write.
          * The first OID byte decodes into two arcs, so outSz must be >= 2. */
         outSz = 1;
-        ExpectIntEQ(DecodeObjectId(oid_sha256rsa, sizeof(oid_sha256rsa),
-                                   out, &outSz),
+        ExpectIntEQ(DecodeObjectId(oid_sha256secp112r1,
+                    sizeof(oid_sha256secp112r1), out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
         /* Test 4: outSz=0 must also return BUFFER_E */
         outSz = 0;
-        ExpectIntEQ(DecodeObjectId(oid_sha256rsa, sizeof(oid_sha256rsa),
-                                   out, &outSz),
+        ExpectIntEQ(DecodeObjectId(oid_sha256secp112r1,
+                    sizeof(oid_sha256secp112r1), out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
         /* Test 5: outSz=2 is enough for a single-byte OID (two arcs) */
@@ -2626,11 +2636,247 @@ int test_wc_DecodeObjectId(void)
 
         /* Test 6: Buffer too small for later arcs */
         outSz = 3; /* only room for 3 arcs, but OID has 7 */
-        ExpectIntEQ(DecodeObjectId(oid_sha256rsa, sizeof(oid_sha256rsa),
-                                   out, &outSz),
+        ExpectIntEQ(DecodeObjectId(oid_sha256secp112r1,
+                    sizeof(oid_sha256secp112r1), out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
+
+        /* Test 7: first Arc is 2 */
+        {
+            word32 trueOutSz2 = sizeof(oid_dot_2) / sizeof(*oid_dot_2);
+            outSz = MAX_OID_SZ;
+            ExpectIntEQ(DecodeObjectId(oid_start_with_2,
+                        sizeof(oid_start_with_2),
+                        out, &outSz), 0);
+            ExpectIntEQ((int)outSz, trueOutSz2);
+            for (i = 0; i < ((outSz <= trueOutSz2) ?
+                        outSz : trueOutSz2); i++) {
+                ExpectIntEQ(out[i], oid_dot_2[i]);
+            }
+        }
+
+        /* Test 8: an OID with an arc that exceeds word16. Tests that wrong
+         * but unchangeable behavior is working correctly,
+         *
+         * word16 version is used in FIPS build
+         */
+        {
+            static const byte oid_large_arc[] = {
+                0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b
+            };
+            static const word16 oid_dot_large_arc[] = {
+                1U, 2U, 840U, (word16)113549U, 1U, 1U, 11U
+            };
+            word32 trueOutSz3 = sizeof(oid_dot_large_arc) / sizeof(word16);
+
+            outSz = MAX_OID_SZ;
+            ExpectIntEQ(DecodeObjectId(oid_large_arc, sizeof(oid_large_arc),
+                                       out, &outSz), 0);
+            ExpectIntEQ((int)outSz, (int)trueOutSz3);
+            for (i = 0; i < ((outSz <= trueOutSz3) ? outSz : trueOutSz3); i++) {
+                ExpectIntEQ(out[i], oid_dot_large_arc[i]);
+            }
+        }
     }
 #endif /* !NO_ASN && (HAVE_OID_DECODING || WOLFSSL_ASN_PRINT) */
+
+    return EXPECT_RESULT();
+}
+
+int test_wc_DecodeObjectId_ex(void)
+{
+    EXPECT_DECLS;
+
+#if !defined(NO_ASN) && \
+    (defined(HAVE_OID_DECODING) || defined(WOLFSSL_ASN_PRINT))
+    {
+        word32 i;
+        static const word32 oid_dot_2[] = {
+            2, 100, 4, 6
+        };
+
+        static const byte oid_start_with_2[] = {
+            0x81, 0x34, 0x04, 0x06
+        };
+
+
+        /* OID 1.3.132.0.6 (secp112r1)
+         * DER encoding: 2b 81 04 00 06
+         * First byte 0x2b = 43 => arc0 = 43/40 = 1, arc1 = 43%40 = 3
+         * Remaining arcs: 132 0 6
+         */
+        static const byte oid_sha256rsa[] = {
+            0x2B, 0x81, 0x04, 0x00, 0x06
+        };
+
+        static const word32 oid_dot_form[] = {
+            1U, 3U, 132U, 0U, 6U
+        };
+
+        word32 out[MAX_OID_SZ];
+        word32 outSz;
+
+        word32 trueOutSz = sizeof(oid_dot_form) / sizeof(word32);
+        /* Test 1: Normal decode */
+        outSz = MAX_OID_SZ;
+        ExpectIntEQ(DecodeObjectId_ex(oid_sha256rsa, sizeof(oid_sha256rsa),
+                                   out, &outSz), 0);
+        ExpectIntEQ((int)outSz, trueOutSz);
+        for (i = 0; i < ((outSz <= trueOutSz) ? outSz : trueOutSz); i++) {
+            ExpectIntEQ(out[i], oid_dot_form[i]);
+        }
+
+        /* Test 2: NULL args */
+        outSz = MAX_OID_SZ;
+        ExpectIntEQ(DecodeObjectId_ex(NULL, sizeof(oid_sha256rsa), out, &outSz),
+                    WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(DecodeObjectId_ex(oid_sha256rsa, sizeof(oid_sha256rsa),
+                                   out, NULL),
+                    WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+        /* Test 3 (Bug 1): outSz=1 must return BUFFER_E, not OOB write.
+         * The first OID byte decodes into two arcs, so outSz must be >= 2. */
+        outSz = 1;
+        ExpectIntEQ(DecodeObjectId_ex(oid_sha256rsa, sizeof(oid_sha256rsa),
+                                   out, &outSz),
+                    WC_NO_ERR_TRACE(BUFFER_E));
+
+        /* Test 4: outSz=0 must also return BUFFER_E */
+        outSz = 0;
+        ExpectIntEQ(DecodeObjectId_ex(oid_sha256rsa, sizeof(oid_sha256rsa),
+                                   out, &outSz),
+                    WC_NO_ERR_TRACE(BUFFER_E));
+
+        /* Test 5: outSz=2 is enough for a single-byte OID (two arcs) */
+        {
+            static const byte oid_one_byte[] = { 0x2a }; /* 1.2 */
+            outSz = 2;
+            ExpectIntEQ(DecodeObjectId_ex(oid_one_byte, sizeof(oid_one_byte),
+                                       out, &outSz), 0);
+            ExpectIntEQ((int)outSz, 2);
+            ExpectIntEQ(out[0], 1);
+            ExpectIntEQ(out[1], 2);
+        }
+
+        /* Test 6: Buffer too small for later arcs */
+        outSz = 3; /* only room for 3 arcs, but OID has 7 */
+        ExpectIntEQ(DecodeObjectId_ex(oid_sha256rsa, sizeof(oid_sha256rsa),
+                                   out, &outSz),
+                    WC_NO_ERR_TRACE(BUFFER_E));
+
+    /* Test 7: first Arc is 2 */
+        {
+            word32 trueOutSz2 = sizeof(oid_dot_2) / sizeof(word32);
+            outSz = MAX_OID_SZ;
+            ExpectIntEQ(DecodeObjectId_ex(oid_start_with_2,
+                        sizeof(oid_start_with_2),
+                        out, &outSz), 0);
+            ExpectIntEQ((int)outSz, trueOutSz2);
+            for (i = 0; i < ((outSz <= trueOutSz2) ?
+                        outSz : trueOutSz2); i++) {
+                ExpectIntEQ(out[i], oid_dot_2[i]);
+            }
+        }
+
+        /* Test 8: an OID with an arc that exceeds word16.
+         */
+        {
+            static const byte oid_large_arc[] = {
+                0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b
+            };
+            static const word32 oid_dot_large_arc[] = {
+                1U, 2U, 840U, 113549U, 1U, 1U, 11U
+            };
+            word32 trueOutSz3 = sizeof(oid_dot_large_arc) / sizeof(word32);
+
+            outSz = MAX_OID_SZ;
+            ExpectIntEQ(DecodeObjectId_ex(oid_large_arc, sizeof(oid_large_arc),
+                                       out, &outSz), 0);
+            ExpectIntEQ((int)outSz, (int)trueOutSz3);
+            for (i = 0; i < ((outSz <= trueOutSz3) ? outSz : trueOutSz3); i++) {
+                ExpectIntEQ(out[i], oid_dot_large_arc[i]);
+            }
+        }
+    }
+#endif /* !NO_ASN && (HAVE_OID_DECODING || WOLFSSL_ASN_PRINT) */
+
+    return EXPECT_RESULT();
+}
+
+int test_wc_EncodeObjectId(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_OID_ENCODING) && !defined(NO_ASN)
+    {
+        /* 1.3.132.0.6 (secp112r1) -- every arc fits in word16, so this
+         * encodes identically in both build configs. */
+        static const word32 oid_small[] = { 1U, 3U, 132U, 0U, 6U };
+        static const byte oid_small_der[] = {
+            0x2b, 0x81, 0x04, 0x00, 0x06
+        };
+        const word32 oid_small_cnt = sizeof(oid_small) / sizeof(word32);
+        byte   out[MAX_OID_SZ];
+        word32 outSz;
+        word32 i;
+
+        /* Test 1: length-only query (out == NULL) */
+        outSz = 0;
+        ExpectIntEQ(wc_EncodeObjectId(oid_small, oid_small_cnt, NULL, &outSz),
+                    0);
+        ExpectIntEQ((int)outSz, (int)sizeof(oid_small_der));
+
+        /* Test 2: normal encode matches expected DER */
+        outSz = sizeof(out);
+        ExpectIntEQ(wc_EncodeObjectId(oid_small, oid_small_cnt, out, &outSz), 0);
+        ExpectIntEQ((int)outSz, (int)sizeof(oid_small_der));
+        for (i = 0; i < outSz && i < sizeof(oid_small_der); i++) {
+            ExpectIntEQ(out[i], oid_small_der[i]);
+        }
+
+        /* Test 3: NULL args */
+        outSz = sizeof(out);
+        ExpectIntEQ(wc_EncodeObjectId(NULL, oid_small_cnt, out, &outSz),
+                    WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(wc_EncodeObjectId(oid_small, oid_small_cnt, out, NULL),
+                    WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+        /* Test 4: output buffer too small */
+        outSz = 1;
+        ExpectIntEQ(wc_EncodeObjectId(oid_small, oid_small_cnt, out, &outSz),
+                    WC_NO_ERR_TRACE(BUFFER_E));
+
+        /* Test 5 : arc greater that SHRT_MAX
+         */
+        {
+            static const word32 oid_large[] = {
+                1U, 2U, 840U, 113549U, 1U, 1U, 11U
+            };
+            static const byte oid_large_der[] = {
+                0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b
+            };
+            const word32 oid_large_cnt = sizeof(oid_large) / sizeof(word32);
+
+            outSz = sizeof(out);
+            ExpectIntEQ(wc_EncodeObjectId(oid_large, oid_large_cnt, out, &outSz),
+                        0);
+            ExpectIntEQ((int)outSz, (int)sizeof(oid_large_der));
+            for (i = 0; i < outSz && i < sizeof(oid_large_der); i++) {
+                ExpectIntEQ(out[i], oid_large_der[i]);
+            }
+
+#if defined(HAVE_OID_DECODING) || defined(WOLFSSL_ASN_PRINT)
+            {
+                word32 dec[MAX_OID_SZ];
+                word32 decSz = MAX_OID_SZ;
+                ExpectIntEQ(DecodeObjectId_ex(out, outSz, dec, &decSz), 0);
+                ExpectIntEQ((int)decSz, (int)oid_large_cnt);
+                for (i = 0; i < decSz && i < oid_large_cnt; i++) {
+                    ExpectIntEQ(dec[i], oid_large[i]);
+                }
+            }
+#endif /* HAVE_OID_DECODING || WOLFSSL_ASN_PRINT */
+        }
+    }
+#endif /* HAVE_OID_ENCODING && !NO_ASN */
 
     return EXPECT_RESULT();
 }

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -2608,6 +2608,9 @@ int test_wc_DecodeObjectId_FIPS16(void)
         ExpectIntEQ(DecodeObjectId(oid_secp112r1,
                     sizeof(oid_secp112r1), out, NULL),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(DecodeObjectId(oid_secp112r1,
+                    sizeof(oid_secp112r1), NULL, &outSz),
+                    WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
         /* Test 3 (Bug 1): outSz=1 must return BUFFER_E, not OOB write.
          * The first OID byte decodes into two arcs, so outSz must be >= 2. */
@@ -2734,6 +2737,9 @@ int test_wc_DecodeObjectId32(void)
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
         ExpectIntEQ(DecodeObjectId32(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, NULL),
+                    WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(DecodeObjectId32(oid_secp112r1, sizeof(oid_secp112r1),
+                                   NULL, &outSz),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
         /* Test 3 (Bug 1): outSz=1 must return BUFFER_E, not OOB write.
@@ -2904,6 +2910,14 @@ int test_wc_EncodeObjectId(void)
         outSz = sizeof(out);
         ExpectIntEQ(wc_EncodeObjectId(oid_small, 1, out, &outSz),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+        /* Test 7: second arc > 39 is invalid when the first arc is 0 or 1 */
+        {
+            static const word16 oid_bad_second[] = { 1U, 40U };
+            outSz = sizeof(out);
+            ExpectIntEQ(wc_EncodeObjectId(oid_bad_second, 2, out, &outSz),
+                        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        }
     }
 #endif /* HAVE_OID_ENCODING && !NO_ASN */
 
@@ -2953,7 +2967,7 @@ int test_wc_EncodeObjectId32(void)
         ExpectIntEQ(wc_EncodeObjectId32(oid_small, oid_small_cnt, out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
-        /* Test 5 : arc greater that SHRT_MAX */
+        /* Test 5 : arc greater than SHRT_MAX */
         {
             static const word32 oid_large[] = {
                 1U, 2U, 840U, 113549U, 1U, 1U, 11U
@@ -3004,6 +3018,14 @@ int test_wc_EncodeObjectId32(void)
             outSz = sizeof(out);
             ExpectIntEQ(wc_EncodeObjectId32(oid_overflow,
                         sizeof(oid_overflow) / sizeof(word32), out, &outSz),
+                        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        }
+
+        /* Test 9: second arc > 39 is invalid when the first arc is 0 or 1 */
+        {
+            static const word32 oid_bad_second[] = { 1U, 40U };
+            outSz = sizeof(out);
+            ExpectIntEQ(wc_EncodeObjectId32(oid_bad_second, 2, out, &outSz),
                         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
         }
     }

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -2796,6 +2796,20 @@ int test_wc_DecodeObjectId_ex(void)
                 ExpectIntEQ(out[i], oid_dot_large_arc[i]);
             }
         }
+
+        /* Test 9: an arc that does not fit in a word32 must be rejected by
+         * the overflow guard rather than silently wrapping. The first byte
+         * (0x2a) decodes to 1.2; the following five continuation bytes encode
+         * a single sub-identifier that needs more than 32 bits. */
+        {
+            static const byte oid_overflow_arc[] = {
+                0x2a, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F
+            };
+            outSz = MAX_OID_SZ;
+            ExpectIntEQ(DecodeObjectId_ex(oid_overflow_arc,
+                        sizeof(oid_overflow_arc), out, &outSz),
+                        WC_NO_ERR_TRACE(ASN_OBJECT_ID_E));
+        }
     }
 #endif /* !NO_ASN && (HAVE_OID_DECODING || WOLFSSL_ASN_PRINT) */
 
@@ -2875,6 +2889,20 @@ int test_wc_EncodeObjectId(void)
             }
 #endif /* HAVE_OID_DECODING || WOLFSSL_ASN_PRINT */
         }
+
+        /* Test 6: first arc greater than 2 is invalid (in[0] > 2) */
+        {
+            static const word32 oid_bad_first[] = { 3U, 1U };
+            outSz = sizeof(out);
+            ExpectIntEQ(wc_EncodeObjectId(oid_bad_first,
+                        sizeof(oid_bad_first) / sizeof(word32), out, &outSz),
+                        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        }
+
+        /* Test 7: fewer than two arcs is invalid (inSz < 2) */
+        outSz = sizeof(out);
+        ExpectIntEQ(wc_EncodeObjectId(oid_small, 1, out, &outSz),
+                    WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     }
 #endif /* HAVE_OID_ENCODING && !NO_ASN */
 

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -2691,13 +2691,13 @@ int test_wc_DecodeObjectId32(void)
         word32 i;
 
         /* Tests multi byte encoding for arc 1 and 2
-         * (only possible when arc 1 is 2 and arc 2 is greater than 48) */
+         * (only possible when arc 1 is 2 and arc 2 is greater than 39) */
         static const word32 oid_dot_2[] = {
             2, 100, 4, 6
         };
 
         /* Tests multi byte encoding for arc 1 and 2
-         * (only possible when arc 1 is 2 and arc 2 is greater than 48) */
+         * (only possible when arc 1 is 2 and arc 2 is greater than 39) */
         static const byte oid_start_with_2[] = {
             0x81, 0x34, 0x04, 0x06
         };

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -2579,8 +2579,7 @@ int test_wc_DecodeObjectId_FIPS16(void)
             0x81, 0x34, 0x04, 0x06
         };
 
-
-        static const byte oid_sha256secp112r1[] = {
+        static const byte oid_secp112r1[] = {
             0x2B, 0x81, 0x04, 0x00, 0x06
         };
 
@@ -2594,8 +2593,8 @@ int test_wc_DecodeObjectId_FIPS16(void)
         word32 trueOutSz = sizeof(oid_dot_form) / sizeof(*oid_dot_form);
         /* Test 1: Normal decode */
         outSz = MAX_OID_SZ;
-        ExpectIntEQ(DecodeObjectId(oid_sha256secp112r1,
-                    sizeof(oid_sha256secp112r1), out, &outSz), 0);
+        ExpectIntEQ(DecodeObjectId(oid_secp112r1,
+                    sizeof(oid_secp112r1), out, &outSz), 0);
         ExpectIntEQ((int)outSz, trueOutSz);
         for (i = 0; i < ((outSz <= trueOutSz) ? outSz : trueOutSz); i++) {
             ExpectIntEQ(out[i], oid_dot_form[i]);
@@ -2603,24 +2602,24 @@ int test_wc_DecodeObjectId_FIPS16(void)
 
         /* Test 2: NULL args */
         outSz = MAX_OID_SZ;
-        ExpectIntEQ(DecodeObjectId(NULL, sizeof(oid_sha256secp112r1),
+        ExpectIntEQ(DecodeObjectId(NULL, sizeof(oid_secp112r1),
                     out, &outSz),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-        ExpectIntEQ(DecodeObjectId(oid_sha256secp112r1,
-                    sizeof(oid_sha256secp112r1), out, NULL),
+        ExpectIntEQ(DecodeObjectId(oid_secp112r1,
+                    sizeof(oid_secp112r1), out, NULL),
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
         /* Test 3 (Bug 1): outSz=1 must return BUFFER_E, not OOB write.
          * The first OID byte decodes into two arcs, so outSz must be >= 2. */
         outSz = 1;
-        ExpectIntEQ(DecodeObjectId(oid_sha256secp112r1,
-                    sizeof(oid_sha256secp112r1), out, &outSz),
+        ExpectIntEQ(DecodeObjectId(oid_secp112r1,
+                    sizeof(oid_secp112r1), out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
         /* Test 4: outSz=0 must also return BUFFER_E */
         outSz = 0;
-        ExpectIntEQ(DecodeObjectId(oid_sha256secp112r1,
-                    sizeof(oid_sha256secp112r1), out, &outSz),
+        ExpectIntEQ(DecodeObjectId(oid_secp112r1,
+                    sizeof(oid_secp112r1), out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
         /* Test 5: outSz=2 is enough for a single-byte OID (two arcs) */
@@ -2635,9 +2634,9 @@ int test_wc_DecodeObjectId_FIPS16(void)
         }
 
         /* Test 6: Buffer too small for later arcs */
-        outSz = 3; /* only room for 3 arcs, but OID has 7 */
-        ExpectIntEQ(DecodeObjectId(oid_sha256secp112r1,
-                    sizeof(oid_sha256secp112r1), out, &outSz),
+        outSz = 3; /* only room for 3 arcs, but OID has 5 */
+        ExpectIntEQ(DecodeObjectId(oid_secp112r1,
+                    sizeof(oid_secp112r1), out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
 
         /* Test 7: first Arc is 2 */
@@ -2762,7 +2761,7 @@ int test_wc_DecodeObjectId32(void)
         }
 
         /* Test 6: Buffer too small for later arcs */
-        outSz = 3; /* only room for 3 arcs, but OID has 7 */
+        outSz = 3; /* only room for 3 arcs, but OID has 5 */
         ExpectIntEQ(DecodeObjectId32(oid_secp112r1, sizeof(oid_secp112r1),
                                    out, &outSz),
                     WC_NO_ERR_TRACE(BUFFER_E));
@@ -2843,7 +2842,8 @@ int test_wc_EncodeObjectId(void)
 
         /* Test 2: normal encode matches expected DER */
         outSz = sizeof(out);
-        ExpectIntEQ(wc_EncodeObjectId(oid_small, oid_small_cnt, out, &outSz), 0);
+        ExpectIntEQ(wc_EncodeObjectId(oid_small, oid_small_cnt, out, &outSz),
+            0);
         ExpectIntEQ((int)outSz, (int)sizeof(oid_small_der));
         for (i = 0; i < outSz && i < sizeof(oid_small_der); i++) {
             ExpectIntEQ(out[i], oid_small_der[i]);

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -38,8 +38,6 @@ int test_DecodeAltNames_length_underflow(void);
 int test_DecodeCertExtensions_dup_certpol(void);
 int test_ParseCert_SM3wSM2_short_pubkey(void);
 int test_ParseCert_dnBufferBoundary(void);
-int test_wc_DecodeObjectId(void);
-int test_wc_DecodeObjectId(void);
 int test_wc_DecodeObjectId_ex(void);
 int test_wc_DecodeObjectId_FIPS16(void);
 int test_wc_EncodeObjectId(void);
@@ -66,16 +64,10 @@ int test_wc_AsnFeatureCoverage(void);
     TEST_DECL_GROUP("asn", test_DecodeAltNames_length_underflow),   \
     TEST_DECL_GROUP("asn", test_DecodeCertExtensions_dup_certpol),  \
     TEST_DECL_GROUP("asn", test_ParseCert_SM3wSM2_short_pubkey),    \
-<<<<<<< HEAD
     TEST_DECL_GROUP("asn", test_ParseCert_dnBufferBoundary),        \
-    TEST_DECL_GROUP("asn", test_wc_DecodeObjectId),                 \
-||||||| parent of a5d67d1ce (Updated size of OID represention to be word32 instead of word16 so OIDs)
-    TEST_DECL_GROUP("asn", test_wc_DecodeObjectId),                 \
-=======
     TEST_DECL_GROUP("asn", test_wc_DecodeObjectId_ex),              \
     TEST_DECL_GROUP("asn", test_wc_EncodeObjectId),                 \
     TEST_DECL_GROUP("asn", test_wc_DecodeObjectId_FIPS16),          \
->>>>>>> a5d67d1ce (Updated size of OID represention to be word32 instead of word16 so OIDs)
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_handcrafted),      \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_roundtrip),        \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_negative),         \

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -66,7 +66,7 @@ int test_wc_AsnFeatureCoverage(void);
     TEST_DECL_GROUP("asn", test_DecodeCertExtensions_dup_certpol),  \
     TEST_DECL_GROUP("asn", test_ParseCert_SM3wSM2_short_pubkey),    \
     TEST_DECL_GROUP("asn", test_ParseCert_dnBufferBoundary),        \
-    TEST_DECL_GROUP("asn", test_wc_DecodeObjectId32),              \
+    TEST_DECL_GROUP("asn", test_wc_DecodeObjectId32),               \
     TEST_DECL_GROUP("asn", test_wc_EncodeObjectId),                 \
     TEST_DECL_GROUP("asn", test_wc_EncodeObjectId32),               \
     TEST_DECL_GROUP("asn", test_wc_DecodeObjectId_FIPS16),          \

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -38,9 +38,10 @@ int test_DecodeAltNames_length_underflow(void);
 int test_DecodeCertExtensions_dup_certpol(void);
 int test_ParseCert_SM3wSM2_short_pubkey(void);
 int test_ParseCert_dnBufferBoundary(void);
-int test_wc_DecodeObjectId_ex(void);
+int test_wc_DecodeObjectId32(void);
 int test_wc_DecodeObjectId_FIPS16(void);
 int test_wc_EncodeObjectId(void);
+int test_wc_EncodeObjectId32(void);
 int test_ToTraditional_ex_handcrafted(void);
 int test_ToTraditional_ex_roundtrip(void);
 int test_ToTraditional_ex_negative(void);
@@ -65,8 +66,9 @@ int test_wc_AsnFeatureCoverage(void);
     TEST_DECL_GROUP("asn", test_DecodeCertExtensions_dup_certpol),  \
     TEST_DECL_GROUP("asn", test_ParseCert_SM3wSM2_short_pubkey),    \
     TEST_DECL_GROUP("asn", test_ParseCert_dnBufferBoundary),        \
-    TEST_DECL_GROUP("asn", test_wc_DecodeObjectId_ex),              \
+    TEST_DECL_GROUP("asn", test_wc_DecodeObjectId32),              \
     TEST_DECL_GROUP("asn", test_wc_EncodeObjectId),                 \
+    TEST_DECL_GROUP("asn", test_wc_EncodeObjectId32),               \
     TEST_DECL_GROUP("asn", test_wc_DecodeObjectId_FIPS16),          \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_handcrafted),      \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_roundtrip),        \

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -39,6 +39,10 @@ int test_DecodeCertExtensions_dup_certpol(void);
 int test_ParseCert_SM3wSM2_short_pubkey(void);
 int test_ParseCert_dnBufferBoundary(void);
 int test_wc_DecodeObjectId(void);
+int test_wc_DecodeObjectId(void);
+int test_wc_DecodeObjectId_ex(void);
+int test_wc_DecodeObjectId_FIPS16(void);
+int test_wc_EncodeObjectId(void);
 int test_ToTraditional_ex_handcrafted(void);
 int test_ToTraditional_ex_roundtrip(void);
 int test_ToTraditional_ex_negative(void);
@@ -62,8 +66,16 @@ int test_wc_AsnFeatureCoverage(void);
     TEST_DECL_GROUP("asn", test_DecodeAltNames_length_underflow),   \
     TEST_DECL_GROUP("asn", test_DecodeCertExtensions_dup_certpol),  \
     TEST_DECL_GROUP("asn", test_ParseCert_SM3wSM2_short_pubkey),    \
+<<<<<<< HEAD
     TEST_DECL_GROUP("asn", test_ParseCert_dnBufferBoundary),        \
     TEST_DECL_GROUP("asn", test_wc_DecodeObjectId),                 \
+||||||| parent of a5d67d1ce (Updated size of OID represention to be word32 instead of word16 so OIDs)
+    TEST_DECL_GROUP("asn", test_wc_DecodeObjectId),                 \
+=======
+    TEST_DECL_GROUP("asn", test_wc_DecodeObjectId_ex),              \
+    TEST_DECL_GROUP("asn", test_wc_EncodeObjectId),                 \
+    TEST_DECL_GROUP("asn", test_wc_DecodeObjectId_FIPS16),          \
+>>>>>>> a5d67d1ce (Updated size of OID represention to be word32 instead of word16 so OIDs)
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_handcrafted),      \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_roundtrip),        \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_negative),         \

--- a/tests/api/test_certman.c
+++ b/tests/api/test_certman.c
@@ -3171,7 +3171,7 @@ typedef struct CRLUnkExtCtx {
 
 /* CRL Reason OID 2.5.29.21 (last component for the entry-ext test) and
  * obsolete X.509v2 AKI 2.5.29.1 (last component for the CRL-level test). */
-static int crl_unk_ext_cb_accept(const word16* oid, word32 oidSz,
+static int crl_unk_ext_cb_accept(const word32* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz, void* ctxIn)
 {
     CRLUnkExtCtx* ctx = (CRLUnkExtCtx*)ctxIn;
@@ -3188,7 +3188,7 @@ static int crl_unk_ext_cb_accept(const word16* oid, word32 oidSz,
     return 0; /* accept */
 }
 
-static int crl_unk_ext_cb_reject(const word16* oid, word32 oidSz,
+static int crl_unk_ext_cb_reject(const word32* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz, void* ctxIn)
 {
     (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
@@ -3197,7 +3197,7 @@ static int crl_unk_ext_cb_reject(const word16* oid, word32 oidSz,
     return ASN_PARSE_E;
 }
 
-static int crl_unk_ext_cb_reject_positive(const word16* oid, word32 oidSz,
+static int crl_unk_ext_cb_reject_positive(const word32* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz, void* ctxIn)
 {
     (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
@@ -3214,7 +3214,7 @@ static int crl_unk_ext_noctx_calls;
 static int crl_unk_ext_noctx_sawCritical;
 static int crl_unk_ext_noctx_oidMatched;
 
-static int crl_unk_ext_cb_noctx_accept(const word16* oid, word32 oidSz,
+static int crl_unk_ext_cb_noctx_accept(const word32* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz)
 {
     (void)der;
@@ -3228,7 +3228,7 @@ static int crl_unk_ext_cb_noctx_accept(const word16* oid, word32 oidSz,
     return 0; /* accept */
 }
 
-static int crl_unk_ext_cb_noctx_reject(const word16* oid, word32 oidSz,
+static int crl_unk_ext_cb_noctx_reject(const word32* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz)
 {
     (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;

--- a/tests/api/test_certman.c
+++ b/tests/api/test_certman.c
@@ -3646,6 +3646,94 @@ int test_wolfSSL_CRL_unknown_ext_cb_noctx(void)
     return EXPECT_RESULT();
 }
 
+#if !defined(NO_CERTS) && defined(HAVE_CRL) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM) && defined(WC_ASN_UNKNOWN_EXT_CB)
+/* Which unknown-extension callback the parser last invoked:
+ * -1 = neither, 0 = the word16 one, 1 = the word32 one. */
+static int crl_unk_ext_last_cb = -1;
+
+/* When both a word16 and a word32 unknown-extension callback are registered,
+ * only the word32 one may run.  The word16 callback here rejects the CRL and
+ * the word32 callback accepts it, so a successful load proves the word32
+ * callback took precedence. */
+static int crl_unk_ext_cb_16_reject(const word16* oid, word32 oidSz,
+        int crit, const unsigned char* der, word32 derSz, void* ctxIn)
+{
+    (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
+    ((CRLUnkExtCtx*)ctxIn)->calls++;
+    crl_unk_ext_last_cb = 0;
+    return 1;
+}
+
+static int crl_unk_ext_cb_32_accept(const word32* oid, word32 oidSz,
+        int crit, const unsigned char* der, word32 derSz, void* ctxIn)
+{
+    (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
+    ((CRLUnkExtCtx*)ctxIn)->calls++;
+    crl_unk_ext_last_cb = 1;
+    return 0;
+}
+#endif
+
+int test_wolfSSL_CRL_unknown_ext_cb_32_preferred(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_CERTS) && defined(HAVE_CRL) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM) && defined(WC_ASN_UNKNOWN_EXT_CB)
+    int reg32First;
+
+    /* Precedence must not depend on registration order, so run it both
+     * ways. */
+    for (reg32First = 0; reg32First < 2; reg32First++) {
+        WOLFSSL_CERT_MANAGER* cm = NULL;
+        CRLUnkExtCtx ctx = { 0, 0, 0 };
+
+        crl_unk_ext_last_cb = -1;
+
+        ExpectNotNull(cm = wolfSSL_CertManagerNew());
+        ExpectIntEQ(wolfSSL_CertManagerLoadCA(cm,
+            "./certs/crl/extra-crls/claim-root.pem", NULL), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
+            WOLFSSL_SUCCESS);
+        if (reg32First) {
+            ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback32Ex(cm,
+                crl_unk_ext_cb_32_accept, &ctx), WOLFSSL_SUCCESS);
+            ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(cm,
+                crl_unk_ext_cb_16_reject, &ctx), WOLFSSL_SUCCESS);
+        }
+        else {
+            ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(cm,
+                crl_unk_ext_cb_16_reject, &ctx), WOLFSSL_SUCCESS);
+            ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback32Ex(cm,
+                crl_unk_ext_cb_32_accept, &ctx), WOLFSSL_SUCCESS);
+        }
+
+        /* This CRL carries an unknown critical entry extension, so it only
+         * loads when a callback accepts it (see
+         * test_wolfSSL_CRL_unknown_critical_entry_ext above).  The word16
+         * callback rejects, so success means the word32 callback ran. */
+        ExpectIntEQ(wolfSSL_CertManagerLoadCRLFile(cm,
+            "./certs/crl/extra-crls/crl_critical_entry.pem",
+            WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+
+        ExpectIntGT(ctx.calls, 0);
+        ExpectIntEQ(crl_unk_ext_last_cb, 1);
+
+        wolfSSL_CertManagerFree(cm);
+        cm = NULL;
+        if (EXPECT_FAIL()) {
+            printf("    (failed with the %s callback registered first; "
+                "last callback invoked: %s)\n",
+                reg32First ? "word32" : "word16",
+                (crl_unk_ext_last_cb < 0) ? "none" :
+                    (crl_unk_ext_last_cb == 0) ? "word16" : "word32");
+            break;
+        }
+    }
+#endif
+    return EXPECT_RESULT();
+}
+
 int test_wolfSSL_CertManagerCheckOCSPResponse(void)
 {
     EXPECT_DECLS;

--- a/tests/api/test_certman.c
+++ b/tests/api/test_certman.c
@@ -3315,7 +3315,7 @@ int test_wolfSSL_CRL_unknown_ext_cb_rescues_critical_entry_ext(void)
 
     for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
             CallbackType++) {
-        ForceZero(&ctx, sizeof(ctx));
+        XMEMSET(&ctx, 0, sizeof(ctx));
         ExpectNotNull(cm = wolfSSL_CertManagerNew());
         ExpectIntEQ(wolfSSL_CertManagerLoadCA(cm,
             "./certs/crl/extra-crls/claim-root.pem", NULL), WOLFSSL_SUCCESS);
@@ -3389,7 +3389,7 @@ int test_wolfSSL_CRL_unknown_ext_cb_rescues_critical_crl_ext(void)
      * seen the critical unknown OID. */
     for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
             CallbackType++) {
-        ForceZero(&ctx, sizeof(ctx));
+        XMEMSET(&ctx, 0, sizeof(ctx));
         ExpectNotNull(cm = wolfSSL_CertManagerNew());
         ExpectIntEQ(wolfSSL_CertManagerLoadCABuffer(cm, crl_unk_ca_der,
             sizeof(crl_unk_ca_der), WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
@@ -3431,7 +3431,7 @@ int test_wolfSSL_CRL_unknown_ext_cb_rescues_critical_crl_ext(void)
     /* Rejecting callback: the same CRL must fail to load. */
     for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
             CallbackType++) {
-        ForceZero(&ctx, sizeof(ctx));
+        XMEMSET(&ctx, 0, sizeof(ctx));
         ExpectNotNull(cm = wolfSSL_CertManagerNew());
         ExpectIntEQ(wolfSSL_CertManagerLoadCABuffer(cm, crl_unk_ca_der,
             sizeof(crl_unk_ca_der), WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
@@ -3492,7 +3492,7 @@ int test_wolfSSL_CRL_unknown_ext_cb_positive_return_fails_load(void)
 
     for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
             CallbackType++) {
-        ForceZero(&ctx, sizeof(ctx));
+        XMEMSET(&ctx, 0, sizeof(ctx));
         ExpectNotNull(cm = wolfSSL_CertManagerNew());
         ExpectIntEQ(wolfSSL_CertManagerLoadCA(cm,
             "./certs/crl/extra-crls/claim-root.pem", NULL), WOLFSSL_SUCCESS);
@@ -3663,6 +3663,9 @@ static int crl_unk_ext_last_cb = -1;
 static int crl_unk_ext_cb_16_reject(const word16* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz, void* ctxIn)
 {
+    if (ctxIn == NULL) {
+        return BAD_FUNC_ARG;
+    }
     (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
     ((CRLUnkExtCtx*)ctxIn)->calls++;
     crl_unk_ext_last_cb = 0;
@@ -3672,6 +3675,9 @@ static int crl_unk_ext_cb_16_reject(const word16* oid, word32 oidSz,
 static int crl_unk_ext_cb_32_accept(const word32* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz, void* ctxIn)
 {
+    if (ctxIn == NULL) {
+        return BAD_FUNC_ARG;
+    }
     (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
     ((CRLUnkExtCtx*)ctxIn)->calls++;
     crl_unk_ext_last_cb = 1;

--- a/tests/api/test_certman.c
+++ b/tests/api/test_certman.c
@@ -3309,7 +3309,8 @@ int test_wolfSSL_CRL_unknown_ext_cb_rescues_critical_entry_ext(void)
         Bit16Callback,
         Bit32Callback,
         CallbackTypeEnd
-    } CallbackType = Bit16Callback;
+    };
+    int CallbackType = Bit16Callback;
     CRLUnkExtCtx ctx;
 
     for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
@@ -3379,8 +3380,9 @@ int test_wolfSSL_CRL_unknown_ext_cb_rescues_critical_crl_ext(void)
     enum {
         Bit16Callback,
         Bit32Callback,
-        CallbackTypeEnd,
-    } CallbackType = Bit16Callback;
+        CallbackTypeEnd
+    };
+    int CallbackType = Bit16Callback;
     CRLUnkExtCtx ctx = { 0, 0, 0 };
 
     /* Accepting callback: the load must succeed and the callback must have
@@ -3484,7 +3486,8 @@ int test_wolfSSL_CRL_unknown_ext_cb_positive_return_fails_load(void)
         Bit16Callback,
         Bit32Callback,
         CallbackTypeEnd
-    } CallbackType = Bit16Callback;
+    };
+    int CallbackType = Bit16Callback;
     int rc;
 
     for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
@@ -3546,7 +3549,8 @@ int test_wolfSSL_CRL_unknown_ext_cb_noctx(void)
         Bit16Callback,
         Bit32Callback,
         CallbackTypeEnd
-    } CallbackType = Bit16Callback;
+    };
+    int CallbackType = Bit16Callback;
 
     /* A NULL cert manager is rejected by both registration entry points. */
     ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback(NULL,

--- a/tests/api/test_certman.c
+++ b/tests/api/test_certman.c
@@ -3171,7 +3171,7 @@ typedef struct CRLUnkExtCtx {
 
 /* CRL Reason OID 2.5.29.21 (last component for the entry-ext test) and
  * obsolete X.509v2 AKI 2.5.29.1 (last component for the CRL-level test). */
-static int crl_unk_ext_cb_accept(const word32* oid, word32 oidSz,
+static int crl_unk_ext_cb_accept(const word16* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz, void* ctxIn)
 {
     CRLUnkExtCtx* ctx = (CRLUnkExtCtx*)ctxIn;
@@ -3188,7 +3188,26 @@ static int crl_unk_ext_cb_accept(const word32* oid, word32 oidSz,
     return 0; /* accept */
 }
 
-static int crl_unk_ext_cb_reject(const word32* oid, word32 oidSz,
+/* CRL Reason OID 2.5.29.21 (last component for the entry-ext test) and
+ * obsolete X.509v2 AKI 2.5.29.1 (last component for the CRL-level test). */
+static int crl_unk_ext_cb_accept32(const word32* oid, word32 oidSz,
+        int crit, const unsigned char* der, word32 derSz, void* ctxIn)
+{
+    CRLUnkExtCtx* ctx = (CRLUnkExtCtx*)ctxIn;
+    (void)der;
+    (void)derSz;
+    if (ctx != NULL) {
+        ctx->calls++;
+        if (crit)
+            ctx->sawCritical = 1;
+        /* Expect OID arc starts at {2, 5, 29, ...}. */
+        if (oidSz >= 4 && oid[0] == 2 && oid[1] == 5 && oid[2] == 29)
+            ctx->oidMatched = 1;
+    }
+    return 0; /* accept */
+}
+
+static int crl_unk_ext_cb_reject(const word16* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz, void* ctxIn)
 {
     (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
@@ -3197,7 +3216,25 @@ static int crl_unk_ext_cb_reject(const word32* oid, word32 oidSz,
     return ASN_PARSE_E;
 }
 
-static int crl_unk_ext_cb_reject_positive(const word32* oid, word32 oidSz,
+static int crl_unk_ext_cb_reject32(const word32* oid, word32 oidSz,
+        int crit, const unsigned char* der, word32 derSz, void* ctxIn)
+{
+    (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
+    if (ctxIn != NULL)
+        ((CRLUnkExtCtx*)ctxIn)->calls++;
+    return ASN_PARSE_E;
+}
+
+static int crl_unk_ext_cb_reject_positive(const word16* oid, word32 oidSz,
+        int crit, const unsigned char* der, word32 derSz, void* ctxIn)
+{
+    (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
+    if (ctxIn != NULL)
+        ((CRLUnkExtCtx*)ctxIn)->calls++;
+    return 1;
+}
+
+static int crl_unk_ext_cb_reject_positive32(const word32* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz, void* ctxIn)
 {
     (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
@@ -3214,7 +3251,7 @@ static int crl_unk_ext_noctx_calls;
 static int crl_unk_ext_noctx_sawCritical;
 static int crl_unk_ext_noctx_oidMatched;
 
-static int crl_unk_ext_cb_noctx_accept(const word32* oid, word32 oidSz,
+static int crl_unk_ext_cb_noctx_accept(const word16* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz)
 {
     (void)der;
@@ -3228,7 +3265,29 @@ static int crl_unk_ext_cb_noctx_accept(const word32* oid, word32 oidSz,
     return 0; /* accept */
 }
 
-static int crl_unk_ext_cb_noctx_reject(const word32* oid, word32 oidSz,
+static int crl_unk_ext_cb_noctx_accept32(const word32* oid, word32 oidSz,
+        int crit, const unsigned char* der, word32 derSz)
+{
+    (void)der;
+    (void)derSz;
+    crl_unk_ext_noctx_calls++;
+    if (crit)
+        crl_unk_ext_noctx_sawCritical = 1;
+    /* Expect OID arc starts at {2, 5, 29, ...}. */
+    if (oidSz >= 4 && oid[0] == 2 && oid[1] == 5 && oid[2] == 29)
+        crl_unk_ext_noctx_oidMatched = 1;
+    return 0; /* accept */
+}
+
+static int crl_unk_ext_cb_noctx_reject(const word16* oid, word32 oidSz,
+        int crit, const unsigned char* der, word32 derSz)
+{
+    (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
+    crl_unk_ext_noctx_calls++;
+    return ASN_PARSE_E;
+}
+
+static int crl_unk_ext_cb_noctx_reject32(const word32* oid, word32 oidSz,
         int crit, const unsigned char* der, word32 derSz)
 {
     (void)oid; (void)oidSz; (void)crit; (void)der; (void)derSz;
@@ -3246,31 +3305,62 @@ int test_wolfSSL_CRL_unknown_ext_cb_rescues_critical_entry_ext(void)
 #if !defined(NO_CERTS) && defined(HAVE_CRL) && !defined(NO_RSA) && \
     !defined(NO_FILESYSTEM) && defined(WC_ASN_UNKNOWN_EXT_CB)
     WOLFSSL_CERT_MANAGER* cm = NULL;
-    CRLUnkExtCtx ctx = { 0, 0, 0 };
+    enum {
+        Bit16Callback,
+        Bit32Callback,
+        CallbackTypeEnd
+    } CallbackType = Bit16Callback;
+    CRLUnkExtCtx ctx;
 
-    ExpectNotNull(cm = wolfSSL_CertManagerNew());
-    ExpectIntEQ(wolfSSL_CertManagerLoadCA(cm,
-        "./certs/crl/extra-crls/claim-root.pem", NULL), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
-        WOLFSSL_SUCCESS);
+    for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
+            CallbackType++) {
+        ForceZero(&ctx, sizeof(ctx));
+        ExpectNotNull(cm = wolfSSL_CertManagerNew());
+        ExpectIntEQ(wolfSSL_CertManagerLoadCA(cm,
+            "./certs/crl/extra-crls/claim-root.pem", NULL), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
+            WOLFSSL_SUCCESS);
 
-    /* Register a callback that accepts any unknown extension. */
-    ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(cm,
-        crl_unk_ext_cb_accept, &ctx), WOLFSSL_SUCCESS);
+        /* Register a callback that accepts any unknown extension. */
+        switch (CallbackType) {
+            case Bit16Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(cm,
+                    crl_unk_ext_cb_accept, &ctx), WOLFSSL_SUCCESS);
+                break;
 
-    /* Without the callback, this load fails (see
-     * test_wolfSSL_CRL_unknown_critical_entry_ext above).  With an
-     * accepting callback registered, the load must succeed. */
-    ExpectIntEQ(wolfSSL_CertManagerLoadCRLFile(cm,
-        "./certs/crl/extra-crls/crl_critical_entry.pem", WOLFSSL_FILETYPE_PEM),
-        WOLFSSL_SUCCESS);
+            case Bit32Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback32Ex(cm,
+                    crl_unk_ext_cb_accept32, &ctx), WOLFSSL_SUCCESS);
+                break;
 
-    /* Callback must have fired at least once on the unknown critical OID. */
-    ExpectIntGT(ctx.calls, 0);
-    ExpectIntEQ(ctx.sawCritical, 1);
-    ExpectIntEQ(ctx.oidMatched, 1);
+            case CallbackTypeEnd:
+            default:
+                /* Not reachable: the loop bound excludes CallbackTypeEnd. */
+                ExpectFail();
+                break;
+        }
 
-    wolfSSL_CertManagerFree(cm);
+        /* Without the callback, this load fails (see
+         * test_wolfSSL_CRL_unknown_critical_entry_ext above).  With an
+         * accepting callback registered, the load must succeed. */
+        ExpectIntEQ(wolfSSL_CertManagerLoadCRLFile(cm,
+            "./certs/crl/extra-crls/crl_critical_entry.pem",
+            WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+
+        /* Callback must have fired at least once on the unknown critical
+         * OID. */
+        ExpectIntGT(ctx.calls, 0);
+        ExpectIntEQ(ctx.sawCritical, 1);
+        ExpectIntEQ(ctx.oidMatched, 1);
+
+        wolfSSL_CertManagerFree(cm);
+        cm = NULL;
+        if (EXPECT_FAIL()) {
+            printf("    (failed with the %s unknown extension callback)\n",
+                (CallbackType == Bit16Callback) ? "16-bit" : "32-bit");
+            break;
+        }
+    }
 #endif
     return EXPECT_RESULT();
 }
@@ -3286,41 +3376,94 @@ int test_wolfSSL_CRL_unknown_ext_cb_rescues_critical_crl_ext(void)
 #if !defined(NO_CERTS) && defined(HAVE_CRL) && !defined(NO_RSA) && \
     !defined(NO_FILESYSTEM) && defined(WC_ASN_UNKNOWN_EXT_CB)
     WOLFSSL_CERT_MANAGER* cm = NULL;
+    enum {
+        Bit16Callback,
+        Bit32Callback,
+        CallbackTypeEnd,
+    } CallbackType = Bit16Callback;
     CRLUnkExtCtx ctx = { 0, 0, 0 };
 
     /* Accepting callback: the load must succeed and the callback must have
      * seen the critical unknown OID. */
-    ExpectNotNull(cm = wolfSSL_CertManagerNew());
-    ExpectIntEQ(wolfSSL_CertManagerLoadCABuffer(cm, crl_unk_ca_der,
-        sizeof(crl_unk_ca_der), WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
-        WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(cm,
-        crl_unk_ext_cb_accept, &ctx), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerLoadCRLBuffer(cm, crl_obsolete_critical,
-        sizeof(crl_obsolete_critical), WOLFSSL_FILETYPE_ASN1),
-        WOLFSSL_SUCCESS);
-    ExpectIntGT(ctx.calls, 0);
-    ExpectIntEQ(ctx.sawCritical, 1);
-    ExpectIntEQ(ctx.oidMatched, 1);
-    wolfSSL_CertManagerFree(cm);
-    cm = NULL;
+    for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
+            CallbackType++) {
+        ForceZero(&ctx, sizeof(ctx));
+        ExpectNotNull(cm = wolfSSL_CertManagerNew());
+        ExpectIntEQ(wolfSSL_CertManagerLoadCABuffer(cm, crl_unk_ca_der,
+            sizeof(crl_unk_ca_der), WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
+            WOLFSSL_SUCCESS);
+        switch (CallbackType) {
+            case Bit16Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(cm,
+                    crl_unk_ext_cb_accept, &ctx), WOLFSSL_SUCCESS);
+                break;
+
+            case Bit32Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback32Ex(cm,
+                    crl_unk_ext_cb_accept32, &ctx), WOLFSSL_SUCCESS);
+                break;
+
+            case CallbackTypeEnd:
+            default:
+                /* Not reachable: the loop bound excludes CallbackTypeEnd. */
+                ExpectFail();
+                break;
+        }
+
+        ExpectIntEQ(wolfSSL_CertManagerLoadCRLBuffer(cm, crl_obsolete_critical,
+            sizeof(crl_obsolete_critical), WOLFSSL_FILETYPE_ASN1),
+            WOLFSSL_SUCCESS);
+        ExpectIntGT(ctx.calls, 0);
+        ExpectIntEQ(ctx.sawCritical, 1);
+        ExpectIntEQ(ctx.oidMatched, 1);
+        wolfSSL_CertManagerFree(cm);
+        cm = NULL;
+        if (EXPECT_FAIL()) {
+            printf("    (failed with the %s unknown extension callback)\n",
+                (CallbackType == Bit16Callback) ? "16-bit" : "32-bit");
+            break;
+        }
+    }
 
     /* Rejecting callback: the same CRL must fail to load. */
-    ctx.calls = 0;
-    ExpectNotNull(cm = wolfSSL_CertManagerNew());
-    ExpectIntEQ(wolfSSL_CertManagerLoadCABuffer(cm, crl_unk_ca_der,
-        sizeof(crl_unk_ca_der), WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
-        WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(cm,
-        crl_unk_ext_cb_reject, &ctx), WOLFSSL_SUCCESS);
-    ExpectIntNE(wolfSSL_CertManagerLoadCRLBuffer(cm, crl_obsolete_critical,
-        sizeof(crl_obsolete_critical), WOLFSSL_FILETYPE_ASN1),
-        WOLFSSL_SUCCESS);
-    ExpectIntGT(ctx.calls, 0);
+    for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
+            CallbackType++) {
+        ForceZero(&ctx, sizeof(ctx));
+        ExpectNotNull(cm = wolfSSL_CertManagerNew());
+        ExpectIntEQ(wolfSSL_CertManagerLoadCABuffer(cm, crl_unk_ca_der,
+            sizeof(crl_unk_ca_der), WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
+            WOLFSSL_SUCCESS);
+        switch (CallbackType) {
+            case Bit16Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(cm,
+                    crl_unk_ext_cb_reject, &ctx), WOLFSSL_SUCCESS);
+                break;
 
-    wolfSSL_CertManagerFree(cm);
+            case Bit32Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback32Ex(cm,
+                    crl_unk_ext_cb_reject32, &ctx), WOLFSSL_SUCCESS);
+                break;
+
+            case CallbackTypeEnd:
+            default:
+                /* Not reachable: the loop bound excludes CallbackTypeEnd. */
+                ExpectFail();
+                break;
+        }
+        ExpectIntNE(wolfSSL_CertManagerLoadCRLBuffer(cm, crl_obsolete_critical,
+            sizeof(crl_obsolete_critical), WOLFSSL_FILETYPE_ASN1),
+            WOLFSSL_SUCCESS);
+        ExpectIntGT(ctx.calls, 0);
+        wolfSSL_CertManagerFree(cm);
+        cm = NULL;
+        if (EXPECT_FAIL()) {
+            printf("    (failed with the %s unknown extension callback)\n",
+                (CallbackType == Bit16Callback) ? "16-bit" : "32-bit");
+            break;
+        }
+    }
 #endif
     return EXPECT_RESULT();
 }
@@ -3337,24 +3480,53 @@ int test_wolfSSL_CRL_unknown_ext_cb_positive_return_fails_load(void)
     !defined(NO_FILESYSTEM) && defined(WC_ASN_UNKNOWN_EXT_CB)
     WOLFSSL_CERT_MANAGER* cm = NULL;
     CRLUnkExtCtx ctx = { 0, 0, 0 };
+    enum {
+        Bit16Callback,
+        Bit32Callback,
+        CallbackTypeEnd
+    } CallbackType = Bit16Callback;
     int rc;
 
-    ExpectNotNull(cm = wolfSSL_CertManagerNew());
-    ExpectIntEQ(wolfSSL_CertManagerLoadCA(cm,
-        "./certs/crl/extra-crls/claim-root.pem", NULL), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
-        WOLFSSL_SUCCESS);
+    for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
+            CallbackType++) {
+        ForceZero(&ctx, sizeof(ctx));
+        ExpectNotNull(cm = wolfSSL_CertManagerNew());
+        ExpectIntEQ(wolfSSL_CertManagerLoadCA(cm,
+            "./certs/crl/extra-crls/claim-root.pem", NULL), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
+            WOLFSSL_SUCCESS);
+        switch (CallbackType) {
+            case Bit16Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(cm,
+                    crl_unk_ext_cb_reject_positive, &ctx), WOLFSSL_SUCCESS);
+                break;
 
-    ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(cm,
-        crl_unk_ext_cb_reject_positive, &ctx), WOLFSSL_SUCCESS);
+            case Bit32Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback32Ex(cm,
+                    crl_unk_ext_cb_reject_positive32, &ctx), WOLFSSL_SUCCESS);
+                break;
 
-    rc = wolfSSL_CertManagerLoadCRLFile(cm,
-        "./certs/crl/extra-crls/crl_critical_entry.pem", WOLFSSL_FILETYPE_PEM);
-    ExpectIntNE(rc, WOLFSSL_SUCCESS);
-    ExpectIntLT(rc, 0);
-    ExpectIntGT(ctx.calls, 0);
+            case CallbackTypeEnd:
+            default:
+                /* Not reachable: the loop bound excludes CallbackTypeEnd. */
+                ExpectFail();
+                break;
+        }
 
-    wolfSSL_CertManagerFree(cm);
+        rc = wolfSSL_CertManagerLoadCRLFile(cm,
+            "./certs/crl/extra-crls/crl_critical_entry.pem",
+            WOLFSSL_FILETYPE_PEM);
+        ExpectIntNE(rc, WOLFSSL_SUCCESS);
+        ExpectIntLT(rc, 0);
+        ExpectIntGT(ctx.calls, 0);
+        wolfSSL_CertManagerFree(cm);
+        cm = NULL;
+        if (EXPECT_FAIL()) {
+            printf("    (failed with the %s unknown extension callback)\n",
+                (CallbackType == Bit16Callback) ? "16-bit" : "32-bit");
+            break;
+        }
+    }
 #endif
     return EXPECT_RESULT();
 }
@@ -3370,50 +3542,106 @@ int test_wolfSSL_CRL_unknown_ext_cb_noctx(void)
 #if !defined(NO_CERTS) && defined(HAVE_CRL) && !defined(NO_RSA) && \
     !defined(NO_FILESYSTEM) && defined(WC_ASN_UNKNOWN_EXT_CB)
     WOLFSSL_CERT_MANAGER* cm = NULL;
+    enum {
+        Bit16Callback,
+        Bit32Callback,
+        CallbackTypeEnd
+    } CallbackType = Bit16Callback;
 
     /* A NULL cert manager is rejected by both registration entry points. */
     ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback(NULL,
         crl_unk_ext_cb_noctx_accept), BAD_FUNC_ARG);
     ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(NULL,
         crl_unk_ext_cb_accept, NULL), BAD_FUNC_ARG);
+    ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback32(NULL,
+        crl_unk_ext_cb_noctx_accept32), BAD_FUNC_ARG);
+    ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback32Ex(NULL,
+        crl_unk_ext_cb_accept32, NULL), BAD_FUNC_ARG);
 
     /* Accepting callback: the critical unknown CRL-level extension in the
      * crl_obsolete_critical fixture is rescued and the load succeeds.  The
      * callback must have seen the critical unknown OID. */
-    crl_unk_ext_noctx_calls = 0;
-    crl_unk_ext_noctx_sawCritical = 0;
-    crl_unk_ext_noctx_oidMatched = 0;
-    ExpectNotNull(cm = wolfSSL_CertManagerNew());
-    ExpectIntEQ(wolfSSL_CertManagerLoadCABuffer(cm, crl_unk_ca_der,
-        sizeof(crl_unk_ca_der), WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
-        WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback(cm,
-        crl_unk_ext_cb_noctx_accept), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerLoadCRLBuffer(cm, crl_obsolete_critical,
-        sizeof(crl_obsolete_critical), WOLFSSL_FILETYPE_ASN1),
-        WOLFSSL_SUCCESS);
-    ExpectIntGT(crl_unk_ext_noctx_calls, 0);
-    ExpectIntEQ(crl_unk_ext_noctx_sawCritical, 1);
-    ExpectIntEQ(crl_unk_ext_noctx_oidMatched, 1);
-    wolfSSL_CertManagerFree(cm);
-    cm = NULL;
+    for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
+            CallbackType++) {
+        crl_unk_ext_noctx_calls = 0;
+        crl_unk_ext_noctx_sawCritical = 0;
+        crl_unk_ext_noctx_oidMatched = 0;
+        ExpectNotNull(cm = wolfSSL_CertManagerNew());
+        ExpectIntEQ(wolfSSL_CertManagerLoadCABuffer(cm, crl_unk_ca_der,
+            sizeof(crl_unk_ca_der), WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
+            WOLFSSL_SUCCESS);
+        switch(CallbackType) {
+            case Bit16Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback(cm,
+                    crl_unk_ext_cb_noctx_accept), WOLFSSL_SUCCESS);
+                break;
+
+            case Bit32Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback32(cm,
+                    crl_unk_ext_cb_noctx_accept32), WOLFSSL_SUCCESS);
+                break;
+
+            case CallbackTypeEnd:
+            default:
+                /* Not reachable: the loop bound excludes CallbackTypeEnd. */
+                ExpectFail();
+                break;
+        }
+        ExpectIntEQ(wolfSSL_CertManagerLoadCRLBuffer(cm, crl_obsolete_critical,
+            sizeof(crl_obsolete_critical), WOLFSSL_FILETYPE_ASN1),
+            WOLFSSL_SUCCESS);
+        ExpectIntGT(crl_unk_ext_noctx_calls, 0);
+        ExpectIntEQ(crl_unk_ext_noctx_sawCritical, 1);
+        ExpectIntEQ(crl_unk_ext_noctx_oidMatched, 1);
+        wolfSSL_CertManagerFree(cm);
+        cm = NULL;
+        if (EXPECT_FAIL()) {
+            printf("    (failed with the %s unknown extension callback)\n",
+                (CallbackType == Bit16Callback) ? "16-bit" : "32-bit");
+            break;
+        }
+    }
 
     /* Rejecting callback: the same CRL must fail to load. */
-    crl_unk_ext_noctx_calls = 0;
-    ExpectNotNull(cm = wolfSSL_CertManagerNew());
-    ExpectIntEQ(wolfSSL_CertManagerLoadCABuffer(cm, crl_unk_ca_der,
-        sizeof(crl_unk_ca_der), WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
-        WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback(cm,
-        crl_unk_ext_cb_noctx_reject), WOLFSSL_SUCCESS);
-    ExpectIntNE(wolfSSL_CertManagerLoadCRLBuffer(cm, crl_obsolete_critical,
-        sizeof(crl_obsolete_critical), WOLFSSL_FILETYPE_ASN1),
-        WOLFSSL_SUCCESS);
-    ExpectIntGT(crl_unk_ext_noctx_calls, 0);
+    for (CallbackType = Bit16Callback; CallbackType < CallbackTypeEnd;
+            CallbackType++) {
+        crl_unk_ext_noctx_calls = 0;
+        ExpectNotNull(cm = wolfSSL_CertManagerNew());
+        ExpectIntEQ(wolfSSL_CertManagerLoadCABuffer(cm, crl_unk_ca_der,
+            sizeof(crl_unk_ca_der), WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECKALL),
+            WOLFSSL_SUCCESS);
+        switch (CallbackType) {
+            case Bit16Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback(cm,
+                    crl_unk_ext_cb_noctx_reject), WOLFSSL_SUCCESS);
+                break;
 
-    wolfSSL_CertManagerFree(cm);
+            case Bit32Callback:
+                ExpectIntEQ(wolfSSL_CertManagerSetCRLUnknownExtCallback32(cm,
+                    crl_unk_ext_cb_noctx_reject32), WOLFSSL_SUCCESS);
+                break;
+
+            case CallbackTypeEnd:
+            default:
+                /* Not reachable: the loop bound excludes CallbackTypeEnd. */
+                ExpectFail();
+                break;
+        }
+        ExpectIntNE(wolfSSL_CertManagerLoadCRLBuffer(cm, crl_obsolete_critical,
+            sizeof(crl_obsolete_critical), WOLFSSL_FILETYPE_ASN1),
+            WOLFSSL_SUCCESS);
+        ExpectIntGT(crl_unk_ext_noctx_calls, 0);
+
+        wolfSSL_CertManagerFree(cm);
+        cm = NULL;
+        if (EXPECT_FAIL()) {
+            printf("    (failed with the %s unknown extension callback)\n",
+                (CallbackType == Bit16Callback) ? "16-bit" : "32-bit");
+            break;
+        }
+    }
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_certman.h
+++ b/tests/api/test_certman.h
@@ -53,6 +53,7 @@ int test_wolfSSL_CRL_unknown_ext_cb_rescues_critical_crl_ext(void);
 int test_wolfSSL_CRL_unknown_ext_cb_positive_return_fails_load(void);
 int test_wolfSSL_CRL_unknown_ext_cb_noctx(void);
 int test_wolfSSL_cert_critical_policy_constraints(void);
+int test_wolfSSL_CRL_unknown_ext_cb_32_preferred(void);
 int test_wolfSSL_CertManagerCheckOCSPResponse(void);
 int test_various_pathlen_chains(void);
 int test_wolfSSL_CertManagerRejectMD5Cert(void);
@@ -96,6 +97,8 @@ int test_wolfSSL_CertManagerNameConstraint_skid_disambiguates(void);
     TEST_DECL_GROUP("certman",                                              \
         test_wolfSSL_CRL_unknown_ext_cb_noctx),                             \
     TEST_DECL_GROUP("certman", test_wolfSSL_cert_critical_policy_constraints), \
+    TEST_DECL_GROUP("certman",                                              \
+        test_wolfSSL_CRL_unknown_ext_cb_32_preferred),                      \
     TEST_DECL_GROUP("certman", test_wolfSSL_CertManagerCheckOCSPResponse),  \
     TEST_DECL_GROUP("certman", test_various_pathlen_chains),                \
     TEST_DECL_GROUP("certman", test_wolfSSL_CertManagerRejectMD5Cert),      \

--- a/tests/unit-mcdc/test_asn_certgen_whitebox.c
+++ b/tests/unit-mcdc/test_asn_certgen_whitebox.c
@@ -1529,7 +1529,6 @@ static void wb_mime_single_canonicalize(void) { }
  * stdout isn't flooded with dump text.
  *   wc_Asn1_SetFile         :~38812  asn1==NULL || file==XBADFILE
  *   wc_Asn1_SetOidToNameCb  :~38834  asn1==NULL || nameCb==NULL
- *   EncodedDottedForm       :~38862  in==NULL || outSz==NULL
  *   PrintObjectIdText       :~39022,39033
  *   PrintAsn1Text           :~39143-39152,39166-39168
  *   DumpData                :~39179,39195,39201
@@ -1817,26 +1816,6 @@ static void wb_asn1_print(void)
     }
 
     fclose(devnull);
-
-    WB_NOTE("EncodedDottedForm(): NULL-arg OR [~38862] (via PrintObjectIdNum path, "
-            "exercised indirectly above through the OID item; direct call for the "
-            "NULL-arg operand pair since no PrintObjectIdNum wrapper is public)");
-    {
-        word32 dotted[8];
-        word32 num = 8;
-        int ret;
-        static const byte oidBytes[] = { 0x55, 0x04, 0x03 };
-        ret = EncodedDottedForm(NULL, 3, dotted, &num);
-        WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), ":38862 1st operand true (in==NULL)");
-        num = 8;
-        ret = EncodedDottedForm(oidBytes, sizeof(oidBytes), dotted, NULL);
-        WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), ":38862 2nd operand true (outSz==NULL)");
-        num = 8;
-        /* 55 04 03 decodes to the four arcs 2.5.4.3: the first byte carries
-         * two of them. */
-        ret = EncodedDottedForm(oidBytes, sizeof(oidBytes), dotted, &num);
-        WB_CHECK(ret == 0 && num == 4, ":38862 both false (valid decode)");
-    }
 }
 #else
 static void wb_asn1_print(void) { WB_NOTE("ASN.1 print (no WOLFSSL_ASN_PRINT); skipped"); }

--- a/tests/unit-mcdc/test_asn_ext_whitebox.c
+++ b/tests/unit-mcdc/test_asn_ext_whitebox.c
@@ -1835,6 +1835,22 @@ static void wb_decode_cert_extensions_badargs(void)
         (void)wc_SetUnknownExtCallback(&cert, NULL);
         ret = DecodeCertExtensions(&cert);
         WB_CHECK(ret == 0, "unknown extension, no callback set (skipped, no crash)");
+
+        XMEMSET(&cert, 0, sizeof(cert));
+        cert.extensions = unknownExt;
+        cert.extensionsSz = (int)sizeof(unknownExt);
+        (void)wc_SetUnknownExtCallback32(&cert, NULL);
+        ret = DecodeCertExtensions(&cert);
+        WB_CHECK(ret == 0,
+            "unknown extension 32 bit, no callback set (skipped, no crash)");
+
+        XMEMSET(&cert, 0, sizeof(cert));
+        cert.extensions = unknownExt;
+        cert.extensionsSz = (int)sizeof(unknownExt);
+        (void)wc_SetUnknownExtCallback32Ex(&cert, NULL, NULL);
+        ret = DecodeCertExtensions(&cert);
+        WB_CHECK(ret == 0,
+            "unknown extension 32 bit Ex, no callback set (skipped, no crash)");
     }
 #endif
 }

--- a/tests/unit-mcdc/test_asn_fault_whitebox.c
+++ b/tests/unit-mcdc/test_asn_fault_whitebox.c
@@ -195,7 +195,7 @@ static void wb_encode_object_id_null_args(void)
 
     outSz = sizeof(out);
     ret = EncodeObjectId(dotted, 0, out, &outSz);
-    WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "inSz<=0");
+    WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "inSz<2");
 }
 #else
 static void wb_encode_object_id_null_args(void) { WB_NOTE("HAVE_OID_ENCODING off; skipped"); }

--- a/tests/unit-mcdc/test_asn_fault_whitebox.c
+++ b/tests/unit-mcdc/test_asn_fault_whitebox.c
@@ -57,7 +57,8 @@
  *
  * Sections (asn.c line numbers as of this writing):
  *   1.  wc_BerToDer() ber/derSz NULL OR ......................... :4269
- *   2.  EncodeObjectId() in/outSz NULL, inSz<2, in[0]>2 OR ...... :7403
+ *   2.  EncodeObjectId() in/outSz NULL, inSz<2, in[0]>2,
+ *       in[0]<2 && in[1]>39 OR ................................. :7403
  *   3.  wc_oid_sum() input NULL / length>MAX_OID_SZ OR ........... :7835
  *   4.  wc_CheckPrivateKeyCert() key/der NULL OR ................. :9956
  *   5.  wc_GetKeyOID() key/algoID NULL OR ......................... :10234
@@ -170,7 +171,8 @@ static void wb_ber_to_der_null_args(void) { WB_NOTE("ASN_BER_TO_DER off; skipped
 
 /* ------------------------------------------------------------------------- *
  * Section 2: EncodeObjectId() (:7403).
- *   if (in == NULL || outSz == NULL || inSz < 2 || in[0] > 2)
+ *   if (in == NULL || outSz == NULL || inSz < 2 || in[0] > 2 ||
+ *           ((in[0] < 2) && (in[1] > 39)))
  *       return BAD_FUNC_ARG;
  * ------------------------------------------------------------------------- */
 #ifdef HAVE_OID_ENCODING
@@ -178,11 +180,13 @@ static void wb_encode_object_id_null_args(void)
 {
     word16 dotted[3] = { 1, 2, 3 };
     word16 badDotted[3] = { 3, 2, 3 };
+    word16 badSecond[2] = { 1, 40 };
     byte   out[16];
     word32 outSz;
     int    ret;
 
-    WB_NOTE("EncodeObjectId(): in/outSz NULL, inSz<2, in[0]>2 OR [:7403]");
+    WB_NOTE("EncodeObjectId(): in/outSz NULL, inSz<2, in[0]>2, "
+            "in[0]<2 && in[1]>39 OR [:7403]");
 
     outSz = sizeof(out);
     ret = EncodeObjectId(dotted, 3, out, &outSz);
@@ -202,6 +206,10 @@ static void wb_encode_object_id_null_args(void)
     outSz = sizeof(out);
     ret = EncodeObjectId(badDotted, 3, out, &outSz);
     WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "in[0]>2");
+
+    outSz = sizeof(out);
+    ret = EncodeObjectId(badSecond, 2, out, &outSz);
+    WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "in[0]<2 && in[1]>39");
 }
 #else
 static void wb_encode_object_id_null_args(void) { WB_NOTE("HAVE_OID_ENCODING off; skipped"); }

--- a/tests/unit-mcdc/test_asn_fault_whitebox.c
+++ b/tests/unit-mcdc/test_asn_fault_whitebox.c
@@ -57,7 +57,7 @@
  *
  * Sections (asn.c line numbers as of this writing):
  *   1.  wc_BerToDer() ber/derSz NULL OR ......................... :4269
- *   2.  EncodeObjectId() in/outSz NULL, inSz<=0 OR ............... :7403
+ *   2.  EncodeObjectId() in/outSz NULL, inSz<2, in[0]>2 OR ...... :7403
  *   3.  wc_oid_sum() input NULL / length>MAX_OID_SZ OR ........... :7835
  *   4.  wc_CheckPrivateKeyCert() key/der NULL OR ................. :9956
  *   5.  wc_GetKeyOID() key/algoID NULL OR ......................... :10234
@@ -170,17 +170,19 @@ static void wb_ber_to_der_null_args(void) { WB_NOTE("ASN_BER_TO_DER off; skipped
 
 /* ------------------------------------------------------------------------- *
  * Section 2: EncodeObjectId() (:7403).
- *   if (in == NULL || outSz == NULL || inSz <= 0) return BAD_FUNC_ARG;
+ *   if (in == NULL || outSz == NULL || inSz < 2 || in[0] > 2)
+ *       return BAD_FUNC_ARG;
  * ------------------------------------------------------------------------- */
 #ifdef HAVE_OID_ENCODING
 static void wb_encode_object_id_null_args(void)
 {
     word16 dotted[3] = { 1, 2, 3 };
+    word16 badDotted[3] = { 3, 2, 3 };
     byte   out[16];
     word32 outSz;
     int    ret;
 
-    WB_NOTE("EncodeObjectId(): in/outSz NULL, inSz<=0 OR [:7403]");
+    WB_NOTE("EncodeObjectId(): in/outSz NULL, inSz<2, in[0]>2 OR [:7403]");
 
     outSz = sizeof(out);
     ret = EncodeObjectId(dotted, 3, out, &outSz);
@@ -196,6 +198,10 @@ static void wb_encode_object_id_null_args(void)
     outSz = sizeof(out);
     ret = EncodeObjectId(dotted, 0, out, &outSz);
     WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "inSz<2");
+
+    outSz = sizeof(out);
+    ret = EncodeObjectId(badDotted, 3, out, &outSz);
+    WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "in[0]>2");
 }
 #else
 static void wb_encode_object_id_null_args(void) { WB_NOTE("HAVE_OID_ENCODING off; skipped"); }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -38013,7 +38013,7 @@ static int ParseCRL_EntryExtensions(const byte* buff, word32 idx, word32 maxIdx,
 #ifdef WC_ASN_UNKNOWN_EXT_CB
             if (dcrl != NULL && (dcrl->unknownExtCallback != NULL ||
                                  dcrl->unknownExtCallbackEx != NULL)) {
-                word16 decOid[MAX_OID_SZ];
+                word32 decOid[MAX_OID_SZ];
                 word32 decOidSz = MAX_OID_SZ;
                 word32 valIdx = idx;
                 int    valLen = 0;
@@ -38035,7 +38035,7 @@ static int ParseCRL_EntryExtensions(const byte* buff, word32 idx, word32 maxIdx,
                  * never sees uninitialized stack" true by construction rather
                  * than by reasoning about DecodeObjectId's internals. */
                 XMEMSET(decOid, 0, sizeof(decOid));
-                cbRet = DecodeObjectId(buff + oidContent, (word32)oidLen,
+                cbRet = DecodeObjectId_ex(buff + oidContent, (word32)oidLen,
                     decOid, &decOidSz);
                 if (cbRet == 0 && dcrl->unknownExtCallback != NULL) {
                     cbRet = dcrl->unknownExtCallback(decOid, decOidSz,
@@ -38498,9 +38498,9 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf, word32 idx,
 #ifdef WC_ASN_UNKNOWN_EXT_CB
                     if (dcrl->unknownExtCallback != NULL ||
                         dcrl->unknownExtCallbackEx != NULL) {
-                        word16 decOid[MAX_OID_SZ];
+                        word32 decOid[MAX_OID_SZ];
                         word32 decOidSz = MAX_OID_SZ;
-                        ret = DecodeObjectId(
+                        ret = DecodeObjectId_ex(
                             dataASN[CERTEXTASN_IDX_OID].data.oid.data,
                             dataASN[CERTEXTASN_IDX_OID].data.oid.length,
                             decOid, &decOidSz);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7460,8 +7460,10 @@ static int CheckCurve(word32 oid)
  *                         On out, number of bytes in buffer.
  * @return  0 on success
  * @return  BAD_FUNC_ARG when in or outSz is NULL, when inSz is less than 2,
- *          or when the first arc in[0] is greater than 2. An OID must have
- *          at least two arcs and, per X.690, its first arc must be 0, 1 or 2.
+ *          when the first arc in[0] is greater than 2, or when in[0] is 0 or
+ *          1 and the second arc in[1] is greater than 39. An OID must have
+ *          at least two arcs and, per X.690, its first arc must be 0, 1 or 2,
+ *          with the second arc limited to 0..39 unless the first arc is 2.
  * @return  BUFFER_E when buffer too small.
  */
 int wc_EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
@@ -7478,19 +7480,21 @@ int wc_EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
  *                         On out, number of bytes in buffer.
  * @return  0 on success
  * @return  BAD_FUNC_ARG when in or outSz is NULL, when inSz is less than 2,
- *          when the first arc in[0] is greater than 2, or when the combined
+ *          when the first arc in[0] is greater than 2, when in[0] is 0 or 1
+ *          and the second arc in[1] is greater than 39, or when the combined
  *          first arc (40 * in[0] + in[1]) would overflow a word32. An OID
  *          must have at least two arcs and, per X.690, its first arc must be
- *          0, 1 or 2.
+ *          0, 1 or 2, with the second arc limited to 0..39 unless the first
+ *          arc is 2.
  * @return  BUFFER_E when buffer too small.
  */
 int wc_EncodeObjectId32(const word32* in, word32 inSz, byte* out, word32* outSz)
 {
-    int i, x, len;
-    word32 d, t;
+    word32 d, t, i, x, len;
 
     /* check args */
-    if (in == NULL || outSz == NULL || inSz < 2 || in[0] > 2) {
+    if (in == NULL || outSz == NULL || inSz < 2 || in[0] > 2 ||
+            ((in[0] < 2) && (in[1] > 39))) {
         return BAD_FUNC_ARG;
     }
 
@@ -7504,7 +7508,7 @@ int wc_EncodeObjectId32(const word32* in, word32 inSz, byte* out, word32* outSz)
     /* compute length of encoded OID */
     d = (in[0] * 40) + in[1];
     len = 0;
-    for (i = 1; i < (int)inSz; i++) {
+    for (i = 1; i < inSz; i++) {
         x = 0;
         t = d;
         while (t) {
@@ -7513,14 +7517,14 @@ int wc_EncodeObjectId32(const word32* in, word32 inSz, byte* out, word32* outSz)
         }
         len += (x / 7) + ((x % 7) ? 1 : 0) + (d == 0 ? 1 : 0);
 
-        if (i < (int)inSz - 1) {
+        if (i < inSz - 1) {
             d = in[i + 1];
         }
     }
 
     if (out) {
         /* verify length */
-        if ((int)*outSz < len) {
+        if (*outSz < len) {
             return BUFFER_E; /* buffer provided is not large enough */
         }
 
@@ -7529,9 +7533,9 @@ int wc_EncodeObjectId32(const word32* in, word32 inSz, byte* out, word32* outSz)
 
         /* encode bytes */
         x = 0;
-        for (i = 1; i < (int)inSz; i++) {
+        for (i = 1; i < inSz; i++) {
             if (d) {
-                int y = x, z;
+                word32 y = x, z;
                 byte mask = 0;
                 while (d) {
                     out[x++] = (byte)((d & 0x7F) | mask);
@@ -7553,14 +7557,14 @@ int wc_EncodeObjectId32(const word32* in, word32 inSz, byte* out, word32* outSz)
             }
 
             /* next word */
-            if (i < (int)inSz - 1) {
+            if (i < inSz - 1) {
                 d = in[i + 1];
             }
         }
     }
 
     /* return length */
-    *outSz = (word32)len;
+    *outSz = len;
 
     return 0;
 }
@@ -7579,24 +7583,26 @@ int wc_EncodeObjectId32(const word32* in, word32 inSz, byte* out, word32* outSz)
  *                         On out, number of bytes in buffer.
  * @return  0 on success
  * @return  BAD_FUNC_ARG when in or outSz is NULL, when inSz is less than 2,
- *          or when the first arc in[0] is greater than 2. An OID must have
- *          at least two arcs and, per X.690, its first arc must be 0, 1 or 2.
+ *          when the first arc in[0] is greater than 2, or when in[0] is 0 or
+ *          1 and the second arc in[1] is greater than 39. An OID must have
+ *          at least two arcs and, per X.690, its first arc must be 0, 1 or 2,
+ *          with the second arc limited to 0..39 unless the first arc is 2.
  * @return  BUFFER_E when buffer too small.
  */
 int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
 {
-    int i, x, len;
-    word32 d, t;
+    word32 d, t, i, x, len;
 
     /* check args */
-    if (in == NULL || outSz == NULL || inSz < 2 || in[0] > 2) {
+    if (in == NULL || outSz == NULL || inSz < 2 || in[0] > 2 ||
+            ((in[0] < 2) && (in[1] > 39))) {
         return BAD_FUNC_ARG;
     }
 
     /* compute length of encoded OID */
     d = ((word32)in[0] * 40) + in[1];
     len = 0;
-    for (i = 1; i < (int)inSz; i++) {
+    for (i = 1; i < inSz; i++) {
         x = 0;
         t = d;
         while (t) {
@@ -7605,14 +7611,14 @@ int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
         }
         len += (x / 7) + ((x % 7) ? 1 : 0) + (d == 0 ? 1 : 0);
 
-        if (i < (int)inSz - 1) {
+        if (i < inSz - 1) {
             d = in[i + 1];
         }
     }
 
     if (out) {
         /* verify length */
-        if ((int)*outSz < len) {
+        if (*outSz < len) {
             return BUFFER_E; /* buffer provided is not large enough */
         }
 
@@ -7621,9 +7627,9 @@ int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
 
         /* encode bytes */
         x = 0;
-        for (i = 1; i < (int)inSz; i++) {
+        for (i = 1; i < inSz; i++) {
             if (d) {
-                int y = x, z;
+                word32 y = x, z;
                 byte mask = 0;
                 while (d) {
                     out[x++] = (byte)((d & 0x7F) | mask);
@@ -7645,14 +7651,14 @@ int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
             }
 
             /* next word */
-            if (i < (int)inSz - 1) {
+            if (i < inSz - 1) {
                 d = in[i + 1];
             }
         }
     }
 
     /* return length */
-    *outSz = (word32)len;
+    *outSz = len;
 
     return 0;
 }
@@ -7697,9 +7703,6 @@ int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
         cnt++;
         if (!(in[x] & 0x80)) {
             if (y == 0) {
-                if ((int)*outSz < 2) {
-                    return BUFFER_E;
-                }
                 if (t < 80) {
                     out[0] = (word16)(t / 40);
                     out[1] = (word16)(t % 40);
@@ -7747,7 +7750,7 @@ int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
 int DecodeObjectId32(const byte* in, word32 inSz, word32* out, word32* outSz)
 {
     int x = 0, y = 0;
-    word32 t = 0;
+    word32 t = 0, cnt = 0;
 
     /* check args */
     if (in == NULL || outSz == NULL) {
@@ -7759,15 +7762,15 @@ int DecodeObjectId32(const byte* in, word32 inSz, word32* out, word32* outSz)
 
     /* decode bytes */
     while (inSz--) {
-        if (t > 0xFFFFFFFFU >> 7) {
+        /* Reject an arc encoded in more than 5 bytes, and one whose next
+         * 7 bits would shift a set bit out of the word32. */
+        if ((cnt == 5) || (t > (0xFFFFFFFFU >> 7))) {
             return ASN_OBJECT_ID_E;
         }
+        cnt++;
         t = (t << 7) | (in[x] & 0x7F);
         if (!(in[x] & 0x80)) {
             if (y == 0) {
-                if ((int)*outSz < 2) {
-                    return BUFFER_E;
-                }
                 if (t < 80) {
                     out[0] = t / 40;
                     out[1] = t % 40;
@@ -7785,6 +7788,7 @@ int DecodeObjectId32(const byte* in, word32 inSz, word32* out, word32* outSz)
                 out[y++] = t;
             }
             t = 0; /* reset tmp */
+            cnt = 0;
         }
         x++;
     }
@@ -13380,6 +13384,7 @@ static int SetCurve(ecc_key* key, byte* output, size_t outSz)
 #endif
     int idx;
     word32 oidSz = 0;
+
     /* validate key */
     if (key == NULL || key->dp == NULL) {
         return BAD_FUNC_ARG;
@@ -13387,7 +13392,7 @@ static int SetCurve(ecc_key* key, byte* output, size_t outSz)
 
 #ifdef HAVE_OID_ENCODING
     /* ecc_oid_t cannot be changed due to it being in the FIPS boundary so we
-     * have a work around of upsizing its representation*/
+     * have a work around of upsizing its representation. */
     /* Get the size of the encoded OID without having an encoded output */
     ret = EncodeObjectId(key->dp->oid, key->dp->oidSz, NULL, &oidSz);
     if (ret != 0) {
@@ -38627,7 +38632,7 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf, word32 idx,
 #ifdef WC_ASN_UNKNOWN_EXT_CB
                     if (dcrl->unknownExtCallback32Ex != NULL ||
                             dcrl->unknownExtCallback32 != NULL) {
-                        word32 decOid[MAX_OID_SZ];
+                        word32 decOid[MAX_OID_SZ] = {0};
                         word32 decOidSz = MAX_OID_SZ;
                         ret = DecodeObjectId32(
                             dataASN[CERTEXTASN_IDX_OID].data.oid.data,
@@ -38660,7 +38665,7 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf, word32 idx,
                     }
                     else if (dcrl->unknownExtCallbackEx != NULL ||
                              dcrl->unknownExtCallback != NULL) {
-                        word16 decOid[MAX_OID_SZ];
+                        word16 decOid[MAX_OID_SZ] = {0};
                         word32 decOidSz = MAX_OID_SZ;
                         ret = DecodeObjectId(
                             dataASN[CERTEXTASN_IDX_OID].data.oid.data,
@@ -40145,7 +40150,7 @@ static void PrintObjectIdNum(XFILE file, unsigned char* oid, word32 len)
     if (DecodeObjectId32(oid, len, dotted_nums, &num) == 0) {
         /* Print out each number of dotted form. */
         for (i = 0; i < num; i++) {
-            XFPRINTF(file, "%d", dotted_nums[i]);
+            XFPRINTF(file, "%u", dotted_nums[i]);
             /* Add separator. */
             if (i < num - 1) {
                 XFPRINTF(file, ".");

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7562,7 +7562,7 @@ int EncodeObjectId(const word16* in, word32 inSz,
     word32 d, t;
 
     /* check args */
-    if (in == NULL || outSz == NULL || inSz < 2) {
+    if (in == NULL || outSz == NULL || inSz < 2 || in[0] > 2) {
         return BAD_FUNC_ARG;
     }
 
@@ -7632,7 +7632,7 @@ int EncodeObjectId(const word16* in, word32 inSz,
 #endif /* HAVE_OID_ENCODING */
 
 #if defined(HAVE_OID_DECODING) || defined(WOLFSSL_ASN_PRINT)
-/* Encode dotted form of OID into byte array version.
+/* Decode DER encoded form of OID into word16 OID dot seperated.
  *
  * @param [in]      in     Byte array containing OID.
  * @param [in]      inSz   Size of OID in bytes.
@@ -7697,7 +7697,7 @@ int DecodeObjectId(const byte* in, word32 inSz,
     return 0;
 }
 
-/* Encode dotted form of OID into word32 array version.
+/* Decode DER encoded form of OID into word32 OID dot seperated.
  *
  * Same as DecodeObjectId() but outputs to a word32 array so that OID
  * arc values larger than a word16 are not truncated.

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7448,6 +7448,11 @@ static int CheckCurve(word32 oid)
 #ifdef HAVE_OID_ENCODING
 /* Encode dotted form of OID into byte array version.
  *
+ * Uses word16 for OIDs and can cause OIDs to be truncated.
+ * Do not use this for new code unless necessary. (use wc_EncodeObjectId32)
+ * We cannot change this function because FIPS code expects
+ * this signature.
+ *
  * @param [in]      in     Dotted form of OID.
  * @param [in]      inSz   Count of numbers in dotted form.
  * @param [in]      out    Buffer to hold OID.
@@ -7457,12 +7462,23 @@ static int CheckCurve(word32 oid)
  * @return  BAD_FUNC_ARG when in or outSz is NULL.
  * @return  BUFFER_E when buffer too small.
  */
-int wc_EncodeObjectId(const word32* in, word32 inSz, byte* out, word32* outSz)
+int wc_EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
 {
-    return EncodeObjectId_ex(in, inSz, out, outSz);
+    return EncodeObjectId(in, inSz, out, outSz);
 }
 
-int EncodeObjectId_ex(const word32* in, word32 inSz, byte* out, word32* outSz)
+/* Encode dotted form of OID into byte array version.
+ *
+ * @param [in]      in     Dotted form of OID.
+ * @param [in]      inSz   Count of numbers in dotted form.
+ * @param [in]      out    Buffer to hold OID.
+ * @param [in, out] outSz  On in, size of buffer.
+ *                         On out, number of bytes in buffer.
+ * @return  0 on success
+ * @return  BAD_FUNC_ARG when in or outSz is NULL.
+ * @return  BUFFER_E when buffer too small.
+ */
+int wc_EncodeObjectId32(const word32* in, word32 inSz, byte* out, word32* outSz)
 {
     int i, x, len;
     word32 d, t;
@@ -7546,8 +7562,7 @@ int EncodeObjectId_ex(const word32* in, word32 inSz, byte* out, word32* outSz)
 /* Encode dotted form of OID into byte array version.
  *
  * Uses word16 for OIDs and can cause OIDs to be truncated.
- * Do not use this for new code unless necessary. (use wc_EncodeObjectId
- * or EncodeObjectId_ex)
+ * Do not use this for new code unless necessary. (use wc_EncodeObjectId32)
  * We cannot change this function because FIPS code expects
  * this signature.
  *
@@ -7714,7 +7729,7 @@ int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
  * @return  BAD_FUNC_ARG when in or outSz is NULL.
  * @return  BUFFER_E when dotted form buffer too small.
  */
-int DecodeObjectId_ex(const byte* in, word32 inSz, word32* out, word32* outSz)
+int DecodeObjectId32(const byte* in, word32 inSz, word32* out, word32* outSz)
 {
     int x = 0, y = 0;
     word32 t = 0;
@@ -7849,7 +7864,7 @@ static int DumpOID(const byte* oidData, word32 oidSz, word32 oid,
         word32 decOid[MAX_OID_SZ];
         word32 decOidSz = MAX_OID_SZ;
         /* Decode the OID into dotted form. */
-        ret = DecodeObjectId_ex(oidData, oidSz, decOid, &decOidSz);
+        ret = DecodeObjectId32(oidData, oidSz, decOid, &decOidSz);
         if (ret == 0) {
             printf("  Decoded (Sz %u): ", decOidSz);
             for (i=0; i<decOidSz; i++) {
@@ -7858,7 +7873,7 @@ static int DumpOID(const byte* oidData, word32 oidSz, word32 oid,
             printf("\n");
         }
         else {
-            printf("DecodeObjectId failed: %d\n", ret);
+            printf("DecodeObjectId32 failed: %d\n", ret);
         }
     }
     #endif /* HAVE_OID_DECODING */
@@ -23126,14 +23141,14 @@ static int DecodeCertExtensions(DecodedCert* cert)
                                  cert->unknownExtCallbackEx != NULL)) {
                 word32 decOid[MAX_OID_SZ];
                 word32 decOidSz = MAX_OID_SZ;
-                ret = DecodeObjectId_ex(
+                ret = DecodeObjectId32(
                           dataASN[CERTEXTASN_IDX_OID].data.oid.data,
                           dataASN[CERTEXTASN_IDX_OID].data.oid.length,
                           decOid, &decOidSz);
                 if (ret != 0) {
                     /* Should never get here as the extension was successfully
                      * decoded earlier. Something might be corrupted. */
-                    WOLFSSL_MSG("DecodeObjectId() failed. Corruption?");
+                    WOLFSSL_MSG("DecodeObjectId32() failed. Corruption?");
                     WOLFSSL_ERROR(ret);
                 }
 
@@ -38025,7 +38040,7 @@ static int ParseCRL_EntryExtensions(const byte* buff, word32 idx, word32 maxIdx,
                 /* Validate the OID encoding before decoding it. GetLength()
                  * returns 0 (not an error) for a zero-length item, and an OID
                  * whose last content octet has bit 8 set encodes no complete
-                 * sub-identifier. In either case DecodeObjectId() returns 0
+                 * sub-identifier. In either case DecodeObjectId32() returns 0
                  * with *outSz == 0, having written nothing to decOid, which
                  * would hand the callback an uninitialized OID buffer. */
                 if (GetASN_ObjectId(buff, oidContent, oidLen) != 0) {
@@ -38033,9 +38048,9 @@ static int ParseCRL_EntryExtensions(const byte* buff, word32 idx, word32 maxIdx,
                 }
                 /* Redundant given the check above, but it makes "the callback
                  * never sees uninitialized stack" true by construction rather
-                 * than by reasoning about DecodeObjectId's internals. */
+                 * than by reasoning about DecodeObjectId32's internals. */
                 XMEMSET(decOid, 0, sizeof(decOid));
-                cbRet = DecodeObjectId_ex(buff + oidContent, (word32)oidLen,
+                cbRet = DecodeObjectId32(buff + oidContent, (word32)oidLen,
                     decOid, &decOidSz);
                 if (cbRet == 0 && dcrl->unknownExtCallback != NULL) {
                     cbRet = dcrl->unknownExtCallback(decOid, decOidSz,
@@ -38500,7 +38515,7 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf, word32 idx,
                         dcrl->unknownExtCallbackEx != NULL) {
                         word32 decOid[MAX_OID_SZ];
                         word32 decOidSz = MAX_OID_SZ;
-                        ret = DecodeObjectId_ex(
+                        ret = DecodeObjectId32(
                             dataASN[CERTEXTASN_IDX_OID].data.oid.data,
                             dataASN[CERTEXTASN_IDX_OID].data.oid.length,
                             decOid, &decOidSz);
@@ -39977,7 +39992,7 @@ static void PrintObjectIdNum(XFILE file, unsigned char* oid, word32 len)
     word32 i;
 
     /* Decode OBJECT_ID into dotted form array. */
-    if (DecodeObjectId_ex(oid, len, dotted_nums, &num) == 0) {
+    if (DecodeObjectId32(oid, len, dotted_nums, &num) == 0) {
         /* Print out each number of dotted form. */
         for (i = 0; i < num; i++) {
             XFPRINTF(file, "%d", dotted_nums[i]);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7676,7 +7676,7 @@ int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
  * @param [in, out] outSz  On in, number of elements in array.
  *                         On out, count of numbers in dotted form.
  * @return  0 on success
- * @return  BAD_FUNC_ARG when in or outSz is NULL.
+ * @return  BAD_FUNC_ARG when in, out or outSz is NULL.
  * @return  BUFFER_E when dotted form buffer too small. At least two elements
  *          are required to hold the two arcs encoded in the first byte.
  * @return  ASN_OBJECT_ID_E when an arc is encoded in more than 4 bytes.
@@ -7688,7 +7688,7 @@ int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
     int cnt = 0;
 
     /* check args */
-    if (in == NULL || outSz == NULL) {
+    if (in == NULL || out == NULL || outSz == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -7742,7 +7742,7 @@ int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
  * @param [in, out] outSz  On in, number of elements in array.
  *                         On out, count of numbers in dotted form.
  * @return  0 on success
- * @return  BAD_FUNC_ARG when in or outSz is NULL.
+ * @return  BAD_FUNC_ARG when in, out or outSz is NULL.
  * @return  BUFFER_E when dotted form buffer too small. At least two elements
  *          are required to hold the two arcs encoded in the first byte.
  * @return  ASN_OBJECT_ID_E when an arc value does not fit in a word32.
@@ -7753,7 +7753,7 @@ int DecodeObjectId32(const byte* in, word32 inSz, word32* out, word32* outSz)
     word32 t = 0, cnt = 0;
 
     /* check args */
-    if (in == NULL || outSz == NULL) {
+    if (in == NULL || out == NULL || outSz == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -23180,7 +23180,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
             ret = DecodeExtensionType(input + idx, length, oid, critical, cert,
                                       &isUnknownExt);
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-            if (isUnknownExt){
+            if (isUnknownExt) {
                 if (cert->unknownExtCallback32Ex != NULL ||
                         cert->unknownExtCallback32 != NULL) {
                     word32 decOid[MAX_OID_SZ];

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7474,6 +7474,13 @@ int EncodeObjectId_ex(const word32* in, word32 inSz,
         return BAD_FUNC_ARG;
     }
 
+    /* guard against word32 overflow of the combined first arc:
+     * ((in[0] * 40) + in[1]) is computed below in both the length and
+     * encode passes, so rejecting it here covers both. */
+    if (in[1] > 0xFFFFFFFFU - (in[0] * 40)) {
+        return BAD_FUNC_ARG;
+    }
+
     /* compute length of encoded OID */
     d = ((word32)in[0] * 40) + in[1];
     len = 0;
@@ -7632,7 +7639,7 @@ int EncodeObjectId(const word16* in, word32 inSz,
 #endif /* HAVE_OID_ENCODING */
 
 #if defined(HAVE_OID_DECODING) || defined(WOLFSSL_ASN_PRINT)
-/* Decode DER encoded form of OID into word16 OID dot seperated.
+/* Decode DER encoded form of OID into word16 OID dot separated.
  *
  * @param [in]      in     Byte array containing OID.
  * @param [in]      inSz   Size of OID in bytes.
@@ -7697,7 +7704,7 @@ int DecodeObjectId(const byte* in, word32 inSz,
     return 0;
 }
 
-/* Decode DER encoded form of OID into word32 OID dot seperated.
+/* Decode DER encoded form of OID into word32 OID dot separated.
  *
  * Same as DecodeObjectId() but outputs to a word32 array so that OID
  * arc values larger than a word16 are not truncated.

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7457,14 +7457,12 @@ static int CheckCurve(word32 oid)
  * @return  BAD_FUNC_ARG when in or outSz is NULL.
  * @return  BUFFER_E when buffer too small.
  */
-int wc_EncodeObjectId(const word32* in, word32 inSz,
-        byte* out, word32* outSz)
+int wc_EncodeObjectId(const word32* in, word32 inSz, byte* out, word32* outSz)
 {
     return EncodeObjectId_ex(in, inSz, out, outSz);
 }
 
-int EncodeObjectId_ex(const word32* in, word32 inSz,
-        byte* out, word32* outSz)
+int EncodeObjectId_ex(const word32* in, word32 inSz, byte* out, word32* outSz)
 {
     int i, x, len;
     word32 d, t;
@@ -7482,7 +7480,7 @@ int EncodeObjectId_ex(const word32* in, word32 inSz,
     }
 
     /* compute length of encoded OID */
-    d = ((word32)in[0] * 40) + in[1];
+    d = (in[0] * 40) + in[1];
     len = 0;
     for (i = 1; i < (int)inSz; i++) {
         x = 0;
@@ -7505,7 +7503,7 @@ int EncodeObjectId_ex(const word32* in, word32 inSz,
         }
 
         /* calc first byte */
-        d = ((word32)in[0] * 40) + in[1];
+        d = (in[0] * 40) + in[1];
 
         /* encode bytes */
         x = 0;
@@ -7562,8 +7560,7 @@ int EncodeObjectId_ex(const word32* in, word32 inSz,
  * @return  BAD_FUNC_ARG when in or outSz is NULL.
  * @return  BUFFER_E when buffer too small.
  */
-int EncodeObjectId(const word16* in, word32 inSz,
-        byte* out, word32* outSz)
+int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
 {
     int i, x, len;
     word32 d, t;
@@ -7650,8 +7647,7 @@ int EncodeObjectId(const word16* in, word32 inSz,
  * @return  BAD_FUNC_ARG when in or outSz is NULL.
  * @return  BUFFER_E when dotted form buffer too small.
  */
-int DecodeObjectId(const byte* in, word32 inSz,
-        word16* out, word32* outSz)
+int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
 {
     int x = 0, y = 0;
     word32 t = 0;
@@ -7718,8 +7714,7 @@ int DecodeObjectId(const byte* in, word32 inSz,
  * @return  BAD_FUNC_ARG when in or outSz is NULL.
  * @return  BUFFER_E when dotted form buffer too small.
  */
-int DecodeObjectId_ex(const byte* in, word32 inSz,
-        word32* out, word32* outSz)
+int DecodeObjectId_ex(const byte* in, word32 inSz, word32* out, word32* outSz)
 {
     int x = 0, y = 0;
     word32 t = 0;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -15097,7 +15097,7 @@ static int GenerateDNSEntryRIDString(DNS_entry* entry, void* heap)
         {
             /* Decode OBJECT_ID into dotted form array. */
             ret = DecodeObjectId32((const byte*)(entry->name),
-                    (word32)entry->len, tmpName, (word32*)&tmpSize);
+                    (word32)entry->len, tmpName, &tmpSize);
 
             if (ret == 0) {
                 j = 0;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7459,7 +7459,9 @@ static int CheckCurve(word32 oid)
  * @param [in, out] outSz  On in, size of buffer.
  *                         On out, number of bytes in buffer.
  * @return  0 on success
- * @return  BAD_FUNC_ARG when in or outSz is NULL.
+ * @return  BAD_FUNC_ARG when in or outSz is NULL, when inSz is less than 2,
+ *          or when the first arc in[0] is greater than 2. An OID must have
+ *          at least two arcs and, per X.690, its first arc must be 0, 1 or 2.
  * @return  BUFFER_E when buffer too small.
  */
 int wc_EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
@@ -7475,7 +7477,11 @@ int wc_EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
  * @param [in, out] outSz  On in, size of buffer.
  *                         On out, number of bytes in buffer.
  * @return  0 on success
- * @return  BAD_FUNC_ARG when in or outSz is NULL.
+ * @return  BAD_FUNC_ARG when in or outSz is NULL, when inSz is less than 2,
+ *          when the first arc in[0] is greater than 2, or when the combined
+ *          first arc (40 * in[0] + in[1]) would overflow a word32. An OID
+ *          must have at least two arcs and, per X.690, its first arc must be
+ *          0, 1 or 2.
  * @return  BUFFER_E when buffer too small.
  */
 int wc_EncodeObjectId32(const word32* in, word32 inSz, byte* out, word32* outSz)
@@ -7530,7 +7536,7 @@ int wc_EncodeObjectId32(const word32* in, word32 inSz, byte* out, word32* outSz)
                 while (d) {
                     out[x++] = (byte)((d & 0x7F) | mask);
                     d     >>= 7;
-                    mask  |= 0x80;  /* upper bit is set on all but the last byte */
+                    mask  |= 0x80;  /* upper bit set on all but last byte */
                 }
                 /* now swap bytes y...x-1 */
                 z = x - 1;
@@ -7572,7 +7578,9 @@ int wc_EncodeObjectId32(const word32* in, word32 inSz, byte* out, word32* outSz)
  * @param [in, out] outSz  On in, size of buffer.
  *                         On out, number of bytes in buffer.
  * @return  0 on success
- * @return  BAD_FUNC_ARG when in or outSz is NULL.
+ * @return  BAD_FUNC_ARG when in or outSz is NULL, when inSz is less than 2,
+ *          or when the first arc in[0] is greater than 2. An OID must have
+ *          at least two arcs and, per X.690, its first arc must be 0, 1 or 2.
  * @return  BUFFER_E when buffer too small.
  */
 int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
@@ -7653,6 +7661,9 @@ int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
 #if defined(HAVE_OID_DECODING) || defined(WOLFSSL_ASN_PRINT)
 /* Decode DER encoded form of OID into word16 OID dot separated.
  *
+ * Each arc is stored as a word16, so arc values larger than 65535 are
+ * truncated. Use DecodeObjectId32() in new code.
+ *
  * @param [in]      in     Byte array containing OID.
  * @param [in]      inSz   Size of OID in bytes.
  * @param [in]      out    Array to hold dotted form of OID.
@@ -7660,7 +7671,9 @@ int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
  *                         On out, count of numbers in dotted form.
  * @return  0 on success
  * @return  BAD_FUNC_ARG when in or outSz is NULL.
- * @return  BUFFER_E when dotted form buffer too small.
+ * @return  BUFFER_E when dotted form buffer too small. At least two elements
+ *          are required to hold the two arcs encoded in the first byte.
+ * @return  ASN_OBJECT_ID_E when an arc is encoded in more than 4 bytes.
  */
 int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
 {
@@ -7727,7 +7740,9 @@ int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
  *                         On out, count of numbers in dotted form.
  * @return  0 on success
  * @return  BAD_FUNC_ARG when in or outSz is NULL.
- * @return  BUFFER_E when dotted form buffer too small.
+ * @return  BUFFER_E when dotted form buffer too small. At least two elements
+ *          are required to hold the two arcs encoded in the first byte.
+ * @return  ASN_OBJECT_ID_E when an arc value does not fit in a word32.
  */
 int DecodeObjectId32(const byte* in, word32 inSz, word32* out, word32* outSz)
 {
@@ -15077,7 +15092,8 @@ static int GenerateDNSEntryRIDString(DNS_entry* entry, void* heap)
         {
             /* Decode OBJECT_ID into dotted form array. */
             ret = DecodeObjectId32((const byte*)(entry->name),
-                    (word32)entry->len, tmpName, &tmpSize);
+                    (word32)entry->len, tmpName, (word32*)&tmpSize);
+
             if (ret == 0) {
                 j = 0;
                 /* Append each number of dotted form. */
@@ -23077,6 +23093,28 @@ int wc_SetUnknownExtCallbackEx(DecodedCert* cert,
     return 0;
 }
 
+int wc_SetUnknownExtCallback32(DecodedCert* cert, wc_UnknownExtCallback32 cb)
+{
+    if (cert == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    cert->unknownExtCallback32 = cb;
+    return 0;
+}
+
+int wc_SetUnknownExtCallback32Ex(DecodedCert* cert,
+                                 wc_UnknownExtCallback32Ex cb, void *ctx)
+{
+    if (cert == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    cert->unknownExtCallback32Ex  = cb;
+    cert->unknownExtCallbackExCtx = ctx;
+    return 0;
+}
+
 #endif /* WC_ASN_UNKNOWN_EXT_CB */
 
 /*
@@ -23137,32 +23175,68 @@ static int DecodeCertExtensions(DecodedCert* cert)
             ret = DecodeExtensionType(input + idx, length, oid, critical, cert,
                                       &isUnknownExt);
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-            if (isUnknownExt && (cert->unknownExtCallback != NULL ||
-                                 cert->unknownExtCallbackEx != NULL)) {
-                word32 decOid[MAX_OID_SZ];
-                word32 decOidSz = MAX_OID_SZ;
-                ret = DecodeObjectId32(
-                          dataASN[CERTEXTASN_IDX_OID].data.oid.data,
-                          dataASN[CERTEXTASN_IDX_OID].data.oid.length,
-                          decOid, &decOidSz);
-                if (ret != 0) {
-                    /* Should never get here as the extension was successfully
-                     * decoded earlier. Something might be corrupted. */
-                    WOLFSSL_MSG("DecodeObjectId32() failed. Corruption?");
-                    WOLFSSL_ERROR(ret);
-                }
+            if (isUnknownExt){
+                if (cert->unknownExtCallback32Ex != NULL ||
+                        cert->unknownExtCallback32 != NULL) {
+                    word32 decOid[MAX_OID_SZ];
+                    word32 decOidSz = MAX_OID_SZ;
+                    ret = DecodeObjectId32(
+                            dataASN[CERTEXTASN_IDX_OID].data.oid.data,
+                            dataASN[CERTEXTASN_IDX_OID].data.oid.length,
+                            decOid, &decOidSz);
+                    if (ret != 0) {
+                        /* Should never get here as the extension was
+                         * successfully decoded earlier.
+                         * Something might be corrupted. */
+                        WOLFSSL_MSG("DecodeObjectId32() failed. Corruption?");
+                        WOLFSSL_ERROR(ret);
+                    }
 
-                if ((ret == 0) && (cert->unknownExtCallback != NULL)) {
-                    ret = cert->unknownExtCallback(decOid, decOidSz, critical,
-                              dataASN[CERTEXTASN_IDX_VAL].data.buffer.data,
-                              dataASN[CERTEXTASN_IDX_VAL].length);
-                }
+                    if (ret == 0 && cert->unknownExtCallback32 != NULL) {
+                        ret = cert->unknownExtCallback32(decOid, decOidSz,
+                                  critical,
+                                  dataASN[CERTEXTASN_IDX_VAL].data.buffer.data,
+                                  dataASN[CERTEXTASN_IDX_VAL].length);
+                    }
 
-                if ((ret == 0) && (cert->unknownExtCallbackEx != NULL)) {
-                    ret = cert->unknownExtCallbackEx(decOid, decOidSz, critical,
-                              dataASN[CERTEXTASN_IDX_VAL].data.buffer.data,
-                              dataASN[CERTEXTASN_IDX_VAL].length,
-                              cert->unknownExtCallbackExCtx);
+                    if (ret == 0 && cert->unknownExtCallback32Ex != NULL) {
+                        ret = cert->unknownExtCallback32Ex(decOid, decOidSz,
+                                  critical,
+                                  dataASN[CERTEXTASN_IDX_VAL].data.buffer.data,
+                                  dataASN[CERTEXTASN_IDX_VAL].length,
+                                  cert->unknownExtCallbackExCtx);
+                    }
+                }
+                else if (cert->unknownExtCallbackEx != NULL ||
+                        cert->unknownExtCallback != NULL) {
+                    word16 decOid[MAX_OID_SZ];
+                    word32 decOidSz = MAX_OID_SZ;
+                    ret = DecodeObjectId(
+                            dataASN[CERTEXTASN_IDX_OID].data.oid.data,
+                            dataASN[CERTEXTASN_IDX_OID].data.oid.length,
+                            decOid, &decOidSz);
+                    if (ret != 0) {
+                        /* Should never get here as the extension was
+                         * successfully decoded earlier.
+                         * Something might be corrupted. */
+                        WOLFSSL_MSG("DecodeObjectId() failed. Corruption?");
+                        WOLFSSL_ERROR(ret);
+                    }
+
+                    if (ret == 0 && cert->unknownExtCallback != NULL) {
+                        ret = cert->unknownExtCallback(decOid, decOidSz,
+                                  critical,
+                                  dataASN[CERTEXTASN_IDX_VAL].data.buffer.data,
+                                  dataASN[CERTEXTASN_IDX_VAL].length);
+                    }
+
+                    if (ret == 0 && cert->unknownExtCallbackEx != NULL) {
+                        ret = cert->unknownExtCallbackEx(decOid, decOidSz,
+                                  critical,
+                                  dataASN[CERTEXTASN_IDX_VAL].data.buffer.data,
+                                  dataASN[CERTEXTASN_IDX_VAL].length,
+                                  cert->unknownExtCallbackExCtx);
+                    }
                 }
             }
 #else
@@ -38026,10 +38100,10 @@ static int ParseCRL_EntryExtensions(const byte* buff, word32 idx, word32 maxIdx,
         else {
             int handled = 0;
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-            if (dcrl != NULL && (dcrl->unknownExtCallback != NULL ||
+            if (dcrl != NULL && (dcrl->unknownExtCallback32 != NULL ||
+                                 dcrl->unknownExtCallback32Ex != NULL ||
+                                 dcrl->unknownExtCallback != NULL ||
                                  dcrl->unknownExtCallbackEx != NULL)) {
-                word32 decOid[MAX_OID_SZ];
-                word32 decOidSz = MAX_OID_SZ;
                 word32 valIdx = idx;
                 int    valLen = 0;
                 int    cbRet;
@@ -38046,28 +38120,68 @@ static int ParseCRL_EntryExtensions(const byte* buff, word32 idx, word32 maxIdx,
                 if (GetASN_ObjectId(buff, oidContent, oidLen) != 0) {
                     return ASN_PARSE_E;
                 }
-                /* Redundant given the check above, but it makes "the callback
-                 * never sees uninitialized stack" true by construction rather
-                 * than by reasoning about DecodeObjectId32's internals. */
-                XMEMSET(decOid, 0, sizeof(decOid));
-                cbRet = DecodeObjectId32(buff + oidContent, (word32)oidLen,
-                    decOid, &decOidSz);
-                if (cbRet == 0 && dcrl->unknownExtCallback != NULL) {
-                    cbRet = dcrl->unknownExtCallback(decOid, decOidSz,
-                        critical, buff + valIdx, (word32)valLen);
+
+                if (dcrl->unknownExtCallback32 != NULL ||
+                                 dcrl->unknownExtCallback32Ex != NULL) {
+
+                    word32 decOid[MAX_OID_SZ];
+                    word32 decOidSz = MAX_OID_SZ;
+                    /* Redundant given the check above, but it makes
+                     * "the callback never sees uninitialized stack" true
+                     * by construction rather than by reasoning about
+                     * DecodeObjectId32's internals. */
+                    XMEMSET(decOid, 0, sizeof(decOid));
+                    cbRet = DecodeObjectId32(buff + oidContent, (word32)oidLen,
+                        decOid, &decOidSz);
+                    if (cbRet == 0 && dcrl->unknownExtCallback32 != NULL) {
+                        cbRet = dcrl->unknownExtCallback32(decOid, decOidSz,
+                            critical, buff + valIdx, (word32)valLen);
+                    }
+                    if (cbRet == 0 && dcrl->unknownExtCallback32Ex != NULL) {
+                        cbRet = dcrl->unknownExtCallback32Ex(decOid, decOidSz,
+                            critical, buff + valIdx, (word32)valLen,
+                            dcrl->unknownExtCallbackExCtx);
+                    }
+                    if (cbRet != 0) {
+                        /* Must stay negative: BufferLoadCRL converts its result
+                         * with "ret ? ret : WOLFSSL_SUCCESS", so a positive
+                         * callback return would collide with
+                         * WOLFSSL_SUCCESS. */
+                        return (cbRet < 0) ? cbRet : ASN_PARSE_E;
+                    }
+                    handled = 1;
                 }
-                if (cbRet == 0 && dcrl->unknownExtCallbackEx != NULL) {
-                    cbRet = dcrl->unknownExtCallbackEx(decOid, decOidSz,
-                        critical, buff + valIdx, (word32)valLen,
-                        dcrl->unknownExtCallbackExCtx);
+                else if (dcrl->unknownExtCallback != NULL ||
+                                 dcrl->unknownExtCallbackEx != NULL) {
+
+                    word16 decOid[MAX_OID_SZ];
+                    word32 decOidSz = MAX_OID_SZ;
+                    /* Redundant given the check above, but it makes
+                     * "the callback never sees uninitialized stack" true
+                     * by construction rather than by reasoning about
+                     * DecodeObjectId's internals. */
+                    XMEMSET(decOid, 0, sizeof(decOid));
+                    cbRet = DecodeObjectId(buff + oidContent, (word32)oidLen,
+                        decOid, &decOidSz);
+                    if (cbRet == 0 && dcrl->unknownExtCallback != NULL) {
+                        cbRet = dcrl->unknownExtCallback(decOid, decOidSz,
+                            critical, buff + valIdx, (word32)valLen);
+                    }
+                    if (cbRet == 0 && dcrl->unknownExtCallbackEx != NULL) {
+                        cbRet = dcrl->unknownExtCallbackEx(decOid, decOidSz,
+                            critical, buff + valIdx, (word32)valLen,
+                            dcrl->unknownExtCallbackExCtx);
+                    }
+                    if (cbRet != 0) {
+                        /* Must stay negative: BufferLoadCRL converts its result
+                         * with "ret ? ret : WOLFSSL_SUCCESS", so a positive
+                         * callback return would collide with
+                         * WOLFSSL_SUCCESS. */
+                        return (cbRet < 0) ? cbRet : ASN_PARSE_E;
+                    }
+                    handled = 1;
+
                 }
-                if (cbRet != 0) {
-                    /* Must stay negative: BufferLoadCRL converts its result
-                     * with "ret ? ret : WOLFSSL_SUCCESS", so a positive
-                     * callback return would collide with WOLFSSL_SUCCESS. */
-                    return (cbRet < 0) ? cbRet : ASN_PARSE_E;
-                }
-                handled = 1;
             }
 #endif
             if (!handled && critical) {
@@ -38511,24 +38625,60 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf, word32 idx,
                      * preserved. */
                     int handled = 0;
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-                    if (dcrl->unknownExtCallback != NULL ||
-                        dcrl->unknownExtCallbackEx != NULL) {
+                    if (dcrl->unknownExtCallback32Ex != NULL ||
+                            dcrl->unknownExtCallback32 != NULL) {
                         word32 decOid[MAX_OID_SZ];
                         word32 decOidSz = MAX_OID_SZ;
                         ret = DecodeObjectId32(
                             dataASN[CERTEXTASN_IDX_OID].data.oid.data,
                             dataASN[CERTEXTASN_IDX_OID].data.oid.length,
                             decOid, &decOidSz);
-                        if (ret == 0 && dcrl->unknownExtCallback != NULL) {
-                            ret = dcrl->unknownExtCallback(decOid, decOidSz,
-                                critical,
-                                dataASN[CERTEXTASN_IDX_VAL].data.buffer.data,
+                        if (ret == 0 &&
+                                dcrl->unknownExtCallback32 != NULL) {
+                            ret = dcrl->unknownExtCallback32(decOid, decOidSz,
+                                critical, dataASN[CERTEXTASN_IDX_VAL]
+                                .data.buffer.data,
                                 dataASN[CERTEXTASN_IDX_VAL].length);
                         }
-                        if (ret == 0 && dcrl->unknownExtCallbackEx != NULL) {
-                            ret = dcrl->unknownExtCallbackEx(decOid, decOidSz,
-                                critical,
-                                dataASN[CERTEXTASN_IDX_VAL].data.buffer.data,
+                        if (ret == 0 &&
+                                dcrl->unknownExtCallback32Ex != NULL) {
+                            ret = dcrl->unknownExtCallback32Ex(decOid,
+                                decOidSz, critical,
+                                dataASN[CERTEXTASN_IDX_VAL]
+                                .data.buffer.data,
+                                dataASN[CERTEXTASN_IDX_VAL].length,
+                                dcrl->unknownExtCallbackExCtx);
+                        }
+                        if (ret > 0) {
+                            /* Must stay negative: BufferLoadCRL converts its
+                             * result with "ret ? ret : WOLFSSL_SUCCESS", so a
+                             * positive callback return would collide with
+                             * WOLFSSL_SUCCESS. */
+                            ret = ASN_PARSE_E;
+                        }
+                        handled = 1;
+                    }
+                    else if (dcrl->unknownExtCallbackEx != NULL ||
+                             dcrl->unknownExtCallback != NULL) {
+                        word16 decOid[MAX_OID_SZ];
+                        word32 decOidSz = MAX_OID_SZ;
+                        ret = DecodeObjectId(
+                            dataASN[CERTEXTASN_IDX_OID].data.oid.data,
+                            dataASN[CERTEXTASN_IDX_OID].data.oid.length,
+                            decOid, &decOidSz);
+                        if (ret == 0 &&
+                                dcrl->unknownExtCallback != NULL) {
+                            ret = dcrl->unknownExtCallback(decOid, decOidSz,
+                                critical, dataASN[CERTEXTASN_IDX_VAL]
+                                .data.buffer.data,
+                                dataASN[CERTEXTASN_IDX_VAL].length);
+                        }
+                        if (ret == 0 &&
+                                dcrl->unknownExtCallbackEx != NULL) {
+                            ret = dcrl->unknownExtCallbackEx(decOid,
+                                decOidSz, critical,
+                                dataASN[CERTEXTASN_IDX_VAL]
+                                .data.buffer.data,
                                 dataASN[CERTEXTASN_IDX_VAL].length,
                                 dcrl->unknownExtCallbackExCtx);
                         }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7457,18 +7457,112 @@ static int CheckCurve(word32 oid)
  * @return  BAD_FUNC_ARG when in or outSz is NULL.
  * @return  BUFFER_E when buffer too small.
  */
-int wc_EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
+int wc_EncodeObjectId(const word32* in, word32 inSz,
+        byte* out, word32* outSz)
 {
-    return EncodeObjectId(in, inSz, out, outSz);
+    return EncodeObjectId_ex(in, inSz, out, outSz);
 }
 
-int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
+int EncodeObjectId_ex(const word32* in, word32 inSz,
+        byte* out, word32* outSz)
 {
     int i, x, len;
     word32 d, t;
 
     /* check args */
-    if (in == NULL || outSz == NULL || inSz <= 0) {
+    if (in == NULL || outSz == NULL || inSz < 2 || in[0] > 2) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* compute length of encoded OID */
+    d = ((word32)in[0] * 40) + in[1];
+    len = 0;
+    for (i = 1; i < (int)inSz; i++) {
+        x = 0;
+        t = d;
+        while (t) {
+            x++;
+            t >>= 1;
+        }
+        len += (x / 7) + ((x % 7) ? 1 : 0) + (d == 0 ? 1 : 0);
+
+        if (i < (int)inSz - 1) {
+            d = in[i + 1];
+        }
+    }
+
+    if (out) {
+        /* verify length */
+        if ((int)*outSz < len) {
+            return BUFFER_E; /* buffer provided is not large enough */
+        }
+
+        /* calc first byte */
+        d = ((word32)in[0] * 40) + in[1];
+
+        /* encode bytes */
+        x = 0;
+        for (i = 1; i < (int)inSz; i++) {
+            if (d) {
+                int y = x, z;
+                byte mask = 0;
+                while (d) {
+                    out[x++] = (byte)((d & 0x7F) | mask);
+                    d     >>= 7;
+                    mask  |= 0x80;  /* upper bit is set on all but the last byte */
+                }
+                /* now swap bytes y...x-1 */
+                z = x - 1;
+                while (y < z) {
+                    mask = out[y];
+                    out[y] = out[z];
+                    out[z] = mask;
+                    ++y;
+                    --z;
+                }
+            }
+            else {
+              out[x++] = 0x00; /* zero value */
+            }
+
+            /* next word */
+            if (i < (int)inSz - 1) {
+                d = in[i + 1];
+            }
+        }
+    }
+
+    /* return length */
+    *outSz = (word32)len;
+
+    return 0;
+}
+
+/* Encode dotted form of OID into byte array version.
+ *
+ * Uses word16 for OIDs and can cause OIDs to be truncated.
+ * Do not use this for new code unless necessary. (use wc_EncodeObjectId
+ * or EncodeObjectId_ex)
+ * We cannot change this function because FIPS code expects
+ * this signature.
+ *
+ * @param [in]      in     Dotted form of OID.
+ * @param [in]      inSz   Count of numbers in dotted form.
+ * @param [in]      out    Buffer to hold OID.
+ * @param [in, out] outSz  On in, size of buffer.
+ *                         On out, number of bytes in buffer.
+ * @return  0 on success
+ * @return  BAD_FUNC_ARG when in or outSz is NULL.
+ * @return  BUFFER_E when buffer too small.
+ */
+int EncodeObjectId(const word16* in, word32 inSz,
+        byte* out, word32* outSz)
+{
+    int i, x, len;
+    word32 d, t;
+
+    /* check args */
+    if (in == NULL || outSz == NULL || inSz < 2) {
         return BAD_FUNC_ARG;
     }
 
@@ -7549,7 +7643,8 @@ int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
  * @return  BAD_FUNC_ARG when in or outSz is NULL.
  * @return  BUFFER_E when dotted form buffer too small.
  */
-int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
+int DecodeObjectId(const byte* in, word32 inSz,
+        word16* out, word32* outSz)
 {
     int x = 0, y = 0;
     word32 t = 0;
@@ -7559,6 +7654,9 @@ int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
     if (in == NULL || outSz == NULL) {
         return BAD_FUNC_ARG;
     }
+
+    if (*outSz < 2)
+        return BUFFER_E;
 
     /* decode bytes */
     while (inSz--) {
@@ -7571,8 +7669,14 @@ int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
                 if ((int)*outSz < 2) {
                     return BUFFER_E;
                 }
-                out[0] = (word16)(t / 40);
-                out[1] = (word16)(t % 40);
+                if (t < 80) {
+                    out[0] = (word16)(t / 40);
+                    out[1] = (word16)(t % 40);
+                }
+                else {
+                    out[0] = 2;
+                    out[1] = (word16)(t - 80);
+                }
                 y = 2;
             }
             else {
@@ -7583,6 +7687,72 @@ int DecodeObjectId(const byte* in, word32 inSz, word16* out, word32* outSz)
             }
             t = 0; /* reset tmp */
             cnt = 0;
+        }
+        x++;
+    }
+
+    /* return length */
+    *outSz = (word32)y;
+
+    return 0;
+}
+
+/* Encode dotted form of OID into word32 array version.
+ *
+ * Same as DecodeObjectId() but outputs to a word32 array so that OID
+ * arc values larger than a word16 are not truncated.
+ *
+ * @param [in]      in     Byte array containing OID.
+ * @param [in]      inSz   Size of OID in bytes.
+ * @param [in]      out    Array to hold dotted form of OID.
+ * @param [in, out] outSz  On in, number of elements in array.
+ *                         On out, count of numbers in dotted form.
+ * @return  0 on success
+ * @return  BAD_FUNC_ARG when in or outSz is NULL.
+ * @return  BUFFER_E when dotted form buffer too small.
+ */
+int DecodeObjectId_ex(const byte* in, word32 inSz,
+        word32* out, word32* outSz)
+{
+    int x = 0, y = 0;
+    word32 t = 0;
+
+    /* check args */
+    if (in == NULL || outSz == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (*outSz < 2)
+        return BUFFER_E;
+
+    /* decode bytes */
+    while (inSz--) {
+        if (t > 0xFFFFFFFFU >> 7) {
+            return ASN_OBJECT_ID_E;
+        }
+        t = (t << 7) | (in[x] & 0x7F);
+        if (!(in[x] & 0x80)) {
+            if (y == 0) {
+                if ((int)*outSz < 2) {
+                    return BUFFER_E;
+                }
+                if (t < 80) {
+                    out[0] = t / 40;
+                    out[1] = t % 40;
+                }
+                else {
+                    out[0] = 2;
+                    out[1] = t - 80;
+                }
+                y = 2;
+            }
+            else {
+                if (y >= (int)*outSz) {
+                    return BUFFER_E;
+                }
+                out[y++] = t;
+            }
+            t = 0; /* reset tmp */
         }
         x++;
     }
@@ -7674,14 +7844,14 @@ static int DumpOID(const byte* oidData, word32 oidSz, word32 oid,
 
     #ifdef HAVE_OID_DECODING
     {
-        word16 decOid[MAX_OID_SZ];
+        word32 decOid[MAX_OID_SZ];
         word32 decOidSz = MAX_OID_SZ;
         /* Decode the OID into dotted form. */
-        ret = DecodeObjectId(oidData, oidSz, decOid, &decOidSz);
+        ret = DecodeObjectId_ex(oidData, oidSz, decOid, &decOidSz);
         if (ret == 0) {
-            printf("  Decoded (Sz %d): ", decOidSz);
+            printf("  Decoded (Sz %u): ", decOidSz);
             for (i=0; i<decOidSz; i++) {
-                printf("%d.", decOid[i]);
+                printf("%u.", decOid[i]);
             }
             printf("\n");
         }
@@ -13178,13 +13348,15 @@ static int SetCurve(ecc_key* key, byte* output, size_t outSz)
 #endif
     int idx;
     word32 oidSz = 0;
-
     /* validate key */
     if (key == NULL || key->dp == NULL) {
         return BAD_FUNC_ARG;
     }
 
 #ifdef HAVE_OID_ENCODING
+    /* ecc_oid_t cannot be changed due to it being in the FIPS boundary so we
+     * have a work around of upsizing its representation*/
+    /* Get the size of the encoded OID without having an encoded output */
     ret = EncodeObjectId(key->dp->oid, key->dp->oidSz, NULL, &oidSz);
     if (ret != 0) {
         return ret;
@@ -14861,7 +15033,7 @@ static int GenerateDNSEntryRIDString(DNS_entry* entry, void* heap)
     word32 tmpSize  = MAX_OID_SZ;
     word32 oid      = 0;
     word32 idx      = 0;
-    word16 tmpName[MAX_OID_SZ];
+    word32 tmpName[MAX_OID_SZ];
     char   oidName[MAX_OID_SZ];
     char*  finalName = NULL;
 
@@ -14887,9 +15059,8 @@ static int GenerateDNSEntryRIDString(DNS_entry* entry, void* heap)
     #endif
         {
             /* Decode OBJECT_ID into dotted form array. */
-            ret = DecodeObjectId((const byte*)(entry->name),(word32)entry->len,
-                    tmpName, &tmpSize);
-
+            ret = DecodeObjectId32((const byte*)(entry->name),
+                    (word32)entry->len, tmpName, &tmpSize);
             if (ret == 0) {
                 j = 0;
                 /* Append each number of dotted form. */
@@ -14900,14 +15071,14 @@ static int GenerateDNSEntryRIDString(DNS_entry* entry, void* heap)
 
                     if ((word32)i < tmpSize - 1) {
                         ret = XSNPRINTF(oidName + j, (word32)(MAX_OID_SZ - j),
-                            "%d.", tmpName[i]);
+                            "%u.", tmpName[i]);
                     }
                     else {
                         ret = XSNPRINTF(oidName + j, (word32)(MAX_OID_SZ - j),
-                            "%d", tmpName[i]);
+                            "%u", tmpName[i]);
                     }
 
-                    if (ret >= 0) {
+                    if (ret >= 0 && ret < MAX_OID_SZ - j) {
                         j += ret;
                     }
                     else {
@@ -22951,9 +23122,9 @@ static int DecodeCertExtensions(DecodedCert* cert)
 #ifdef WC_ASN_UNKNOWN_EXT_CB
             if (isUnknownExt && (cert->unknownExtCallback != NULL ||
                                  cert->unknownExtCallbackEx != NULL)) {
-                word16 decOid[MAX_OID_SZ];
+                word32 decOid[MAX_OID_SZ];
                 word32 decOidSz = MAX_OID_SZ;
-                ret = DecodeObjectId(
+                ret = DecodeObjectId_ex(
                           dataASN[CERTEXTASN_IDX_OID].data.oid.data,
                           dataASN[CERTEXTASN_IDX_OID].data.oid.length,
                           decOid, &decOidSz);
@@ -39791,64 +39962,6 @@ int wc_Asn1_SetOidToNameCb(Asn1* asn1, Asn1OidToNameCb nameCb)
     return ret;
 }
 
-/* Encode dotted form of OID into byte array version.
- *
- * @param [in]      in     Byte array containing OID.
- * @param [in]      inSz   Size of OID in bytes.
- * @param [in]      out    Array to hold dotted form of OID.
- * @param [in, out] outSz  On in, number of elements in array.
- *                         On out, count of numbers in dotted form.
- * @return  0 on success
- * @return  BAD_FUNC_ARG when in or outSz is NULL.
- * @return  BUFFER_E when dotted form buffer too small.
- */
-static int EncodedDottedForm(const byte* in, word32 inSz, word32* out,
-    word32* outSz)
-{
-    int x = 0, y = 0;
-    word32 t = 0;
-
-    /* check args */
-    if (in == NULL || outSz == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    if (*outSz < 2) {
-        return BUFFER_E;
-    }
-
-    /* decode bytes */
-    while (inSz--) {
-        t = (t << 7) | (in[x] & 0x7F);
-        if (!(in[x] & 0x80)) {
-            if (y >= (int)*outSz) {
-                return BUFFER_E;
-            }
-            if (y == 0) {
-                /* Special case for when first arc is 2 */
-                if (t < 80) {
-                    out[0] = t / 40;
-                    out[1] = t % 40;
-                }
-                else {
-                    out[0] = 2;
-                    out[1] = t - 80;
-                }
-                y = 2;
-            }
-            else {
-                out[y++] = t;
-            }
-            t = 0; /* reset tmp */
-        }
-        x++;
-    }
-
-    /* return length */
-    *outSz = (word32)y;
-
-    return 0;
-}
 /* Print OID in dotted form or as hex bytes.
  *
  * @param [in]  file        File pointer to write to.
@@ -39862,7 +39975,7 @@ static void PrintObjectIdNum(XFILE file, unsigned char* oid, word32 len)
     word32 i;
 
     /* Decode OBJECT_ID into dotted form array. */
-    if (EncodedDottedForm(oid, len, dotted_nums, &num) == 0) {
+    if (DecodeObjectId_ex(oid, len, dotted_nums, &num) == 0) {
         /* Print out each number of dotted form. */
         for (i = 0; i < num; i++) {
             XFPRINTF(file, "%d", dotted_nums[i]);

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -935,6 +935,14 @@ void wc_PKCS7_SetUnknownExtCallback(wc_PKCS7* pkcs7, wc_UnknownExtCallback cb)
         pkcs7->unknownExtCallback = cb;
     }
 }
+
+void wc_PKCS7_SetUnknownExtCallback32(wc_PKCS7* pkcs7,
+        wc_UnknownExtCallback32 cb)
+{
+    if (pkcs7 != NULL) {
+        pkcs7->unknownExtCallback32 = cb;
+    }
+}
 #endif
 
 /* Certificate structure holding der pointer, size, and pointer to next
@@ -1252,6 +1260,7 @@ int wc_PKCS7_InitWithCert(wc_PKCS7* pkcs7, byte* derCert, word32 derCertSz)
     Pkcs7Cert* lastCert;
 #ifdef WC_ASN_UNKNOWN_EXT_CB
     wc_UnknownExtCallback cb;
+    wc_UnknownExtCallback32 cb32;
 #endif
 
     if (pkcs7 == NULL || (derCert == NULL && derCertSz != 0)) {
@@ -1262,6 +1271,7 @@ int wc_PKCS7_InitWithCert(wc_PKCS7* pkcs7, byte* derCert, word32 derCertSz)
     devId = pkcs7->devId;
     cert = pkcs7->certList;
 #ifdef WC_ASN_UNKNOWN_EXT_CB
+    cb32 = pkcs7->unknownExtCallback32; /* save / restore callback */
     cb = pkcs7->unknownExtCallback; /* save / restore callback */
 #endif
     ret = wc_PKCS7_Init(pkcs7, heap, devId);
@@ -1269,6 +1279,7 @@ int wc_PKCS7_InitWithCert(wc_PKCS7* pkcs7, byte* derCert, word32 derCertSz)
         return ret;
 
 #ifdef WC_ASN_UNKNOWN_EXT_CB
+    pkcs7->unknownExtCallback32 = cb32;
     pkcs7->unknownExtCallback = cb;
 #endif
     pkcs7->certList = cert;
@@ -1318,8 +1329,13 @@ int wc_PKCS7_InitWithCert(wc_PKCS7* pkcs7, byte* derCert, word32 derCertSz)
 
         InitDecodedCert(dCert, derCert, derCertSz, pkcs7->heap);
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-        if (pkcs7->unknownExtCallback != NULL)
+        if (pkcs7->unknownExtCallback32 != NULL) {
+            wc_SetUnknownExtCallback32(dCert, pkcs7->unknownExtCallback32);
+        }
+
+        if (pkcs7->unknownExtCallback != NULL) {
             wc_SetUnknownExtCallback(dCert, pkcs7->unknownExtCallback);
+        }
 #endif
         ret = ParseCert(dCert, CA_TYPE, NO_VERIFY, 0);
         if (ret < 0) {
@@ -5453,8 +5469,13 @@ static int wc_PKCS7_EcdsaVerify(wc_PKCS7* pkcs7, byte* sig, int sigSz,
         /* This allows the user to not error out in the case of extensions that
          * we are not aware of. */
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-        if (pkcs7->unknownExtCallback != NULL)
+        if (pkcs7->unknownExtCallback32 != NULL) {
+            wc_SetUnknownExtCallback32(dCert, pkcs7->unknownExtCallback32);
+        }
+
+        if (pkcs7->unknownExtCallback != NULL) {
             wc_SetUnknownExtCallback(dCert, pkcs7->unknownExtCallback);
+        }
 #endif
 
         /* not verifying, only using this to extract public key */
@@ -5591,8 +5612,13 @@ static int wc_PKCS7_MlDsaVerify(wc_PKCS7* pkcs7, byte* sig, int sigSz,
         InitDecodedCert(dCert, pkcs7->cert[i], pkcs7->certSz[i], pkcs7->heap);
 
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-        if (pkcs7->unknownExtCallback != NULL)
+        if (pkcs7->unknownExtCallback32 != NULL) {
+            wc_SetUnknownExtCallback32(dCert, pkcs7->unknownExtCallback32);
+        }
+
+        if (pkcs7->unknownExtCallback != NULL) {
             wc_SetUnknownExtCallback(dCert, pkcs7->unknownExtCallback);
+        }
 #endif
 
         /* not verifying, only using this to extract public key */

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -1383,7 +1383,7 @@ static int Pkcs11EccSetParams(ecc_key* key, CK_ATTRIBUTE* tmpl, int idx)
         unsigned char* derParams = tmpl[idx].pValue;
     #if defined(HAVE_OID_ENCODING)
         word32 oidSz = ECC_MAX_OID_LEN - 2;
-        ret = wc_EncodeObjectId(key->dp->oid, key->dp->oidSz, derParams+2, &oidSz);
+        ret = EncodeObjectId(key->dp->oid, key->dp->oidSz, derParams+2, &oidSz);
         if (ret != 0) {
             return ret;
         }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2819,11 +2819,15 @@ struct WOLFSSL_CERT_MANAGER {
     short           minMlDsaKeySz;      /* minimum allowed ML-DSA key size */
 #endif
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-    wc_UnknownExtCallback unknownExtCallback;
+    wc_UnknownExtCallback     unknownExtCallback;
+    wc_UnknownExtCallback32   unknownExtCallback32;
 #if defined(HAVE_CRL)
-    wc_UnknownExtCallback   crlUnknownExtCallback;
-    wc_UnknownExtCallbackEx crlUnknownExtCallbackEx;
-    void*                   crlUnknownExtCallbackExCtx;
+    wc_UnknownExtCallback     crlUnknownExtCallback;
+    wc_UnknownExtCallback32   crlUnknownExtCallback32;
+    wc_UnknownExtCallbackEx   crlUnknownExtCallbackEx;
+    wc_UnknownExtCallback32Ex crlUnknownExtCallback32Ex;
+    /* Shared by crlUnknownExtCallbackEx and crlUnknownExtCallback32Ex. */
+    void*                     crlUnknownExtCallbackExCtx;
 #endif
 #endif
 #ifdef HAVE_CRL_UPDATE_CB

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4525,9 +4525,20 @@ WOLFSSL_API void wolfSSL_CTX_SetPerformTlsRecordProcessingCb(WOLFSSL_CTX* ctx,
     WOLFSSL_API int wolfSSL_CertManager_up_ref(WOLFSSL_CERT_MANAGER* cm);
 
 #ifdef WC_ASN_UNKNOWN_EXT_CB
+    /* Register a callback invoked for each certificate extension whose OID
+     * the parser does not recognize.  Returning 0 accepts the extension; a
+     * non-zero return rejects the certificate.
+     *
+     * The word16 form truncates OID arcs with values > 65535; the ...32 form
+     * receives every arc untruncated and should be preferred in new code.
+     * A registered word32 callback takes precedence: when both are set on the
+     * same cert manager only the word32 callback is invoked. */
     WOLFSSL_API void wolfSSL_CertManagerSetUnknownExtCallback(
         WOLFSSL_CERT_MANAGER* cm,
         wc_UnknownExtCallback cb);
+    WOLFSSL_API void wolfSSL_CertManagerSetUnknownExtCallback32(
+        WOLFSSL_CERT_MANAGER* cm,
+        wc_UnknownExtCallback32 cb);
 #if defined(HAVE_CRL)
     /* Register a callback invoked for each CRL extension (CRL-level and
      * revoked-entry) whose OID the parser does not recognize, critical or
@@ -4544,6 +4555,27 @@ WOLFSSL_API void wolfSSL_CTX_SetPerformTlsRecordProcessingCb(WOLFSSL_CTX* ctx,
     WOLFSSL_API int wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(
         WOLFSSL_CERT_MANAGER* cm,
         wc_UnknownExtCallbackEx cb,
+        void* ctx);
+
+    /* word32 forms of the two registration calls above.  Each OID arc is
+     * passed to the callback as a word32, so arcs with values > 65535 are
+     * not truncated; prefer these in new code.
+     *
+     * A registered word32 callback takes precedence: when both a word16 and
+     * a word32 CRL callback are set on the same cert manager, only the word32
+     * callback is invoked.
+     *
+     * The Ex variants share one context slot with
+     * wolfSSL_CertManagerSetCRLUnknownExtCallbackEx(), so registering one
+     * overwrites the context registered by the other.
+     *
+     * Both return WOLFSSL_SUCCESS, or BAD_FUNC_ARG when cm is NULL. */
+    WOLFSSL_API int wolfSSL_CertManagerSetCRLUnknownExtCallback32(
+        WOLFSSL_CERT_MANAGER* cm,
+        wc_UnknownExtCallback32 cb);
+    WOLFSSL_API int wolfSSL_CertManagerSetCRLUnknownExtCallback32Ex(
+        WOLFSSL_CERT_MANAGER* cm,
+        wc_UnknownExtCallback32Ex cb,
         void* ctx);
 #endif
 #endif

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2471,7 +2471,7 @@ typedef enum MimeStatus
     #if defined(HAVE_OID_DECODING) || defined(WOLFSSL_ASN_PRINT) || \
         defined(OPENSSL_ALL)
         #define DecodeObjectId wc_DecodeObjectId
-        #define DecodeObjectId_ex wc_DecodeObjectId_ex
+        #define DecodeObjectId32 wc_DecodeObjectId32
     #endif
     #if defined(WOLFSSL_AKID_NAME) && !defined(GetCAByAKID)
         /* GetCAByAKID() has two implementations, a full implementation in
@@ -2716,9 +2716,9 @@ WOLFSSL_ASN_API int GetASNInt(const byte* input, word32* inOutIdx, int* len,
 WOLFSSL_LOCAL word32 wc_oid_sum(const byte* input, int length);
 
 #ifdef HAVE_OID_ENCODING
-    WOLFSSL_API int wc_EncodeObjectId(const word32* in, word32 inSz,
+    WOLFSSL_API int wc_EncodeObjectId(const word16* in, word32 inSz,
         byte* out, word32* outSz);
-    WOLFSSL_LOCAL int EncodeObjectId_ex(const word32* in, word32 inSz,
+    WOLFSSL_API int wc_EncodeObjectId32(const word32* in, word32 inSz,
         byte* out, word32* outSz);
     /* Unchangeable due to being called from FIPS code expecting word16 in */
     WOLFSSL_LOCAL int EncodeObjectId(const word16* in, word32 inSz,
@@ -2729,7 +2729,7 @@ WOLFSSL_LOCAL word32 wc_oid_sum(const byte* input, int length);
     /* Unchangeable due to being called from FIPS code expecting word16 out */
     WOLFSSL_TEST_VIS int DecodeObjectId(const byte* in, word32 inSz,
         word16* out, word32* outSz);
-    WOLFSSL_TEST_VIS int DecodeObjectId_ex(const byte* in, word32 inSz,
+    WOLFSSL_TEST_VIS int DecodeObjectId32(const byte* in, word32 inSz,
         word32* out, word32* outSz);
 #endif
 WOLFSSL_LOCAL int GetASNObjectId(const byte* input, word32* inOutIdx, int* len,

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1850,13 +1850,12 @@ typedef struct WOLFSSL_AIA_ENTRY {
     word32      uriSz;  /* Length of URI data. */
 } WOLFSSL_AIA_ENTRY;
 #endif /* WOLFSSL_AIA_ENTRY_DEFINED */
-
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-typedef int (*wc_UnknownExtCallback)(const word16* oid, word32 oidSz, int crit,
-                                     const unsigned char* der, word32 derSz);
-typedef int (*wc_UnknownExtCallbackEx)(const word16* oid, word32 oidSz,
-                                       int crit, const unsigned char* der,
-                                       word32 derSz, void *ctx);
+    typedef int (*wc_UnknownExtCallback)(const word32* oid, word32 oidSz,
+                            int crit, const unsigned char* der, word32 derSz);
+    typedef int (*wc_UnknownExtCallbackEx)(const word32* oid, word32 oidSz,
+                                           int crit, const unsigned char* der,
+                                           word32 derSz, void *ctx);
 #endif
 
 struct DecodedCert {
@@ -2472,6 +2471,7 @@ typedef enum MimeStatus
     #if defined(HAVE_OID_DECODING) || defined(WOLFSSL_ASN_PRINT) || \
         defined(OPENSSL_ALL)
         #define DecodeObjectId wc_DecodeObjectId
+        #define DecodeObjectId_ex wc_DecodeObjectId_ex
     #endif
     #if defined(WOLFSSL_AKID_NAME) && !defined(GetCAByAKID)
         /* GetCAByAKID() has two implementations, a full implementation in
@@ -2716,15 +2716,21 @@ WOLFSSL_ASN_API int GetASNInt(const byte* input, word32* inOutIdx, int* len,
 WOLFSSL_LOCAL word32 wc_oid_sum(const byte* input, int length);
 
 #ifdef HAVE_OID_ENCODING
-    WOLFSSL_API int wc_EncodeObjectId(const word16* in, word32 inSz,
+    WOLFSSL_API int wc_EncodeObjectId(const word32* in, word32 inSz,
         byte* out, word32* outSz);
+    WOLFSSL_LOCAL int EncodeObjectId_ex(const word32* in, word32 inSz,
+        byte* out, word32* outSz);
+    /* Unchangeable due to being called from FIPS code expecting word16 in */
     WOLFSSL_LOCAL int EncodeObjectId(const word16* in, word32 inSz,
         byte* out, word32* outSz);
 #endif
 #if defined(HAVE_OID_DECODING) || defined(WOLFSSL_ASN_PRINT) || \
     defined(OPENSSL_ALL)
+    /* Unchangeable due to being called from FIPS code expecting word16 out */
     WOLFSSL_TEST_VIS int DecodeObjectId(const byte* in, word32 inSz,
         word16* out, word32* outSz);
+    WOLFSSL_TEST_VIS int DecodeObjectId_ex(const byte* in, word32 inSz,
+        word32* out, word32* outSz);
 #endif
 WOLFSSL_LOCAL int GetASNObjectId(const byte* input, word32* inOutIdx, int* len,
                                  word32 maxIdx);

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1850,12 +1850,25 @@ typedef struct WOLFSSL_AIA_ENTRY {
     word32      uriSz;  /* Length of URI data. */
 } WOLFSSL_AIA_ENTRY;
 #endif /* WOLFSSL_AIA_ENTRY_DEFINED */
+
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-    typedef int (*wc_UnknownExtCallback)(const word32* oid, word32 oidSz,
-                            int crit, const unsigned char* der, word32 derSz);
-    typedef int (*wc_UnknownExtCallbackEx)(const word32* oid, word32 oidSz,
-                                           int crit, const unsigned char* der,
-                                           word32 derSz, void *ctx);
+/* Unknown extension callbacks.  The word16 forms truncate OID arcs with
+ * values > 65535; the ...32 forms receive every arc untruncated and should be
+ * preferred in new code.  When both a word16 and a word32 callback are
+ * registered on the same object, only the word32 callback is invoked.  The
+ * two Ex forms share a single context slot, so registering one overwrites the
+ * context registered by the other. */
+typedef int (*wc_UnknownExtCallback)(const word16* oid, word32 oidSz, int crit,
+                                     const unsigned char* der, word32 derSz);
+typedef int (*wc_UnknownExtCallbackEx)(const word16* oid, word32 oidSz,
+                                       int crit, const unsigned char* der,
+                                       word32 derSz, void *ctx);
+typedef int (*wc_UnknownExtCallback32)(const word32* oid, word32 oidSz,
+                                       int crit, const unsigned char* der,
+                                       word32 derSz);
+typedef int (*wc_UnknownExtCallback32Ex)(const word32* oid, word32 oidSz,
+                                         int crit, const unsigned char* der,
+                                         word32 derSz, void *ctx);
 #endif
 
 struct DecodedCert {
@@ -2233,9 +2246,11 @@ struct DecodedCert {
                                          * TRUSTED CERTIFICATE auxiliary trust
                                          * info. */
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-    wc_UnknownExtCallback unknownExtCallback;
-    wc_UnknownExtCallbackEx unknownExtCallbackEx;
-    void *unknownExtCallbackExCtx;
+    wc_UnknownExtCallback     unknownExtCallback;
+    wc_UnknownExtCallback32   unknownExtCallback32;
+    wc_UnknownExtCallbackEx   unknownExtCallbackEx;
+    wc_UnknownExtCallback32Ex unknownExtCallback32Ex;
+    void*                     unknownExtCallbackExCtx;
 #endif
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     /* Subject Alternative Public Key Info */
@@ -2527,6 +2542,11 @@ WOLFSSL_API int wc_SetUnknownExtCallback(DecodedCert* cert,
                                              wc_UnknownExtCallback cb);
 WOLFSSL_API int wc_SetUnknownExtCallbackEx(DecodedCert* cert,
                                                wc_UnknownExtCallbackEx cb,
+                                               void *ctx);
+WOLFSSL_API int wc_SetUnknownExtCallback32(DecodedCert* cert,
+                                             wc_UnknownExtCallback32 cb);
+WOLFSSL_API int wc_SetUnknownExtCallback32Ex(DecodedCert* cert,
+                                               wc_UnknownExtCallback32Ex cb,
                                                void *ctx);
 #endif
 
@@ -3283,9 +3303,11 @@ struct DecodedCRL {
 #endif
     WC_BITFIELD crlNumberSet:1;          /* CRL number set indicator */
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-    wc_UnknownExtCallback   unknownExtCallback;
-    wc_UnknownExtCallbackEx unknownExtCallbackEx;
-    void*                   unknownExtCallbackExCtx;
+    wc_UnknownExtCallback     unknownExtCallback;
+    wc_UnknownExtCallback32   unknownExtCallback32;
+    wc_UnknownExtCallbackEx   unknownExtCallbackEx;
+    wc_UnknownExtCallback32Ex unknownExtCallback32Ex;
+    void*                     unknownExtCallbackExCtx;
 #endif
 };
 

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -375,7 +375,10 @@ struct wc_PKCS7 {
     word32 pkcs7DigestSz;
 
 #ifdef WC_ASN_UNKNOWN_EXT_CB
-    wc_UnknownExtCallback unknownExtCallback;
+    /* The word32 callback receives untruncated OID arcs, so it takes
+     * precedence: when both are set only unknownExtCallback32 is invoked. */
+    wc_UnknownExtCallback   unknownExtCallback;
+    wc_UnknownExtCallback32 unknownExtCallback32;
 #endif
 
 #if defined(HAVE_PKCS7_RSA_RAW_SIGN_CALLBACK) && !defined(NO_RSA)
@@ -430,6 +433,8 @@ WOLFSSL_API wc_PKCS7* wc_PKCS7_New(void* heap, int devId);
 #ifdef WC_ASN_UNKNOWN_EXT_CB
     WOLFSSL_API void wc_PKCS7_SetUnknownExtCallback(wc_PKCS7* pkcs7,
         wc_UnknownExtCallback cb);
+    WOLFSSL_API void wc_PKCS7_SetUnknownExtCallback32(wc_PKCS7* pkcs7,
+        wc_UnknownExtCallback32 cb);
 #endif
 WOLFSSL_API int  wc_PKCS7_Init(wc_PKCS7* pkcs7, void* heap, int devId);
 WOLFSSL_API int  wc_PKCS7_InitWithCert(wc_PKCS7* pkcs7, byte* der, word32 derSz);


### PR DESCRIPTION
# Description
This fixes two issues in how OIDs are represented in wolfSSL.
Breaking change.  Word16 cannot represent many real OID arcs -- e.g. 1.2.840.113549.1.1.1 (RSA encryption). This was widened to word 32 in three public symbols:

- Two callback types: wc_UnknownExtCallback and wc_UnknownExtCallbackEx
- One function: wc_EncodeObjectId

The callback types appear as fields in WOLFSSL_CERT_MANAGER, wc_PKCS7, and DecodedCert.

New internal functions were added to handle this change EncodeObjectId_ex and DecodeObjectId_ex both handle
word32 OIDs. The non _ex functions were left due to them being called by FIPS code and that code expects word16.

Non-breaking bug fix. DER encoding packs the first two arcs into a single value (40 x first + second), so decoding assumed the second arc was 0-39. That assumption holds only when the first arc is 0 or 1; when the first arc is 2, the second arc is unbounded and base-128 encodes to a value above 127. Decoding now special-cases this.



Example -- 2.100.3:
encodes -> 0x81, 0x34, 0x03
before:  decoded as 4.20.3   (0x81,0x34 unpacked to 180; 180/40=4 rem 20)
after:   decodes as 2.100.3

# Testing
Added tests for DecodeObjectId and EncodeObjectId covering word32 OIDs, plus a test for an OID whose first arc is 2 and second arc is 100, verifying correct decoding of the byte form.

# Checklist

- [x] added tests
- [x] updated/added doxygen
- [x] updated appropriate READMEs
- [x] updated manual and documentation


