### PR TITLE
24062026 Coverity fixes

### DIFF
--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -1188,10 +1188,6 @@ OcspResponse* wolfSSL_d2i_OCSP_RESPONSE(OcspResponse** response,
 
     if (data == NULL || *data == NULL || len <= 0)
         return NULL;
-    if (*data == NULL)
-        return NULL;
-    if (len <= 0)
-        return NULL;
 
     if (response != NULL)
         resp = *response;

--- a/tests/api.c
+++ b/tests/api.c
@@ -15284,6 +15284,9 @@ static int ech_find_extension(byte* buf, word16* idx_p, word16 extType)
     word16 innerExtLen;
 
     innerExtIdx = ech_seek_extensions(buf + *idx_p, &innerExtLen) + *idx_p;
+    if (innerExtLen > MAX_RECORD_SIZE) {
+        return BAD_FUNC_ARG;
+    }
     idx = innerExtIdx;
 
     while (idx - innerExtIdx < innerExtLen) {
@@ -15298,6 +15301,10 @@ static int ech_find_extension(byte* buf, word16* idx_p, word16 extType)
 
         idx += OPAQUE16_LEN;
         ato16(buf + idx, &len);
+        if (len > MAX_RECORD_SIZE ||
+            (word16)(idx + OPAQUE16_LEN + len) < idx) {
+            break;
+        }
         idx += OPAQUE16_LEN + len;
     }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -15260,18 +15260,26 @@ static int ech_seek_extensions(byte* buf, word16* innerExtLen)
     word16 cipherSuitesLen;
     byte compressionLen;
 
+    *innerExtLen = 0;
+
     idx = OPAQUE16_LEN + RAN_LEN;
 
     sessionIdLen = buf[idx++];
     idx += sessionIdLen;
 
     ato16(buf + idx, &cipherSuitesLen);
+    if (cipherSuitesLen > MAX_RECORD_SIZE) {
+        return BAD_FUNC_ARG;
+    }
     idx += OPAQUE16_LEN + cipherSuitesLen;
 
     compressionLen = buf[idx++];
     idx += compressionLen;
 
     ato16(buf + idx, innerExtLen);
+    if (*innerExtLen > MAX_RECORD_SIZE) {
+        return BAD_FUNC_ARG;
+    }
     idx += OPAQUE16_LEN;
 
     return idx;
@@ -15282,11 +15290,13 @@ static int ech_find_extension(byte* buf, word16* idx_p, word16 extType)
     word16 idx;
     word16 innerExtIdx;
     word16 innerExtLen;
+    int    seekRet;
 
-    innerExtIdx = ech_seek_extensions(buf + *idx_p, &innerExtLen) + *idx_p;
-    if (innerExtLen > MAX_RECORD_SIZE) {
+    seekRet = ech_seek_extensions(buf + *idx_p, &innerExtLen);
+    if (seekRet < 0) {
         return BAD_FUNC_ARG;
     }
+    innerExtIdx = (word16)seekRet + *idx_p;
     idx = innerExtIdx;
 
     while (idx - innerExtIdx < innerExtLen) {
@@ -15713,20 +15723,23 @@ static int ech_tamper_padding(byte* innerCh, word32 innerChLen)
 {
     word16 idx;
     word16 innerExtLen;
+    int    seekRet;
 
     /* get the unpadded length */
-    idx = ech_seek_extensions(innerCh, &innerExtLen);
+    seekRet = ech_seek_extensions(innerCh, &innerExtLen);
+    if (seekRet < 0) {
+        return BAD_FUNC_ARG;
+    }
+    idx = (word16)seekRet;
     idx += innerExtLen;
 
     /* no padding, but the test would fail if the message is not incorrect...
      * so fail the callback */
-    if (idx == innerChLen) {
+    if (idx >= innerChLen) {
         return BAD_FUNC_ARG;
     }
-    else {
-        innerCh[idx] = '\x01';
-        return 0;
-    }
+    innerCh[idx] = '\x01';
+    return 0;
 }
 
 static int ech_tamper_type(byte* innerCh, word32 innerChLen)

--- a/tests/api/test_dtls.c
+++ b/tests/api/test_dtls.c
@@ -5499,7 +5499,9 @@ int test_wolfSSL_dtls_create_free_peer(void)
     ExpectIntEQ(wolfSSL_dtls_free_peer(peer), WOLFSSL_SUCCESS);
 
     /* Invalid address string returns NULL. */
-    ExpectNull(wolfSSL_dtls_create_peer(11111, (char*)"not-an-ip-address"));
+    ExpectNull(peer = wolfSSL_dtls_create_peer(11111,
+                                               (char*)"not-an-ip-address"));
+    wolfSSL_dtls_free_peer(peer);
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_dtls13.c
+++ b/tests/api/test_dtls13.c
@@ -1001,7 +1001,7 @@ int test_dtls13_epochs(void) {
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfDTLSv1_3_client_method()));
     ExpectNotNull(ssl = wolfSSL_new(ctx));
     /* Some manual setup to enter the epoch check */
-    ExpectTrue(ssl->options.tls1_3 = 1);
+    if (ssl != NULL) ssl->options.tls1_3 = 1;
 
     inOutIdx = 0;
     if (ssl != NULL) ssl->keys.curEpoch64 = w64From32(0x0, 0x0);

--- a/tests/api/test_lms_xmss.c
+++ b/tests/api/test_lms_xmss.c
@@ -122,7 +122,7 @@ int test_wc_LmsKey_sign_verify(void)
 
     ExpectIntEQ(wc_InitRng(&rng), 0);
 
-    remove(LMS_TEST_PRIV_KEY_FILE);
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
     ExpectIntEQ(test_lms_init_key(&key, &rng), 0);
     ExpectIntEQ(wc_LmsKey_MakeKey(&key, &rng), 0);
 
@@ -134,7 +134,7 @@ int test_wc_LmsKey_sign_verify(void)
 
     wc_LmsKey_Free(&key);
     wc_FreeRng(&rng);
-    remove(LMS_TEST_PRIV_KEY_FILE);
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
 #endif
     return EXPECT_RESULT();
 }
@@ -180,7 +180,7 @@ int test_wc_LmsKey_reload_cache(void)
     ExpectIntEQ(wc_InitRng(&rng), 0);
 
     /* Phase 1: Generate key and sign past cache window */
-    remove(LMS_TEST_PRIV_KEY_FILE);
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
     ExpectIntEQ(test_lms_init_key(&key, &rng), 0);
     ExpectIntEQ(wc_LmsKey_MakeKey(&key, &rng), 0);
 
@@ -214,7 +214,7 @@ int test_wc_LmsKey_reload_cache(void)
     wc_LmsKey_Free(&vkey);
     wc_LmsKey_Free(&key);
     wc_FreeRng(&rng);
-    remove(LMS_TEST_PRIV_KEY_FILE);
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
 #endif
     return EXPECT_RESULT();
 }
@@ -975,7 +975,7 @@ int test_rfc9802_lms_x509_gen(void)
     ExpectIntEQ(wc_InitRng(&rng), 0);
 
     /* Single-level LMS (L1-H5-W8). */
-    remove(LMS_TEST_PRIV_KEY_FILE);
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
     ExpectIntEQ(rfc9802_gen_lms_init(&key, 1, 5, 8), 0);
     ExpectIntEQ(wc_LmsKey_MakeKey(&key, &rng), 0);
     ExpectIntEQ(rfc9802_gen_roundtrip(&key, LMS_TYPE, CTC_HSS_LMS, &rng, 8192),
@@ -1012,31 +1012,31 @@ int test_rfc9802_lms_x509_gen(void)
 #endif
 
     wc_LmsKey_Free(&key);
-    remove(LMS_TEST_PRIV_KEY_FILE);
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
 
 #if !defined(WOLFSSL_LMS_MAX_LEVELS) || (WOLFSSL_LMS_MAX_LEVELS >= 2)
     /* Multi-level HSS (L2-H5-W8): the signature embeds a lower-level LMS
      * public key + signature, exercising the larger, multi-level encoding. */
-    remove(LMS_TEST_PRIV_KEY_FILE);
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
     ExpectIntEQ(rfc9802_gen_lms_init(&key, 2, 5, 8), 0);
     ExpectIntEQ(wc_LmsKey_MakeKey(&key, &rng), 0);
     ExpectIntEQ(rfc9802_gen_roundtrip(&key, LMS_TYPE, CTC_HSS_LMS, &rng, 8192),
         TEST_SUCCESS);
     wc_LmsKey_Free(&key);
-    remove(LMS_TEST_PRIV_KEY_FILE);
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
 #endif
 
 #if !defined(WOLFSSL_LMS_MAX_LEVELS) || (WOLFSSL_LMS_MAX_LEVELS >= 3)
     /* Three-level HSS with Winternitz 4 (L3-H5-W4): exercises the deepest
      * multi-level encoding and a different Winternitz parameter than the
      * W8 cases above. */
-    remove(LMS_TEST_PRIV_KEY_FILE);
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
     ExpectIntEQ(rfc9802_gen_lms_init(&key, 3, 5, 4), 0);
     ExpectIntEQ(wc_LmsKey_MakeKey(&key, &rng), 0);
     ExpectIntEQ(rfc9802_gen_roundtrip(&key, LMS_TYPE, CTC_HSS_LMS, &rng, 8192),
         TEST_SUCCESS);
     wc_LmsKey_Free(&key);
-    remove(LMS_TEST_PRIV_KEY_FILE);
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
 #endif
 
     wc_FreeRng(&rng);
@@ -1180,7 +1180,7 @@ int test_rfc9802_xmss_x509_gen(void)
     ExpectIntEQ(wc_InitRng(&rng), 0);
 
     /* Single-tree XMSS. */
-    remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
+    (void)remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
     ExpectIntEQ(rfc9802_gen_xmss_init(&key, "XMSS-SHA2_10_256"), 0);
     ExpectIntEQ(wc_XmssKey_MakeKey(&key, &rng), 0);
     ExpectIntEQ((int)key.is_xmssmt, 0);
@@ -1224,11 +1224,11 @@ int test_rfc9802_xmss_x509_gen(void)
         /* XMSS */ 0x22, /* swap */ 0x23), TEST_SUCCESS);
 
     wc_XmssKey_Free(&key);
-    remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
+    (void)remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
 
     /* Multi-tree XMSS^MT: exercises the XMSSMT_TYPE selector, the
      * XMSSMTk public-key OID branch and the CTC_XMSSMT signature OID. */
-    remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
+    (void)remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
     ExpectIntEQ(rfc9802_gen_xmss_init(&key, "XMSSMT-SHA2_20/2_256"), 0);
     ExpectIntEQ(wc_XmssKey_MakeKey(&key, &rng), 0);
     ExpectIntEQ((int)key.is_xmssmt, 1);
@@ -1241,19 +1241,19 @@ int test_rfc9802_xmss_x509_gen(void)
     ExpectIntEQ(rfc9802_gen_xmss_oid_tamper(&key, XMSSMT_TYPE, CTC_XMSSMT, &rng,
         /* XMSS^MT */ 0x23, /* swap */ 0x22), TEST_SUCCESS);
     wc_XmssKey_Free(&key);
-    remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
+    (void)remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
 
     /* A second XMSS^MT parameter set (different embedded param-set OID and a
      * larger signature) to keep the encoder/auto-derive decoder exercised
      * across sizes now that the committed multi-size fixtures are gone. */
-    remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
+    (void)remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
     ExpectIntEQ(rfc9802_gen_xmss_init(&key, "XMSSMT-SHA2_20/4_256"), 0);
     ExpectIntEQ(wc_XmssKey_MakeKey(&key, &rng), 0);
     ExpectIntEQ((int)key.is_xmssmt, 1);
     ExpectIntEQ(rfc9802_gen_roundtrip(&key, XMSSMT_TYPE, CTC_XMSSMT, &rng,
         16384), TEST_SUCCESS);
     wc_XmssKey_Free(&key);
-    remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
+    (void)remove(XMSS_GEN_TEST_PRIV_KEY_FILE);
 
     wc_FreeRng(&rng);
 #endif

--- a/tests/api/test_ossl_pem.c
+++ b/tests/api/test_ossl_pem.c
@@ -802,7 +802,7 @@ int test_wolfSSL_PEM_write_PrivateKey(void)
 
     EVP_PKEY_free(readPriv);
     EVP_PKEY_free(pkey);
-    remove(privFile);
+    (void)remove(privFile);
 #endif
     return EXPECT_RESULT();
 }
@@ -860,7 +860,7 @@ int test_wolfSSL_PEM_write_PUBKEY(void)
     XFREE(pubDer, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
     EVP_PKEY_free(readPub);
     EVP_PKEY_free(pkey);
-    remove(pubFile);
+    (void)remove(pubFile);
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_ossl_pem.c
+++ b/tests/api/test_ossl_pem.c
@@ -768,8 +768,6 @@ int test_wolfSSL_PEM_write_PrivateKey(void)
     EVP_PKEY* readPriv = NULL;
     XFILE fp = XBADFILE;
 
-    remove(privFile);
-
     ExpectNotNull(wolfSSL_d2i_PrivateKey(EVP_PKEY_RSA, &pkey, &serverKey,
         (long)sizeof_server_key_der_2048));
 
@@ -804,9 +802,6 @@ int test_wolfSSL_PEM_write_PrivateKey(void)
 
     EVP_PKEY_free(readPriv);
     EVP_PKEY_free(pkey);
-    if (fp != XBADFILE) {
-        XFCLOSE(fp);
-    }
     remove(privFile);
 #endif
     return EXPECT_RESULT();
@@ -828,8 +823,6 @@ int test_wolfSSL_PEM_write_PUBKEY(void)
     XFILE fp = XBADFILE;
     int pubDerSz = 0;
     int readPubDerSz = 0;
-
-    remove(pubFile);
 
     ExpectNotNull(wolfSSL_d2i_PrivateKey(EVP_PKEY_RSA, &pkey, &serverKey,
         (long)sizeof_server_key_der_2048));
@@ -867,9 +860,6 @@ int test_wolfSSL_PEM_write_PUBKEY(void)
     XFREE(pubDer, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
     EVP_PKEY_free(readPub);
     EVP_PKEY_free(pkey);
-    if (fp != XBADFILE) {
-        XFCLOSE(fp);
-    }
     remove(pubFile);
 #endif
     return EXPECT_RESULT();

--- a/tests/api/test_ssl_ext.c
+++ b/tests/api/test_ssl_ext.c
@@ -574,6 +574,7 @@ int test_wolfSSL_ALPN_GetPeerProtocol_inval_ext(void)
     ExpectIntEQ(wolfSSL_ALPN_GetPeerProtocol(ssl, &list, &listSz),
         WC_NO_ERR_TRACE(BUFFER_ERROR));
 
+    wolfSSL_ALPN_FreePeerProtocol(ssl, &list);
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
 #endif

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1635,8 +1635,14 @@ static int EncodeAttributes(EncodedAttrib* ea, int eaSz,
                                             PKCS7Attrib* attribs, int attribsSz)
 {
     int i;
-    int maxSz = (int)min((word32)eaSz, (word32)attribsSz);
-    int allAttribsSz = 0;
+    int maxSz;
+    word32 allAttribsSz = 0;
+
+    if (eaSz < 0 || attribsSz < 0) {
+        return BAD_FUNC_ARG;
+    }
+
+    maxSz = (int)min((word32)eaSz, (word32)attribsSz);
 
     for (i = 0; i < maxSz; i++)
     {
@@ -1675,13 +1681,13 @@ static int EncodeAttributes(EncodedAttrib* ea, int eaSz,
          * against the build's actual int maximum rather than assuming 32-bit
          * int, so the (int) cast below cannot overflow on narrow-int targets. */
         if (attribSz > (word32)WC_MAX_SINT_OF(int) ||
-            (word32)allAttribsSz > (word32)WC_MAX_SINT_OF(int) - attribSz) {
+            allAttribsSz > (word32)WC_MAX_SINT_OF(int) - attribSz) {
             WOLFSSL_MSG("PKCS7 attributes total size overflow");
             return BUFFER_E;
         }
-        allAttribsSz += (int)attribSz;
+        allAttribsSz += attribSz;
     }
-    return allAttribsSz;
+    return (int)allAttribsSz;
 }
 
 


### PR DESCRIPTION
# Description

- Logically dead code
  - 561219: remove `XBADFILE` check
  - 561215/561216: remove dead check
- Untrusted loop bound
  - 561218: Add bounds check to test helper
- Overflowed return value
  - 561217: move casts and harden function
-  Unchecked return value
  - 561216/561205: Remove call to `remove(pubFile/privFile)`, add `(void)` cast
- Assign instead of compare
  - 561214: change `ExpectTrue()` to assignment
- Untrusted pointer read
  - 561207: Bound tainted lengths in ECH test helper

# Testing

`./configure --enable-all && make check`

