### PR TITLE
bsdkm: fenrir and misc cleanup.

### DIFF
--- a/bsdkm/bsdkm_wc_port.h
+++ b/bsdkm/bsdkm_wc_port.h
@@ -81,9 +81,10 @@ extern struct malloc_type M_WOLFSSL[1];
 #if defined(WOLFSSL_BSDKM_MEMORY_DEBUG)
     #define XMALLOC(s, h, t) ({                                              \
         (void)(h); (void)(t);                                                \
+        size_t _sz = (size_t)(s);                                            \
         int _wait_flag = curthread->td_critnest == 0 ? M_WAITOK : M_NOWAIT;  \
-        void * _ptr = malloc((s), M_WOLFSSL, _wait_flag | M_ZERO);           \
-        printf("info: malloc: %p, M_WOLFSSL, %zu\n", _ptr, (size_t) s);      \
+        void * _ptr = malloc(_sz, M_WOLFSSL, _wait_flag | M_ZERO);           \
+        printf("info: malloc: %p, M_WOLFSSL, %zu\n", _ptr, _sz);             \
         (void *)_ptr;                                                        \
     })
 

--- a/bsdkm/wolfkmod.c
+++ b/bsdkm/wolfkmod.c
@@ -830,7 +830,7 @@ static int wolfkdriv_cbc_work(device_t dev, wolfkdriv_session_t * session,
         else {
             error = wc_AesCbcDecrypt(&aes, out_block, in_block, seg_len);
             if (error) {
-                device_printf(dev, "error: wc_AesCbcEncrypt: %d\n", error);
+                device_printf(dev, "error: wc_AesCbcDecrypt: %d\n", error);
                 goto cbc_work_out;
             }
         }
@@ -930,7 +930,7 @@ static int wolfkdriv_gcm_work(device_t dev, wolfkdriv_session_t * session,
 
     /* process aad first */
     if (crp->crp_aad != NULL) {
-        /* they passed aad in separate buffer. */
+        /* they passed aad in separate buffer. process it in one go. */
         if (is_encrypt) {
             error = wc_AesGcmEncryptUpdate(&aes, NULL, NULL, 0,
                                            crp->crp_aad, crp->crp_aad_length);
@@ -955,6 +955,13 @@ static int wolfkdriv_gcm_work(device_t dev, wolfkdriv_session_t * session,
         for (aad_len = crp->crp_aad_length; aad_len > 0; aad_len -= seg_len) {
             in_seg = crypto_cursor_segment(&cc_in, &in_len);
             seg_len = MIN(aad_len, in_len);
+
+            if (seg_len == 0) {
+                /* the crypto_cursor logic should prevent this from happening,
+                 * but just in case. */
+                error = EINVAL;
+                goto gcm_work_out;
+            }
 
             if (is_encrypt) {
                 error = wc_AesGcmEncryptUpdate(&aes, NULL, NULL, 0,
@@ -982,8 +989,6 @@ static int wolfkdriv_gcm_work(device_t dev, wolfkdriv_session_t * session,
     crypto_cursor_init(&cc_in, &crp->crp_buf);
     crypto_cursor_advance(&cc_in, crp->crp_payload_start);
 
-    in_seg = crypto_cursor_segment(&cc_in, &in_len);
-
     /* handle if the user supplied a separate out buffer. */
     if (CRYPTO_HAS_OUTPUT_BUFFER(crp)) {
         crypto_cursor_init(&cc_out, &crp->crp_obuf);
@@ -993,19 +998,25 @@ static int wolfkdriv_gcm_work(device_t dev, wolfkdriv_session_t * session,
         cc_out = cc_in;
     }
 
-    out_seg = crypto_cursor_segment(&cc_out, &out_len);
-
     while (data_len) {
         /* process through the available segments. */
         in_seg = crypto_cursor_segment(&cc_in, &in_len);
         out_seg = crypto_cursor_segment(&cc_out, &out_len);
         seg_len = MIN(data_len, MIN(in_len, out_len));
 
+        if (seg_len == 0) {
+            /* the crypto_cursor logic should prevent this from happening,
+             * but just in case. */
+            error = EINVAL;
+            goto gcm_work_out;
+        }
+
         if (is_encrypt) {
             error = wc_AesGcmEncryptUpdate(&aes, out_seg, in_seg, seg_len,
                                            NULL, 0);
             if (error) {
-                device_printf(dev, "error: wc_AesGcmEncrypt: %d\n", error);
+                device_printf(dev, "error: wc_AesGcmEncryptUpdate: %d\n",
+                              error);
                 goto gcm_work_out;
             }
         }
@@ -1013,7 +1024,8 @@ static int wolfkdriv_gcm_work(device_t dev, wolfkdriv_session_t * session,
             error = wc_AesGcmDecryptUpdate(&aes, out_seg, in_seg, seg_len,
                                            NULL, 0);
             if (error) {
-                device_printf(dev, "error: wc_AesGcmDecrypt: %d\n", error);
+                device_printf(dev, "error: wc_AesGcmDecryptUpdate: %d\n",
+                              error);
                 goto gcm_work_out;
             }
         }

--- a/bsdkm/wolfkmod_aes.c
+++ b/bsdkm/wolfkmod_aes.c
@@ -20,7 +20,7 @@ static int wolfkdriv_test_aes_cbc_big(device_t dev, int crid)
     struct crypto_session_params csp;
     struct cryptop * crp = NULL;
     Aes *            aes_encrypt = NULL;
-    int    error = 0;
+    int              error = -1;
     byte msg[] = {
         0x6e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
         0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20,
@@ -50,7 +50,7 @@ static int wolfkdriv_test_aes_cbc_big(device_t dev, int crid)
 
     error = wc_AesInit(aes_encrypt, NULL, INVALID_DEVID);
     if (error) {
-        device_printf(dev, "error: newsession_cipher: aes init: %d\n", error);
+        device_printf(dev, "error: wc_AesInit: %d\n", error);
         goto test_aes_cbc_big_out;
     }
 
@@ -72,14 +72,20 @@ static int wolfkdriv_test_aes_cbc_big(device_t dev, int crid)
     csp.csp_ivlen = WC_AES_BLOCK_SIZE;
     csp.csp_cipher_key = key;
     csp.csp_cipher_klen = WC_AES_BLOCK_SIZE;
+
+    /* get crypto session handle */
     error = crypto_newsession(&session, &csp, crid);
     if (error || session == NULL) {
+        device_printf(dev, "error: test_aes: crypto_newsession: %d, %p\n",
+                      error, (void *)session);
+        error = ENOMEM;
         goto test_aes_cbc_big_out;
     }
 
     crp = crypto_getreq(session, M_WAITOK);
     if (crp == NULL) {
         device_printf(dev, "error: test_aes: crypto_getreq failed\n");
+        error = ENOMEM;
         goto test_aes_cbc_big_out;
     }
 
@@ -121,6 +127,7 @@ static int wolfkdriv_test_aes_cbc_big(device_t dev, int crid)
         goto test_aes_cbc_big_out;
     }
 
+    device_printf(dev, "info: test_aes_cbc_big: passed\n");
 test_aes_cbc_big_out:
     #if defined(WOLFSSL_BSDKM_VERBOSE_DEBUG)
     device_printf(dev, "info: test_aes_cbc_big: error=%d, session=%p, crp=%p\n",
@@ -155,7 +162,7 @@ static int wolfkdriv_test_aes_gcm(device_t dev, int crid)
     struct crypto_session_params csp;
     struct cryptop * crp = NULL;
     Aes *            enc = NULL;
-    int              error = 0;
+    int              error = -1;
 
     WOLFSSL_SMALL_STACK_STATIC const byte p[] =
     {
@@ -226,6 +233,12 @@ static int wolfkdriv_test_aes_gcm(device_t dev, int crid)
         goto test_aes_gcm_out;
     }
 
+    error = wc_AesInit(enc, NULL, INVALID_DEVID);
+    if (error) {
+        device_printf(dev, "error: wc_AesInit: %d\n", error);
+        goto test_aes_gcm_out;
+    }
+
     error = wc_AesGcmEncryptInit(enc, k1, sizeof(k1), iv1, sizeof(iv1));
     if (error) { goto test_aes_gcm_out; }
 
@@ -259,6 +272,7 @@ static int wolfkdriv_test_aes_gcm(device_t dev, int crid)
     if (error || session == NULL) {
         device_printf(dev, "error: test_aes: crypto_newsession: %d, %p\n",
                       error, (void *)session);
+        error = ENOMEM;
         goto test_aes_gcm_out;
     }
 
@@ -266,6 +280,7 @@ static int wolfkdriv_test_aes_gcm(device_t dev, int crid)
     crp = crypto_getreq(session, M_WAITOK);
     if (crp == NULL) {
         device_printf(dev, "error: test_aes: crypto_getreq failed\n");
+        error = ENOMEM;
         goto test_aes_gcm_out;
     }
 
@@ -309,6 +324,7 @@ static int wolfkdriv_test_aes_gcm(device_t dev, int crid)
     error = XMEMCMP(resultC2, p, sizeof(p));
     if (error) { goto test_aes_gcm_out; }
 
+    device_printf(dev, "info: test_aes_gcm: passed\n");
 test_aes_gcm_out:
     #if defined(WOLFSSL_BSDKM_VERBOSE_DEBUG)
     device_printf(dev, "info: test_aes_gcm: error=%d, session=%p, crp=%p\n",

--- a/bsdkm/x86_vecreg.c
+++ b/bsdkm/x86_vecreg.c
@@ -107,22 +107,25 @@ void wolfkmod_vecreg_exit(void)
  * Build with WOLFSSL_BSDKM_FPU_DEBUG to see verbose FPU logging.
  */
 #if defined(WOLFSSL_BSDKM_FPU_DEBUG)
-    #define wolfkmod_print_curthread(what)                                   \
+    #define wolfkmod_print_curthread(what) do {                              \
         printf("%s: cpuid = %d, curthread: td_tid = %d, pid = %d (%s), "     \
                "td_critnest = %d, kernfpu = %02x\n",                         \
                (what), PCPU_GET(cpuid), curthread->td_tid,                   \
                curthread->td_proc ? curthread->td_proc->p_pid : -1,          \
                curthread->td_proc ? curthread->td_proc->p_comm : "noproc",   \
                curthread->td_critnest,                                       \
-               curthread->td_pcb->pcb_flags & PCB_KERNFPU);
+               curthread->td_pcb->pcb_flags & PCB_KERNFPU);                  \
+    } while (0)
 
-    #define wolfkmod_fpu_kern_enter()                                        \
+    #define wolfkmod_fpu_kern_enter() do {                                   \
         wolfkmod_print_curthread("fpu_kern_enter");                          \
-        fpu_kern_enter(curthread, NULL, FPU_KERN_NOCTX);
+        fpu_kern_enter(curthread, NULL, FPU_KERN_NOCTX);                     \
+    } while (0)
 
-    #define wolfkmod_fpu_kern_leave()                                        \
+    #define wolfkmod_fpu_kern_leave() do {                                   \
         wolfkmod_print_curthread("fpu_kern_leave");                          \
-        fpu_kern_leave(curthread, NULL);
+        fpu_kern_leave(curthread, NULL);                                     \
+    } while (0)
 #else
     #define wolfkmod_fpu_kern_enter()                                        \
         fpu_kern_enter(curthread, NULL, FPU_KERN_NOCTX);


### PR DESCRIPTION
## Description

Fenrir issues and misc cleanup.

Fixes F-1845, 1844, 2541, 1404, 1232, 3933, 3275, 702, 3932, 3724, 3018, 1403.

## Testing

```
BSDKM_CFLAGS="-DWOLFSSL_BSDKM_VERBOSE_DEBUG -DWOLFSSL_BSDKM_FPU_DEBUG -DWOLFSSL_BSDKM_MEMORY_DEBUG"
                                                                                
./configure --enable-freebsdkm --enable-freebsdkm-crypto-register \
  --enable-cryptonly --enable-crypttests \
  --enable-kernel-benchmarks --enable-all-crypto --enable-aesni \
  --enable-aesni-with-avx \
  CFLAGS="$BSDKM_CFLAGS" && make \
  || exit 1

file bsdkm/libwolfssl.ko && sudo kldload bsdkm/libwolfssl.ko || exit 1
```

```
#!/bin/sh
./configure --enable-freebsdkm --enable-cryptonly --enable-crypttests \
  --enable-kernel-benchmarks --enable-all-crypto --enable-aesni \
  --enable-aesni-with-avx CFLAGS="-DWOLFSSL_BSDKM_VERBOSE_DEBUG" && make \
  || exit 1
file bsdkm/libwolfssl.ko && sudo kldload bsdkm/libwolfssl.ko || exit 1
```