### PR TITLE
Apache mynewt header build fix

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3044,7 +3044,7 @@
     #define HAVE_ECC
     #define NO_SESSION_CACHE
     #define NO_ERROR_STRINGS
-    #define XMALLOC_USER
+    #define XMALLOC_OVERRIDE
     #define XMALLOC(sz, heap, type)     ((void)(heap), (void)(type), os_malloc(sz))
     #define XREALLOC(p, sz, heap, type) ((void)(heap), (void)(type), os_realloc(p, sz))
     #define XFREE(p, heap, type)        ((void)(heap), (void)(type), os_free(p))

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -520,6 +520,9 @@
         #elif defined(NUCLEUS_PLUS_2_3)
             typedef int socklen_t;
             #define XSOCKLENT socklen_t
+        #elif defined(WOLFSSL_APACHE_MYNEWT)
+            /* mn_socket doesn't provide socklen_t */
+            #define XSOCKLENT int
         #else
             #define XSOCKLENT socklen_t
         #endif


### PR DESCRIPTION
# Description

Fix build issues for Apache Mynewt

WolfSSL's  WOLFSSL_APACHE_MYNEWT  block was setting XMALLOC_USER  while defining  XMALLOC  as a macro. Changed it to  XMALLOC_OVERRIDE
Define XSOCKLENT as int for WOLFSSL_APACHE_MYNEWT in wolfssl/wolfio.h, since mn_socket does not provide socklen_t.