### PR TITLE
fix: add debian/copyright.commercial for commercial .deb builds

### DIFF
--- a/debian/copyright.commercial
+++ b/debian/copyright.commercial
@@ -1,0 +1,243 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: wolfssl
+Upstream-Contact: licensing@wolfssl.com
+Source: https://www.wolfssl.com
+
+Files:
+ *
+Copyright:
+ 2006-2026 wolfSSL Inc.
+License: wolfSSL-Commercial
+Comment:
+ Contact wolfSSL with licensing, usage, or support questions:
+ licensing@wolfssl.com or support@wolfssl.com.
+
+Files:
+ wolfcrypt/src/camellia.c
+ wolfssl/wolfcrypt/camellia.h
+Copyright:
+ 2006-2007 NTT (Nippon Telegraph and Telephone Corporation)
+License: NTT-BSD-2-Clause
+
+Files:
+ wolfcrypt/src/blake2b.c
+ wolfcrypt/src/blake2s.c
+Copyright:
+ 2012 Samuel Neves <sneves@dei.uc.pt>
+License: CC0-1.0
+
+Files:
+ zephyr/Kconfig
+Copyright:
+ 2016 Intel Corporation
+License: Apache-2.0
+
+Files:
+ zephyr/Kconfig.tls-generic
+Copyright:
+ 2018 Intel Corporation
+ 2018 Nordic Semiconductor ASA
+License: Apache-2.0
+
+Files:
+ m4/ax_append_link_flags.m4
+Copyright:
+ 2011 Maarten Bosmans <mkbosmans@gmail.com>
+License: GPL-3+-with-autoconf
+
+Files:
+ m4/ax_pthread.m4
+Copyright:
+ 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+ 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+License: GPL-3+-with-autoconf
+
+Files:
+ m4/ax_check_library.m4
+Copyright:
+ 2012 Brian Aker <brian@tangent.org>
+ 2010 Diego Elio Petteno` <flameeyes@gmail.com>
+License: GPL-3+-with-autoconf
+
+Files:
+ m4/ax_append_flag.m4
+ m4/ax_check_compile_flag.m4
+ m4/ax_check_link_flag.m4
+Copyright:
+ 2008 Guido U. Draheim <guidod@gmx.de>
+ 2011 Maarten Bosmans <mkbosmans@gmail.com>
+License: GPL-3+-with-autoconf
+
+Files:
+ m4/ax_append_compile_flags.m4
+Copyright:
+ 2011 Maarten Bosmans <mkbosmans@gmail.com>
+License: GPL-3+-with-autoconf
+
+Files:
+ m4/ax_tls.m4
+Copyright:
+ 2008 Alan Woodland <ajw05@aber.ac.uk>
+ 2010 Diego Elio Petteno` <flameeyes@gmail.com>
+License: GPL-3+-with-autoconf
+
+Files:
+ m4/ax_create_generic_config.m4
+Copyright:
+ 2008 Guido U. Draheim <guidod@gmx.de>
+License: GPL-3+-with-autoconf
+
+Files:
+ m4/ax_compiler_version.m4
+ m4/ax_debug.m4
+ m4/ax_harden_compiler_flags.m4
+ m4/ax_vcs_checkout.m4
+Copyright:
+ 2012 Brian Aker
+License: BSD-3-Clause
+
+Files:
+ m4/ax_append_to_file.m4
+ m4/ax_file_escapes.m4
+ m4/ax_print_to_file.m4
+Copyright:
+ 2008 Tom Howard <tomhoward@users.sf.net>
+License: FSFAP
+
+Files:
+ m4/ax_add_am_macro.m4
+ m4/ax_am_macros.m4
+Copyright:
+ 2009 Tom Howard <tomhoward@users.sf.net>
+License: FSFAP
+
+Files:
+ m4/ax_am_jobserver.m4
+Copyright:
+ 2008 Michael Paul Bailey <jinxidoru@byu.net>
+License: FSFAP
+
+Files:
+ m4/ax_count_cpus.m4
+Copyright:
+ 2012 Brian Aker <brian@tangent.org>
+ 2008 Michael Paul Bailey <jinxidoru@byu.net>
+ 2008 Christophe Tournayre <turn3r@users.sourceforge.net>
+License: FSFAP
+
+Files:
+ m4/visibility.m4
+Copyright:
+ 2005, 2008, 2010-2018 Free Software Foundation, Inc.
+License: FSFAP
+
+Files:
+ debian/*
+Copyright:
+ 2014-2022 Felix Lechner <felix.lechner@lease-up.com>
+ 2024-2026 wolfSSL Inc.
+License: wolfSSL-Commercial
+
+
+License: wolfSSL-Commercial
+ Copyright (C) 2006-2026 wolfSSL Inc.  All rights reserved.
+ .
+ This software is provided under a commercial license agreement with
+ wolfSSL Inc.  Use, modification, and distribution of this software are
+ governed by the terms of the applicable wolfSSL commercial license
+ agreement.  No part of this software may be copied, modified, or
+ distributed except in accordance with that agreement.
+ .
+ Contact licensing@wolfssl.com with any questions or comments.
+ .
+ wolfSSL Inc.
+ 10016 Edmonds Way, Suite C-300
+ Edmonds, WA 98020
+ USA
+ .
+ https://www.wolfssl.com
+
+License: NTT-BSD-2-Clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer as
+    the first lines of this file unmodified.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY NTT ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL NTT BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: CC0-1.0
+ To the extent possible under law, the author(s) have dedicated all copyright
+ and related and neighboring rights to this software to the public domain
+ worldwide. This software is distributed without any warranty.
+ .
+ On Debian systems, the complete text of the CC0 1.0 Universal license
+ can be found in "/usr/share/common-licenses/CC0-1.0".
+
+License: Apache-2.0
+ On Debian systems, the complete text of the Apache License version 2.0
+ can be found in "/usr/share/common-licenses/Apache-2.0".
+
+License: GPL-3+-with-autoconf
+ This program is free software; you can redistribute it and/or modify it
+ under the terms of the GNU General Public License as published by the
+ Free Software Foundation; either version 3 of the License, or (at your
+ option) any later version.
+ .
+ As a special exception, the respective Autoconf Macro's copyright owner
+ gives unlimited permission to copy, distribute and modify the configure
+ scripts that are the output of Autoconf when processing the Macro. You
+ need not follow the terms of the GNU General Public License when using
+ or distributing such scripts, even though portions of the text of the
+ Macro appear in them.
+ .
+ On Debian systems, the complete text of the GNU General Public License
+ version 3 can be found in "/usr/share/common-licenses/GPL-3".
+
+License: BSD-3-Clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ .
+     * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ .
+     * Redistributions in binary form must reproduce the above
+ copyright notice, this list of conditions and the following disclaimer
+ in the documentation and/or other materials provided with the
+ distribution.
+ .
+     * The names of its contributors may not be used to endorse or
+ promote products derived from this software without specific prior
+ written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: FSFAP
+ Copying and distribution of this file, with or without modification, are
+ permitted in any medium without royalty provided the copyright notice
+ and this notice are preserved. This file is offered as-is, without any
+ warranty.

--- a/debian/copyright.commercial
+++ b/debian/copyright.commercial
@@ -17,6 +17,7 @@ Files:
  wolfssl/wolfcrypt/camellia.h
 Copyright:
  2006-2007 NTT (Nippon Telegraph and Telephone Corporation)
+ 2006-2026 wolfSSL Inc.
 License: NTT-BSD-2-Clause
 
 Files:

--- a/rpm/spec.in.commercial
+++ b/rpm/spec.in.commercial
@@ -1,0 +1,177 @@
+Summary: Embedded SSL Library
+Name: @PACKAGE@
+Version: @VERSION@
+Release: 1
+License: LicenseRef-wolfSSL-Commercial
+Group: System Environment/Libraries
+BuildRequires: gcc
+BuildRequires: glibc
+BuildRequires: glibc-common
+BuildRequires: glibc-devel
+BuildRequires: glibc-headers
+BuildRequires: make
+BuildRequires: pkgconfig
+BuildRequires: sed
+BuildRequires: tar
+%if 0%{?rhel} == 10
+BuildRequires: gcc-toolset-15 gcc-toolset-15-gcc-plugin-annobin
+%endif
+URL: http://www.wolfssl.com/
+
+Packager: wolfSSL <support@wolfssl.com>
+
+Source: http://wolfssl.com/%{name}-%{version}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+
+%description
+wolfSSL embedded SSL/TLS library — commercial license.
+
+Contact wolfSSL with licensing, usage, or support questions:
+licensing@wolfssl.com or support@wolfssl.com.
+
+%package devel
+Summary: Header files and development libraries for %{name}
+Group: Development/Libraries
+Requires: %{name} = %{version}-%{release}
+
+%description devel
+This package contains the header files and development libraries
+for %{name}. If you like to develop programs using %{name},
+you will need to install %{name}-devel.
+
+%prep
+%setup -q
+
+%build
+%if 0%{?rhel} == 10
+source /usr/lib/gcc-toolset/15-env.source
+%endif
+%configure @WOLFSSL_CONFIG_ARGS@
+%{__make} %{?_smp_mflags}
+if [ "@ENABLED_FIPS@" = "yes" ]
+then
+echo Updating wolfSSL FIPS hash
+./fips-hash.sh
+%{__make} %{?_smp_mflags}
+fi
+
+%install
+%{__rm} -rf %{buildroot}
+%{__make} install  DESTDIR="%{buildroot}" AM_INSTALL_PROGRAM_FLAGS=""
+%{__rm} -f %{buildroot}/%{_libdir}/libwolfssl@LIBSUFFIX@.la
+%{__rm} -f %{buildroot}/%{_libdir}/libwolfssl.a
+%{__cp} wolfssl/options.h %{buildroot}/%{_includedir}/%{name}/
+
+%check
+
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(-,root,root,-)
+%doc AUTHORS ChangeLog.md COPYING README README.md
+%{_docdir}/wolfssl/taoCert.txt
+%{_docdir}/wolfssl/example/client.c
+%{_docdir}/wolfssl/example/server.c
+%{_docdir}/wolfssl/example/echoclient.c
+%{_docdir}/wolfssl/example/echoserver.c
+%{_docdir}/wolfssl/example/ocsp_responder.c
+%{_docdir}/wolfssl/example/sctp-client.c
+%{_docdir}/wolfssl/example/sctp-server.c
+%{_docdir}/wolfssl/example/sctp-client-dtls.c
+%{_docdir}/wolfssl/example/sctp-server-dtls.c
+%{_docdir}/wolfssl/example/tls_bench.c
+%{_docdir}/wolfssl/example/ocsp_responder.c
+%{_docdir}/wolfssl/README.txt
+%{_docdir}/wolfssl/QUIC.md
+%{_libdir}/libwolfssl@LIBSUFFIX@.so.*
+%{_libdir}/cmake/wolfssl/wolfssl-config-version.cmake
+%{_libdir}/cmake/wolfssl/wolfssl-config.cmake
+%{_libdir}/cmake/wolfssl/wolfssl-targets.cmake
+
+%files devel
+%defattr(-,root,root,-)
+%doc AUTHORS ChangeLog.md COPYING README README.md
+%{_bindir}/wolfssl-config
+%{_includedir}/wolfssl/*.h
+%{_includedir}/wolfssl/wolfcrypt/*.h
+%{_includedir}/wolfssl/openssl/*.h
+%{_libdir}/pkgconfig/wolfssl.pc
+%{_libdir}/libwolfssl@LIBSUFFIX@.so
+%{_libdir}/cmake/wolfssl
+
+%changelog
+* Mon Oct 17 2022 Juliusz Sosinowicz <juliusz@wolfssl.com>
+- Updates for building FIPS packages and general maintenance
+* Tue Sep 27 2022 Jacob Barthelmeh <jacob@wolfssl.com>
+- Add include of kyber headers
+* Tue Aug 30 2022 Jacob Barthelmeh <jacob@wolfssl.com>
+- Add include of QUIC documentation
+* Wed Jul 20 2022 Anthony Hu <anthony@wolfssl.com>
+- Add a new header dilithium.h.
+* Fri Jul 8 2022 Jacob Barthelmeh <jacob@wolfssl.com>
+- Add missing sp_int.h file
+* Mon May 2 2022 Jacob Barthelmeh <jacob@wolfssl.com>
+- Add missing kdf.h file
+* Wed Feb 16 2022 John Safranek <john@wolfssl.com>
+- Update for new release.
+* Mon Dec 27 2021 Jacob Barthelmeh <jacob@wolfssl.com>
+- Add a missing headers camellia.h, modes.h from compat layer.
+- Add a missing header falcon.h.
+* Mon Nov 01 2021 Jacob Barthelmeh <jacob@wolfssl.com>
+- Add a missing headers cmac.h, compat_types.h from compat layer.
+* Thu Jul 08 2021 Jacob Barthelmeh <jacob@wolfssl.com>
+- Add a missing header eccsi, sakke.
+* Thu Mar 25 2021 John Safranek <john@wolfssl.com>
+- Add new header kdf.h
+* Mon Aug 17 2020 John Safranek <john@wolfssl.com>
+- Add a missing header.
+- Update for release.
+* Thu Apr 16 2020 John Safranek <john@wolfssl.com>
+- Add some missing headers.
+- Sort the file list.
+* Thu Dec 19 2019 Jacob Barthelmeh <jacob@wolfssl.com>
+- Add wolfssl/openssl/tls1.h, wolfssl/openssl/x509_vfy.h
+* Fri Mar 15 2019 John Safranek <john@wolfssl.com>
+- Updates for the v4 release.
+* Thu Dec 20 2018 Jacob Barthelmeh <jacob@wolfssl.com>
+- Remove wolfssl/wolfcrypt/fips.h, add wolfssl/openssl/pkcs7.h
+* Wed Jun 20 2018 Jacob Barthelmeh <jacob@wolfssl.com>
+- Remove NEWS, update ChangeLog to ChangeLog.md, remove wolfssl/wolfcrypt/fips.h, add wolfssl/wolfcrypt/cryptocb.h
+* Thu May 31 2018 John Safranek <john@wolfssl.com>
+- Update the version number on the library SO file.
+* Fri Mar 02 2018 Jacob Barthelmeh <jacob@wolfssl.com>
+- Added header files fips.h, buffer.h, objects.h, rc4.h and example tls_bench.c
+* Fri Sep 08 2017 Jacob Barthelmeh <jacob@wolfssl.com>
+- Change name for header wolfssl/io.h to wolfssl/wolfio.h
+* Fri Aug 04 2017 Jacob Barthelmeh <jacob@wolfssl.com>
+- Added header for wolfssl/wolfcrypt/cpuid.h, wolfssl/wolfcrypt/sha3.h
+* Thu May 04 2017 Jacob Barthelmeh <jacob@wolfssl.com>
+- Added header for wolfssl/io.h, wolfssl/openssl/ssl23.h, cyassl/openssl/ssl23.h
+* Thu Feb 09 2017 Jacob Barthelmeh <jacob@wolfssl.com>
+- Added header for wolfssl/wolfcrypt/wolfmath.h
+* Fri Nov 11 2016 Jacob Barthelmeh <jacob@wolfssl.com>
+- Added header for wolfssl/openssl/aes.h
+* Fri Oct 28 2016 Jacob Barthelmeh <jacob@wolfssl.com>
+- Added header for pkcs12
+* Fri Sep 23 2016 John Safranek <john@wolfssl.com>
+- Add the dtls-sctp example sources
+* Tue Jun 14 2016 Jacob Barthelmeh <jacob@wolfssl.com>
+- Change location for mem_track.h header
+- Added header for cmac.h
+* Thu Mar 17 2016 Jacob Barthelmeh <jacob@wolfssl.com>
+- Added header for mem_track.h
+* Wed Dec 30 2015 Jacob Barthelmeh <jacob@wolfssl.com>
+- Added headers for curve25519 and ed25519 openssl compatibility
+- Added headers for Idea, srp, signature, and wc_encrypt
+* Tue Mar 31 2015 John Safranek <john@wolfssl.com>
+- Added recent new wolfcrypt headers for curve25519
+* Fri Jan 09 2015 John Safranek <john@wolfssl.com>
+- Update for cyassl->wolfssl name change
+* Sat Oct 20 2012 Brian Aker <brian@tangent.org>
+- Initial package


### PR DESCRIPTION
## Summary

Adds commercial-license packaging metadata for .deb and .rpm builds.

The Jenkins packaging jobs run `license.pl` to replace source headers and COPYING with commercial text, but packaging metadata (`debian/copyright`, RPM spec `License:` field) was left unchanged, shipping GPL references in commercial packages.

### Files added

- `debian/copyright.commercial` -- DEP-5 format, declares `wolfSSL-Commercial` for wolfSSL code, preserves correct third-party attribution (NTT camellia, BLAKE2, Zephyr, m4 macros)
- `rpm/spec.in.commercial` -- `License: LicenseRef-wolfSSL-Commercial` (SPDX custom identifier for proprietary), commercial description text

Both are drop-in replacements: the build pipeline copies them over the GPL originals after `license.pl` runs. Also adds previously missing blake2b.c/blake2s.c attribution (CC0-1.0, Samuel Neves).

## Test plan

- [ ] Corresponding wolfSSL/scripts#589 adds the `license.pl` swap logic
- [ ] Neither file contains "GPL" or "General Public" (safe for `license.pl` post-build grep)