### PR TITLE
Fix ret check in test.c

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -67879,7 +67879,7 @@ static wc_test_ret_t pkcs7_signed_no_content_test(byte* cert, word32 certSz,
     if (pkcs7 == NULL)
         ERROR_OUT(WC_TEST_RET_ENC_ERRNO, out_lbl);
     ret = wc_PKCS7_VerifySignedData(pkcs7, out, (word32)encSz);
-    if (ret != SIG_VERIFY_E)
+    if (ret != WC_NO_ERR_TRACE(SIG_VERIFY_E))
         ERROR_OUT(WC_TEST_RET_ENC_NC, out_lbl);
 
     ret = 0;


### PR DESCRIPTION
Add missing `WC_NO_ERR_TRACE()`.
