### PR TITLE
ML-DSA: Fix misspelled `__arch64__` macro to `__aarch64__`

### DIFF
--- a/.wolfssl_known_macro_extras
+++ b/.wolfssl_known_macro_extras
@@ -1136,7 +1136,6 @@ __XTENSA__
 __ZEPHYR__
 __aarch64__
 __alpha__
-__arch64__
 __arm__
 __clang__
 __clang_major__

--- a/wolfssl/wolfcrypt/wc_mldsa.h
+++ b/wolfssl/wolfcrypt/wc_mldsa.h
@@ -105,7 +105,7 @@
 /* Macros Definitions */
 
 #ifndef WOLFSSL_MLDSA_ALIGNMENT
-    #if defined(__arch64__)
+    #if defined(__aarch64__)
         #define WOLFSSL_MLDSA_ALIGNMENT     8
     #elif defined(__arm__)
         #define WOLFSSL_MLDSA_ALIGNMENT     4


### PR DESCRIPTION
# Description

This PR replaces `__arch64__` with `__aarch64__` on ML-DSA.
`__arch64__` must be a typo because no compiler defines the macro.

This change doesn't affect the current behavior because both defining `__aarch64__` and not will fall into the same `WOLFSSL_MLDSA_ALIGNMENT`=8. 

Also `__arch64__` is removed from `.wolfssl_known_macro_extras`.

# Testing

- On AArch64 Mac
    - `./configure --enable-mldsa`
    - `make test`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation