### PR TITLE
Bound remaining hangable operations in test scripts

### DIFF
--- a/scripts/benchmark.test
+++ b/scripts/benchmark.test
@@ -2,6 +2,12 @@
 
 #benchmark.test
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 # if we can, isolate the network namespace to eliminate port collisions.
 if [ -n "$NETWORK_UNSHARE_HELPER" ]; then
      if [ -z "$NETWORK_UNSHARE_HELPER_CALLED" ]; then
@@ -111,7 +117,7 @@ if [ $1 -eq 1 ]
 then
     echo "Starting example client to benchmark connection average time"
     # start client to benchmark average time for each connection using port
-    ./examples/client/client -b $2 -p $bench_port $3
+    timeout -s KILL 2m ./examples/client/client -b $2 -p $bench_port $3
     client_result=$?
 fi
 
@@ -120,7 +126,7 @@ if [ $1 -eq 2 ]
 then
     echo "Starting example client to benchmark throughput"
     # start client in non-blocking mode, benchmark throughput using port
-    ./examples/client/client -N -B $2 -p $bench_port $3
+    timeout -s KILL 2m ./examples/client/client -N -B $2 -p $bench_port $3
     client_result=$?
 fi
 

--- a/scripts/benchmark.test
+++ b/scripts/benchmark.test
@@ -4,8 +4,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 # if we can, isolate the network namespace to eliminate port collisions.
@@ -117,7 +122,7 @@ if [ $1 -eq 1 ]
 then
     echo "Starting example client to benchmark connection average time"
     # start client to benchmark average time for each connection using port
-    timeout -s KILL 2m ./examples/client/client -b $2 -p $bench_port $3
+    $TIMEOUT_KILL_2M ./examples/client/client -b $2 -p $bench_port $3
     client_result=$?
 fi
 
@@ -126,7 +131,7 @@ if [ $1 -eq 2 ]
 then
     echo "Starting example client to benchmark throughput"
     # start client in non-blocking mode, benchmark throughput using port
-    timeout -s KILL 2m ./examples/client/client -N -B $2 -p $bench_port $3
+    $TIMEOUT_KILL_2M ./examples/client/client -N -B $2 -p $bench_port $3
     client_result=$?
 fi
 

--- a/scripts/crl-revoked.test
+++ b/scripts/crl-revoked.test
@@ -2,8 +2,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 
@@ -106,7 +111,7 @@ run_test() {
     # starts the server on crl_port, -R generates ready file to be used as a
     # mutex lock, -c loads the revoked certificate. We capture the processid
     # into the variable server_pid
-    timeout -s KILL 2m ./examples/server/server -R "$ready_file" -p $crl_port \
+    $TIMEOUT_KILL_2M ./examples/server/server -R "$ready_file" -p $crl_port \
                              -c ${CERT_DIR}/server-revoked-cert.pem \
                              -k ${CERT_DIR}/server-revoked-key.pem &
     server_pid=$!
@@ -184,7 +189,7 @@ run_hashdir_test() {
   # starts the server on crl_port, -R generates ready file to be used as a
   # mutex lock, -c loads the revoked certificate. We capture the processid
   # into the variable server_pid
-  timeout -s KILL 2m ./examples/server/server -R "$ready_file" -p $crl_port \
+  $TIMEOUT_KILL_2M ./examples/server/server -R "$ready_file" -p $crl_port \
                              -c ${CERT_DIR}/server-revoked-cert.pem \
                              -k ${CERT_DIR}/server-revoked-key.pem &
   server_pid=$!

--- a/scripts/dtls.test
+++ b/scripts/dtls.test
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 # This script can be run with several environment variables set dictating its
 # run. You can set the following to what you like:
 WOLFSSL_ROOT=${WOLFSSL_ROOT:-$(pwd)}
@@ -85,9 +91,9 @@ prepend() { # Usage: cmd 2>&1 | prepend "sometext "
 
 run_test() { # usage: run_test "<testName>" "<udp-proxy args>" "<server args>" "<client args>"
     ((NUM_TESTS_RUN++))
-    echo "" | nc -u 127.0.0.1 $SERVER_PORT # This is a marker for the PCAP file
-    echo "$1" | nc -u 127.0.0.1 $SERVER_PORT # This is a marker for the PCAP file
-    echo "" | nc -u 127.0.0.1 $SERVER_PORT # This is a marker for the PCAP file
+    echo "" | nc -u -w 1 127.0.0.1 $SERVER_PORT # This is a marker for the PCAP file
+    echo "$1" | nc -u -w 1 127.0.0.1 $SERVER_PORT # This is a marker for the PCAP file
+    echo "" | nc -u -w 1 127.0.0.1 $SERVER_PORT # This is a marker for the PCAP file
     echo -e "\n${1}\n"
     stdbuf -oL -eL $WOLFSSL_ROOT/examples/server/server -u -p$SERVER_PORT $DTLS_VERSION $3 2>&1 | prepend "[server] " &
     sleep 0.2

--- a/scripts/dtls.test
+++ b/scripts/dtls.test
@@ -2,8 +2,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_1M="timeout -s KILL 1m"
+else
+    TIMEOUT_KILL_1M=""
 fi
 
 # This script can be run with several environment variables set dictating its
@@ -100,7 +105,7 @@ run_test() { # usage: run_test "<testName>" "<udp-proxy args>" "<server args>" "
     stdbuf -oL -eL $UDP_PROXY_BIN -p $PROXY_PORT -s 127.0.0.1:$SERVER_PORT $UDP_PROXY_EXTRA_ARGS $2 2>&1 | prepend "[udp-proxy] " &
     sleep 0.2
     # Wrap this command in a timeout so that a deadlock won't bring down the entire test
-    timeout -s KILL 1m stdbuf -oL -eL $WOLFSSL_ROOT/examples/client/client -u -p$PROXY_PORT $DTLS_VERSION $4 2>&1 | prepend "[client] "
+    $TIMEOUT_KILL_1M stdbuf -oL -eL $WOLFSSL_ROOT/examples/client/client -u -p$PROXY_PORT $DTLS_VERSION $4 2>&1 | prepend "[client] "
     if [ $? != 0 ]; then
         echo "***Test failed***"
         ((NUM_TESTS_FAILED++))

--- a/scripts/dtlscid.test
+++ b/scripts/dtlscid.test
@@ -64,7 +64,7 @@ test_cid () {
     timeout -s KILL 2m $WOLFSSL_ROOT/examples/server/server -v4 -u --cid $SCID 1> $SERVER_FILE &
     SERVER_PID=$!
     sleep 0.2
-    $WOLFSSL_ROOT/examples/client/client -v4 -u --cid $CCID 1> $CLIENT_FILE
+    timeout -s KILL 2m $WOLFSSL_ROOT/examples/client/client -v4 -u --cid $CCID 1> $CLIENT_FILE
     wait $SERVER_PID
     SERVER_PID=
     grep "Sending CID is ${HEXSCID}" $CLIENT_FILE > /dev/null

--- a/scripts/dtlscid.test
+++ b/scripts/dtlscid.test
@@ -2,8 +2,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 
@@ -61,10 +66,10 @@ test_cid () {
     echo "Running test_cid"
     SERVER_FILE=$(mktemp)
     CLIENT_FILE=$(mktemp)
-    timeout -s KILL 2m $WOLFSSL_ROOT/examples/server/server -v4 -u --cid $SCID 1> $SERVER_FILE &
+    $TIMEOUT_KILL_2M $WOLFSSL_ROOT/examples/server/server -v4 -u --cid $SCID 1> $SERVER_FILE &
     SERVER_PID=$!
     sleep 0.2
-    timeout -s KILL 2m $WOLFSSL_ROOT/examples/client/client -v4 -u --cid $CCID 1> $CLIENT_FILE
+    $TIMEOUT_KILL_2M $WOLFSSL_ROOT/examples/client/client -v4 -u --cid $CCID 1> $CLIENT_FILE
     wait $SERVER_PID
     SERVER_PID=
     grep "Sending CID is ${HEXSCID}" $CLIENT_FILE > /dev/null

--- a/scripts/external.test
+++ b/scripts/external.test
@@ -2,6 +2,12 @@
 
 # external.test
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 SCRIPT_DIR="$(dirname "$0")"
 
 server=www.wolfssl.com
@@ -45,7 +51,7 @@ RESULT=$?
 [ $RESULT -ne 0 ] && exit 0
 
 # client test against the server
-./examples/client/client -X -C -h $server -p 443 -g -A $ca
+timeout -s KILL 2m ./examples/client/client -X -C -h $server -p 443 -g -A $ca
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 

--- a/scripts/external.test
+++ b/scripts/external.test
@@ -4,8 +4,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 SCRIPT_DIR="$(dirname "$0")"
@@ -51,7 +56,7 @@ RESULT=$?
 [ $RESULT -ne 0 ] && exit 0
 
 # client test against the server
-timeout -s KILL 2m ./examples/client/client -X -C -h $server -p 443 -g -A $ca
+$TIMEOUT_KILL_2M ./examples/client/client -X -C -h $server -p 443 -g -A $ca
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 

--- a/scripts/google.test
+++ b/scripts/google.test
@@ -4,8 +4,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 server=www.google.com
@@ -37,7 +42,7 @@ RESULT=$?
 # so treat it like the unreachable-server case above and skip instead of
 # failing.
 run_client() {
-    OUTPUT="$(timeout -s KILL 2m ./examples/client/client "$@" 2>&1)"
+    OUTPUT="$($TIMEOUT_KILL_2M ./examples/client/client "$@" 2>&1)"
     RESULT=$?
     echo "$OUTPUT"
     if [ $RESULT -ne 0 ] && echo "$OUTPUT" | grep -q 'tcp connect failed'; then

--- a/scripts/google.test
+++ b/scripts/google.test
@@ -2,6 +2,12 @@
 
 # google.test
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 server=www.google.com
 
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
@@ -31,7 +37,7 @@ RESULT=$?
 # so treat it like the unreachable-server case above and skip instead of
 # failing.
 run_client() {
-    OUTPUT="$(./examples/client/client "$@" 2>&1)"
+    OUTPUT="$(timeout -s KILL 2m ./examples/client/client "$@" 2>&1)"
     RESULT=$?
     echo "$OUTPUT"
     if [ $RESULT -ne 0 ] && echo "$OUTPUT" | grep -q 'tcp connect failed'; then

--- a/scripts/ocsp-responder-openssl-interop.test
+++ b/scripts/ocsp-responder-openssl-interop.test
@@ -95,6 +95,7 @@ ready_files=""
 
 cleanup() {
     exit_status=$?
+    local counter
     for p in $resp_pids; do
         kill $p 2>/dev/null
         # Escalate to KILL so a wedged responder cannot hang this trap.
@@ -103,7 +104,9 @@ cleanup() {
             sleep 0.1
             counter=$((counter + 1))
         done
-        kill -s KILL $p 2>/dev/null
+        if kill -0 $p 2>/dev/null; then
+            kill -s KILL $p 2>/dev/null
+        fi
         wait $p 2>/dev/null
     done
     # Clean up log files

--- a/scripts/ocsp-responder-openssl-interop.test
+++ b/scripts/ocsp-responder-openssl-interop.test
@@ -9,6 +9,12 @@
 # Uses: examples/ocsp_responder/ocsp_responder as the OCSP responder
 #       openssl ocsp as the client
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 if ! test -n "$WOLFSSL_OPENSSL_TEST"; then
     echo "WOLFSSL_OPENSSL_TEST NOT set, won't run"
     exit 77
@@ -91,6 +97,13 @@ cleanup() {
     exit_status=$?
     for p in $resp_pids; do
         kill $p 2>/dev/null
+        # Escalate to KILL so a wedged responder cannot hang this trap.
+        counter=0
+        while kill -0 $p 2>/dev/null && [ "$counter" -lt 50 ]; do
+            sleep 0.1
+            counter=$((counter + 1))
+        done
+        kill -s KILL $p 2>/dev/null
         wait $p 2>/dev/null
     done
     # Clean up log files
@@ -131,14 +144,20 @@ print_responder_logs() {
 
 get_first_free_port() {
     local ret="$1"
+    local scanned=0
     while :; do
         if [[ "$ret" -ge 65536 ]]; then
             ret=1024
         fi
-        if ! nc -z ${LOCALHOST_FOR_NC} "$ret"; then
+        if ! nc -w 1 -z ${LOCALHOST_FOR_NC} "$ret"; then
             break
         fi
         ret=$((ret+1))
+        scanned=$((scanned+1))
+        if [ "$scanned" -ge 100 ]; then
+            echo "ERROR: no free port found after scanning 100 ports" 1>&2
+            exit 1
+        fi
     done
     echo "$ret"
     return 0
@@ -180,7 +199,7 @@ query_ocsp() {
     printf "  TEST %2d: %-55s " "$tests_run" "$desc"
 
     local output
-    output=$($OPENSSL ocsp \
+    output=$(timeout -s KILL 2m $OPENSSL ocsp \
         -issuer "$issuer" \
         -cert "$cert" \
         -url "http://127.0.0.1:$_port/" \
@@ -395,7 +414,7 @@ echo "=== Negative tests: unsupported features ==="
 tests_run=$((tests_run+1))
 printf "  TEST %2d: %-55s " "$tests_run" "SHA-384 hash -> good"
 
-output=$($OPENSSL ocsp \
+output=$(timeout -s KILL 2m $OPENSSL ocsp \
     -sha384 \
     -issuer "$OCSP_DIR/intermediate1-ca-cert.pem" \
     -cert "$OCSP_DIR/server1-cert.pem" \
@@ -433,7 +452,7 @@ printf "  TEST %2d: %-55s " "$tests_run" "Authorized responder"
 
 # Query using OpenSSL - asks about intermediate1-ca which was issued by root-ca
 # Response will be signed by ocsp-responder-cert (authorized responder)
-output=$($OPENSSL ocsp \
+output=$(timeout -s KILL 2m $OPENSSL ocsp \
     -issuer "$OCSP_DIR/root-ca-cert.pem" \
     -cert "$OCSP_DIR/intermediate1-ca-cert.pem" \
     -url "http://127.0.0.1:$port5/" \
@@ -468,7 +487,7 @@ echo "=== Unknown certificate tests ==="
 tests_run=$((tests_run+1))
 printf "  TEST %2d: %-55s " "$tests_run" "Wrong issuer: server3 to responder 1 (wrong issuer)"
 
-output=$($OPENSSL ocsp \
+output=$(timeout -s KILL 2m $OPENSSL ocsp \
     -issuer "$OCSP_DIR/intermediate1-ca-cert.pem" \
     -cert "$OCSP_DIR/server3-cert.pem" \
     -url "http://127.0.0.1:$port1/" \
@@ -495,7 +514,7 @@ fi
 tests_run=$((tests_run+1))
 printf "  TEST %2d: %-55s " "$tests_run" "Wrong issuer: server1 to responder 2 (wrong issuer)"
 
-output=$($OPENSSL ocsp \
+output=$(timeout -s KILL 2m $OPENSSL ocsp \
     -issuer "$OCSP_DIR/intermediate2-ca-cert.pem" \
     -cert "$OCSP_DIR/server1-cert.pem" \
     -url "http://127.0.0.1:$port2/" \
@@ -528,7 +547,7 @@ tests_run=$((tests_run+1))
 printf "  TEST %2d: %-55s " "$tests_run" "Multiple requests (should return OCSP error)"
 
 # Using multiple -cert options creates one OCSP request with multiple certificate IDs
-output=$($OPENSSL ocsp \
+output=$(timeout -s KILL 2m $OPENSSL ocsp \
     -issuer "$OCSP_DIR/intermediate1-ca-cert.pem" \
     -cert "$OCSP_DIR/server1-cert.pem" \
     -cert "$OCSP_DIR/server2-cert.pem" \

--- a/scripts/ocsp-responder-openssl-interop.test
+++ b/scripts/ocsp-responder-openssl-interop.test
@@ -11,8 +11,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 if ! test -n "$WOLFSSL_OPENSSL_TEST"; then
@@ -159,7 +164,9 @@ get_first_free_port() {
         scanned=$((scanned+1))
         if [ "$scanned" -ge 100 ]; then
             echo "ERROR: no free port found after scanning 100 ports" 1>&2
-            exit 1
+            # return, not exit: every caller runs this in a command
+            # substitution, where exit would only end the subshell.
+            return 1
         fi
     done
     echo "$ret"
@@ -202,7 +209,7 @@ query_ocsp() {
     printf "  TEST %2d: %-55s " "$tests_run" "$desc"
 
     local output
-    output=$(timeout -s KILL 2m $OPENSSL ocsp \
+    output=$($TIMEOUT_KILL_2M $OPENSSL ocsp \
         -issuer "$issuer" \
         -cert "$cert" \
         -url "http://127.0.0.1:$_port/" \
@@ -234,11 +241,11 @@ query_ocsp() {
 
 
 base_port=$((((($$ + $RETRIES_REMAINING) * 5) % (65536 - 2048)) + 1024))
-port1=$(get_first_free_port $base_port)        # OCSP responder: intermediate1-ca
-port2=$(get_first_free_port $((port1 + 1)))    # OCSP responder: intermediate2-ca
-port3=$(get_first_free_port $((port2 + 1)))    # OCSP responder: intermediate3-ca
-port4=$(get_first_free_port $((port3 + 1)))    # OCSP responder: root-ca
-port5=$(get_first_free_port $((port4 + 1)))    # TLS server
+port1=$(get_first_free_port $base_port) || exit 1        # OCSP responder: intermediate1-ca
+port2=$(get_first_free_port $((port1 + 1))) || exit 1    # OCSP responder: intermediate2-ca
+port3=$(get_first_free_port $((port2 + 1))) || exit 1    # OCSP responder: intermediate3-ca
+port4=$(get_first_free_port $((port3 + 1))) || exit 1    # OCSP responder: root-ca
+port5=$(get_first_free_port $((port4 + 1))) || exit 1    # TLS server
 
 # Responder 1: intermediate1-ca (server1=valid, server2=revoked)
 log1=$(mktemp "${TMPDIR:-/tmp}/ocsp_resp1.XXXXXX")
@@ -417,7 +424,7 @@ echo "=== Negative tests: unsupported features ==="
 tests_run=$((tests_run+1))
 printf "  TEST %2d: %-55s " "$tests_run" "SHA-384 hash -> good"
 
-output=$(timeout -s KILL 2m $OPENSSL ocsp \
+output=$($TIMEOUT_KILL_2M $OPENSSL ocsp \
     -sha384 \
     -issuer "$OCSP_DIR/intermediate1-ca-cert.pem" \
     -cert "$OCSP_DIR/server1-cert.pem" \
@@ -455,7 +462,7 @@ printf "  TEST %2d: %-55s " "$tests_run" "Authorized responder"
 
 # Query using OpenSSL - asks about intermediate1-ca which was issued by root-ca
 # Response will be signed by ocsp-responder-cert (authorized responder)
-output=$(timeout -s KILL 2m $OPENSSL ocsp \
+output=$($TIMEOUT_KILL_2M $OPENSSL ocsp \
     -issuer "$OCSP_DIR/root-ca-cert.pem" \
     -cert "$OCSP_DIR/intermediate1-ca-cert.pem" \
     -url "http://127.0.0.1:$port5/" \
@@ -490,7 +497,7 @@ echo "=== Unknown certificate tests ==="
 tests_run=$((tests_run+1))
 printf "  TEST %2d: %-55s " "$tests_run" "Wrong issuer: server3 to responder 1 (wrong issuer)"
 
-output=$(timeout -s KILL 2m $OPENSSL ocsp \
+output=$($TIMEOUT_KILL_2M $OPENSSL ocsp \
     -issuer "$OCSP_DIR/intermediate1-ca-cert.pem" \
     -cert "$OCSP_DIR/server3-cert.pem" \
     -url "http://127.0.0.1:$port1/" \
@@ -517,7 +524,7 @@ fi
 tests_run=$((tests_run+1))
 printf "  TEST %2d: %-55s " "$tests_run" "Wrong issuer: server1 to responder 2 (wrong issuer)"
 
-output=$(timeout -s KILL 2m $OPENSSL ocsp \
+output=$($TIMEOUT_KILL_2M $OPENSSL ocsp \
     -issuer "$OCSP_DIR/intermediate2-ca-cert.pem" \
     -cert "$OCSP_DIR/server1-cert.pem" \
     -url "http://127.0.0.1:$port2/" \
@@ -550,7 +557,7 @@ tests_run=$((tests_run+1))
 printf "  TEST %2d: %-55s " "$tests_run" "Multiple requests (should return OCSP error)"
 
 # Using multiple -cert options creates one OCSP request with multiple certificate IDs
-output=$(timeout -s KILL 2m $OPENSSL ocsp \
+output=$($TIMEOUT_KILL_2M $OPENSSL ocsp \
     -issuer "$OCSP_DIR/intermediate1-ca-cert.pem" \
     -cert "$OCSP_DIR/server1-cert.pem" \
     -cert "$OCSP_DIR/server2-cert.pem" \

--- a/scripts/ocsp-stapling-with-ca-as-responder.test
+++ b/scripts/ocsp-stapling-with-ca-as-responder.test
@@ -2,6 +2,12 @@
 
 # ocsp-stapling-with-ca-as-responder.test
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 SCRIPT_DIR="$(dirname "$0")"
 
 # if we can, isolate the network namespace to eliminate port collisions.
@@ -197,14 +203,20 @@ ca=certs/external/DigiCertGlobalRootCA.pem
 
 get_first_free_port() {
     local ret="$1"
+    local scanned=0
     while :; do
         if [[ "$ret" -ge 65536 ]]; then
             ret=1024
         fi
-        if ! nc -z 127.0.0.1 "$ret"; then
+        if ! nc -w 1 -z 127.0.0.1 "$ret"; then
             break
         fi
         ret=$((ret+1))
+        scanned=$((scanned+1))
+        if [ "$scanned" -ge 100 ]; then
+            echo "ERROR: no free port found after scanning 100 ports" 1>&2
+            exit 1
+        fi
     done
     echo "$ret"
     return 0
@@ -225,7 +237,7 @@ if [ ! -f "$ready_file" ]; then
 else
     printf '%s\n' "Random port selected: $port1"
     # Use client connection to shutdown the server cleanly
-    ./examples/client/client -p $port1
+    timeout -s KILL 2m ./examples/client/client -p $port1
     create_new_cnf $port1
 fi
 sleep 0.1
@@ -263,7 +275,7 @@ printf '%s\n\n' "------------- TEST CASE 1 SHOULD PASS ------------------------"
                          -p $port2 &
 wolf_pid2=$!
 wait_for_readyFile "$ready_file2" $wolf_pid2 $port2
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 \
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 \
                          -p $port2
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection failed" && exit 1
@@ -277,7 +289,7 @@ remove_single_rF "$ready_file2"
                          -p $port2 &
 wolf_pid2=$!
 wait_for_readyFile "$ready_file2" $wolf_pid2 $port2
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 \
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 \
                          -p $port2
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1

--- a/scripts/ocsp-stapling-with-ca-as-responder.test
+++ b/scripts/ocsp-stapling-with-ca-as-responder.test
@@ -4,8 +4,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 SCRIPT_DIR="$(dirname "$0")"
@@ -215,7 +220,9 @@ get_first_free_port() {
         scanned=$((scanned+1))
         if [ "$scanned" -ge 100 ]; then
             echo "ERROR: no free port found after scanning 100 ports" 1>&2
-            exit 1
+            # return, not exit: every caller runs this in a command
+            # substitution, where exit would only end the subshell.
+            return 1
         fi
     done
     echo "$ret"
@@ -223,8 +230,8 @@ get_first_free_port() {
 }
 
 base_port=$((((($$ + $RETRIES_REMAINING) * 5) % (65536 - 2048)) + 1024))
-port1=$(get_first_free_port $base_port)
-port2=$(get_first_free_port $((port1 + 1)))
+port1=$(get_first_free_port $base_port) || exit 1
+port2=$(get_first_free_port $((port1 + 1))) || exit 1
 
 
 # create a port to use with openssl ocsp responder
@@ -237,7 +244,7 @@ if [ ! -f "$ready_file" ]; then
 else
     printf '%s\n' "Random port selected: $port1"
     # Use client connection to shutdown the server cleanly
-    timeout -s KILL 2m ./examples/client/client -p $port1
+    $TIMEOUT_KILL_2M ./examples/client/client -p $port1
     create_new_cnf $port1
 fi
 sleep 0.1
@@ -275,7 +282,7 @@ printf '%s\n\n' "------------- TEST CASE 1 SHOULD PASS ------------------------"
                          -p $port2 &
 wolf_pid2=$!
 wait_for_readyFile "$ready_file2" $wolf_pid2 $port2
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 \
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 \
                          -p $port2
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection failed" && exit 1
@@ -289,7 +296,7 @@ remove_single_rF "$ready_file2"
                          -p $port2 &
 wolf_pid2=$!
 wait_for_readyFile "$ready_file2" $wolf_pid2 $port2
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 \
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 \
                          -p $port2
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1

--- a/scripts/ocsp-stapling-with-wolfssl-responder.test
+++ b/scripts/ocsp-stapling-with-wolfssl-responder.test
@@ -349,14 +349,20 @@ fi
 
 get_first_free_port() {
     local ret="$1"
+    local scanned=0
     while :; do
         if [[ "$ret" -ge 65536 ]]; then
             ret=1024
         fi
-        if ! nc -z ${LOCALHOST_FOR_NC} "$ret"; then
+        if ! nc -w 1 -z ${LOCALHOST_FOR_NC} "$ret"; then
             break
         fi
         ret=$((ret+1))
+        scanned=$((scanned+1))
+        if [ "$scanned" -ge 100 ]; then
+            echo "ERROR: no free port found after scanning 100 ports" 1>&2
+            exit 1
+        fi
     done
     echo "$ret"
     return 0
@@ -408,10 +414,10 @@ printf '%s\n' "OCSP responder ports: $port1 $port2 $port3 $port4"
 printf '%s\n' "TLS server port: $port5"
 printf '%s\n' "-----------------------------------"
 # Use client connections to cleanly shutdown the servers
-./examples/client/client -p $port1
-./examples/client/client -p $port2
-./examples/client/client -p $port3
-./examples/client/client -p $port4
+timeout -s KILL 2m ./examples/client/client -p $port1
+timeout -s KILL 2m ./examples/client/client -p $port2
+timeout -s KILL 2m ./examples/client/client -p $port3
+timeout -s KILL 2m ./examples/client/client -p $port4
 create_new_cnf $port1 $port2 $port3 $port4
 
 # Start wolfSSL OCSP responders (CA signs responses directly)
@@ -467,7 +473,7 @@ if [ "$stapling_v1" == "yes" ]; then
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p $port5
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p $port5
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
     printf '%s\n\n' "Test PASSED!"
@@ -481,7 +487,7 @@ if [ "$stapling_v1" == "yes" ]; then
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
     sleep 0.1
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p $port5
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection 2 succeeded $RESULT" \
                       && exit 1
@@ -498,7 +504,7 @@ if [ "$stapling_v1" == "yes" ]; then
                                  -R $ready_file5 -p $port5 &
         server_pid5=$!
         wait_for_readyFile $ready_file5 $server_pid5 $port5
-        ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
+        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
                                  -p $port5
         RESULT=$?
         [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 3 failed" && exit 1
@@ -512,7 +518,7 @@ if [ "$stapling_v1" == "yes" ]; then
                                  -R $ready_file5 -p $port5 &
         server_pid5=$!
         wait_for_readyFile $ready_file5 $server_pid5 $port5
-        ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1m -v 4 -F 1 \
+        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1m -v 4 -F 1 \
                                  -p $port5
         RESULT=$?
         [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 4 failed" && exit 1
@@ -526,7 +532,7 @@ if [ "$stapling_v1" == "yes" ]; then
                                  -R $ready_file5 -p $port5 &
         server_pid5=$!
         wait_for_readyFile $ready_file5 $server_pid5 $port5
-        ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
+        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
                                  -p $port5
         RESULT=$?
         [ $RESULT -ne 1 ] && \
@@ -545,7 +551,7 @@ if [ "$stapling_v1" == "yes" ]; then
                                  -p $port5 &
         server_pid5=$!
         sleep 0.2
-        ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 3 \
+        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 3 \
                                  -W 1 -p $port5
         RESULT=$?
         [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client DTLS12 connection failed" && exit 1
@@ -561,7 +567,7 @@ if [ "$stapling_v1" == "yes" ]; then
                                  -p $port5 &
         server_pid5=$!
         sleep 0.2
-        ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 4 \
+        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 4 \
                                  -W 1 -p $port5
         RESULT=$?
         [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client DTLS13 connection failed" && exit 1
@@ -587,7 +593,7 @@ if [ "$stapling_v2" == "yes" ]; then
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection V2-1 failed" && exit 1
@@ -600,7 +606,7 @@ if [ "$stapling_v2" == "yes" ]; then
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection V2-2 failed" && exit 1
@@ -614,7 +620,7 @@ if [ "$stapling_v2" == "yes" ]; then
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection V2-3 succeeded $RESULT" && exit 1
@@ -627,7 +633,7 @@ if [ "$stapling_v2" == "yes" ]; then
                              -k certs/ocsp/server4-key.pem -R $ready_file5 \
                              -p $port5 &
     sleep 0.1
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection V2-4 succeeded $RESULT" && exit 1
@@ -642,7 +648,7 @@ if [ "$stapling_v2" == "yes" ]; then
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection V2-5 failed $RESULT" && exit 1
@@ -655,7 +661,7 @@ if [ "$stapling_v2" == "yes" ]; then
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection V2-6 succeeded $RESULT" && exit 1
@@ -671,7 +677,7 @@ if [ "$stapling_v2" == "yes" ]; then
                                      -p $port5 -u -v 3 &
             server_pid5=$!
             sleep 0.2
-            ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -u -v 3 \
+            timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -u -v 3 \
                                      -p $port5
             RESULT=$?
             [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client DTLS12 v2 connection failed" && exit 1
@@ -697,7 +703,7 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
                              -p $port5 -v 4 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection T13-1 failed" && exit 1
@@ -711,7 +717,7 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
                              -p $port5 -v 4 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection T13-2 succeeded $RESULT" && exit 1
@@ -726,7 +732,7 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
                              -p $port5 -v 4 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection T13-3 succeeded $RESULT" && exit 1
@@ -742,7 +748,7 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
                                  -p $port5 -u -v 4 &
         server_pid5=$!
         sleep 0.2
-        ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -u -v 4 \
+        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -u -v 4 \
                                  -p $port5
         RESULT=$?
         [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client DTLS13 connection failed" && exit 1
@@ -755,7 +761,7 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
                                  -p $port5 -v 4 &
         server_pid5=$!
         sleep 0.2
-        ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                                  -p $port5
         RESULT=$?
         [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client DTLS13 connection succeeded $RESULT" && exit 1

--- a/scripts/ocsp-stapling-with-wolfssl-responder.test
+++ b/scripts/ocsp-stapling-with-wolfssl-responder.test
@@ -2,8 +2,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 
@@ -361,7 +366,9 @@ get_first_free_port() {
         scanned=$((scanned+1))
         if [ "$scanned" -ge 100 ]; then
             echo "ERROR: no free port found after scanning 100 ports" 1>&2
-            exit 1
+            # return, not exit: every caller runs this in a command
+            # substitution, where exit would only end the subshell.
+            return 1
         fi
     done
     echo "$ret"
@@ -369,11 +376,11 @@ get_first_free_port() {
 }
 
 base_port=$((((($$ + $RETRIES_REMAINING) * 5) % (65536 - 2048)) + 1024))
-port1=$(get_first_free_port $base_port)        # OCSP responder: intermediate1-ca
-port2=$(get_first_free_port $((port1 + 1)))    # OCSP responder: intermediate2-ca
-port3=$(get_first_free_port $((port2 + 1)))    # OCSP responder: intermediate3-ca
-port4=$(get_first_free_port $((port3 + 1)))    # OCSP responder: root-ca
-port5=$(get_first_free_port $((port4 + 1)))    # TLS server
+port1=$(get_first_free_port $base_port) || exit 1        # OCSP responder: intermediate1-ca
+port2=$(get_first_free_port $((port1 + 1))) || exit 1    # OCSP responder: intermediate2-ca
+port3=$(get_first_free_port $((port2 + 1))) || exit 1    # OCSP responder: intermediate3-ca
+port4=$(get_first_free_port $((port3 + 1))) || exit 1    # OCSP responder: root-ca
+port5=$(get_first_free_port $((port4 + 1))) || exit 1    # TLS server
 
 # Verify ports by starting and stopping dummy servers
 # 1:
@@ -414,10 +421,10 @@ printf '%s\n' "OCSP responder ports: $port1 $port2 $port3 $port4"
 printf '%s\n' "TLS server port: $port5"
 printf '%s\n' "-----------------------------------"
 # Use client connections to cleanly shutdown the servers
-timeout -s KILL 2m ./examples/client/client -p $port1
-timeout -s KILL 2m ./examples/client/client -p $port2
-timeout -s KILL 2m ./examples/client/client -p $port3
-timeout -s KILL 2m ./examples/client/client -p $port4
+$TIMEOUT_KILL_2M ./examples/client/client -p $port1
+$TIMEOUT_KILL_2M ./examples/client/client -p $port2
+$TIMEOUT_KILL_2M ./examples/client/client -p $port3
+$TIMEOUT_KILL_2M ./examples/client/client -p $port4
 create_new_cnf $port1 $port2 $port3 $port4
 
 # Start wolfSSL OCSP responders (CA signs responses directly)
@@ -468,12 +475,12 @@ if [ "$stapling_v1" == "yes" ]; then
 
     printf '%s\n\n' "------------- TEST CASE 1 SHOULD PASS -------------------------"
     # client test against our own server - GOOD CERT
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server1-cert.pem \
                              -k certs/ocsp/server1-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p $port5
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p $port5
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
     printf '%s\n\n' "Test PASSED!"
@@ -481,13 +488,13 @@ if [ "$stapling_v1" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE 2 SHOULD REVOKE -----------------------"
     # client test against our own server - REVOKED CERT
     remove_single_rF $ready_file5
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server2-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server2-cert.pem \
                              -k certs/ocsp/server2-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
     sleep 0.1
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p $port5
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection 2 succeeded $RESULT" \
                       && exit 1
@@ -499,12 +506,12 @@ if [ "$stapling_v1" == "yes" ]; then
         printf '%s\n\n' "------------- TEST CASE 3 TLS13 SHOULD PASS -----------------"
         # client test against our own server - GOOD CERT
         remove_single_rF $ready_file5
-        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem \
+        $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server1-cert.pem \
                                  -k certs/ocsp/server1-key.pem -v 4 \
                                  -R $ready_file5 -p $port5 &
         server_pid5=$!
         wait_for_readyFile $ready_file5 $server_pid5 $port5
-        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
+        $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
                                  -p $port5
         RESULT=$?
         [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 3 failed" && exit 1
@@ -513,12 +520,12 @@ if [ "$stapling_v1" == "yes" ]; then
         printf '%s\n\n' "------------- TEST CASE 4 TLS13 MUST-STAPLE SHOULD PASS -----"
         # client test against our own server, must staple - GOOD CERT
         remove_single_rF $ready_file5
-        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem \
+        $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server1-cert.pem \
                                  -k certs/ocsp/server1-key.pem -v 4 \
                                  -R $ready_file5 -p $port5 &
         server_pid5=$!
         wait_for_readyFile $ready_file5 $server_pid5 $port5
-        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1m -v 4 -F 1 \
+        $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1m -v 4 -F 1 \
                                  -p $port5
         RESULT=$?
         [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 4 failed" && exit 1
@@ -527,12 +534,12 @@ if [ "$stapling_v1" == "yes" ]; then
         printf '%s\n\n' "------------- TEST CASE 5 TLS13 SHOULD REVOKE ---------------"
         # client test against our own server - REVOKED CERT
         remove_single_rF $ready_file5
-        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server2-cert.pem \
+        $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server2-cert.pem \
                                  -k certs/ocsp/server2-key.pem -v 4 \
                                  -R $ready_file5 -p $port5 &
         server_pid5=$!
         wait_for_readyFile $ready_file5 $server_pid5 $port5
-        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
+        $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
                                  -p $port5
         RESULT=$?
         [ $RESULT -ne 1 ] && \
@@ -546,12 +553,12 @@ if [ "$stapling_v1" == "yes" ]; then
     if [[ "$dtls12" == "yes" ]]; then
         printf '%s\n\n' "------------- TEST CASE DTLS12-1 SHOULD PASS ----------------"
         remove_single_rF $ready_file5
-        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem -R $ready_file5 \
+        $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server1-cert.pem -R $ready_file5 \
                                  -k certs/ocsp/server1-key.pem -u -v 3 \
                                  -p $port5 &
         server_pid5=$!
         sleep 0.2
-        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 3 \
+        $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 3 \
                                  -W 1 -p $port5
         RESULT=$?
         [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client DTLS12 connection failed" && exit 1
@@ -562,12 +569,12 @@ if [ "$stapling_v1" == "yes" ]; then
     if [ "$dtls13" == "yes" ]; then
         printf '%s\n\n' "------------- TEST CASE DTLS13-1 SHOULD PASS ----------------"
         remove_single_rF $ready_file5
-        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem -R $ready_file5 \
+        $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server1-cert.pem -R $ready_file5 \
                                  -k certs/ocsp/server1-key.pem -u -v 4 \
                                  -p $port5 &
         server_pid5=$!
         sleep 0.2
-        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 4 \
+        $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 4 \
                                  -W 1 -p $port5
         RESULT=$?
         [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client DTLS13 connection failed" && exit 1
@@ -588,12 +595,12 @@ if [ "$stapling_v2" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE V2-1 SHOULD PASS ----------------------"
     # client test against our own server - GOOD CERTS
     remove_single_rF $ready_file5
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server3-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server3-cert.pem \
                              -k certs/ocsp/server3-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection V2-1 failed" && exit 1
@@ -601,12 +608,12 @@ if [ "$stapling_v2" == "yes" ]; then
 
     printf '%s\n\n' "------------- TEST CASE V2-2 SHOULD PASS ----------------------"
     remove_single_rF $ready_file5
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server3-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server3-cert.pem \
                              -k certs/ocsp/server3-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection V2-2 failed" && exit 1
@@ -615,12 +622,12 @@ if [ "$stapling_v2" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE V2-3 SHOULD REVOKE --------------------"
     # client test against our own server - REVOKED SERVER CERT
     remove_single_rF $ready_file5
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server4-cert.pem \
                              -k certs/ocsp/server4-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection V2-3 succeeded $RESULT" && exit 1
@@ -629,11 +636,11 @@ if [ "$stapling_v2" == "yes" ]; then
 
     printf '%s\n\n' "------------- TEST CASE V2-4 SHOULD REVOKE --------------------"
     remove_single_rF $ready_file5
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server4-cert.pem \
                              -k certs/ocsp/server4-key.pem -R $ready_file5 \
                              -p $port5 &
     sleep 0.1
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection V2-4 succeeded $RESULT" && exit 1
@@ -643,12 +650,12 @@ if [ "$stapling_v2" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE V2-5 SHOULD PASS ----------------------"
     # client test against our own server - REVOKED INTERMEDIATE CERT
     remove_single_rF $ready_file5
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server5-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server5-cert.pem \
                              -k certs/ocsp/server5-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection V2-5 failed $RESULT" && exit 1
@@ -656,12 +663,12 @@ if [ "$stapling_v2" == "yes" ]; then
 
     printf '%s\n\n' "------------- TEST CASE V2-6 SHOULD REVOKE --------------------"
     remove_single_rF $ready_file5
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server5-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server5-cert.pem \
                              -k certs/ocsp/server5-key.pem -R $ready_file5 \
                              -p $port5 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection V2-6 succeeded $RESULT" && exit 1
@@ -672,12 +679,12 @@ if [ "$stapling_v2" == "yes" ]; then
         if [[ "$dtls12" == "yes" ]]; then
             printf '%s\n\n' "------------- TEST CASE DTLS12-V2 SHOULD PASS ----------------"
             remove_single_rF $ready_file5
-            timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server3-cert.pem \
+            $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server3-cert.pem \
                                      -k certs/ocsp/server3-key.pem -R $ready_file5 \
                                      -p $port5 -u -v 3 &
             server_pid5=$!
             sleep 0.2
-            timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -u -v 3 \
+            $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -u -v 3 \
                                      -p $port5
             RESULT=$?
             [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client DTLS12 v2 connection failed" && exit 1
@@ -698,12 +705,12 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE T13-1 SHOULD PASS --------------------"
     # client test against our own server - GOOD CERTS
     remove_single_rF $ready_file5
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server3-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server3-cert.pem \
                              -k certs/ocsp/server3-key.pem -R $ready_file5 \
                              -p $port5 -v 4 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection T13-1 failed" && exit 1
@@ -712,12 +719,12 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE T13-2 SHOULD REVOKE ------------------"
     # client test against our own server - REVOKED SERVER CERT
     remove_single_rF $ready_file5
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server4-cert.pem \
                              -k certs/ocsp/server4-key.pem -R $ready_file5 \
                              -p $port5 -v 4 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection T13-2 succeeded $RESULT" && exit 1
@@ -727,12 +734,12 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
     printf '%s\n\n' "------------- TEST CASE T13-3 SHOULD REVOKE ------------------"
     # client test against our own server - REVOKED INTERMEDIATE CERT
     remove_single_rF $ready_file5
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server5-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server5-cert.pem \
                              -k certs/ocsp/server5-key.pem -R $ready_file5 \
                              -p $port5 -v 4 &
     server_pid5=$!
     wait_for_readyFile $ready_file5 $server_pid5 $port5
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                              -p $port5
     RESULT=$?
     [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection T13-3 succeeded $RESULT" && exit 1
@@ -743,12 +750,12 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
     if [ "$dtls13" == "yes" ]; then
         printf '%s\n\n' "------------- TEST CASE DTLS13-V2 SHOULD PASS ----------------"
         remove_single_rF $ready_file5
-        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server3-cert.pem \
+        $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server3-cert.pem \
                                  -k certs/ocsp/server3-key.pem -R $ready_file5 \
                                  -p $port5 -u -v 4 &
         server_pid5=$!
         sleep 0.2
-        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -u -v 4 \
+        $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -u -v 4 \
                                  -p $port5
         RESULT=$?
         [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client DTLS13 connection failed" && exit 1
@@ -756,12 +763,12 @@ if [ "$tls13" == "yes" ] && [ "$stapling_v1" == "yes" ]; then
 
         printf '%s\n\n' "------------- TEST CASE DTLS13-V2-REVOKE SHOULD REVOKE -------"
         remove_single_rF $ready_file5
-        timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
+        $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server4-cert.pem \
                                  -k certs/ocsp/server4-key.pem -R $ready_file5 \
                                  -p $port5 -v 4 &
         server_pid5=$!
         sleep 0.2
-        timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+        $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                                  -p $port5
         RESULT=$?
         [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client DTLS13 connection succeeded $RESULT" && exit 1

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -275,14 +275,20 @@ fi
 
 get_first_free_port() {
     local ret="$1"
+    local scanned=0
     while :; do
         if [[ "$ret" -ge 65536 ]]; then
             ret=1024
         fi
-        if ! nc -z $V4V6_FLAG $LOCALHOST_FOR_NC "$ret"; then
+        if ! nc -w 1 -z $V4V6_FLAG $LOCALHOST_FOR_NC "$ret"; then
             break
         fi
         ret=$((ret+1))
+        scanned=$((scanned+1))
+        if [ "$scanned" -ge 100 ]; then
+            echo "ERROR: no free port found after scanning 100 ports" 1>&2
+            exit 1
+        fi
     done
     echo "$ret"
     return 0
@@ -335,7 +341,7 @@ if [ ! -f "$ready_file" ]; then
 else
     printf '%s\n' "Random port selected: $port2"
     # Use client connection to shutdown the server cleanly
-    ./examples/client/client -p "$port2"
+    timeout -s KILL 2m ./examples/client/client -p "$port2"
     create_new_cnf "$port2"
 fi
 sleep 0.1
@@ -351,7 +357,7 @@ ca=./certs/external/ca_collection.pem
 if [[ -z "${WOLFSSL_EXTERNAL_TEST-}" || "$WOLFSSL_EXTERNAL_TEST" == "0" ]]; then
     echo "Skipping OCSP test on $server (set WOLFSSL_EXTERNAL_TEST=1 to run)"
 elif [[ "$V4V6" == "4" ]]; then
-    retry_with_backoff 3 ./examples/client/client -C -h "$server" -p 443 -A "$ca" -g -W 1
+    retry_with_backoff 3 timeout -s KILL 2m ./examples/client/client -C -h "$server" -p 443 -A "$ca" -g -W 1
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 else
@@ -386,7 +392,7 @@ printf '%s\n\n' "------------- TEST CASE 1 SHOULD PASS ------------------------"
                          -k certs/ocsp/server1-key.pem -p "$port3" &
 wolf_pid3=$!
 wait_for_readyFile "$ready_file2" "$wolf_pid3" "$port3"
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p "$port3"
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p "$port3"
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
 printf '%s\n\n' "Test PASSED!"
@@ -399,7 +405,7 @@ remove_single_rF "$ready_file2"
 wolf_pid3=$!
 wait_for_readyFile "$ready_file2" "$wolf_pid3" "$port3"
 sleep 0.1
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p "$port3"
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p "$port3"
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection 2 succeeded $RESULT" \
                   && exit 1
@@ -415,7 +421,7 @@ printf '%s\n\n' "Test successfully REVOKED!"
                              -p "$port3" &
     wolf_pid3=$!
     wait_for_readyFile "$ready_file2" "$wolf_pid3" "$port3"
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
                              -p "$port3"
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 3 failed" && exit 1
@@ -429,7 +435,7 @@ printf '%s\n\n' "Test successfully REVOKED!"
                              -p "$port3" &
     wolf_pid3=$!
     wait_for_readyFile "$ready_file2" "$wolf_pid3" "$port3"
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1m -v 4 -F 1 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1m -v 4 -F 1 \
                              -p "$port3"
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 4 failed" && exit 1
@@ -443,7 +449,7 @@ printf '%s\n\n' "Test successfully REVOKED!"
                              -p "$port3" &
     wolf_pid3=$!
     wait_for_readyFile "$ready_file2" "$wolf_pid3" "$port3"
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
                              -p "$port3"
     RESULT=$?
     [ $RESULT -ne 1 ] && \
@@ -465,7 +471,7 @@ if ./examples/client/client -? 2>&1 | grep -q 'DTLSv1.2'; then
   wolf_pid3=$!
 
   sleep 0.2
-  ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 3 \
+  timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 3 \
                            -W 1 -p "$port3"
   RESULT=$?
   [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 5 failed" && exit 1
@@ -480,7 +486,7 @@ fi
                           -p "$port3" &
   wolf_pid3=$!
   sleep 0.2
-  ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 4 \
+  timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 4 \
                            -W 1 -p "$port3"
   RESULT=$?
   [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 5 failed" && exit 1
@@ -545,7 +551,7 @@ generate_port() {
 generate_port
 openssl s_server $V4V6_FLAG -cert ./certs/server-cert.pem -key certs/server-key.pem -www -port "$port" &
 MAX_TIMEOUT=10
-until nc -z localhost "$port" # Wait for openssl to be ready
+until nc -w 1 -z localhost "$port" # Wait for openssl to be ready
 do
     sleep 0.05
     if [ "$MAX_TIMEOUT" == "0" ]; then
@@ -556,7 +562,7 @@ done
 
 printf '%s\n\n' "------------- TEST CASE 6 SHOULD PASS ----------------------"
 # client asks for OCSP staple but doesn't fail when none returned
-./examples/client/client -p "$port" -g -v 3 -W 1
+timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 3 -W 1
 
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 6 failed" && exit 1
@@ -564,7 +570,7 @@ printf '%s\n\n' "Test PASSED!"
 
 printf '%s\n\n' "------------- TEST CASE 7 SHOULD UNKNOWN -------------------"
 # client asks for OCSP staple but doesn't fail when none returned
-./examples/client/client -p "$port" -g -v 3 -W 1m
+timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 3 -W 1m
 
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection 7 succeeded $RESULT" \
@@ -578,7 +584,7 @@ wolfssl_tls13=$?
 if [ "$openssl_tls13" = "0" ] && [ "$wolfssl_tls13" = "0" ]; then
     printf '%s\n\n' "------------- TEST CASE 8 SHOULD PASS --------------------"
     # client asks for OCSP staple but doesn't fail when none returned
-    ./examples/client/client -p "$port" -g -v 4 -W 1
+    timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 4 -W 1
 
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 8 failed" && exit 1
@@ -586,7 +592,7 @@ if [ "$openssl_tls13" = "0" ] && [ "$wolfssl_tls13" = "0" ]; then
 
     printf '%s\n\n' "------------- TEST CASE 9 SHOULD UNKNOWN -----------------"
     # client asks for OCSP staple but doesn't fail when none returned
-    ./examples/client/client -p "$port" -g -v 4 -W 1m
+    timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 4 -W 1m
 
     RESULT=$?
     [ $RESULT -ne 1 ] \

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -2,8 +2,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 
@@ -287,7 +292,9 @@ get_first_free_port() {
         scanned=$((scanned+1))
         if [ "$scanned" -ge 100 ]; then
             echo "ERROR: no free port found after scanning 100 ports" 1>&2
-            exit 1
+            # return, not exit: every caller runs this in a command
+            # substitution, where exit would only end the subshell.
+            return 1
         fi
     done
     echo "$ret"
@@ -295,15 +302,15 @@ get_first_free_port() {
 }
 
 base_port=$((((($$ + RETRIES_REMAINING) * 5) % (65536 - 2048)) + 1024))
-port1=$(get_first_free_port $base_port)
-port2=$(get_first_free_port $((port1 + 1)))
-port3=$(get_first_free_port $((port2 + 1)))
+port1=$(get_first_free_port $base_port) || exit 1
+port2=$(get_first_free_port $((port1 + 1))) || exit 1
+port3=$(get_first_free_port $((port2 + 1))) || exit 1
 
 
 # test interop fail case
 ready_file=$PWD/wolf_ocsp_readyF$$
 printf '%s\n' "ready file:  \"$ready_file\""
-timeout -s KILL 2m ./examples/server/server -b -p "$port1" -o -R "$ready_file" &
+$TIMEOUT_KILL_2M ./examples/server/server -b -p "$port1" -o -R "$ready_file" &
 wolf_pid=$!
 wait_for_readyFile "$ready_file" "$wolf_pid" "$port1"
 if [ ! -f "$ready_file" ]; then
@@ -341,7 +348,7 @@ if [ ! -f "$ready_file" ]; then
 else
     printf '%s\n' "Random port selected: $port2"
     # Use client connection to shutdown the server cleanly
-    timeout -s KILL 2m ./examples/client/client -p "$port2"
+    $TIMEOUT_KILL_2M ./examples/client/client -p "$port2"
     create_new_cnf "$port2"
 fi
 sleep 0.1
@@ -357,7 +364,7 @@ ca=./certs/external/ca_collection.pem
 if [[ -z "${WOLFSSL_EXTERNAL_TEST-}" || "$WOLFSSL_EXTERNAL_TEST" == "0" ]]; then
     echo "Skipping OCSP test on $server (set WOLFSSL_EXTERNAL_TEST=1 to run)"
 elif [[ "$V4V6" == "4" ]]; then
-    retry_with_backoff 3 timeout -s KILL 2m ./examples/client/client -C -h "$server" -p 443 -A "$ca" -g -W 1
+    retry_with_backoff 3 $TIMEOUT_KILL_2M ./examples/client/client -C -h "$server" -p 443 -A "$ca" -g -W 1
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 else
@@ -392,7 +399,7 @@ printf '%s\n\n' "------------- TEST CASE 1 SHOULD PASS ------------------------"
                          -k certs/ocsp/server1-key.pem -p "$port3" &
 wolf_pid3=$!
 wait_for_readyFile "$ready_file2" "$wolf_pid3" "$port3"
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p "$port3"
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p "$port3"
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
 printf '%s\n\n' "Test PASSED!"
@@ -405,7 +412,7 @@ remove_single_rF "$ready_file2"
 wolf_pid3=$!
 wait_for_readyFile "$ready_file2" "$wolf_pid3" "$port3"
 sleep 0.1
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p "$port3"
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p "$port3"
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection 2 succeeded $RESULT" \
                   && exit 1
@@ -421,7 +428,7 @@ printf '%s\n\n' "Test successfully REVOKED!"
                              -p "$port3" &
     wolf_pid3=$!
     wait_for_readyFile "$ready_file2" "$wolf_pid3" "$port3"
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
                              -p "$port3"
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 3 failed" && exit 1
@@ -435,7 +442,7 @@ printf '%s\n\n' "Test successfully REVOKED!"
                              -p "$port3" &
     wolf_pid3=$!
     wait_for_readyFile "$ready_file2" "$wolf_pid3" "$port3"
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1m -v 4 -F 1 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1m -v 4 -F 1 \
                              -p "$port3"
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 4 failed" && exit 1
@@ -449,7 +456,7 @@ printf '%s\n\n' "Test successfully REVOKED!"
                              -p "$port3" &
     wolf_pid3=$!
     wait_for_readyFile "$ready_file2" "$wolf_pid3" "$port3"
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 -F 1 \
                              -p "$port3"
     RESULT=$?
     [ $RESULT -ne 1 ] && \
@@ -471,7 +478,7 @@ if ./examples/client/client -? 2>&1 | grep -q 'DTLSv1.2'; then
   wolf_pid3=$!
 
   sleep 0.2
-  timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 3 \
+  $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 3 \
                            -W 1 -p "$port3"
   RESULT=$?
   [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 5 failed" && exit 1
@@ -486,7 +493,7 @@ fi
                           -p "$port3" &
   wolf_pid3=$!
   sleep 0.2
-  timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 4 \
+  $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -u -v 4 \
                            -W 1 -p "$port3"
   RESULT=$?
   [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 5 failed" && exit 1
@@ -562,7 +569,7 @@ done
 
 printf '%s\n\n' "------------- TEST CASE 6 SHOULD PASS ----------------------"
 # client asks for OCSP staple but doesn't fail when none returned
-timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 3 -W 1
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port" -g -v 3 -W 1
 
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 6 failed" && exit 1
@@ -570,7 +577,7 @@ printf '%s\n\n' "Test PASSED!"
 
 printf '%s\n\n' "------------- TEST CASE 7 SHOULD UNKNOWN -------------------"
 # client asks for OCSP staple but doesn't fail when none returned
-timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 3 -W 1m
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port" -g -v 3 -W 1m
 
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection 7 succeeded $RESULT" \
@@ -584,7 +591,7 @@ wolfssl_tls13=$?
 if [ "$openssl_tls13" = "0" ] && [ "$wolfssl_tls13" = "0" ]; then
     printf '%s\n\n' "------------- TEST CASE 8 SHOULD PASS --------------------"
     # client asks for OCSP staple but doesn't fail when none returned
-    timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 4 -W 1
+    $TIMEOUT_KILL_2M ./examples/client/client -p "$port" -g -v 4 -W 1
 
     RESULT=$?
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 8 failed" && exit 1
@@ -592,7 +599,7 @@ if [ "$openssl_tls13" = "0" ] && [ "$wolfssl_tls13" = "0" ]; then
 
     printf '%s\n\n' "------------- TEST CASE 9 SHOULD UNKNOWN -----------------"
     # client asks for OCSP staple but doesn't fail when none returned
-    timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 4 -W 1m
+    $TIMEOUT_KILL_2M ./examples/client/client -p "$port" -g -v 4 -W 1m
 
     RESULT=$?
     [ $RESULT -ne 1 ] \

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -258,14 +258,20 @@ fi
 
 get_first_free_port() {
     local ret="$1"
+    local scanned=0
     while :; do
         if [[ "$ret" -ge 65536 ]]; then
             ret=1024
         fi
-        if ! nc -z ${LOCALHOST_FOR_NC} "$ret"; then
+        if ! nc -w 1 -z ${LOCALHOST_FOR_NC} "$ret"; then
             break
         fi
         ret=$((ret+1))
+        scanned=$((scanned+1))
+        if [ "$scanned" -ge 100 ]; then
+            echo "ERROR: no free port found after scanning 100 ports" 1>&2
+            exit 1
+        fi
     done
     echo "$ret"
     return 0
@@ -316,10 +322,10 @@ printf '%s' "Random ports selected: $port1 $port2"
 printf '%s\n' " $port3 $port4"
 printf '%s\n' "-----------------------------------"
 # Use client connections to cleanly shutdown the servers
-./examples/client/client -p "$port1"
-./examples/client/client -p "$port2"
-./examples/client/client -p "$port3"
-./examples/client/client -p "$port4"
+timeout -s KILL 2m ./examples/client/client -p "$port1"
+timeout -s KILL 2m ./examples/client/client -p "$port2"
+timeout -s KILL 2m ./examples/client/client -p "$port3"
+timeout -s KILL 2m ./examples/client/client -p "$port4"
 create_new_cnf "$port1" "$port2" "$port3" \
                "$port4"
 
@@ -381,7 +387,7 @@ printf '%s\n\n' "------------- TEST CASE 1 SHOULD PASS ------------------------"
                          -p "$port5" &
 server_pid5=$!
 wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
@@ -394,7 +400,7 @@ remove_single_rF "$ready_file5"
                          -p "$port5" &
 server_pid5=$!
 wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 2 failed" && exit 1
@@ -408,7 +414,7 @@ remove_single_rF "$ready_file5"
                          -p "$port5" &
 server_pid5=$!
 wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -420,7 +426,7 @@ remove_single_rF "$ready_file5"
                          -k certs/ocsp/server4-key.pem -R "$ready_file5" \
                          -p "$port5" &
 sleep 0.1
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -434,7 +440,7 @@ remove_single_rF "$ready_file5"
                          -p "$port5" &
 server_pid5=$!
 wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 3 failed $RESULT" && exit 1
@@ -447,7 +453,7 @@ remove_single_rF "$ready_file5"
                          -p "$port5" &
 server_pid5=$!
 wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -474,7 +480,7 @@ timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
                          -p "$port5" -H loadSSL &
 server_pid5=$!
 sleep 0.1
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -554,7 +560,7 @@ done
 
 printf '%s\n\n' "------------- TEST CASE 9 SHOULD PASS ----------------------"
 # client asks for OCSP staple but doesn't fail when none returned
-./examples/client/client -p "$port" -g -v 3 -W 2
+timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 3 -W 2
 
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 9 failed" && exit 1
@@ -562,7 +568,7 @@ printf '%s\n\n' "Test PASSED!"
 
 printf '%s\n\n' "------------- TEST CASE 10 SHOULD UNKNOWN -------------------"
 # client asks for OCSP staple but doesn't fail when none returned
-./examples/client/client -p "$port" -g -v 3 -W 2m
+timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 3 -W 2m
 
 RESULT=$?
 [ $RESULT -ne 1 ] \
@@ -579,7 +585,7 @@ printf '%s\n\n' "------------- TEST CASE DTLS-1 SHOULD PASS -------------------"
                          -p "$port5" -u -v 3 &
 server_pid5=$!
 sleep 0.2
-./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -u -v 3 \
+timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -u -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -2,8 +2,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 
@@ -270,7 +275,9 @@ get_first_free_port() {
         scanned=$((scanned+1))
         if [ "$scanned" -ge 100 ]; then
             echo "ERROR: no free port found after scanning 100 ports" 1>&2
-            exit 1
+            # return, not exit: every caller runs this in a command
+            # substitution, where exit would only end the subshell.
+            return 1
         fi
     done
     echo "$ret"
@@ -278,11 +285,11 @@ get_first_free_port() {
 }
 
 base_port=$((((($$ + RETRIES_REMAINING) * 5) % (65536 - 2048)) + 1024))
-port1=$(get_first_free_port "$base_port")
-port2=$(get_first_free_port $((port1 + 1)))
-port3=$(get_first_free_port $((port2 + 1)))
-port4=$(get_first_free_port $((port3 + 1)))
-port5=$(get_first_free_port $((port4 + 1)))
+port1=$(get_first_free_port "$base_port") || exit 1
+port2=$(get_first_free_port $((port1 + 1))) || exit 1
+port3=$(get_first_free_port $((port2 + 1))) || exit 1
+port4=$(get_first_free_port $((port3 + 1))) || exit 1
+port5=$(get_first_free_port $((port4 + 1))) || exit 1
 
 # 1:
 ./examples/server/server -R "$ready_file1" -p "$port1" &
@@ -322,10 +329,10 @@ printf '%s' "Random ports selected: $port1 $port2"
 printf '%s\n' " $port3 $port4"
 printf '%s\n' "-----------------------------------"
 # Use client connections to cleanly shutdown the servers
-timeout -s KILL 2m ./examples/client/client -p "$port1"
-timeout -s KILL 2m ./examples/client/client -p "$port2"
-timeout -s KILL 2m ./examples/client/client -p "$port3"
-timeout -s KILL 2m ./examples/client/client -p "$port4"
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port1"
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port2"
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port3"
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port4"
 create_new_cnf "$port1" "$port2" "$port3" \
                "$port4"
 
@@ -387,7 +394,7 @@ printf '%s\n\n' "------------- TEST CASE 1 SHOULD PASS ------------------------"
                          -p "$port5" &
 server_pid5=$!
 wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
@@ -400,7 +407,7 @@ remove_single_rF "$ready_file5"
                          -p "$port5" &
 server_pid5=$!
 wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 2 failed" && exit 1
@@ -414,7 +421,7 @@ remove_single_rF "$ready_file5"
                          -p "$port5" &
 server_pid5=$!
 wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -426,7 +433,7 @@ remove_single_rF "$ready_file5"
                          -k certs/ocsp/server4-key.pem -R "$ready_file5" \
                          -p "$port5" &
 sleep 0.1
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -440,7 +447,7 @@ remove_single_rF "$ready_file5"
                          -p "$port5" &
 server_pid5=$!
 wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 3 failed $RESULT" && exit 1
@@ -453,14 +460,14 @@ remove_single_rF "$ready_file5"
                          -p "$port5" &
 server_pid5=$!
 wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
 printf '%s\n\n' "Test successfully REVOKED!"
 printf '%s\n\n' "------------- TEST CASE 7 LOAD CERT IN SSL -------------------"
 remove_single_rF "$ready_file5"
-timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem \
+$TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server1-cert.pem \
                          -k certs/ocsp/server1-key.pem -R "$ready_file5" \
                          -p "$port5" -H loadSSL &
 server_pid5=$!
@@ -475,12 +482,12 @@ fi
 printf '%s\n\n' "Test successful"
 printf '%s\n\n' "------------- TEST CASE 8 SHOULD REVOKE ----------------------"
 remove_single_rF "$ready_file5"
-timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
+$TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server4-cert.pem \
                          -k certs/ocsp/server4-key.pem -R "$ready_file5" \
                          -p "$port5" -H loadSSL &
 server_pid5=$!
 sleep 0.1
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -560,7 +567,7 @@ done
 
 printf '%s\n\n' "------------- TEST CASE 9 SHOULD PASS ----------------------"
 # client asks for OCSP staple but doesn't fail when none returned
-timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 3 -W 2
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port" -g -v 3 -W 2
 
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 9 failed" && exit 1
@@ -568,7 +575,7 @@ printf '%s\n\n' "Test PASSED!"
 
 printf '%s\n\n' "------------- TEST CASE 10 SHOULD UNKNOWN -------------------"
 # client asks for OCSP staple but doesn't fail when none returned
-timeout -s KILL 2m ./examples/client/client -p "$port" -g -v 3 -W 2m
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port" -g -v 3 -W 2m
 
 RESULT=$?
 [ $RESULT -ne 1 ] \
@@ -585,7 +592,7 @@ printf '%s\n\n' "------------- TEST CASE DTLS-1 SHOULD PASS -------------------"
                          -p "$port5" -u -v 3 &
 server_pid5=$!
 sleep 0.2
-timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -u -v 3 \
+$TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2 -u -v 3 \
                          -p "$port5"
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1

--- a/scripts/ocsp-stapling_tls13multi.test
+++ b/scripts/ocsp-stapling_tls13multi.test
@@ -276,14 +276,20 @@ fi
 
 get_first_free_port() {
     local ret="$1"
+    local scanned=0
     while :; do
         if [[ "$ret" -ge 65536 ]]; then
             ret=1024
         fi
-        if ! nc -z ${LOCALHOST_FOR_NC} "$ret"; then
+        if ! nc -w 1 -z ${LOCALHOST_FOR_NC} "$ret"; then
             break
         fi
         ret=$((ret+1))
+        scanned=$((scanned+1))
+        if [ "$scanned" -ge 100 ]; then
+            echo "ERROR: no free port found after scanning 100 ports" 1>&2
+            exit 1
+        fi
     done
     echo "$ret"
     return 0
@@ -334,10 +340,10 @@ printf '%s' "Random ports selected: $port1 $port2"
 printf '%s\n' " $port3 $port4 $port5"
 printf '%s\n' "-----------------------------------"
 # Use client connections to cleanly shutdown the servers
-./examples/client/client -p "$port1"
-./examples/client/client -p "$port2"
-./examples/client/client -p "$port3"
-./examples/client/client -p "$port4"
+timeout -s KILL 2m ./examples/client/client -p "$port1"
+timeout -s KILL 2m ./examples/client/client -p "$port2"
+timeout -s KILL 2m ./examples/client/client -p "$port3"
+timeout -s KILL 2m ./examples/client/client -p "$port4"
 create_new_cnf "$port1" "$port2" "$port3" \
                "$port4"
 
@@ -401,7 +407,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
@@ -415,7 +421,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -427,7 +433,7 @@ if [ "$tls13" == "yes" ]; then
                             -k certs/ocsp/server4-key.pem -R "$ready_file5" \
                             -p "$port5" &
     sleep 0.1
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -441,7 +447,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -454,7 +460,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -482,7 +488,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -H loadSSL -v 4 &
     server_pid5=$!
     sleep 0.1
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -502,7 +508,7 @@ if [ "$dtls13" == "yes" ]; then
                             -p "$port5" -u -v 4 &
     server_pid5=$!
     sleep 0.2
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -u -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -u -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
@@ -516,7 +522,7 @@ if [ "$dtls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     sleep 0.2
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1

--- a/scripts/ocsp-stapling_tls13multi.test
+++ b/scripts/ocsp-stapling_tls13multi.test
@@ -2,8 +2,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 
@@ -300,7 +305,9 @@ get_first_free_port() {
         scanned=$((scanned+1))
         if [ "$scanned" -ge 100 ]; then
             echo "ERROR: no free port found after scanning 100 ports" 1>&2
-            exit 1
+            # return, not exit: every caller runs this in a command
+            # substitution, where exit would only end the subshell.
+            return 1
         fi
     done
     echo "$ret"
@@ -308,11 +315,11 @@ get_first_free_port() {
 }
 
 base_port=$((((($$ + RETRIES_REMAINING) * 5) % (65536 - 2048)) + 1024))
-port1=$(get_first_free_port "$base_port")
-port2=$(get_first_free_port $((port1 + 1)))
-port3=$(get_first_free_port $((port2 + 1)))
-port4=$(get_first_free_port $((port3 + 1)))
-port5=$(get_first_free_port $((port4 + 1)))
+port1=$(get_first_free_port "$base_port") || exit 1
+port2=$(get_first_free_port $((port1 + 1))) || exit 1
+port3=$(get_first_free_port $((port2 + 1))) || exit 1
+port4=$(get_first_free_port $((port3 + 1))) || exit 1
+port5=$(get_first_free_port $((port4 + 1))) || exit 1
 
 # 1:
 ./examples/server/server -R "$ready_file1" -p "$port1" &
@@ -352,10 +359,10 @@ printf '%s' "Random ports selected: $port1 $port2"
 printf '%s\n' " $port3 $port4 $port5"
 printf '%s\n' "-----------------------------------"
 # Use client connections to cleanly shutdown the servers
-timeout -s KILL 2m ./examples/client/client -p "$port1"
-timeout -s KILL 2m ./examples/client/client -p "$port2"
-timeout -s KILL 2m ./examples/client/client -p "$port3"
-timeout -s KILL 2m ./examples/client/client -p "$port4"
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port1"
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port2"
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port3"
+$TIMEOUT_KILL_2M ./examples/client/client -p "$port4"
 create_new_cnf "$port1" "$port2" "$port3" \
                "$port4"
 
@@ -419,7 +426,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
@@ -433,7 +440,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -445,7 +452,7 @@ if [ "$tls13" == "yes" ]; then
                             -k certs/ocsp/server4-key.pem -R "$ready_file5" \
                             -p "$port5" &
     sleep 0.1
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -459,7 +466,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -472,7 +479,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -480,7 +487,7 @@ if [ "$tls13" == "yes" ]; then
 
     printf '%s\n\n' "------------- TEST CASE 6 LOAD CERT IN SSL -------------------"
     remove_single_rF "$ready_file5"
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server1-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server1-cert.pem \
                             -k certs/ocsp/server1-key.pem -R "$ready_file5" -v 4 \
                             -p "$port5" -H loadSSL &
     server_pid5=$!
@@ -495,12 +502,12 @@ if [ "$tls13" == "yes" ]; then
     printf '%s\n\n' "Test successful"
     printf '%s\n\n' "------------- TEST CASE 7 SHOULD REVOKE ----------------------"
     remove_single_rF "$ready_file5"
-    timeout -s KILL 2m ./examples/server/server -c certs/ocsp/server4-cert.pem \
+    $TIMEOUT_KILL_2M ./examples/server/server -c certs/ocsp/server4-cert.pem \
                             -k certs/ocsp/server4-key.pem -R "$ready_file5" \
                             -p "$port5" -H loadSSL -v 4 &
     server_pid5=$!
     sleep 0.1
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -541,7 +548,7 @@ if [ "$dtls13" == "yes" ]; then
                             -p "$port5" -u -v 4 &
     server_pid5=$!
     sleep 0.2
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -u -v 4 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -u -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
@@ -555,7 +562,7 @@ if [ "$dtls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     sleep 0.2
-    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    $TIMEOUT_KILL_2M ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1

--- a/scripts/ocsp-stapling_tls13multi.test
+++ b/scripts/ocsp-stapling_tls13multi.test
@@ -288,14 +288,20 @@ fi
 
 get_first_free_port() {
     local ret="$1"
+    local scanned=0
     while :; do
         if [[ "$ret" -ge 65536 ]]; then
             ret=1024
         fi
-        if ! nc -z ${LOCALHOST_FOR_NC} "$ret"; then
+        if ! nc -w 1 -z ${LOCALHOST_FOR_NC} "$ret"; then
             break
         fi
         ret=$((ret+1))
+        scanned=$((scanned+1))
+        if [ "$scanned" -ge 100 ]; then
+            echo "ERROR: no free port found after scanning 100 ports" 1>&2
+            exit 1
+        fi
     done
     echo "$ret"
     return 0
@@ -346,10 +352,10 @@ printf '%s' "Random ports selected: $port1 $port2"
 printf '%s\n' " $port3 $port4 $port5"
 printf '%s\n' "-----------------------------------"
 # Use client connections to cleanly shutdown the servers
-./examples/client/client -p "$port1"
-./examples/client/client -p "$port2"
-./examples/client/client -p "$port3"
-./examples/client/client -p "$port4"
+timeout -s KILL 2m ./examples/client/client -p "$port1"
+timeout -s KILL 2m ./examples/client/client -p "$port2"
+timeout -s KILL 2m ./examples/client/client -p "$port3"
+timeout -s KILL 2m ./examples/client/client -p "$port4"
 create_new_cnf "$port1" "$port2" "$port3" \
                "$port4"
 
@@ -413,7 +419,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
@@ -427,7 +433,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -439,7 +445,7 @@ if [ "$tls13" == "yes" ]; then
                             -k certs/ocsp/server4-key.pem -R "$ready_file5" \
                             -p "$port5" &
     sleep 0.1
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -453,7 +459,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -466,7 +472,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     wait_for_readyFile "$ready_file5" "$server_pid5" "$port5"
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -494,7 +500,7 @@ if [ "$tls13" == "yes" ]; then
                             -p "$port5" -H loadSSL -v 4 &
     server_pid5=$!
     sleep 0.1
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1
@@ -535,7 +541,7 @@ if [ "$dtls13" == "yes" ]; then
                             -p "$port5" -u -v 4 &
     server_pid5=$!
     sleep 0.2
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -u -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -u -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
@@ -549,7 +555,7 @@ if [ "$dtls13" == "yes" ]; then
                             -p "$port5" -v 4 &
     server_pid5=$!
     sleep 0.2
-    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
+    timeout -s KILL 2m ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -v 4 \
                             -p "$port5"
     RESULT=$?
     [ "$RESULT" -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" && exit 1

--- a/scripts/ocsp.test
+++ b/scripts/ocsp.test
@@ -2,6 +2,12 @@
 
 # ocsp.test
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 # Note, this script makes connection(s) to the public Internet.
 
 SCRIPT_DIR="$(dirname "$0")"
@@ -38,7 +44,7 @@ if [ "$OUTPUT" = "SNI is: ON" ]; then
     if [ $RESULT -eq 0 ]; then
         # client test against the server
         echo "./examples/client/client -X -C -h $server -p 443 -A \"$ca\" -g -o -N -v d -S $server"
-        ./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N -v d -S $server
+        timeout -s KILL 2m ./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N -v d -S $server
         GL_RESULT=$?
         [ $GL_RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection failed"
     else
@@ -63,7 +69,7 @@ fi
 if [ $RESULT -eq 0 ]; then
     # client test against the server
     echo "./examples/client/client -X -C -h $server -p 443 -A \"$ca\" -g -o -N"
-    ./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N
+    timeout -s KILL 2m ./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N
     GR_RESULT=$?
     [ $GR_RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection failed"
 else

--- a/scripts/ocsp.test
+++ b/scripts/ocsp.test
@@ -4,8 +4,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 # Note, this script makes connection(s) to the public Internet.
@@ -44,7 +49,7 @@ if [ "$OUTPUT" = "SNI is: ON" ]; then
     if [ $RESULT -eq 0 ]; then
         # client test against the server
         echo "./examples/client/client -X -C -h $server -p 443 -A \"$ca\" -g -o -N -v d -S $server"
-        timeout -s KILL 2m ./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N -v d -S $server
+        $TIMEOUT_KILL_2M ./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N -v d -S $server
         GL_RESULT=$?
         [ $GL_RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection failed"
     else
@@ -69,7 +74,7 @@ fi
 if [ $RESULT -eq 0 ]; then
     # client test against the server
     echo "./examples/client/client -X -C -h $server -p 443 -A \"$ca\" -g -o -N"
-    timeout -s KILL 2m ./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N
+    $TIMEOUT_KILL_2M ./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N
     GR_RESULT=$?
     [ $GR_RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection failed"
 else

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -2,6 +2,12 @@
 
 # openssl.test
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 # Environment variables used:
 # OPENSSL            (openssl app to use)
 # OPENSSL_ENGINE_ID  (engine id if any i.e. "wolfengine")
@@ -363,13 +369,13 @@ do_wolfssl_client() {
         echo "#"
         echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite -v $version $psk $adh \"$wolfssl_cert\" \"$wolfssl_key\" \"$wolfssl_caCert\" $crl"
         # shellcheck disable=SC2086
-        $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" -v "$version" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
+        timeout -s KILL 2m $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" -v "$version" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
     else
         echo "#"
         echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite $psk $adh \"$wolfssl_cert\" \"$wolfssl_key\" \"$wolfssl_caCert\" $crl"
         # do all versions
         # shellcheck disable=SC2086
-        $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
+        timeout -s KILL 2m $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
     fi
 
     client_result=$?
@@ -425,11 +431,11 @@ do_openssl_client() {
     then
         echo "#"
         echo "# $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
-        echo "Hello" | eval "$OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
+        echo "Hello" | eval "timeout -s KILL 2m $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
     else
         echo "#"
         echo "# $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
-        echo "Hello" | eval "$OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
+        echo "Hello" | eval "timeout -s KILL 2m $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
     fi
 
     client_result=$?
@@ -536,7 +542,7 @@ if [ "$wolf_certs" != "" ]
 then
     echo
     # Check if RSA certificates supported in wolfSSL
-    wolf_rsa=$($WOLFSSL_CLIENT -A "${CERT_DIR}/ca-cert.pem" 2>&1)
+    wolf_rsa=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-cert.pem" 2>&1)
     case $wolf_rsa in
     *"ca file"*)
         echo "wolfSSL does not support RSA"
@@ -549,7 +555,7 @@ then
         echo "wolfSSL supports RSA"
     fi
     # Check if RSA-PSS certificates supported in wolfSSL
-    wolf_rsapss=$($WOLFSSL_CLIENT -A "${CERT_DIR}/rsapss/ca-rsapss.pem" 2>&1)
+    wolf_rsapss=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/rsapss/ca-rsapss.pem" 2>&1)
     case $wolf_rsapss in
     *"ca file"*)
         echo "wolfSSL does not support RSA-PSS"
@@ -562,7 +568,7 @@ then
         echo "wolfSSL supports RSA-PSS"
     fi
     # Check if ECC certificates supported in wolfSSL
-    wolf_ecc=$($WOLFSSL_CLIENT -A "${CERT_DIR}/ca-ecc-cert.pem" 2>&1)
+    wolf_ecc=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-ecc-cert.pem" 2>&1)
     case $wolf_ecc in
     *"ca file"*)
         echo "wolfSSL does not support ECDSA"
@@ -575,7 +581,7 @@ then
         echo "wolfSSL supports ECDSA"
     fi
     # Check if Ed25519 certificates supported in wolfSSL
-    wolf_ed25519=$($WOLFSSL_CLIENT -A "${CERT_DIR}/ed25519/root-ed25519.pem" 2>&1)
+    wolf_ed25519=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ed25519/root-ed25519.pem" 2>&1)
     case $wolf_ed25519 in
     *"ca file"*)
         echo "wolfSSL does not support Ed25519"
@@ -588,7 +594,7 @@ then
         echo "wolfSSL supports Ed25519"
     fi
     # Check if Ed25519 certificates supported in OpenSSL
-    openssl_ed25519=$($OPENSSL s_client -cert "${CERT_DIR}/ed25519/client-ed25519.pem" -key "${CERT_DIR}/ed25519/client-ed25519-priv.pem" 2>&1)
+    openssl_ed25519=$(timeout -s KILL 2m $OPENSSL s_client -cert "${CERT_DIR}/ed25519/client-ed25519.pem" -key "${CERT_DIR}/ed25519/client-ed25519-priv.pem" 2>&1)
     case $openssl_ed25519 in
     *"unable to load"*)
         echo "OpenSSL does not support Ed25519"
@@ -601,7 +607,7 @@ then
         echo "OpenSSL supports Ed25519"
     fi
     # Check if Ed448 certificates supported in wolfSSL
-    wolf_ed448=$($WOLFSSL_CLIENT -A "${CERT_DIR}/ed448/root-ed448.pem" 2>&1)
+    wolf_ed448=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ed448/root-ed448.pem" 2>&1)
     case $wolf_ed448 in
     *"ca file"*)
         echo "wolfSSL does not support Ed448"
@@ -614,7 +620,7 @@ then
         echo "wolfSSL supports Ed448"
     fi
     # Check if Ed448 certificates supported in OpenSSL
-    openssl_ed448=$($OPENSSL s_client -cert "${CERT_DIR}/ed448/client-ed448.pem" -key "${CERT_DIR}/ed448/client-ed448-priv.pem" 2>&1)
+    openssl_ed448=$(timeout -s KILL 2m $OPENSSL s_client -cert "${CERT_DIR}/ed448/client-ed448.pem" -key "${CERT_DIR}/ed448/client-ed448-priv.pem" 2>&1)
     case $openssl_ed448 in
     *"unable to load"*)
         echo "OpenSSL does not support Ed448"
@@ -870,7 +876,7 @@ do
 
         # double check that can actually do a sslv3 connection using
         # client-cert.pem to send but any file with EOF works
-        $OPENSSL s_client -ssl3 -no_ign_eof -host localhost -port "$openssl_port" < "${CERT_DIR}/client-cert.pem"
+        timeout -s KILL 2m $OPENSSL s_client -ssl3 -no_ign_eof -host localhost -port "$openssl_port" < "${CERT_DIR}/client-cert.pem"
         sslv3_sup=$?
         if [ "$sslv3_sup" != 0 ]
         then
@@ -881,7 +887,7 @@ do
         openssl_version="-ssl3"
         ;;
     "1")
-        proto_check=$(echo "hell" | $OPENSSL s_client -connect localhost:"$openssl_port" -tls1 2>&1)
+        proto_check=$(echo "hell" | timeout -s KILL 2m $OPENSSL s_client -connect localhost:"$openssl_port" -tls1 2>&1)
         tlsv1_sup=$?
         if [ "$tlsv1_sup" != 0 ]
         then
@@ -902,7 +908,7 @@ do
     "2")
         # Same ciphers for TLSv1.1 as TLSv1
         # shellcheck disable=SC2034
-        proto_check=$(echo "hello" | $OPENSSL s_client -connect localhost:"$openssl_port" -tls1_1 2>&1)
+        proto_check=$(echo "hello" | timeout -s KILL 2m $OPENSSL s_client -connect localhost:"$openssl_port" -tls1_1 2>&1)
         tlsv1_1_sup=$?
         if [ "$tlsv1_1_sup" != 0 ]
         then

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -19,6 +19,20 @@ fi
 # here while IFS still holds its default value.
 TIMEOUT_KILL_2M_EVAL="${TIMEOUT_KILL_2M[*]}"
 
+# timeout(1) exits 124, or 128+signal when it must signal the child (137 for
+# the SIGKILL used here). The capability and protocol probes below decide what
+# to test from a command's output, so a killed probe would read as "feature not
+# supported" and silently drop interop coverage instead of failing.
+timed_out() { [ "$1" -eq 124 ] || [ "$1" -eq 137 ]; }
+
+# Abort when the probe named $2 was killed by timeout(1) with status $1.
+abort_if_timed_out() {
+    if timed_out "$1"; then
+        echo "$2 probe timed out"
+        exit 1
+    fi
+}
+
 # Environment variables used:
 # OPENSSL            (openssl app to use)
 # OPENSSL_ENGINE_ID  (engine id if any i.e. "wolfengine")
@@ -555,6 +569,7 @@ then
     echo
     # Check if RSA certificates supported in wolfSSL
     wolf_rsa=$("${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-cert.pem" 2>&1)
+    abort_if_timed_out $? "wolf_rsa"
     case $wolf_rsa in
     *"ca file"*)
         echo "wolfSSL does not support RSA"
@@ -568,6 +583,7 @@ then
     fi
     # Check if RSA-PSS certificates supported in wolfSSL
     wolf_rsapss=$("${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -A "${CERT_DIR}/rsapss/ca-rsapss.pem" 2>&1)
+    abort_if_timed_out $? "wolf_rsapss"
     case $wolf_rsapss in
     *"ca file"*)
         echo "wolfSSL does not support RSA-PSS"
@@ -581,6 +597,7 @@ then
     fi
     # Check if ECC certificates supported in wolfSSL
     wolf_ecc=$("${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-ecc-cert.pem" 2>&1)
+    abort_if_timed_out $? "wolf_ecc"
     case $wolf_ecc in
     *"ca file"*)
         echo "wolfSSL does not support ECDSA"
@@ -594,6 +611,7 @@ then
     fi
     # Check if Ed25519 certificates supported in wolfSSL
     wolf_ed25519=$("${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -A "${CERT_DIR}/ed25519/root-ed25519.pem" 2>&1)
+    abort_if_timed_out $? "wolf_ed25519"
     case $wolf_ed25519 in
     *"ca file"*)
         echo "wolfSSL does not support Ed25519"
@@ -607,6 +625,7 @@ then
     fi
     # Check if Ed25519 certificates supported in OpenSSL
     openssl_ed25519=$("${TIMEOUT_KILL_2M[@]}" $OPENSSL s_client -cert "${CERT_DIR}/ed25519/client-ed25519.pem" -key "${CERT_DIR}/ed25519/client-ed25519-priv.pem" 2>&1)
+    abort_if_timed_out $? "openssl_ed25519"
     case $openssl_ed25519 in
     *"unable to load"*)
         echo "OpenSSL does not support Ed25519"
@@ -620,6 +639,7 @@ then
     fi
     # Check if Ed448 certificates supported in wolfSSL
     wolf_ed448=$("${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -A "${CERT_DIR}/ed448/root-ed448.pem" 2>&1)
+    abort_if_timed_out $? "wolf_ed448"
     case $wolf_ed448 in
     *"ca file"*)
         echo "wolfSSL does not support Ed448"
@@ -633,6 +653,7 @@ then
     fi
     # Check if Ed448 certificates supported in OpenSSL
     openssl_ed448=$("${TIMEOUT_KILL_2M[@]}" $OPENSSL s_client -cert "${CERT_DIR}/ed448/client-ed448.pem" -key "${CERT_DIR}/ed448/client-ed448-priv.pem" 2>&1)
+    abort_if_timed_out $? "openssl_ed448"
     case $openssl_ed448 in
     *"unable to load"*)
         echo "OpenSSL does not support Ed448"
@@ -890,6 +911,7 @@ do
         # client-cert.pem to send but any file with EOF works
         "${TIMEOUT_KILL_2M[@]}" $OPENSSL s_client -ssl3 -no_ign_eof -host localhost -port "$openssl_port" < "${CERT_DIR}/client-cert.pem"
         sslv3_sup=$?
+        abort_if_timed_out $sslv3_sup "SSLv3 connection"
         if [ "$sslv3_sup" != 0 ]
         then
             echo -e "Not testing SSLv3. No OpenSSL support for 'SSLv3' modifier"
@@ -901,6 +923,7 @@ do
     "1")
         proto_check=$(echo "hell" | "${TIMEOUT_KILL_2M[@]}" $OPENSSL s_client -connect localhost:"$openssl_port" -tls1 2>&1)
         tlsv1_sup=$?
+        abort_if_timed_out $tlsv1_sup "TLSv1 connection"
         if [ "$tlsv1_sup" != 0 ]
         then
             echo -e "Not testing TLSv1. No OpenSSL support for '-tls1'"
@@ -922,6 +945,7 @@ do
         # shellcheck disable=SC2034
         proto_check=$(echo "hello" | "${TIMEOUT_KILL_2M[@]}" $OPENSSL s_client -connect localhost:"$openssl_port" -tls1_1 2>&1)
         tlsv1_1_sup=$?
+        abort_if_timed_out $tlsv1_1_sup "TLSv1.1 connection"
         if [ "$tlsv1_1_sup" != 0 ]
         then
             echo -e "Not testing TLSv1.1. No OpenSSL support for 'TLSv1.1' modifier"

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -4,8 +4,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 # Environment variables used:
@@ -370,13 +375,13 @@ do_wolfssl_client() {
         echo "#"
         echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite -v $version $psk $adh \"$wolfssl_cert\" \"$wolfssl_key\" \"$wolfssl_caCert\" $crl"
         # shellcheck disable=SC2086
-        timeout -s KILL 2m $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" -v "$version" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
+        $TIMEOUT_KILL_2M $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" -v "$version" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
     else
         echo "#"
         echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite $psk $adh \"$wolfssl_cert\" \"$wolfssl_key\" \"$wolfssl_caCert\" $crl"
         # do all versions
         # shellcheck disable=SC2086
-        timeout -s KILL 2m $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
+        $TIMEOUT_KILL_2M $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
     fi
 
     client_result=$?
@@ -432,11 +437,11 @@ do_openssl_client() {
     then
         echo "#"
         echo "# $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
-        echo "Hello" | eval "timeout -s KILL 2m $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
+        echo "Hello" | eval "$TIMEOUT_KILL_2M $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
     else
         echo "#"
         echo "# $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
-        echo "Hello" | eval "timeout -s KILL 2m $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
+        echo "Hello" | eval "$TIMEOUT_KILL_2M $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
     fi
 
     client_result=$?
@@ -543,7 +548,7 @@ if [ "$wolf_certs" != "" ]
 then
     echo
     # Check if RSA certificates supported in wolfSSL
-    wolf_rsa=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-cert.pem" 2>&1)
+    wolf_rsa=$($TIMEOUT_KILL_2M $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-cert.pem" 2>&1)
     case $wolf_rsa in
     *"ca file"*)
         echo "wolfSSL does not support RSA"
@@ -556,7 +561,7 @@ then
         echo "wolfSSL supports RSA"
     fi
     # Check if RSA-PSS certificates supported in wolfSSL
-    wolf_rsapss=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/rsapss/ca-rsapss.pem" 2>&1)
+    wolf_rsapss=$($TIMEOUT_KILL_2M $WOLFSSL_CLIENT -A "${CERT_DIR}/rsapss/ca-rsapss.pem" 2>&1)
     case $wolf_rsapss in
     *"ca file"*)
         echo "wolfSSL does not support RSA-PSS"
@@ -569,7 +574,7 @@ then
         echo "wolfSSL supports RSA-PSS"
     fi
     # Check if ECC certificates supported in wolfSSL
-    wolf_ecc=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-ecc-cert.pem" 2>&1)
+    wolf_ecc=$($TIMEOUT_KILL_2M $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-ecc-cert.pem" 2>&1)
     case $wolf_ecc in
     *"ca file"*)
         echo "wolfSSL does not support ECDSA"
@@ -582,7 +587,7 @@ then
         echo "wolfSSL supports ECDSA"
     fi
     # Check if Ed25519 certificates supported in wolfSSL
-    wolf_ed25519=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ed25519/root-ed25519.pem" 2>&1)
+    wolf_ed25519=$($TIMEOUT_KILL_2M $WOLFSSL_CLIENT -A "${CERT_DIR}/ed25519/root-ed25519.pem" 2>&1)
     case $wolf_ed25519 in
     *"ca file"*)
         echo "wolfSSL does not support Ed25519"
@@ -595,7 +600,7 @@ then
         echo "wolfSSL supports Ed25519"
     fi
     # Check if Ed25519 certificates supported in OpenSSL
-    openssl_ed25519=$(timeout -s KILL 2m $OPENSSL s_client -cert "${CERT_DIR}/ed25519/client-ed25519.pem" -key "${CERT_DIR}/ed25519/client-ed25519-priv.pem" 2>&1)
+    openssl_ed25519=$($TIMEOUT_KILL_2M $OPENSSL s_client -cert "${CERT_DIR}/ed25519/client-ed25519.pem" -key "${CERT_DIR}/ed25519/client-ed25519-priv.pem" 2>&1)
     case $openssl_ed25519 in
     *"unable to load"*)
         echo "OpenSSL does not support Ed25519"
@@ -608,7 +613,7 @@ then
         echo "OpenSSL supports Ed25519"
     fi
     # Check if Ed448 certificates supported in wolfSSL
-    wolf_ed448=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ed448/root-ed448.pem" 2>&1)
+    wolf_ed448=$($TIMEOUT_KILL_2M $WOLFSSL_CLIENT -A "${CERT_DIR}/ed448/root-ed448.pem" 2>&1)
     case $wolf_ed448 in
     *"ca file"*)
         echo "wolfSSL does not support Ed448"
@@ -621,7 +626,7 @@ then
         echo "wolfSSL supports Ed448"
     fi
     # Check if Ed448 certificates supported in OpenSSL
-    openssl_ed448=$(timeout -s KILL 2m $OPENSSL s_client -cert "${CERT_DIR}/ed448/client-ed448.pem" -key "${CERT_DIR}/ed448/client-ed448-priv.pem" 2>&1)
+    openssl_ed448=$($TIMEOUT_KILL_2M $OPENSSL s_client -cert "${CERT_DIR}/ed448/client-ed448.pem" -key "${CERT_DIR}/ed448/client-ed448-priv.pem" 2>&1)
     case $openssl_ed448 in
     *"unable to load"*)
         echo "OpenSSL does not support Ed448"
@@ -877,7 +882,7 @@ do
 
         # double check that can actually do a sslv3 connection using
         # client-cert.pem to send but any file with EOF works
-        timeout -s KILL 2m $OPENSSL s_client -ssl3 -no_ign_eof -host localhost -port "$openssl_port" < "${CERT_DIR}/client-cert.pem"
+        $TIMEOUT_KILL_2M $OPENSSL s_client -ssl3 -no_ign_eof -host localhost -port "$openssl_port" < "${CERT_DIR}/client-cert.pem"
         sslv3_sup=$?
         if [ "$sslv3_sup" != 0 ]
         then
@@ -888,7 +893,7 @@ do
         openssl_version="-ssl3"
         ;;
     "1")
-        proto_check=$(echo "hell" | timeout -s KILL 2m $OPENSSL s_client -connect localhost:"$openssl_port" -tls1 2>&1)
+        proto_check=$(echo "hell" | $TIMEOUT_KILL_2M $OPENSSL s_client -connect localhost:"$openssl_port" -tls1 2>&1)
         tlsv1_sup=$?
         if [ "$tlsv1_sup" != 0 ]
         then
@@ -909,7 +914,7 @@ do
     "2")
         # Same ciphers for TLSv1.1 as TLSv1
         # shellcheck disable=SC2034
-        proto_check=$(echo "hello" | timeout -s KILL 2m $OPENSSL s_client -connect localhost:"$openssl_port" -tls1_1 2>&1)
+        proto_check=$(echo "hello" | $TIMEOUT_KILL_2M $OPENSSL s_client -connect localhost:"$openssl_port" -tls1_1 2>&1)
         tlsv1_1_sup=$?
         if [ "$tlsv1_1_sup" != 0 ]
         then

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -2,6 +2,12 @@
 
 # openssl.test
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 # Environment variables used:
 # OPENSSL            (openssl app to use)
 # OPENSSL_ENGINE_ID  (engine id if any i.e. "wolfengine")
@@ -364,13 +370,13 @@ do_wolfssl_client() {
         echo "#"
         echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite -v $version $psk $adh \"$wolfssl_cert\" \"$wolfssl_key\" \"$wolfssl_caCert\" $crl"
         # shellcheck disable=SC2086
-        $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" -v "$version" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
+        timeout -s KILL 2m $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" -v "$version" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
     else
         echo "#"
         echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite $psk $adh \"$wolfssl_cert\" \"$wolfssl_key\" \"$wolfssl_caCert\" $crl"
         # do all versions
         # shellcheck disable=SC2086
-        $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
+        timeout -s KILL 2m $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
     fi
 
     client_result=$?
@@ -426,11 +432,11 @@ do_openssl_client() {
     then
         echo "#"
         echo "# $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
-        echo "Hello" | eval "$OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
+        echo "Hello" | eval "timeout -s KILL 2m $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
     else
         echo "#"
         echo "# $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
-        echo "Hello" | eval "$OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
+        echo "Hello" | eval "timeout -s KILL 2m $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
     fi
 
     client_result=$?
@@ -537,7 +543,7 @@ if [ "$wolf_certs" != "" ]
 then
     echo
     # Check if RSA certificates supported in wolfSSL
-    wolf_rsa=$($WOLFSSL_CLIENT -A "${CERT_DIR}/ca-cert.pem" 2>&1)
+    wolf_rsa=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-cert.pem" 2>&1)
     case $wolf_rsa in
     *"ca file"*)
         echo "wolfSSL does not support RSA"
@@ -550,7 +556,7 @@ then
         echo "wolfSSL supports RSA"
     fi
     # Check if RSA-PSS certificates supported in wolfSSL
-    wolf_rsapss=$($WOLFSSL_CLIENT -A "${CERT_DIR}/rsapss/ca-rsapss.pem" 2>&1)
+    wolf_rsapss=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/rsapss/ca-rsapss.pem" 2>&1)
     case $wolf_rsapss in
     *"ca file"*)
         echo "wolfSSL does not support RSA-PSS"
@@ -563,7 +569,7 @@ then
         echo "wolfSSL supports RSA-PSS"
     fi
     # Check if ECC certificates supported in wolfSSL
-    wolf_ecc=$($WOLFSSL_CLIENT -A "${CERT_DIR}/ca-ecc-cert.pem" 2>&1)
+    wolf_ecc=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-ecc-cert.pem" 2>&1)
     case $wolf_ecc in
     *"ca file"*)
         echo "wolfSSL does not support ECDSA"
@@ -576,7 +582,7 @@ then
         echo "wolfSSL supports ECDSA"
     fi
     # Check if Ed25519 certificates supported in wolfSSL
-    wolf_ed25519=$($WOLFSSL_CLIENT -A "${CERT_DIR}/ed25519/root-ed25519.pem" 2>&1)
+    wolf_ed25519=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ed25519/root-ed25519.pem" 2>&1)
     case $wolf_ed25519 in
     *"ca file"*)
         echo "wolfSSL does not support Ed25519"
@@ -589,7 +595,7 @@ then
         echo "wolfSSL supports Ed25519"
     fi
     # Check if Ed25519 certificates supported in OpenSSL
-    openssl_ed25519=$($OPENSSL s_client -cert "${CERT_DIR}/ed25519/client-ed25519.pem" -key "${CERT_DIR}/ed25519/client-ed25519-priv.pem" 2>&1)
+    openssl_ed25519=$(timeout -s KILL 2m $OPENSSL s_client -cert "${CERT_DIR}/ed25519/client-ed25519.pem" -key "${CERT_DIR}/ed25519/client-ed25519-priv.pem" 2>&1)
     case $openssl_ed25519 in
     *"unable to load"*)
         echo "OpenSSL does not support Ed25519"
@@ -602,7 +608,7 @@ then
         echo "OpenSSL supports Ed25519"
     fi
     # Check if Ed448 certificates supported in wolfSSL
-    wolf_ed448=$($WOLFSSL_CLIENT -A "${CERT_DIR}/ed448/root-ed448.pem" 2>&1)
+    wolf_ed448=$(timeout -s KILL 2m $WOLFSSL_CLIENT -A "${CERT_DIR}/ed448/root-ed448.pem" 2>&1)
     case $wolf_ed448 in
     *"ca file"*)
         echo "wolfSSL does not support Ed448"
@@ -615,7 +621,7 @@ then
         echo "wolfSSL supports Ed448"
     fi
     # Check if Ed448 certificates supported in OpenSSL
-    openssl_ed448=$($OPENSSL s_client -cert "${CERT_DIR}/ed448/client-ed448.pem" -key "${CERT_DIR}/ed448/client-ed448-priv.pem" 2>&1)
+    openssl_ed448=$(timeout -s KILL 2m $OPENSSL s_client -cert "${CERT_DIR}/ed448/client-ed448.pem" -key "${CERT_DIR}/ed448/client-ed448-priv.pem" 2>&1)
     case $openssl_ed448 in
     *"unable to load"*)
         echo "OpenSSL does not support Ed448"
@@ -871,7 +877,7 @@ do
 
         # double check that can actually do a sslv3 connection using
         # client-cert.pem to send but any file with EOF works
-        $OPENSSL s_client -ssl3 -no_ign_eof -host localhost -port "$openssl_port" < "${CERT_DIR}/client-cert.pem"
+        timeout -s KILL 2m $OPENSSL s_client -ssl3 -no_ign_eof -host localhost -port "$openssl_port" < "${CERT_DIR}/client-cert.pem"
         sslv3_sup=$?
         if [ "$sslv3_sup" != 0 ]
         then
@@ -882,7 +888,7 @@ do
         openssl_version="-ssl3"
         ;;
     "1")
-        proto_check=$(echo "hell" | $OPENSSL s_client -connect localhost:"$openssl_port" -tls1 2>&1)
+        proto_check=$(echo "hell" | timeout -s KILL 2m $OPENSSL s_client -connect localhost:"$openssl_port" -tls1 2>&1)
         tlsv1_sup=$?
         if [ "$tlsv1_sup" != 0 ]
         then
@@ -903,7 +909,7 @@ do
     "2")
         # Same ciphers for TLSv1.1 as TLSv1
         # shellcheck disable=SC2034
-        proto_check=$(echo "hello" | $OPENSSL s_client -connect localhost:"$openssl_port" -tls1_1 2>&1)
+        proto_check=$(echo "hello" | timeout -s KILL 2m $OPENSSL s_client -connect localhost:"$openssl_port" -tls1_1 2>&1)
         tlsv1_1_sup=$?
         if [ "$tlsv1_1_sup" != 0 ]
         then

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -4,14 +4,20 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-# A prefix variable rather than a shell function: backgrounding a function
-# makes $! the forked subshell, so a later "kill $server_pid" would stop the
-# wrapper and orphan the server it was meant to kill.
+# A prefix rather than a shell function: backgrounding a function makes $! the
+# forked subshell, so a later "kill $server_pid" would stop the wrapper and
+# orphan the server it was meant to kill. It is an array because this script
+# sets IFS=: around its main loops, where an unquoted expansion of a plain
+# string would not split back into separate words.
 if command -v timeout >/dev/null 2>&1; then
-    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+    TIMEOUT_KILL_2M=(timeout -s KILL 2m)
 else
-    TIMEOUT_KILL_2M=""
+    TIMEOUT_KILL_2M=()
 fi
+# The same prefix flattened, for the eval call sites: eval re-parses its
+# argument, so the shell grammar splits it there and IFS does not apply. Built
+# here while IFS still holds its default value.
+TIMEOUT_KILL_2M_EVAL="${TIMEOUT_KILL_2M[*]}"
 
 # Environment variables used:
 # OPENSSL            (openssl app to use)
@@ -375,13 +381,13 @@ do_wolfssl_client() {
         echo "#"
         echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite -v $version $psk $adh \"$wolfssl_cert\" \"$wolfssl_key\" \"$wolfssl_caCert\" $crl"
         # shellcheck disable=SC2086
-        $TIMEOUT_KILL_2M $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" -v "$version" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
+        "${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" -v "$version" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
     else
         echo "#"
         echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite $psk $adh \"$wolfssl_cert\" \"$wolfssl_key\" \"$wolfssl_caCert\" $crl"
         # do all versions
         # shellcheck disable=SC2086
-        $TIMEOUT_KILL_2M $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
+        "${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -p "$port" -g $wolfssl_resume -l "$wolfSuite" $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
     fi
 
     client_result=$?
@@ -437,11 +443,11 @@ do_openssl_client() {
     then
         echo "#"
         echo "# $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
-        echo "Hello" | eval "$TIMEOUT_KILL_2M $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
+        echo "Hello" | eval "$TIMEOUT_KILL_2M_EVAL $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -cipher $cmpSuite $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
     else
         echo "#"
         echo "# $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
-        echo "Hello" | eval "$TIMEOUT_KILL_2M $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
+        echo "Hello" | eval "$TIMEOUT_KILL_2M_EVAL $OPENSSL s_client -connect localhost:$port -reconnect -legacy_renegotiation -ciphersuites=$cmpSuite $openssl_seclevel $openssl_version $openssl_psk $openssl_cert1 \"$openssl_cert2\" $openssl_key1 \"$openssl_key2\" $openssl_caCert1 \"$openssl_caCert2\""
     fi
 
     client_result=$?
@@ -548,7 +554,7 @@ if [ "$wolf_certs" != "" ]
 then
     echo
     # Check if RSA certificates supported in wolfSSL
-    wolf_rsa=$($TIMEOUT_KILL_2M $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-cert.pem" 2>&1)
+    wolf_rsa=$("${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-cert.pem" 2>&1)
     case $wolf_rsa in
     *"ca file"*)
         echo "wolfSSL does not support RSA"
@@ -561,7 +567,7 @@ then
         echo "wolfSSL supports RSA"
     fi
     # Check if RSA-PSS certificates supported in wolfSSL
-    wolf_rsapss=$($TIMEOUT_KILL_2M $WOLFSSL_CLIENT -A "${CERT_DIR}/rsapss/ca-rsapss.pem" 2>&1)
+    wolf_rsapss=$("${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -A "${CERT_DIR}/rsapss/ca-rsapss.pem" 2>&1)
     case $wolf_rsapss in
     *"ca file"*)
         echo "wolfSSL does not support RSA-PSS"
@@ -574,7 +580,7 @@ then
         echo "wolfSSL supports RSA-PSS"
     fi
     # Check if ECC certificates supported in wolfSSL
-    wolf_ecc=$($TIMEOUT_KILL_2M $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-ecc-cert.pem" 2>&1)
+    wolf_ecc=$("${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -A "${CERT_DIR}/ca-ecc-cert.pem" 2>&1)
     case $wolf_ecc in
     *"ca file"*)
         echo "wolfSSL does not support ECDSA"
@@ -587,7 +593,7 @@ then
         echo "wolfSSL supports ECDSA"
     fi
     # Check if Ed25519 certificates supported in wolfSSL
-    wolf_ed25519=$($TIMEOUT_KILL_2M $WOLFSSL_CLIENT -A "${CERT_DIR}/ed25519/root-ed25519.pem" 2>&1)
+    wolf_ed25519=$("${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -A "${CERT_DIR}/ed25519/root-ed25519.pem" 2>&1)
     case $wolf_ed25519 in
     *"ca file"*)
         echo "wolfSSL does not support Ed25519"
@@ -600,7 +606,7 @@ then
         echo "wolfSSL supports Ed25519"
     fi
     # Check if Ed25519 certificates supported in OpenSSL
-    openssl_ed25519=$($TIMEOUT_KILL_2M $OPENSSL s_client -cert "${CERT_DIR}/ed25519/client-ed25519.pem" -key "${CERT_DIR}/ed25519/client-ed25519-priv.pem" 2>&1)
+    openssl_ed25519=$("${TIMEOUT_KILL_2M[@]}" $OPENSSL s_client -cert "${CERT_DIR}/ed25519/client-ed25519.pem" -key "${CERT_DIR}/ed25519/client-ed25519-priv.pem" 2>&1)
     case $openssl_ed25519 in
     *"unable to load"*)
         echo "OpenSSL does not support Ed25519"
@@ -613,7 +619,7 @@ then
         echo "OpenSSL supports Ed25519"
     fi
     # Check if Ed448 certificates supported in wolfSSL
-    wolf_ed448=$($TIMEOUT_KILL_2M $WOLFSSL_CLIENT -A "${CERT_DIR}/ed448/root-ed448.pem" 2>&1)
+    wolf_ed448=$("${TIMEOUT_KILL_2M[@]}" $WOLFSSL_CLIENT -A "${CERT_DIR}/ed448/root-ed448.pem" 2>&1)
     case $wolf_ed448 in
     *"ca file"*)
         echo "wolfSSL does not support Ed448"
@@ -626,7 +632,7 @@ then
         echo "wolfSSL supports Ed448"
     fi
     # Check if Ed448 certificates supported in OpenSSL
-    openssl_ed448=$($TIMEOUT_KILL_2M $OPENSSL s_client -cert "${CERT_DIR}/ed448/client-ed448.pem" -key "${CERT_DIR}/ed448/client-ed448-priv.pem" 2>&1)
+    openssl_ed448=$("${TIMEOUT_KILL_2M[@]}" $OPENSSL s_client -cert "${CERT_DIR}/ed448/client-ed448.pem" -key "${CERT_DIR}/ed448/client-ed448-priv.pem" 2>&1)
     case $openssl_ed448 in
     *"unable to load"*)
         echo "OpenSSL does not support Ed448"
@@ -882,7 +888,7 @@ do
 
         # double check that can actually do a sslv3 connection using
         # client-cert.pem to send but any file with EOF works
-        $TIMEOUT_KILL_2M $OPENSSL s_client -ssl3 -no_ign_eof -host localhost -port "$openssl_port" < "${CERT_DIR}/client-cert.pem"
+        "${TIMEOUT_KILL_2M[@]}" $OPENSSL s_client -ssl3 -no_ign_eof -host localhost -port "$openssl_port" < "${CERT_DIR}/client-cert.pem"
         sslv3_sup=$?
         if [ "$sslv3_sup" != 0 ]
         then
@@ -893,7 +899,7 @@ do
         openssl_version="-ssl3"
         ;;
     "1")
-        proto_check=$(echo "hell" | $TIMEOUT_KILL_2M $OPENSSL s_client -connect localhost:"$openssl_port" -tls1 2>&1)
+        proto_check=$(echo "hell" | "${TIMEOUT_KILL_2M[@]}" $OPENSSL s_client -connect localhost:"$openssl_port" -tls1 2>&1)
         tlsv1_sup=$?
         if [ "$tlsv1_sup" != 0 ]
         then
@@ -914,7 +920,7 @@ do
     "2")
         # Same ciphers for TLSv1.1 as TLSv1
         # shellcheck disable=SC2034
-        proto_check=$(echo "hello" | $TIMEOUT_KILL_2M $OPENSSL s_client -connect localhost:"$openssl_port" -tls1_1 2>&1)
+        proto_check=$(echo "hello" | "${TIMEOUT_KILL_2M[@]}" $OPENSSL s_client -connect localhost:"$openssl_port" -tls1_1 2>&1)
         tlsv1_1_sup=$?
         if [ "$tlsv1_1_sup" != 0 ]
         then

--- a/scripts/openssl_srtp.test
+++ b/scripts/openssl_srtp.test
@@ -3,6 +3,12 @@
 #
 # TODO: add OpenSSL client with WolfSSL server
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 set -e
 
 # if we can, isolate the network namespace to eliminate port collisions.
@@ -151,7 +157,7 @@ start_wolfssl_client() {
     fi
 
     client_output_file=/tmp/wolfssl_srtp_out
-    ${WOLFSSL_CLIENT} -u\
+    timeout -s KILL 2m ${WOLFSSL_CLIENT} -u\
                       -x \
                       -v${dtls_version} \
                       --srtp "${srtp_profile}" \

--- a/scripts/openssl_srtp.test
+++ b/scripts/openssl_srtp.test
@@ -5,8 +5,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 set -e
@@ -157,7 +162,7 @@ start_wolfssl_client() {
     fi
 
     client_output_file=/tmp/wolfssl_srtp_out
-    timeout -s KILL 2m ${WOLFSSL_CLIENT} -u\
+    $TIMEOUT_KILL_2M ${WOLFSSL_CLIENT} -u\
                       -x \
                       -v${dtls_version} \
                       --srtp "${srtp_profile}" \

--- a/scripts/pkcallbacks.test
+++ b/scripts/pkcallbacks.test
@@ -2,8 +2,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 
@@ -108,7 +113,7 @@ run_test() {
     # starts the server on pk_port, -R generates ready file to be used as a
     # mutex lock, -P does pkcallbacks. We capture the processid
     # into the variable server_pid
-    timeout -s KILL 2m ./examples/server/server -P -R "$ready_file" -p $pk_port &
+    $TIMEOUT_KILL_2M ./examples/server/server -P -R "$ready_file" -p $pk_port &
     server_pid=$!
 
     counter=0

--- a/scripts/psk.test
+++ b/scripts/psk.test
@@ -122,7 +122,12 @@ echo ""
 ###############################
 
 timeout -s KILL 2m ./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
-if [ $? -ne 0 ]; then
+pipe_rc=("${PIPESTATUS[@]}")
+if [ "${pipe_rc[0]}" -ge 124 ]; then
+    echo "client version probe timed out"
+    exit 1
+fi
+if [ "${pipe_rc[1]}" -ne 0 ]; then
     # Usual server / client. This use case is tested in
     # tests/unit.test and is used here for just checking if cipher suite
     # is available (one case for example is with disable-asn)

--- a/scripts/psk.test
+++ b/scripts/psk.test
@@ -3,6 +3,12 @@
 # psk.test
 # copyright wolfSSL 2016
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 # if we can, isolate the network namespace to eliminate port collisions.
 if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then
      if [[ -z "$NETWORK_UNSHARE_HELPER_CALLED" ]]; then
@@ -101,7 +107,7 @@ port=0
 ./examples/server/server -s -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -s -p $port
+timeout -s KILL 2m ./examples/client/client -s -p $port
 RESULT=$?
 remove_ready_file
 # if fail here then is a settings issue so return 0
@@ -115,7 +121,7 @@ echo ""
 # client test against the server
 ###############################
 
-./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
+timeout -s KILL 2m ./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
 if [ $? -ne 0 ]; then
     # Usual server / client. This use case is tested in
     # tests/unit.test and is used here for just checking if cipher suite
@@ -124,7 +130,7 @@ if [ $? -ne 0 ]; then
     ./examples/server/server -R "$ready_file" -p $port -l DHE-RSA-AES128-SHA:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-DES-CBC3-SHA &
     server_pid=$!
     create_port
-    ./examples/client/client -p $port
+    timeout -s KILL 2m ./examples/client/client -p $port
     RESULT=$?
     remove_ready_file
     # if fail here then is a settings issue so return 0
@@ -140,7 +146,7 @@ if [ $? -ne 0 ]; then
     ./examples/server/server -j -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    ./examples/client/client -p $port
+    timeout -s KILL 2m ./examples/client/client -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -ne 0 ]; then
@@ -157,7 +163,7 @@ if [ $? -ne 0 ]; then
         ./examples/server/server -j -R "$ready_file" -p $port &
         server_pid=$!
         create_port
-        ./examples/client/client -x -p $port
+        timeout -s KILL 2m ./examples/client/client -x -p $port
         RESULT=$?
         remove_ready_file
         if [ $RESULT -eq 0 ]; then

--- a/scripts/psk.test
+++ b/scripts/psk.test
@@ -5,9 +5,20 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
+
+# timeout(1) exits 124, or 128+signal when it must signal the child (137 for
+# the SIGKILL used here). Skip branches below turn a non-zero status into
+# "feature not compiled in" and exit 0, so a hang must be told apart from a
+# genuine failure or it lands in CI as a silent pass.
+timed_out() { [ "$1" -eq 124 ] || [ "$1" -eq 137 ]; }
 
 # if we can, isolate the network namespace to eliminate port collisions.
 if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then
@@ -108,9 +119,14 @@ port=0
 ./examples/server/server -s -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -s -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -s -p $port
 RESULT=$?
 remove_ready_file
+if timed_out $RESULT; then
+    echo -e "\n\nPSK probe client timed out"
+    do_cleanup
+    exit 1
+fi
 # if fail here then is a settings issue so return 0
 if [ $RESULT -ne 0 ]; then
     echo -e "\n\nPSK not enabled"
@@ -122,9 +138,9 @@ echo ""
 # client test against the server
 ###############################
 
-timeout -s KILL 2m ./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
+$TIMEOUT_KILL_2M ./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
 pipe_rc=("${PIPESTATUS[@]}")
-if [ "${pipe_rc[0]}" -ge 124 ]; then
+if timed_out "${pipe_rc[0]}"; then
     echo "client version probe timed out"
     exit 1
 fi
@@ -136,9 +152,14 @@ if [ "${pipe_rc[1]}" -ne 0 ]; then
     ./examples/server/server -R "$ready_file" -p $port -l DHE-RSA-AES128-SHA:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-DES-CBC3-SHA &
     server_pid=$!
     create_port
-    timeout -s KILL 2m ./examples/client/client -p $port
+    $TIMEOUT_KILL_2M ./examples/client/client -p $port
     RESULT=$?
     remove_ready_file
+    if timed_out $RESULT; then
+        echo -e "\n\nnon PSK suite probe client timed out"
+        do_cleanup
+        exit 1
+    fi
     # if fail here then is a settings issue so return 0
     if [ $RESULT -ne 0 ]; then
         echo -e "\n\nIssue with chosen non PSK suites"
@@ -152,7 +173,7 @@ if [ "${pipe_rc[1]}" -ne 0 ]; then
     ./examples/server/server -j -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    timeout -s KILL 2m ./examples/client/client -p $port
+    $TIMEOUT_KILL_2M ./examples/client/client -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -ne 0 ]; then
@@ -169,7 +190,7 @@ if [ "${pipe_rc[1]}" -ne 0 ]; then
         ./examples/server/server -j -R "$ready_file" -p $port &
         server_pid=$!
         create_port
-        timeout -s KILL 2m ./examples/client/client -x -p $port
+        $TIMEOUT_KILL_2M ./examples/client/client -x -p $port
         RESULT=$?
         remove_ready_file
         if [ $RESULT -eq 0 ]; then

--- a/scripts/psk.test
+++ b/scripts/psk.test
@@ -3,6 +3,12 @@
 # psk.test
 # copyright wolfSSL 2016
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 # if we can, isolate the network namespace to eliminate port collisions.
 if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then
      if [[ -z "$NETWORK_UNSHARE_HELPER_CALLED" ]]; then
@@ -102,7 +108,7 @@ port=0
 ./examples/server/server -s -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -s -p $port
+timeout -s KILL 2m ./examples/client/client -s -p $port
 RESULT=$?
 remove_ready_file
 # if fail here then is a settings issue so return 0
@@ -116,7 +122,7 @@ echo ""
 # client test against the server
 ###############################
 
-./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
+timeout -s KILL 2m ./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
 if [ $? -ne 0 ]; then
     # Usual server / client. This use case is tested in
     # tests/unit.test and is used here for just checking if cipher suite
@@ -125,7 +131,7 @@ if [ $? -ne 0 ]; then
     ./examples/server/server -R "$ready_file" -p $port -l DHE-RSA-AES128-SHA:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-DES-CBC3-SHA &
     server_pid=$!
     create_port
-    ./examples/client/client -p $port
+    timeout -s KILL 2m ./examples/client/client -p $port
     RESULT=$?
     remove_ready_file
     # if fail here then is a settings issue so return 0
@@ -141,7 +147,7 @@ if [ $? -ne 0 ]; then
     ./examples/server/server -j -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    ./examples/client/client -p $port
+    timeout -s KILL 2m ./examples/client/client -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -ne 0 ]; then
@@ -158,7 +164,7 @@ if [ $? -ne 0 ]; then
         ./examples/server/server -j -R "$ready_file" -p $port &
         server_pid=$!
         create_port
-        ./examples/client/client -x -p $port
+        timeout -s KILL 2m ./examples/client/client -x -p $port
         RESULT=$?
         remove_ready_file
         if [ $RESULT -eq 0 ]; then

--- a/scripts/psk.test
+++ b/scripts/psk.test
@@ -193,6 +193,11 @@ if [ "${pipe_rc[1]}" -ne 0 ]; then
         $TIMEOUT_KILL_2M ./examples/client/client -x -p $port
         RESULT=$?
         remove_ready_file
+        if timed_out $RESULT; then
+            echo -e "\n\nClient timed out, expected a connection failure"
+            do_cleanup
+            exit 1
+        fi
         if [ $RESULT -eq 0 ]; then
             echo -e "\n\nClient connected when supposed to fail"
             do_cleanup

--- a/scripts/psk.test
+++ b/scripts/psk.test
@@ -123,7 +123,12 @@ echo ""
 ###############################
 
 timeout -s KILL 2m ./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
-if [ $? -ne 0 ]; then
+pipe_rc=("${PIPESTATUS[@]}")
+if [ "${pipe_rc[0]}" -ge 124 ]; then
+    echo "client version probe timed out"
+    exit 1
+fi
+if [ "${pipe_rc[1]}" -ne 0 ]; then
     # Usual server / client. This use case is tested in
     # tests/unit.test and is used here for just checking if cipher suite
     # is available (one case for example is with disable-asn)

--- a/scripts/resume.test
+++ b/scripts/resume.test
@@ -2,8 +2,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 
@@ -84,7 +89,7 @@ do_test() {
 
     remove_ready_file
     echo "./examples/server/server -r -R \"$ready_file\" -p $resume_port"
-    timeout -s KILL 2m ./examples/server/server -r -R "$ready_file" -p $resume_port &
+    $TIMEOUT_KILL_2M ./examples/server/server -r -R "$ready_file" -p $resume_port &
     server_pid=$!
 
     counter=0

--- a/scripts/rsapss.test
+++ b/scripts/rsapss.test
@@ -2,6 +2,12 @@
 
 # rsapss.test
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
                                   && exit 1
 
@@ -109,14 +115,14 @@ WOLFSSL_SERVER=./examples/server/server
 start_wolfssl_server() {
     generate_port
     server_port=$port
-    $WOLFSSL_SERVER -p "$server_port" -v 4 -c "$CERT_DIR"/rsapss/server-rsapss.pem -k "$CERT_DIR"/rsapss/server-rsapss-priv.pem -A "$CERT_DIR"/rsapss/root-rsapss.pem -d &
+    timeout -s KILL 2m $WOLFSSL_SERVER -p "$server_port" -v 4 -c "$CERT_DIR"/rsapss/server-rsapss.pem -k "$CERT_DIR"/rsapss/server-rsapss-priv.pem -A "$CERT_DIR"/rsapss/root-rsapss.pem -d &
 }
 
 #
 # Run OpenSSL client against wolfSSL server
 #
 do_openssl_client() {
-    echo "test connection" | $OPENSSL s_client -connect 127.0.0.1:"$server_port" -cert "$CERT_DIR"/rsapss/client-rsapss.pem -key "$CERT_DIR"/rsapss/client-rsapss-priv.pem -CAfile "$CERT_DIR"/rsapss/root-rsapss.pem > rsapss.test.log
+    echo "test connection" | timeout -s KILL 2m $OPENSSL s_client -connect 127.0.0.1:"$server_port" -cert "$CERT_DIR"/rsapss/client-rsapss.pem -key "$CERT_DIR"/rsapss/client-rsapss-priv.pem -CAfile "$CERT_DIR"/rsapss/root-rsapss.pem > rsapss.test.log
     result=$?
     cat rsapss.test.log
     if [ "$result" != 0 ]

--- a/scripts/rsapss.test
+++ b/scripts/rsapss.test
@@ -4,8 +4,13 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
 
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
@@ -115,14 +120,14 @@ WOLFSSL_SERVER=./examples/server/server
 start_wolfssl_server() {
     generate_port
     server_port=$port
-    timeout -s KILL 2m $WOLFSSL_SERVER -p "$server_port" -v 4 -c "$CERT_DIR"/rsapss/server-rsapss.pem -k "$CERT_DIR"/rsapss/server-rsapss-priv.pem -A "$CERT_DIR"/rsapss/root-rsapss.pem -d &
+    $TIMEOUT_KILL_2M $WOLFSSL_SERVER -p "$server_port" -v 4 -c "$CERT_DIR"/rsapss/server-rsapss.pem -k "$CERT_DIR"/rsapss/server-rsapss-priv.pem -A "$CERT_DIR"/rsapss/root-rsapss.pem -d &
 }
 
 #
 # Run OpenSSL client against wolfSSL server
 #
 do_openssl_client() {
-    echo "test connection" | timeout -s KILL 2m $OPENSSL s_client -connect 127.0.0.1:"$server_port" -cert "$CERT_DIR"/rsapss/client-rsapss.pem -key "$CERT_DIR"/rsapss/client-rsapss-priv.pem -CAfile "$CERT_DIR"/rsapss/root-rsapss.pem > rsapss.test.log
+    echo "test connection" | $TIMEOUT_KILL_2M $OPENSSL s_client -connect 127.0.0.1:"$server_port" -cert "$CERT_DIR"/rsapss/client-rsapss.pem -key "$CERT_DIR"/rsapss/client-rsapss-priv.pem -CAfile "$CERT_DIR"/rsapss/root-rsapss.pem > rsapss.test.log
     result=$?
     cat rsapss.test.log
     if [ "$result" != 0 ]

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -180,7 +180,12 @@ fi
 
 # Check for TLS 1.2 support
 timeout -s KILL 2m ./examples/client/client -v 3 2>&1 | grep -F -e 'Bad SSL version'
-if [ $? -ne 0 ]; then
+pipe_rc=("${PIPESTATUS[@]}")
+if [ "${pipe_rc[0]}" -ge 124 ]; then
+    echo -e "\n\nTLS v1.2 support probe timed out"
+    exit 1
+fi
+if [ "${pipe_rc[1]}" -ne 0 ]; then
     # TLS 1.3 server / TLS 1.2 client.
     echo -e "\n\nTLS v1.3 server downgrading to TLS v1.2"
     port=0

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -129,7 +129,7 @@ timeout -s KILL 2m ./examples/server/server -v 4 -R "$ready_file" -p $port &
 server_pid=$!
 create_port
 timeout -s KILL 2m ./examples/client/client -v 4 -p $port | tee "$client_file"
-RESULT=$?
+RESULT=${PIPESTATUS[0]}
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
     echo -e "\n\nTLS v1.3 not enabled"

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -86,7 +86,7 @@ do_cleanup() {
         # sleep to give sanitizers time to dump backtraces.
         sleep 1
         echo "killing server"
-        kill -9 $server_pid 2>/dev/null
+        kill $server_pid 2>/dev/null
         server_pid=$no_pid
     fi
     remove_ready_file
@@ -125,10 +125,10 @@ fi
 # Usual TLS v1.3 server / TLS v1.3 client.
 echo -e "\n\nTLS v1.3 server with TLS v1.3 client"
 port=0
-./examples/server/server -v 4 -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -v 4 -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -v 4 -p $port | tee "$client_file"
+timeout -s KILL 2m ./examples/client/client -v 4 -p $port | tee "$client_file"
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -141,10 +141,10 @@ echo ""
 # TLS 1.3 cipher suites server / client.
 echo -e "\n\nTLS v1.3 cipher suite mismatch"
 port=0
-./examples/server/server -v 4 -R "$ready_file" -p $port -l TLS13-AES128-GCM-SHA256 &
+timeout -s KILL 2m ./examples/server/server -v 4 -R "$ready_file" -p $port -l TLS13-AES128-GCM-SHA256 &
 server_pid=$!
 create_port
-./examples/client/client -v 4 -p $port -l TLS13-AES256-GCM-SHA384
+timeout -s KILL 2m ./examples/client/client -v 4 -p $port -l TLS13-AES256-GCM-SHA384
 RESULT=$?
 remove_ready_file
 if [ $RESULT -eq 0 ]; then
@@ -163,10 +163,10 @@ if [ $NO_CERTS -ne 0 -a $NO_CLIENT_AUTH -ne 0 ]; then
     # TLS 1.3 mutual auth required but client doesn't send certificates.
     echo -e "\n\nTLS v1.3 mutual auth fail"
     port=0
-    ./examples/server/server -v 4 -F -R "$ready_file" -p $port &
+    timeout -s KILL 2m ./examples/server/server -v 4 -F -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    ./examples/client/client -v 4 -x -p $port
+    timeout -s KILL 2m ./examples/client/client -v 4 -x -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
@@ -179,15 +179,15 @@ if [ $NO_CERTS -ne 0 -a $NO_CLIENT_AUTH -ne 0 ]; then
 fi
 
 # Check for TLS 1.2 support
-./examples/client/client -v 3 2>&1 | grep -F -e 'Bad SSL version'
+timeout -s KILL 2m ./examples/client/client -v 3 2>&1 | grep -F -e 'Bad SSL version'
 if [ $? -ne 0 ]; then
     # TLS 1.3 server / TLS 1.2 client.
     echo -e "\n\nTLS v1.3 server downgrading to TLS v1.2"
     port=0
-    ./examples/server/server -v 4 -R "$ready_file" -p $port &
+    timeout -s KILL 2m ./examples/server/server -v 4 -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    ./examples/client/client -v 3 -p $port
+    timeout -s KILL 2m ./examples/client/client -v 3 -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
@@ -201,10 +201,10 @@ if [ $? -ne 0 ]; then
     # TLS 1.2 server / TLS 1.3 client.
     echo -e "\n\nTLS v1.3 client upgrading server to TLS v1.3"
     port=0
-    ./examples/server/server -v 3 -R "$ready_file" -p $port &
+    timeout -s KILL 2m ./examples/server/server -v 3 -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    ./examples/client/client -v 4 -p $port
+    timeout -s KILL 2m ./examples/client/client -v 4 -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
@@ -232,10 +232,10 @@ if [ $? -ne 0 ]; then
         port=0
         SERVER_CS="TLS13-AES256-GCM-SHA384:$TLS12_CS"
         CLIENT_CS="TLS13-AES128-GCM-SHA256:$TLS12_CS"
-        ./examples/server/server -v d -l $SERVER_CS -R "$ready_file" -p $port &
+        timeout -s KILL 2m ./examples/server/server -v d -l $SERVER_CS -R "$ready_file" -p $port &
         server_pid=$!
         create_port
-        ./examples/client/client -v d -l $CLIENT_CS -p $port
+        timeout -s KILL 2m ./examples/client/client -v d -l $CLIENT_CS -p $port
         RESULT=$?
         remove_ready_file
         if [ $RESULT -eq 0 ]; then

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -2,9 +2,19 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
+
+# timeout(1) exits 124, or 128+signal when it must signal the child (137 for
+# the SIGKILL used here). A hang must be told apart from a genuine non-zero
+# exit, or it is misread as a feature-not-available skip.
+timed_out() { [ "$1" -eq 124 ] || [ "$1" -eq 137 ]; }
 
 
 # tls13.test
@@ -126,10 +136,10 @@ fi
 # Usual TLS v1.3 server / TLS v1.3 client.
 echo -e "\n\nTLS v1.3 server with TLS v1.3 client"
 port=0
-timeout -s KILL 2m ./examples/server/server -v 4 -R "$ready_file" -p $port &
+$TIMEOUT_KILL_2M ./examples/server/server -v 4 -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -v 4 -p $port | tee "$client_file"
+$TIMEOUT_KILL_2M ./examples/client/client -v 4 -p $port | tee "$client_file"
 RESULT=${PIPESTATUS[0]}
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -142,10 +152,10 @@ echo ""
 # TLS 1.3 cipher suites server / client.
 echo -e "\n\nTLS v1.3 cipher suite mismatch"
 port=0
-timeout -s KILL 2m ./examples/server/server -v 4 -R "$ready_file" -p $port -l TLS13-AES128-GCM-SHA256 &
+$TIMEOUT_KILL_2M ./examples/server/server -v 4 -R "$ready_file" -p $port -l TLS13-AES128-GCM-SHA256 &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -v 4 -p $port -l TLS13-AES256-GCM-SHA384
+$TIMEOUT_KILL_2M ./examples/client/client -v 4 -p $port -l TLS13-AES256-GCM-SHA384
 RESULT=$?
 remove_ready_file
 if [ $RESULT -eq 0 ]; then
@@ -164,10 +174,10 @@ if [ $NO_CERTS -ne 0 -a $NO_CLIENT_AUTH -ne 0 ]; then
     # TLS 1.3 mutual auth required but client doesn't send certificates.
     echo -e "\n\nTLS v1.3 mutual auth fail"
     port=0
-    timeout -s KILL 2m ./examples/server/server -v 4 -F -R "$ready_file" -p $port &
+    $TIMEOUT_KILL_2M ./examples/server/server -v 4 -F -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    timeout -s KILL 2m ./examples/client/client -v 4 -x -p $port
+    $TIMEOUT_KILL_2M ./examples/client/client -v 4 -x -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
@@ -180,9 +190,9 @@ if [ $NO_CERTS -ne 0 -a $NO_CLIENT_AUTH -ne 0 ]; then
 fi
 
 # Check for TLS 1.2 support
-timeout -s KILL 2m ./examples/client/client -v 3 2>&1 | grep -F -e 'Bad SSL version'
+$TIMEOUT_KILL_2M ./examples/client/client -v 3 2>&1 | grep -F -e 'Bad SSL version'
 pipe_rc=("${PIPESTATUS[@]}")
-if [ "${pipe_rc[0]}" -ge 124 ]; then
+if timed_out "${pipe_rc[0]}"; then
     echo -e "\n\nTLS v1.2 support probe timed out"
     exit 1
 fi
@@ -190,10 +200,10 @@ if [ "${pipe_rc[1]}" -ne 0 ]; then
     # TLS 1.3 server / TLS 1.2 client.
     echo -e "\n\nTLS v1.3 server downgrading to TLS v1.2"
     port=0
-    timeout -s KILL 2m ./examples/server/server -v 4 -R "$ready_file" -p $port &
+    $TIMEOUT_KILL_2M ./examples/server/server -v 4 -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    timeout -s KILL 2m ./examples/client/client -v 3 -p $port
+    $TIMEOUT_KILL_2M ./examples/client/client -v 3 -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
@@ -207,10 +217,10 @@ if [ "${pipe_rc[1]}" -ne 0 ]; then
     # TLS 1.2 server / TLS 1.3 client.
     echo -e "\n\nTLS v1.3 client upgrading server to TLS v1.3"
     port=0
-    timeout -s KILL 2m ./examples/server/server -v 3 -R "$ready_file" -p $port &
+    $TIMEOUT_KILL_2M ./examples/server/server -v 3 -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    timeout -s KILL 2m ./examples/client/client -v 4 -p $port
+    $TIMEOUT_KILL_2M ./examples/client/client -v 4 -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
@@ -238,10 +248,10 @@ if [ "${pipe_rc[1]}" -ne 0 ]; then
         port=0
         SERVER_CS="TLS13-AES256-GCM-SHA384:$TLS12_CS"
         CLIENT_CS="TLS13-AES128-GCM-SHA256:$TLS12_CS"
-        timeout -s KILL 2m ./examples/server/server -v d -l $SERVER_CS -R "$ready_file" -p $port &
+        $TIMEOUT_KILL_2M ./examples/server/server -v d -l $SERVER_CS -R "$ready_file" -p $port &
         server_pid=$!
         create_port
-        timeout -s KILL 2m ./examples/client/client -v d -l $CLIENT_CS -p $port
+        $TIMEOUT_KILL_2M ./examples/client/client -v d -l $CLIENT_CS -p $port
         RESULT=$?
         remove_ready_file
         if [ $RESULT -eq 0 ]; then
@@ -273,7 +283,7 @@ if [ "$early_data" = "yes" ]; then
 
         echo -e "\n\nTLS v1.3 Early Data - session ticket"
         port=0
-        (timeout -s KILL 2m ./examples/server/server -v 4 -r -0 -R "$ready_file" -p $port 2>&1 | \
+        ($TIMEOUT_KILL_2M ./examples/server/server -v 4 -r -0 -R "$ready_file" -p $port 2>&1 | \
              tee "$server_out_file") &
         server_pid=$!
         create_port
@@ -321,7 +331,7 @@ if [ "$early_data" = "yes" -a "$psk" = "yes" ]; then
     early_data_try_num=1
     while :; do
 
-        (timeout -s KILL 2m ./examples/server/server -v 4 -s -0 -R "$ready_file" -p $port 2>&1 | \
+        ($TIMEOUT_KILL_2M ./examples/server/server -v 4 -s -0 -R "$ready_file" -p $port 2>&1 | \
              tee "$server_out_file") &
         server_pid=$!
         create_port

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -158,6 +158,11 @@ create_port
 $TIMEOUT_KILL_2M ./examples/client/client -v 4 -p $port -l TLS13-AES256-GCM-SHA384
 RESULT=$?
 remove_ready_file
+if timed_out $RESULT; then
+    echo -e "\n\nMismatched TLS v1.3 cipher suite test timed out"
+    do_cleanup
+    exit 1
+fi
 if [ $RESULT -eq 0 ]; then
     echo -e "\n\nIssue with mismatched TLS v1.3 cipher suites"
     do_cleanup
@@ -180,6 +185,11 @@ if [ $NO_CERTS -ne 0 -a $NO_CLIENT_AUTH -ne 0 ]; then
     $TIMEOUT_KILL_2M ./examples/client/client -v 4 -x -p $port
     RESULT=$?
     remove_ready_file
+    if timed_out $RESULT; then
+        echo -e "\n\nMutual authentication test timed out"
+        do_cleanup
+        exit 1
+    fi
     if [ $RESULT -eq 0 ]; then
         echo -e "\n\nIssue with requiring mutual authentication"
         do_cleanup
@@ -206,6 +216,11 @@ if [ "${pipe_rc[1]}" -ne 0 ]; then
     $TIMEOUT_KILL_2M ./examples/client/client -v 3 -p $port
     RESULT=$?
     remove_ready_file
+    if timed_out $RESULT; then
+        echo -e "\n\nTLS v1.3 server downgrade test timed out"
+        do_cleanup
+        exit 1
+    fi
     if [ $RESULT -eq 0 ]; then
         echo -e "\n\nIssue with TLS v1.3 server downgrading to TLS v1.2"
         do_cleanup
@@ -223,6 +238,11 @@ if [ "${pipe_rc[1]}" -ne 0 ]; then
     $TIMEOUT_KILL_2M ./examples/client/client -v 4 -p $port
     RESULT=$?
     remove_ready_file
+    if timed_out $RESULT; then
+        echo -e "\n\nTLS v1.3 client upgrade test timed out"
+        do_cleanup
+        exit 1
+    fi
     if [ $RESULT -eq 0 ]; then
         echo -e "\n\nIssue with TLS v1.3 client upgrading server to TLS v1.3"
         do_cleanup
@@ -254,6 +274,11 @@ if [ "${pipe_rc[1]}" -ne 0 ]; then
         $TIMEOUT_KILL_2M ./examples/client/client -v d -l $CLIENT_CS -p $port
         RESULT=$?
         remove_ready_file
+        if timed_out $RESULT; then
+            echo -e "\n\nTLS v1.3 cipher downgrade test timed out"
+            do_cleanup
+            exit 1
+        fi
         if [ $RESULT -eq 0 ]; then
             echo -e "\n\nTLS v1.3 downgrading to TLS v1.2 due to ciphers"
             do_cleanup

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -87,7 +87,7 @@ do_cleanup() {
         # sleep to give sanitizers time to dump backtraces.
         sleep 1
         echo "killing server"
-        kill -9 $server_pid 2>/dev/null
+        kill $server_pid 2>/dev/null
         server_pid=$no_pid
     fi
     remove_ready_file
@@ -126,10 +126,10 @@ fi
 # Usual TLS v1.3 server / TLS v1.3 client.
 echo -e "\n\nTLS v1.3 server with TLS v1.3 client"
 port=0
-./examples/server/server -v 4 -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -v 4 -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -v 4 -p $port | tee "$client_file"
+timeout -s KILL 2m ./examples/client/client -v 4 -p $port | tee "$client_file"
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -142,10 +142,10 @@ echo ""
 # TLS 1.3 cipher suites server / client.
 echo -e "\n\nTLS v1.3 cipher suite mismatch"
 port=0
-./examples/server/server -v 4 -R "$ready_file" -p $port -l TLS13-AES128-GCM-SHA256 &
+timeout -s KILL 2m ./examples/server/server -v 4 -R "$ready_file" -p $port -l TLS13-AES128-GCM-SHA256 &
 server_pid=$!
 create_port
-./examples/client/client -v 4 -p $port -l TLS13-AES256-GCM-SHA384
+timeout -s KILL 2m ./examples/client/client -v 4 -p $port -l TLS13-AES256-GCM-SHA384
 RESULT=$?
 remove_ready_file
 if [ $RESULT -eq 0 ]; then
@@ -164,10 +164,10 @@ if [ $NO_CERTS -ne 0 -a $NO_CLIENT_AUTH -ne 0 ]; then
     # TLS 1.3 mutual auth required but client doesn't send certificates.
     echo -e "\n\nTLS v1.3 mutual auth fail"
     port=0
-    ./examples/server/server -v 4 -F -R "$ready_file" -p $port &
+    timeout -s KILL 2m ./examples/server/server -v 4 -F -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    ./examples/client/client -v 4 -x -p $port
+    timeout -s KILL 2m ./examples/client/client -v 4 -x -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
@@ -180,15 +180,15 @@ if [ $NO_CERTS -ne 0 -a $NO_CLIENT_AUTH -ne 0 ]; then
 fi
 
 # Check for TLS 1.2 support
-./examples/client/client -v 3 2>&1 | grep -F -e 'Bad SSL version'
+timeout -s KILL 2m ./examples/client/client -v 3 2>&1 | grep -F -e 'Bad SSL version'
 if [ $? -ne 0 ]; then
     # TLS 1.3 server / TLS 1.2 client.
     echo -e "\n\nTLS v1.3 server downgrading to TLS v1.2"
     port=0
-    ./examples/server/server -v 4 -R "$ready_file" -p $port &
+    timeout -s KILL 2m ./examples/server/server -v 4 -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    ./examples/client/client -v 3 -p $port
+    timeout -s KILL 2m ./examples/client/client -v 3 -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
@@ -202,10 +202,10 @@ if [ $? -ne 0 ]; then
     # TLS 1.2 server / TLS 1.3 client.
     echo -e "\n\nTLS v1.3 client upgrading server to TLS v1.3"
     port=0
-    ./examples/server/server -v 3 -R "$ready_file" -p $port &
+    timeout -s KILL 2m ./examples/server/server -v 3 -R "$ready_file" -p $port &
     server_pid=$!
     create_port
-    ./examples/client/client -v 4 -p $port
+    timeout -s KILL 2m ./examples/client/client -v 4 -p $port
     RESULT=$?
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
@@ -233,10 +233,10 @@ if [ $? -ne 0 ]; then
         port=0
         SERVER_CS="TLS13-AES256-GCM-SHA384:$TLS12_CS"
         CLIENT_CS="TLS13-AES128-GCM-SHA256:$TLS12_CS"
-        ./examples/server/server -v d -l $SERVER_CS -R "$ready_file" -p $port &
+        timeout -s KILL 2m ./examples/server/server -v d -l $SERVER_CS -R "$ready_file" -p $port &
         server_pid=$!
         create_port
-        ./examples/client/client -v d -l $CLIENT_CS -p $port
+        timeout -s KILL 2m ./examples/client/client -v d -l $CLIENT_CS -p $port
         RESULT=$?
         remove_ready_file
         if [ $RESULT -eq 0 ]; then

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -181,7 +181,12 @@ fi
 
 # Check for TLS 1.2 support
 timeout -s KILL 2m ./examples/client/client -v 3 2>&1 | grep -F -e 'Bad SSL version'
-if [ $? -ne 0 ]; then
+pipe_rc=("${PIPESTATUS[@]}")
+if [ "${pipe_rc[0]}" -ge 124 ]; then
+    echo -e "\n\nTLS v1.2 support probe timed out"
+    exit 1
+fi
+if [ "${pipe_rc[1]}" -ne 0 ]; then
     # TLS 1.3 server / TLS 1.2 client.
     echo -e "\n\nTLS v1.3 server downgrading to TLS v1.2"
     port=0

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -130,7 +130,7 @@ timeout -s KILL 2m ./examples/server/server -v 4 -R "$ready_file" -p $port &
 server_pid=$!
 create_port
 timeout -s KILL 2m ./examples/client/client -v 4 -p $port | tee "$client_file"
-RESULT=$?
+RESULT=${PIPESTATUS[0]}
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
     echo -e "\n\nTLS v1.3 not enabled"

--- a/scripts/trusted_peer.test
+++ b/scripts/trusted_peer.test
@@ -3,6 +3,12 @@
 # trusted_peer.test
 # copyright wolfSSL 2016
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
                                   && exit 1
 
@@ -92,7 +98,7 @@ do_cleanup() {
         # sleep to give sanitizers time to dump backtraces.
         sleep 1
         echo "killing server"
-        kill -9 $server_pid
+        kill $server_pid
     fi
     remove_ready_file
 }
@@ -138,10 +144,10 @@ echo "Checking built with trusted peer certs "
 echo "-----------------------------------------------------"
 port=0
 remove_ready_file
-./examples/server/server -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -p $port
 RESULT=$?
 remove_ready_file
 # if fail here then is a settings issue so return 0
@@ -156,10 +162,10 @@ echo ""
 echo "Server and Client relying on trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$wrong_ca" -E "$server_cert" -c "$client_cert" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$wrong_ca" -E "$server_cert" -c "$client_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -173,10 +179,10 @@ echo ""
 echo "Server relying on trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -c "$client_cert" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$client_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -190,10 +196,10 @@ echo ""
 echo "Client relying on trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$wrong_ca" -E "$server_cert" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$wrong_ca" -E "$server_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -207,10 +213,10 @@ echo ""
 echo "Client fall through to loaded CAs"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -E "$wrong_cert" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -E "$wrong_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -226,10 +232,10 @@ if [[ $wrong_ca != *"ecc"* ]]; then
 echo "Client wrong CA and wrong trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$wrong_ca" -E "$wrong_cert" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$wrong_ca" -E "$wrong_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -eq 0 ]; then
@@ -244,10 +250,10 @@ fi
 echo "Server wrong CA and wrong trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -A "$wrong_ca" -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -A "$wrong_ca" -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -eq 0 ]; then
@@ -261,10 +267,10 @@ echo ""
 echo "Server fall through to loaded CAs"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -280,24 +286,24 @@ echo "Test two success cases and one fail case"
 echo "-----------------------------------------------------"
 port=0
 cat "$client_cert" "$client_ca" > "$combined_cert"
-./examples/server/server -i -A "$wrong_ca" -E "$combined_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -i -A "$wrong_ca" -E "$combined_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -c "$client_cert" -k "$client_key" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$client_cert" -k "$client_key" -p $port
 RESULT=$?
 if [ $RESULT -ne 0 ]; then
     echo -e "\nServer load multiple trusted peer certs failed!"
     do_cleanup
     exit 1
 fi
-./examples/client/client -A "$client_ca" -c "$client_ca" -k "$ca_key"  -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$client_ca" -k "$ca_key"  -p $port
 RESULT=$?
 if [ $RESULT -ne 0 ]; then
     echo -e "\nServer load multiple trusted peer certs failed!"
     do_cleanup
     exit 1
 fi
-./examples/client/client -A "$client_ca" -c "$wrong_cert" -k "$client_key" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$wrong_cert" -k "$client_key" -p $port
 RESULT=$?
 if [ $RESULT -eq 0 ]; then
     echo -e "\nServer load multiple trusted peer certs failed!"

--- a/scripts/trusted_peer.test
+++ b/scripts/trusted_peer.test
@@ -3,6 +3,12 @@
 # trusted_peer.test
 # copyright wolfSSL 2016
 
+# timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
+# command unbounded (the flaky hang this guards against is Linux-only CI).
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+fi
+
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
                                   && exit 1
 
@@ -93,7 +99,7 @@ do_cleanup() {
         # sleep to give sanitizers time to dump backtraces.
         sleep 1
         echo "killing server"
-        kill -9 $server_pid
+        kill $server_pid
     fi
     remove_ready_file
 }
@@ -139,10 +145,10 @@ echo "Checking built with trusted peer certs "
 echo "-----------------------------------------------------"
 port=0
 remove_ready_file
-./examples/server/server -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -p $port
 RESULT=$?
 remove_ready_file
 # if fail here then is a settings issue so return 0
@@ -157,10 +163,10 @@ echo ""
 echo "Server and Client relying on trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$wrong_ca" -E "$server_cert" -c "$client_cert" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$wrong_ca" -E "$server_cert" -c "$client_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -174,10 +180,10 @@ echo ""
 echo "Server relying on trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -c "$client_cert" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$client_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -191,10 +197,10 @@ echo ""
 echo "Client relying on trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$wrong_ca" -E "$server_cert" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$wrong_ca" -E "$server_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -208,10 +214,10 @@ echo ""
 echo "Client fall through to loaded CAs"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -E "$wrong_cert" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -E "$wrong_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -227,10 +233,10 @@ if [[ $wrong_ca != *"ecc"* ]]; then
 echo "Client wrong CA and wrong trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$wrong_ca" -E "$wrong_cert" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$wrong_ca" -E "$wrong_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -eq 0 ]; then
@@ -245,10 +251,10 @@ fi
 echo "Server wrong CA and wrong trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -A "$wrong_ca" -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -A "$wrong_ca" -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -eq 0 ]; then
@@ -262,10 +268,10 @@ echo ""
 echo "Server fall through to loaded CAs"
 echo "-----------------------------------------------------"
 port=0
-./examples/server/server -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -281,24 +287,24 @@ echo "Test two success cases and one fail case"
 echo "-----------------------------------------------------"
 port=0
 cat "$client_cert" "$client_ca" > "$combined_cert"
-./examples/server/server -i -A "$wrong_ca" -E "$combined_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+timeout -s KILL 2m ./examples/server/server -i -A "$wrong_ca" -E "$combined_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-./examples/client/client -A "$client_ca" -c "$client_cert" -k "$client_key" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$client_cert" -k "$client_key" -p $port
 RESULT=$?
 if [ $RESULT -ne 0 ]; then
     echo -e "\nServer load multiple trusted peer certs failed!"
     do_cleanup
     exit 1
 fi
-./examples/client/client -A "$client_ca" -c "$client_ca" -k "$ca_key"  -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$client_ca" -k "$ca_key"  -p $port
 RESULT=$?
 if [ $RESULT -ne 0 ]; then
     echo -e "\nServer load multiple trusted peer certs failed!"
     do_cleanup
     exit 1
 fi
-./examples/client/client -A "$client_ca" -c "$wrong_cert" -k "$client_key" -p $port
+timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$wrong_cert" -k "$client_key" -p $port
 RESULT=$?
 if [ $RESULT -eq 0 ]; then
     echo -e "\nServer load multiple trusted peer certs failed!"

--- a/scripts/trusted_peer.test
+++ b/scripts/trusted_peer.test
@@ -5,9 +5,20 @@
 
 # timeout(1) is GNU coreutils and absent on macOS; where it's missing, run the
 # command unbounded (the flaky hang this guards against is Linux-only CI).
-if ! command -v timeout >/dev/null 2>&1; then
-    timeout() { while [ "${1:-}" = "-s" ] || [ "${1:-}" = "-k" ]; do shift 2; done; shift; "$@"; }
+# A prefix variable rather than a shell function: backgrounding a function
+# makes $! the forked subshell, so a later "kill $server_pid" would stop the
+# wrapper and orphan the server it was meant to kill.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_KILL_2M="timeout -s KILL 2m"
+else
+    TIMEOUT_KILL_2M=""
 fi
+
+# timeout(1) exits 124, or 128+signal when it must signal the child (137 for
+# the SIGKILL used here). Skip branches below turn a non-zero status into
+# "feature not compiled in" and exit 0, so a hang must be told apart from a
+# genuine failure or it lands in CI as a silent pass.
+timed_out() { [ "$1" -eq 124 ] || [ "$1" -eq 137 ]; }
 
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
                                   && exit 1
@@ -145,12 +156,17 @@ echo "Checking built with trusted peer certs "
 echo "-----------------------------------------------------"
 port=0
 remove_ready_file
-timeout -s KILL 2m ./examples/server/server -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+$TIMEOUT_KILL_2M ./examples/server/server -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -A "$client_ca" -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -A "$client_ca" -p $port
 RESULT=$?
 remove_ready_file
+if timed_out $RESULT; then
+    echo -e "\n\nTrusted peer cert probe client timed out"
+    do_cleanup
+    exit 1
+fi
 # if fail here then is a settings issue so return 0
 if [ $RESULT -ne 0 ]; then
     echo -e "\n\nTrusted peer certs not enabled \"WOLFSSL_TRUST_PEER_CERT\""
@@ -163,10 +179,10 @@ echo ""
 echo "Server and Client relying on trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-timeout -s KILL 2m ./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+$TIMEOUT_KILL_2M ./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -A "$wrong_ca" -E "$server_cert" -c "$client_cert" -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -A "$wrong_ca" -E "$server_cert" -c "$client_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -180,10 +196,10 @@ echo ""
 echo "Server relying on trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-timeout -s KILL 2m ./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+$TIMEOUT_KILL_2M ./examples/server/server -A "$wrong_ca" -E "$client_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$client_cert" -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -A "$client_ca" -c "$client_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -197,10 +213,10 @@ echo ""
 echo "Client relying on trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-timeout -s KILL 2m ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+$TIMEOUT_KILL_2M ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -A "$wrong_ca" -E "$server_cert" -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -A "$wrong_ca" -E "$server_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -214,10 +230,10 @@ echo ""
 echo "Client fall through to loaded CAs"
 echo "-----------------------------------------------------"
 port=0
-timeout -s KILL 2m ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+$TIMEOUT_KILL_2M ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -A "$client_ca" -E "$wrong_cert" -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -A "$client_ca" -E "$wrong_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -233,10 +249,10 @@ if [[ $wrong_ca != *"ecc"* ]]; then
 echo "Client wrong CA and wrong trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-timeout -s KILL 2m ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+$TIMEOUT_KILL_2M ./examples/server/server -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -A "$wrong_ca" -E "$wrong_cert" -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -A "$wrong_ca" -E "$wrong_cert" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -eq 0 ]; then
@@ -251,10 +267,10 @@ fi
 echo "Server wrong CA and wrong trusted peer cert loaded"
 echo "-----------------------------------------------------"
 port=0
-timeout -s KILL 2m ./examples/server/server -A "$wrong_ca" -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+$TIMEOUT_KILL_2M ./examples/server/server -A "$wrong_ca" -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -A "$client_ca" -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -A "$client_ca" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -eq 0 ]; then
@@ -268,10 +284,10 @@ echo ""
 echo "Server fall through to loaded CAs"
 echo "-----------------------------------------------------"
 port=0
-timeout -s KILL 2m ./examples/server/server -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+$TIMEOUT_KILL_2M ./examples/server/server -E "$wrong_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -A "$client_ca" -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -A "$client_ca" -p $port
 RESULT=$?
 remove_ready_file
 if [ $RESULT -ne 0 ]; then
@@ -287,24 +303,24 @@ echo "Test two success cases and one fail case"
 echo "-----------------------------------------------------"
 port=0
 cat "$client_cert" "$client_ca" > "$combined_cert"
-timeout -s KILL 2m ./examples/server/server -i -A "$wrong_ca" -E "$combined_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
+$TIMEOUT_KILL_2M ./examples/server/server -i -A "$wrong_ca" -E "$combined_cert" -c "$server_cert" -k "$server_key" -R "$ready_file" -p $port &
 server_pid=$!
 create_port
-timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$client_cert" -k "$client_key" -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -A "$client_ca" -c "$client_cert" -k "$client_key" -p $port
 RESULT=$?
 if [ $RESULT -ne 0 ]; then
     echo -e "\nServer load multiple trusted peer certs failed!"
     do_cleanup
     exit 1
 fi
-timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$client_ca" -k "$ca_key"  -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -A "$client_ca" -c "$client_ca" -k "$ca_key"  -p $port
 RESULT=$?
 if [ $RESULT -ne 0 ]; then
     echo -e "\nServer load multiple trusted peer certs failed!"
     do_cleanup
     exit 1
 fi
-timeout -s KILL 2m ./examples/client/client -A "$client_ca" -c "$wrong_cert" -k "$client_key" -p $port
+$TIMEOUT_KILL_2M ./examples/client/client -A "$client_ca" -c "$wrong_cert" -k "$client_key" -p $port
 RESULT=$?
 if [ $RESULT -eq 0 ]; then
     echo -e "\nServer load multiple trusted peer certs failed!"

--- a/scripts/trusted_peer.test
+++ b/scripts/trusted_peer.test
@@ -255,6 +255,11 @@ create_port
 $TIMEOUT_KILL_2M ./examples/client/client -A "$wrong_ca" -E "$wrong_cert" -p $port
 RESULT=$?
 remove_ready_file
+if timed_out $RESULT; then
+    echo -e "\nClient trusted peer cert test timed out!"
+    do_cleanup
+    exit 1
+fi
 if [ $RESULT -eq 0 ]; then
     echo -e "\nClient trusted peer cert test failed!"
     do_cleanup
@@ -273,6 +278,11 @@ create_port
 $TIMEOUT_KILL_2M ./examples/client/client -A "$client_ca" -p $port
 RESULT=$?
 remove_ready_file
+if timed_out $RESULT; then
+    echo -e "\nServer trusted peer cert test timed out!"
+    do_cleanup
+    exit 1
+fi
 if [ $RESULT -eq 0 ]; then
     echo -e "\nServer trusted peer cert test failed!"
     do_cleanup
@@ -322,6 +332,11 @@ if [ $RESULT -ne 0 ]; then
 fi
 $TIMEOUT_KILL_2M ./examples/client/client -A "$client_ca" -c "$wrong_cert" -k "$client_key" -p $port
 RESULT=$?
+if timed_out $RESULT; then
+    echo -e "\nServer load multiple trusted peer certs timed out!"
+    do_cleanup
+    exit 1
+fi
 if [ $RESULT -eq 0 ]; then
     echo -e "\nServer load multiple trusted peer certs failed!"
     do_cleanup


### PR DESCRIPTION
## Summary
A test script that blocks forever burns the CI job's full timeout-minutes with no logs. e82ecdff93 and 5c5cbd3094 bounded the waited-on servers; this covers the remaining hang classes in `scripts/*.test`:

- Wrap foreground example client/server, `openssl s_client`, and `openssl ocsp` invocations in `timeout -s KILL 2m`. A client wedged before or without a live peer (e.g. blocked in first-seed entropy gathering, or DTLS with no reset from a dead peer) is not bounded by its peer's timeout.
- Add the macOS `timeout()` fallback shim to scripts that now use `timeout`.
- Bound the `get_first_free_port` scan loops (`nc -w 1`, 100-port cap).
- Add `-w 1` to the remaining `nc` probes and `dtls.test` UDP pcap markers.
- `ocsp-responder-openssl-interop.test`: bound the responder reap in cleanup: give each responder 5 s to exit after SIGTERM, then SIGKILL before waiting, so a wedged responder cannot hang the EXIT trap.
- `benchmark.test`: bound the clients but leave the `-i` servers unwrapped: the script ends them with `kill -6`, which `timeout(1)` does not forward, so wrapping would orphan the server.
- `trusted_peer`/`tls13`: kill the server with SIGTERM instead of SIGKILL in cleanup so the signal forwards through the timeout wrapper to the wrapped server.

## Test plan
- [ ] Affected `scripts/*.test` pass locally
- [ ] CI passes