### PR TITLE
Lock globalRNGMutex around all shared globalRNG access

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15733,7 +15733,11 @@ const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
 }
 
 
-/* Writes 1024 bytes from the RNG to the given file name.
+#ifndef WOLFSSL_RAND_WRITE_FILE_BUF_SZ
+#define WOLFSSL_RAND_WRITE_FILE_BUF_SZ 1024
+#endif
+/* Writes WOLFSSL_RAND_WRITE_FILE_BUF_SZ bytes (1024 by default) from the RNG
+ * to the given file name.
  *
  * fname name of file to write to
  *
@@ -15752,16 +15756,16 @@ int wolfSSL_RAND_write_file(const char* fname)
 #ifndef NO_FILESYSTEM
     {
     #ifndef WOLFSSL_SMALL_STACK
-        unsigned char buf[1024];
+        unsigned char buf[WOLFSSL_RAND_WRITE_FILE_BUF_SZ];
     #else
-        unsigned char* buf = (unsigned char *)XMALLOC(1024, NULL,
-                                                       DYNAMIC_TYPE_TMP_BUFFER);
+        unsigned char* buf = (unsigned char *)XMALLOC(
+            WOLFSSL_RAND_WRITE_FILE_BUF_SZ, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (buf == NULL) {
             WOLFSSL_MSG("malloc failed");
             return WOLFSSL_FAILURE;
         }
     #endif
-        bytes = 1024; /* default size of buf */
+        bytes = WOLFSSL_RAND_WRITE_FILE_BUF_SZ;
 
         if (initGlobalRNG == 0 && wolfSSL_RAND_Init() != WOLFSSL_SUCCESS) {
             WOLFSSL_MSG("No RNG to use");
@@ -15769,12 +15773,21 @@ int wolfSSL_RAND_write_file(const char* fname)
             return 0;
         }
 
+        if (wc_LockMutex(&globalRNGMutex) != 0) {
+            WOLFSSL_MSG("Bad Lock Mutex rng");
+            WC_FREE_VAR_EX(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            return 0;
+        }
+
         if (wc_RNG_GenerateBlock(&globalRNG, buf, (word32)bytes) != 0) {
+            wc_UnLockMutex(&globalRNGMutex);
             WOLFSSL_MSG("Error generating random buffer");
             bytes = 0;
         }
         else {
             XFILE f;
+
+            wc_UnLockMutex(&globalRNGMutex);
 
         #ifdef WOLFSSL_CHECK_MEM_ZERO
             wc_MemZero_Add("wolfSSL_RAND_write_file buf", buf, bytes);
@@ -15791,7 +15804,9 @@ int wolfSSL_RAND_write_file(const char* fname)
                 XFCLOSE(f);
             }
         }
-        ForceZero(buf, (word32)bytes);
+        /* wipe the whole buffer, not just (word32)bytes: error paths set
+         * bytes = 0 but the buffer may still hold generated random data */
+        ForceZero(buf, WOLFSSL_RAND_WRITE_FILE_BUF_SZ);
     #ifdef WOLFSSL_SMALL_STACK
         XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     #elif defined(WOLFSSL_CHECK_MEM_ZERO)
@@ -15925,21 +15940,30 @@ int wolfSSL_RAND_egd(const char* nm)
             WOLFSSL_MSG("Error with initializing global RNG structure");
             ret = WOLFSSL_FATAL_ERROR;
         }
-        else if (wc_RNG_DRBG_Reseed(&globalRNG, (const byte*) buf, bytes)
-                != 0) {
-            WOLFSSL_MSG("Error with reseeding DRBG structure");
+        else if (wc_LockMutex(&globalRNGMutex) != 0) {
+            WOLFSSL_MSG("Bad Lock Mutex rng");
             ret = WOLFSSL_FATAL_ERROR;
         }
-        #ifdef SHOW_SECRETS
-        else { /* print out entropy found only when no error occurred */
-            word32 i;
-            printf("EGD Entropy = ");
-            for (i = 0; i < bytes; i++) {
-                printf("%02X", buf[i]);
+        else {
+            if (wc_RNG_DRBG_Reseed(&globalRNG, (const byte*) buf, bytes)
+                    != 0) {
+                WOLFSSL_MSG("Error with reseeding DRBG structure");
+                ret = WOLFSSL_FATAL_ERROR;
             }
-            printf("\n");
+            wc_UnLockMutex(&globalRNGMutex);
+
+            #ifdef SHOW_SECRETS
+            /* print out entropy found only when no error occurred */
+            if (ret == WOLFSSL_SUCCESS) {
+                word32 i;
+                printf("EGD Entropy = ");
+                for (i = 0; i < bytes; i++) {
+                    printf("%02X", buf[i]);
+                }
+                printf("\n");
+            }
+            #endif
         }
-        #endif
     }
 
     ForceZero(buf, bytes);
@@ -16167,18 +16191,21 @@ int wolfSSL_RAND_poll(void)
         WOLFSSL_MSG("Global RNG no Init");
         return  WOLFSSL_FAILURE;
     }
+
+    /* lock intentionally covers wc_GenerateSeed as well, since it writes
+     * globalRNG.seed; do not narrow this scope or the seed write races */
+    if (wc_LockMutex(&globalRNGMutex) != 0) {
+        WOLFSSL_MSG("Bad Lock Mutex rng");
+        return WOLFSSL_FAILURE;
+    }
+
     ret = wc_GenerateSeed(&globalRNG.seed, entropy, entropy_sz);
     if (ret != 0) {
-        WOLFSSL_MSG("Bad wc_RNG_GenerateBlock");
+        WOLFSSL_MSG("Bad wc_GenerateSeed");
         ret = WOLFSSL_FAILURE;
     }
     else {
 #ifdef HAVE_HASHDRBG
-        if (wc_LockMutex(&globalRNGMutex) != 0) {
-            WOLFSSL_MSG("Bad Lock Mutex rng");
-            return ret;
-        }
-
         ret = wc_RNG_DRBG_Reseed(&globalRNG, entropy, entropy_sz);
         if (ret != 0) {
             WOLFSSL_MSG("Error reseeding DRBG");
@@ -16187,7 +16214,6 @@ int wolfSSL_RAND_poll(void)
         else {
             ret = WOLFSSL_SUCCESS;
         }
-        wc_UnLockMutex(&globalRNGMutex);
 #elif defined(HAVE_INTEL_RDRAND)
         WOLFSSL_MSG("Not polling with RAND_poll, RDRAND used without "
                     "HAVE_HASHDRBG");
@@ -16197,6 +16223,8 @@ int wolfSSL_RAND_poll(void)
         ret = WOLFSSL_FAILURE;
 #endif
     }
+
+    wc_UnLockMutex(&globalRNGMutex);
 
     return ret;
 }

--- a/src/ssl_p7p12.c
+++ b/src/ssl_p7p12.c
@@ -1560,11 +1560,19 @@ int wolfSSL_SMIME_write_PKCS7(WOLFSSL_BIO* out, PKCS7* pkcs7, WOLFSSL_BIO* in,
                 ret = 0;
             }
 
+            if ((ret > 0) && (wc_LockMutex(&globalRNGMutex) != 0)) {
+                WOLFSSL_MSG("Bad Lock Mutex rng");
+                ret = 0;
+            }
+
             /* no need to generate random byte for null terminator (size-1) */
-            if ((ret > 0) && (wc_RNG_GenerateBlock(&globalRNG, (byte*)boundary,
-                                  sizeof(boundary) - 1 ) != 0)) {
+            if (ret > 0) {
+                if (wc_RNG_GenerateBlock(&globalRNG, (byte*)boundary,
+                                  sizeof(boundary) - 1 ) != 0) {
                     WOLFSSL_MSG("Error in wc_RNG_GenerateBlock");
                     ret = 0;
+                }
+                wc_UnLockMutex(&globalRNGMutex);
             }
 
             if (ret > 0) {


### PR DESCRIPTION
## Description

The OpenSSL-compat layer shares a single static `WC_RNG globalRNG` whose
Hash-DRBG state is not internally thread-safe. The canonical access pattern
(`wolfSSL_RAND_bytes`) holds `globalRNGMutex` for the entire duration of any
operation on `globalRNG`. Several sibling functions mutated the same
`globalRNG` **without** taking the lock, so concurrent callers — or one
running alongside a lock-holding `RAND_bytes`/`RAND_add` caller — could race
on the shared DRBG V/C/reseed-counter and seed state, corrupting the DRBG and
the randomness it yields to compat consumers (IVs, nonces, keys).

This PR extends the existing `globalRNGMutex` discipline to every remaining
unprotected access.
Addressed by f_6555 and f_6556.

## Changes

**`src/ssl.c`**
- `wolfSSL_RAND_write_file`: acquire `globalRNGMutex` around
  `wc_RNG_GenerateBlock(&globalRNG, ...)`, unlocking before the file I/O to
  keep the critical section minimal.
- `wolfSSL_RAND_egd`: lock around the `wc_RNG_DRBG_Reseed(&globalRNG, ...)`
  of the collected EGD entropy.
- `wolfSSL_RAND_poll`: hold the lock from before `wc_GenerateSeed(&globalRNG.seed, ...)`
  (previously an unlocked write to `globalRNG.seed`) through
  `wc_RNG_DRBG_Reseed`, unlocking on every path (including the
  `HAVE_INTEL_RDRAND` and no-HASHDRBG branches). Added a comment noting the
  lock intentionally covers `wc_GenerateSeed` so the scope is not narrowed
  back later.

**`src/ssl_p7p12.c`**
- `wolfSSL_SMIME_write_PKCS7`: lock around the `wc_RNG_GenerateBlock(&globalRNG, ...)`
  that generates the detached S/MIME MIME boundary, following the function's
  existing `ret > 0` fallthrough style.

## Notes

- `wolfSSL_RAND_poll` is called by `wolfSSL_RAND_bytes` only after that
  function releases `globalRNGMutex` (and it re-acquires it afterward), so
  having `RAND_poll` take the lock itself does not self-deadlock.
- `globalRNGMutex` is in scope for `ssl_p7p12.c` because it is `#include`d
  into `ssl.c` after the mutex's `static` definition, within the same
  `OPENSSL_EXTRA`/`HAVE_GLOBAL_RNG` context.

## Testing

- `./configure --enable-all` built under `-fsanitize=address,undefined
  -fno-omit-frame-pointer`; full `./tests/unit.test` passes (exit 0),
  including `test_wolfSSL_RAND_poll`, the `ossl_rand` group, and
  `test_wolfSSL_SMIME_write_PKCS7`.