### PR TITLE
2020714 Coverity fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -27258,11 +27258,6 @@ int SendCertificateStatus(WOLFSSL* ssl)
             else {
                 while (ret == 0 && i < MAX_CHAIN_DEPTH &&
                             NULL != (request = ssl->ctx->chainOcspRequest[i])) {
-                    if ((i + 1) >= MAX_CERT_EXTENSIONS) {
-                        ret = MAX_CERT_EXTENSIONS_ERR;
-                        break;
-                    }
-
                     request->ssl = ssl;
                     ret = CheckOcspRequest(SSL_CM(ssl)->ocsp_stapling,
                                            request, &responses[++i], ssl->heap);

--- a/tests/api.c
+++ b/tests/api.c
@@ -15038,6 +15038,9 @@ static int ech_find_extension(byte* buf, word16* idx_p, word16 extType)
     if (seekRet < 0) {
         return seekRet;
     }
+    if (extLen > MAX_RECORD_SIZE) {
+        return BAD_FUNC_ARG;
+    }
     idx = extIdx = ((word16)seekRet + *idx_p);
 
     while (idx - extIdx < extLen) {

--- a/tests/api/test_dh.c
+++ b/tests/api/test_dh.c
@@ -625,6 +625,9 @@ int test_wc_DhAgree_nonblock(void)
     int ret;
     int rounds;
 
+    XMEMSET(&aliceKey, 0, sizeof(aliceKey));
+    XMEMSET(&bobKey, 0, sizeof(bobKey));
+
     ExpectIntEQ(wc_InitRng(&rng), 0);
     ExpectIntEQ(wc_InitDhKey(&aliceKey), 0);
     ExpectIntEQ(wc_InitDhKey(&bobKey), 0);
@@ -690,6 +693,8 @@ int test_wc_DhImportExportKeyPair(void)
     word32 privSz = sizeof(priv), pubSz = sizeof(pub);
     byte privOut[TEST_DH_BUF_SIZE], pubOut[TEST_DH_BUF_SIZE];
     word32 privOutSz, pubOutSz;
+
+    XMEMSET(&key, 0, sizeof(key));
 
     ExpectIntEQ(wc_InitRng(&rng), 0);
     ExpectIntEQ(wc_InitDhKey(&key), 0);
@@ -770,6 +775,8 @@ int test_wc_DhCheckPubKey(void)
     word32 privSz = sizeof(priv), pubSz = sizeof(pub);
     byte tiny[1] = { 0x01 };
 
+    XMEMSET(&key, 0, sizeof(key));
+
     ExpectIntEQ(wc_InitRng(&rng), 0);
     ExpectNotNull(params = wc_Dh_ffdhe2048_Get());
 
@@ -837,6 +844,8 @@ int test_wc_DhCheckPrivKey(void)
     byte priv[TEST_DH_BUF_SIZE], pub[TEST_DH_BUF_SIZE];
     word32 privSz = sizeof(priv), pubSz = sizeof(pub);
     byte zero[1] = { 0x00 };
+
+    XMEMSET(&key, 0, sizeof(key));
 
     ExpectIntEQ(wc_InitRng(&rng), 0);
     ExpectNotNull(params = wc_Dh_ffdhe2048_Get());
@@ -910,6 +919,8 @@ int test_wc_DhCheckKeyPair(void)
     byte priv[TEST_DH_BUF_SIZE] = {0}, pub[TEST_DH_BUF_SIZE] = {0};
     word32 privSz = sizeof(priv), pubSz = sizeof(pub);
 
+    XMEMSET(&key, 0, sizeof(key));
+
     ExpectIntEQ(wc_InitRng(&rng), 0);
     ExpectIntEQ(wc_InitDhKey(&key), 0);
     ExpectIntEQ(wc_DhSetNamedKey(&key, WC_FFDHE_2048), 0);
@@ -969,6 +980,8 @@ int test_wc_DhGenerateParams_and_ExportRaw(void)
     byte pOut[TEST_DH_BUF_SIZE], qOut[TEST_DH_BUF_SIZE];
     byte gOut[TEST_DH_BUF_SIZE];
     word32 pSz, qSz, gSz;
+
+    XMEMSET(&dh, 0, sizeof(dh));
 
     ExpectIntEQ(wc_InitRng(&rng), 0);
     ExpectIntEQ(wc_InitDhKey(&dh), 0);

--- a/tests/api/test_ed25519.c
+++ b/tests/api/test_ed25519.c
@@ -1040,6 +1040,7 @@ int test_wc_ed25519_verify_streaming(void)
 
     XMEMSET(&key, 0, sizeof(key));
     XMEMSET(&rng, 0, sizeof(WC_RNG));
+    XMEMSET(sig, 0, sizeof(sig));
 
     ExpectIntEQ(wc_ed25519_init(&key), 0);
     ExpectIntEQ(wc_InitRng(&rng), 0);

--- a/tests/api/test_ossl_x509_vp.c
+++ b/tests/api/test_ossl_x509_vp.c
@@ -170,13 +170,13 @@ int test_wolfSSL_X509_VERIFY_PARAM(void)
     paramTo->flags = WOLFSSL_USE_CHECK_TIME;
     paramFrom->check_time = 22;
     ExpectIntEQ(X509_VERIFY_PARAM_inherit(paramTo, paramFrom), 1);
-    ExpectIntEQ(paramTo->check_time, 11);
+    ExpectTrue(paramTo->check_time == 11);
     ExpectIntEQ(paramTo->flags & WOLFSSL_USE_CHECK_TIME,
         WOLFSSL_USE_CHECK_TIME);
 
     paramTo->inherit_flags = X509_VP_FLAG_OVERWRITE;
     ExpectIntEQ(X509_VERIFY_PARAM_inherit(paramTo, paramFrom), 1);
-    ExpectIntEQ(paramTo->check_time, 22);
+    ExpectTrue(paramTo->check_time == 22);
     ExpectIntEQ(paramTo->flags & WOLFSSL_USE_CHECK_TIME, 0);
 
     /* test for incorrect parameters */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -76425,7 +76425,7 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
                                                    use SW */
     myCryptoDevCtx* myCtx = (myCryptoDevCtx*)ctx;
 
-    if (info == NULL)
+    if (info == NULL || myCtx == NULL)
         return BAD_FUNC_ARG;
 
 #ifdef DEBUG_WOLFSSL
@@ -76718,7 +76718,7 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
             }
             else {
                 ret = 0;
-                if (myCtx != NULL && myCtx->eccCheckPubExpectZeroPoint) {
+                if (myCtx->eccCheckPubExpectZeroPoint) {
                     const byte* pub = info->pk.ecc_check_pub.pubKey;
                     word32 curveSz = (word32)k->dp->size;
                     word32 ptSz = 1 + 2 * curveSz;


### PR DESCRIPTION
# Description

Various coverity fixes

Use of 32-bit time_t - 561736: compare to `paramTo->check_time` directly to value.
Logically dead code - 561704: Remove dead check
Dereference before null check - 561665: Move `myCtx` check
Untrusted loop bound - 561218: Add bounds checks
Uninitialized scalar variable - 561786/561785/561784/561783/561782/561781: Add `XMEMSET()` to init vars

# Testing

`./configure --enable-all && make check`