### PR TITLE
Fix possible memcpy length overflow in wolfSSL_d2i_ASN1_INTEGER

### DIFF
--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -1368,6 +1368,11 @@ WOLFSSL_ASN1_INTEGER* wolfSSL_d2i_ASN1_INTEGER(WOLFSSL_ASN1_INTEGER** a,
         WOLFSSL_MSG("ASN.1 length not valid.");
         err = 1;
     }
+    /* Check that len + idx won't overflow a signed int */
+    if ((!err) && (len > INT_MAX - (int)idx)) {
+        WOLFSSL_MSG("ASN.1 length too large.");
+        err = 1;
+    }
     /* Allocate a new ASN.1 INTEGER object. */
     if ((!err) && ((ret = wolfSSL_ASN1_INTEGER_new()) == NULL)) {
         err = 1;

--- a/tests/api/test_ossl_asn1.c
+++ b/tests/api/test_ossl_asn1.c
@@ -434,6 +434,8 @@ int test_wolfSSL_d2i_ASN1_INTEGER(void)
         0xd2, 0x96, 0xdf, 0xd9, 0xd0, 0x4f, 0xad, 0xd7
     };
     static const byte garbageDer[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    /* Long-form length with INT_MAX content bytes for overflow testing */
+    static const byte overflowLenDer[] = {0x02, 0x84, 0x7F, 0xFF, 0xFF, 0xFF};
 
     static const ASN1IntTestVector testVectors[] = {
         {zeroDer, sizeof(zeroDer), 0},
@@ -464,6 +466,12 @@ int test_wolfSSL_d2i_ASN1_INTEGER(void)
     p = garbageDer;
     ExpectNull((a = wolfSSL_d2i_ASN1_INTEGER(&b, &p, sizeof(garbageDer))));
     ExpectNull(b);
+    /* Only run on 64-bit systems where the `long` inSz param fits */
+    if (LONG_MAX >= 0x80000005L) {
+        p = overflowLenDer;
+        ExpectNull((a = wolfSSL_d2i_ASN1_INTEGER(&b, &p, 0x80000005L)));
+        ExpectNull(b);
+    }
 
     /* Check i2d error conditions */
     /* NULL input. */


### PR DESCRIPTION
# Description

Fixes possibility of a buffer overrun due to signed integer overflow.

Credit to SecBuddyF, Tencent KeenLab for reporting.

Fixes zd 22108.

# Testing

Added unit test

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
