### PR TITLE
Ed25519 support in the OpenSSL compatibility layer

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -5550,8 +5550,8 @@ int wolfSSL_ED25519_verify(const unsigned char *msg, unsigned int msgSz,
 
 #endif /* OPENSSL_EXTRA && HAVE_ED25519 */
 
-#if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)) && \
-    defined(HAVE_ED25519)
+#if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || \
+    defined(OPENSSL_EXTRA_X509_SMALL)) && defined(HAVE_ED25519)
 /* Allocate and initialize a new ed25519_key.
  *
  * @param [in] heap   Heap hint for memory allocation.
@@ -5602,7 +5602,8 @@ void wolfSSL_ED25519_free(ed25519_key* key)
     #endif
     }
 }
-#endif /* (OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL) && HAVE_ED25519 */
+#endif /* (OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL || OPENSSL_EXTRA_X509_SMALL) &&
+        * HAVE_ED25519 */
 
 /*******************************************************************************
  * END OF ED25519 API
@@ -7374,13 +7375,53 @@ int pkcs8_encrypt(WOLFSSL_EVP_PKEY* pkey,
         }
 
         if (ret == 0) {
-            /* Encrypt private into buffer. */
-            ret = TraditionalEnc((byte*)pkey->pkey.ptr + pkey->pkcs8HeaderSz,
-                (word32)pkey->pkey_sz - pkey->pkcs8HeaderSz,
-                key, keySz, passwd, passwdSz, PKCS5, PBES2, encAlgId,
-                NULL, 0, WC_PKCS12_ITT_DEFAULT, &rng, NULL);
-            if (ret > 0) {
-                *keySz = (word32)ret;
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
+            if (pkey->type == WC_EVP_PKEY_ED25519) {
+                /* The cached pkey.ptr is a full PKCS#8 blob and TraditionalEnc
+                 * requires a *traditional* (unwrapped) key.  Build the PKCS#8
+                 * from the key object via pkcs8_encode() and encrypt it with
+                 * wc_EncryptPKCS8Key(), which expects PKCS#8 input. */
+                byte*  edDer = NULL;
+                word32 edDerSz = 0;
+
+                if (pkcs8_encode(pkey, NULL, &edDerSz) !=
+                        WC_NO_ERR_TRACE(LENGTH_ONLY_E) || edDerSz == 0) {
+                    ret = BAD_FUNC_ARG;
+                }
+                else {
+                    edDer = (byte*)XMALLOC(edDerSz, pkey->heap,
+                        DYNAMIC_TYPE_TMP_BUFFER);
+                    if (edDer == NULL)
+                        ret = MEMORY_E;
+                    else
+                        ret = pkcs8_encode(pkey, edDer, &edDerSz);
+                }
+                if (ret > 0) {
+                    edDerSz = (word32)ret;
+                    ret = wc_EncryptPKCS8Key(edDer, edDerSz, key, keySz,
+                        passwd, passwdSz, PKCS5, PBES2, encAlgId,
+                        NULL, 0, WC_PKCS12_ITT_DEFAULT, &rng, NULL);
+                    if (ret > 0) {
+                        *keySz = (word32)ret;
+                    }
+                }
+                if (edDer != NULL) {
+                    ForceZero(edDer, edDerSz);
+                    XFREE(edDer, pkey->heap, DYNAMIC_TYPE_TMP_BUFFER);
+                }
+            }
+            else
+#endif /* HAVE_ED25519 && HAVE_ED25519_KEY_EXPORT */
+            {
+                /* Encrypt private into buffer. */
+                ret = TraditionalEnc(
+                    (byte*)pkey->pkey.ptr + pkey->pkcs8HeaderSz,
+                    (word32)pkey->pkey_sz - pkey->pkcs8HeaderSz,
+                    key, keySz, passwd, passwdSz, PKCS5, PBES2, encAlgId,
+                    NULL, 0, WC_PKCS12_ITT_DEFAULT, &rng, NULL);
+                if (ret > 0) {
+                    *keySz = (word32)ret;
+                }
             }
         }
         /* Dispose of random number generator. */
@@ -7449,6 +7490,36 @@ int pkcs8_encode(WOLFSSL_EVP_PKEY* pkey, byte* key, word32* keySz)
         algId = DHk;
         curveOid = NULL;
         oidSz = 0;
+    }
+#endif
+#if defined(HAVE_ED25519)
+    else if (pkey->type == WC_EVP_PKEY_ED25519) {
+    #if defined(HAVE_ED25519_KEY_EXPORT)
+        /* Build the PKCS#8 PrivateKeyInfo from the key object. A public-only
+         * key (e.g. from wolfSSL_X509_get_pubkey()) has no private half to
+         * encode (privKeySet == 0) and is rejected. */
+        if (keySz == NULL || pkey->ed25519 == NULL ||
+                !pkey->ed25519->privKeySet)
+            return BAD_FUNC_ARG;
+
+        ret = wc_Ed25519PrivateKeyToDer(pkey->ed25519, NULL, 0);
+        if (ret <= 0)
+            return (ret < 0) ? ret : BAD_FUNC_ARG;
+
+        if (key == NULL) {          /* length query */
+            *keySz = (word32)ret;
+            return LENGTH_ONLY_E;
+        }
+        if (*keySz < (word32)ret)   /* honour the caller's buffer size */
+            return BUFFER_E;
+
+        ret = wc_Ed25519PrivateKeyToDer(pkey->ed25519, key, *keySz);
+        if (ret > 0)
+            *keySz = (word32)ret;   /* only set on success */
+        return ret;
+    #else
+        return NOT_COMPILED_IN;
+    #endif /* HAVE_ED25519_KEY_EXPORT */
     }
 #endif
     else {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -63,6 +63,9 @@
     || defined(OPENSSL_EXTRA_X509_SMALL)                    \
     || defined(HAVE_WEBSERVER) || defined(WOLFSSL_KEY_GEN))
     #include <wolfssl/openssl/evp.h>
+    /* ed25519 compat helpers (wolfSSL_ED25519_new/free) are used by the X509
+     * Ed25519 paths, which also build under OPENSSL_EXTRA_X509_SMALL. */
+    #include <wolfssl/openssl/ed25519.h>
     /* openssl headers end, wolfssl internal headers next */
 #endif
 
@@ -90,7 +93,6 @@
     #include <wolfssl/openssl/pem.h>
     #include <wolfssl/openssl/ec.h>
     #include <wolfssl/openssl/ec25519.h>
-    #include <wolfssl/openssl/ed25519.h>
     #include <wolfssl/openssl/ec448.h>
     #include <wolfssl/openssl/ed448.h>
     #include <wolfssl/openssl/ecdsa.h>

--- a/src/x509.c
+++ b/src/x509.c
@@ -6439,6 +6439,11 @@ WOLFSSL_EVP_PKEY* wolfSSL_X509_get_pubkey(WOLFSSL_X509* x509)
                 WOLFSSL_ATOMIC_STORE(key->mldsaOID, x509->pubKeyOID);
             }
         #endif
+        #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
+            else if (x509->pubKeyOID == ED25519k) {
+                key->type = WC_EVP_PKEY_ED25519;
+            }
+        #endif
             else {
                 key->type = WC_EVP_PKEY_EC;
             }
@@ -6529,6 +6534,29 @@ WOLFSSL_EVP_PKEY* wolfSSL_X509_get_pubkey(WOLFSSL_X509* x509)
                 }
             }
             #endif /* NO_DSA */
+
+            /* decode Ed25519 key */
+            #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
+            if (key->type == WC_EVP_PKEY_ED25519) {
+                key->ed25519 = wolfSSL_ED25519_new(x509->heap, INVALID_DEVID);
+                if (key->ed25519 == NULL) {
+                    wolfSSL_EVP_PKEY_free(key);
+                    return NULL;
+                }
+                key->ownEd25519 = 1;
+
+                /* The X.509 public key buffer holds the raw Ed25519 key
+                 * (CopyDecodedToX509 / StoreKey store the BIT STRING
+                 * contents), so import it directly. */
+                if (wc_ed25519_import_public(
+                            (const unsigned char*)key->pkey.ptr,
+                            (word32)key->pkey_sz, key->ed25519) != 0) {
+                    WOLFSSL_MSG("wc_ed25519_import_public failed");
+                    wolfSSL_EVP_PKEY_free(key);
+                    return NULL;
+                }
+            }
+            #endif /* HAVE_ED25519 */
         }
     }
     return key;
@@ -8983,6 +9011,12 @@ static int verifyX509orX509REQ(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
     const byte* der;
     int derSz = 0;
     int type;
+    const byte* pubKey;
+    int pubKeySz;
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
+    byte edPubKey[ED25519_PUB_KEY_SIZE];
+    word32 edPubKeySz = (word32)sizeof(edPubKey);
+#endif
 
     (void)req;
 
@@ -8995,6 +9029,10 @@ static int verifyX509orX509REQ(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
         WOLFSSL_MSG("Error getting WOLFSSL_X509 DER");
         return WOLFSSL_FATAL_ERROR;
     }
+
+    /* Most key types verify against the cached public-key DER. */
+    pubKey   = (const byte*)pkey->pkey.ptr;
+    pubKeySz = pkey->pkey_sz;
 
     switch (pkey->type) {
         case WC_EVP_PKEY_RSA:
@@ -9018,6 +9056,22 @@ static int verifyX509orX509REQ(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
             }
             break;
     #endif
+    #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
+        case WC_EVP_PKEY_ED25519:
+            /* The signature check needs the raw public key; for Ed25519
+             * pkey->pkey.ptr holds a PKCS#8 private blob (or nothing), so
+             * export the public key from the ed25519_key instead. */
+            if (pkey->ed25519 == NULL ||
+                    wc_ed25519_export_public(pkey->ed25519, edPubKey,
+                        &edPubKeySz) != 0) {
+                WOLFSSL_MSG("Unable to export Ed25519 public key");
+                return WOLFSSL_FATAL_ERROR;
+            }
+            pubKey   = edPubKey;
+            pubKeySz = (int)edPubKeySz;
+            type     = ED25519k;
+            break;
+    #endif
 
         default:
             WOLFSSL_MSG("Unknown pkey key type");
@@ -9027,11 +9081,11 @@ static int verifyX509orX509REQ(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
 #ifdef WOLFSSL_CERT_REQ
     if (req)
         ret = CheckCSRSignaturePubKey(der, (word32)derSz, x509->heap,
-                (unsigned char*)pkey->pkey.ptr, pkey->pkey_sz, type);
+                (unsigned char*)pubKey, pubKeySz, type);
     else
 #endif
         ret = CheckCertSignaturePubKey(der, (word32)derSz, x509->heap,
-                (unsigned char*)pkey->pkey.ptr, pkey->pkey_sz, type);
+                (unsigned char*)pubKey, pubKeySz, type);
     if (ret == 0) {
         return WOLFSSL_SUCCESS;
     }
@@ -12239,7 +12293,25 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
     #if !defined(NO_PWDBASED) && defined(OPENSSL_EXTRA)
         int hashType;
         int sigType = WOLFSSL_FAILURE;
+    #endif
 
+        if (pkey == NULL) {
+            return WOLFSSL_FAILURE;
+        }
+
+    #if defined(HAVE_ED25519)
+        /* Ed25519 carries its own hash and needs no hash/PWDBASED info, so
+         * resolve it outside the guard below (works in --disable-pwdbased).
+         * OpenSSL rejects a non-NULL digest for Ed25519 -- match that rather
+         * than silently ignoring the caller's md. */
+        if (pkey->type == WC_EVP_PKEY_ED25519) {
+            if (md != NULL)
+                return WOLFSSL_FAILURE;
+            return CTC_ED25519;
+        }
+    #endif
+
+    #if !defined(NO_PWDBASED) && defined(OPENSSL_EXTRA)
     #ifdef WOLFSSL_MLDSA_X509_SIGN
         if (pkey->type == WC_EVP_PKEY_DILITHIUM) {
             /* ML-DSA does not use a separate hash. A NULL md matches
@@ -12276,6 +12348,14 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             return sigType;
         }
     #endif /* WOLFSSL_MLDSA_X509_SIGN */
+
+        /* Every remaining key type signs a digest, and
+         * wolfSSL_EVP_get_hashinfo() below dereferences md without a NULL
+         * check of its own.  (Checked after ML-DSA, which accepts a NULL md.)
+         */
+        if (md == NULL) {
+            return WOLFSSL_FAILURE;
+        }
 
         /* Convert key type and hash algorithm to a signature algorithm */
         if (wolfSSL_EVP_get_hashinfo(md, &hashType, NULL)
@@ -12388,6 +12468,9 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
     #endif
     #ifndef NO_DSA
         DsaKey* dsa = NULL;
+    #endif
+    #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
+        ed25519_key* ed25519 = NULL;
     #endif
     #if defined(HAVE_FALCON)
         falcon_key* falcon = NULL;
@@ -12522,6 +12605,28 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
                 return ret;
             }
             key = (void*)dsa;
+        }
+    #endif
+    #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
+        if (x509->pubKeyOID == ED25519k) {
+            ed25519 = wolfSSL_ED25519_new(x509->heap, INVALID_DEVID);
+            if (ed25519 == NULL) {
+                WOLFSSL_MSG("Failed to allocate memory for ed25519_key");
+                XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
+                return WOLFSSL_FAILURE;
+            }
+
+            type = ED25519_TYPE;
+            /* The X.509 public key buffer holds the raw Ed25519 key. */
+            ret = wc_ed25519_import_public(x509->pubKey.buffer,
+                                           x509->pubKey.length, ed25519);
+            if (ret != 0) {
+                WOLFSSL_ERROR_VERBOSE(ret);
+                wolfSSL_ED25519_free(ed25519);
+                XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
+                return ret;
+            }
+            key = (void*)ed25519;
         }
     #endif
     #if defined(HAVE_FALCON)
@@ -12775,6 +12880,11 @@ cleanup:
             XFREE(ecc, NULL, DYNAMIC_TYPE_ECC);
         }
     #endif
+    #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
+        if (x509->pubKeyOID == ED25519k) {
+            wolfSSL_ED25519_free(ed25519);
+        }
+    #endif
     #ifndef NO_DSA
         if (x509->pubKeyOID == DSAk) {
             wc_FreeDsaKey(dsa);
@@ -12935,6 +13045,20 @@ cleanup:
             key = mldsa;
         }
     #endif /* WOLFSSL_MLDSA_X509_SIGN */
+    #if defined(HAVE_ED25519)
+        if (pkey->type == WC_EVP_PKEY_ED25519) {
+            /* Reject a missing key here, as the other Ed25519 entry points do,
+             * so a public-only or uninitialised EVP_PKEY fails clearly instead
+             * of reaching wc_SignCert_ex() with a NULL key and coming back as
+             * an algorithm-id error. */
+            if (pkey->ed25519 == NULL) {
+                WOLFSSL_MSG("No Ed25519 key in EVP_PKEY");
+                return WOLFSSL_FATAL_ERROR;
+            }
+            type = ED25519_TYPE;
+            key = pkey->ed25519;
+        }
+    #endif
 
         /* Sign the certificate (request) body. */
         ret = wc_InitRng(&rng);
@@ -13066,16 +13190,6 @@ int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
         ret = WOLFSSL_FAILURE;
         goto out;
     }
-    /* md may be NULL for hash-free algorithms (ML-DSA), as in OpenSSL's
-     * X509_sign(x, pkey, NULL). */
-    if (md == NULL
-#ifdef WOLFSSL_MLDSA_X509_SIGN
-        && pkey->type != WC_EVP_PKEY_DILITHIUM
-#endif
-        ) {
-        ret = WOLFSSL_FAILURE;
-        goto out;
-    }
 
     bufSz = x509_gen_buf_sz(x509, pkey);
     derSz = bufSz;
@@ -13085,8 +13199,10 @@ int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
         goto out;
     }
 
-    /* Only update sigOID on success to keep the object unmodified on a
-     * rejected key/md combination. */
+    /* Resolves the (pkey, md) combination - most key types require an explicit
+     * digest, Ed25519 requires a NULL one, ML-DSA ignores it - and only
+     * updates sigOID on success, so the object is unmodified on a rejected
+     * key/md combination. */
     sigType = wolfSSL_sigTypeFromPKEY((WOLFSSL_EVP_MD*)md, pkey);
     if (sigType == WC_NO_ERR_TRACE(WOLFSSL_FAILURE)) {
         WOLFSSL_MSG("Unsupported key/md combination for signing");
@@ -16689,6 +16805,30 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
         break;
 #endif /* WOLFSSL_HAVE_MLDSA && WOLFSSL_MLDSA_PUBLIC_KEY &&
         * !WOLFSSL_MLDSA_NO_ASN1 && WC_ENABLE_ASYM_KEY_EXPORT */
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
+    case WC_EVP_PKEY_ED25519:
+        {
+            word32 rawLen = ED25519_PUB_KEY_SIZE;
+
+            if (pkey->ed25519 == NULL)
+                return WOLFSSL_FAILURE;
+
+            /* Store the RAW public key: wolfSSL keeps an X.509 Ed25519
+             * public key as the bare key bytes (see StoreKey /
+             * CopyDecodedToX509), not a SubjectPublicKeyInfo. */
+            p = (byte*)XMALLOC(rawLen, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+            if (p == NULL)
+                return WOLFSSL_FAILURE;
+
+            if (wc_ed25519_export_public(pkey->ed25519, p, &rawLen) != 0) {
+                XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+                return WOLFSSL_FAILURE;
+            }
+            derSz = (int)rawLen;
+            cert->pubKeyOID = ED25519k;
+        }
+        break;
+#endif
     default:
         return WOLFSSL_FAILURE;
     }
@@ -17043,13 +17183,7 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
     int derSz;
     int sigType;
 
-    /* md may be NULL for hash-free algorithms (ML-DSA), as in OpenSSL's
-     * X509_REQ_sign(req, pkey, NULL). */
-    if (req == NULL || pkey == NULL || (md == NULL
-#ifdef WOLFSSL_MLDSA_X509_SIGN
-        && pkey->type != WC_EVP_PKEY_DILITHIUM
-#endif
-        )) {
+    if (req == NULL || pkey == NULL) {
         WOLFSSL_LEAVE("wolfSSL_X509_REQ_sign", BAD_FUNC_ARG);
         return WOLFSSL_FAILURE;
     }
@@ -17061,9 +17195,11 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
         return WOLFSSL_FAILURE;
     }
 
-    /* Create a Cert that has the certificate request fields. Only update
-     * sigOID on success to keep the object unmodified on a rejected
-     * key/md combination. */
+    /* Create a Cert that has the certificate request fields.  The (pkey, md)
+     * combination is resolved by wolfSSL_sigTypeFromPKEY() - Ed25519 CSRs sign
+     * with a NULL digest, ML-DSA ignores the digest, every other key type
+     * requires one - and sigOID is only updated on success, so the object is
+     * unmodified on a rejected key/md combination. */
     sigType = wolfSSL_sigTypeFromPKEY((WOLFSSL_EVP_MD*)md, pkey);
     if (sigType == WC_NO_ERR_TRACE(WOLFSSL_FAILURE)) {
         WOLFSSL_MSG("Unsupported key/md combination for signing");

--- a/tests/api.c
+++ b/tests/api.c
@@ -11141,6 +11141,508 @@ static int test_wolfSSL_PKCS8(void)
     return EXPECT_RESULT();
 }
 
+/* Exercise Ed25519 through the OpenSSL-compatibility EVP/X509 surface the
+ * way an application does: generate a key, serialise the public
+ * (SubjectPublicKeyInfo) and private (PKCS#8) parts, build and sign an
+ * in-memory self-signed certificate with a NULL digest, read the public key
+ * back out, and load the key + cert into an SSL_CTX. */
+static int test_wolfSSL_EVP_PKEY_ED25519_openssl(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ED25519) && \
+    defined(HAVE_ED25519_KEY_EXPORT) && defined(HAVE_ED25519_KEY_IMPORT) && \
+    defined(HAVE_ED25519_MAKE_KEY) && \
+    defined(WOLFSSL_CERT_GEN) && !defined(NO_CERTS) && !defined(NO_ASN_TIME)
+    /* RFC 8032 Ed25519 test vector 1: secret seed and the public key it must
+     * derive to. */
+    static const unsigned char ed25519Seed[ED25519_KEY_SIZE] = {
+        0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60,
+        0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c, 0xc4,
+        0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19,
+        0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae, 0x7f, 0x60
+    };
+    static const unsigned char ed25519SeedPub[ED25519_PUB_KEY_SIZE] = {
+        0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7,
+        0xd5, 0x4b, 0xfe, 0xd3, 0xc9, 0x64, 0x07, 0x3a,
+        0x0e, 0xe1, 0x72, 0xf3, 0xda, 0xa6, 0x23, 0x25,
+        0xaf, 0x02, 0x1a, 0x68, 0xf7, 0x07, 0x51, 0x1a
+    };
+    WOLFSSL_EVP_PKEY_CTX* ctx = NULL;
+    WOLFSSL_EVP_PKEY* pkey = NULL;
+    WOLFSSL_EVP_PKEY* certPub = NULL;
+    WOLFSSL_X509* x509 = NULL;
+    WOLFSSL_X509_NAME* name = NULL;
+    WOLFSSL_ASN1_TIME* notBefore = NULL;
+    WOLFSSL_ASN1_TIME* notAfter = NULL;
+    unsigned char* spki = NULL;
+    unsigned char* spki2 = NULL;
+    int spkiSz = 0;
+    int spki2Sz = 0;
+    time_t t = 0;
+
+    /* (1) Generate an Ed25519 key purely through the EVP API. */
+    ExpectNotNull(ctx = wolfSSL_EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519, NULL));
+    ExpectIntEQ(wolfSSL_EVP_PKEY_keygen_init(ctx), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_EVP_PKEY_keygen(ctx, &pkey), WOLFSSL_SUCCESS);
+    ExpectNotNull(pkey);
+
+    /* (2) Encode the public key as SubjectPublicKeyInfo. */
+    ExpectIntGT((spkiSz = wolfSSL_i2d_PUBKEY(pkey, &spki)), 0);
+
+    /* (2c) The SPKI decodes back via d2i_PUBKEY to an equivalent public key --
+     * the d2i_PUBKEY half of the round-trip the i2d_PublicKey SPKI design
+     * targets -- which must re-export byte-identical SPKI. */
+    {
+        const unsigned char* spkiTmp = spki;
+        WOLFSSL_EVP_PKEY* pubFromSpki = NULL;
+        unsigned char* reSpki = NULL;
+        int reSpkiSz = 0;
+
+        ExpectNotNull(pubFromSpki = wolfSSL_d2i_PUBKEY(NULL, &spkiTmp,
+            (long)spkiSz));
+        ExpectIntGT((reSpkiSz = wolfSSL_i2d_PUBKEY(pubFromSpki, &reSpki)), 0);
+        ExpectIntEQ(reSpkiSz, spkiSz);
+        if ((spki != NULL) && (reSpki != NULL) && (reSpkiSz == spkiSz)) {
+            ExpectIntEQ(XMEMCMP(spki, reSpki, (size_t)spkiSz), 0);
+        }
+        XFREE(reSpki, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+        wolfSSL_EVP_PKEY_free(pubFromSpki);
+    }
+
+    /* (2b) Raw-key constructors populate the EVP_PKEY differently from
+     * keygen/decode (no cached PKCS#8 DER), so exercise them directly: a
+     * public-only raw key must serialize to the same SPKI, and a raw private
+     * seed must import as an Ed25519 key. */
+    {
+        /* The Ed25519 SubjectPublicKeyInfo header SetAsymKeyDerPublic emits:
+         * SEQUENCE(42) { SEQUENCE(5) { OID 1.3.101.112 } BIT STRING(33) 0x00 }.
+         * Pinned bytewise so a re-layout cannot silently move the raw key
+         * (a length-only check would not notice). */
+        static const unsigned char ed25519SpkiHdr[] = {
+            0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65,
+            0x70, 0x03, 0x21, 0x00
+        };
+        WOLFSSL_EVP_PKEY* rawPub = NULL;
+        WOLFSSL_EVP_PKEY* rawPriv = NULL;
+        WOLFSSL_EVP_PKEY* seedPub = NULL;
+        unsigned char* rawSpki = NULL;
+        unsigned char* privSpki = NULL;
+        int rawSpkiSz = 0;
+        int privSpkiSz = 0;
+        const int ed25519SpkiHdrSz = (int)sizeof(ed25519SpkiHdr);
+
+        /* An Ed25519 SPKI is a fixed-size header followed by the raw public
+         * key, which is what new_raw_public_key() wants. */
+        ExpectIntEQ(spkiSz, (int)(ED25519_PUB_KEY_SIZE + ed25519SpkiHdrSz));
+        if (spki != NULL) {
+            ExpectIntEQ(XMEMCMP(spki, ed25519SpkiHdr, sizeof(ed25519SpkiHdr)),
+                0);
+        }
+        if ((spki != NULL) &&
+                (spkiSz == (int)(ED25519_PUB_KEY_SIZE + ed25519SpkiHdrSz))) {
+            ExpectNotNull(rawPub = wolfSSL_EVP_PKEY_new_raw_public_key(
+                EVP_PKEY_ED25519, NULL, spki + ed25519SpkiHdrSz,
+                ED25519_PUB_KEY_SIZE));
+            ExpectIntGT((rawSpkiSz = wolfSSL_i2d_PUBKEY(rawPub, &rawSpki)), 0);
+            ExpectIntEQ(rawSpkiSz, spkiSz);
+            if ((rawSpki != NULL) && (rawSpkiSz == spkiSz)) {
+                ExpectIntEQ(XMEMCMP(spki, rawSpki, (size_t)spkiSz), 0);
+            }
+        }
+
+        ExpectNotNull(rawPriv = wolfSSL_EVP_PKEY_new_raw_private_key(
+            EVP_PKEY_ED25519, NULL, ed25519Seed, ED25519_KEY_SIZE));
+
+        /* The raw input is only the seed, so the key must derive its public
+         * half on import -- otherwise a key built this way is unusable with
+         * i2d_PUBKEY / EVP_PKEY_cmp / signing, unlike the same key decoded
+         * from PKCS#8.  Checked against the RFC 8032 vector, so a wrong
+         * derivation cannot pass. */
+        ExpectNotNull(seedPub = wolfSSL_EVP_PKEY_new_raw_public_key(
+            EVP_PKEY_ED25519, NULL, ed25519SeedPub, ED25519_PUB_KEY_SIZE));
+        ExpectIntGT((privSpkiSz = wolfSSL_i2d_PUBKEY(rawPriv, &privSpki)), 0);
+        ExpectIntEQ(privSpkiSz, (int)(ED25519_PUB_KEY_SIZE +
+            ed25519SpkiHdrSz));
+        if ((privSpki != NULL) &&
+                (privSpkiSz == (int)(ED25519_PUB_KEY_SIZE +
+                    ed25519SpkiHdrSz))) {
+            ExpectIntEQ(XMEMCMP(privSpki + ed25519SpkiHdrSz, ed25519SeedPub,
+                ED25519_PUB_KEY_SIZE), 0);
+        }
+        /* Same key, two construction paths -> EVP_PKEY_cmp must match; the
+         * unrelated generated key must not. */
+#ifdef WOLFSSL_ERROR_CODE_OPENSSL
+        ExpectIntEQ(wolfSSL_EVP_PKEY_cmp(rawPriv, seedPub), 1);
+        ExpectIntEQ(wolfSSL_EVP_PKEY_cmp(rawPriv, rawPub), 0);
+#else
+        ExpectIntEQ(wolfSSL_EVP_PKEY_cmp(rawPriv, seedPub), 0);
+        ExpectIntEQ(wolfSSL_EVP_PKEY_cmp(rawPriv, rawPub), -1);
+#endif
+
+        /* A raw private key caches the bare 32-byte seed, not PKCS#8, so
+         * pkcs8_encode() must build the PKCS#8 wrapper from the key object
+         * rather than emit the seed as-is. */
+#if defined(OPENSSL_ALL) && !defined(NO_BIO) && !defined(NO_PWDBASED) && \
+    defined(HAVE_PKCS8)
+        if (rawPriv != NULL) {
+            WOLFSSL_BIO* rawBio = NULL;
+            WOLFSSL_EVP_PKEY* decRaw = NULL;
+
+            ExpectNotNull(rawBio = BIO_new(BIO_s_mem()));
+            ExpectIntGT(PEM_write_bio_PKCS8PrivateKey(rawBio, rawPriv, NULL,
+                NULL, 0, NULL, NULL), 0);
+            /* The emitted PEM must be a real PKCS#8 PrivateKeyInfo: reading it
+             * back recovers an Ed25519 key only if the seed was wrapped, not
+             * emitted as the bare 32 bytes. */
+            ExpectNotNull(decRaw = PEM_read_bio_PrivateKey(rawBio, NULL, NULL,
+                NULL));
+            wolfSSL_EVP_PKEY_free(decRaw);
+            BIO_free(rawBio);
+        }
+#endif
+
+        XFREE(rawSpki, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(privSpki, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+        wolfSSL_EVP_PKEY_free(rawPub);
+        wolfSSL_EVP_PKEY_free(rawPriv);
+        wolfSSL_EVP_PKEY_free(seedPub);
+    }
+
+    /* (3) Encode the private key as PKCS#8 PrivateKeyInfo and (7) decode it
+     * back.  These compat helpers (EVP_PKEY2PKCS8, i2d_PKCS8_PKEY,
+     * d2i_AutoPrivateKey) are only built with OPENSSL_ALL. */
+#if defined(OPENSSL_ALL) && !defined(NO_AES)
+    {
+        WOLFSSL_PKCS8_PRIV_KEY_INFO* p8 = NULL;
+        WOLFSSL_EVP_PKEY* decPriv = NULL;
+        unsigned char* p8der = NULL;
+        const unsigned char* tmp = NULL;
+        int p8Sz = 0;
+
+        ExpectNotNull(p8 = wolfSSL_EVP_PKEY2PKCS8(pkey));
+        ExpectIntGT((p8Sz = wolfSSL_i2d_PKCS8_PKEY(p8, &p8der)), 0);
+        tmp = p8der;
+        ExpectNotNull(decPriv = wolfSSL_d2i_AutoPrivateKey(NULL, &tmp, p8Sz));
+        /* d2i must advance the pointer by exactly the object size, not the
+         * caller's buffer length (no trailing bytes consumed/cached). */
+        ExpectPtrEq(tmp, p8der + p8Sz);
+
+        /* The PKCS#8-decoded private key must re-export the same public key /
+         * SPKI, not merely decode to non-NULL. */
+        {
+            unsigned char* decSpki = NULL;
+            int decSpkiSz = 0;
+
+            ExpectIntGT((decSpkiSz = wolfSSL_i2d_PUBKEY(decPriv, &decSpki)), 0);
+            ExpectIntEQ(decSpkiSz, spkiSz);
+            if ((spki != NULL) && (decSpki != NULL) && (decSpkiSz == spkiSz)) {
+                ExpectIntEQ(XMEMCMP(spki, decSpki, (size_t)spkiSz), 0);
+            }
+            XFREE(decSpki, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+        }
+
+        XFREE(p8der, NULL, DYNAMIC_TYPE_ASN1);
+        wolfSSL_EVP_PKEY_free(decPriv);
+        wolfSSL_EVP_PKEY_free((WOLFSSL_EVP_PKEY*)p8);
+    }
+
+    /* (7b) The same, for the PKCS#8 form wolfSSL itself emits from
+     * wc_Ed25519KeyToDer(): RFC 5958 version 1 with the optional [1] publicKey
+     * following the privateKey OCTET STRING.  d2i_AutoPrivateKey must size the
+     * object from the outer SEQUENCE -- sizing it from the inner key's
+     * offset+length instead truncates this form and fails to decode. */
+    {
+        ed25519_key v2Key;
+        WOLFSSL_EVP_PKEY* v2Priv = NULL;
+        const unsigned char* v2Tmp = NULL;
+        byte v2Der[128];
+        int v2DerSz = 0;
+
+        /* Zeroed first: the Expect* chain short-circuits after an earlier
+         * failure, so wc_ed25519_init() may never run while the free below
+         * always does. */
+        XMEMSET(&v2Key, 0, sizeof(v2Key));
+        ExpectIntEQ(wc_ed25519_init(&v2Key), 0);
+        ExpectIntEQ(wc_ed25519_import_private_key(ed25519Seed,
+            ED25519_KEY_SIZE, ed25519SeedPub, ED25519_PUB_KEY_SIZE, &v2Key), 0);
+        ExpectIntGT((v2DerSz = wc_Ed25519KeyToDer(&v2Key, v2Der,
+            (word32)sizeof(v2Der))), 0);
+        /* This form carries the public key after the privateKey OCTET STRING,
+         * so it is longer than the seed-only v1 form (48 bytes) -- that is the
+         * whole point of the case. */
+        ExpectIntGT(v2DerSz, 48);
+
+        v2Tmp = v2Der;
+        ExpectNotNull(v2Priv = wolfSSL_d2i_AutoPrivateKey(NULL, &v2Tmp,
+            (long)v2DerSz));
+        ExpectPtrEq(v2Tmp, v2Der + v2DerSz);
+
+        if (v2Priv != NULL) {
+            WOLFSSL_PKCS8_PRIV_KEY_INFO* v2P8 = NULL;
+            unsigned char* v2Spki = NULL;
+            unsigned char* v2P8Der = NULL;
+            int v2SpkiSz = 0;
+            int v2P8Sz = 0;
+
+            /* Decoded to the RFC 8032 key, not merely to something non-NULL. */
+            ExpectIntGT((v2SpkiSz = wolfSSL_i2d_PUBKEY(v2Priv, &v2Spki)), 0);
+            ExpectIntEQ(v2SpkiSz, spkiSz);
+            if ((v2Spki != NULL) && (v2SpkiSz == spkiSz)) {
+                ExpectIntEQ(XMEMCMP(v2Spki + (v2SpkiSz - ED25519_PUB_KEY_SIZE),
+                    ed25519SeedPub, ED25519_PUB_KEY_SIZE), 0);
+            }
+            /* The DER d2i cached must be a complete PrivateKeyInfo, not one
+             * cut short at the privateKey field: re-exporting it has to yield
+             * a PKCS#8 blob that parses back to the same key. */
+            ExpectNotNull(v2P8 = wolfSSL_EVP_PKEY2PKCS8(v2Priv));
+            ExpectIntGT((v2P8Sz = wolfSSL_i2d_PKCS8_PKEY(v2P8, &v2P8Der)), 0);
+            if (v2P8Der != NULL) {
+                const unsigned char* v2P8Tmp = v2P8Der;
+                WOLFSSL_EVP_PKEY* v2Again = NULL;
+
+                ExpectNotNull(v2Again = wolfSSL_d2i_AutoPrivateKey(NULL,
+                    &v2P8Tmp, v2P8Sz));
+#ifdef WOLFSSL_ERROR_CODE_OPENSSL
+                ExpectIntEQ(wolfSSL_EVP_PKEY_cmp(v2Again, v2Priv), 1);
+#else
+                ExpectIntEQ(wolfSSL_EVP_PKEY_cmp(v2Again, v2Priv), 0);
+#endif
+                wolfSSL_EVP_PKEY_free(v2Again);
+            }
+            XFREE(v2P8Der, NULL, DYNAMIC_TYPE_ASN1);
+            wolfSSL_EVP_PKEY_free((WOLFSSL_EVP_PKEY*)v2P8);
+            XFREE(v2Spki, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+        }
+        wolfSSL_EVP_PKEY_free(v2Priv);
+        wc_ed25519_free(&v2Key);
+    }
+#endif
+
+    /* (4)(5) Build an in-memory self-signed cert; Ed25519 signs with a NULL
+     * digest (it carries its own hash). */
+    ExpectNotNull(x509 = wolfSSL_X509_new());
+    ExpectIntEQ(wolfSSL_X509_set_version(x509, 2), WOLFSSL_SUCCESS);
+    ExpectNotNull(name = wolfSSL_X509_NAME_new());
+    ExpectIntEQ(wolfSSL_X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+        (const byte*)"ed25519 test", -1, -1, 0), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_X509_set_subject_name(x509, name), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_X509_set_issuer_name(x509, name), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, pkey), WOLFSSL_SUCCESS);
+    t = XTIME(NULL);
+    ExpectNotNull(notBefore = wolfSSL_ASN1_TIME_adj(NULL, t, 0, 0));
+    ExpectNotNull(notAfter = wolfSSL_ASN1_TIME_adj(NULL, t, 365, 0));
+    ExpectTrue(wolfSSL_X509_set_notBefore(x509, notBefore));
+    ExpectTrue(wolfSSL_X509_set_notAfter(x509, notAfter));
+    ExpectIntGT(wolfSSL_X509_sign(x509, pkey, NULL), 0);
+
+    /* (5b) The self-signed certificate verifies under its own key, proving
+     * the generated Ed25519 signature, OID and public-key encoding are
+     * usable. */
+    ExpectIntEQ(wolfSSL_X509_verify(x509, pkey), WOLFSSL_SUCCESS);
+
+    /* (8) The certificate's public key round-trips to the same SPKI. */
+    ExpectNotNull(certPub = wolfSSL_X509_get_pubkey(x509));
+    ExpectIntGT((spki2Sz = wolfSSL_i2d_PUBKEY(certPub, &spki2)), 0);
+    ExpectIntEQ(spki2Sz, spkiSz);
+    if ((spki != NULL) && (spki2 != NULL) && (spkiSz == spki2Sz)) {
+        ExpectIntEQ(XMEMCMP(spki, spki2, (size_t)spkiSz), 0);
+    }
+
+    /* (8a) EVP_PKEY_cmp matches the certificate's public key with the private
+     * key (exercises the new Ed25519 EVP_PKEY_cmp case).  Success is 1 with
+     * WOLFSSL_ERROR_CODE_OPENSSL, 0 otherwise. */
+#ifdef WOLFSSL_ERROR_CODE_OPENSSL
+    ExpectIntEQ(wolfSSL_EVP_PKEY_cmp(certPub, pkey), 1);
+#else
+    ExpectIntEQ(wolfSSL_EVP_PKEY_cmp(certPub, pkey), 0);
+#endif
+
+    /* (5c) Verification must fail under a different key. */
+    {
+        WOLFSSL_EVP_PKEY_CTX* wrongCtx = NULL;
+        WOLFSSL_EVP_PKEY* wrongKey = NULL;
+
+        ExpectNotNull(wrongCtx = wolfSSL_EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519,
+            NULL));
+        ExpectIntEQ(wolfSSL_EVP_PKEY_keygen_init(wrongCtx), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_EVP_PKEY_keygen(wrongCtx, &wrongKey),
+            WOLFSSL_SUCCESS);
+        ExpectIntNE(wolfSSL_X509_verify(x509, wrongKey), WOLFSSL_SUCCESS);
+        /* ... and EVP_PKEY_cmp reports the mismatch (the branch (8a) above
+         * does not reach). */
+#ifdef WOLFSSL_ERROR_CODE_OPENSSL
+        ExpectIntEQ(wolfSSL_EVP_PKEY_cmp(pkey, wrongKey), 0);
+#else
+        ExpectIntEQ(wolfSSL_EVP_PKEY_cmp(pkey, wrongKey), -1);
+#endif
+        wolfSSL_EVP_PKEY_free(wrongKey);
+        wolfSSL_EVP_PKEY_CTX_free(wrongCtx);
+    }
+
+    /* (8d) Everything above works on an in-memory X509, where X509_set_pubkey
+     * wrote x509->pubKey itself.  Round-trip the certificate through DER so
+     * the public-key buffer comes from the certificate parser (StoreKey())
+     * instead, which is the case X509_get_pubkey() and wolfssl_x509_make_der()
+     * actually assume when they treat it as the raw Ed25519 key. */
+    {
+        WOLFSSL_X509* derX509 = NULL;
+        WOLFSSL_EVP_PKEY* derPub = NULL;
+        const unsigned char* certTmp = NULL;
+        unsigned char* certDer = NULL;
+        unsigned char* derSpki = NULL;
+        int certDerSz = 0;
+        int derSpkiSz = 0;
+
+        ExpectIntGT((certDerSz = wolfSSL_i2d_X509(x509, &certDer)), 0);
+        certTmp = certDer;
+        ExpectNotNull(derX509 = wolfSSL_d2i_X509(NULL, &certTmp,
+            (int)certDerSz));
+        ExpectNotNull(derPub = wolfSSL_X509_get_pubkey(derX509));
+        ExpectIntGT((derSpkiSz = wolfSSL_i2d_PUBKEY(derPub, &derSpki)), 0);
+        ExpectIntEQ(derSpkiSz, spkiSz);
+        if ((spki != NULL) && (derSpki != NULL) && (derSpkiSz == spkiSz)) {
+            ExpectIntEQ(XMEMCMP(spki, derSpki, (size_t)spkiSz), 0);
+        }
+        /* The parsed certificate still verifies under the signing key. */
+        ExpectIntEQ(wolfSSL_X509_verify(derX509, pkey), WOLFSSL_SUCCESS);
+
+        XFREE(derSpki, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(certDer, NULL, DYNAMIC_TYPE_OPENSSL);
+        wolfSSL_EVP_PKEY_free(derPub);
+        wolfSSL_X509_free(derX509);
+    }
+
+    /* (9) The same NULL-digest rule applies to certificate requests, which go
+     * through wolfSSL_X509_REQ_sign()/sigTypeFromPKEY() as well. */
+#if defined(OPENSSL_ALL) && defined(WOLFSSL_CERT_REQ)
+    {
+        WOLFSSL_X509* req = NULL;
+
+        ExpectNotNull(req = wolfSSL_X509_REQ_new());
+        ExpectIntEQ(wolfSSL_X509_REQ_set_subject_name(req, name),
+            WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_X509_REQ_set_pubkey(req, pkey), WOLFSSL_SUCCESS);
+        /* An explicit digest is rejected for Ed25519, as for X509_sign. */
+        ExpectIntEQ(wolfSSL_X509_REQ_sign(req, pkey, wolfSSL_EVP_sha256()),
+            WOLFSSL_FAILURE);
+        ExpectIntEQ(wolfSSL_X509_REQ_sign(req, pkey, NULL), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_X509_REQ_verify(req, pkey), WOLFSSL_SUCCESS);
+        wolfSSL_X509_free(req);
+    }
+#endif
+
+    /* (5d) The relaxed NULL-digest rule is Ed25519-only: signing a
+     * non-Ed25519 key with a NULL digest must still be rejected. */
+#if defined(HAVE_ECC) && defined(WOLFSSL_KEY_GEN)
+    {
+        WOLFSSL_EVP_PKEY_CTX* ecCtx = NULL;
+        WOLFSSL_EVP_PKEY* ecKey = NULL;
+
+        ExpectNotNull(ecCtx = wolfSSL_EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL));
+        ExpectIntEQ(wolfSSL_EVP_PKEY_keygen_init(ecCtx), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ecCtx,
+            NID_X9_62_prime256v1), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_EVP_PKEY_keygen(ecCtx, &ecKey), WOLFSSL_SUCCESS);
+        ExpectIntLE(wolfSSL_X509_sign(x509, ecKey, NULL), 0);
+        wolfSSL_EVP_PKEY_free(ecKey);
+        wolfSSL_EVP_PKEY_CTX_free(ecCtx);
+    }
+#endif
+
+    /* (8b) PKCS#8 private-key export from a public-only key (certPub holds
+     * only the raw public key) must fail cleanly rather than emit the raw
+     * public bytes or cached non-PKCS#8 data as if they were a private key. */
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_WPAS_SMALL)
+    ExpectNull(wolfSSL_EVP_PKEY2PKCS8(certPub));
+#endif
+
+    /* (8c) The PKCS#8 PEM writer drives pkcs8_encode() directly (unlike
+     * EVP_PKEY2PKCS8 above, which re-decodes the cached DER): the generated
+     * key carries a cached PKCS#8 PrivateKeyInfo and must write, while the
+     * public-only key has no private half and must fail rather than emit its
+     * raw public bytes wrapped as a bogus PKCS#8 private key. */
+#if defined(OPENSSL_ALL) && !defined(NO_BIO) && !defined(NO_PWDBASED) && \
+    defined(HAVE_PKCS8)
+    {
+        WOLFSSL_BIO* pkcs8Bio = NULL;
+
+        ExpectNotNull(pkcs8Bio = BIO_new(BIO_s_mem()));
+        ExpectIntGT(PEM_write_bio_PKCS8PrivateKey(pkcs8Bio, pkey, NULL, NULL, 0,
+            NULL, NULL), 0);
+        BIO_free(pkcs8Bio);
+
+        pkcs8Bio = NULL;
+        ExpectNotNull(pkcs8Bio = BIO_new(BIO_s_mem()));
+        ExpectIntEQ(PEM_write_bio_PKCS8PrivateKey(pkcs8Bio, certPub, NULL, NULL,
+            0, NULL, NULL), 0);
+        BIO_free(pkcs8Bio);
+
+        /* (8d) Encrypted PKCS#8 round-trip: the enc != NULL branch is the one
+         * the PR newly makes reachable.  Write an AES-256-CBC encrypted PKCS#8
+         * PEM and read it back to the same public key. */
+    #if !defined(NO_AES) && defined(WOLFSSL_AES_256) && defined(HAVE_AES_CBC)
+        {
+            WOLFSSL_BIO* encBio = NULL;
+            WOLFSSL_EVP_PKEY* decEnc = NULL;
+            char pkcs8Pass[] = "wolfssl-ed25519";
+
+            ExpectNotNull(encBio = BIO_new(BIO_s_mem()));
+            ExpectIntGT(PEM_write_bio_PKCS8PrivateKey(encBio, pkey,
+                wolfSSL_EVP_aes_256_cbc(), pkcs8Pass, (int)XSTRLEN(pkcs8Pass),
+                NULL, NULL), 0);
+            ExpectNotNull(decEnc = PEM_read_bio_PrivateKey(encBio, NULL, NULL,
+                pkcs8Pass));
+            if (decEnc != NULL) {
+                unsigned char* encSpki = NULL;
+                int encSpkiSz = 0;
+
+                ExpectIntGT((encSpkiSz = wolfSSL_i2d_PUBKEY(decEnc, &encSpki)),
+                    0);
+                ExpectIntEQ(encSpkiSz, spkiSz);
+                if ((spki != NULL) && (encSpki != NULL) &&
+                        (encSpkiSz == spkiSz)) {
+                    ExpectIntEQ(XMEMCMP(spki, encSpki, (size_t)spkiSz), 0);
+                }
+                XFREE(encSpki, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+            }
+            wolfSSL_EVP_PKEY_free(decEnc);
+            BIO_free(encBio);
+        }
+    #endif
+    }
+#endif
+
+    /* (6) Load the generated key and cert into an SSL_CTX. */
+#if !defined(NO_TLS) && \
+    (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER))
+    {
+        WOLFSSL_CTX* sslCtx = NULL;
+#ifndef NO_WOLFSSL_SERVER
+        ExpectNotNull(sslCtx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
+#else
+        ExpectNotNull(sslCtx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
+#endif
+        ExpectIntEQ(wolfSSL_CTX_use_certificate(sslCtx, x509),
+            WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey(sslCtx, pkey),
+            WOLFSSL_SUCCESS);
+        wolfSSL_CTX_free(sslCtx);
+    }
+#endif
+
+    XFREE(spki, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+    XFREE(spki2, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+    wolfSSL_ASN1_TIME_free(notBefore);
+    wolfSSL_ASN1_TIME_free(notAfter);
+    wolfSSL_X509_NAME_free(name);
+    wolfSSL_X509_free(x509);
+    wolfSSL_EVP_PKEY_free(certPub);
+    wolfSSL_EVP_PKEY_free(pkey);
+    wolfSSL_EVP_PKEY_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 static int test_wolfSSL_PKCS8_ED25519(void)
 {
     EXPECT_DECLS;
@@ -39138,6 +39640,7 @@ TEST_CASE testCases[] = {
     /* PKCS8 testing */
     TEST_DECL(test_wolfSSL_no_password_cb),
     TEST_DECL(test_wolfSSL_PKCS8),
+    TEST_DECL(test_wolfSSL_EVP_PKEY_ED25519_openssl),
     TEST_DECL(test_wolfSSL_PKCS8_ED25519),
     TEST_DECL(test_wolfSSL_PKCS8_ED448),
 

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -320,10 +320,27 @@ static int ed25519_pairwise_consistency_test(ed25519_key* key, WC_RNG* rng)
 }
 #endif
 
+/* Mirror a derived public key into the key structure itself, leaving the same
+ * layout wc_ed25519_make_key() does: the compressed point in key->p and a copy
+ * in the second half of key->k.  Only called when the key had no public half
+ * yet, so an existing public key is never overwritten - deriving into a
+ * scratch buffer and comparing against key->p is how wc_ed25519_check_key()
+ * validates a keypair.
+ */
+static void ed25519_store_public(ed25519_key* key, const byte* pubKey)
+{
+    if (pubKey != key->p) {
+        XMEMCPY(key->p, pubKey, ED25519_PUB_KEY_SIZE);
+    }
+    /* put public key after private key, on the same buffer */
+    XMEMMOVE(key->k + ED25519_KEY_SIZE, key->p, ED25519_PUB_KEY_SIZE);
+}
+
 int wc_ed25519_make_public(ed25519_key* key, unsigned char* pubKey,
                            word32 pubKeySz)
 {
     int   ret = 0;
+    int   storePub = 0;
 #ifndef WOLF_CRYPTO_CB_ONLY_ED25519
     ALIGN16 byte az[ED25519_PRV_KEY_SIZE];
 #if !defined(FREESCALE_LTC_ECC)
@@ -338,6 +355,14 @@ int wc_ed25519_make_public(ed25519_key* key, unsigned char* pubKey,
         ret = ECC_PRIV_KEY_E;
     }
 
+    if (ret == 0) {
+        /* The key doesn't carry its public half yet (e.g. it was decoded from
+         * a PKCS#8 v1 PrivateKeyInfo, which holds only the seed): fill it in
+         * as well, so pubKeySet below doesn't end up set on a key whose p/k
+         * are still empty. */
+        storePub = !key->pubKeySet;
+    }
+
 #ifdef WOLF_CRYPTO_CB
     /* Device-first: offload the public-key derivation. Fall through to the
      * software path below only when the device reports the operation
@@ -350,8 +375,11 @@ int wc_ed25519_make_public(ed25519_key* key, unsigned char* pubKey,
     {
         ret = wc_CryptoCb_Ed25519MakePub(key, pubKey, pubKeySz);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
-            if (ret == 0)
+            if (ret == 0) {
+                if (storePub)
+                    ed25519_store_public(key, pubKey);
                 key->pubKeySet = 1;
+            }
             return ret;
         }
         ret = 0; /* device declined the offload; fall back */
@@ -384,6 +412,8 @@ int wc_ed25519_make_public(ed25519_key* key, unsigned char* pubKey,
         ge_p3_tobytes(pubKey, &A);
     #endif
 
+        if (storePub)
+            ed25519_store_public(key, pubKey);
         key->pubKeySet = 1;
     }
 #endif /* WOLF_CRYPTO_CB_ONLY_ED25519 */
@@ -428,15 +458,14 @@ int wc_ed25519_make_key(WC_RNG* rng, int keySz, ed25519_key* key)
         return ret;
 
     key->privKeySet = 1;
+    /* pubKeySet was just cleared, so this also stores the public key in key->p
+     * and after the private key in key->k */
     ret = wc_ed25519_make_public(key, key->p, ED25519_PUB_KEY_SIZE);
     if (ret != 0) {
         key->privKeySet = 0;
         ForceZero(key->k, ED25519_KEY_SIZE);
         return ret;
     }
-
-    /* put public key after private key, on the same buffer */
-    XMEMMOVE(key->k + ED25519_KEY_SIZE, key->p, ED25519_PUB_KEY_SIZE);
 
 #if FIPS_VERSION3_GE(6,0,0)
     ret = wc_ed25519_check_key(key);

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3837,6 +3837,10 @@ int wolfSSL_EVP_PKEY_keygen(WOLFSSL_EVP_PKEY_CTX *ctx,
             #ifdef HAVE_CURVE448
                  ctx->pkey->type != WC_EVP_PKEY_X448 &&
             #endif
+            #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT) && \
+                defined(HAVE_ED25519_MAKE_KEY)
+                 ctx->pkey->type != WC_EVP_PKEY_ED25519 &&
+            #endif
                  ctx->pkey->type != WC_EVP_PKEY_DH)) {
             WOLFSSL_MSG("Key not set or key type not supported");
             return WOLFSSL_FAILURE;
@@ -3963,6 +3967,86 @@ int wolfSSL_EVP_PKEY_keygen(WOLFSSL_EVP_PKEY_CTX *ctx,
                 ret = WOLFSSL_SUCCESS;
             }
             break;
+#endif
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT) && \
+    defined(HAVE_ED25519_MAKE_KEY)
+        case WC_EVP_PKEY_ED25519: {
+            /* Only free a key THIS call allocated on the failure path; a
+             * caller-supplied key (ownEd25519 already set) must survive. */
+            int newEd25519 = 0;
+            if (pkey->ed25519 == NULL) {
+                pkey->ed25519 = wolfSSL_ED25519_new(pkey->heap, INVALID_DEVID);
+                if (pkey->ed25519 == NULL) {
+                    ret = MEMORY_E;
+                    break;
+                }
+                pkey->ownEd25519 = 1;
+                newEd25519 = 1;
+            }
+            /* Reuse the RNG already initialized on the EVP_PKEY. */
+            if (wc_ed25519_make_key(&pkey->rng, ED25519_KEY_SIZE,
+                    pkey->ed25519) == 0) {
+                /* Cache the PKCS#8 PrivateKeyInfo DER so the EVP/SSL paths
+                 * (use_PrivateKey, EVP_PKEY2PKCS8) can load and serialize the
+                 * key, mirroring the state the decode path produces. */
+                int edDerSz = wc_Ed25519PrivateKeyToDer(pkey->ed25519, NULL, 0);
+                if (edDerSz > 0) {
+                    /* DYNAMIC_TYPE_PUBLIC_KEY: the tag wolfSSL_EVP_PKEY_free()
+                     * and the d2i path use for pkey.ptr. */
+                    byte* edDer = (byte*)XMALLOC((size_t)edDerSz, pkey->heap,
+                        DYNAMIC_TYPE_PUBLIC_KEY);
+                    if (edDer != NULL) {
+                        word32 hdrIdx = 0;
+                        word32 hdrAlg = 0;
+                        /* Locate the PKCS#8 header in the DER just built: its
+                         * length marks pkey.ptr as PKCS#8-wrapped, exactly as
+                         * d2i_evp_pkey() does on the decode path, and the
+                         * i2d_PrivateKey / EVP_PKEY2PKCS8 paths rely on it.
+                         * A blob we cannot parse back is unusable, so treat a
+                         * failure here as a keygen failure rather than caching
+                         * a DER whose pkcs8HeaderSz says "not PKCS#8". */
+                        if (wc_Ed25519PrivateKeyToDer(pkey->ed25519, edDer,
+                                (word32)edDerSz) == edDerSz &&
+                                ToTraditionalInline_ex(edDer, &hdrIdx,
+                                    (word32)edDerSz, &hdrAlg) >= 0) {
+                            XFREE(pkey->pkey.ptr, pkey->heap,
+                                DYNAMIC_TYPE_PUBLIC_KEY);
+                            pkey->pkey.ptr = (char*)edDer;
+                            pkey->pkey_sz = edDerSz;
+                            pkey->pkcs8HeaderSz = (word16)hdrIdx;
+                            ret = WOLFSSL_SUCCESS;
+                        }
+                        else {
+                            ForceZero(edDer, (word32)edDerSz);
+                            XFREE(edDer, pkey->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+                        }
+                    }
+                }
+            }
+            /* Do not leave a half-initialized object behind on a FAILURE
+             * return.  wc_ed25519_make_key() has already overwritten (or, on
+             * its own failure, cleared) whatever key the EVP_PKEY held, so any
+             * cached DER now describes a key that is gone - drop it even for a
+             * caller-supplied EVP_PKEY, where the key object itself must
+             * survive because we did not allocate it. */
+            if (ret != WOLFSSL_SUCCESS) {
+                if (pkey->pkey.ptr != NULL) {
+                    if (pkey->pkey_sz > 0) {
+                        ForceZero(pkey->pkey.ptr, (word32)pkey->pkey_sz);
+                    }
+                    XFREE(pkey->pkey.ptr, pkey->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+                    pkey->pkey.ptr = NULL;
+                }
+                pkey->pkey_sz = 0;
+                pkey->pkcs8HeaderSz = 0;
+                if (newEd25519) {
+                    wolfSSL_ED25519_free(pkey->ed25519);
+                    pkey->ed25519 = NULL;
+                    pkey->ownEd25519 = 0;
+                }
+            }
+            break;
+        }
 #endif
         default:
             break;
@@ -4279,6 +4363,28 @@ int wolfSSL_EVP_PKEY_cmp(const WOLFSSL_EVP_PKEY *a, const WOLFSSL_EVP_PKEY *b)
         break;
     }
 #endif /* HAVE_ECC */
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
+    case WC_EVP_PKEY_ED25519:
+    {
+        byte   pubA[ED25519_PUB_KEY_SIZE];
+        byte   pubB[ED25519_PUB_KEY_SIZE];
+        word32 pubASz = (word32)sizeof(pubA);
+        word32 pubBSz = (word32)sizeof(pubB);
+
+        if (a->ed25519 == NULL || b->ed25519 == NULL) {
+            return ret;
+        }
+        /* Compare the raw 32-byte public keys. */
+        if (wc_ed25519_export_public(a->ed25519, pubA, &pubASz) != 0 ||
+            wc_ed25519_export_public(b->ed25519, pubB, &pubBSz) != 0) {
+            return ret;
+        }
+        if (pubASz != pubBSz || XMEMCMP(pubA, pubB, pubASz) != 0) {
+            return WS_RETURN_CODE(ret, WOLFSSL_FAILURE);
+        }
+        break;
+    }
+#endif /* HAVE_ED25519 && HAVE_ED25519_KEY_EXPORT */
     default:
         return WS_RETURN_CODE(ret, -2);
     } /* switch (a->type) */

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -324,6 +324,22 @@ static int d2iTryEd25519Key(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         return WOLFSSL_FATAL_ERROR;
     }
 
+#ifdef HAVE_ED25519_MAKE_KEY
+    /* A PKCS#8 v1 PrivateKeyInfo carries only the private seed, so the
+     * decoded key has no public part.  Derive it (deterministic from the
+     * seed; wc_ed25519_make_public also stores it in the key) so the
+     * resulting EVP_PKEY is complete and callers can later export/embed the
+     * public key.  Best-effort: on failure the key is left private-only. */
+    if (priv && !edKey->pubKeySet) {
+        byte pub[ED25519_PUB_KEY_SIZE];
+
+        if (wc_ed25519_make_public(edKey, pub, sizeof(pub)) != 0) {
+            WOLFSSL_MSG("wc_ed25519_make_public failed; "
+                        "EVP_PKEY has no public part");
+        }
+    }
+#endif /* HAVE_ED25519_MAKE_KEY */
+
     /* Copy the consumed DER into pkey->pkey.ptr, unless the caller
      * pre-filled the EVP PKEY with the input bytes (d2i_evp_pkey()).
      * A reused key must be re-populated here. */
@@ -588,6 +604,9 @@ WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_raw_private_key(int type,
     #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
         case WC_EVP_PKEY_ED25519: {
             ed25519_key* edKey;
+        #ifdef HAVE_ED25519_MAKE_KEY
+            byte edPub[ED25519_PUB_KEY_SIZE];
+        #endif
             if (len != ED25519_KEY_SIZE) {
                 break;
             }
@@ -600,6 +619,16 @@ WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_raw_private_key(int type,
                 wolfSSL_ED25519_free(edKey);
                 break;
             }
+        #ifdef HAVE_ED25519_MAKE_KEY
+            /* The raw input is the seed alone, so the imported key has no
+             * public half.  Derive it (wc_ed25519_make_public stores it in the
+             * key) so a key built this way is interchangeable with one decoded
+             * from PKCS#8: i2d_PUBKEY, EVP_PKEY_cmp and signing all need it. */
+            if (wc_ed25519_make_public(edKey, edPub, sizeof(edPub)) != 0) {
+                wolfSSL_ED25519_free(edKey);
+                break;
+            }
+        #endif
             pkey->type       = WC_EVP_PKEY_ED25519;
             pkey->ed25519    = edKey;
             pkey->ownEd25519 = 1;
@@ -1703,6 +1732,29 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
 
     /* Take off PKCS#8 wrapper if found. */
     if ((len = ToTraditionalInline_ex(der, &idx, keyLen, &algId)) >= 0) {
+    #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
+        if (algId == ED25519k) {
+            word32 seqIdx = 0;
+            int seqLen = 0;
+
+            /* Ed25519's inner key is an OCTET STRING, not a SEQUENCE, so the
+             * RSA/ECC element-count heuristic below cannot classify it.
+             * Decode the full PKCS#8 PrivateKeyInfo directly (keeps the
+             * cached DER complete so the key can be re-loaded later).  Pass
+             * the size of the whole PrivateKeyInfo, taken from its outer
+             * SEQUENCE header: ToTraditionalInline_ex() reports the offset and
+             * length of the inner privateKey OCTET STRING only, and RFC 5958
+             * allows optional attributes and a publicKey to follow it - the
+             * form wolfSSL's own wc_Ed25519KeyToDer() emits - which that offset
+             * would cut off.  With the object size, *pp advances by exactly one
+             * object and no trailing bytes are cached. */
+            if (GetSequence(der, &seqIdx, &seqLen, keyLen) < 0) {
+                return NULL;
+            }
+            return wolfSSL_d2i_PrivateKey(WC_EVP_PKEY_ED25519, pkey, pp,
+                (long)seqIdx + (long)seqLen);
+        }
+    #endif
         der += idx;
         keyLen = (word32)len;
     }
@@ -2480,6 +2532,56 @@ static int wolfssl_i_i2d_ecpublickey(const WOLFSSL_EVP_PKEY* key,
 }
 #endif
 
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
+/* Encode an Ed25519 public key as DER SubjectPublicKeyInfo.  Follows the
+ * i2d output convention: der == NULL returns the size only; *der == NULL
+ * allocates the buffer (caller frees); otherwise writes into *der and
+ * advances it.  Returns the DER size or WOLFSSL_FATAL_ERROR. */
+static int wolfssl_i_i2d_ed25519_pubkey(const ed25519_key* key,
+    unsigned char **der)
+{
+    int derSz;
+    unsigned char* buf;
+
+    if (key == NULL) {
+        return WOLFSSL_FATAL_ERROR;
+    }
+
+    /* withAlg = 1 -> wrap the raw key in a SubjectPublicKeyInfo. */
+    derSz = wc_Ed25519PublicKeyToDer(key, NULL, 0, 1);
+    if (derSz <= 0) {
+        return WOLFSSL_FATAL_ERROR;
+    }
+    if (der == NULL) {
+        return derSz;
+    }
+
+    if (*der != NULL) {
+        /* Caller supplied the buffer: the size is known up front, so encode
+         * straight into it and advance past the encoding. */
+        if (wc_Ed25519PublicKeyToDer(key, *der, (word32)derSz, 1) != derSz) {
+            return WOLFSSL_FATAL_ERROR;
+        }
+        *der += derSz;
+        return derSz;
+    }
+
+    buf = (unsigned char*)XMALLOC((size_t)derSz, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+    if (buf == NULL) {
+        return WOLFSSL_FATAL_ERROR;
+    }
+    if (wc_Ed25519PublicKeyToDer(key, buf, (word32)derSz, 1)
+            != derSz) {
+        XFREE(buf, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+        return WOLFSSL_FATAL_ERROR;
+    }
+    /* Hand the buffer to the caller (no advance, per the i2d convention). */
+    *der = buf;
+
+    return derSz;
+}
+#endif /* HAVE_ED25519 && HAVE_ED25519_KEY_EXPORT */
+
 /* Encode the WOLFSSL_EVP_PKEY object as public key DER.
  *
  * @param [in]  key  WOLFSLS_EVP_PKEY object to encode.
@@ -2507,6 +2609,16 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
     #ifdef HAVE_ECC
         case WC_EVP_PKEY_EC:
             return wolfssl_i_i2d_ecpublickey(key, key->ecc, der);
+    #endif
+    #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
+        /* Emit a SubjectPublicKeyInfo (withAlg=1) rather than the bare key:
+         * wolfSSL_i2d_PUBKEY aliases to this function (below), so the SPKI is
+         * what wolfSSL_d2i_PUBKEY has to be able to read back.  Matches the
+         * adjacent EC case, which encodes with withAlg=1 for the same reason.
+         * (Note this differs from OpenSSL, where i2d_PublicKey emits the raw
+         * key for Ed25519 and only i2d_PUBKEY emits the SPKI.) */
+        case WC_EVP_PKEY_ED25519:
+            return wolfssl_i_i2d_ed25519_pubkey(key->ed25519, der);
     #endif
         default:
             ret = WOLFSSL_FATAL_ERROR;

--- a/wolfssl/openssl/ed25519.h
+++ b/wolfssl/openssl/ed25519.h
@@ -42,7 +42,8 @@ int wolfSSL_ED25519_verify(const unsigned char *msg, unsigned int msgSz,
                            const unsigned char *pub, unsigned int pubSz,
                            const unsigned char *sig, unsigned int sigSz);
 
-#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || \
+    defined(OPENSSL_EXTRA_X509_SMALL)
 #ifndef WC_ED25519KEY_TYPE_DEFINED
     typedef struct ed25519_key ed25519_key;
     #define WC_ED25519KEY_TYPE_DEFINED


### PR DESCRIPTION
# Description

wolfCrypt has full Ed25519 (keygen, sign/verify, ASN.1 import/export) and the TLS 1.3 stack already authenticates with Ed25519 certificates, but the OpenSSL-compatibility surface was missing the dispatch for several common operations, so an application driving Ed25519 purely through the OpenSSL API (EVP_PKEY_keygen, i2d_PUBKEY, X509_sign of an in-memory self-signed cert, then loading it into an SSL_CTX) could not use it.

This PR adds the required glue code to have full OpenSSL API support for Ed25591 (by mirroring the existing RSA/ECC/X25519 code).

Note: requires --enable-ed25519 --enable-certgen

# Testing

The commit comes with the relevant unit test code.
Moreover, this code is used by an experimental TLS-based VPN client that uses Ed25591 keys/certs.