### PR TITLE
Fix a couple of Valgrind hits

### DIFF
--- a/tests/api/test_aes.c
+++ b/tests/api/test_aes.c
@@ -9173,7 +9173,7 @@ int test_wc_AesGcmArgMcdc(void)
     /* ---- wc_AesGcmDecryptFinal(): nonceSet AND ---- */
     {
         Aes aes;
-        byte tag[WC_AES_BLOCK_SIZE];
+        byte tag[WC_AES_BLOCK_SIZE] = { 0 };
 
         XMEMSET(&aes, 0, sizeof(aes));
         ExpectIntEQ(wc_AesInit(&aes, NULL, INVALID_DEVID), 0);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -12502,7 +12502,7 @@ static wc_test_ret_t des_key_wrap_test(void)
     {
         0x12,0x34,0x56,0x78,0x90,0xab,0xcd,0xef
     };
-    byte cipher[24];
+    byte cipher[24] = { 0 };
     EncryptedInfo info;
     wc_test_ret_t ret;
 
@@ -12759,7 +12759,7 @@ static wc_test_ret_t des3_key_wrap_test(void)
         0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,
         0x11,0x21,0x31,0x41,0x51,0x61,0x71,0x81
     };
-    byte cipher[24];
+    byte cipher[24] = { 0 };
     EncryptedInfo info;
     wc_test_ret_t ret;
 


### PR DESCRIPTION
```
==485951==  Uninitialised value was created by a stack allocation
==485951==    at 0x207D47: des3_key_wrap_test (test.c:12773)
```

and

```
==485951==  Uninitialised value was created by a stack allocation
==485951==    at 0x3A075E: test_wc_AesGcmArgMcdc (test_aes.c:8968)
```
