### PR TITLE
Bound waited example servers with timeout to fix flaky CI test hangs

### DIFF
--- a/scripts/crl-revoked.test
+++ b/scripts/crl-revoked.test
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
+
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
                                   && exit 1
 

--- a/scripts/crl-revoked.test
+++ b/scripts/crl-revoked.test
@@ -99,7 +99,7 @@ run_test() {
     # starts the server on crl_port, -R generates ready file to be used as a
     # mutex lock, -c loads the revoked certificate. We capture the processid
     # into the variable server_pid
-    ./examples/server/server -R "$ready_file" -p $crl_port \
+    timeout -s KILL 2m ./examples/server/server -R "$ready_file" -p $crl_port \
                              -c ${CERT_DIR}/server-revoked-cert.pem \
                              -k ${CERT_DIR}/server-revoked-key.pem &
     server_pid=$!
@@ -176,7 +176,7 @@ run_hashdir_test() {
   # starts the server on crl_port, -R generates ready file to be used as a
   # mutex lock, -c loads the revoked certificate. We capture the processid
   # into the variable server_pid
-  ./examples/server/server -R "$ready_file" -p $crl_port \
+  timeout -s KILL 2m ./examples/server/server -R "$ready_file" -p $crl_port \
                              -c ${CERT_DIR}/server-revoked-cert.pem \
                              -k ${CERT_DIR}/server-revoked-key.pem &
   server_pid=$!

--- a/scripts/dtlscid.test
+++ b/scripts/dtlscid.test
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
+
 # dtlscid.test
 # Copyright wolfSSL 2022-2024
 

--- a/scripts/dtlscid.test
+++ b/scripts/dtlscid.test
@@ -54,7 +54,7 @@ test_cid () {
     echo "Running test_cid"
     SERVER_FILE=$(mktemp)
     CLIENT_FILE=$(mktemp)
-    $WOLFSSL_ROOT/examples/server/server -v4 -u --cid $SCID 1> $SERVER_FILE &
+    timeout -s KILL 2m $WOLFSSL_ROOT/examples/server/server -v4 -u --cid $SCID 1> $SERVER_FILE &
     SERVER_PID=$!
     sleep 0.2
     $WOLFSSL_ROOT/examples/client/client -v4 -u --cid $CCID 1> $CLIENT_FILE

--- a/scripts/ocsp-stapling-with-wolfssl-responder.test
+++ b/scripts/ocsp-stapling-with-wolfssl-responder.test
@@ -455,7 +455,7 @@ if [ "$stapling_v1" == "yes" ]; then
 
     printf '%s\n\n' "------------- TEST CASE 1 SHOULD PASS -------------------------"
     # client test against our own server - GOOD CERT
-    ./examples/server/server -c certs/ocsp/server1-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem \
                              -k certs/ocsp/server1-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
@@ -468,7 +468,7 @@ if [ "$stapling_v1" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE 2 SHOULD REVOKE -----------------------"
     # client test against our own server - REVOKED CERT
     remove_single_rF $ready_file5
-    ./examples/server/server -c certs/ocsp/server2-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server2-cert.pem \
                              -k certs/ocsp/server2-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
@@ -486,7 +486,7 @@ if [ "$stapling_v1" == "yes" ]; then
         printf '%s\n\n' "------------- TEST CASE 3 TLS13 SHOULD PASS -----------------"
         # client test against our own server - GOOD CERT
         remove_single_rF $ready_file5
-        ./examples/server/server -c certs/ocsp/server1-cert.pem \
+        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem \
                                  -k certs/ocsp/server1-key.pem -v 4 \
                                  -R $ready_file5 -p $port5 &
         server_pid5=$!
@@ -500,7 +500,7 @@ if [ "$stapling_v1" == "yes" ]; then
         printf '%s\n\n' "------------- TEST CASE 4 TLS13 MUST-STAPLE SHOULD PASS -----"
         # client test against our own server, must staple - GOOD CERT
         remove_single_rF $ready_file5
-        ./examples/server/server -c certs/ocsp/server1-cert.pem \
+        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem \
                                  -k certs/ocsp/server1-key.pem -v 4 \
                                  -R $ready_file5 -p $port5 &
         server_pid5=$!
@@ -514,7 +514,7 @@ if [ "$stapling_v1" == "yes" ]; then
         printf '%s\n\n' "------------- TEST CASE 5 TLS13 SHOULD REVOKE ---------------"
         # client test against our own server - REVOKED CERT
         remove_single_rF $ready_file5
-        ./examples/server/server -c certs/ocsp/server2-cert.pem \
+        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server2-cert.pem \
                                  -k certs/ocsp/server2-key.pem -v 4 \
                                  -R $ready_file5 -p $port5 &
         server_pid5=$!
@@ -533,7 +533,7 @@ if [ "$stapling_v1" == "yes" ]; then
     if [[ "$dtls12" == "yes" ]]; then
         printf '%s\n\n' "------------- TEST CASE DTLS12-1 SHOULD PASS ----------------"
         remove_single_rF $ready_file5
-        ./examples/server/server -c certs/ocsp/server1-cert.pem -R $ready_file5 \
+        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem -R $ready_file5 \
                                  -k certs/ocsp/server1-key.pem -u -v 3 \
                                  -p $port5 &
         server_pid5=$!
@@ -549,7 +549,7 @@ if [ "$stapling_v1" == "yes" ]; then
     if [ "$dtls13" == "yes" ]; then
         printf '%s\n\n' "------------- TEST CASE DTLS13-1 SHOULD PASS ----------------"
         remove_single_rF $ready_file5
-        ./examples/server/server -c certs/ocsp/server1-cert.pem -R $ready_file5 \
+        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem -R $ready_file5 \
                                  -k certs/ocsp/server1-key.pem -u -v 4 \
                                  -p $port5 &
         server_pid5=$!
@@ -575,7 +575,7 @@ if [ "$stapling_v2" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE V2-1 SHOULD PASS ----------------------"
     # client test against our own server - GOOD CERTS
     remove_single_rF $ready_file5
-    ./examples/server/server -c certs/ocsp/server3-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server3-cert.pem \
                              -k certs/ocsp/server3-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
@@ -588,7 +588,7 @@ if [ "$stapling_v2" == "yes" ]; then
 
     printf '%s\n\n' "------------- TEST CASE V2-2 SHOULD PASS ----------------------"
     remove_single_rF $ready_file5
-    ./examples/server/server -c certs/ocsp/server3-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server3-cert.pem \
                              -k certs/ocsp/server3-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
@@ -602,7 +602,7 @@ if [ "$stapling_v2" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE V2-3 SHOULD REVOKE --------------------"
     # client test against our own server - REVOKED SERVER CERT
     remove_single_rF $ready_file5
-    ./examples/server/server -c certs/ocsp/server4-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
                              -k certs/ocsp/server4-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
@@ -616,7 +616,7 @@ if [ "$stapling_v2" == "yes" ]; then
 
     printf '%s\n\n' "------------- TEST CASE V2-4 SHOULD REVOKE --------------------"
     remove_single_rF $ready_file5
-    ./examples/server/server -c certs/ocsp/server4-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
                              -k certs/ocsp/server4-key.pem -R $ready_file5 \
                              -p $port5 &
     sleep 0.1
@@ -630,7 +630,7 @@ if [ "$stapling_v2" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE V2-5 SHOULD PASS ----------------------"
     # client test against our own server - REVOKED INTERMEDIATE CERT
     remove_single_rF $ready_file5
-    ./examples/server/server -c certs/ocsp/server5-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server5-cert.pem \
                              -k certs/ocsp/server5-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
@@ -643,7 +643,7 @@ if [ "$stapling_v2" == "yes" ]; then
 
     printf '%s\n\n' "------------- TEST CASE V2-6 SHOULD REVOKE --------------------"
     remove_single_rF $ready_file5
-    ./examples/server/server -c certs/ocsp/server5-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server5-cert.pem \
                              -k certs/ocsp/server5-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
@@ -659,7 +659,7 @@ if [ "$stapling_v2" == "yes" ]; then
         if [[ "$dtls12" == "yes" ]]; then
             printf '%s\n\n' "------------- TEST CASE DTLS12-V2 SHOULD PASS ----------------"
             remove_single_rF $ready_file5
-            ./examples/server/server -c certs/ocsp/server3-cert.pem \
+            timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server3-cert.pem \
                                      -k certs/ocsp/server3-key.pem -R $ready_file5 \
                                      -p $port5 -u -v 3 &
             server_pid5=$!
@@ -685,7 +685,7 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE T13-1 SHOULD PASS --------------------"
     # client test against our own server - GOOD CERTS
     remove_single_rF $ready_file5
-    ./examples/server/server -c certs/ocsp/server3-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server3-cert.pem \
                              -k certs/ocsp/server3-key.pem -R $ready_file5 \
                              -p $port5 -v 4 &
     server_pid5=$!
@@ -699,7 +699,7 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE T13-2 SHOULD REVOKE ------------------"
     # client test against our own server - REVOKED SERVER CERT
     remove_single_rF $ready_file5
-    ./examples/server/server -c certs/ocsp/server4-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
                              -k certs/ocsp/server4-key.pem -R $ready_file5 \
                              -p $port5 -v 4 &
     server_pid5=$!
@@ -714,7 +714,7 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE T13-3 SHOULD REVOKE ------------------"
     # client test against our own server - REVOKED INTERMEDIATE CERT
     remove_single_rF $ready_file5
-    ./examples/server/server -c certs/ocsp/server5-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server5-cert.pem \
                              -k certs/ocsp/server5-key.pem -R $ready_file5 \
                              -p $port5 -v 4 &
     server_pid5=$!
@@ -730,7 +730,7 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
     if [ "$dtls13" == "yes" ]; then
         printf '%s\n\n' "------------- TEST CASE DTLS13-V2 SHOULD PASS ----------------"
         remove_single_rF $ready_file5
-        ./examples/server/server -c certs/ocsp/server3-cert.pem \
+        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server3-cert.pem \
                                  -k certs/ocsp/server3-key.pem -R $ready_file5 \
                                  -p $port5 -u -v 4 &
         server_pid5=$!
@@ -743,7 +743,7 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
 
         printf '%s\n\n' "------------- TEST CASE DTLS13-V2-REVOKE SHOULD REVOKE -------"
         remove_single_rF $ready_file5
-        ./examples/server/server -c certs/ocsp/server4-cert.pem \
+        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
                                  -k certs/ocsp/server4-key.pem -R $ready_file5 \
                                  -p $port5 -v 4 &
         server_pid5=$!

--- a/scripts/ocsp-stapling-with-wolfssl-responder.test
+++ b/scripts/ocsp-stapling-with-wolfssl-responder.test
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
+
 # ocsp-stapling-with-wolfssl-responder.test
 # Tests OCSP stapling using wolfSSL's own ocsp_responder example
 # instead of the OpenSSL ocsp utility.

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
+
 # ocsp-stapling.test
 # Test requires HAVE_OCSP and HAVE_CERTIFICATE_STATUS_REQUEST
 

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -290,7 +290,7 @@ port3=$(get_first_free_port $((port2 + 1)))
 # test interop fail case
 ready_file=$PWD/wolf_ocsp_readyF$$
 printf '%s\n' "ready file:  \"$ready_file\""
-./examples/server/server -b -p "$port1" -o -R "$ready_file" &
+timeout -s KILL 2m ./examples/server/server -b -p "$port1" -o -R "$ready_file" &
 wolf_pid=$!
 wait_for_readyFile "$ready_file" "$wolf_pid" "$port1"
 if [ ! -f "$ready_file" ]; then

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
+
 # ocsp-stapling2.test
 # Test requires HAVE_OCSP and HAVE_CERTIFICATE_STATUS_REQUEST_V2
 

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -447,7 +447,7 @@ RESULT=$?
 printf '%s\n\n' "Test successfully REVOKED!"
 printf '%s\n\n' "------------- TEST CASE 7 LOAD CERT IN SSL -------------------"
 remove_single_rF "$ready_file5"
-./examples/server/server -c certs/ocsp/server1-cert.pem \
+timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem \
                          -k certs/ocsp/server1-key.pem -R "$ready_file5" \
                          -p "$port5" -H loadSSL &
 server_pid5=$!
@@ -462,7 +462,7 @@ fi
 printf '%s\n\n' "Test successful"
 printf '%s\n\n' "------------- TEST CASE 8 SHOULD REVOKE ----------------------"
 remove_single_rF "$ready_file5"
-./examples/server/server -c certs/ocsp/server4-cert.pem \
+timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
                          -k certs/ocsp/server4-key.pem -R "$ready_file5" \
                          -p "$port5" -H loadSSL &
 server_pid5=$!

--- a/scripts/ocsp-stapling_tls13multi.test
+++ b/scripts/ocsp-stapling_tls13multi.test
@@ -455,7 +455,7 @@ if [ "$tls13" == "yes" ]; then
 
     printf '%s\n\n' "------------- TEST CASE 6 LOAD CERT IN SSL -------------------"
     remove_single_rF "$ready_file5"
-    ./examples/server/server -c certs/ocsp/server1-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem \
                             -k certs/ocsp/server1-key.pem -R "$ready_file5" -v 4 \
                             -p "$port5" -H loadSSL &
     server_pid5=$!
@@ -470,7 +470,7 @@ if [ "$tls13" == "yes" ]; then
     printf '%s\n\n' "Test successful"
     printf '%s\n\n' "------------- TEST CASE 7 SHOULD REVOKE ----------------------"
     remove_single_rF "$ready_file5"
-    ./examples/server/server -c certs/ocsp/server4-cert.pem \
+    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
                             -k certs/ocsp/server4-key.pem -R "$ready_file5" \
                             -p "$port5" -H loadSSL -v 4 &
     server_pid5=$!

--- a/scripts/ocsp-stapling_tls13multi.test
+++ b/scripts/ocsp-stapling_tls13multi.test
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
+
 # ocsp-stapling_tls13multi.test
 # Test requires HAVE_OCSP and HAVE_CERTIFICATE_STATUS_REQUEST_V2
 

--- a/scripts/pkcallbacks.test
+++ b/scripts/pkcallbacks.test
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
+
 #pkcallbacks.test
 
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \

--- a/scripts/pkcallbacks.test
+++ b/scripts/pkcallbacks.test
@@ -101,7 +101,7 @@ run_test() {
     # starts the server on pk_port, -R generates ready file to be used as a
     # mutex lock, -P does pkcallbacks. We capture the processid
     # into the variable server_pid
-    ./examples/server/server -P -R "$ready_file" -p $pk_port &
+    timeout -s KILL 2m ./examples/server/server -P -R "$ready_file" -p $pk_port &
     server_pid=$!
 
     while [ ! -s "$ready_file" -a "$counter" -lt 20 ]; do

--- a/scripts/resume.test
+++ b/scripts/resume.test
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
+
 #resume.test
 
 # if we can, isolate the network namespace to eliminate port collisions.

--- a/scripts/resume.test
+++ b/scripts/resume.test
@@ -77,7 +77,7 @@ do_test() {
 
     remove_ready_file
     echo "./examples/server/server -r -R \"$ready_file\" -p $resume_port"
-    ./examples/server/server -r -R "$ready_file" -p $resume_port &
+    timeout -s KILL 2m ./examples/server/server -r -R "$ready_file" -p $resume_port &
     server_pid=$!
 
     while [ ! -s "$ready_file" -a "$counter" -lt 20 ]; do

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
+
 # tls13.test
 # Copyright wolfSSL 2016-2021
 

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -260,7 +260,7 @@ if [ "$early_data" = "yes" ]; then
 
         echo -e "\n\nTLS v1.3 Early Data - session ticket"
         port=0
-        (./examples/server/server -v 4 -r -0 -R "$ready_file" -p $port 2>&1 | \
+        (timeout -s KILL 2m ./examples/server/server -v 4 -r -0 -R "$ready_file" -p $port 2>&1 | \
              tee "$server_out_file") &
         server_pid=$!
         create_port
@@ -308,7 +308,7 @@ if [ "$early_data" = "yes" -a "$psk" = "yes" ]; then
     early_data_try_num=1
     while :; do
 
-        (./examples/server/server -v 4 -s -0 -R "$ready_file" -p $port 2>&1 | \
+        (timeout -s KILL 2m ./examples/server/server -v 4 -s -0 -R "$ready_file" -p $port 2>&1 | \
              tee "$server_out_file") &
         server_pid=$!
         create_port


### PR DESCRIPTION
### Problem

Several test scripts background the example server and then `wait` for it to
exit with no timeout. When the server occasionally fails to exit — a timing
race seen under heavy parallel CI load — the script blocks until the CI job's
`timeout-minutes`, cancelling the whole `trackmemory` run. This was seen
consistently on the `all-wolfentropy` config via
`ocsp-stapling_tls13multi.test` (cases 6 and 7).

### Fix

Wrap the waited example servers in `timeout -s KILL 2m` (the same pattern
`scripts/dtls.test` already uses), so a stuck server is killed and the test
fails fast instead of hanging the entire job.

Scripts updated:

- `ocsp-stapling_tls13multi.test`
- `ocsp-stapling.test`
- `ocsp-stapling2.test`
- `ocsp-stapling-with-wolfssl-responder.test`
- `crl-revoked.test`
- `tls13.test`
- `resume.test`
- `pkcallbacks.test`
- `dtlscid.test`
