### PR TITLE
Include the correct wolfSSL header for inline C asm.

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/arm/armv8-32-aes-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/arm/armv8-32-chacha-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/arm/armv8-32-curve25519.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/armv8-32-mlkem-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-mlkem-asm_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/arm/armv8-32-mlkem-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/arm/armv8-32-poly1305-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/arm/armv8-32-sha256-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/arm/armv8-32-sha3-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/arm/armv8-32-sha512-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/armv8-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-aes-asm_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):

--- a/wolfcrypt/src/port/arm/armv8-chacha-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-chacha-asm_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):

--- a/wolfcrypt/src/port/arm/armv8-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/armv8-curve25519_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):

--- a/wolfcrypt/src/port/arm/armv8-mlkem-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-mlkem-asm_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):

--- a/wolfcrypt/src/port/arm/armv8-poly1305-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-poly1305-asm_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):

--- a/wolfcrypt/src/port/arm/armv8-sha256-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-sha256-asm_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):

--- a/wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):

--- a/wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):

--- a/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
@@ -25,7 +25,7 @@
  *       thumb2 ../wolfssl/wolfcrypt/src/port/arm/thumb2-aes-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c
@@ -25,7 +25,7 @@
  *       thumb2 ../wolfssl/wolfcrypt/src/port/arm/thumb2-chacha-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
@@ -25,7 +25,7 @@
  *       thumb2 ../wolfssl/wolfcrypt/src/port/arm/thumb2-curve25519.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/thumb2-mlkem-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-mlkem-asm_c.c
@@ -25,7 +25,7 @@
  *       thumb2 ../wolfssl/wolfcrypt/src/port/arm/thumb2-mlkem-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/thumb2-poly1305-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-poly1305-asm_c.c
@@ -25,7 +25,7 @@
  *       thumb2 ../wolfssl/wolfcrypt/src/port/arm/thumb2-poly1305-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
@@ -25,7 +25,7 @@
  *       thumb2 ../wolfssl/wolfcrypt/src/port/arm/thumb2-sha256-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c
@@ -25,7 +25,7 @@
  *       thumb2 ../wolfssl/wolfcrypt/src/port/arm/thumb2-sha3-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
@@ -25,7 +25,7 @@
  *       thumb2 ../wolfssl/wolfcrypt/src/port/arm/thumb2-sha512-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/ppc32/ppc32-aes-asm_c.c
+++ b/wolfcrypt/src/port/ppc32/ppc32-aes-asm_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/ppc32/ppc32-aes-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_PPC32_ASM

--- a/wolfcrypt/src/port/ppc32/ppc32-aes-asm_cr.c
+++ b/wolfcrypt/src/port/ppc32/ppc32-aes-asm_cr.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/ppc32/ppc32-aes-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_PPC32_ASM

--- a/wolfcrypt/src/port/ppc32/ppc32-sha256-asm_c.c
+++ b/wolfcrypt/src/port/ppc32/ppc32-sha256-asm_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/ppc32/ppc32-sha256-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_PPC32_ASM

--- a/wolfcrypt/src/port/ppc32/ppc32-sha256-asm_cr.c
+++ b/wolfcrypt/src/port/ppc32/ppc32-sha256-asm_cr.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/ppc32/ppc32-sha256-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_PPC32_ASM

--- a/wolfcrypt/src/port/ppc32/ppc32-sha3-asm_c.c
+++ b/wolfcrypt/src/port/ppc32/ppc32-sha3-asm_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/ppc32/ppc32-sha3-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_PPC32_ASM

--- a/wolfcrypt/src/port/ppc32/ppc32-sha3-asm_cr.c
+++ b/wolfcrypt/src/port/ppc32/ppc32-sha3-asm_cr.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/ppc32/ppc32-sha3-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_PPC32_ASM

--- a/wolfcrypt/src/port/ppc32/ppc32-sha512-asm_c.c
+++ b/wolfcrypt/src/port/ppc32/ppc32-sha512-asm_c.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/ppc32/ppc32-sha512-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_PPC32_ASM

--- a/wolfcrypt/src/port/ppc32/ppc32-sha512-asm_cr.c
+++ b/wolfcrypt/src/port/ppc32/ppc32-sha512-asm_cr.c
@@ -25,7 +25,7 @@
  *       ../wolfssl/wolfcrypt/src/port/ppc32/ppc32-sha512-asm.c
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_PPC32_ASM

--- a/wolfcrypt/src/port/ppc64/ppc64-aes-asm_c.c
+++ b/wolfcrypt/src/port/ppc64/ppc64-aes-asm_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):

--- a/wolfcrypt/src/port/ppc64/ppc64-sha256-asm_c.c
+++ b/wolfcrypt/src/port/ppc64/ppc64-sha256-asm_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):

--- a/wolfcrypt/src/port/ppc64/ppc64-sha3-asm_c.c
+++ b/wolfcrypt/src/port/ppc64/ppc64-sha3-asm_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):

--- a/wolfcrypt/src/port/ppc64/ppc64-sha512-asm_c.c
+++ b/wolfcrypt/src/port/ppc64/ppc64-sha512-asm_c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/wolfcrypt/libwolfssl_sources_asm.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Generated using (from wolfssl):


### PR DESCRIPTION
# Description

wolfssl/wolfcrypt/libwolfssl_sources_asm.h is for assembly files.
wolfssl/wolfcrypt/libwolfssl_sources.h is for C files.

# Testing

Checked source.