### PR TITLE
Testing fixes: unit.test - PKCS#7 and --send-ticket

### DIFF
--- a/tests/api/test_pkcs7.c
+++ b/tests/api/test_pkcs7.c
@@ -5024,7 +5024,19 @@ int test_wc_PKCS7_BER(void)
     if (EXPECT_SUCCESS()) {
         ret = wc_PKCS7_DecodeEnvelopedData(
             pkcs7, berContent, sizeof(berContent), decoded, sizeof(decoded));
-        ExpectTrue((ret == WC_NO_ERR_TRACE(WC_KEY_SIZE_E)) ||
+        /* The 1024-bit RSA key is not supported by SP math, so the internal
+         * KTRI key unwrap fails with WC_KEY_SIZE_E. When the Bleichenbacher
+         * padding-oracle mitigation is compiled in (needs HMAC + SHA-256), that
+         * failure is deliberately hidden: wc_PKCS7_DecryptKtri() substitutes a
+         * randomly-seeded fake CEK and lets content decryption proceed so the
+         * RSA error is not observable to the caller. The outcome is therefore
+         * non-deterministic - the DES3 content decrypts to random data that
+         * almost always trips a later length/padding check (BUFFER_E), but on
+         * rare seeds forms a valid-looking structure and the decode "succeeds"
+         * (ret >= 0). Without the mitigation the raw WC_KEY_SIZE_E is returned.
+         * Accept any of these; only an unexpected negative error fails. */
+        ExpectTrue((ret >= 0) ||
+                   (ret == WC_NO_ERR_TRACE(WC_KEY_SIZE_E)) ||
                    (ret == WC_NO_ERR_TRACE(BUFFER_E)));
     }
 #else

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -506,6 +506,14 @@ static int IsOnlyPskDheKe(int argc, char** argv)
 }
 #endif /* WOLFSSL_STATIC_PSK */
 
+#ifndef HAVE_SESSION_TICKET
+/* if the line uses --send-ticket return 1, else 0 */
+static int IsSendTicket(const char* line)
+{
+    return XSTRSTR(line, "--send-ticket") != NULL;
+}
+#endif
+
 static int execute_test_case(int svr_argc, char** svr_argv,
                              int cli_argc, char** cli_argv,
                              int addNoVerify, int addNonBlocking,
@@ -556,6 +564,19 @@ static int execute_test_case(int svr_argc, char** svr_argv,
         XSTRLCAT(commandLine, svr_argv[i], sizeof commandLine);
         XSTRLCAT(commandLine, flagSep, sizeof commandLine);
     }
+#ifndef HAVE_SESSION_TICKET
+    /* --send-ticket is only a recognized server option when session tickets
+     * are compiled in. Without them, mygetopt_long stops parsing at the
+     * unknown option and the harness-appended "-p 0" is dropped, so the server
+     * binds the default port 11111 instead of an ephemeral one. Skip the case
+     * rather than let it race on 11111. */
+    if (IsSendTicket(commandLine)) {
+        #ifdef DEBUG_SUITE_TESTS
+            printf("send-ticket not supported in build: %s\n", commandLine);
+        #endif
+        return NOT_BUILT_IN;
+    }
+#endif
     if (IsValidCipherSuite(commandLine, cipherSuite, sizeof cipherSuite) == 0) {
         #ifdef DEBUG_SUITE_TESTS
             printf("cipher suite %s not supported in build\n", cipherSuite);


### PR DESCRIPTION
# Description

test_pkcs7.c: test_wc_PKCS7_BER also accepts ret >= 0 (Bleichenbacher mitigation hides the RSA key error, making the result non-deterministic).
suites.c: skip --send-ticket cases as NOT_BUILT_IN when HAVE_SESSION_TICKET
  is off (avoids port-11111 race).

# Testing

Intermittent with:
./configure --enable-sp-math --enable-pkcs7 --enable-des3
./configure --enable-tls13 --disable-session-ticket