### PR TITLE
Fix PKCS7 streamed SignedData dropping content

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -3192,6 +3192,9 @@ static int wc_PKCS7_EncodeContentStreamHelper(wc_PKCS7* pkcs7, int cipherType,
                 ret = wc_HashUpdate(&esd->hash, esd->hashType,
                     contentData, (word32)contentDataSz);
             }
+            else {
+                ret = 0;
+            }
             break;
 
     #ifndef NO_AES


### PR DESCRIPTION
`wc_PKCS7_EncodeContentStreamHelper()` initializes `ret` to `BAD_FUNC_ARG` and, in the `WC_CIPHER_NONE` case, only assigns it inside `if (esd->contentDigestSet != 1)`. When the caller passes a precomputed hash to `wc_PKCS7_EncodeSignedData_ex()`, `contentDigestSet` is 1, so that branch is skipped, `ret` keeps `BAD_FUNC_ARG`, and the `if (ret == 0)` block that writes the content never runs. `PKCS7_EncodeSigned()` does not check the return value, so encoding reports success while emitting a bundle with an empty eContent.

Found with `wolfssl-examples` `pkcs7/signedData-stream`, which failed verification with `ASN_PARSE_E (-140)`. OpenSSL rejected the same bundle with `CMS Verification failure`, confirming the bundle was malformed rather than wolfSSL being strict.

With the fix the bundle grows by the 32 bytes that were missing (2 byte OCTET STRING header plus 30 bytes of content), and it verifies with both wolfSSL and `openssl cms -verify`.

`testwolfcrypt` and `tests/unit.test` pass.
