### PR TITLE
bsdkm: fix bsdkm build with rdseed.

### DIFF
--- a/bsdkm/Makefile
+++ b/bsdkm/Makefile
@@ -82,7 +82,7 @@ WOLFKMOD_SIMD_AVX  = -mavx -mavx2
 .endif # ENABLED_AESNI
 
 .if ${ENABLED_ASM} == "yes"
-.for f in chacha dilithium poly1305 sha sha256 sha3 sha512
+.for f in chacha dilithium poly1305 sha sha256 sha3 sha512 random
   CFLAGS.${f}.c += ${WOLFKMOD_SIMD_BASE}
   CFLAGS.${f}.c += ${WOLFKMOD_SIMD_AVX}
   CFLAGS.${f}.c := ${CFLAGS.${f}.c:N-nostdinc}


### PR DESCRIPTION
## Description

Fix build error with rdseed.

## Testing

```
BSDKM_CFLAGS="-DWOLFSSL_BSDKM_VERBOSE_DEBUG"
./configure --enable-freebsdkm --enable-cryptonly --enable-crypttests \
  --enable-kernel-benchmarks --enable-all-crypto --enable-aesni \
  --enable-aesni-with-avx --enable-sp-asm --enable-intelrdseed \
  CFLAGS="$BSDKM_CFLAGS" && make \
  || exit 1
file bsdkm/libwolfssl.ko && sudo kldload bsdkm/libwolfssl.ko || exit 1
```

