### PR TITLE
also check ctx->extensions in TLS 1.3 Certificate extension check

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -18047,7 +18047,8 @@ WOLFSSL_TEST_VIS int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length,
          * CertificateRequest (server). Reject anything we did not offer. */
         if (msgType == certificate &&
             IsAtLeastTLSv1_3(ssl->version) &&
-            TLSX_Find(ssl->extensions, (TLSX_Type)type) == NULL) {
+            TLSX_Find(ssl->extensions, (TLSX_Type)type) == NULL &&
+            TLSX_Find(ssl->ctx->extensions, (TLSX_Type)type) == NULL) {
             WOLFSSL_MSG("Cert-msg extension not offered in CH/CR");
             SendAlert(ssl, alert_fatal, unsupported_extension);
             WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_EXTENSION);


### PR DESCRIPTION
# Description

CTX-level OCSP stapling (wolfSSL_CTX_UseOCSPStapling) stores status_request on
ctx->extensions, so the RFC 8446 4.4.2 check added in 8d9af257a wrongly
rejected the server's stapled Certificate with unsupported_extension(110).
Fall back to ssl->ctx->extensions; ssl->ctx is always non-NULL.

Fixes zd#21814

# Testing

local test only

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
