### PR TITLE
MAX32666 fixes for old SDK

### DIFF
--- a/wolfcrypt/src/port/maxim/max3266x.c
+++ b/wolfcrypt/src/port/maxim/max3266x.c
@@ -50,7 +50,8 @@
     #error  MXC Not Compatible with Fast Math or Heap Math
     #include <wolfssl/wolfcrypt/tfm.h>
     #define MXC_WORD_SIZE               DIGIT_BIT
-#elif defined(WOLFSSL_SP_MATH_ALL)
+#elif defined(WOLFSSL_SP_MATH_ALL) || \
+      (defined(WOLFSSL_SP_MATH) && !defined(MAX3266X_MATH))
     #include <wolfssl/wolfcrypt/sp_int.h>
     #define MXC_WORD_SIZE               SP_WORD_SIZE
 #else

--- a/wolfcrypt/src/port/maxim/max3266x.c
+++ b/wolfcrypt/src/port/maxim/max3266x.c
@@ -625,7 +625,11 @@ int wc_MXC_TRNG_Random(unsigned char* output, unsigned int sz)
     if (status != 0) {
         return status;
     }
+#if defined(WOLFSSL_MAX3266X_OLD)
+    status = TRNG_Init(NULL);
+#else
     status = MXC_TPU_Init(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
     if (status == 0) {
         /* void return function */
         MXC_TPU_TRNG_Read(MXC_TRNG, output, sz);
@@ -643,6 +647,13 @@ int wc_MXC_TRNG_Random(unsigned char* output, unsigned int sz)
 /* Implements TRNG on-demand health test (the older SDK does not provide one) */
 int wc_MXC_TRNG_HealthTest(void)
 {
+    if (TRNG_Init(NULL) != 0) {
+        MAX3266X_MSG("TRNG Device did not initialize");
+        return RNG_FAILURE_E;
+    }
+
+    while ((MXC_TRNG->st & MXC_F_TRNG_ST_RND_RDY) == 0) {}
+
     /* Clear on-going test if necessary */
     if (MXC_TRNG->cn & MXC_F_TRNG_CN_ODHT) {
         MXC_TRNG->cn &= ~MXC_F_TRNG_CN_ODHT;

--- a/wolfcrypt/src/port/maxim/max3266x.c
+++ b/wolfcrypt/src/port/maxim/max3266x.c
@@ -638,6 +638,31 @@ int wc_MXC_TRNG_Random(unsigned char* output, unsigned int sz)
     wolfSSL_HwRngMutexUnLock(); /* Unlock Mutex no matter status value */
     return status;
 }
+
+#if defined(WOLFSSL_MAX3266X_OLD)
+/* Implements TRNG on-demand health test (the older SDK does not provide one) */
+int wc_MXC_TRNG_HealthTest(void)
+{
+    /* Clear on-going test if necessary */
+    if (MXC_TRNG->cn & MXC_F_TRNG_CN_ODHT) {
+        MXC_TRNG->cn &= ~MXC_F_TRNG_CN_ODHT;
+        while (MXC_TRNG->st & MXC_F_TRNG_ST_ODHTS) {}
+    }
+
+    /* Start on-demand health test */
+    MXC_TRNG->cn |= MXC_F_TRNG_CN_ODHT;
+
+    /* Wait for the test to finish */
+    while (MXC_TRNG->st & MXC_F_TRNG_ST_ODHTS) {}
+
+    /* Check results of test */
+    if (MXC_TRNG->st & MXC_F_TRNG_ST_HTS) {
+        MAX3266X_MSG("TRNG HW Health Test Failed");
+        return WC_HW_E;
+    }
+    return 0;
+}
+#endif /* WOLFSSL_MAX3266X_OLD */
 #endif /* MAX3266X_RNG */
 
 #if defined(MAX3266X_AES)
@@ -1051,6 +1076,12 @@ int wc_MXC_TPU_SHA_Final(unsigned char** msg, unsigned int* used,
 
 /* TPU hash helpers (bare-metal SHA accelerator) */
 
+#if defined(WOLFSSL_MAX3266X_OLD)
+    #define MXC_TPU_DATA_IN din
+#else
+    #define MXC_TPU_DATA_IN data_in
+#endif
+
 /* Reset TPU, select hash function, and restore intermediate state into
  * the HASH_DIGEST registers. */
 void wc_MXC_TPU_Hash_Setup(MXC_TPU_HASH_TYPE algo,
@@ -1089,7 +1120,7 @@ void wc_MXC_TPU_Hash_Feed_Block(const unsigned char* data,
 
     for (word = 0; word < blockSz; word += 4) {
         while (!(MXC_TPU->ctrl & MXC_F_TPU_CTRL_RDY)) {}
-        MXC_TPU->data_in[0] = (unsigned int)data[word]
+        MXC_TPU->MXC_TPU_DATA_IN[0] = (unsigned int)data[word]
                              | ((unsigned int)data[word + 1] << 8)
                              | ((unsigned int)data[word + 2] << 16)
                              | ((unsigned int)data[word + 3] << 24);
@@ -1117,26 +1148,26 @@ void wc_MXC_TPU_Hash_Feed_Last(const unsigned char* data,
      * trigger processing of the padding-only block. */
     if (totalLenLo == 0 && totalLenHi == 0) {
         while (!(MXC_TPU->ctrl & MXC_F_TPU_CTRL_RDY)) {}
-        MXC_TPU->data_in[0] = 0;
+        MXC_TPU->MXC_TPU_DATA_IN[0] = 0;
     }
 
     for (word = 0; word < dataLen; word += 4) {
         while (!(MXC_TPU->ctrl & MXC_F_TPU_CTRL_RDY)) {}
         if (dataLen >= (word + 4)) {
-            MXC_TPU->data_in[0] = (unsigned int)data[word]
+            MXC_TPU->MXC_TPU_DATA_IN[0] = (unsigned int)data[word]
                                  | ((unsigned int)data[word + 1] << 8)
                                  | ((unsigned int)data[word + 2] << 16)
                                  | ((unsigned int)data[word + 3] << 24);
         }
         else if ((dataLen & 3) == 1) {
-            MXC_TPU->data_in[0] = (unsigned int)data[word];
+            MXC_TPU->MXC_TPU_DATA_IN[0] = (unsigned int)data[word];
         }
         else if ((dataLen & 3) == 2) {
-            MXC_TPU->data_in[0] = (unsigned int)data[word]
+            MXC_TPU->MXC_TPU_DATA_IN[0] = (unsigned int)data[word]
                                  | ((unsigned int)data[word + 1] << 8);
         }
         else if ((dataLen & 3) == 3) {
-            MXC_TPU->data_in[0] = (unsigned int)data[word]
+            MXC_TPU->MXC_TPU_DATA_IN[0] = (unsigned int)data[word]
                                  | ((unsigned int)data[word + 1] << 8)
                                  | ((unsigned int)data[word + 2] << 16);
         }

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -5193,30 +5193,22 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #elif defined(MAX3266X_RNG)
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
-        #ifdef WOLFSSL_MAX3266X
         int status;
-        #endif /* WOLFSSL_MAX3266X */
         static int initDone = 0;
         (void)os;
         if (initDone == 0) {
-            #ifdef WOLFSSL_MAX3266X
             status = wolfSSL_HwRngMutexLock();
             if (status != 0) {
                 return status;
             }
-            #endif /* WOLFSSL_MAX3266X */
             if(MXC_TRNG_HealthTest() != 0) {
                 #ifdef DEBUG_WOLFSSL
                 WOLFSSL_MSG("TRNG HW Health Test Failed");
                 #endif /* DEBUG_WOLFSSL */
-                #ifdef WOLFSSL_MAX3266X
                 wolfSSL_HwRngMutexUnLock();
-                #endif /* WOLFSSL_MAX3266X */
                 return WC_HW_E;
             }
-            #ifdef WOLFSSL_MAX3266X
             wolfSSL_HwRngMutexUnLock();
-            #endif /* WOLFSSL_MAX3266X */
             initDone = 1;
         }
         return wc_MXC_TRNG_Random(output, sz);

--- a/wolfssl/wolfcrypt/port/maxim/max3266x.h
+++ b/wolfssl/wolfcrypt/port/maxim/max3266x.h
@@ -93,8 +93,7 @@
     #if defined(MAX3266X_RNG)
         #include "trng.h"   /* Provides TRNG Drivers */
         #define MXC_TPU_TRNG_Read           TRNG_Read
-        #warning "TRNG Health Test not available in older Maxim SDK"
-        #define MXC_TRNG_HealthTest(...)    0
+        #define MXC_TRNG_HealthTest         wc_MXC_TRNG_HealthTest
     #endif
     #if defined(MAX3266X_AES)
         #include "cipher.h" /* Provides Drivers for AES */
@@ -152,7 +151,7 @@
     #endif
 
     /* TPU Functions */
-    #define MXC_TPU_Init                SYS_TPU_Init
+    #define MXC_TPU_Init(clock)         SYS_TPU_Init(NULL)
     #define MXC_TPU_Shutdown            SYS_TPU_Shutdown
     #define MXC_SYS_PERIPH_CLOCK_TPU    SYS_PERIPH_CLOCK_TPU
 
@@ -228,6 +227,9 @@
 #ifdef MAX3266X_RNG
     WOLFSSL_LOCAL int wc_MXC_TRNG_Random(unsigned char* output,
                                                 unsigned int sz);
+#if defined(WOLFSSL_MAX3266X_OLD)
+    WOLFSSL_LOCAL int wc_MXC_TRNG_HealthTest(void);
+#endif /* WOLFSSL_MAX3266X_OLD */
 #endif
 
 #ifdef MAX3266X_AES


### PR DESCRIPTION
# Description

- Allows streaming SHA implementation to work on the old SDK
- Implements TRNG health test as bare-metal since old SDK doesn't implement it

# Testing

Temporary test firmware: https://moffa.xyz/tmp/test_max32666.tar.gz
