### PR TITLE
CI: only save dependency caches on master, restore on PRs

### DIFF
--- a/.github/workflows/haproxy.yml
+++ b/.github/workflows/haproxy.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
+  # Daily run on master reseeds the shared cache (see save step below).
+  schedule:
+    - cron: '0 4 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -71,8 +74,8 @@ jobs:
       run: tar -xf build-dir.tgz
 
     # check cache for haproxy if not there then download it
-    - name: Check haproxy cache
-      uses: actions/cache@v5
+    - name: Restore haproxy cache
+      uses: actions/cache/restore@v5
       id: cache-haproxy
       with:
         path: build-dir/haproxy-${{matrix.haproxy_ref}}
@@ -86,6 +89,14 @@ jobs:
         ref: ${{matrix.haproxy_ref}}
         path: build-dir/haproxy-${{matrix.haproxy_ref}}
         fetch-depth: 1
+
+    # Only master (the daily schedule) saves, so all PRs share one entry.
+    - name: Save haproxy cache
+      if: github.ref == 'refs/heads/master' && steps.cache-haproxy.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: build-dir/haproxy-${{matrix.haproxy_ref}}
+        key: haproxy-${{matrix.haproxy_ref}}
 
     - name: Build haproxy
       working-directory: build-dir/haproxy-${{matrix.haproxy_ref}}

--- a/.github/workflows/hostap-vm.yml
+++ b/.github/workflows/hostap-vm.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
+  # Daily run on master reseeds the shared cache (see save steps below).
+  schedule:
+    - cron: '40 5 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -72,7 +75,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checking if we have hostap in cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         id: cache
         with:
           path: hostap
@@ -81,6 +84,14 @@ jobs:
       - name: Checkout hostap
         if: steps.cache.outputs.cache-hit != 'true'
         run: git clone https://w1.fi/hostap.git hostap
+
+      # Only master (the daily schedule) saves, so all PRs share one entry.
+      - name: Save hostap cache
+        if: github.ref == 'refs/heads/master' && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: hostap
+          key: hostap-repo
 
       - name: tar hostap
         run: tar -zcf hostap.tgz hostap
@@ -101,7 +112,7 @@ jobs:
     needs: checkout_hostap
     steps:
       - name: Checking if we have kernel in cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         id: cache
         with:
           path: linux/linux
@@ -132,6 +143,14 @@ jobs:
           cp hostap/tests/hwsim/vm/kernel-config.uml linux/.config
           cd linux
           yes "" | ARCH=um make -j $(nproc)
+
+      # Only master (the daily schedule) saves, so all PRs share one entry.
+      - name: Save kernel cache
+        if: github.ref == 'refs/heads/master' && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: linux/linux
+          key: hostap-linux-${{ env.LINUX_REF }}
 
       - name: Upload kernel binary
         uses: actions/upload-artifact@v6

--- a/.github/workflows/mbedtls.yml
+++ b/.github/workflows/mbedtls.yml
@@ -65,6 +65,20 @@ jobs:
           path: mbedtls
           key: mbedtls-${{ env.MBED_REF }}
 
+      # On a cache miss, hand the freshly built mbedtls to mbedtls_test via an
+      # artifact so it is not compiled a second time in the same run.
+      - name: tar mbedtls
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: tar -zcf mbedtls.tgz mbedtls
+
+      - name: Upload mbedtls build
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: mbedtls-build
+          path: mbedtls.tgz
+          retention-days: 1
+
   mbedtls_test:
     name: Test interop with mbedtls
     if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
@@ -83,26 +97,17 @@ jobs:
           path: mbedtls
           key: mbedtls-${{ env.MBED_REF }}
 
-      - name: Checkout mbedtls (fallback on cache miss)
+      # On a cache miss, reuse the build_mbedtls artifact instead of
+      # recompiling. master restores from the cache above instead.
+      - name: Download mbedtls build (fallback on cache miss)
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v5
+        uses: actions/download-artifact@v7
         with:
-          repository: Mbed-TLS/mbedtls
-          ref: ${{ env.MBED_REF }}
-          path: mbedtls
-          fetch-depth: 1
+          name: mbedtls-build
 
-      - name: Compile mbedtls (fallback on cache miss)
+      - name: untar mbedtls (fallback on cache miss)
         if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: mbedtls
-        run: |
-          git submodule update --init
-          mkdir build
-          cd build
-          cmake ..
-          make -j$(nproc)
-          openssl pkey -in framework/data_files/cli-rsa-sha256.key.der -text > framework/data_files/cli-rsa-sha256.key.pem
-          openssl pkey -in framework/data_files/server2.key.der -text > framework/data_files/server2.key.pem
+        run: tar -xf mbedtls.tgz
 
       - name: Build wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1

--- a/.github/workflows/mbedtls.yml
+++ b/.github/workflows/mbedtls.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
+  # Daily run on master reseeds the shared cache (see save steps below).
+  schedule:
+    - cron: '20 4 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +28,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checking if we have mbed in cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         id: cache
         with:
           path: mbedtls
@@ -54,6 +57,14 @@ jobs:
           openssl pkey -in framework/data_files/cli-rsa-sha256.key.der -text > framework/data_files/cli-rsa-sha256.key.pem
           openssl pkey -in framework/data_files/server2.key.der -text > framework/data_files/server2.key.pem
 
+      # Only master (the daily schedule) saves, so all PRs share one entry.
+      - name: Save mbedtls cache
+        if: github.ref == 'refs/heads/master' && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: mbedtls
+          key: mbedtls-${{ env.MBED_REF }}
+
   mbedtls_test:
     name: Test interop with mbedtls
     if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
@@ -64,8 +75,9 @@ jobs:
       - name: Disable IPv6 (IMPORTANT, OTHERWISE DTLS MBEDTLS CLIENT WON'T CONNECT)
         run: echo 1 | sudo tee /proc/sys/net/ipv6/conf/lo/disable_ipv6
 
+      # Restore only: the build_mbedtls job (master/schedule) owns the save.
       - name: Checking if we have mbed in cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         id: cache
         with:
           path: mbedtls

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -27,6 +27,9 @@ jobs:
           msystem: msys
           update: true
           install: git gcc autotools base-devel autoconf netcat
+          # Per-PR cache entries can't be shared across PRs; the action
+          # offers no master-only save, so disable caching entirely.
+          cache: false
       - name: configure wolfSSL
         run: ./autogen.sh && ./configure --disable-sys-ca-certs CFLAGS="-DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DNO_WRITE_TEMP_FILES"
       - name: build wolfSSL

--- a/.github/workflows/nss.yml
+++ b/.github/workflows/nss.yml
@@ -74,6 +74,20 @@ jobs:
           path: dist
           key: nss-${{ env.NSS_REF }}
 
+      # On a cache miss, hand the freshly built dist/ to nss_test via an
+      # artifact so nss is not compiled a second time in the same run.
+      - name: tar nss dist
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: tar -zcf nss-dist.tgz dist
+
+      - name: Upload nss build
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: nss-build
+          path: nss-dist.tgz
+          retention-days: 1
+
   nss_test:
     name: Test interop with nss
     if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
@@ -89,35 +103,17 @@ jobs:
           path: dist
           key: nss-${{ env.NSS_REF }}
 
-      - name: Checkout wolfSSL CI actions (fallback on cache miss)
+      # On a cache miss, reuse the build_nss artifact instead of recompiling.
+      # master restores from the cache above instead.
+      - name: Download nss build (fallback on cache miss)
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v5
+        uses: actions/download-artifact@v7
         with:
-          sparse-checkout: .github/actions
-          fetch-depth: 1
+          name: nss-build
 
-      - name: Install dependencies (fallback on cache miss)
+      - name: untar nss dist (fallback on cache miss)
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: ./.github/actions/install-apt-deps
-        with:
-          packages: gyp ninja-build
-          ghcr-debs-tag: ubuntu-24.04-full
-
-      - name: Checkout nss (fallback on cache miss)
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v5
-        with:
-          repository: nss-dev/nss
-          ref: ${{ env.NSS_REF }}
-          path: nss
-          fetch-depth: 1
-
-      - name: Compile nss (fallback on cache miss)
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          hg clone https://hg.mozilla.org/projects/nspr
-          cd nss
-          ./build.sh
+        run: tar -xf nss-dist.tgz
 
       - name: Build wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1

--- a/.github/workflows/nss.yml
+++ b/.github/workflows/nss.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
+  # Daily run on master reseeds the shared cache (see save steps below).
+  schedule:
+    - cron: '40 4 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +36,7 @@ jobs:
           fetch-depth: 1
 
       - name: Checking if we have nss in cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         id: cache
         with:
           path: dist
@@ -63,6 +66,14 @@ jobs:
           cd nss
           ./build.sh
 
+      # Only master (the daily schedule) saves, so all PRs share one entry.
+      - name: Save nss cache
+        if: github.ref == 'refs/heads/master' && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: dist
+          key: nss-${{ env.NSS_REF }}
+
   nss_test:
     name: Test interop with nss
     if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
@@ -70,8 +81,9 @@ jobs:
     needs: build_nss
     timeout-minutes: 30
     steps:
+      # Restore only: the build_nss job (master/schedule) owns the save.
       - name: Checking if we have nss in cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         id: cache
         with:
           path: dist

--- a/.github/workflows/ntp.yml
+++ b/.github/workflows/ntp.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
+  # Daily run on master reseeds the shared cache (see save step below).
+  schedule:
+    - cron: '0 5 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -70,7 +73,7 @@ jobs:
 
       # Avoid DoS'ing ntp site so cache the tar.gz
       - name: Check if we have ntp
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         id: cache
         with:
           path: ntp-${{ matrix.ref }}.tar.gz
@@ -80,6 +83,14 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           wget https://downloads.nwtime.org/ntp/4.2.8/ntp-${{ matrix.ref }}.tar.gz
+
+      # Only master (the daily schedule) saves, so all PRs share one entry.
+      - name: Save ntp cache
+        if: github.ref == 'refs/heads/master' && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ntp-${{ matrix.ref }}.tar.gz
+          key: ntp-${{ matrix.ref }}.tar.gz
 
       - name: Extract ntp
         run: |

--- a/.github/workflows/pic32mz-sim.yml
+++ b/.github/workflows/pic32mz-sim.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [ 'master', 'main', 'release/**' ]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
   # Weekend cron and manual workflow_dispatch refresh the shared ghcr build
   # cache that PR runs read (cache-to below is gated to those two events).

--- a/.github/workflows/pic32mz-sim.yml
+++ b/.github/workflows/pic32mz-sim.yml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   pic32mz_sim:
     name: wolfCrypt on PIC32MZ ${{ matrix.chip_label }} (${{ matrix.port_label }})
-    if: github.repository_owner == 'wolfssl'
+    if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/threadx.yml
+++ b/.github/workflows/threadx.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
+  # Daily run on master reseeds the shared cache (see save step below).
+  schedule:
+    - cron: '20 5 * * *'
 
 jobs:
   build:
@@ -15,9 +18,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - name: Cache NetXDuo bundle
+    - name: Restore NetXDuo bundle cache
       id: cache-netxduo
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: ./v6.4.3_rel.tar.gz
         key: netxduo-bundle-v6.4.3_rel
@@ -26,6 +29,14 @@ jobs:
       if: steps.cache-netxduo.outputs.cache-hit != 'true'
       run: |
         wget https://github.com/eclipse-threadx/netxduo/archive/refs/tags/v6.4.3_rel.tar.gz
+
+    # Only master (the daily schedule) saves, so all PRs share one entry.
+    - name: Save NetXDuo bundle cache
+      if: github.ref == 'refs/heads/master' && steps.cache-netxduo.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: ./v6.4.3_rel.tar.gz
+        key: netxduo-bundle-v6.4.3_rel
 
     - name: Extract NetXDuo bundle
       run: |

--- a/.github/workflows/threadx.yml
+++ b/.github/workflows/threadx.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '20 5 * * *'
 
+env:
+  NETXDUO_REF: v6.4.3_rel
+
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
@@ -22,26 +25,26 @@ jobs:
       id: cache-netxduo
       uses: actions/cache/restore@v5
       with:
-        path: ./v6.4.3_rel.tar.gz
-        key: netxduo-bundle-v6.4.3_rel
+        path: ./${{ env.NETXDUO_REF }}.tar.gz
+        key: netxduo-bundle-${{ env.NETXDUO_REF }}
 
     - name: Download NetXDuo bundle if not cached
       if: steps.cache-netxduo.outputs.cache-hit != 'true'
       run: |
-        wget https://github.com/eclipse-threadx/netxduo/archive/refs/tags/v6.4.3_rel.tar.gz
+        wget https://github.com/eclipse-threadx/netxduo/archive/refs/tags/${{ env.NETXDUO_REF }}.tar.gz
 
     # Only master (the daily schedule) saves, so all PRs share one entry.
     - name: Save NetXDuo bundle cache
       if: github.ref == 'refs/heads/master' && steps.cache-netxduo.outputs.cache-hit != 'true'
       uses: actions/cache/save@v5
       with:
-        path: ./v6.4.3_rel.tar.gz
-        key: netxduo-bundle-v6.4.3_rel
+        path: ./${{ env.NETXDUO_REF }}.tar.gz
+        key: netxduo-bundle-${{ env.NETXDUO_REF }}
 
     - name: Extract NetXDuo bundle
       run: |
         mkdir -p netxduo_src
-        tar -xzf v6.4.3_rel.tar.gz -C netxduo_src --strip-components=1
+        tar -xzf ${{ env.NETXDUO_REF }}.tar.gz -C netxduo_src --strip-components=1
 
     - name: Install NetXDuo Dependencies
       working-directory: ./netxduo_src


### PR DESCRIPTION
GitHub Actions caches are branch-scoped: an entry written by a `pull_request`
run lives under `refs/pull/<N>/merge` and is invisible to other PRs. The
haproxy, mbedtls, nss, ntp, threadx and hostap-vm workflows used combined
`actions/cache` with fixed keys, so every PR re-saved its own copy of the same
dependency, yielding one duplicate cache entry per PR.

**`CI: only save dependency caches on master, restore on PRs`**

- Split each into `actions/cache/restore` (always) plus `actions/cache/save`
  gated to `refs/heads/master`, and add a daily schedule so a master run
  reseeds the single shared entry that all PRs restore.
- mbedtls/nss save in their build job only; the test jobs restore-only.
- Disable the `setup-msys2` package cache: the action only toggles caching
  on/off and cannot save on master while restoring on PRs.

**`CI: factor threadx NetXDuo version into NETXDUO_REF env var`**

- The `v6.4.3_rel` version was repeated in the cache path, cache key, download
  URL and extract command. Define it once as a workflow-level env var and
  reference it everywhere.
