### PR TITLE
Crypto layer: Add missing input validation

### DIFF
--- a/tests/api/test_aes.c
+++ b/tests/api/test_aes.c
@@ -3381,7 +3381,7 @@ int test_wc_AesGcmEncryptDecrypt(void)
         sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) + 1, a, sizeof(a)),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_AesGcmEncrypt(&aes, enc, vector, sizeof(vector), iv,
-        sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) - 5, a, sizeof(a)),
+        sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) - 10, a, sizeof(a)),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
 #if (defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
@@ -4928,7 +4928,7 @@ int test_wc_GmacUpdate(void)
     ExpectIntEQ(wc_GmacUpdate(NULL, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
         tagOut3, sizeof(tag3)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_GmacUpdate(&gmac, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
-        tagOut3, sizeof(tag3) - 5), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        tagOut3, sizeof(tag3) - 10), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_GmacUpdate(&gmac, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
         tagOut3, sizeof(tag3) + 1),  WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     wc_AesFree(&gmac.aes);

--- a/tests/api/test_aes.c
+++ b/tests/api/test_aes.c
@@ -3387,7 +3387,7 @@ int test_wc_AesGcmEncryptDecrypt(void)
         sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) + 1, a, sizeof(a)),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_AesGcmEncrypt(&aes, enc, vector, sizeof(vector), iv,
-        sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) - 5, a, sizeof(a)),
+        sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) - 10, a, sizeof(a)),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
 #if (defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
@@ -4936,7 +4936,7 @@ int test_wc_GmacUpdate(void)
     ExpectIntEQ(wc_GmacUpdate(NULL, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
         tagOut3, sizeof(tag3)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_GmacUpdate(&gmac, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
-        tagOut3, sizeof(tag3) - 5), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        tagOut3, sizeof(tag3) - 10), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_GmacUpdate(&gmac, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
         tagOut3, sizeof(tag3) + 1),  WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     wc_AesFree(&gmac.aes);

--- a/tests/api/test_aes.c
+++ b/tests/api/test_aes.c
@@ -3381,8 +3381,8 @@ int test_wc_AesGcmEncryptDecrypt(void)
         sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) + 1, a, sizeof(a)),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_AesGcmEncrypt(&aes, enc, vector, sizeof(vector), iv,
-        sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) - 10, a, sizeof(a)),
-        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        sizeof(iv)/sizeof(byte), resultT, WOLFSSL_MIN_AUTH_TAG_SZ - 1, a,
+        sizeof(a)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
 #if (defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
         (HAVE_FIPS_VERSION == 2)) || defined(HAVE_SELFTEST) || \
@@ -4928,7 +4928,7 @@ int test_wc_GmacUpdate(void)
     ExpectIntEQ(wc_GmacUpdate(NULL, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
         tagOut3, sizeof(tag3)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_GmacUpdate(&gmac, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
-        tagOut3, sizeof(tag3) - 10), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        tagOut3, WOLFSSL_MIN_AUTH_TAG_SZ - 1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_GmacUpdate(&gmac, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
         tagOut3, sizeof(tag3) + 1),  WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     wc_AesFree(&gmac.aes);

--- a/tests/api/test_aes.c
+++ b/tests/api/test_aes.c
@@ -3387,8 +3387,8 @@ int test_wc_AesGcmEncryptDecrypt(void)
         sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) + 1, a, sizeof(a)),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_AesGcmEncrypt(&aes, enc, vector, sizeof(vector), iv,
-        sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) - 10, a, sizeof(a)),
-        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        sizeof(iv)/sizeof(byte), resultT, WOLFSSL_MIN_AUTH_TAG_SZ - 1, a,
+        sizeof(a)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
 #if (defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
         (HAVE_FIPS_VERSION == 2)) || defined(HAVE_SELFTEST) || \
@@ -4936,7 +4936,7 @@ int test_wc_GmacUpdate(void)
     ExpectIntEQ(wc_GmacUpdate(NULL, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
         tagOut3, sizeof(tag3)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_GmacUpdate(&gmac, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
-        tagOut3, sizeof(tag3) - 10), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        tagOut3, WOLFSSL_MIN_AUTH_TAG_SZ - 1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_GmacUpdate(&gmac, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
         tagOut3, sizeof(tag3) + 1),  WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     wc_AesFree(&gmac.aes);

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -1138,7 +1138,7 @@ static int GeneratePrivateDh186(DhKey* key, WC_RNG* rng, byte* priv,
      * WOLFSSL_SMALL_STACK path to avoid unbounded heap allocation. */
     if (*privSz > DH_MAX_SIZE) {
         WOLFSSL_MSG("DH private key size exceeds DH_MAX_SIZE");
-        return BAD_FUNC_ARG;
+        return WC_KEY_SIZE_E;
     }
 
     qSz = (word32)mp_unsigned_bin_size(&key->q);
@@ -1731,6 +1731,9 @@ int wc_DhCheckPubValue(const byte* prime, word32 primeSz, const byte* pub,
 {
     int ret = 0;
     word32 i;
+
+    if (prime == NULL || pub == NULL)
+        return BAD_FUNC_ARG;
 
     for (i = 0; i < pubSz && pub[i] == 0; i++) {
     }

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -1174,7 +1174,7 @@ static int GeneratePrivateDh186(DhKey* key, WC_RNG* rng, byte* priv,
      * WOLFSSL_SMALL_STACK path to avoid unbounded heap allocation. */
     if (*privSz > DH_MAX_SIZE) {
         WOLFSSL_MSG("DH private key size exceeds DH_MAX_SIZE");
-        return BAD_FUNC_ARG;
+        return WC_KEY_SIZE_E;
     }
 
     qSz = (word32)mp_unsigned_bin_size(&key->q);
@@ -1772,6 +1772,9 @@ int wc_DhCheckPubValue(const byte* prime, word32 primeSz, const byte* pub,
 {
     int ret = 0;
     word32 i;
+
+    if (prime == NULL || pub == NULL)
+        return BAD_FUNC_ARG;
 
     for (i = 0; i < pubSz && pub[i] == 0; i++) {
     }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -11414,16 +11414,24 @@ static int _ecc_import_x963_ex2(const byte* in, word32 inLen, ecc_key* key,
     if (err == MP_OKAY) {
     #ifdef HAVE_COMP_KEY
         /* adjust inLen if compressed */
-        if (compressed)
-            inLen = inLen*2 + 1;  /* used uncompressed len */
+        if (compressed) {
+            /* a compressed coordinate cannot exceed MAX_ECC_BYTES; bound it
+             * before doubling so inLen*2 + 1 cannot overflow word32. */
+            if (inLen > MAX_ECC_BYTES)
+                err = ECC_BAD_ARG_E;
+            else
+                inLen = inLen*2 + 1;  /* used uncompressed len */
+        }
     #endif
 
         /* determine key size */
-        keysize = (int)(inLen>>1);
-        /* NOTE: FIPS v6.0.0 or greater, no restriction on imported keys, only
-         *       on created keys or signatures */
-        err = wc_ecc_set_curve(key, keysize, curve_id);
-        key->type = ECC_PUBLICKEY;
+        if (err == MP_OKAY) {
+            keysize = (int)(inLen>>1);
+            /* NOTE: FIPS v6.0.0 or greater, no restriction on imported keys,
+             *       only on created keys or signatures */
+            err = wc_ecc_set_curve(key, keysize, curve_id);
+            key->type = ECC_PUBLICKEY;
+        }
     }
 
     /* read data */

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -11518,16 +11518,24 @@ static int _ecc_import_x963_ex2(const byte* in, word32 inLen, ecc_key* key,
     if (err == MP_OKAY) {
     #ifdef HAVE_COMP_KEY
         /* adjust inLen if compressed */
-        if (compressed)
-            inLen = inLen*2 + 1;  /* used uncompressed len */
+        if (compressed) {
+            /* a compressed coordinate cannot exceed MAX_ECC_BYTES; bound it
+             * before doubling so inLen*2 + 1 cannot overflow word32. */
+            if (inLen > MAX_ECC_BYTES)
+                err = ECC_BAD_ARG_E;
+            else
+                inLen = inLen*2 + 1;  /* used uncompressed len */
+        }
     #endif
 
         /* determine key size */
-        keysize = (int)(inLen>>1);
-        /* NOTE: FIPS v6.0.0 or greater, no restriction on imported keys, only
-         *       on created keys or signatures */
-        err = wc_ecc_set_curve(key, keysize, curve_id);
-        key->type = ECC_PUBLICKEY;
+        if (err == MP_OKAY) {
+            keysize = (int)(inLen>>1);
+            /* NOTE: FIPS v6.0.0 or greater, no restriction on imported keys,
+             *       only on created keys or signatures */
+            err = wc_ecc_set_curve(key, keysize, curve_id);
+            key->type = ECC_PUBLICKEY;
+        }
     }
 
     /* read data */

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -91,7 +91,7 @@ int wc_PRF(byte* result, word32 resLen, const byte* secret,
 
     if ((result == NULL && resLen != 0) || (secret == NULL && secLen != 0) ||
        (seed == NULL && seedLen != 0))
-      return BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
 
     switch (hash_type) {
     #ifndef NO_MD5

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -89,6 +89,10 @@ int wc_PRF(byte* result, word32 resLen, const byte* secret,
     Hmac   hmac[1];
 #endif
 
+    if ((result == NULL && resLen != 0) || (secret == NULL && secLen != 0) ||
+       (seed == NULL && seedLen != 0))
+      return BAD_FUNC_ARG;
+
     switch (hash_type) {
     #ifndef NO_MD5
         case md5_mac:
@@ -234,8 +238,18 @@ int wc_PRF_TLSv1(byte* digest, word32 digLen, const byte* secret,
     WC_DECLARE_VAR(sha_result, byte, MAX_PRF_DIG, heap); /* digLen is real size */
     WC_DECLARE_VAR(labelSeed, byte, MAX_PRF_LABSEED, heap);
 
+    if ((digest == NULL && digLen  != 0) ||
+        (secret == NULL && secLen  != 0) ||
+        (label  == NULL && labLen  != 0) ||
+        (seed   == NULL && seedLen != 0)) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* labLen + seedLen is checked with subtraction to avoid word32 wraparound
+     * (the labLen bound first ensures MAX_PRF_LABSEED - labLen cannot
+     * underflow). */
     if (half > MAX_PRF_HALF ||
-        labLen + seedLen > MAX_PRF_LABSEED ||
+        labLen > MAX_PRF_LABSEED || seedLen > (MAX_PRF_LABSEED - labLen) ||
         digLen > MAX_PRF_DIG)
     {
         return BUFFER_E;
@@ -251,8 +265,10 @@ int wc_PRF_TLSv1(byte* digest, word32 digLen, const byte* secret,
     sha_half = secret + half - secLen % 2;
     md5_result = digest;
 
-    XMEMCPY(labelSeed, label, labLen);
-    XMEMCPY(labelSeed + labLen, seed, seedLen);
+    if (labLen != 0)
+        XMEMCPY(labelSeed, label, labLen);
+    if (seedLen != 0)
+        XMEMCPY(labelSeed + labLen, seed, seedLen);
 
     if ((ret = wc_PRF(md5_result, digLen, md5_half, half, labelSeed,
                                 labLen + seedLen, md5_mac, heap, devId)) == 0) {
@@ -286,6 +302,13 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
 {
     int ret = 0;
 
+    if ((digest == NULL && digLen  != 0) ||
+        (secret == NULL && secLen  != 0) ||
+        (label  == NULL && labLen  != 0) ||
+        (seed   == NULL && seedLen != 0)) {
+        return BAD_FUNC_ARG;
+    }
+
 #ifdef WOLFSSL_DEBUG_TLS
     WOLFSSL_MSG("  secret");
     WOLFSSL_BUFFER(secret, secLen);
@@ -298,15 +321,19 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
     if (useAtLeastSha256) {
         WC_DECLARE_VAR(labelSeed, byte, MAX_PRF_LABSEED, 0);
 
-        if (labLen + seedLen > MAX_PRF_LABSEED) {
+        /* Checked with subtraction to avoid word32 wraparound of
+         * labLen + seedLen. */
+        if (labLen > MAX_PRF_LABSEED || seedLen > (MAX_PRF_LABSEED - labLen)) {
             return BUFFER_E;
         }
 
         WC_ALLOC_VAR_EX(labelSeed, byte, MAX_PRF_LABSEED, heap,
             DYNAMIC_TYPE_DIGEST, return MEMORY_E);
 
-        XMEMCPY(labelSeed, label, labLen);
-        XMEMCPY(labelSeed + labLen, seed, seedLen);
+        if (labLen != 0)
+            XMEMCPY(labelSeed, label, labLen);
+        if (seedLen != 0)
+            XMEMCPY(labelSeed + labLen, seed, seedLen);
 
         /* If a cipher suite wants an algorithm better than sha256, it
          * should use better. */

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -87,6 +87,10 @@ int wc_PRF(byte* result, word32 resLen, const byte* secret,
     Hmac   hmac[1];
 #endif
 
+    if ((result == NULL && resLen != 0) || (secret == NULL && secLen != 0) ||
+       (seed == NULL && seedLen != 0))
+      return BAD_FUNC_ARG;
+
     switch (hash_type) {
     #ifndef NO_MD5
         case md5_mac:
@@ -232,8 +236,18 @@ int wc_PRF_TLSv1(byte* digest, word32 digLen, const byte* secret,
     WC_DECLARE_VAR(sha_result, byte, MAX_PRF_DIG, heap); /* digLen is real size */
     WC_DECLARE_VAR(labelSeed, byte, MAX_PRF_LABSEED, heap);
 
+    if ((digest == NULL && digLen  != 0) ||
+        (secret == NULL && secLen  != 0) ||
+        (label  == NULL && labLen  != 0) ||
+        (seed   == NULL && seedLen != 0)) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* labLen + seedLen is checked with subtraction to avoid word32 wraparound
+     * (the labLen bound first ensures MAX_PRF_LABSEED - labLen cannot
+     * underflow). */
     if (half > MAX_PRF_HALF ||
-        labLen + seedLen > MAX_PRF_LABSEED ||
+        labLen > MAX_PRF_LABSEED || seedLen > (MAX_PRF_LABSEED - labLen) ||
         digLen > MAX_PRF_DIG)
     {
         return BUFFER_E;
@@ -249,8 +263,10 @@ int wc_PRF_TLSv1(byte* digest, word32 digLen, const byte* secret,
     sha_half = secret + half - secLen % 2;
     md5_result = digest;
 
-    XMEMCPY(labelSeed, label, labLen);
-    XMEMCPY(labelSeed + labLen, seed, seedLen);
+    if (labLen != 0)
+        XMEMCPY(labelSeed, label, labLen);
+    if (seedLen != 0)
+        XMEMCPY(labelSeed + labLen, seed, seedLen);
 
     if ((ret = wc_PRF(md5_result, digLen, md5_half, half, labelSeed,
                                 labLen + seedLen, md5_mac, heap, devId)) == 0) {
@@ -284,6 +300,13 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
 {
     int ret = 0;
 
+    if ((digest == NULL && digLen  != 0) ||
+        (secret == NULL && secLen  != 0) ||
+        (label  == NULL && labLen  != 0) ||
+        (seed   == NULL && seedLen != 0)) {
+        return BAD_FUNC_ARG;
+    }
+
 #ifdef WOLFSSL_DEBUG_TLS
     WOLFSSL_MSG("  secret");
     WOLFSSL_BUFFER(secret, secLen);
@@ -296,15 +319,19 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
     if (useAtLeastSha256) {
         WC_DECLARE_VAR(labelSeed, byte, MAX_PRF_LABSEED, 0);
 
-        if (labLen + seedLen > MAX_PRF_LABSEED) {
+        /* Checked with subtraction to avoid word32 wraparound of
+         * labLen + seedLen. */
+        if (labLen > MAX_PRF_LABSEED || seedLen > (MAX_PRF_LABSEED - labLen)) {
             return BUFFER_E;
         }
 
         WC_ALLOC_VAR_EX(labelSeed, byte, MAX_PRF_LABSEED, heap,
             DYNAMIC_TYPE_DIGEST, return MEMORY_E);
 
-        XMEMCPY(labelSeed, label, labLen);
-        XMEMCPY(labelSeed + labLen, seed, seedLen);
+        if (labLen != 0)
+            XMEMCPY(labelSeed, label, labLen);
+        if (seedLen != 0)
+            XMEMCPY(labelSeed + labLen, seed, seedLen);
 
         /* If a cipher suite wants an algorithm better than sha256, it
          * should use better. */

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -89,7 +89,7 @@ int wc_PRF(byte* result, word32 resLen, const byte* secret,
 
     if ((result == NULL && resLen != 0) || (secret == NULL && secLen != 0) ||
        (seed == NULL && seedLen != 0))
-      return BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
 
     switch (hash_type) {
     #ifndef NO_MD5

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1825,7 +1825,7 @@ static int RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
     if (ret != 0) {
         ForceZero(tmp, hLen);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(tmp, NULL, DYNAMIC_TYPE_RSA_BUFFER);
+        XFREE(tmp, heap, DYNAMIC_TYPE_RSA_BUFFER);
 #elif defined(WOLFSSL_CHECK_MEM_ZERO)
         wc_MemZero_Check(tmp, hLen);
 #endif
@@ -5445,7 +5445,11 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
         goto out;
     }
 
+#if defined(HAVE_FIPS)
+    if (e < WC_RSA_EXPONENT || (e & 1) == 0) {
+#else
     if (e < 3 || (e & 1) == 0) {
+#endif
         err = BAD_FUNC_ARG;
         goto out;
     }

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1823,7 +1823,7 @@ static int RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
     if (ret != 0) {
         ForceZero(tmp, hLen);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(tmp, NULL, DYNAMIC_TYPE_RSA_BUFFER);
+        XFREE(tmp, heap, DYNAMIC_TYPE_RSA_BUFFER);
 #elif defined(WOLFSSL_CHECK_MEM_ZERO)
         wc_MemZero_Check(tmp, hLen);
 #endif
@@ -5482,7 +5482,11 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
         goto out;
     }
 
+#if defined(HAVE_FIPS)
+    if (e < WC_RSA_EXPONENT || (e & 1) == 0) {
+#else
     if (e < 3 || (e & 1) == 0) {
+#endif
         err = BAD_FUNC_ARG;
         goto out;
     }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -31197,7 +31197,7 @@ static wc_test_ret_t dh_fips_generate_test(WC_RNG *rng)
     #if defined(WOLFSSL_ASYNC_CRYPT)
         ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_NONE);
     #endif
-        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        if (ret != WC_NO_ERR_TRACE(WC_KEY_SIZE_E))
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     }
 #endif /* !WOLFSSL_NO_DH186 && !HAVE_SELFTEST && !HAVE_FIPS */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -31722,7 +31722,7 @@ static wc_test_ret_t dh_fips_generate_test(WC_RNG *rng)
     #if defined(WOLFSSL_ASYNC_CRYPT)
         ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_NONE);
     #endif
-        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        if (ret != WC_NO_ERR_TRACE(WC_KEY_SIZE_E))
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     }
 #endif /* !WOLFSSL_NO_DH186 && !HAVE_SELFTEST && !HAVE_FIPS */

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -98,14 +98,13 @@ struct Cmac {
 
 
 
-
-#ifndef NO_AES
-#define WC_CMAC_TAG_MAX_SZ WC_AES_BLOCK_SIZE
-#define WC_CMAC_TAG_MIN_SZ (WC_AES_BLOCK_SIZE/4)
-#else
 /* Reasonable defaults */
-#define WC_CMAC_TAG_MAX_SZ 16
-#define WC_CMAC_TAG_MIN_SZ 4
+/* SP800-38b recommends a minimum tag length of 64-bits */
+#ifndef WC_CMAC_TAG_MAX_SZ
+    #define WC_CMAC_TAG_MAX_SZ 16
+#endif
+#ifndef WC_CMAC_TAG_MIN_SZ
+    #define WC_CMAC_TAG_MIN_SZ 8
 #endif
 
 #if FIPS_VERSION3_GE(6,0,0)

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -99,12 +99,14 @@ struct Cmac {
 
 
 /* Reasonable defaults */
-/* SP800-38b recommends a minimum tag length of 64-bits */
 #ifndef WC_CMAC_TAG_MAX_SZ
     #define WC_CMAC_TAG_MAX_SZ 16
 #endif
-#ifndef WC_CMAC_TAG_MIN_SZ
+/* SP800-38b recommends a minimum tag length of 64-bits */
+#if FIPS_VERSION3_GE(7,0,0)
     #define WC_CMAC_TAG_MIN_SZ 8
+#elif !defined(WC_CMAC_TAG_MIN_SZ)
+    #define WC_CMAC_TAG_MIN_SZ 4
 #endif
 
 #if FIPS_VERSION3_GE(6,0,0)

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -99,14 +99,13 @@ struct Cmac {
 
 
 
-
-#ifndef NO_AES
-#define WC_CMAC_TAG_MAX_SZ WC_AES_BLOCK_SIZE
-#define WC_CMAC_TAG_MIN_SZ (WC_AES_BLOCK_SIZE/4)
-#else
 /* Reasonable defaults */
-#define WC_CMAC_TAG_MAX_SZ 16
-#define WC_CMAC_TAG_MIN_SZ 4
+/* SP800-38b recommends a minimum tag length of 64-bits */
+#ifndef WC_CMAC_TAG_MAX_SZ
+    #define WC_CMAC_TAG_MAX_SZ 16
+#endif
+#ifndef WC_CMAC_TAG_MIN_SZ
+    #define WC_CMAC_TAG_MIN_SZ 8
 #endif
 
 #if FIPS_VERSION3_GE(6,0,0)

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -103,8 +103,14 @@ struct Cmac {
 #ifndef WC_CMAC_TAG_MAX_SZ
     #define WC_CMAC_TAG_MAX_SZ 16
 #endif
+
+#if !defined(NO_AES) && (WC_CMAC_TAG_MAX_SZ > 16)
+    #error WC_CMAC_TAG_MAX_SZ cannot exceed WC_AES_BLOCK_SIZE
+#endif
+
 /* SP800-38b recommends a minimum tag length of 64-bits */
 #if FIPS_VERSION3_GE(7,0,0)
+    #undef WC_CMAC_TAG_MIN_SZ
     #define WC_CMAC_TAG_MIN_SZ 8
 #elif !defined(WC_CMAC_TAG_MIN_SZ)
     #define WC_CMAC_TAG_MIN_SZ 4

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -100,12 +100,14 @@ struct Cmac {
 
 
 /* Reasonable defaults */
-/* SP800-38b recommends a minimum tag length of 64-bits */
 #ifndef WC_CMAC_TAG_MAX_SZ
     #define WC_CMAC_TAG_MAX_SZ 16
 #endif
-#ifndef WC_CMAC_TAG_MIN_SZ
+/* SP800-38b recommends a minimum tag length of 64-bits */
+#if FIPS_VERSION3_GE(7,0,0)
     #define WC_CMAC_TAG_MIN_SZ 8
+#elif !defined(WC_CMAC_TAG_MIN_SZ)
+    #define WC_CMAC_TAG_MIN_SZ 4
 #endif
 
 #if FIPS_VERSION3_GE(6,0,0)

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -102,8 +102,14 @@ struct Cmac {
 #ifndef WC_CMAC_TAG_MAX_SZ
     #define WC_CMAC_TAG_MAX_SZ 16
 #endif
+
+#if !defined(NO_AES) && (WC_CMAC_TAG_MAX_SZ > 16)
+    #error WC_CMAC_TAG_MAX_SZ cannot exceed WC_AES_BLOCK_SIZE
+#endif
+
 /* SP800-38b recommends a minimum tag length of 64-bits */
 #if FIPS_VERSION3_GE(7,0,0)
+    #undef WC_CMAC_TAG_MIN_SZ
     #define WC_CMAC_TAG_MIN_SZ 8
 #elif !defined(WC_CMAC_TAG_MIN_SZ)
     #define WC_CMAC_TAG_MIN_SZ 4

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3899,6 +3899,32 @@
     #endif
 #endif
 
+#if defined(HAVE_FIPS)
+    #if FIPS_VERSION3_EQ(5, 2, 4)
+        /* support RFC 4106 IPsec ESP 64 bit tags */
+       #undef WOLFSSL_MIN_AUTH_TAG_SZ
+       #define WOLFSSL_MIN_AUTH_TAG_SZ 8
+    #else
+        /* No short (<96 bit) tags per SP 800-38D 2026 revision in process. */
+        #if WOLFSSL_MIN_AUTH_TAG_SZ < 12
+            #undef WOLFSSL_MIN_AUTH_TAG_SZ
+            #define WOLFSSL_MIN_AUTH_TAG_SZ 12
+        #endif
+    #endif
+#elif defined(CONFIG_CRYPTO_MANAGER_EXTRA_TESTS) || defined(CONFIG_CRYPTO_SELFTESTS_FULL)
+    /* The Linux kernel native crypto fuzzer expects small AES-GCM tag sizes to succeed. */
+    #if WOLFSSL_MIN_AUTH_TAG_SZ > 4
+        #undef WOLFSSL_MIN_AUTH_TAG_SZ
+        #define WOLFSSL_MIN_AUTH_TAG_SZ 4
+    #endif
+#elif defined(WOLFSSL_LINUXKM)
+    /* support RFC 4106 IPsec ESP */
+    #if WOLFSSL_MIN_AUTH_TAG_SZ > 8
+        #undef WOLFSSL_MIN_AUTH_TAG_SZ
+        #define WOLFSSL_MIN_AUTH_TAG_SZ 8
+    #endif
+#endif
+
 #if defined(HAVE_FIPS) && defined(HAVE_AESGCM) && FIPS_VERSION3_LT(7,0,0) && \
     defined(WC_FIPS_AESGCM_ONE_SHOT_EXT_IV_ALLOWED) && \
     !defined(WOLFSSL_EXPERIMENTAL_SETTINGS)
@@ -4369,32 +4395,6 @@
             #define WOLFSSL_NO_PUBLIC_FFDHE
         #endif
         #undef HAVE_PUBLIC_FFDHE
-    #endif
-
-    #if defined(HAVE_FIPS)
-        #if FIPS_VERSION3_LT(7, 0, 0)
-            /* support RFC 4106 IPsec ESP 64 bit tags */
-           #undef WOLFSSL_MIN_AUTH_TAG_SZ
-           #define WOLFSSL_MIN_AUTH_TAG_SZ 8
-        #else
-            /* No short (<96 bit) tags per SP 800-38D 2026 revision in process. */
-            #if WOLFSSL_MIN_AUTH_TAG_SZ < 12
-                #undef WOLFSSL_MIN_AUTH_TAG_SZ
-                #define WOLFSSL_MIN_AUTH_TAG_SZ 12
-            #endif
-        #endif
-    #elif defined(CONFIG_CRYPTO_MANAGER_EXTRA_TESTS) || defined(CONFIG_CRYPTO_SELFTESTS_FULL)
-        /* The Linux kernel native crypto fuzzer expects small AES-GCM tag sizes to succeed. */
-        #if WOLFSSL_MIN_AUTH_TAG_SZ > 4
-            #undef WOLFSSL_MIN_AUTH_TAG_SZ
-            #define WOLFSSL_MIN_AUTH_TAG_SZ 4
-        #endif
-    #else
-        /* support RFC 4106 IPsec ESP */
-        #if WOLFSSL_MIN_AUTH_TAG_SZ > 8
-            #undef WOLFSSL_MIN_AUTH_TAG_SZ
-            #define WOLFSSL_MIN_AUTH_TAG_SZ 8
-        #endif
     #endif
 
     #if defined(LINUXKM_LKCAPI_REGISTER) && !defined(WOLFSSL_ASN_INT_LEAD_0_ANY)

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3892,15 +3892,9 @@
     #error WOLFSSL_MIN_AUTH_TAG_SZ must be at least 1
 #endif
 
-#if defined(HAVE_FIPS) && FIPS_VERSION3_GE(7, 0, 0)
-    /* No short (<96 bit) tags per SP 800-38D 2026 revision in process. */
-    #if WOLFSSL_MIN_AUTH_TAG_SZ < 12
-        #error WOLFSSL_MIN_AUTH_TAG_SZ must be >= 12 per SP 800-38D Rev 1
-    #endif
-#endif
-
 #if defined(HAVE_FIPS)
-    #if FIPS_VERSION3_EQ(5, 2, 4)
+    #if FIPS_VERSION3_EQ(5, 2, 4) || (FIPS_VERSION3_LT(7, 0, 0) && \
+            defined(WOLFSSL_LINUXKM))
         /* support RFC 4106 IPsec ESP 64 bit tags */
        #undef WOLFSSL_MIN_AUTH_TAG_SZ
        #define WOLFSSL_MIN_AUTH_TAG_SZ 8
@@ -3911,8 +3905,10 @@
             #define WOLFSSL_MIN_AUTH_TAG_SZ 12
         #endif
     #endif
-#elif defined(CONFIG_CRYPTO_MANAGER_EXTRA_TESTS) || defined(CONFIG_CRYPTO_SELFTESTS_FULL)
-    /* The Linux kernel native crypto fuzzer expects small AES-GCM tag sizes to succeed. */
+#elif defined(WOLFSSL_LINUXKM) && (defined(CONFIG_CRYPTO_MANAGER_EXTRA_TESTS) \
+        || defined(CONFIG_CRYPTO_SELFTESTS_FULL))
+    /* The Linux kernel native crypto fuzzer expects small AES-GCM tag
+     * sizes to succeed. */
     #if WOLFSSL_MIN_AUTH_TAG_SZ > 4
         #undef WOLFSSL_MIN_AUTH_TAG_SZ
         #define WOLFSSL_MIN_AUTH_TAG_SZ 4

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3925,6 +3925,32 @@
     #endif
 #endif
 
+#if defined(HAVE_FIPS)
+    #if FIPS_VERSION3_EQ(5, 2, 4)
+        /* support RFC 4106 IPsec ESP 64 bit tags */
+       #undef WOLFSSL_MIN_AUTH_TAG_SZ
+       #define WOLFSSL_MIN_AUTH_TAG_SZ 8
+    #else
+        /* No short (<96 bit) tags per SP 800-38D 2026 revision in process. */
+        #if WOLFSSL_MIN_AUTH_TAG_SZ < 12
+            #undef WOLFSSL_MIN_AUTH_TAG_SZ
+            #define WOLFSSL_MIN_AUTH_TAG_SZ 12
+        #endif
+    #endif
+#elif defined(CONFIG_CRYPTO_MANAGER_EXTRA_TESTS) || defined(CONFIG_CRYPTO_SELFTESTS_FULL)
+    /* The Linux kernel native crypto fuzzer expects small AES-GCM tag sizes to succeed. */
+    #if WOLFSSL_MIN_AUTH_TAG_SZ > 4
+        #undef WOLFSSL_MIN_AUTH_TAG_SZ
+        #define WOLFSSL_MIN_AUTH_TAG_SZ 4
+    #endif
+#elif defined(WOLFSSL_LINUXKM)
+    /* support RFC 4106 IPsec ESP */
+    #if WOLFSSL_MIN_AUTH_TAG_SZ > 8
+        #undef WOLFSSL_MIN_AUTH_TAG_SZ
+        #define WOLFSSL_MIN_AUTH_TAG_SZ 8
+    #endif
+#endif
+
 #if defined(HAVE_FIPS) && defined(HAVE_AESGCM) && FIPS_VERSION3_LT(7,0,0) && \
     defined(WC_FIPS_AESGCM_ONE_SHOT_EXT_IV_ALLOWED) && \
     !defined(WOLFSSL_EXPERIMENTAL_SETTINGS)
@@ -4406,30 +4432,6 @@
         #if defined(WC_DEBUG_CIPHER_LIFECYCLE) && FIPS_VERSION3_LT(6, 0, 0)
             #error Configured FIPS version does not support WC_DEBUG_CIPHER_LIFECYCLE.
         #endif
-        #if FIPS_VERSION3_LT(7, 0, 0)
-            /* support RFC 4106 IPsec ESP 64 bit tags */
-           #undef WOLFSSL_MIN_AUTH_TAG_SZ
-           #define WOLFSSL_MIN_AUTH_TAG_SZ 8
-        #else
-            /* No short (<96 bit) tags per SP 800-38D 2026 revision in process. */
-            #if WOLFSSL_MIN_AUTH_TAG_SZ < 12
-                #undef WOLFSSL_MIN_AUTH_TAG_SZ
-                #define WOLFSSL_MIN_AUTH_TAG_SZ 12
-            #endif
-        #endif
-    #elif defined(CONFIG_CRYPTO_MANAGER_EXTRA_TESTS) || defined(CONFIG_CRYPTO_SELFTESTS_FULL)
-        /* The Linux kernel native crypto fuzzer expects small AES-GCM tag sizes to succeed. */
-        #if WOLFSSL_MIN_AUTH_TAG_SZ > 4
-            #undef WOLFSSL_MIN_AUTH_TAG_SZ
-            #define WOLFSSL_MIN_AUTH_TAG_SZ 4
-        #endif
-    #else
-        /* support RFC 4106 IPsec ESP */
-        #if WOLFSSL_MIN_AUTH_TAG_SZ > 8
-            #undef WOLFSSL_MIN_AUTH_TAG_SZ
-            #define WOLFSSL_MIN_AUTH_TAG_SZ 8
-        #endif
-    #endif
 
     #if defined(LINUXKM_LKCAPI_REGISTER) && !defined(WOLFSSL_ASN_INT_LEAD_0_ANY)
         /* kernel 5.10 crypto manager tests key(s) that fail unless leading

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3918,15 +3918,9 @@
     #error WOLFSSL_MIN_AUTH_TAG_SZ must be at least 1
 #endif
 
-#if defined(HAVE_FIPS) && FIPS_VERSION3_GE(7, 0, 0)
-    /* No short (<96 bit) tags per SP 800-38D 2026 revision in process. */
-    #if WOLFSSL_MIN_AUTH_TAG_SZ < 12
-        #error WOLFSSL_MIN_AUTH_TAG_SZ must be >= 12 per SP 800-38D Rev 1
-    #endif
-#endif
-
 #if defined(HAVE_FIPS)
-    #if FIPS_VERSION3_EQ(5, 2, 4)
+    #if FIPS_VERSION3_EQ(5, 2, 4) || (FIPS_VERSION3_LT(7, 0, 0) && \
+            defined(WOLFSSL_LINUXKM))
         /* support RFC 4106 IPsec ESP 64 bit tags */
        #undef WOLFSSL_MIN_AUTH_TAG_SZ
        #define WOLFSSL_MIN_AUTH_TAG_SZ 8
@@ -3937,8 +3931,10 @@
             #define WOLFSSL_MIN_AUTH_TAG_SZ 12
         #endif
     #endif
-#elif defined(CONFIG_CRYPTO_MANAGER_EXTRA_TESTS) || defined(CONFIG_CRYPTO_SELFTESTS_FULL)
-    /* The Linux kernel native crypto fuzzer expects small AES-GCM tag sizes to succeed. */
+#elif defined(WOLFSSL_LINUXKM) && (defined(CONFIG_CRYPTO_MANAGER_EXTRA_TESTS) \
+        || defined(CONFIG_CRYPTO_SELFTESTS_FULL))
+    /* The Linux kernel native crypto fuzzer expects small AES-GCM tag
+     * sizes to succeed. */
     #if WOLFSSL_MIN_AUTH_TAG_SZ > 4
         #undef WOLFSSL_MIN_AUTH_TAG_SZ
         #define WOLFSSL_MIN_AUTH_TAG_SZ 4
@@ -4432,6 +4428,7 @@
         #if defined(WC_DEBUG_CIPHER_LIFECYCLE) && FIPS_VERSION3_LT(6, 0, 0)
             #error Configured FIPS version does not support WC_DEBUG_CIPHER_LIFECYCLE.
         #endif
+    #endif
 
     #if defined(LINUXKM_LKCAPI_REGISTER) && !defined(WOLFSSL_ASN_INT_LEAD_0_ANY)
         /* kernel 5.10 crypto manager tests key(s) that fail unless leading


### PR DESCRIPTION
# Description

- commit 1 - Adding miscellaneous input validation throughout wolfcrypt files.
- commit 2 - Appendix A in [SP800-38b](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38b.pdf) recommends a minimum CMAC tag length of 64-bits
- commit 3 - Synchronizes user-space and kernel-space builds so that similar FIPS versions and build settings will default to the same `WOLFSSL_MIN_AUTH_TAG_SZ`

# Testing

./configure --enable-all && make check

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
