### PR TITLE
20260623-WC_16BIT_CPU-WC_ATOMIC_INT_ARG

### DIFF
--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -253,8 +253,11 @@ int wc_local_InitUp(wc_init_state_t *s)
      * WC_INIT_ERROR_WHEN_CONTENDED.
      */
     for (;;) {
-        wc_static_assert(WC_INIT_STATE_STATE_BITS + WC_INIT_STATE_COUNT_BITS ==
-                         sizeof(WC_ATOMIC_UINT_ARG) * 8);
+        wc_static_assert(WC_INIT_STATE_STATE_BITS < sizeof(WC_ATOMIC_UINT_ARG) * 8);
+#ifdef CHAR_BIT
+        wc_static_assert(WC_INIT_STATE_STATE_BITS + WC_INIT_STATE_COUNT_BITS <=
+                         sizeof(WC_ATOMIC_UINT_ARG) * CHAR_BIT);
+#endif
         if (exp_wc_init_state.c.count ==
             (((WC_ATOMIC_UINT_ARG)1 << WC_INIT_STATE_COUNT_BITS)
              - (WC_ATOMIC_UINT_ARG)1))

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -516,11 +516,13 @@
     typedef wolfSSL_Mutex wolfSSL_RwLock;
 #endif
 
-#ifdef WC_16BIT_CPU
-    #define WC_ATOMIC_INT_ARG long int
-    #define WC_ATOMIC_UINT_ARG long unsigned int
-#else
+#if defined(WC_ATOMIC_INT_ARG) != defined(WC_ATOMIC_UINT_ARG)
+    #error WC_ATOMIC_INT_ARG and WC_ATOMIC_UINT_ARG overrides must be paired.
+#endif
+#ifndef WC_ATOMIC_INT_ARG
     #define WC_ATOMIC_INT_ARG int
+#endif
+#ifndef WC_ATOMIC_UINT_ARG
     #define WC_ATOMIC_UINT_ARG unsigned int
 #endif
 
@@ -998,7 +1000,7 @@ WOLFSSL_API mutex_cb* wc_GetMutexCb(void);
 #define WC_INIT_STATE_CLEANING_UP 3U
 #define WC_INIT_STATE_BAD_STATE 4U
 #define WC_INIT_STATE_STATE_BITS 3
-#define WC_INIT_STATE_COUNT_BITS 29
+#define WC_INIT_STATE_COUNT_BITS ((sizeof(WC_ATOMIC_UINT_ARG) * 8) - WC_INIT_STATE_STATE_BITS)
 union wc_init_state_bitfields {
     WC_ATOMIC_UINT_ARG u;
     struct {


### PR DESCRIPTION
`wolfssl/wolfcrypt/wc_port.h` and `wolfcrypt/src/wc_port.c`: for 16 bit portability, use target native `int` for `WC_ATOMIC_INT_ARG`, add user overrideability, and adjust `WC_INIT_STATE_COUNT_BITS` to depend on `sizeof(WC_ATOMIC_UINT_ARG)`.  add a `wc_static_assert` to sanity-check `WC_INIT_STATE_STATE_BITS`, and use `CHAR_BIT` opportunistically in the other `wc_static_assert` to sanity check that `CHAR_BIT` is at least `8`.

fixes ZD#22027

tested with
```
wolfssl-multi-test.sh ...
check-source-text
clang-tidy-all-sp-all
```
