### PR TITLE
add macro guard around new test case for specific builds

### DIFF
--- a/tests/api/test_ecc.c
+++ b/tests/api/test_ecc.c
@@ -579,7 +579,10 @@ int test_wc_ecc_shared_secret(void)
 } /* END tests_wc_ecc_shared_secret */
 
 #if defined(HAVE_ECC) && defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG) && \
-    (defined(HAVE_ECC384) || defined(HAVE_ECC521) || defined(HAVE_ALL_CURVES))
+    (defined(HAVE_ECC384) || defined(HAVE_ECC521) || \
+     defined(HAVE_ALL_CURVES)) && \
+    (!defined(WOLFSSL_SP_521) || \
+     ((!defined(HAVE_FIPS) || FIPS_VERSION_GT(7,0)) && !defined(HAVE_SELFTEST)))
 /* Verify the output-buffer size contract of wc_ecc_shared_secret() at the
  * field-size boundary. The single-precision (SP) math secret generators for
  * P-384/P-521 historically validated the caller's buffer against the wrong
@@ -655,7 +658,10 @@ int test_wc_ecc_shared_secret_size_bounds(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG) && \
-    (defined(HAVE_ECC384) || defined(HAVE_ECC521) || defined(HAVE_ALL_CURVES))
+    (defined(HAVE_ECC384) || defined(HAVE_ECC521) || \
+     defined(HAVE_ALL_CURVES)) && \
+    (!defined(WOLFSSL_SP_521) || \
+     ((!defined(HAVE_FIPS) || FIPS_VERSION_GT(7,0)) && !defined(HAVE_SELFTEST)))
     WC_RNG rng;
     int    rngInit = 0;
 

--- a/tests/api/test_ossl_x509_str.c
+++ b/tests/api/test_ossl_x509_str.c
@@ -1510,7 +1510,7 @@ int test_X509_verify_cert_untrusted_inter(void)
 #if defined(OPENSSL_EXTRA) && !defined(NO_RSA) && !defined(NO_CERTS) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT) && \
     !defined(NO_SHA256) && defined(USE_CERT_BUFFERS_2048) && \
-    !defined(NO_ASN_TIME)
+    !defined(NO_ASN_TIME) && !defined(ALLOW_INVALID_CERTSIGN)
 /* Build a CA:TRUE intermediate signed by the 2048-bit test root
  * (ca_cert_der_2048 / ca_key_der_2048).  keyUsage == NULL omits the KeyUsage
  * extension entirely.  Returns the DER length, or <= 0 on failure. */
@@ -1619,7 +1619,9 @@ int test_X509_verify_cert_ca_no_keycertsign(void)
 #if defined(OPENSSL_EXTRA) && !defined(NO_RSA) && !defined(NO_CERTS) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT) && \
     !defined(NO_SHA256) && defined(USE_CERT_BUFFERS_2048) && \
-    !defined(NO_ASN_TIME)
+    !defined(NO_ASN_TIME) && !defined(ALLOW_INVALID_CERTSIGN)
+    /* ALLOW_INVALID_CERTSIGN disables the keyCertSign enforcement that Case 1
+     * relies on, so the test is only meaningful when it is not defined. */
     WC_RNG rng;
     RsaKey caKey, intKey, leafKey;
     int rngI = 0, caI = 0, intI = 0, leafI = 0;


### PR DESCRIPTION
Fixes:
- nightly QT test
- FIPS v6 test with --enable-sp