### PR TITLE
Minor bugfixes

### DIFF
--- a/tests/api/test_dsa.c
+++ b/tests/api/test_dsa.c
@@ -426,9 +426,11 @@ int test_wc_DsaImportParamsRawCheck(void)
     /* null param pointers */
     ExpectIntEQ(wc_DsaImportParamsRawCheck(&key, NULL, NULL, NULL, trusted,
         NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-    /* illegal p length */
+    /* illegal p length: the checked path now preserves the specific
+     * primality failure from p validation instead of overwriting it with
+     * BAD_FUNC_ARG during the later (L,N) size check. */
     ExpectIntEQ(wc_DsaImportParamsRawCheck(&key, invalidP, q, g, trusted, NULL),
-        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        WC_NO_ERR_TRACE(DH_CHECK_PUB_E));
     /* illegal q length */
     ExpectIntEQ(wc_DsaImportParamsRawCheck(&key, p, invalidQ, g, trusted, NULL),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
@@ -731,4 +733,3 @@ int test_wc_DsaCheckPubKey(void)
 #endif
     return EXPECT_RESULT();
 } /* END test_wc_DsaCheckPubKey */
-

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -977,7 +977,7 @@ int wc_curve25519_check_public(const byte* pub, word32 pubSz, int endian)
         /* Check for order-1 or higher. */
         if (pub[0] == 0x7f) {
             for (i = 1; i < CURVE25519_KEYSIZE - 1; i++) {
-                if (pub[i] != 0)
+                if (pub[i] != 0xff)
                     break;
             }
             if (i == CURVE25519_KEYSIZE - 1 && (pub[i] >= 0xec))

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -1013,6 +1013,13 @@ int wc_FreeDhKey(DhKey* key)
     #ifdef WOLFSSL_KCAPI_DH
         KcapiDh_Free(key);
     #endif
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        /* Deregister any mem-zero entries covering this key (e.g. key->priv
+         * registered by wc_DhImportKeyPair) now that its fields are zeroed.
+         * Mirrors wc_FreeRsaKey(); mp_forcezero() alone does not remove the
+         * registration, so without this the entry leaks into later checks. */
+        wc_MemZero_Check(key, sizeof(*key));
+    #endif
     }
     return 0;
 }

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -546,13 +546,17 @@ static int _DsaImportParamsRaw(DsaKey* dsa, const char* p, const char* q,
     if (err == MP_OKAY)
         err = mp_read_radix(&dsa->g, g, MP_RADIX_HEX);
 
-    /* verify (L,N) pair bit lengths */
-    pSz = mp_unsigned_bin_size(&dsa->p);
-    qSz = mp_unsigned_bin_size(&dsa->q);
+    /* verify (L,N) pair bit lengths - only when the reads above succeeded, so
+     * a more specific earlier error (e.g. DH_CHECK_PUB_E from the primality
+     * check) is not overwritten and qSz is not read from an unset q. */
+    if (err == MP_OKAY) {
+        pSz = mp_unsigned_bin_size(&dsa->p);
+        qSz = mp_unsigned_bin_size(&dsa->q);
 
-    if (CheckDsaLN(pSz * WOLFSSL_BIT_SIZE, qSz * WOLFSSL_BIT_SIZE) != 0) {
-        WOLFSSL_MSG("Invalid DSA p or q parameter size");
-        err = BAD_FUNC_ARG;
+        if (CheckDsaLN(pSz * WOLFSSL_BIT_SIZE, qSz * WOLFSSL_BIT_SIZE) != 0) {
+            WOLFSSL_MSG("Invalid DSA p or q parameter size");
+            err = BAD_FUNC_ARG;
+        }
     }
 
     if (err != MP_OKAY) {

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2234,7 +2234,7 @@ int wc_InitRngNonce_ex(WC_RNG* rng, byte* nonce, word32 nonceSz,
     return _InitRng(rng, nonce, nonceSz, heap, devId);
 }
 
-#ifdef HAVE_HASHDRBG
+#if defined(HAVE_HASHDRBG) && !defined(CUSTOM_RAND_GENERATE_BLOCK)
 static int PollAndReSeed(WC_RNG* rng)
 {
     int ret   = DRBG_NEED_RESEED;

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -5320,7 +5320,10 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
         int ret = 0;
 
-        if (os == NULL) {
+        /* Validate output before any entropy backend dereferences it: some
+         * (e.g. glibc's vDSO getrandom()) fault on a NULL buffer rather than
+         * returning an error. Mirrors wc_RNG_GenerateBlock's NULL check. */
+        if (os == NULL || output == NULL) {
             return BAD_FUNC_ARG;
         }
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -5402,6 +5402,23 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 #endif /* !WOLFSSL_CRYPTOCELL && !WOLFSSL_SE050 */
     int err;
 
+#if !defined(WOLFSSL_CRYPTOCELL) && \
+    (!defined(WOLFSSL_SE050) || defined(WOLFSSL_SE050_NO_RSA)) && \
+    !defined(WOLF_CRYPTO_CB_ONLY_RSA) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
+    !defined(WOLFSSL_SMALL_STACK) && defined(WOLFSSL_CHECK_MEM_ZERO)
+    /* Zero the stack temporaries so the mp_memzero_check() in the 'out'
+     * cleanup is safe even when an early argument/size check leaves via
+     * 'goto out' before these are mp_init'd - an uninitialized mp_int's size
+     * field would otherwise make the check scan an arbitrary stack range.
+     * Done here, after all declarations, to satisfy C89. */
+    XMEMSET(&p_buf, 0, sizeof(p_buf));
+    XMEMSET(&q_buf, 0, sizeof(q_buf));
+    XMEMSET(&tmp1_buf, 0, sizeof(tmp1_buf));
+    XMEMSET(&tmp2_buf, 0, sizeof(tmp2_buf));
+    XMEMSET(&tmp3_buf, 0, sizeof(tmp3_buf));
+#endif
+
     if (key == NULL || rng == NULL) {
         err = BAD_FUNC_ARG;
         goto out;

--- a/wolfssl/wolfcrypt/fe_operations.h
+++ b/wolfssl/wolfcrypt/fe_operations.h
@@ -40,6 +40,20 @@
     #define CURVED25519_ASM_64BIT
     #define CURVED25519_ASM
 #endif
+
+/* The small (reduced-C) curve25519/ed25519 code and the Intel x64 assembly
+ * both provide the same fe_, sc_ and curve25519 symbols, so selecting both
+ * (for example a user_settings.h that keeps CURVE25519_SMALL/ED25519_SMALL
+ * while USE_INTEL_SPEEDUP enables the x64 assembly) produces duplicate-symbol
+ * link errors that are hard to diagnose. Detect the incompatible combination
+ * at compile time with a clear message instead. To keep the small
+ * implementation define NO_CURVED25519_X64; to use the assembly drop
+ * CURVE25519_SMALL / ED25519_SMALL. */
+#if defined(CURVED25519_X64) && \
+    (defined(CURVE25519_SMALL) || defined(ED25519_SMALL))
+    #error "CURVE25519_SMALL/ED25519_SMALL are incompatible with the Intel x64 curve25519/ed25519 assembly (CURVED25519_X64); define NO_CURVED25519_X64 to keep the small implementation, or remove the SMALL settings to use the assembly"
+#endif
+
 #if defined(WOLFSSL_ARMASM)
     #ifdef __aarch64__
         #define CURVED25519_ASM_64BIT

--- a/wolfssl/wolfcrypt/fe_operations.h
+++ b/wolfssl/wolfcrypt/fe_operations.h
@@ -112,6 +112,13 @@ WOLFSSL_LOCAL int curve25519_nb(byte * q, const byte * n, const byte * p,
 WOLFSSL_LOCAL void fe_init(void);
 
 WOLFSSL_LOCAL int curve25519(byte * q, const byte * n, const byte * p);
+#if defined(CURVED25519_X64) || (defined(WOLFSSL_ARMASM) && defined(__aarch64__))
+/* Fixed-base scalar multiply provided by the x64/aarch64 assembly
+ * (fe_x25519_asm.S, armv8-curve25519); declared here as no other header
+ * prototypes it, which otherwise breaks a strict C (implicit-declaration)
+ * build of curve25519.c. */
+WOLFSSL_LOCAL int curve25519_base(byte * q, const byte * n);
+#endif
 #ifdef WOLFSSL_CURVE25519_BLINDING
 WOLFSSL_LOCAL int curve25519_blind(byte* q, const byte* n, const byte* mask,
     const byte* p, const byte* rz);


### PR DESCRIPTION
# Description

A bunch of bugs surfaced during [wolfcrypt mc-dc coverage campaign](https://github.com/wolfSSL/wolfssl/pull/10876) have been fixed.


### curve25519 big-endian public-key validation.
600880a0a4930f71884a3207ba39dcaf68c3e698
wc_curve25519_check_public screens out weak/out-of-range X25519 public keys, and it has mirrored little-endian and big-endian code paths. The "order-1 or higher" boundary loop in the little-endian branch scans for middle bytes equal to 0xff (if (pub[i] != 0xff) break;), which is correct because the field prime p = 2²⁵⁵−19 is 0x7fff…ffed, its interior bytes are 0xff. The big-endian branch instead tested if (pub[i] != 0), so it broke out of the loop on the first non-zero byte and never actually detected the near-prime range. The fix changes that one operand to 0xff so big-endian callers get the same near-field-prime rejection as little-endian ones.

###   DSA import parameter error-gating.
30ceba03c553188e18cb46789dd25ec293bdace3
In _DsaImportParamsRaw, each step (read p, primality-check p, read q, read g) is guarded by if (err == MP_OKAY), but the final (L,N) size check via CheckDsaLN ran unconditionally. So if p failed its primality check (err = DH_CHECK_PUB_E), execution still fell through to the size check, which read qSz from a q that was never actually parsed (its own read is gated on success), and unconditionally overwrote the specific DH_CHECK_PUB_E with a generic BAD_FUNC_ARG. The fix wraps the size check in the same if (err == MP_OKAY) guard, so the first and most specific error is preserved and no stale/unset q is measured.

**Note: the associated hardcoded faulty test has been temporarily fixed** in 8dcef499701990e5bbf0befe270371a83eb77dd4 until the final fixed test lands in #10876 

###  curve25519_base prototype for strict-C builds
3aecf6f31ef0dadc8dc1e4dabc9d291abe553aaa
On the CURVED25519_X64 (Intel x64 assembly) and aarch64 ARMASM paths, wc_curve25519_make_pub calls curve25519_base(pub, priv), but that function is provided only in assembly (fe_x25519_asm.S, armv8-curve25519) and had no C prototype in any header,  unlike its sibling curve25519(), which is declared in fe_operations.h. A strict C compiler treating implicit function declarations as errors (e.g. clang 21 with -Werror=implicit-function-declaration) therefore failed to build that configuration. The fix adds WOLFSSL_LOCAL int curve25519_base(byte* q, const byte* n); next to the curve25519() prototype, guarded by the same config, so the assembly path compiles under strict C. I reproduced the exact config and confirmed the object now references the symbol.

### RNG PollAndReSeed build guard.
666de7d0bb999061a8c993de96689005becdd0f2
PollAndReSeed was compiled under #ifdef HAVE_HASHDRBG alone, but its only callers live in the !CUSTOM_RAND_GENERATE_BLOCK branch of wc_RNG_GenerateBlock, and it references wc_GenerateSeed, which isn't provided when a custom block generator replaces the seed layer. So defining HAVE_HASHDRBG together with CUSTOM_RAND_GENERATE_BLOCK compiled a function that referenced an undefined symbol, producing a link error. The fix narrows the guard to #if defined(HAVE_HASHDRBG) && !defined(CUSTOM_RAND_GENERATE_BLOCK) , matching how _InitRng already guards its DRBG code  so the function is compiled exactly when it can be called.

###  RNG wc_GenerateSeed NULL-output check.
0a0e08470bef41df39ec6b73342f6c0b59db603a
The Unix wc_GenerateSeed validated its os argument for NULL but not its output buffer, so a NULL output pointer passed straight into the entropy backend. glibc's vDSO-accelerated getrandom() dereferences the destination without validating it and segfaults rather than returning an error, so a NULL output crashed the process instead of failing cleanly. The fix adds output to the NULL check at the top of the function — mirroring the convention already used in wc_RNG_GenerateBlock so the seed API returns BAD_FUNC_ARG for a NULL buffer regardless of which entropy backend is active.

###  compile-time guard for small-vs-asm 25519.
9721c5221f8f8cb7b69747c83e391caedebc5f5c
The small (reduced-C) curve25519/ed25519 code and the Intel x64 assembly both define the same fe_, sc_, and curve25519 symbols, so building both yields duplicate-symbol link errors. This happens with --enable-usersettings (which bypasses configure's implementation selection) when a user_settings.h keeps CURVE25519_SMALL/ED25519_SMALL while USE_INTEL_SPEEDUP enables the x64 asm. Rather than change the build system (broad blast radius, per your steer), the fix adds an #error in fe_operations.h keyed on CURVED25519_X64 && (CURVE25519_SMALL || ED25519_SMALL). CURVED25519_X64 being the single source of truth for "x64 25519 asm active", so the conflict fails fast with a clear message, with NO_CURVED25519_X64 as the documented escape hatch. I verified it stays silent on --enable-all (no false-positive) and fires on the incompatible combination.

###  deregister mem-zero entries in wc_FreeDhKey
cf5c126a40246fd4c28f96b5ef22fe709806477a
wc_DhImportKeyPair() registers key->priv for zero-on-free tracking via mp_memzero_add() under WOLFSSL_CHECK_MEM_ZERO, but wc_FreeDhKey() cleared priv with mp_forcezero(), which zeroes the data without removing the registration. Unlike wc_FreeRsaKey(), wc_FreeDhKey() had no wc_MemZero_Check() to remove the entry, so the registration leaked past  the DhKey's lifetime and a later, unrelated wc_MemZero_Check() over reused stack could false-abort on it. Add wc_MemZero_Check(key, sizeof(*key)) at the end of wc_FreeDhKey(), mirroring wc_FreeRsaKey().

### zero wc_MakeRsaKey stack temporaries for mem-zero check
3fed5f90f234aedcd22a1605612eb040ebeb042a
wc_MakeRsaKey()'s non-small-stack path declares p/q/tmp1..3 as stack mp_ints and only mp_init's them after the argument and size checks. An early 'goto out' from those checks reaches the WOLFSSL_CHECK_MEM_ZERO cleanup, which calls mp_memzero_check() on the still-uninitialized structs; the garbage size field makes the check scan an arbitrary stack range and can false-abort on unrelated registered memory. Zero the temporaries up front (under WOLFSSL_CHECK_MEM_ZERO) so the early-out cleanup is safe.

# Testing

mc-dc campaign phase 2 PR #10876 

