### PR TITLE
Fix PKCS#7 padding for block-aligned input in wc_EncryptPKCS8Key_ex

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -79,7 +79,9 @@
     #include <wolfssl/wolfcrypt/signature.h>
 #endif
 
-#ifdef WOLFSSL_SMALL_CERT_VERIFY
+#if defined(WOLFSSL_SMALL_CERT_VERIFY) || \
+    (defined(HAVE_PKCS8) && !defined(NO_ASN))
+    /* for ASN tag and PBE/PKCS enum values used by the PKCS#8 encrypt tests */
     #include <wolfssl/wolfcrypt/asn.h>
 #endif
 
@@ -23157,6 +23159,109 @@ static int test_wc_CreateEncryptedPKCS8Key(void)
     return EXPECT_RESULT();
 }
 
+#if defined(HAVE_PKCS8) && !defined(NO_ASN) && !defined(NO_PWDBASED) && \
+    !defined(NO_SHA) && !defined(NO_ASN_CRYPT) && ((defined(WOLFSSL_AES_256) && \
+    !defined(NO_AES_CBC)) || !defined(NO_DES3) || !defined(NO_RC4))
+/* Encrypt a block-aligned plaintext PKCS#8 and verify the trailing encrypted
+ * OCTET STRING length. expExtra is the padding expected: a full block for CBC
+ * ciphers, 0 for stream ciphers. Also confirms a decrypt round-trip. */
+static int enc_pkcs8_pad_check(int vPKCS, int pbeOid, int encAlgId,
+    word32 expExtra)
+{
+    EXPECT_DECLS;
+    WC_RNG rng;
+    byte* encKey = NULL;
+    word32 encKeySz = 0;
+    int decKeySz = 0;
+    word32 expEncLen = 0;
+    const char password[] = "Lorem ipsum dolor sit amet";
+    word32 passwordSz = (word32)XSTRLEN(password);
+    /* Block-aligned plaintext: a valid 48-byte DER SEQUENCE (a multiple of both
+     * the 8- and 16-byte block sizes). Content is arbitrary; only the header
+     * must parse so decrypt can strip padding by re-reading the DER length. */
+    byte plain[48];
+
+    XMEMSET(plain, 0, sizeof(plain));
+    plain[0] = ASN_SEQUENCE | ASN_CONSTRUCTED;
+    plain[1] = (byte)(sizeof(plain) - 2); /* content length = 46 */
+
+    XMEMSET(&rng, 0, sizeof(WC_RNG));
+    ExpectIntEQ(wc_InitRng(&rng), 0);
+    PRIVATE_KEY_UNLOCK();
+    /* Query required output size. */
+    ExpectIntEQ(wc_EncryptPKCS8Key(plain, (word32)sizeof(plain), NULL, &encKeySz,
+        password, (int)passwordSz, vPKCS, pbeOid, encAlgId, NULL, 0,
+        WC_PKCS12_ITT_DEFAULT, &rng, NULL), WC_NO_ERR_TRACE(LENGTH_ONLY_E));
+    ExpectNotNull(encKey = (byte*)XMALLOC(encKeySz, HEAP_HINT,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    ExpectIntGT(wc_EncryptPKCS8Key(plain, (word32)sizeof(plain), encKey,
+        &encKeySz, password, (int)passwordSz, vPKCS, pbeOid, encAlgId, NULL, 0,
+        WC_PKCS12_ITT_DEFAULT, &rng, NULL), 0);
+
+    /* The encrypted content is the trailing OCTET STRING, extending to the end
+     * of the buffer: plaintext + expected pad, a full block for a block cipher
+     * and none for a stream cipher. Read below assumes a short-form length. */
+    expEncLen = (word32)sizeof(plain) + expExtra;
+    ExpectIntLT(expEncLen, 128);
+    ExpectIntGE(encKeySz, expEncLen + 2);
+    if (EXPECT_SUCCESS() && (encKey != NULL) && (encKeySz >= expEncLen + 2)) {
+        ExpectIntEQ(encKey[encKeySz - expEncLen - 2], ASN_OCTET_STRING);
+        ExpectIntEQ(encKey[encKeySz - expEncLen - 1], (byte)expEncLen);
+    }
+
+    /* Round-trip: decrypt recovers the original plaintext. */
+    ExpectIntGT(decKeySz = wc_DecryptPKCS8Key(encKey, encKeySz, password,
+        (int)passwordSz), 0);
+    ExpectIntEQ(decKeySz, (int)sizeof(plain));
+    ExpectIntEQ(XMEMCMP(encKey, plain, sizeof(plain)), 0);
+    PRIVATE_KEY_LOCK();
+
+    XFREE(encKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    wc_FreeRng(&rng);
+    return EXPECT_RESULT();
+}
+#endif
+
+/* PBES2 / AES-256-CBC (blockSz 16): a block-aligned plaintext must get a full
+ * pad block. The path the fix corrects; the helper's direct length check (not
+ * its round-trip, which false-passes here) is what detects a missing block. */
+static int test_wc_EncryptPKCS8Key_blockAligned(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_PKCS8) && !defined(NO_ASN) && !defined(NO_PWDBASED) \
+ && defined(WOLFSSL_AES_256) && !defined(NO_AES_CBC) && !defined(NO_SHA) \
+ && !defined(NO_ASN_CRYPT)
+    EXPECT_TEST(enc_pkcs8_pad_check(PKCS5, PBES2, AES256CBCb, AES_BLOCK_SIZE));
+#endif
+    return EXPECT_RESULT();
+}
+
+/* PBES1 / SHA1-DES (blockSz 8): exercises the PBES1 encoder branch and a
+ * different block size; a block-aligned plaintext gets a full 8-byte pad
+ * block. */
+static int test_wc_EncryptPKCS8Key_pbes1BlockAligned(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_PKCS8) && !defined(NO_ASN) && !defined(NO_PWDBASED) \
+ && !defined(NO_DES3) && !defined(NO_SHA) && !defined(NO_ASN_CRYPT)
+    EXPECT_TEST(enc_pkcs8_pad_check(PKCS5, PBES1_SHA1_DES, 0, DES_BLOCK_SIZE));
+#endif
+    return EXPECT_RESULT();
+}
+
+/* PKCS12 / RC4 (blockSz 1): a stream cipher adds no padding even for a
+ * block-aligned plaintext. Exercises the blockSz > 1 guard in
+ * wc_EncryptPKCS8Key_ex. */
+static int test_wc_EncryptPKCS8Key_rc4NoPad(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_PKCS8) && !defined(NO_ASN) && !defined(NO_PWDBASED) \
+ && !defined(NO_RC4) && !defined(NO_SHA) && !defined(NO_ASN_CRYPT)
+    EXPECT_TEST(enc_pkcs8_pad_check(1, PBE_SHA1_RC4_128, 0, 0));
+#endif
+    return EXPECT_RESULT();
+}
+
 static int test_wc_DecryptedPKCS8Key(void)
 {
     EXPECT_DECLS;
@@ -36898,6 +37003,9 @@ TEST_CASE testCases[] = {
     /* wolfCrypt ASN tests */
     TEST_DECL(test_ToTraditional),
     TEST_DECL(test_wc_CreateEncryptedPKCS8Key),
+    TEST_DECL(test_wc_EncryptPKCS8Key_blockAligned),
+    TEST_DECL(test_wc_EncryptPKCS8Key_pbes1BlockAligned),
+    TEST_DECL(test_wc_EncryptPKCS8Key_rc4NoPad),
     TEST_DECL(test_wc_DecryptedPKCS8Key),
     TEST_DECL(test_wc_GetPkcs8TraditionalOffset),
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10473,8 +10473,12 @@ int wc_EncryptPKCS8Key_ex(byte* key, word32 keySz, byte* out, word32* outSz,
         ret = GetAlgoV2(encAlgId, &encOid, &encOidSz, &pbeId, &blockSz);
     }
     if (ret == 0) {
-        padSz = (word32)((blockSz - ((int)keySz & (blockSz - 1))) &
-            (blockSz - 1));
+        /* CBC block ciphers use PKCS#7 padding: 1..blockSz bytes, a full
+         * block when the input is already block-aligned. Stream ciphers
+         * (blockSz == 1, e.g. RC4) take no padding. */
+        if (blockSz > 1) {
+            padSz = (word32)(blockSz - ((int)keySz & (blockSz - 1)));
+        }
         ret = SetShortInt(tmpShort, &tmpIdx, (word32)itt, MAX_SHORT_SZ);
         if (ret > 0) {
             /* inner = OCT salt INT itt */


### PR DESCRIPTION

## Description

`wc_EncryptPKCS8Key_ex` computed the PKCS#7 pad length with an extra
`(blockSz - 1)` mask:

```c
padSz = (word32)((blockSz - ((int)keySz & (blockSz - 1))) & (blockSz - 1));
```

When the plaintext length is an exact multiple of the cipher block size,
`keySz & (blockSz - 1) == 0`, so the inner term is `blockSz` and the trailing
mask collapses it to `0` — no padding is emitted. PKCS#7 (and CBC as OpenSSL
implements it) requires a pad length of `1..blockSz`, i.e. a **whole extra
block** when the input is already block-aligned.

The fix removes the mask and guards the computation on `blockSz > 1` so stream
ciphers (RC4, `blockSz == 1`) still receive no padding, matching the sibling
`wc_PkcsPad` helper and PKCS#7.

## Impact

Any private key whose plaintext PKCS#8 DER length is an exact multiple of the
cipher block size produced an `EncryptedPrivateKeyInfo` that non-wolfSSL parsers
reject (OpenSSL: `bad decrypt`). Examples with AES (16-byte block):

- **X25519 / Ed25519** — 48-byte PKCS#8 (a multiple of 16) → 0 padding → broken.
- **RSA / EC / DH** in common sizes are usually not block-aligned, so they padded
  correctly and worked, which is why this went unnoticed.

wolfCrypt's own `wc_DecryptPKCS8Key` strips padding by re-reading the inner DER
`SEQUENCE` length rather than validating PKCS#7, so wolfSSL↔wolfSSL round-trips
succeeded and the bug hid in self-tests — only wolfSSL↔OpenSSL interop exposed it.

## Changes

- `wolfcrypt/src/asn.c` — correct the `padSz` computation in
  `wc_EncryptPKCS8Key_ex`; gate padding on `blockSz > 1`.
- `tests/api.c` — add `enc_pkcs8_pad_check` helper and three cases covering
  block-aligned input at different block sizes plus the stream-cipher path:
  - PBES2 / AES-256-CBC (blockSz 16) — full 16-byte pad block
  - PBES1 / SHA1-DES (blockSz 8) — full 8-byte pad block, exercises the PBES1
    encoder branch
  - PKCS#12 / RC4 (blockSz 1) — no padding, exercises the `blockSz > 1` guard

  Each asserts the encrypted `OCTET STRING` length directly, since a decrypt
  round-trip alone false-passes on a missing pad block.

## Notes

- No public API or signature changes; decrypt side needs no change (correctly
  padded output already decrypts, and previously-written blobs still read).
- `blockSz` is always `1`, `8`, or `16` where `padSz` is computed
  (`CheckAlgo`/`GetAlgoV2` set it on every success path), so the mask arithmetic
  is well-defined.

## Testing

Built with `--enable-des3 --enable-arc4 --enable-aescbc` under ASan+UBSan
(macOS, no LeakSanitizer); all four PKCS#8 API tests pass, full API suite clean
(0 failures). Negative control confirmed: reverting the fix fails the
block-aligned length assertion at exactly the padding check.