### PR TITLE
Fix TSIP SHA error propagation in TSIPHashFinal / TSIPHashGet

### DIFF
--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/Simple/build.bat
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/Simple/build.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal
+
+set MAKE=C:\Renesas\e2_studio\eclipse\plugins\com.renesas.ide.exttools.gnumake.win32.x86_64_4.3.1.v20240909-0854\mk\make.exe
+set CCRX_BIN=C:\PROGRA~2\Renesas\RX\3_6_0\bin
+set E2_UTILS=%USERPROFILE%\.eclipse\com.renesas.platform_1435879475\Utilities\ccrx
+set PATH=%CCRX_BIN%;%E2_UTILS%;%PATH%
+set BASEDIR=%~dp0
+
+set TARGET=all
+if /i "%1"=="clean" set TARGET=clean
+
+echo ============================================================
+echo  wolfssl library  [%TARGET%]
+echo ============================================================
+cd /d "%BASEDIR%wolfssl\Debug"
+"%MAKE%" %TARGET%
+if %ERRORLEVEL% neq 0 (
+    echo [ERROR] wolfssl build failed.
+    exit /b %ERRORLEVEL%
+)
+
+echo.
+echo ============================================================
+echo  test application  [%TARGET%]
+echo ============================================================
+cd /d "%BASEDIR%test\HardwareDebug"
+"%MAKE%" %TARGET%
+if %ERRORLEVEL% neq 0 (
+    echo [ERROR] test build failed.
+    exit /b %ERRORLEVEL%
+)
+
+echo.
+echo ============================================================
+echo  Done.
+echo ============================================================
+endlocal

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/include.am
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/include.am
@@ -37,3 +37,4 @@ EXTRA_DIST+= IDE/Renesas/e2studio/RX72N/EnvisionKit/Simple/test/test.rcpc
 EXTRA_DIST+= IDE/Renesas/e2studio/RX72N/EnvisionKit/Simple/test/test.scfg
 EXTRA_DIST+= IDE/Renesas/e2studio/RX72N/EnvisionKit/Simple/wolfssl/.cproject
 EXTRA_DIST+= IDE/Renesas/e2studio/RX72N/EnvisionKit/Simple/wolfssl/.project
+EXTRA_DIST+= IDE/Renesas/e2studio/RX72N/EnvisionKit/Simple/build.bat

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
@@ -101,6 +101,7 @@
   #define HAVE_TLS_EXTENSIONS
 
   #define HAVE_AESGCM
+  #define GCM_TABLE_4BIT
   #define HAVE_AESCCM
   #define HAVE_AES_CBC
   #define WOLFSSL_AES_DIRECT

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
@@ -1630,7 +1630,6 @@ static int tsip_sha1_hash_test(int prnt)
         ret = -2;
         goto out;
     }
-    
     XMEMSET(hash1, 0, sizeof(hash1));
     ret = wc_ShaFinal(&sha, hash1);
     if (ret != 0) {
@@ -1658,7 +1657,6 @@ static int tsip_sha1_hash_test(int prnt)
         ret = -7;
         goto out;
     }
-    
     XMEMSET(hash2, 0, sizeof(hash2));
     ret = wc_ShaGetHash(&sha, hash2);
     if (ret != 0) {

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
@@ -1506,12 +1506,192 @@ int tsip_crypt_Sha_AesCbcGcm_multitest(void)
 #endif
 
 
+#if !defined(NO_SHA256) && !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
+static int tsip_sha256_hash_test(int prnt)
+{
+    wc_Sha256 sha;
+    byte hash1[WC_SHA256_DIGEST_SIZE];
+    byte hash2[WC_SHA256_DIGEST_SIZE];
+    int  ret = 0;
+
+    /* SHA-256("abc") */
+    static const byte msg[] = { 0x61, 0x62, 0x63 };
+    static const byte expected[WC_SHA256_DIGEST_SIZE] = {
+        0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
+        0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+        0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+        0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad
+    };
+
+    if (prnt)
+        printf(" tsip_sha256_hash_test() ");
+
+    /* wc_Sha256Final: correct digest */
+    ret = wc_InitSha256_ex(&sha, NULL, 0);
+    if (ret != 0) {
+        ret = -1;
+        goto out;
+    }
+    ret = wc_Sha256Update(&sha, msg, sizeof(msg));
+    if (ret != 0) {
+        ret = -2;
+        goto out;
+    }
+    XMEMSET(hash1, 0, sizeof(hash1));
+    ret = wc_Sha256Final(&sha, hash1);
+    if (ret != 0) {
+        ret = -3;
+        goto out;
+    }
+    if (XMEMCMP(hash1, expected, WC_SHA256_DIGEST_SIZE) != 0) {
+        ret = -4; goto out;
+    }
+
+    /* wc_Sha256GetHash: non-destructive, same digest on repeated calls */
+    ret = wc_Sha256Update(&sha, msg, sizeof(msg));
+    if (ret != 0) {
+        ret = -5;
+        goto out;
+    }
+    XMEMSET(hash1, 0, sizeof(hash1));
+    ret = wc_Sha256GetHash(&sha, hash1);
+    if (ret != 0) {
+        ret = -6;
+        goto out;
+    }
+    if (XMEMCMP(hash1, expected, WC_SHA256_DIGEST_SIZE) != 0) {
+        ret = -7;
+        goto out;
+    }
+    XMEMSET(hash2, 0, sizeof(hash2));
+    ret = wc_Sha256GetHash(&sha, hash2);
+    if (ret != 0) {
+        ret = -8;
+        goto out;
+    }
+    if (XMEMCMP(hash1, hash2, WC_SHA256_DIGEST_SIZE) != 0) {
+        ret = -9; goto out;
+    }
+
+    /* Final after GetHash must also match */
+    XMEMSET(hash2, 0, sizeof(hash2));
+    ret = wc_Sha256Final(&sha, hash2);
+    if (ret != 0) {
+        ret = -10;
+        goto out;
+    }
+    if (XMEMCMP(hash1, hash2, WC_SHA256_DIGEST_SIZE) != 0) {
+        ret = -11; goto out;
+    }
+
+out:
+    if (prnt) {
+        if (ret != 0)
+            printf("(code=%d) ", ret);
+        RESULT_STR(ret)
+    }
+    return ret;
+}
+#endif /* !NO_SHA256 && !NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH */
+
+#if !defined(NO_SHA) && !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
+static int tsip_sha1_hash_test(int prnt)
+{
+    wc_Sha sha;
+    byte hash1[WC_SHA_DIGEST_SIZE];
+    byte hash2[WC_SHA_DIGEST_SIZE];
+    int  ret = 0;
+
+    /* NIST FIPS 180-4: SHA-1("abc") */
+    static const byte msg[] = { 0x61, 0x62, 0x63 };
+    static const byte expected[WC_SHA_DIGEST_SIZE] = {
+        0xa9, 0x99, 0x3e, 0x36, 0x47, 0x06, 0x81, 0x6a,
+        0xba, 0x3e, 0x25, 0x71, 0x78, 0x50, 0xc2, 0x6c,
+        0x9c, 0xd0, 0xd8, 0x9d
+    };
+
+    if (prnt)
+        printf(" tsip_sha1_hash_test() ");
+
+    /* wc_ShaFinal: correct digest */
+    ret = wc_InitSha_ex(&sha, NULL, 0);
+    if (ret != 0) {
+        ret = -1;
+        goto out;
+    }
+    
+    ret = wc_ShaUpdate(&sha, msg, sizeof(msg));
+    if (ret != 0) {
+        ret = -2;
+        goto out;
+    }
+    
+    XMEMSET(hash1, 0, sizeof(hash1));
+    ret = wc_ShaFinal(&sha, hash1);
+    if (ret != 0) {
+        ret = -3;
+        goto out;
+    }
+    if (XMEMCMP(hash1, expected, WC_SHA_DIGEST_SIZE) != 0) {
+        ret = -4;
+        goto out;
+    }
+
+    /* wc_ShaGetHash: non-destructive, same digest on repeated calls */
+    ret = wc_ShaUpdate(&sha, msg, sizeof(msg));
+    if (ret != 0) {
+        ret = -5;
+        goto out;
+    }
+    XMEMSET(hash1, 0, sizeof(hash1));
+    ret = wc_ShaGetHash(&sha, hash1);
+    if (ret != 0) {
+        ret = -6;
+        goto out;
+    }
+    if (XMEMCMP(hash1, expected, WC_SHA_DIGEST_SIZE) != 0) {
+        ret = -7;
+        goto out;
+    }
+    
+    XMEMSET(hash2, 0, sizeof(hash2));
+    ret = wc_ShaGetHash(&sha, hash2);
+    if (ret != 0) {
+        ret = -8;
+        goto out;
+    }
+
+    if (XMEMCMP(hash1, hash2, WC_SHA_DIGEST_SIZE) != 0) {
+        ret = -9;
+        goto out;
+    }
+
+    /* Final after GetHash must also match */
+    XMEMSET(hash2, 0, sizeof(hash2));
+    ret = wc_ShaFinal(&sha, hash2);
+    if (ret != 0) {
+        ret = -10;
+        goto out;
+    }
+    if (XMEMCMP(hash1, hash2, WC_SHA_DIGEST_SIZE) != 0) {
+        ret = -11; goto out;
+    }
+
+out:
+    if (prnt) {
+        if (ret != 0)
+            printf("(code=%d) ", ret);
+        RESULT_STR(ret)
+    }
+    return ret;
+}
+#endif /* !NO_SHA && !NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH */
+
 int tsip_crypt_test(void)
 {
     int ret = 0;
     int devId;
 
-    Clr_CallbackCtx(&userContext);
     if (ret != 0) {
         printf("TSIP Key Generation failed\n");
         return -1;
@@ -1535,6 +1715,16 @@ int tsip_crypt_test(void)
             ret = sha256_test();
             RESULT_STR(ret);
         }
+    #endif
+
+    #if !defined(NO_SHA256) && !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
+        if (ret == 0)
+            ret = tsip_sha256_hash_test(1);
+    #endif
+
+    #if !defined(NO_SHA) && !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
+        if (ret == 0)
+            ret = tsip_sha1_hash_test(1);
     #endif
 
     #ifdef HAVE_AES_CBC

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
@@ -1513,6 +1513,7 @@ static int tsip_sha256_hash_test(int prnt)
     byte hash1[WC_SHA256_DIGEST_SIZE];
     byte hash2[WC_SHA256_DIGEST_SIZE];
     int  ret = 0;
+    int  shaInited = 0;
 
     /* SHA-256("abc") */
     static const byte msg[] = { 0x61, 0x62, 0x63 };
@@ -1532,6 +1533,7 @@ static int tsip_sha256_hash_test(int prnt)
         ret = -1;
         goto out;
     }
+    shaInited = 1;
     ret = wc_Sha256Update(&sha, msg, sizeof(msg));
     if (ret != 0) {
         ret = -2;
@@ -1585,6 +1587,8 @@ static int tsip_sha256_hash_test(int prnt)
     }
 
 out:
+    if (shaInited)
+        wc_Sha256Free(&sha);
     if (prnt) {
         if (ret != 0)
             printf("(code=%d) ", ret);
@@ -1601,6 +1605,7 @@ static int tsip_sha1_hash_test(int prnt)
     byte hash1[WC_SHA_DIGEST_SIZE];
     byte hash2[WC_SHA_DIGEST_SIZE];
     int  ret = 0;
+    int  shaInited = 0;
 
     /* NIST FIPS 180-4: SHA-1("abc") */
     static const byte msg[] = { 0x61, 0x62, 0x63 };
@@ -1619,7 +1624,7 @@ static int tsip_sha1_hash_test(int prnt)
         ret = -1;
         goto out;
     }
-    
+    shaInited = 1;
     ret = wc_ShaUpdate(&sha, msg, sizeof(msg));
     if (ret != 0) {
         ret = -2;
@@ -1678,6 +1683,8 @@ static int tsip_sha1_hash_test(int prnt)
     }
 
 out:
+    if (shaInited)
+        wc_ShaFree(&sha);
     if (prnt) {
         if (ret != 0)
             printf("(code=%d) ", ret);

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_sha.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_sha.c
@@ -400,7 +400,7 @@ static int TSIPHashFinal(wolfssl_TSIP_Hash* hash, byte* out, word32 outSz)
             ret = Final(&handle, out, (uint32_t*)&sz);
             if (ret != TSIP_SUCCESS || sz != outSz) {
                 tsip_hw_unlock();
-                return ret;
+                return (ret == TSIP_SUCCESS) ? WC_HW_E : ret;
             }
         }
         else {
@@ -452,7 +452,7 @@ static int TSIPHashGet(wolfssl_TSIP_Hash* hash, byte* out, word32 outSz)
             ret = Final(&handle, out, &sz);
             if (ret != TSIP_SUCCESS || sz != outSz) {
                 tsip_hw_unlock();
-                return ret;
+                return (ret == TSIP_SUCCESS) ? WC_HW_E : ret;
             }
         }
         else {

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_sha.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_sha.c
@@ -364,7 +364,7 @@ static int TSIPHashUpdate(wolfssl_TSIP_Hash* hash, const byte* data, word32 sz)
 
 static int TSIPHashFinal(wolfssl_TSIP_Hash* hash, byte* out, word32 outSz)
 {
-    int ret;
+    int ret = WC_HW_E;
     void* heap;
     tsip_sha_md5_handle_t handle;
     uint32_t sz;
@@ -403,8 +403,15 @@ static int TSIPHashFinal(wolfssl_TSIP_Hash* hash, byte* out, word32 outSz)
                 return ret;
             }
         }
+        else {
+            ret = WC_HW_E;
+        }
     }
     tsip_hw_unlock();
+
+    if (ret != 0) {
+        return ret;
+    }
 
     TSIPHashFree(hash);
     return TSIPHashInit(hash, heap, 0, hash->sha_type);
@@ -412,7 +419,7 @@ static int TSIPHashFinal(wolfssl_TSIP_Hash* hash, byte* out, word32 outSz)
 
 static int TSIPHashGet(wolfssl_TSIP_Hash* hash, byte* out, word32 outSz)
 {
-    int ret;
+    int ret = WC_HW_E;
     tsip_sha_md5_handle_t handle;
     uint32_t sz;
 
@@ -448,11 +455,14 @@ static int TSIPHashGet(wolfssl_TSIP_Hash* hash, byte* out, word32 outSz)
                 return ret;
             }
         }
+        else {
+            ret = WC_HW_E;
+        }
     }
 
     tsip_hw_unlock();
 
-    return 0;
+    return ret;
 }
 
 static int TSIPHashCopy(wolfssl_TSIP_Hash* src, wolfssl_TSIP_Hash* dst)


### PR DESCRIPTION
# Description

# Fix TSIP SHA error propagation in TSIPHashFinal / TSIPHashGet

## Problem

`TSIPHashFinal` and `TSIPHashGet` in `renesas_tsip_sha.c` silently returned 0
(success) when the TSIP hardware `Init()` or `Update()` step failed, leaving
the digest buffer unwritten. Same defect class as issue #5420 (FSPSM path).

## Fix

- Initialize `ret = WC_HW_E` instead of leaving it uninitialized.
- Add `else { ret = WC_HW_E; }` for `Update()` failure.
- Add early return after the hardware block so failures are not swallowed by the
  trailing `TSIPHashFree` / `TSIPHashInit` calls.
- Replace the hardcoded `return 0` at the end of `TSIPHashGet` with `return ret`.

## Tests Added (`wolfssl_tsip_unit_test.c`)

- `tsip_sha256_hash_test()` — verifies `wc_Sha256Final` digest and confirms
  `wc_Sha256GetHash` is non-destructive.
- `tsip_sha1_hash_test()` — same for SHA-1.

Both tests pass on RX72N EnvisionKit.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
