### PR TITLE
check RSA key size for PSS

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -31062,6 +31062,8 @@ int SetSuitesHashSigAlgo(Suites* suites, const char* list)
 #endif /* OPENSSL_EXTRA */
 
 #if !defined(NO_TLS) && (!defined(NO_WOLFSSL_SERVER) || !defined(NO_CERTS))
+/* Smallest RSA key able to make an RSA-PSS/SHA-256 signature: emLen >= 2*hLen+2 = 66 bytes (RFC 8017 9.1.1, salt len = hash len). */
+#define RSA_PSS_SHA256_MIN_SZ  66   /* bytes: 2*WC_SHA256_DIGEST_SIZE + 2 */
 static int MatchSigAlgo(WOLFSSL* ssl, int sigAlgo)
 {
 #ifdef HAVE_ED25519
@@ -31124,9 +31126,14 @@ static int MatchSigAlgo(WOLFSSL* ssl, int sigAlgo)
         if (IsAtLeastTLSv1_3(ssl->version))
             return sigAlgo == rsa_pss_sa_algo;
     #endif
-        /* TLS 1.2 and below - RSA-PSS allowed. */
-        if (sigAlgo == rsa_pss_sa_algo)
+        /* TLS 1.2 and below - RSA-PSS allowed, but only if the RSA key is big
+         * enough to actually produce an RSA-PSS/SHA-256 signature. */
+        if (sigAlgo == rsa_pss_sa_algo) {
+            if (ssl->buffers.keySz != 0 &&
+                    ssl->buffers.keySz < RSA_PSS_SHA256_MIN_SZ)
+                return 0;
             return 1;
+        }
     }
 #endif
 #ifdef HAVE_ECC_BRAINPOOL

--- a/src/internal.c
+++ b/src/internal.c
@@ -31062,10 +31062,42 @@ int SetSuitesHashSigAlgo(Suites* suites, const char* list)
 #endif /* OPENSSL_EXTRA */
 
 #if !defined(NO_TLS) && (!defined(NO_WOLFSSL_SERVER) || !defined(NO_CERTS))
-/* Smallest RSA key able to make an RSA-PSS/SHA-256 signature: emLen >= 2*hLen+2 = 66 bytes (RFC 8017 9.1.1, salt len = hash len). */
-#define RSA_PSS_SHA256_MIN_SZ  66   /* bytes: 2*WC_SHA256_DIGEST_SIZE + 2 */
-static int MatchSigAlgo(WOLFSSL* ssl, int sigAlgo)
+#ifdef WC_RSA_PSS
+/* Smallest RSA key able to make an RSA-PSS signature with the given hash:
+ * emLen >= 2*hLen + 2 (RFC 8017 9.1.1, salt length = hash length).
+ * Returns 0 when the hash isn't one used with RSA-PSS - no restriction. */
+static word32 MinRsaPssKeySz(int hashAlgo)
 {
+    word32 hLen;
+
+    switch (hashAlgo) {
+    #ifndef NO_SHA256
+        case sha256_mac:
+            hLen = WC_SHA256_DIGEST_SIZE;
+            break;
+    #endif
+    #ifdef WOLFSSL_SHA384
+        case sha384_mac:
+            hLen = WC_SHA384_DIGEST_SIZE;
+            break;
+    #endif
+    #ifdef WOLFSSL_SHA512
+        case sha512_mac:
+            hLen = WC_SHA512_DIGEST_SIZE;
+            break;
+    #endif
+        default:
+            return 0;
+    }
+
+    return 2 * hLen + 2;
+}
+#endif /* WC_RSA_PSS */
+
+static int MatchSigAlgo(WOLFSSL* ssl, int hashAlgo, int sigAlgo)
+{
+    (void)hashAlgo;
+
 #ifdef HAVE_ED25519
     if (ssl->pkCurveOID == ECC_ED25519_OID) {
         /* Certificate has Ed25519 key, only match with Ed25519 sig alg  */
@@ -31127,10 +31159,12 @@ static int MatchSigAlgo(WOLFSSL* ssl, int sigAlgo)
             return sigAlgo == rsa_pss_sa_algo;
     #endif
         /* TLS 1.2 and below - RSA-PSS allowed, but only if the RSA key is big
-         * enough to actually produce an RSA-PSS/SHA-256 signature. */
+         * enough to actually produce an RSA-PSS signature with this hash. */
         if (sigAlgo == rsa_pss_sa_algo) {
-            if (ssl->buffers.keySz != 0 &&
-                    ssl->buffers.keySz < RSA_PSS_SHA256_MIN_SZ)
+            word32 minSz = MinRsaPssKeySz(hashAlgo);
+
+            if (minSz != 0 && ssl->buffers.keySz != 0 &&
+                    (word32)ssl->buffers.keySz < minSz)
                 return 0;
             return 1;
         }
@@ -31280,7 +31314,7 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz,
         if (hashAlgo < minHash)
             continue;
         /* Keep looking if signature algorithm isn't supported by cert. */
-        if (!MatchSigAlgo(ssl, sigAlgo))
+        if (!MatchSigAlgo(ssl, hashAlgo, sigAlgo))
             continue;
 
         if (matchSuites) {


### PR DESCRIPTION
# Description

Don't select RSA-PSS in MatchSigAlgo when the RSA key is too small for the signature.
When a TLS 1.2 server holds a small RSA certificate (e.g. 512bit) and the ClientHello's signature_algorithms extension offers rsa_pss_rsae_sha256 (0x0804), the handshake is aborted even though the client also offers rsa_pkcs1_sha256 (0x0401), which the key can use.

Fixes zd#22091

# Testing

Local test with 512bit cert and run time SetMinRsaKey_Sz.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
