### PR TITLE
fix: add missing error-crypt.h include in pico.c for BAD_FUNC_ARG

### DIFF
--- a/wolfcrypt/src/port/rpi_pico/pico.c
+++ b/wolfcrypt/src/port/rpi_pico/pico.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
 
 #if defined(WOLFSSL_RPIPICO)
 #include "pico/rand.h"


### PR DESCRIPTION
## Summary

Commit 30cb25e498 added a \BAD_FUNC_ARG\ return to \wc_pico_rng_gen_block()\ but did not add the required \#include <wolfssl/wolfcrypt/error-crypt.h>\, causing a compile error when \WOLFSSL_RPIPICO\ is defined:

\\\
wolfssl/wolfcrypt/src/port/rpi_pico/pico.c:45:16: error: 'BAD_FUNC_ARG' undeclared (first use in this function)
\\\

## Fix

Add \#include <wolfssl/wolfcrypt/error-crypt.h>\ alongside the existing \	ypes.h\ include.

## Testing

- Single-line include addition; no behavioral change to existing callers
- Restores successful compilation on Raspberry Pi Pico targets

Fixes #10741