### PR TITLE
Fix: WolfCrypt 7 fenrir fixes

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6482,8 +6482,8 @@ int wc_ecc_init_id(ecc_key* key, unsigned char* id, int len, void* heap,
 {
     int ret = 0;
 #ifdef WOLFSSL_SE050
-    /* SE050 TLS users store a word32 at id, need to cast back */
-    word32* keyPtr = NULL;
+    /* SE050 TLS users store a word32 at id, need to read it back */
+    word32 keyId = 0;
 #endif
 
     if (key == NULL)
@@ -6498,8 +6498,8 @@ int wc_ecc_init_id(ecc_key* key, unsigned char* id, int len, void* heap,
     #ifdef WOLFSSL_SE050
         /* Set SE050 ID from word32, populate ecc_key with public from SE050 */
         if (len == (int)sizeof(word32)) {
-            keyPtr = (word32*)key->id;
-            ret = wc_ecc_use_key_id(key, *keyPtr, 0);
+            keyId = readUnalignedWord32(key->id);
+            ret = wc_ecc_use_key_id(key, keyId, 0);
         }
     #endif
     }

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_rsa.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_rsa.c
@@ -199,12 +199,12 @@ WOLFSSL_LOCAL int wc_fspsm_RsaFunction(const byte* in, word32 inLen, byte* out,
             if (keySize == 1024) {
                 ret = FSPSM_RSA1024_PKCSDEC_FUNC(&cipher, &plain,
                             (FSPSM_RSA1024_WPI_KEY*)
-                                key->ctx.wrapped_pri1024_key, &outLen);
+                                key->ctx.wrapped_pri1024_key, outLen);
             }
             else {
                 ret = FSPSM_RSA2048_PKCSDEC_FUNC(&cipher, &plain,
                             (FSPSM_RSA2048_WPI_KEY*)
-                                key->ctx.wrapped_pri2048_key, &outLen);
+                                key->ctx.wrapped_pri2048_key, outLen);
             }
         }
 

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -952,7 +952,8 @@ static void scryptROMix(byte* x, byte* v, byte* y, int r, word32 n)
 #endif
 #else
         byte* t = x + (2*r - 1) * 64;
-        j = (t[0] | (t[1] << 8) | (t[2] << 16) | ((word32)t[3] << 24)) & (n-1);
+        j = ((word32)t[0] | ((word32)t[1] << 8) | ((word32)t[2] << 16) |
+                ((word32)t[3] << 24)) & (n-1);
 #endif
 #ifdef WORD64_AVAILABLE
         for (k = 0; k < bSz / 8; k++)

--- a/wolfcrypt/src/wc_slhdsa.c
+++ b/wolfcrypt/src/wc_slhdsa.c
@@ -1815,14 +1815,14 @@ do {                                                                        \
  */
 #define SHAKE256_SET_HASH_X4_16(state, hash)                                \
 do {                                                                        \
-    (state)[24] = ((word64*)((hash) + 0 * 16))[0];                          \
-    (state)[25] = ((word64*)((hash) + 1 * 16))[0];                          \
-    (state)[26] = ((word64*)((hash) + 2 * 16))[0];                          \
-    (state)[27] = ((word64*)((hash) + 3 * 16))[0];                          \
-    (state)[28] = ((word64*)((hash) + 0 * 16))[1];                          \
-    (state)[29] = ((word64*)((hash) + 1 * 16))[1];                          \
-    (state)[30] = ((word64*)((hash) + 2 * 16))[1];                          \
-    (state)[31] = ((word64*)((hash) + 3 * 16))[1];                          \
+    (state)[24] = readUnalignedWord64((hash) + 0 * 16 + 0 * 8);             \
+    (state)[25] = readUnalignedWord64((hash) + 1 * 16 + 0 * 8);             \
+    (state)[26] = readUnalignedWord64((hash) + 2 * 16 + 0 * 8);             \
+    (state)[27] = readUnalignedWord64((hash) + 3 * 16 + 0 * 8);             \
+    (state)[28] = readUnalignedWord64((hash) + 0 * 16 + 1 * 8);             \
+    (state)[29] = readUnalignedWord64((hash) + 1 * 16 + 1 * 8);             \
+    (state)[30] = readUnalignedWord64((hash) + 2 * 16 + 1 * 8);             \
+    (state)[31] = readUnalignedWord64((hash) + 3 * 16 + 1 * 8);             \
 } while (0)
 
 /* Get the four SHAKE-256 16-byte hash results.
@@ -1832,14 +1832,14 @@ do {                                                                        \
  */
 #define SHAKE256_GET_HASH_X4_16(state, hash)                                \
 do {                                                                        \
-    ((word64*)((hash) + 0 * 16))[0] = (state)[0];                           \
-    ((word64*)((hash) + 1 * 16))[0] = (state)[1];                           \
-    ((word64*)((hash) + 2 * 16))[0] = (state)[2];                           \
-    ((word64*)((hash) + 3 * 16))[0] = (state)[3];                           \
-    ((word64*)((hash) + 0 * 16))[1] = (state)[4];                           \
-    ((word64*)((hash) + 1 * 16))[1] = (state)[5];                           \
-    ((word64*)((hash) + 2 * 16))[1] = (state)[6];                           \
-    ((word64*)((hash) + 3 * 16))[1] = (state)[7];                           \
+    writeUnalignedWord64((hash) + 0 * 16 + 0 * 8, (state)[0]);              \
+    writeUnalignedWord64((hash) + 1 * 16 + 0 * 8, (state)[1]);              \
+    writeUnalignedWord64((hash) + 2 * 16 + 0 * 8, (state)[2]);              \
+    writeUnalignedWord64((hash) + 3 * 16 + 0 * 8, (state)[3]);              \
+    writeUnalignedWord64((hash) + 0 * 16 + 1 * 8, (state)[4]);              \
+    writeUnalignedWord64((hash) + 1 * 16 + 1 * 8, (state)[5]);              \
+    writeUnalignedWord64((hash) + 2 * 16 + 1 * 8, (state)[6]);              \
+    writeUnalignedWord64((hash) + 3 * 16 + 1 * 8, (state)[7]);              \
 } while (0)
 #endif
 
@@ -1876,18 +1876,18 @@ do {                                                                        \
  */
 #define SHAKE256_SET_HASH_X4_24(state, hash)                                \
 do {                                                                        \
-    (state)[28] = ((word64*)((hash) + 0 * 24))[0];                          \
-    (state)[29] = ((word64*)((hash) + 1 * 24))[0];                          \
-    (state)[30] = ((word64*)((hash) + 2 * 24))[0];                          \
-    (state)[31] = ((word64*)((hash) + 3 * 24))[0];                          \
-    (state)[32] = ((word64*)((hash) + 0 * 24))[1];                          \
-    (state)[33] = ((word64*)((hash) + 1 * 24))[1];                          \
-    (state)[34] = ((word64*)((hash) + 2 * 24))[1];                          \
-    (state)[35] = ((word64*)((hash) + 3 * 24))[1];                          \
-    (state)[36] = ((word64*)((hash) + 0 * 24))[2];                          \
-    (state)[37] = ((word64*)((hash) + 1 * 24))[2];                          \
-    (state)[38] = ((word64*)((hash) + 2 * 24))[2];                          \
-    (state)[39] = ((word64*)((hash) + 3 * 24))[2];                          \
+    (state)[28] = readUnalignedWord64((hash) + 0 * 24 + 0 * 8);             \
+    (state)[29] = readUnalignedWord64((hash) + 1 * 24 + 0 * 8);             \
+    (state)[30] = readUnalignedWord64((hash) + 2 * 24 + 0 * 8);             \
+    (state)[31] = readUnalignedWord64((hash) + 3 * 24 + 0 * 8);             \
+    (state)[32] = readUnalignedWord64((hash) + 0 * 24 + 1 * 8);             \
+    (state)[33] = readUnalignedWord64((hash) + 1 * 24 + 1 * 8);             \
+    (state)[34] = readUnalignedWord64((hash) + 2 * 24 + 1 * 8);             \
+    (state)[35] = readUnalignedWord64((hash) + 3 * 24 + 1 * 8);             \
+    (state)[36] = readUnalignedWord64((hash) + 0 * 24 + 2 * 8);             \
+    (state)[37] = readUnalignedWord64((hash) + 1 * 24 + 2 * 8);             \
+    (state)[38] = readUnalignedWord64((hash) + 2 * 24 + 2 * 8);             \
+    (state)[39] = readUnalignedWord64((hash) + 3 * 24 + 2 * 8);             \
 } while (0)
 
 /* Get the four SHAKE-256 24-byte (hash) results.
@@ -1897,18 +1897,18 @@ do {                                                                        \
  */
 #define SHAKE256_GET_HASH_X4_24(state, hash)                                \
 do {                                                                        \
-    ((word64*)((hash) + 0 * 24))[0] = (state)[ 0];                          \
-    ((word64*)((hash) + 1 * 24))[0] = (state)[ 1];                          \
-    ((word64*)((hash) + 2 * 24))[0] = (state)[ 2];                          \
-    ((word64*)((hash) + 3 * 24))[0] = (state)[ 3];                          \
-    ((word64*)((hash) + 0 * 24))[1] = (state)[ 4];                          \
-    ((word64*)((hash) + 1 * 24))[1] = (state)[ 5];                          \
-    ((word64*)((hash) + 2 * 24))[1] = (state)[ 6];                          \
-    ((word64*)((hash) + 3 * 24))[1] = (state)[ 7];                          \
-    ((word64*)((hash) + 0 * 24))[2] = (state)[ 8];                          \
-    ((word64*)((hash) + 1 * 24))[2] = (state)[ 9];                          \
-    ((word64*)((hash) + 2 * 24))[2] = (state)[10];                          \
-    ((word64*)((hash) + 3 * 24))[2] = (state)[11];                          \
+    writeUnalignedWord64((hash) + 0 * 24 + 0 * 8, (state)[ 0]);             \
+    writeUnalignedWord64((hash) + 1 * 24 + 0 * 8, (state)[ 1]);             \
+    writeUnalignedWord64((hash) + 2 * 24 + 0 * 8, (state)[ 2]);             \
+    writeUnalignedWord64((hash) + 3 * 24 + 0 * 8, (state)[ 3]);             \
+    writeUnalignedWord64((hash) + 0 * 24 + 1 * 8, (state)[ 4]);             \
+    writeUnalignedWord64((hash) + 1 * 24 + 1 * 8, (state)[ 5]);             \
+    writeUnalignedWord64((hash) + 2 * 24 + 1 * 8, (state)[ 6]);             \
+    writeUnalignedWord64((hash) + 3 * 24 + 1 * 8, (state)[ 7]);             \
+    writeUnalignedWord64((hash) + 0 * 24 + 2 * 8, (state)[ 8]);             \
+    writeUnalignedWord64((hash) + 1 * 24 + 2 * 8, (state)[ 9]);             \
+    writeUnalignedWord64((hash) + 2 * 24 + 2 * 8, (state)[10]);             \
+    writeUnalignedWord64((hash) + 3 * 24 + 2 * 8, (state)[11]);             \
 } while (0)
 #endif
 
@@ -1947,22 +1947,22 @@ do {                                                                        \
  */
 #define SHAKE256_SET_HASH_X4_32(state, hash)                                \
 do {                                                                        \
-    (state)[32] = ((word64*)((hash) + 0 * 32))[0];                          \
-    (state)[33] = ((word64*)((hash) + 1 * 32))[0];                          \
-    (state)[34] = ((word64*)((hash) + 2 * 32))[0];                          \
-    (state)[35] = ((word64*)((hash) + 3 * 32))[0];                          \
-    (state)[36] = ((word64*)((hash) + 0 * 32))[1];                          \
-    (state)[37] = ((word64*)((hash) + 1 * 32))[1];                          \
-    (state)[38] = ((word64*)((hash) + 2 * 32))[1];                          \
-    (state)[39] = ((word64*)((hash) + 3 * 32))[1];                          \
-    (state)[40] = ((word64*)((hash) + 0 * 32))[2];                          \
-    (state)[41] = ((word64*)((hash) + 1 * 32))[2];                          \
-    (state)[42] = ((word64*)((hash) + 2 * 32))[2];                          \
-    (state)[43] = ((word64*)((hash) + 3 * 32))[2];                          \
-    (state)[44] = ((word64*)((hash) + 0 * 32))[3];                          \
-    (state)[45] = ((word64*)((hash) + 1 * 32))[3];                          \
-    (state)[46] = ((word64*)((hash) + 2 * 32))[3];                          \
-    (state)[47] = ((word64*)((hash) + 3 * 32))[3];                          \
+    (state)[32] = readUnalignedWord64((hash) + 0 * 32 + 0 * 8);             \
+    (state)[33] = readUnalignedWord64((hash) + 1 * 32 + 0 * 8);             \
+    (state)[34] = readUnalignedWord64((hash) + 2 * 32 + 0 * 8);             \
+    (state)[35] = readUnalignedWord64((hash) + 3 * 32 + 0 * 8);             \
+    (state)[36] = readUnalignedWord64((hash) + 0 * 32 + 1 * 8);             \
+    (state)[37] = readUnalignedWord64((hash) + 1 * 32 + 1 * 8);             \
+    (state)[38] = readUnalignedWord64((hash) + 2 * 32 + 1 * 8);             \
+    (state)[39] = readUnalignedWord64((hash) + 3 * 32 + 1 * 8);             \
+    (state)[40] = readUnalignedWord64((hash) + 0 * 32 + 2 * 8);             \
+    (state)[41] = readUnalignedWord64((hash) + 1 * 32 + 2 * 8);             \
+    (state)[42] = readUnalignedWord64((hash) + 2 * 32 + 2 * 8);             \
+    (state)[43] = readUnalignedWord64((hash) + 3 * 32 + 2 * 8);             \
+    (state)[44] = readUnalignedWord64((hash) + 0 * 32 + 3 * 8);             \
+    (state)[45] = readUnalignedWord64((hash) + 1 * 32 + 3 * 8);             \
+    (state)[46] = readUnalignedWord64((hash) + 2 * 32 + 3 * 8);             \
+    (state)[47] = readUnalignedWord64((hash) + 3 * 32 + 3 * 8);             \
 } while (0)
 
 /* Get the four SHAKE-256 32-byte hash results.
@@ -1972,22 +1972,22 @@ do {                                                                        \
  */
 #define SHAKE256_GET_HASH_X4_32(state, hash)                                \
 do {                                                                        \
-    ((word64*)((hash) + 0 * 32))[0] = (state)[ 0];                          \
-    ((word64*)((hash) + 1 * 32))[0] = (state)[ 1];                          \
-    ((word64*)((hash) + 2 * 32))[0] = (state)[ 2];                          \
-    ((word64*)((hash) + 3 * 32))[0] = (state)[ 3];                          \
-    ((word64*)((hash) + 0 * 32))[1] = (state)[ 4];                          \
-    ((word64*)((hash) + 1 * 32))[1] = (state)[ 5];                          \
-    ((word64*)((hash) + 2 * 32))[1] = (state)[ 6];                          \
-    ((word64*)((hash) + 3 * 32))[1] = (state)[ 7];                          \
-    ((word64*)((hash) + 0 * 32))[2] = (state)[ 8];                          \
-    ((word64*)((hash) + 1 * 32))[2] = (state)[ 9];                          \
-    ((word64*)((hash) + 2 * 32))[2] = (state)[10];                          \
-    ((word64*)((hash) + 3 * 32))[2] = (state)[11];                          \
-    ((word64*)((hash) + 0 * 32))[3] = (state)[12];                          \
-    ((word64*)((hash) + 1 * 32))[3] = (state)[13];                          \
-    ((word64*)((hash) + 2 * 32))[3] = (state)[14];                          \
-    ((word64*)((hash) + 3 * 32))[3] = (state)[15];                          \
+    writeUnalignedWord64((hash) + 0 * 32 + 0 * 8, (state)[ 0]);             \
+    writeUnalignedWord64((hash) + 1 * 32 + 0 * 8, (state)[ 1]);             \
+    writeUnalignedWord64((hash) + 2 * 32 + 0 * 8, (state)[ 2]);             \
+    writeUnalignedWord64((hash) + 3 * 32 + 0 * 8, (state)[ 3]);             \
+    writeUnalignedWord64((hash) + 0 * 32 + 1 * 8, (state)[ 4]);             \
+    writeUnalignedWord64((hash) + 1 * 32 + 1 * 8, (state)[ 5]);             \
+    writeUnalignedWord64((hash) + 2 * 32 + 1 * 8, (state)[ 6]);             \
+    writeUnalignedWord64((hash) + 3 * 32 + 1 * 8, (state)[ 7]);             \
+    writeUnalignedWord64((hash) + 0 * 32 + 2 * 8, (state)[ 8]);             \
+    writeUnalignedWord64((hash) + 1 * 32 + 2 * 8, (state)[ 9]);             \
+    writeUnalignedWord64((hash) + 2 * 32 + 2 * 8, (state)[10]);             \
+    writeUnalignedWord64((hash) + 3 * 32 + 2 * 8, (state)[11]);             \
+    writeUnalignedWord64((hash) + 0 * 32 + 3 * 8, (state)[12]);             \
+    writeUnalignedWord64((hash) + 1 * 32 + 3 * 8, (state)[13]);             \
+    writeUnalignedWord64((hash) + 2 * 32 + 3 * 8, (state)[14]);             \
+    writeUnalignedWord64((hash) + 3 * 32 + 3 * 8, (state)[15]);             \
 } while (0)
 #endif
 
@@ -2084,10 +2084,10 @@ static void slhdsakey_shake256_get_hash_x4(const word64* state, byte* hash,
     int i;
 
     for (i = 0; i < (n / 8); i++) {
-        ((word64*)(hash + 0 * n))[i] = state[4 * i + 0];
-        ((word64*)(hash + 1 * n))[i] = state[4 * i + 1];
-        ((word64*)(hash + 2 * n))[i] = state[4 * i + 2];
-        ((word64*)(hash + 3 * n))[i] = state[4 * i + 3];
+        writeUnalignedWord64(hash + 0 * n + i * 8, state[4 * i + 0]);
+        writeUnalignedWord64(hash + 1 * n + i * 8, state[4 * i + 1]);
+        writeUnalignedWord64(hash + 2 * n + i * 8, state[4 * i + 2]);
+        writeUnalignedWord64(hash + 3 * n + i * 8, state[4 * i + 3]);
     }
 }
 
@@ -5155,10 +5155,10 @@ static int slhdsakey_hash_f_ti_x4(const byte* pk_seed, byte* addr, byte* node,
         o = slhdsakey_shake256_set_seed_ha_x4(state, pk_seed, addr, n);
         SHAKE256_SET_TREE_INDEX(state, o, ti);
         for (i = 0; i < n / 8; i++) {
-            state[o + 0] = ((word64*)(node + 0 * n))[i];
-            state[o + 1] = ((word64*)(node + 1 * n))[i];
-            state[o + 2] = ((word64*)(node + 2 * n))[i];
-            state[o + 3] = ((word64*)(node + 3 * n))[i];
+            state[o + 0] = readUnalignedWord64(node + 0 * n + i * 8);
+            state[o + 1] = readUnalignedWord64(node + 1 * n + i * 8);
+            state[o + 2] = readUnalignedWord64(node + 2 * n + i * 8);
+            state[o + 3] = readUnalignedWord64(node + 3 * n + i * 8);
             o += 4;
         }
         SHAKE256_SET_END_X4(state, o);
@@ -5212,10 +5212,10 @@ static int slhdsakey_hash_h_ti_x4(const byte* pk_seed, byte* addr,
         o = slhdsakey_shake256_set_seed_ha_x4(state, pk_seed, addr, n);
         SHAKE256_SET_TREE_INDEX(state, o, ti);
         for (i = 0; i < 2 * n / 8; i++) {
-            state[o + 0] = ((const word64*)(m + 0 * n))[i];
-            state[o + 1] = ((const word64*)(m + 2 * n))[i];
-            state[o + 2] = ((const word64*)(m + 4 * n))[i];
-            state[o + 3] = ((const word64*)(m + 6 * n))[i];
+            state[o + 0] = readUnalignedWord64(m + 0 * n + i * 8);
+            state[o + 1] = readUnalignedWord64(m + 2 * n + i * 8);
+            state[o + 2] = readUnalignedWord64(m + 4 * n + i * 8);
+            state[o + 3] = readUnalignedWord64(m + 6 * n + i * 8);
             o += 4;
         }
         SHAKE256_SET_END_X4(state, o);
@@ -6009,10 +6009,10 @@ static int slhdsakey_hash_f_ti4_x4(const byte* pk_seed, byte* addr,
         o = slhdsakey_shake256_set_seed_ha_x4(state, pk_seed, addr, n);
         SHAKE256_SET_TREE_INDEX_IDX(state, o, ti);
         for (i = 0; i < n / 8; i++) {
-            state[o + 0] = ((const word64*)(sig_fors + 0 * so * n))[i];
-            state[o + 1] = ((const word64*)(sig_fors + 1 * so * n))[i];
-            state[o + 2] = ((const word64*)(sig_fors + 2 * so * n))[i];
-            state[o + 3] = ((const word64*)(sig_fors + 3 * so * n))[i];
+            state[o + 0] = readUnalignedWord64(sig_fors + 0 * so * n + i * 8);
+            state[o + 1] = readUnalignedWord64(sig_fors + 1 * so * n + i * 8);
+            state[o + 2] = readUnalignedWord64(sig_fors + 2 * so * n + i * 8);
+            state[o + 3] = readUnalignedWord64(sig_fors + 3 * so * n + i * 8);
             o += 4;
         }
         SHAKE256_SET_END_X4(state, o);
@@ -6074,11 +6074,12 @@ static int slhdsakey_hash_h_2_x4(const byte* pk_seed, byte* addr, byte* node,
         for (i = 0; i < n / 8; i++) {
             for (j = 0; j < 4; j++) {
                 if (bit[j] == 0) {
-                    state[o + j] = ((const word64*)(node + j * n))[i];
+                    state[o + j] = readUnalignedWord64(node + j * n + i * 8);
                 }
                 else {
                     state[o + j] =
-                        ((const word64*)(sig_fors + j * (word32)so * n))[i];
+                        readUnalignedWord64(sig_fors + j *
+                                        (word32)so * n + i * 8);
                 }
             }
             o += 4;
@@ -6087,10 +6088,11 @@ static int slhdsakey_hash_h_2_x4(const byte* pk_seed, byte* addr, byte* node,
             for (j = 0; j < 4; j++) {
                 if (bit[j] == 0) {
                     state[o + j] =
-                        ((const word64*)(sig_fors + j * (word32)so * n))[i];
+                        readUnalignedWord64(sig_fors + j *
+                                        (word32)so * n + i * 8);
                 }
                 else {
-                    state[o + j] = ((const word64*)(node + j * n))[i];
+                    state[o + j] = readUnalignedWord64(node + j * n + i * 8);
                 }
             }
             o += 4;

--- a/wolfcrypt/src/wc_xmss_impl.c
+++ b/wolfcrypt/src/wc_xmss_impl.c
@@ -478,29 +478,24 @@ do {                                                  \
 #define XMSS_ADDR_TREE_SET_SUBTREE(a, s) \
     XMSS_ADDR_SET_SUBTREE(a, s, WC_XMSS_ADDR_TYPE_TREE)
 
-#ifdef LITTLE_ENDIAN_ORDER
-
 /* Set a byte value into a word of an encoded address.
+ *
+ * The address is a byte array whose alignment is not guaranteed, so encode the
+ * word value with byte-wise stores rather than casting to word32* (which can be
+ * an unaligned access and violates strict aliasing). The word is stored in
+ * network byte order, so the value occupies the least significant (last) byte.
  *
  * @param [in, out] a  Encoded hash address.
  * @param [in]      i  Index of word.
  * @param [in]      b  Byte to set.
  */
-#define XMSS_ADDR_SET_BYTE(a, i, b)     \
-    ((word32*)(a))[i] = (word32)(b) << 24
-
-#else
-
-/* Set a byte value into a word of an encoded address.
- *
- * @param [in, out] a  Encoded hash address.
- * @param [in]      i  Index of word.
- * @param [in]      b  Byte to set.
- */
-#define XMSS_ADDR_SET_BYTE(a, i, b)     \
-    ((word32*)(a))[i] = (b)
-
-#endif /* LITTLE_ENDIAN_ORDER */
+#define XMSS_ADDR_SET_BYTE(a, i, b)             \
+    do {                                        \
+        (a)[(i) * 4 + 0] = 0;                   \
+        (a)[(i) * 4 + 1] = 0;                   \
+        (a)[(i) * 4 + 2] = 0;                   \
+        (a)[(i) * 4 + 3] = (byte)(b);           \
+    } while (0)
 
 /* Convert hash address to bytes.
  *
@@ -702,7 +697,7 @@ static void wc_xmss_chain_hash_sha256_32(XmssState* state, const byte* tmp,
     int ret;
 
     /* Calculate n-byte key - KEY. */
-    ((word32*)addr)[XMSS_ADDR_KEY_MASK] = 0;
+    XMSS_ADDR_SET_BYTE(addr, XMSS_ADDR_KEY_MASK, 0);
     /* Copy back state after first 64 bytes. */
     XMSS_SHA256_STATE_RESTORE_DATA(state, addr, WC_XMSS_ADDR_LEN,
         XMSS_HASH_PRF_DATA_LEN_SHA256_32);
@@ -762,7 +757,7 @@ static void wc_xmss_chain_hash_sha256_32(XmssState* state, const byte* tmp,
     byte* bm = key + XMSS_SHA256_32_N;
 
     /* Calculate n-byte key - KEY. */
-    ((word32*)addr)[XMSS_ADDR_KEY_MASK] = 0;
+    XMSS_ADDR_SET_BYTE(addr, XMSS_ADDR_KEY_MASK, 0);
     wc_xmss_hash(state, state->prf_buf, XMSS_HASH_PRF_DATA_LEN_SHA256_32, key);
     /* Calculate the n-byte mask. */
     addr[XMSS_ADDR_KEY_MASK * 4 + 3] = 1;
@@ -803,7 +798,7 @@ static void wc_xmss_chain_hash(XmssState* state, const byte* tmp, byte* hash)
     byte* bm = key + params->n;
 
     /* Calculate n-byte key - KEY. */
-    ((word32*)addr)[XMSS_ADDR_KEY_MASK] = 0;
+    XMSS_ADDR_SET_BYTE(addr, XMSS_ADDR_KEY_MASK, 0);
     wc_xmss_hash(state, state->prf_buf, XMSS_HASH_PRF_DATA_LEN(params), key);
     /* Calculate n-byte bit mask - BM. */
     addr[XMSS_ADDR_KEY_MASK * 4 + 3] = 1;
@@ -1452,9 +1447,9 @@ static void wc_xmss_wots_get_wots_sk_sha256_32(XmssState* state,
     byte* addr_buf = seed + XMSS_SHA256_32_N;
     int ret;
 
-    ((word32*)addr)[XMSS_ADDR_CHAIN] = 0;
-    ((word32*)addr)[XMSS_ADDR_HASH] = 0;
-    ((word32*)addr)[XMSS_ADDR_KEY_MASK] = 0;
+    XMSS_ADDR_SET_BYTE(addr, XMSS_ADDR_CHAIN, 0);
+    XMSS_ADDR_SET_BYTE(addr, XMSS_ADDR_HASH, 0);
+    XMSS_ADDR_SET_BYTE(addr, XMSS_ADDR_KEY_MASK, 0);
 
     XMSS_PAD_ENC(XMSS_HASH_PADDING_PRF_KEYGEN, pad, XMSS_SHA256_32_PAD_LEN);
     XMEMCPY(s_xmss, sk_seed, XMSS_SHA256_32_N);
@@ -1543,9 +1538,9 @@ static void wc_xmss_wots_get_wots_sk(XmssState* state, const byte* sk_seed,
 #endif /* XMSS_CALL_PRF_KEYGEN */
 
     /* Ensure hash address fields are 0. */
-    ((word32*)addr)[XMSS_ADDR_CHAIN] = 0;
-    ((word32*)addr)[XMSS_ADDR_HASH] = 0;
-    ((word32*)addr)[XMSS_ADDR_KEY_MASK] = 0;
+    XMSS_ADDR_SET_BYTE(addr, XMSS_ADDR_CHAIN, 0);
+    XMSS_ADDR_SET_BYTE(addr, XMSS_ADDR_HASH, 0);
+    XMSS_ADDR_SET_BYTE(addr, XMSS_ADDR_KEY_MASK, 0);
 
 #ifdef XMSS_CALL_PRF_KEYGEN
     /* Copy the seed and address into PRF keygen message buffer. */


### PR DESCRIPTION
# Description
Fixed a series of Fenrir issues that mostly pertained to alignment UB when reading byte arrays as various sizes of integers.

## https://fenrir.wolfssl.com/finding/6438
FSPSM RSA private-decrypt never updates caller's *outLen (passes &outLen instead of outLen)

- Swapped the double reference to just pass the outLen ptr

## https://fenrir.wolfssl.com/finding/5414
SLH-DSA AVX2 x4 SHAKE helpers cast hash byte streams to word64

- Changed from direct cast byte -> word64 / word64 -> byte to use Unaligned memory helpers 

## https://fenrir.wolfssl.com/finding/5415
ML-DSA little-endian pack/unpack paths cast encoded byte buffers to word pointers

- Fixed a variety of possible alignment issues.

## https://fenrir.wolfssl.com/finding/6165
scrypt scryptROMix big-endian Integerify shifts bytes without width cast (signed overflow/oversized shift on 16-bit int)

- Explicitly cast all intermediate values to word32 to make sure that there is no chance of signed in overflow during bit shifting.

## https://fenrir.wolfssl.com/finding/6166
wc_ecc_init_id (SE050) reinterprets byte id[] array as word32 via pointer cast

- Used unaligned helper function to read byte array as word32

## https://fenrir.wolfssl.com/finding/6167
XMSS hash-address byte buffers cast to word32* in address-encoding helpers (unaligned access / strict aliasing)

- Removed cast to use endian independent operation that copies the byte value in to the last byte because the word is stored in network byte order 

## https://fenrir.wolfssl.com/finding/6177
PKCS#12 parse leaves decrypted SafeContents (incl. plaintext private KeyBag) in freed heap buffer

- Added new variable to track temp buffer size and ForceZero it when it is freed 
