### PR TITLE
20260618-FORCE_FAILURE_RDSEED-fixes

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -217,7 +217,7 @@
         #endif
     #endif
 
-    #if defined(HAVE_FIPS) && FIPS_VERSION3_LT(5, 2, 4)
+    #if defined(HAVE_FIPS) && FIPS_VERSION3_LT(7, 0, 0)
         #if defined(HAVE_HASHDRBG) && \
             defined(HAVE_ENTROPY_MEMUSE) && \
             !defined(WC_LINUXKM_WOLFENTROPY_IN_GLUE_LAYER)
@@ -227,6 +227,11 @@
               !defined(HAVE_ENTROPY_MEMUSE) && \
               !defined(WC_LINUXKM_RDSEED_IN_GLUE_LAYER)
             #define WC_LINUXKM_RDSEED_IN_GLUE_LAYER
+            /* Work around -Wmaybe-uninitialized in old FIPS random.c.
+             * Glue-layer wc_linuxkm_GenerateSeed_IntelRD() always forces
+             * failure if RDSEED is missing or fails.
+             */
+            #undef FORCE_FAILURE_RDSEED
         #endif
     #endif
     #if defined(WC_LINUXKM_WOLFENTROPY_IN_GLUE_LAYER)

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -3934,7 +3934,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     }
 #endif
 
-    #ifdef HAVE_INTEL_RDSEED
+    #if defined(HAVE_INTEL_RDSEED) || defined(HAVE_AMD_RDSEED)
         if (IS_INTEL_RDSEED(intel_flags)) {
              if (!wc_GenerateSeed_IntelRD(NULL, output, sz)) {
                  /* success, we're done */
@@ -3945,7 +3945,13 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
              return READ_RAN_E;
         #endif
         }
-    #endif /* HAVE_INTEL_RDSEED */
+    #ifdef FORCE_FAILURE_RDSEED
+        else {
+            /* Don't fall back to system randomness */
+            return MISSING_RNG_E;
+        }
+    #endif
+    #endif /* HAVE_INTEL_RDSEED || HAVE_AMD_RDSEED */
 
 #ifdef WIN_REUSE_CRYPT_HANDLE
     /* Check that handle was initialized.
@@ -4914,7 +4920,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
         (void)os;
-        int ret;
+        int ret = WC_NO_ERR_TRACE(RNG_FAILURE_E);
 
     #ifdef HAVE_ENTROPY_MEMUSE
         ret = wc_Entropy_Get(MAX_ENTROPY_BITS, output, sz);
@@ -4934,6 +4940,12 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
             return ret;
             #endif
         }
+    #ifdef FORCE_FAILURE_RDSEED
+        else {
+            /* Don't fall back to get_random_bytes() */
+            return MISSING_RNG_E;
+        }
+    #endif
     #endif /* HAVE_INTEL_RDSEED || HAVE_AMD_RDSEED */
 
     #ifdef LINUXKM_LKCAPI_REGISTER_HASH_DRBG_DEFAULT
@@ -4957,7 +4969,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
         (void)os;
-        int ret;
+        int ret = WC_NO_ERR_TRACE(RNG_FAILURE_E);
 
     #ifdef HAVE_ENTROPY_MEMUSE
         ret = wc_Entropy_Get(MAX_ENTROPY_BITS, output, sz);
@@ -4980,6 +4992,12 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
                 return ret;
             }
         }
+    #ifdef FORCE_FAILURE_RDSEED
+        else {
+            /* Don't fall back to arc4random_buf() */
+            return MISSING_RNG_E;
+        }
+    #endif
     #endif /* HAVE_INTEL_RDSEED || HAVE_AMD_RDSEED */
 
         (void)ret;


### PR DESCRIPTION
`wolfcrypt/src/random.c`:

* in `USE_WINDOWS_API` `wc_GenerateSeed()`, recognize `HAVE_AMD_RDSEED`, and properly enforce `FORCE_FAILURE_RDSEED` when CPU support is missing;

* in `WOLFSSL_LINUXKM` `wc_GenerateSeed()`, initialize `ret` to `RNG_FAILURE_E`, and properly enforce `FORCE_FAILURE_RDSEED` when CPU support is missing;

* in `WOLFSSL_BSDKM` `wc_GenerateSeed()`, properly enforce `FORCE_FAILURE_RDSEED` when CPU support is missing;

detected and tested with
```
wolfssl-multi-test.sh ...
check-source-text
linuxkm-fips-v5-strict-dist-insmod-cust-kernel-2-amdrdseed
quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-rdseed-fips-dev-linuxkm-next-insmod
clang-tidy-all-sp-all
```
