### PR TITLE
configure.ac: fix -Wno-deprecated-enum-enum-conversion probe under ccache

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12700,8 +12700,14 @@ fi
 # our use of enum constructs to define fungible constants.
 if test "$KERNEL_MODE_DEFAULTS" != "yes"
 then
-    AX_CHECK_COMPILE_FLAG([-Werror -Wno-deprecated-enum-enum-conversion],
+    # Probe with ac_c_werror_flag (fail on any stderr output), not -Werror:
+    # ccache reorders -Werror after the -Wno- option, so gcc accepts it with
+    # only a warning.
+    ax_save_c_werror_flag=$ac_c_werror_flag
+    ac_c_werror_flag=yes
+    AX_CHECK_COMPILE_FLAG([-Wno-deprecated-enum-enum-conversion],
       [AX_APPEND_FLAG([-Wno-deprecated-enum-enum-conversion], [AM_CFLAGS])])
+    ac_c_werror_flag=$ax_save_c_werror_flag
 fi
 
 case $host_os in


### PR DESCRIPTION
## Summary
- gcc only promotes `-Wno-deprecated-enum-enum-conversion` (a C++/ObjC++-only option) to an error when `-Werror` is processed before the `-Wno-` option. ccache splits the command line into preprocessor and compiler-only options and re-appends `-Werror` after the `-Wno-` option, so with `CC="ccache gcc"` the `AX_CHECK_COMPILE_FLAG` probe exits 0 and configure adds the C++-only option to `AM_CFLAGS`, causing gcc to emit the cc1 warning on every C compilation unit (e.g. in the multi-arch workflow).
- Gate the probe on `ac_c_werror_flag` instead: `AC_COMPILE_IFELSE` then fails on any stderr output, independent of option order. gcc (with or without ccache) now rejects the flag; clang still accepts it silently and keeps it.

## Test plan
- [ ] `./configure CC="ccache gcc"` no longer adds `-Wno-deprecated-enum-enum-conversion` to `AM_CFLAGS`
- [ ] CI passes