### PR TITLE
Testing: Guard RSA OversizedModulus test result by FIPS version

### DIFF
--- a/tests/api/test_rsa.c
+++ b/tests/api/test_rsa.c
@@ -1271,7 +1271,12 @@ int test_wc_RsaFunctionCheckIn_OversizedModulus(void)
         flatCSz = (word32)encSz;
         XMEMSET(flatC, 0, flatCSz);
         ExpectIntEQ(wc_RsaDirect(flatC, flatCSz, out, &outSz, &key,
-            RSA_PRIVATE_DECRYPT, &rng), WC_NO_ERR_TRACE(WC_KEY_SIZE_E));
+            RSA_PRIVATE_DECRYPT, &rng),
+    #if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
+                WC_NO_ERR_TRACE(WC_KEY_SIZE_E));
+    #else
+                WC_NO_ERR_TRACE(RSA_OUT_OF_RANGE_E));
+    #endif
     }
 
     DoExpectIntEQ(wc_FreeRsaKey(&key), 0);


### PR DESCRIPTION
# Description

FIPS < v7 returns `RSA_OUT_OF_RANGE_E` on an Oversized Modulus

# Testing

./configure --enable-fips=v5 --enable-sp-math-all now passes unit tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
