### PR TITLE
dtls: fail explicitly on oversized HelloVerifyRequest cookie (#10608)

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -32855,10 +32855,19 @@ static void MakePSKPreMasterSecret(Arrays* arrays, byte use_psk_key)
                 return BUFFER_ERROR;
 
 #ifdef WOLFSSL_DTLS
-            if (cookieSz <= MAX_COOKIE_LEN) {
-                XMEMCPY(ssl->arrays->cookie, input + *inOutIdx, cookieSz);
-                ssl->arrays->cookieSz = cookieSz;
-            }
+            /* RFC 6347 allows a cookie of up to 255 bytes
+             * (opaque cookie<0..2^8-1>). If the peer's cookie doesn't fit
+             * in our configured buffer (MAX_COOKIE_LEN, adjustable via
+             * WOLFSSL_COOKIE_LEN), fail explicitly instead of silently
+             * dropping it - a silently-dropped cookie is never echoed
+             * back in the retransmitted ClientHello, causing the
+             * handshake to fail later in a way that gives no indication
+             * of the real cause. */
+            if (cookieSz > MAX_COOKIE_LEN)
+                return BUFFER_ERROR;
+
+            XMEMCPY(ssl->arrays->cookie, input + *inOutIdx, cookieSz);
+            ssl->arrays->cookieSz = cookieSz;
 #endif
             *inOutIdx += cookieSz;
         }


### PR DESCRIPTION
Fixes #10608.

## Problem

RFC 6347 defines the DTLS 1.2 `HelloVerifyRequest`/`ClientHello` cookie as an 8-bit-length opaque vector (`cookie<0..2^8-1>`), so a conforming server can legally send a cookie up to 255 bytes. wolfSSL's client-side buffer for this cookie is `MAX_COOKIE_LEN` (`WOLFSSL_COOKIE_LEN`, default 32, user-overridable at compile time up to the RFC's 255-byte limit).

`DoHelloVerifyRequest()` previously handled a cookie larger than the configured buffer by simply not copying it:

```c
if (cookieSz <= MAX_COOKIE_LEN) {
    XMEMCPY(ssl->arrays->cookie, input + *inOutIdx, cookieSz);
    ssl->arrays->cookieSz = cookieSz;
}
/* no else - falls through as if nothing happened */

*inOutIdx += cookieSz; /* still correctly advances past the cookie bytes */
```

The function still returns success, and `ssl->arrays->cookieSz` is left at its previous value (0 on a fresh handshake). The retransmitted `ClientHello` then goes out without the cookie the server asked for, and the handshake fails later - typically as a generic verification failure or timeout on the server side - with nothing in the client-side return value indicating that an oversized cookie was silently dropped.

## Fix

When the received cookie doesn't fit in the client's configured buffer, return `BUFFER_ERROR` immediately instead of silently continuing. This surfaces the real cause of the handshake failure at the point where it actually occurs, and matches the sibling server-side check a few thousand lines away in the same file (the equivalent `peerCookieSz > MAX_COOKIE_LEN` check while parsing a `ClientHello`'s returned cookie already returns `BUFFER_ERROR` rather than silently proceeding).

I deliberately did **not** change the default value of `WOLFSSL_COOKIE_LEN` itself (e.g. bumping it to 255) - that's a memory/interoperability tradeoff (every DTLS SSL object's cookie buffer would grow accordingly) that's better left as a build-time choice via the existing `WOLFSSL_COOKIE_LEN` override, not something this fix should silently impose on every user by changing the shipped default.

## Verification

I don't have a live DTLS 1.2 peer configured to send an oversized cookie handy, so I verified the corrected branch logic with a standalone C reproduction of the exact `cookieSz`/`MAX_COOKIE_LEN` comparison and buffer-copy sequence:

- A 40-byte cookie (RFC-legal, exceeds the default 32-byte `MAX_COOKIE_LEN`): before the fix, the function returns success while silently leaving `cookieSz` at 0. After the fix, it returns `BUFFER_ERROR` immediately.
- A normal 20-byte cookie (within the default limit): unchanged before and after - copied correctly, `cookieSz` set, function returns success.

## Disclosure

Generative AI (Claude) was used to help investigate this issue, implement, and verify this fix. All changes were reviewed by me before submission.
