### PR TITLE
fix: heap-buffer-overflow READ in wolfSSL_i2c_ASN1_INTEGER via CRL revoked serial

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -2474,10 +2474,42 @@ int wolfSSL_X509_CRL_add_revoked(WOLFSSL_X509_CRL* crl,
     }
 
     {
-        const byte* serial = rev->serialNumber->data;
-        int serialSz = rev->serialNumber->length;
+        const byte* serial;
+        int serialSz;
         int i;
         int allZero = 1;
+
+        if (rev->serialNumber->isDer) {
+            /* serialNumber->data is a DER encoded INTEGER, as produced by
+             * wolfSSL_X509_CRL_get_REVOKED(). Skip the tag and the length
+             * octets so the checks below see the content octets only. */
+            word32 idx = 1;
+            int len = 0;
+
+            if (rev->serialNumber->data == NULL ||
+                    rev->serialNumber->length < 2 ||
+                    rev->serialNumber->data[0] != ASN_INTEGER) {
+                return BAD_FUNC_ARG;
+            }
+            /* Bound the header parse by the allocation, then require the
+             * encoding to exactly fill the declared length. */
+            if (GetLength_ex(rev->serialNumber->data, &idx, &len,
+                    rev->serialNumber->dataMax, 1) < 0) {
+                return BAD_FUNC_ARG;
+            }
+            if (idx + (word32)len != (word32)rev->serialNumber->length) {
+                return BAD_FUNC_ARG;
+            }
+
+            serial = rev->serialNumber->data + idx;
+            serialSz = len;
+        }
+        else {
+            /* Bare serial value. This is the public input contract of this
+             * API and must keep working byte for byte. */
+            serial = rev->serialNumber->data;
+            serialSz = rev->serialNumber->length;
+        }
 
         if (serial == NULL || serialSz <= 0) {
             return BAD_FUNC_ARG;

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -1689,7 +1689,7 @@ int wolfSSL_i2c_ASN1_INTEGER(WOLFSSL_ASN1_INTEGER *a, unsigned char **pp)
     }
 
     /* Get length from DER encoding. */
-    if ((!err) && (GetLength_ex(a->data, &idx, &len, a->dataMax, 0) < 0)) {
+    if ((!err) && (GetLength_ex(a->data, &idx, &len, a->dataMax, 1) < 0)) {
         err = 1;
     }
 

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -1080,6 +1080,8 @@ static void wolfssl_asn1_integer_reset_data(WOLFSSL_ASN1_INTEGER* a)
     a->length = 0;
     /* No data, not negative. */
     a->negative = 0;
+    /* No data, so nothing is DER encoded. */
+    a->isDer = 0;
     /* Set type to positive INTEGER. */
     a->type = WOLFSSL_V_ASN1_INTEGER;
 }
@@ -1157,6 +1159,8 @@ WOLFSSL_ASN1_INTEGER* wolfSSL_ASN1_INTEGER_dup(const WOLFSSL_ASN1_INTEGER* src)
         dst->length   = src->length;
         dst->negative = src->negative;
         dst->type     = src->type;
+        /* Data layout is copied verbatim below, so carry the flag with it. */
+        dst->isDer    = src->isDer;
 
         if (!src->isDynamic) {
             /* Copy over data from/to fixed buffer. */
@@ -1968,6 +1972,8 @@ int wolfSSL_ASN1_INTEGER_set(WOLFSSL_ASN1_INTEGER *a, long v)
         a->data[i++] = pad + j;
         /* Set length of DER encoding. +2 for tag and length */
         a->length = 2 + pad + j;
+        /* Tag and length octets are present. */
+        a->isDer = 1;
 
         /* Add pad byte if required. */
         if (pad == 1) {

--- a/src/x509.c
+++ b/src/x509.c
@@ -11031,6 +11031,8 @@ static WOLFSSL_X509_REVOKED* RevokedCertToRevoked(RevokedCert* rc, int seq)
         serial->length = rc->serialSz + 2;
         serial->dataMax = (word32)rc->serialSz + 2;
         serial->isDynamic = 1;
+        /* Tell consumers that the tag and length octets are present. */
+        serial->isDer = 1;
     }
     rev->serialNumber = serial;
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -11013,16 +11013,23 @@ static WOLFSSL_X509_REVOKED* RevokedCertToRevoked(RevokedCert* rc, int seq)
         return NULL;
     }
     if (rc->serialSz > 0 && rc->serialSz <= EXTERNAL_SERIAL_SIZE) {
-        serial->data = (unsigned char*)XMALLOC((size_t)rc->serialSz, NULL,
+        /* Allocate tag byte + length byte + content so that
+         * i2c_ASN1_INTEGER can read data[0] as tag and data[1] as length
+         * without overrunning the allocation. */
+        serial->data = (unsigned char*)XMALLOC((size_t)rc->serialSz + 2, NULL,
                                                DYNAMIC_TYPE_OPENSSL);
         if (serial->data == NULL) {
             wolfSSL_ASN1_INTEGER_free(serial);
             XFREE(rev, NULL, DYNAMIC_TYPE_OPENSSL);
             return NULL;
         }
-        XMEMCPY(serial->data, rc->serialNumber, (size_t)rc->serialSz);
-        serial->length = rc->serialSz;
-        serial->dataMax = rc->serialSz;
+        serial->data[0] = ASN_INTEGER;
+        serial->data[1] = (unsigned char)rc->serialSz;
+        XMEMCPY(serial->data + 2, rc->serialNumber, (size_t)rc->serialSz);
+        /* Length is the size of the whole DER encoding. +2 for tag and
+         * length, matching wolfSSL_X509_get_serialNumber(). */
+        serial->length = rc->serialSz + 2;
+        serial->dataMax = (word32)rc->serialSz + 2;
         serial->isDynamic = 1;
     }
     rev->serialNumber = serial;

--- a/tests/api.c
+++ b/tests/api.c
@@ -24041,6 +24041,69 @@ static int test_wolfSSL_X509_CRL_add_revoked_oversized_revocation_date(void)
 #endif
 
 #if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)) && !defined(NO_CERTS) && \
+    defined(HAVE_CRL) && defined(WOLFSSL_CERT_GEN) && !defined(NO_ASN_TIME) && \
+    !defined(NO_RSA) && !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
+/* A serial number obtained from wolfSSL_X509_CRL_get_REVOKED() must survive a
+ * round trip back through wolfSSL_X509_CRL_add_revoked() unchanged. The getter
+ * hands out a DER encoded INTEGER, so a consumer that reads the buffer as a
+ * bare serial stores the tag and length bytes as serial content. */
+static int test_wolfSSL_X509_CRL_add_revoked_roundtrip(void)
+{
+    EXPECT_DECLS;
+    /* Serial of the single revoked entry in certs/crl/crl.der, DER encoded.
+     * Oracle is the system openssl, not wolfSSL:
+     *   openssl asn1parse -in certs/crl/crl.der -inform DER
+     * reports inside the revokedCertificates SEQUENCE:
+     *   210:d=4  hl=2 l=   1 prim: INTEGER           :02
+     * i.e. tag 0x02, length 0x01, content 0x02. */
+    const unsigned char expSerialDer[3] = { 0x02, 0x01, 0x02 };
+    WOLFSSL_X509_CRL* src = NULL;
+    WOLFSSL_X509_CRL* dst = NULL;
+    XFILE fp = XBADFILE;
+    WOLFSSL_STACK* sk = NULL;
+    WOLFSSL_X509_REVOKED* rev = NULL;
+    WOLFSSL_ASN1_INTEGER* serial = NULL;
+    unsigned char out[8];
+    unsigned char* p = NULL;
+
+    ExpectTrue((fp = XFOPEN("./certs/crl/crl.der", "rb")) != XBADFILE);
+    ExpectNotNull(src = wolfSSL_d2i_X509_CRL_fp(fp, NULL));
+    if (fp != XBADFILE) {
+        XFCLOSE(fp);
+        fp = XBADFILE;
+    }
+
+    ExpectNotNull(sk = wolfSSL_X509_CRL_get_REVOKED(src));
+    ExpectIntEQ(wolfSSL_sk_X509_REVOKED_num(sk), 1);
+    ExpectNotNull(rev = wolfSSL_sk_X509_REVOKED_value(sk, 0));
+
+    /* Copy the parsed entry into a fresh CRL. */
+    ExpectNotNull(dst = wolfSSL_X509_CRL_new());
+    ExpectIntEQ(wolfSSL_X509_CRL_add_revoked(dst, rev), WOLFSSL_SUCCESS);
+
+    /* Read it back. The serial must still encode 2, not the DER header. */
+    sk = NULL;
+    ExpectNotNull(sk = wolfSSL_X509_CRL_get_REVOKED(dst));
+    ExpectIntEQ(wolfSSL_sk_X509_REVOKED_num(sk), 1);
+    ExpectNotNull(rev = wolfSSL_sk_X509_REVOKED_value(sk, 0));
+    ExpectNotNull(serial = (WOLFSSL_ASN1_INTEGER*)
+        wolfSSL_X509_REVOKED_get0_serial_number(rev));
+
+    ExpectIntEQ(wolfSSL_i2d_ASN1_INTEGER(serial, NULL), 3);
+    XMEMSET(out, 0, sizeof(out));
+    p = out;
+    ExpectIntEQ(wolfSSL_i2d_ASN1_INTEGER(serial, &p), 3);
+    ExpectBufEQ(out, expSerialDer, sizeof(expSerialDer));
+    ExpectIntEQ(wolfSSL_ASN1_INTEGER_get(serial), 2);
+
+    wolfSSL_X509_CRL_free(dst);
+    wolfSSL_X509_CRL_free(src);
+
+    return EXPECT_RESULT();
+}
+#endif
+
+#if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)) && !defined(NO_CERTS) && \
     defined(HAVE_CRL) && !defined(NO_FILESYSTEM) && \
     !defined(NO_STDIO_FILESYSTEM)
 /* Ensure reason-code parsing handles optional critical BOOLEAN in entry ext. */
@@ -35100,6 +35163,11 @@ TEST_CASE testCases[] = {
 #if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)) && !defined(NO_CERTS) && \
     defined(HAVE_CRL) && defined(WOLFSSL_CERT_GEN) && !defined(NO_ASN_TIME)
     TEST_DECL(test_wolfSSL_X509_CRL_add_revoked_oversized_revocation_date),
+#endif
+#if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)) && !defined(NO_CERTS) && \
+    defined(HAVE_CRL) && defined(WOLFSSL_CERT_GEN) && !defined(NO_ASN_TIME) && \
+    !defined(NO_RSA) && !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
+    TEST_DECL(test_wolfSSL_X509_CRL_add_revoked_roundtrip),
 #endif
 #if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)) && !defined(NO_CERTS) && \
     defined(HAVE_CRL) && !defined(NO_FILESYSTEM) && \

--- a/tests/api/test_ossl_asn1.c
+++ b/tests/api/test_ossl_asn1.c
@@ -848,6 +848,114 @@ int test_wolfSSL_i2c_ASN1_INTEGER(void)
     return EXPECT_RESULT();
 }
 
+int test_wolfSSL_X509_REVOKED_serialNumber(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_ASN)
+#if defined(HAVE_CRL) && !defined(NO_RSA) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_STDIO_FILESYSTEM)
+    /* DER encoding of the serial number of the single certificate revoked by
+     * certs/crl/crl.der. Oracle is the system openssl, not wolfSSL:
+     *   openssl asn1parse -in certs/crl/crl.der -inform DER
+     * reports inside the revokedCertificates SEQUENCE:
+     *   210:d=4  hl=2 l=   1 prim: INTEGER           :02
+     * i.e. tag 0x02, length 0x01, content 0x02.
+     */
+    const unsigned char expSerialDer[3] = { 0x02, 0x01, 0x02 };
+    WOLFSSL_X509_CRL* crl = NULL;
+    XFILE fp = XBADFILE;
+    WOLFSSL_STACK* revokedSk = NULL;
+    WOLFSSL_X509_REVOKED* rev = NULL;
+    WOLFSSL_ASN1_INTEGER* serial = NULL;
+    WOLFSSL_ASN1_INTEGER* expected = NULL;
+    unsigned char out[8];
+    unsigned char* p = NULL;
+
+    ExpectTrue((fp = XFOPEN("./certs/crl/crl.der", "rb")) != XBADFILE);
+    ExpectNotNull(crl = wolfSSL_d2i_X509_CRL_fp(fp, NULL));
+    if (fp != XBADFILE) {
+        XFCLOSE(fp);
+        fp = XBADFILE;
+    }
+
+    ExpectNotNull(revokedSk = wolfSSL_X509_CRL_get_REVOKED(crl));
+    ExpectIntEQ(wolfSSL_sk_X509_REVOKED_num(revokedSk), 1);
+    ExpectNotNull(rev = wolfSSL_sk_X509_REVOKED_value(revokedSk, 0));
+    ExpectNotNull(serial = (WOLFSSL_ASN1_INTEGER*)
+        wolfSSL_X509_REVOKED_get0_serial_number(rev));
+
+    /* i2d must emit the whole DER encoding: 02 01 02. i2d copies length bytes
+     * starting at the tag byte, so a content-only length truncates it. Note
+     * that checking get0_data() would not discriminate here because the serial
+     * value 0x02 happens to equal the ASN_INTEGER tag byte. */
+    ExpectIntEQ(wolfSSL_i2d_ASN1_INTEGER(serial, NULL), 3);
+    XMEMSET(out, 0, sizeof(out));
+    p = out;
+    ExpectIntEQ(wolfSSL_i2d_ASN1_INTEGER(serial, &p), 3);
+    ExpectBufEQ(out, expSerialDer, sizeof(expSerialDer));
+    ExpectIntEQ((int)(p - out), 3);
+
+    /* Comparing against an independently built ASN.1 INTEGER holding 2.
+     * wolfSSL_ASN1_INTEGER_cmp() compares lengths before data, so a
+     * content-only length makes this non-zero. */
+    ExpectNotNull(expected = wolfSSL_ASN1_INTEGER_new());
+    ExpectIntEQ(wolfSSL_ASN1_INTEGER_set(expected, 2), 1);
+    ExpectIntEQ(wolfSSL_ASN1_INTEGER_cmp(serial, expected), 0);
+
+    /* Value must decode back to 2. */
+    ExpectIntEQ(wolfSSL_ASN1_INTEGER_get(serial), 2);
+
+    /* i2c writes only the content octets. Guards the original out-of-bounds
+     * read reachable through X509_REVOKED_get0_serialNumber(). */
+    ExpectIntEQ(wolfSSL_i2c_ASN1_INTEGER(serial, NULL), 1);
+    XMEMSET(out, 0, sizeof(out));
+    p = out;
+    ExpectIntEQ(wolfSSL_i2c_ASN1_INTEGER(serial, &p), 1);
+    ExpectIntEQ(out[0], 0x02);
+    ExpectIntEQ((int)(p - out), 1);
+
+    wolfSSL_ASN1_INTEGER_free(expected);
+    /* revokedSk is cached in and owned by crl. */
+    wolfSSL_X509_CRL_free(crl);
+#endif /* HAVE_CRL && !NO_RSA && !NO_FILESYSTEM && !NO_STDIO_FILESYSTEM */
+
+    /* wolfSSL_i2c_ASN1_INTEGER() must reject a DER length that runs past the
+     * buffer instead of reading 127 octets beyond it. The data buffer is a
+     * heap allocation of exactly 4 bytes so ASAN traps any regression. */
+    {
+        WOLFSSL_ASN1_INTEGER bad;
+        unsigned char* badData = NULL;
+        unsigned char badOut[128];
+        unsigned char* q = badOut;
+
+        ExpectNotNull(badData = (unsigned char*)XMALLOC(4, NULL,
+            DYNAMIC_TYPE_TMP_BUFFER));
+        if (badData != NULL) {
+            badData[0] = ASN_INTEGER;
+            badData[1] = 0x7f;      /* claims 127 content octets */
+            badData[2] = 0x01;
+            badData[3] = 0x02;
+
+            XMEMSET(&bad, 0, sizeof(bad));
+            bad.data = badData;
+            bad.dataMax = 4;
+            bad.length = 4;
+
+            ExpectIntLE(wolfSSL_i2c_ASN1_INTEGER(&bad, NULL), 0);
+
+            XMEMSET(badOut, 0, sizeof(badOut));
+            q = badOut;
+            ExpectIntLE(wolfSSL_i2c_ASN1_INTEGER(&bad, &q), 0);
+            /* Nothing written, output pointer not advanced. */
+            ExpectIntEQ((int)(q - badOut), 0);
+            ExpectIntEQ(badOut[0], 0);
+        }
+        XFREE(badData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+#endif /* OPENSSL_EXTRA && !NO_CERTS && !NO_ASN */
+    return EXPECT_RESULT();
+}
+
 int test_wolfSSL_ASN1_OBJECT(void)
 {
     EXPECT_DECLS;

--- a/tests/api/test_ossl_asn1.h
+++ b/tests/api/test_ossl_asn1.h
@@ -32,6 +32,7 @@ int test_wolfSSL_ASN1_INTEGER_get_set(void);
 int test_wolfSSL_d2i_ASN1_INTEGER(void);
 int test_wolfSSL_a2i_ASN1_INTEGER(void);
 int test_wolfSSL_i2c_ASN1_INTEGER(void);
+int test_wolfSSL_X509_REVOKED_serialNumber(void);
 int test_wolfSSL_ASN1_OBJECT(void);
 int test_wolfSSL_ASN1_get_object(void);
 int test_wolfSSL_i2a_ASN1_OBJECT(void);
@@ -70,7 +71,8 @@ int test_ASN1_strings(void);
     TEST_DECL_GROUP("ossl_asn1_int", test_wolfSSL_ASN1_INTEGER_get_set),    \
     TEST_DECL_GROUP("ossl_asn1_int", test_wolfSSL_d2i_ASN1_INTEGER),        \
     TEST_DECL_GROUP("ossl_asn1_int", test_wolfSSL_a2i_ASN1_INTEGER),        \
-    TEST_DECL_GROUP("ossl_asn1_int", test_wolfSSL_i2c_ASN1_INTEGER)
+    TEST_DECL_GROUP("ossl_asn1_int", test_wolfSSL_i2c_ASN1_INTEGER),        \
+    TEST_DECL_GROUP("ossl_asn1_int", test_wolfSSL_X509_REVOKED_serialNumber)
 
 #define TEST_OSSL_ASN1_OBJECT_DECLS                                         \
     TEST_DECL_GROUP("ossl_asn1_obj", test_wolfSSL_ASN1_OBJECT),             \

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -345,6 +345,8 @@ typedef struct WOLFSSL_ASN1_INTEGER {
     unsigned char* data;
     unsigned int   dataMax;   /* max size of data buffer */
     WC_BITFIELD    isDynamic:1; /* flag for if data pointer dynamic (1 is yes 0 is no) */
+    WC_BITFIELD    isDer:1;     /* flag for if data holds a DER encoded INTEGER,
+                                 * tag and length included (1 is yes 0 is no) */
 
     int length;   /* Length of DER encoding. */
     int type;     /* ASN.1 type. Includes negative flag. */


### PR DESCRIPTION
Heap out-of-bounds read from an attacker supplied CRL, no signature verification required. Present in 5.9.0 through 5.9.2. Reachable as `d2i_X509_CRL` (NO_VERIFY) -> `X509_CRL_get_REVOKED` -> `X509_REVOKED_get0_serialNumber` -> `i2c_ASN1_INTEGER`. ASAN reports READ of size 127 from a 4 byte region.

Needs a ChangeLog entry under Vulnerabilities.

**Two commits, both required.** Commit 1 changes the revoked serial to DER. `wolfSSL_X509_CRL_add_revoked` reads that buffer as a bare serial, so commit 1 alone would ship silent serial corruption when a revocation is copied between CRLs. Commit 2 fixes that.

**Why an explicit flag instead of detecting the layout.** A bare serial can be valid DER. Raw `02 02 00 00` parses as a two octet INTEGER holding zero, which `test_wolfSSL_X509_CRL_sign_large` produces at i=514. I implemented the detection approach first and it breaks that test.

**ABI.** `isDer` packs into the storage unit already holding `isDynamic`. `sizeof` and every member offset are unchanged for both `WOLFSSL_ASN1_INTEGER` and `WOLFSSL_X509_REVOKED`, checked with `offsetof` probes compiled against the old and new headers. No soname bump.

**Verified.** 8 configurations for commit 1, 6 for commit 2, ASAN clean, `make check` green. Each new test fails without its corresponding fix.


