### PR TITLE
IDE resource handling and error-path improvements

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/server-tls.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/server-tls.c
@@ -406,6 +406,7 @@ WOLFSSL_ESP_TASK tls_smp_server_task(void *args)
         ESP_LOGI(TAG, "Done! Cleanup...");
         /* Cleanup after this connection */
         wolfSSL_free(ssl);      /* Free the wolfSSL object              */
+        ssl = NULL;
         close(connd);           /* Close the connection to the client   */
 #ifdef WOLFSSL_EXAMPLE_VERBOSITY
         ESP_LOGI(TAG, "Stack used: %d\n",

--- a/IDE/GCC-ARM/Source/tls_client.c
+++ b/IDE/GCC-ARM/Source/tls_client.c
@@ -84,7 +84,8 @@ static int tls_client(void)
 
     if ((ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method())) == NULL) {
         printf("CTXnew failed.\n");
-        goto fail;
+        ret = -1;
+        goto cleanup;
     }
 
     /*------------------------------------------------------------------------*/
@@ -105,9 +106,9 @@ static int tls_client(void)
     /* end peer auth option*/
     /*---------------------*/
     if ((ret = wolfSSL_CTX_set_cipher_list(ctx, "ECDHE-ECDSA-AES128-SHA256")) != WOLFSSL_SUCCESS) {
-        wolfSSL_CTX_free(ctx);
         printf("CTXset_cipher_list failed, error: %d\n", ret);
-        goto fail;
+        ret = -1;
+        goto cleanup;
     }
     /*------------------------------------------------------------------------*/
     /* END CIPHER SUITE OPTIONS */
@@ -118,8 +119,8 @@ static int tls_client(void)
     if ((ssl = wolfSSL_new(ctx)) == NULL) {
         error = wolfSSL_get_error(ssl, 0);
         printf("wolfSSL_new failed %d\n", error);
-        wolfSSL_CTX_free(ctx);
-        return -1;
+        ret = -1;
+        goto cleanup;
     }
 
     /* non blocking accept and connect */
@@ -133,7 +134,8 @@ static int tls_client(void)
             if (error != WOLFSSL_ERROR_WANT_READ && error != WOLFSSL_ERROR_WANT_WRITE) {
                 /* Fail */
                 printf("wolfSSL connect failed with return code %d\n", error);
-                goto fail;
+                ret = -1;
+                goto cleanup;
             }
         }
         /* Success */
@@ -148,7 +150,8 @@ static int tls_client(void)
         if (ret != msgSz) {
             if (error != WOLFSSL_ERROR_WANT_READ && error != WOLFSSL_ERROR_WANT_WRITE) {
                 /* Write failed */
-                goto fail;
+                ret = -1;
+                goto cleanup;
             }
         }
         /* Write succeeded */
@@ -163,7 +166,8 @@ static int tls_client(void)
                 /* Can put print here, the server enters a loop waiting to read
                  * a confirmation message at this point */
                 // printf("client read failed\n");
-                goto fail;
+                ret = -1;
+                goto cleanup;
             }
             continue;
         }
@@ -177,14 +181,14 @@ static int tls_client(void)
 
     }
 
-    return 0;
+    ret = 0;
 
-fail:
+cleanup:
     wolfSSL_shutdown(ssl);
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
 
-    return -1;
+    return ret;
 }
 #endif /* !WOLFCRYPT_ONLY && !NO_WOLFSSL_CLIENT */
 

--- a/IDE/GCC-ARM/Source/tls_server.c
+++ b/IDE/GCC-ARM/Source/tls_server.c
@@ -83,7 +83,8 @@ static int tls_server(void)
 
     if ((ctx = wolfSSL_CTX_new(wolfTLSv1_2_server_method())) == NULL) {
         printf("CTXnew failed.\n");
-        goto fail;
+        ret = -1;
+        goto cleanup;
     }
 
     /*------------------------------------------------------------------------*/
@@ -104,9 +105,9 @@ static int tls_server(void)
     /* end peer auth option*/
     /*---------------------*/
     if ((ret = wolfSSL_CTX_set_cipher_list(ctx, "ECDHE-ECDSA-AES128-SHA256")) != WOLFSSL_SUCCESS) {
-        wolfSSL_CTX_free(ctx);
         printf("CTXset_cipher_list failed, error: %d\n", ret);
-        goto fail;
+        ret = -1;
+        goto cleanup;
     }
     /*------------------------------------------------------------------------*/
     /* END CIPHER SUITE OPTIONS */
@@ -117,8 +118,8 @@ static int tls_server(void)
     if ((ssl = wolfSSL_new(ctx)) == NULL) {
         error = wolfSSL_get_error(ssl, 0);
         printf("wolfSSL_new failed %d\n", error);
-        wolfSSL_CTX_free(ctx);
-        return -1;
+        ret = -1;
+        goto cleanup;
     }
 
     /* non blocking accept and connect */
@@ -132,7 +133,8 @@ static int tls_server(void)
             if (error != WOLFSSL_ERROR_WANT_READ && error != WOLFSSL_ERROR_WANT_WRITE) {
                 /* Fail */
                 printf("wolfSSL accept failed with return code %d\n", error);
-                goto fail;
+                ret = -1;
+                goto cleanup;
             }
         }
         /* Success */
@@ -148,7 +150,8 @@ static int tls_server(void)
                 /* Can put print here, the server enters a loop waiting to read
                  * a confirmation message at this point */
                 // printf("server read failed\n");
-                goto fail;
+                ret = -1;
+                goto cleanup;
             }
             continue;
         }
@@ -169,21 +172,22 @@ static int tls_server(void)
         if (ret != XSTRLEN(reply)) {
             if (error != WOLFSSL_ERROR_WANT_READ && error != WOLFSSL_ERROR_WANT_WRITE) {
                 /* Write failed */
-                goto fail;
+                ret = -1;
+                goto cleanup;
             }
         }
         /* Write succeeded */
         break;
     }
 
-    return 0;
+    ret = 0;
 
-fail:
+cleanup:
     wolfSSL_shutdown(ssl);
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
 
-    return -1;
+    return ret;
 }
 #endif /* !WOLFCRYPT_ONLY && !NO_WOLFSSL_SERVER */
 

--- a/IDE/MQX/client-tls.c
+++ b/IDE/MQX/client-tls.c
@@ -41,8 +41,8 @@ int main(int argc, char** argv)
     int                ret;
 
     /* declare wolfSSL objects */
-    WOLFSSL_CTX* ctx;
-    WOLFSSL*     ssl;
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL*     ssl = NULL;
 
 
 
@@ -72,14 +72,14 @@ int main(int argc, char** argv)
     if (inet_pton(AF_INET, argv[1], &servAddr.sin_addr, sizeof(servAddr.sin_addr)) != 1) {
         fprintf(stderr, "ERROR: invalid address\n");
         ret = -1;
-        goto end;
+        goto socket_cleanup;
     }
 
     /* Connect to the server */
     if ((ret = connect(sockfd, (struct sockaddr*) &servAddr, sizeof(servAddr)))
          == -1) {
         fprintf(stderr, "ERROR: failed to connect\n");
-        goto end;
+        goto socket_cleanup;
     }
 
     /*---------------------------------*/
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
     if ((ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method())) == NULL) {
         fprintf(stderr, "ERROR: failed to create WOLFSSL_CTX\n");
         ret = -1;
-        goto socket_cleanup;
+        goto ctx_cleanup;
     }
 
     /* Load client certificates into WOLFSSL_CTX */

--- a/IDE/MQX/server-tls.c
+++ b/IDE/MQX/server-tls.c
@@ -35,20 +35,20 @@
 
 int main()
 {
-    int                sockfd;
-    int                connd;
+    int                sockfd = -1;
+    int                connd  = -1;
     struct sockaddr_in servAddr;
     struct sockaddr_in clientAddr;
     socklen_t          size = sizeof(clientAddr);
     char               buff[256];
     size_t             len;
     int                shutdown = 0;
-    int                ret;
+    int                ret = 0;
     const char*        reply = "I hear ya fa shizzle!\n";
 
     /* declare wolfSSL objects */
-    WOLFSSL_CTX* ctx;
-    WOLFSSL*     ssl;
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL*     ssl = NULL;
 
 
 
@@ -62,7 +62,8 @@ int main()
      * 0 means choose the default protocol. */
     if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
         fprintf(stderr, "ERROR: failed to create the socket\n");
-        return -1;
+        ret = -1;
+        goto exit;
     }
 
 
@@ -70,7 +71,8 @@ int main()
     /* Create and initialize WOLFSSL_CTX */
     if ((ctx = wolfSSL_CTX_new(wolfTLSv1_2_server_method())) == NULL) {
         fprintf(stderr, "ERROR: failed to create WOLFSSL_CTX\n");
-        return -1;
+        ret = -1;
+        goto exit;
     }
 
     /* Load server certificates into WOLFSSL_CTX */
@@ -78,7 +80,8 @@ int main()
         != SSL_SUCCESS) {
         fprintf(stderr, "ERROR: failed to load %s, please check the file.\n",
                 CERT_FILE);
-        return -1;
+        ret = -1;
+        goto exit;
     }
 
     /* Load server key into WOLFSSL_CTX */
@@ -86,7 +89,8 @@ int main()
         != SSL_SUCCESS) {
         fprintf(stderr, "ERROR: failed to load %s, please check the file.\n",
                 KEY_FILE);
-        return -1;
+        ret = -1;
+        goto exit;
     }
 
 
@@ -104,13 +108,15 @@ int main()
     /* Bind the server socket to our port */
     if (bind(sockfd, (struct sockaddr*)&servAddr, sizeof(servAddr)) == -1) {
         fprintf(stderr, "ERROR: failed to bind\n");
-        return -1;
+        ret = -1;
+        goto exit;
     }
 
     /* Listen for a new connection, allow 5 pending connections */
     if (listen(sockfd, 5) == -1) {
         fprintf(stderr, "ERROR: failed to listen\n");
-        return -1;
+        ret = -1;
+        goto exit;
     }
 
 
@@ -123,13 +129,15 @@ int main()
         if ((connd = accept(sockfd, (struct sockaddr*)&clientAddr, &size))
             == -1) {
             fprintf(stderr, "ERROR: failed to accept the connection\n\n");
-            return -1;
+            ret = -1;
+            goto exit;
         }
 
         /* Create a WOLFSSL object */
         if ((ssl = wolfSSL_new(ctx)) == NULL) {
             fprintf(stderr, "ERROR: failed to create WOLFSSL object\n");
-            return -1;
+            ret = -1;
+            goto exit;
         }
 
         /* Attach wolfSSL to the socket */
@@ -140,7 +148,8 @@ int main()
         if (ret != SSL_SUCCESS) {
             fprintf(stderr, "wolfSSL_accept error = %d\n",
                 wolfSSL_get_error(ssl, ret));
-            return -1;
+            ret = -1;
+            goto exit;
         }
 
 
@@ -152,7 +161,8 @@ int main()
         memset(buff, 0, sizeof(buff));
         if (wolfSSL_read(ssl, buff, sizeof(buff)-1) == -1) {
             fprintf(stderr, "ERROR: failed to read\n");
-            return -1;
+            ret = -1;
+            goto exit;
         }
 
         /* Print to stdout any data the client sends */
@@ -174,23 +184,31 @@ int main()
         /* Reply back to the client */
         if (wolfSSL_write(ssl, buff, len) != len) {
             fprintf(stderr, "ERROR: failed to write\n");
-            return -1;
+            ret = -1;
+            goto exit;
         }
 
 
 
         /* Cleanup after this connection */
         wolfSSL_free(ssl);      /* Free the wolfSSL object              */
+        ssl = NULL;
         close(connd);           /* Close the connection to the client   */
+        connd = -1;
     }
 
     printf("Shutdown complete\n");
+    ret = 0;
 
-
-
-    /* Cleanup and return */
-    wolfSSL_CTX_free(ctx);  /* Free the wolfSSL context object          */
-    wolfSSL_Cleanup();      /* Cleanup the wolfSSL environment          */
-    close(sockfd);          /* Close the socket listening for clients   */
-    return 0;               /* Return reporting a success               */
+exit:
+    if (ssl != NULL)
+        wolfSSL_free(ssl);      /* Free the wolfSSL object                */
+    if (connd != -1)
+        close(connd);           /* Close the connection to the client     */
+    if (ctx != NULL)
+        wolfSSL_CTX_free(ctx);  /* Free the wolfSSL context object        */
+    wolfSSL_Cleanup();          /* Cleanup the wolfSSL environment        */
+    if (sockfd != -1)
+        close(sockfd);          /* Close the socket listening for clients */
+    return ret;                 /* Return reporting success or failure    */
 }

--- a/IDE/MSVS-2019-AZSPHERE/server/server.c
+++ b/IDE/MSVS-2019-AZSPHERE/server/server.c
@@ -56,8 +56,8 @@ int azsphere_server_app(void)
 #endif
 {
     bool isNetworkingReady = false;
-    int                sockfd;
-    int                connd;
+    int                sockfd = -1;
+    int                connd = -1;
     struct sockaddr_in servAddr;
     struct sockaddr_in clientAddr;
     socklen_t          size = sizeof(clientAddr);
@@ -153,6 +153,7 @@ int azsphere_server_app(void)
         /* Create a WOLFSSL object */
         if ((ssl = wolfSSL_new(ctx)) == NULL) {
             fprintf(stderr, "ERROR: failed to create WOLFSSL object\n");
+            close(connd);
             util_Cleanup(sockfd, ctx, ssl);
             return -1;
         }
@@ -165,6 +166,7 @@ int azsphere_server_app(void)
         if (ret != SSL_SUCCESS) {
             fprintf(stderr, "wolfSSL_accept error = %d\n",
                 wolfSSL_get_error(ssl, ret));
+            close(connd);
             util_Cleanup(sockfd, ctx, ssl);
             return -1;
         }
@@ -175,6 +177,7 @@ int azsphere_server_app(void)
         memset(buff, 0, sizeof(buff));
         if (wolfSSL_read(ssl, buff, sizeof(buff)-1) == -1) {
             fprintf(stderr, "ERROR: failed to read\n");
+            close(connd);
             util_Cleanup(sockfd, ctx, ssl);
             return -1;
         }
@@ -196,13 +199,16 @@ int azsphere_server_app(void)
         /* Reply back to the client */
         if (wolfSSL_write(ssl, buff, (int)len) != len) {
             fprintf(stderr, "ERROR: failed to write\n");
+            close(connd);
             util_Cleanup(sockfd, ctx, ssl);
             return -1;
         }
 
         /* Cleanup after this connection */
         wolfSSL_free(ssl);      /* Free the wolfSSL object              */
+        ssl = NULL;
         close(connd);           /* Close the connection to the client   */
+        connd = -1;
     }
 
     printf("Shutdown complete\n");

--- a/IDE/QNX/example-client/client-tls.c
+++ b/IDE/QNX/example-client/client-tls.c
@@ -88,8 +88,8 @@ int main(int argc, char** argv)
     FILE* f;
 
     /* declare wolfSSL objects */
-    WOLFSSL_CTX* ctx;
-    WOLFSSL*     ssl;
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL*     ssl = NULL;
 
     /* Check for proper calling convention */
     if (argc != 6) {
@@ -119,14 +119,14 @@ int main(int argc, char** argv)
     if (inet_pton(AF_INET, argv[2], &servAddr.sin_addr) != 1) {
         fprintf(stderr, "ERROR: invalid address\n");
         ret = -1;
-        goto end;
+        goto socket_cleanup;
     }
 
     /* Connect to the server */
     if ((ret = connect(sockfd, (struct sockaddr*) &servAddr, sizeof(servAddr)))
          == -1) {
         fprintf(stderr, "ERROR: failed to connect\n");
-        goto end;
+        goto socket_cleanup;
     }
 
     /*---------------------------------*/
@@ -142,7 +142,7 @@ int main(int argc, char** argv)
     if ((ctx = wolfSSL_CTX_new(wolfSSLv23_client_method())) == NULL) {
         fprintf(stderr, "ERROR: failed to create WOLFSSL_CTX\n");
         ret = -1;
-        goto socket_cleanup;
+        goto ctx_cleanup;
     }
 
     /* load cert and convert DER to PEM using dynamic length */
@@ -150,7 +150,7 @@ int main(int argc, char** argv)
     if (pemSz <= 0) {
         fprintf(stderr, "ERROR: converting DER cert to PEM\n");
         ret = -1;
-        goto socket_cleanup;
+        goto ctx_cleanup;
     }
 
     if (wolfSSL_CTX_use_certificate_buffer(ctx, pem, pemSz,
@@ -158,7 +158,7 @@ int main(int argc, char** argv)
         fprintf(stderr, "issue loading in pem cert\n");
         ret = -1;
         free(pem);
-        goto socket_cleanup;
+        goto ctx_cleanup;
     }
     free(pem);
 
@@ -167,7 +167,7 @@ int main(int argc, char** argv)
     if (pemSz <= 0) {
         fprintf(stderr, "ERROR: converting DER key to PEM\n");
         ret = -1;
-        goto socket_cleanup;
+        goto ctx_cleanup;
     }
 
     if (wolfSSL_CTX_use_PrivateKey_buffer(ctx, pem, pemSz,
@@ -175,7 +175,7 @@ int main(int argc, char** argv)
         fprintf(stderr, "issue loading in pem key\n");
         ret = -1;
         free(pem);
-        goto socket_cleanup;
+        goto ctx_cleanup;
     }
     free(pem);
 
@@ -184,7 +184,7 @@ int main(int argc, char** argv)
     if (f == NULL) {
         fprintf(stderr, "unable to open %s\n", argv[3]);
         ret = -1;
-        goto socket_cleanup;
+        goto ctx_cleanup;
     }
     fseek(f, 0, SEEK_END);
     pemSz = ftell(f);
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
     if (pem == NULL) {
         fclose(f);
         ret = -1;
-        goto socket_cleanup;
+        goto ctx_cleanup;
     }
     pemSz = fread(pem, 1, pemSz, f);
     fclose(f);

--- a/IDE/QNX/example-server/server-tls.c
+++ b/IDE/QNX/example-server/server-tls.c
@@ -246,7 +246,7 @@ static int TLS_ECDH_callback(WOLFSSL* ssl, struct ecc_key* otherKey,
 int main()
 {
     int                sockfd;
-    int                connd = 0;
+    int                connd = -1;
     struct sockaddr_in servAddr;
     struct sockaddr_in clientAddr;
     socklen_t          size = sizeof(clientAddr);
@@ -379,7 +379,8 @@ int main()
 end:
     /* Cleanup after this connection */
     wolfSSL_free(ssl);      /* Free the wolfSSL object              */
-    close(connd);           /* Close the connection to the client   */
+    if (connd != -1)
+        close(connd);       /* Close the connection to the client   */
     wc_ecc_free(&blackKey);
 
     printf("Shutdown complete\n");

--- a/IDE/VS-AZURE-SPHERE/server/server.c
+++ b/IDE/VS-AZURE-SPHERE/server/server.c
@@ -51,8 +51,8 @@
 int main(void)
 {
     bool isNetworkingReady = false;
-    int                sockfd;
-    int                connd;
+    int                sockfd = -1;
+    int                connd = -1;
     struct sockaddr_in servAddr;
     struct sockaddr_in clientAddr;
     socklen_t          size = sizeof(clientAddr);
@@ -148,6 +148,7 @@ int main(void)
         /* Create a WOLFSSL object */
         if ((ssl = wolfSSL_new(ctx)) == NULL) {
             fprintf(stderr, "ERROR: failed to create WOLFSSL object\n");
+            close(connd);
             util_Cleanup(sockfd, ctx, ssl);
             return -1;
         }
@@ -160,6 +161,7 @@ int main(void)
         if (ret != SSL_SUCCESS) {
             fprintf(stderr, "wolfSSL_accept error = %d\n",
                 wolfSSL_get_error(ssl, ret));
+            close(connd);
             util_Cleanup(sockfd, ctx, ssl);
             return -1;
         }
@@ -170,6 +172,7 @@ int main(void)
         memset(buff, 0, sizeof(buff));
         if (wolfSSL_read(ssl, buff, sizeof(buff)-1) == -1) {
             fprintf(stderr, "ERROR: failed to read\n");
+            close(connd);
             util_Cleanup(sockfd, ctx, ssl);
             return -1;
         }
@@ -191,13 +194,16 @@ int main(void)
         /* Reply back to the client */
         if (wolfSSL_write(ssl, buff, (int)len) != len) {
             fprintf(stderr, "ERROR: failed to write\n");
+            close(connd);
             util_Cleanup(sockfd, ctx, ssl);
             return -1;
         }
 
         /* Cleanup after this connection */
         wolfSSL_free(ssl);      /* Free the wolfSSL object              */
+        ssl = NULL;
         close(connd);           /* Close the connection to the client   */
+        connd = -1;
     }
 
     printf("Shutdown complete\n");

--- a/IDE/iotsafe-raspberrypi/client-tls13.c
+++ b/IDE/iotsafe-raspberrypi/client-tls13.c
@@ -161,6 +161,7 @@ int client_loop(const char *peer_ip, const char *peer_name,
     /* Declare certificate temporary buffer */
     uint8_t      cert_buffer[2048] = {0};
     uint32_t     cert_buffer_size  = 0;
+    int          cert_sz           = 0;
     uint8_t     *cert_iter         = NULL;
 
     /* Declare wolfSSL objects */
@@ -306,16 +307,17 @@ int client_loop(const char *peer_ip, const char *peer_name,
 
     /* Extract client certificate from IoTSAFE*/
     printf("----     Extracting client certificate from IoTSAFE\n");
-    if ((cert_buffer_size = wolfIoTSafe_GetCert(
+    cert_sz = wolfIoTSafe_GetCert(
                                 CRT_CLIENT_FILE_ID,
                                 cert_buffer,
-                                sizeof(cert_buffer)))
-         < 1)
+                                sizeof(cert_buffer));
+    if (cert_sz < 1)
     {
         fprintf(stderr, "ERROR: Bad client certificate\n");
         ret = -1;
         goto exit;
     }
+    cert_buffer_size = (uint32_t)cert_sz;
 
     /* Print extracted client certificate */
     printf("----     Printing extracted client certificate\n");
@@ -332,21 +334,22 @@ int client_loop(const char *peer_ip, const char *peer_name,
          != WOLFSSL_SUCCESS)
     {
         fprintf(stderr, "ERROR: Failed to load client certificate\n");
-        return -1;
+        goto exit;
     }
 
     /* Extract server certificate from IoTSAFE*/
     printf("----     Extracting server certificate from IoTSAFE\n");
-    if ((cert_buffer_size = wolfIoTSafe_GetCert(
+    cert_sz = wolfIoTSafe_GetCert(
                                 CRT_SERVER_FILE_ID,
                                 cert_buffer,
-                                sizeof(cert_buffer)))
-         < 1)
+                                sizeof(cert_buffer));
+    if (cert_sz < 1)
     {
         fprintf(stderr, "ERROR: Bad server certificate\n");
         ret = -1;
         goto exit;
     }
+    cert_buffer_size = (uint32_t)cert_sz;
 
     /* Print extracted server certificate */
     printf("----     Printing extracted server certificate\n");
@@ -363,7 +366,7 @@ int client_loop(const char *peer_ip, const char *peer_name,
          != WOLFSSL_SUCCESS)
     {
         fprintf(stderr, "ERROR: Failed to load server certificate\n");
-        return -1;
+        goto exit;
     }
 
     /* Set client to authenticate server */


### PR DESCRIPTION
# Description

Fixes resource-cleanup bugs on error/shutdown paths across the IDE TLS examples. 

- MQX server/client, QNX client/server, iotsafe client: fix error paths that bypassed cleanup or jumped to the wrong cleanup level, leaking socket/ctx/ssl. Reworked to single-exit / corrected cleanup.
- Azure Sphere servers: fix ssl double-free on shutdown + accepted-socket (`connd`) leak on TLS error paths.
- ESP-IDF server: ssl double-free on shutdown.
- GCC-ARM client/server: fix ssl/ctx leak on the success path and a ctx double-free on the cipher-list error path; unified to a single cleanup `exit:`.
- iotsafe client: `wolfIoTSafe_GetCert()` negative `int` return was cast to `uint32_t`, change to be validated as signed before casting.

Fixes #10846 and Fixes #10847 
Fixes https://github.com/wolfSSL/wolfssl/issues/10800