### PR TITLE
Time-Stamping Protocol testing: fix CI loop static-memory

### DIFF
--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -75,7 +75,7 @@ jobs:
             "CFLAGS=-DWOLFSSL_NO_MALLOC -pedantic -Wdeclaration-after-statement -Wnull-dereference -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE"],
            "check": false,
            "run": [["./wolfcrypt/test/testwolfcrypt"]]},
-          {"name": "tps-staticmemory", "minutes": 0.8,
+          {"name": "tsp-staticmemory", "minutes": 0.8,
            "configure": ["--enable-ecc", "--enable-rsa", "--enable-keygen",
             "--enable-ed25519", "--enable-curve25519", "--enable-ed448",
             "--enable-curve448", "--enable-mlkem", "--enable-tsp",

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -68706,7 +68706,10 @@ static wc_test_ret_t pkcs7_signed_multi_cert_test(
     byte*  out = NULL;
     byte*  content = NULL;
     int    encSz = 0;
-    const word32 outSz = FOURK_BUF * 4;
+    /* Encoded output is ~8.6 KB (4 KB content + three RSA certs); keep the
+     * buffer within the default WOLFSSL_STATIC_MEMORY largest bucket (16128)
+     * so it also runs under --enable-staticmemory with WOLFSSL_NO_MALLOC. */
+    const word32 outSz = FOURK_BUF * 3;
     const word32 contentSz = FOURK_BUF;   /* larger than the certificate set */
     int    found1 = 0, found2 = 0, found3 = 0, j;
 
@@ -68815,7 +68818,9 @@ static wc_test_ret_t pkcs7_signed_multi_cert_malformed_test(
     int    verifyRet;
     word32 p;
     word32 setStart = 0;
-    const word32 outSz = FOURK_BUF * 4;
+    /* See pkcs7_signed_multi_cert_test: keep within the default static-memory
+     * largest bucket (16128) so this runs under WOLFSSL_NO_MALLOC too. */
+    const word32 outSz = FOURK_BUF * 3;
     const word32 contentSz = FOURK_BUF;   /* pushes the cert set to a high offset */
 
     content = (byte*)XMALLOC(contentSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);


### PR DESCRIPTION
# Description

Static-memory CI loop failed as tests were using too much memory. Tests changed.
Name of loop change to tsp-staticmemory to make more sense.

# Testing

tsp-staticmemory configuration tested.