### PR TITLE
Address possible UAF in BufferLoadCRL

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -70,7 +70,6 @@ int InitCRL(WOLFSSL_CRL* crl, WOLFSSL_CERT_MANAGER* cm)
         crl->heap = NULL;
     crl->cm = cm;
     crl->crlList  = NULL;
-    crl->currentEntry = NULL;
 #ifdef HAVE_CRL_MONITOR
     crl->monitors[0].path = NULL;
     crl->monitors[1].path = NULL;
@@ -364,8 +363,6 @@ void FreeCRL(WOLFSSL_CRL* crl, int dynamic)
         crl->revokedStack = NULL;
     }
 #endif
-    XFREE(crl->currentEntry, crl->heap, DYNAMIC_TYPE_CRL_ENTRY);
-    crl->currentEntry = NULL;
     while(tmp) {
         CRL_Entry* next = tmp->next;
         CRL_Entry_free(tmp, crl->heap);
@@ -845,6 +842,7 @@ int BufferLoadCRL(WOLFSSL_CRL* crl, const byte* buff, long sz, int type,
     int          ret = WOLFSSL_SUCCESS;
     const byte*  myBuffer = buff;    /* if DER ok, otherwise switch */
     DerBuffer*   der = NULL;
+    CRL_Entry*   currentEntry = NULL;
     WC_DECLARE_VAR(dcrl, DecodedCRL, 1, 0);
 
     WOLFSSL_ENTER("BufferLoadCRL");
@@ -877,8 +875,8 @@ int BufferLoadCRL(WOLFSSL_CRL* crl, const byte* buff, long sz, int type,
     }
 #endif
 
-    crl->currentEntry = CRL_Entry_new(crl->heap);
-    if (crl->currentEntry == NULL) {
+    currentEntry = CRL_Entry_new(crl->heap);
+    if (currentEntry == NULL) {
         WOLFSSL_MSG_CERT_LOG("alloc CRL Entry failed");
         WC_FREE_VAR_EX(dcrl, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         FreeDer(&der);
@@ -886,25 +884,23 @@ int BufferLoadCRL(WOLFSSL_CRL* crl, const byte* buff, long sz, int type,
     }
 
     InitDecodedCRL(dcrl, crl->heap);
-    ret = ParseCRL(crl->currentEntry->certs, dcrl, myBuffer, (word32)sz,
+    ret = ParseCRL(currentEntry->certs, dcrl, myBuffer, (word32)sz,
                    verify, crl->cm);
 
     if (ret != 0 && !(ret == WC_NO_ERR_TRACE(ASN_CRL_NO_SIGNER_E)
                       && verify == NO_VERIFY)) {
         WOLFSSL_MSG_CERT_LOG("ParseCRL error");
         WOLFSSL_MSG_CERT_EX("ParseCRL verify = %d, ret = %d", verify, ret);
-        CRL_Entry_free(crl->currentEntry, crl->heap);
-        crl->currentEntry = NULL;
+        CRL_Entry_free(currentEntry, crl->heap);
     }
     else {
-        ret = AddCRL(crl, dcrl, crl->currentEntry, myBuffer,
+        ret = AddCRL(crl, dcrl, currentEntry, myBuffer,
                      ret != WC_NO_ERR_TRACE(ASN_CRL_NO_SIGNER_E));
         if (ret != 0) {
             WOLFSSL_MSG_CERT_LOG("AddCRL error");
-            CRL_Entry_free(crl->currentEntry, crl->heap);
+            CRL_Entry_free(currentEntry, crl->heap);
         }
         /* Entry now is in the list, or has been freed due to error */
-        crl->currentEntry = NULL;
     }
 
     FreeDecodedCRL(dcrl);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2595,7 +2595,6 @@ typedef HANDLE wolfSSL_CRL_mfd_t; /* monitor fd, INVALID_HANDLE_VALUE if
 /* wolfSSL CRL controller */
 struct WOLFSSL_CRL {
     WOLFSSL_CERT_MANAGER* cm;            /* pointer back to cert manager */
-    CRL_Entry*            currentEntry;  /* Current CRL entry being processed */
     CRL_Entry*            crlList;       /* our CRL list */
 #ifdef HAVE_CRL_IO
     CbCrlIO               crlIOCb;


### PR DESCRIPTION
# Description

Fix a reentrancy issue with a shared object, only in an atypical use case of concurrent CRL loads with one shared `CertManager`

Fixes `crl-load-race-uaf` in zd 21992

# Testing

No test added due to the non-deterministic nature of the failure. Multithreaded test could silently pass, or fail in an unrepeatable way, at random.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
