### PR TITLE
0 memset kop in devcrypto_x25519 before use

### DIFF
--- a/wolfcrypt/src/port/devcrypto/devcrypto_x25519.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_x25519.c
@@ -53,6 +53,7 @@ int wc_DevCryptoCurve25519(byte* out, word32 outSz, const byte* k,
 
     ret = wc_DevCryptoCreate(&ctx, CRYPTO_ASYM_MUL_MOD, NULL, 0);
     if (ret == 0) {
+        XMEMSET(&kop, 0, sizeof(kop));
         kop.crk_op = CRK_MUL_MOD;
         kop.ses    = ctx.sess.ses;
         kop.crk_flags = 0;


### PR DESCRIPTION
# Description

0 memset kop in devcrypto_x25519 before use

This is the same change as in 51698759fa9ea47759e4ecf67ee13188345c3ef9 but for devcrypto_x25519.c instead of devcrypto_ecdsa.c

Fixes F-4444

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
