### PR TITLE
wolfcrypt: fix several redefinition of typedef errors.

### DIFF
--- a/wolfcrypt/src/wc_slhdsa.c
+++ b/wolfcrypt/src/wc_slhdsa.c
@@ -299,7 +299,10 @@ wc_static_assert(SLHDSA_MAX_MSG_SZ <= 255);
  */
 
 /* HashAddress type. */
+#ifndef WC_HASHADDRESS_TYPE_DEFINED
 typedef word32 HashAddress[8];
+    #define WC_HASHADDRESS_TYPE_DEFINED
+#endif
 
 /* Encode a HashAddress.
  *

--- a/wolfssl/wolfcrypt/wc_mlkem.h
+++ b/wolfssl/wolfcrypt/wc_mlkem.h
@@ -362,7 +362,7 @@ enum {
 #define MLKEM_PRF_T     wc_Shake
 
 /* ML-KEM key. */
-typedef struct MlKemKey {
+struct MlKemKey {
     /* Type of key: WC_ML_KEM_512, WC_ML_KEM_768, WC_ML_KEM_1024 */
     int type;
 #ifdef WOLFSSL_MLKEM_DYNAMIC_KEYS
@@ -418,8 +418,12 @@ typedef struct MlKemKey {
     sword16* a;
 #endif
 #endif
-} MlKemKey;
+};
 
+#ifndef WC_MLKEMKEY_TYPE_DEFINED
+    typedef struct MlKemKey MlKemKey;
+    #define WC_MLKEMKEY_TYPE_DEFINED
+#endif
 
 WOLFSSL_API MlKemKey* wc_MlKemKey_New(int type, void* heap, int devId);
 WOLFSSL_API int wc_MlKemKey_Delete(MlKemKey* key, MlKemKey** key_p);

--- a/wolfssl/wolfcrypt/wc_slhdsa.h
+++ b/wolfssl/wolfcrypt/wc_slhdsa.h
@@ -601,7 +601,7 @@ typedef struct SlhDsaParameters {
 #endif
 
 /* SLH-DSA key data and state. */
-typedef struct SlhDsaKey {
+struct SlhDsaKey {
     /* Parameters. */
     const SlhDsaParameters* params;
     /* Flags of the key. */
@@ -654,7 +654,12 @@ typedef struct SlhDsaKey {
         } sha2;
 #endif
     } hash;
-} SlhDsaKey;
+};
+
+#ifndef WC_SLHDSAKEY_TYPE_DEFINED
+    typedef struct SlhDsaKey SlhDsaKey;
+    #define WC_SLHDSAKEY_TYPE_DEFINED
+#endif
 
 WOLFSSL_API int  wc_SlhDsaKey_Init(SlhDsaKey* key, enum SlhDsaParam param,
     void* heap, int devId);

--- a/wolfssl/wolfcrypt/wc_xmss.h
+++ b/wolfssl/wolfcrypt/wc_xmss.h
@@ -307,7 +307,10 @@ typedef enum wc_XmssRc (*wc_xmss_read_private_key_cb)(byte* priv, word32 privSz,
 
 
 /* Type for hash address. */
+#ifndef WC_HASHADDRESS_TYPE_DEFINED
 typedef word32 HashAddress[8];
+    #define WC_HASHADDRESS_TYPE_DEFINED
+#endif
 
 /* XMSS/XMSS^MT fixed parameters. */
 typedef struct XmssParams {


### PR DESCRIPTION
## Description

Fix several `error: redefinition of typedef` build errors when building fips=v7 on bsdkm.

Related PR:
- https://github.com/wolfSSL/fips/pull/398

## Testing

```
#!/bin/sh
fips_hash=9F1C309BEFD23152ED9061B0A8FE315F09164D919BEFC3127DC18A6B1D30D024
BSDKM_CFLAGS="-DWOLFCRYPT_FIPS_CORE_HASH_VALUE=$fips_hash -DWOLFSSL_BSDKM_VERBOSE_DEBUG"
./configure --enable-freebsdkm --enable-cryptonly --enable-crypttests \         
  --enable-kernel-benchmarks --enable-all-crypto --enable-aesni \
  --enable-aesni-with-avx --enable-fips=v7 \
  CFLAGS="$BSDKM_CFLAGS" && make \
  || exit 1
file bsdkm/libwolfssl.ko && sudo kldload bsdkm/libwolfssl.ko || exit 1
```

```
#!/bin/sh                                                                       
BSDKM_CFLAGS="-DWOLFSSL_BSDKM_VERBOSE_DEBUG -DWOLFSSL_BSDKM_FPU_DEBUG -DWOLFSSL_BSDKM_MEMORY_DEBUG"
                                                                                
./configure --enable-freebsdkm --enable-freebsdkm-crypto-register \
  --enable-cryptonly --enable-crypttests \ 
  --enable-kernel-benchmarks --enable-all-crypto --enable-aesni \
  --enable-aesni-with-avx \
  CFLAGS="$BSDKM_CFLAGS" && make \
  || exit 1
file bsdkm/libwolfssl.ko && sudo kldload bsdkm/libwolfssl.ko || exit 1
```