### PR TITLE
fix: bound nest counter in bsdkm vecreg save

### DIFF
--- a/bsdkm/x86_vecreg.c
+++ b/bsdkm/x86_vecreg.c
@@ -165,6 +165,10 @@ int wolfkmod_vecreg_save(int flags_unused)
                    td_tid, curthread->td_tid);
             return (EINVAL);
         }
+        if (fpu_states[PCPU_GET(cpuid)].nest == UINT_MAX) {
+            printf("error: wolfkmod_vecreg_save: nest overflow\n");
+            return (EINVAL);
+        }
         fpu_states[PCPU_GET(cpuid)].nest++;
     }
     else {
@@ -184,6 +188,10 @@ int wolfkmod_vecreg_save(int flags_unused)
         }
 
         /* increment nest and save td_tid. */
+        if (fpu_states[PCPU_GET(cpuid)].nest == UINT_MAX) {
+            printf("error: wolfkmod_vecreg_save: nest overflow\n");
+            return (EINVAL);
+        }
         fpu_states[PCPU_GET(cpuid)].nest++;
         fpu_states[PCPU_GET(cpuid)].td_tid = curthread->td_tid;
     }


### PR DESCRIPTION
Bug: In `bsdkm/x86_vecreg.c`, `wolfkmod_vecreg_save()` increments the per-CPU `nest` counter (`volatile u_int`, line 33) with no upper bound. The re-entrant KERNFPU-active path (was line 168) increments `nest` on every nested `SAVE_VECTOR_REGISTERS()`. If it ever wrapped `UINT_MAX -> 0`, `wolfkmod_vecreg_restore()` would treat `nest == 0` as the last level and call `fpu_kern_leave()` prematurely, releasing kernel FPU context while outer logical nesting frames still hold it — corrupting FPU/SIMD state or leaking kernel register state to userspace.

Fix: Add a bound check before each increment in `wolfkmod_vecreg_save()`; on saturation, print an error and return `EINVAL` (the `RESTORE_VECTOR_REGISTERS()` path already tolerates a failed save). No behavioral change on the normal path. `UINT_MAX` is available via `<sys/param.h>` -> `<sys/limits.h>`, already included by `wolfkmod.c:25`.

Severity is low (defense-in-depth): reaching the wrap requires 2^32 unmatched save calls, which would itself be a runaway calling-code bug. The second increment site is already guarded by the preceding `nest != 0` check, so it cannot overflow in practice; the guard is added there too for symmetry.

How verified: BSD/amd64 kernel module — not buildable on Linux. Source- and preprocessor-analyzed against master `4c68523`; the edited guard construct was compiled clean with `gcc -Wall -Wextra -Werror -fsyntax-only`, and `<sys/param.h>` inclusion at `wolfkmod.c:25` was confirmed to supply `UINT_MAX`.

Reported by static analysis (Fenrir finding F-655).

`[fenrir-sweep:released]`