### PR TITLE
sha512: free SHA-512/384 W cache with its allocated memory type

### DIFF
--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -2306,7 +2306,7 @@ void wc_Sha512Free(wc_Sha512* sha512)
 #ifdef WOLFSSL_SMALL_STACK_CACHE
     if (sha512->W != NULL) {
         ForceZero(sha512->W, (sizeof(word64) * 16) + WC_SHA512_BLOCK_SIZE);
-        XFREE(sha512->W, sha512->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(sha512->W, sha512->heap, DYNAMIC_TYPE_DIGEST);
         sha512->W = NULL;
     }
 #endif
@@ -2779,7 +2779,7 @@ void wc_Sha384Free(wc_Sha384* sha384)
 #ifdef WOLFSSL_SMALL_STACK_CACHE
     if (sha384->W != NULL) {
         ForceZero(sha384->W, (sizeof(word64) * 16) + WC_SHA512_BLOCK_SIZE);
-        XFREE(sha384->W, sha384->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(sha384->W, sha384->heap, DYNAMIC_TYPE_DIGEST);
         sha384->W = NULL;
     }
 #endif


### PR DESCRIPTION
### Description

With `WOLFSSL_SMALL_STACK_CACHE`, `wc_Sha512Free` and `wc_Sha384Free` freed the
cached `W` buffer as `DYNAMIC_TYPE_TMP_BUFFER`, but it is allocated as
`DYNAMIC_TYPE_DIGEST` in `InitSha512_Family`/`InitSha384` and in the `Copy`
functions (the in-`Init` error-cleanup path already frees it as
`DYNAMIC_TYPE_DIGEST`).

This mismatch is harmless for a plain heap, but it matters for type-bucketed
static memory pools, where allocation and free must use the same memory type.
SHA-256/224 already use `DYNAMIC_TYPE_DIGEST` consistently.

Free `W` as `DYNAMIC_TYPE_DIGEST` in both free functions.

### Testing

The mismatch is flagged by the memusage test (DHE_RSA TLS1.2 reported
`Errors: 2`); with this fix the count returns to 0.
