### PR TITLE
random.c: fix fips v7 define guards.

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -367,16 +367,17 @@ static int Hash512_DRBG_Uninstantiate(DRBG_SHA512_internal* drbg);
  * calls cannot bypass the mutual-exclusion guard and disable both DRBG types.
  * _InitRng also holds the mutex while reading the flags to get a consistent
  * snapshot, and returns BAD_STATE_E if both are somehow disabled. */
+#if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || FIPS_VERSION3_GE(7,0,0))
 #ifndef NO_SHA256
 #ifdef WOLFSSL_NO_SHA256_DRBG
 static int sha256DrbgDisabled = 1;
 #else
 static int sha256DrbgDisabled = 0;
-#endif
-#endif
+#endif /* WOLFSSL_NO_SHA256_DRBG */
+#endif /* !NO_SHA256 */
 #ifdef WOLFSSL_DRBG_SHA512
 static int sha512DrbgDisabled = 0;
-#endif
+#endif /* WOLFSSL_DRBG_SHA512 */
 
 #ifndef SINGLE_THREADED
 static wolfSSL_Mutex drbgStateMutex
@@ -432,6 +433,8 @@ static int UnlockDrbgState(void)
     return 0;
 #endif
 }
+
+#endif /* !HAVE_SELFTEST && (!HAVE_FIPS || FIPS v7+) */
 
 static int wc_RNG_HealthTestLocal(WC_RNG* rng, int reseed, void* heap,
                                   int devId);
@@ -1669,7 +1672,6 @@ int wc_Sha256Drbg_Disable(void) { return NOT_COMPILED_IN; }
 int wc_Sha256Drbg_Enable(void) { return 0; }
 int wc_Sha256Drbg_IsDisabled(void) { return 1; } /* always disabled */
 #endif /* !NO_SHA256 */
-#endif /* !HAVE_SELFTEST && (!HAVE_FIPS || FIPS v7+) */
 
 #ifdef WOLFSSL_DRBG_SHA512
 int wc_Sha512Drbg_Disable(void)
@@ -1708,7 +1710,7 @@ int wc_Sha512Drbg_IsDisabled(void)
     return val;
 }
 #endif /* WOLFSSL_DRBG_SHA512 */
-
+#endif /* !HAVE_SELFTEST && (!HAVE_FIPS || FIPS v7+) */
 #endif /* HAVE_HASHDRBG */
 /* End NIST DRBG Code */
 
@@ -1764,20 +1766,20 @@ static int _InitRng(WC_RNG* rng, byte* nonce, word32 nonceSz,
     #ifdef WOLFSSL_SMALL_STACK_CACHE
     rng->drbg_scratch = NULL;
     #endif
-#endif
+#endif /* !NO_SHA256 */
 #ifdef WOLFSSL_DRBG_SHA512
     rng->drbg512 = NULL;
     #ifdef WOLFSSL_SMALL_STACK_CACHE
     rng->drbg512_scratch = NULL;
     rng->health_check_scratch_512 = NULL;
     #endif
-#endif
+#endif /* WOLFSSL_DRBG_SHA512 */
 #ifdef WOLFSSL_SMALL_STACK_CACHE
     rng->newSeed_buf = NULL;
-#ifndef NO_SHA256
+    #ifndef NO_SHA256
     rng->health_check_scratch = NULL;
-#endif
-#endif
+    #endif /* !NO_SHA256 */
+#endif /* WOLFSSL_SMALL_STACK_CACHE */
     rng->status = DRBG_NOT_INIT;
 
     /* Select DRBG type: prefer SHA-512 unless disabled or not compiled.
@@ -1786,16 +1788,16 @@ static int _InitRng(WC_RNG* rng, byte* nonce, word32 nonceSz,
     ret = LockDrbgState();
     if (ret != 0)
         return ret;
-#ifdef WOLFSSL_DRBG_SHA512
+    #ifdef WOLFSSL_DRBG_SHA512
     if (!sha512DrbgDisabled)
         rng->drbgType = WC_DRBG_SHA512;
     else
-#endif
-#ifndef NO_SHA256
+    #endif /* WOLFSSL_DRBG_SHA512 */
+    #ifndef NO_SHA256
     if (!sha256DrbgDisabled)
         rng->drbgType = WC_DRBG_SHA256;
     else
-#endif
+    #endif /* !NO_SHA256 */
     {
         UnlockDrbgState();
         return BAD_STATE_E; /* no DRBG available */
@@ -1803,8 +1805,8 @@ static int _InitRng(WC_RNG* rng, byte* nonce, word32 nonceSz,
     UnlockDrbgState();
 #else
     rng->drbgType = WC_DRBG_SHA256;
-#endif
-#endif
+#endif /* !HAVE_SELFTEST && (!HAVE_FIPS || FIPS v7+) */
+#endif /* HAVE_HASHDRBG */
 
 #if defined(HAVE_INTEL_RDSEED) || defined(HAVE_INTEL_RDRAND) || \
     defined(HAVE_AMD_RDSEED)
@@ -3289,7 +3291,8 @@ int wc_RNG_HealthTest_SHA512(int reseed,
 
 #endif /* WOLFSSL_DRBG_SHA512 */
 
-#ifndef NO_SHA256
+#if !defined(NO_SHA256) && !defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION3_GE(7,0,0))
 /* Extended SHA-256 Hash_DRBG health test per SP 800-90A.
  * Supports flexible output sizes, prediction resistance, personalization
  * strings, and additional input.
@@ -3387,7 +3390,7 @@ exit_sha256_ex:
 
     return ret;
 }
-#endif /* !NO_SHA256 */
+#endif /* !NO_SHA256 && !HAVE_SELFTEST && FIPS v7+ */
 
 
 #ifdef WOLFSSL_DRBG_SHA512

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -3390,7 +3390,7 @@ exit_sha256_ex:
 
     return ret;
 }
-#endif /* !NO_SHA256 && !HAVE_SELFTEST && FIPS v7+ */
+#endif /* !NO_SHA256 && !HAVE_SELFTEST && (!HAVE_FIPS || FIPS v7+) */
 
 
 #ifdef WOLFSSL_DRBG_SHA512


### PR DESCRIPTION
## Description

Add some fips v7 define guards to `random.c`. They were present in `random.h`, but missing for the corresponding functions in `random.c`.

Also cleans up some missing `#endif` comments and indents.

Fixes fips=v6 build errors on freebsd userspace:
```
wolfcrypt/src/random.c:389:5: error: no previous prototype for function 'wc_DrbgState_MutexInit' [-Werror,-Wmissing-prototypes]
  389 | int wc_DrbgState_MutexInit(void)
      |     ^
```

Requires:
- https://github.com/wolfSSL/fips/pull/401

## Testing

```
fips_hash=30CF65D11002855703E8184481BB871FAA511410A03A008CAD6DD066D36F4860
BSDKM_CFLAGS="-DWOLFCRYPT_FIPS_CORE_HASH_VALUE=$fips_hash -DWOLFSSL_BSDKM_VERBOSE_DEBUG"
./configure --enable-cryptonly --enable-crypttests \
  --enable-all-crypto --enable-aesni \
  --enable-aesni-with-avx --enable-fips=v7 \
  CFLAGS="$BSDKM_CFLAGS" && make -j1 \
  || exit 1
```

```
fips_hash=54FA63BED6A82155BD5F76FE031FB285DDD7825FC5D9D95D157FF4805DC2A1A5
BSDKM_CFLAGS="-DWOLFCRYPT_FIPS_CORE_HASH_VALUE=$fips_hash -DWOLFSSL_BSDKM_VERBOSE_DEBUG"
./configure --enable-cryptonly --enable-crypttests \
  --enable-fips=v6 \
  CFLAGS="$BSDKM_CFLAGS" && make -j1 \
  || exit 1
```