### PR TITLE
memory.c: add wc_ConstantCompare wrapper.

### DIFF
--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -1685,6 +1685,15 @@ void wc_ForceZero(void *mem, size_t len)
 }
 #endif
 
+#ifndef WOLFSSL_NO_CONST_CMP
+/* Exported version of ConstantCompare(). */
+int wc_ConstantCompare(const byte* a, const byte* b, int length)
+
+{
+    return ConstantCompare(a, b, length);
+}
+#endif
+
 #ifdef WC_DEBUG_CIPHER_LIFECYCLE
 static const byte wc_debug_cipher_lifecycle_tag_value[] =
     { 'W', 'o', 'l', 'f' };

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -335,6 +335,10 @@ WOLFSSL_LOCAL void wc_MemZero_Check(void* addr, size_t len);
 WOLFSSL_API void wc_ForceZero(void *mem, size_t len);
 #endif
 
+#ifndef WOLFSSL_NO_CONST_CMP
+WOLFSSL_API int wc_ConstantCompare(const byte* a, const byte* b, int length);
+#endif
+
 #ifdef WC_DEBUG_CIPHER_LIFECYCLE
 WOLFSSL_LOCAL int wc_debug_CipherLifecycleInit(void **CipherLifecycleTag,
                                                void *heap);


### PR DESCRIPTION
## Description

Add a public `wc_ConstantCompare` wrapper, similar to the existing `wc_ForceZero` wrapper. Other project integrations regularly reuse wc_ForceZero, but then reimplement their own ConstantCompare if they don't include `misc.c`.

The `wc_ConstantCompare` is guarded by `#ifndef WOLFSSL_NO_CONST_CMP`.

## Testing

Tested with bsdkm, linuxkm, and `all-c89-clang-tidy`.
