### PR TITLE
[Renesas RA6M4] Fix Renesas RA6M4 SCE session-key generation issues

### DIFF
--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_aes.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_aes.c
@@ -586,7 +586,7 @@ int  wc_fspsm_AesGcmDecrypt(struct Aes* aes, byte* out,
     }
 
     if (authTagSz < WOLFSSL_MIN_AUTH_TAG_SZ) {
-        WOLFSSL_MSG("GcmEncrypt authTagSz too small error");
+        WOLFSSL_MSG("GcmDecrypt authTagSz too small error");
         return BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
@@ -798,6 +798,8 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
                     enc->aes = (Aes*)XMALLOC(sizeof(Aes), ssl->heap,
                                                     DYNAMIC_TYPE_CIPHER);
                     if (enc->aes == NULL) {
+                        XFREE(key_client_aes, ssl->heap, DYNAMIC_TYPE_AES);
+                        XFREE(key_server_aes, ssl->heap, DYNAMIC_TYPE_AES);
                         wc_fspsm_hw_unlock();
                         return MEMORY_E;
                     }
@@ -807,6 +809,10 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
                                             (sizeof(FSPSM_AES_WKEY),
                                             ssl->heap, DYNAMIC_TYPE_AES);
                 if (enc->aes->ctx.wrapped_key == NULL) {
+                    XFREE(enc->aes, ssl->heap, DYNAMIC_TYPE_CIPHER);
+                    enc->aes = NULL;
+                    XFREE(key_client_aes, ssl->heap, DYNAMIC_TYPE_AES);
+                    XFREE(key_server_aes, ssl->heap, DYNAMIC_TYPE_AES);
                     wc_fspsm_hw_unlock();
                     return MEMORY_E;
                 }
@@ -822,6 +828,8 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
                             XFREE(enc->aes, ssl->heap, DYNAMIC_TYPE_CIPHER);
                             enc->aes = NULL;
                         }
+                        XFREE(key_client_aes, ssl->heap, DYNAMIC_TYPE_AES);
+                        XFREE(key_server_aes, ssl->heap, DYNAMIC_TYPE_AES);
                         wc_fspsm_hw_unlock();
                         return MEMORY_E;
                     }
@@ -831,6 +839,16 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
                                             (sizeof(FSPSM_AES_WKEY),
                                             ssl->heap, DYNAMIC_TYPE_AES);
                     if (dec->aes->ctx.wrapped_key == NULL) {
+                        if (enc) {
+                            XFREE(enc->aes->ctx.wrapped_key, ssl->heap,
+                                                        DYNAMIC_TYPE_AES);
+                            XFREE(enc->aes, ssl->heap, DYNAMIC_TYPE_CIPHER);
+                            enc->aes = NULL;
+                        }
+                        XFREE(dec->aes, ssl->heap, DYNAMIC_TYPE_CIPHER);
+                        dec->aes = NULL;
+                        XFREE(key_client_aes, ssl->heap, DYNAMIC_TYPE_AES);
+                        XFREE(key_server_aes, ssl->heap, DYNAMIC_TYPE_AES);
                         wc_fspsm_hw_unlock();
                         return MEMORY_E;
                     }

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
@@ -759,6 +759,12 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
             key_server_aes = (FSPSM_AES_PWKEY)XMALLOC(sizeof(FSPSM_AES_WKEY),
                                             ssl->heap, DYNAMIC_TYPE_AES);
             if (key_client_aes == NULL || key_server_aes == NULL) {
+                if (key_client_aes != NULL) {
+                    XFREE(key_client_aes, ssl->heap, DYNAMIC_TYPE_AES);
+                }
+                if (key_server_aes != NULL) {
+                    XFREE(key_server_aes, ssl->heap, DYNAMIC_TYPE_AES);
+                }
                 wc_fspsm_hw_unlock();
                 return MEMORY_E;
             }
@@ -811,7 +817,10 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
                                                     DYNAMIC_TYPE_CIPHER);
                     if (dec->aes == NULL) {
                         if (enc) {
-                            XFREE(enc->aes, NULL, DYNAMIC_TYPE_CIPHER);
+                            XFREE(enc->aes->ctx.wrapped_key, ssl->heap,
+                                                        DYNAMIC_TYPE_AES);
+                            XFREE(enc->aes, ssl->heap, DYNAMIC_TYPE_CIPHER);
+                            enc->aes = NULL;
                         }
                         wc_fspsm_hw_unlock();
                         return MEMORY_E;
@@ -827,9 +836,10 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
                     }
                     }
             }
-            /* copy key index into aes. Skipped when AES-GCM session-key
-             * generation was deferred above -- key_client_aes/key_server_aes
-             * are NULL in that case, and the real per-record key is
+            /* copy key/mac index into aes/keys. Skipped when AES-GCM
+             * session-key generation was deferred above -- key_client_aes/
+             * key_server_aes/key_client_mac/key_server_mac are all
+             * uninitialized in that case, and the real per-record key is
              * generated later inside wc_fspsm_AesGcmEncrypt/Decrypt. */
             if (key_client_aes != NULL && key_server_aes != NULL) {
                 if (ssl->options.side == PROVISION_CLIENT) {
@@ -844,10 +854,9 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
                     XMEMCPY(dec->aes->ctx.wrapped_key, key_client_aes,
                                                         sizeof(FSPSM_AES_WKEY));
                 }
+                ssl->keys.fspsm_client_write_MAC_secret = key_client_mac;
+                ssl->keys.fspsm_server_write_MAC_secret = key_server_mac;
             }
-            /* copy mac key index into keys */
-            ssl->keys.fspsm_client_write_MAC_secret = key_client_mac;
-            ssl->keys.fspsm_server_write_MAC_secret = key_server_mac;
 
             /* set up key size and marked ready */
             if (enc) {

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
@@ -759,6 +759,7 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
             key_server_aes = (FSPSM_AES_PWKEY)XMALLOC(sizeof(FSPSM_AES_WKEY),
                                             ssl->heap, DYNAMIC_TYPE_AES);
             if (key_client_aes == NULL || key_server_aes == NULL) {
+                wc_fspsm_hw_unlock();
                 return MEMORY_E;
             }
 
@@ -790,15 +791,19 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
                 if (enc->aes == NULL) {
                     enc->aes = (Aes*)XMALLOC(sizeof(Aes), ssl->heap,
                                                     DYNAMIC_TYPE_CIPHER);
-                    if (enc->aes == NULL)
+                    if (enc->aes == NULL) {
+                        wc_fspsm_hw_unlock();
                         return MEMORY_E;
+                    }
                 }
                 XMEMSET(enc->aes, 0, sizeof(Aes));
                 enc->aes->ctx.wrapped_key = (FSPSM_AES_PWKEY)XMALLOC
                                             (sizeof(FSPSM_AES_WKEY),
                                             ssl->heap, DYNAMIC_TYPE_AES);
-                if (enc->aes->ctx.wrapped_key == NULL)
+                if (enc->aes->ctx.wrapped_key == NULL) {
+                    wc_fspsm_hw_unlock();
                     return MEMORY_E;
+                }
             }
             if (dec) {
                 if (dec->aes == NULL) {
@@ -808,6 +813,7 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
                         if (enc) {
                             XFREE(enc->aes, NULL, DYNAMIC_TYPE_CIPHER);
                         }
+                        wc_fspsm_hw_unlock();
                         return MEMORY_E;
                     }
                     XMEMSET(dec->aes, 0, sizeof(Aes));
@@ -815,22 +821,29 @@ int wc_fspsm_generateSessionKey(WOLFSSL *ssl,
                     dec->aes->ctx.wrapped_key = (FSPSM_AES_PWKEY)XMALLOC
                                             (sizeof(FSPSM_AES_WKEY),
                                             ssl->heap, DYNAMIC_TYPE_AES);
-                    if (dec->aes->ctx.wrapped_key == NULL)
+                    if (dec->aes->ctx.wrapped_key == NULL) {
+                        wc_fspsm_hw_unlock();
                         return MEMORY_E;
                     }
+                    }
             }
-            /* copy key index into aes */
-            if (ssl->options.side == PROVISION_CLIENT) {
-                XMEMCPY(enc->aes->ctx.wrapped_key, key_client_aes,
-                                                    sizeof(FSPSM_AES_WKEY));
-                XMEMCPY(dec->aes->ctx.wrapped_key, key_server_aes,
-                                                    sizeof(FSPSM_AES_WKEY));
-            }
-            else {
-                XMEMCPY(enc->aes->ctx.wrapped_key, key_server_aes,
-                                                    sizeof(FSPSM_AES_WKEY));
-                XMEMCPY(dec->aes->ctx.wrapped_key, key_client_aes,
-                                                    sizeof(FSPSM_AES_WKEY));
+            /* copy key index into aes. Skipped when AES-GCM session-key
+             * generation was deferred above -- key_client_aes/key_server_aes
+             * are NULL in that case, and the real per-record key is
+             * generated later inside wc_fspsm_AesGcmEncrypt/Decrypt. */
+            if (key_client_aes != NULL && key_server_aes != NULL) {
+                if (ssl->options.side == PROVISION_CLIENT) {
+                    XMEMCPY(enc->aes->ctx.wrapped_key, key_client_aes,
+                                                        sizeof(FSPSM_AES_WKEY));
+                    XMEMCPY(dec->aes->ctx.wrapped_key, key_server_aes,
+                                                        sizeof(FSPSM_AES_WKEY));
+                }
+                else {
+                    XMEMCPY(enc->aes->ctx.wrapped_key, key_server_aes,
+                                                        sizeof(FSPSM_AES_WKEY));
+                    XMEMCPY(dec->aes->ctx.wrapped_key, key_client_aes,
+                                                        sizeof(FSPSM_AES_WKEY));
+                }
             }
             /* copy mac key index into keys */
             ssl->keys.fspsm_client_write_MAC_secret = key_client_mac;


### PR DESCRIPTION
## Summary

Three fixes to the Renesas FSPSM (RA6M4 Secure Cryptography Engine) port, driven by cases
found in wolfSSL's internal issue tracker:

- **`renesas_fspsm_util.c`** — `wc_fspsm_generateSessionKey()`:
  - Fix a NULL-pointer dereference when the AES-GCM deferred-key-generation path leaves the
    session key buffers NULL.
  - Fix a hardware mutex leak on out-of-memory during session-key setup.
- **`renesas_fspsm_aes.c`** — `wc_fspsm_AesGcmDecrypt()`:
  - Fix a copy-paste error in an error message.

## Details

### NULL-pointer dereference in `wc_fspsm_generateSessionKey` (issue f5408)

When AES-GCM session-key generation takes the deferred path, `key_client_aes` and
`key_server_aes` are left `NULL` (the real per-record key is generated later, inside
`wc_fspsm_AesGcmEncrypt`/`Decrypt`). The subsequent `XMEMCPY` into
`enc/dec->aes->ctx.wrapped_key` did not check for this and copied from the NULL pointers
unconditionally, crashing — remotely triggerable via cipher suite choice.

Fix: guard the copy with `if (key_client_aes != NULL && key_server_aes != NULL)`.

### Hardware mutex leak on allocation failure (issues f5417, f5409 — duplicate)

Five `return MEMORY_E;` exit paths inside the `wc_fspsm_hw_lock()`'d block of
`wc_fspsm_generateSessionKey` (client/server AES key alloc, encrypt-side `Aes`/wrapped-key
alloc, decrypt-side `Aes`/wrapped-key alloc) returned without calling
`wc_fspsm_hw_unlock()`, leaving the hardware mutex permanently locked after an allocation
failure.

Fix: add `wc_fspsm_hw_unlock();` before each of the 5 early returns.

(f5409 reported the same root cause under a different description; no additional change was
needed beyond the f5417 fix.)

### Copy-paste error in `wc_fspsm_AesGcmDecrypt` error message (issue 1537)

The `authTagSz`-too-small error message read `"GcmEncrypt authTagSz too small error"` inside
the *decrypt* function — copy-pasted from the encrypt path. Message-only fix, no functional
impact: now reads `"GcmDecrypt authTagSz too small error"`.

## Testing

Run crypt and benchmark test on the board


# Checklist

 - [n/a] added tests
 - [n/a] updated/added doxygen
 - [n/a] updated appropriate READMEs
 - [n/a] Updated manual and documentation
