### PR TITLE
Zero AllocKey's allocation so its failure path cannot free garbage

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8537,6 +8537,11 @@ int AllocKey(WOLFSSL* ssl, int type, void** pKey)
         return MEMORY_E;
     }
 
+    /* Zero the key so the failure path below can run the type's free
+     * function even when its init function failed before initializing
+     * anything: freeing an uninitialized key walks garbage lengths. */
+    XMEMSET(*pKey, 0, sz);
+
     /* Initialize key */
     switch (type) {
     #ifndef NO_RSA


### PR DESCRIPTION
# Description

`AllocKey` hands `FreeKey` a never-initialized key whenever the type's init function fails: the allocation comes straight from `XMALLOC`, and e.g. `wc_FreeRsaKey` then walks uninitialized multiprecision integers whose length fields are garbage. AddressSanitizer caught sp_clear doing a 390KB memset past the allocation during a TLS 1.3 handshake whose `wc_InitRsaKey` failed transiently (a FIPS known-answer-test error), so a recoverable handshake error becomes... heap corruption.

Zero the key after allocation; every `wc_Free*` implementation treats an all-zero key as empty.

# Testing

I built the Qumulo product with this patch; prior to that, we had sporadic ASAN failures.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
