### PR TITLE
Fix compiler error when WOLFSSL_RPIPICO is used.

### DIFF
--- a/wolfcrypt/src/port/rpi_pico/pico.c
+++ b/wolfcrypt/src/port/rpi_pico/pico.c
@@ -20,7 +20,7 @@
  */
 
 
-
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #include <inttypes.h>
 #include <string.h>


### PR DESCRIPTION
# Description

Fix compiler error when ```WOLFSSL_RPIPICO``` is defined.

Fixes #10741 

# Testing

Compiling no longer fails after this fix has been applied.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
