### PR TITLE
Retry the ISO TP flow control wait up to N_Bs

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -3851,9 +3851,21 @@ static int isotp_send_flow_control(struct isotp_wolfssl_ctx *ctx,
 static int isotp_receive_flow_control(struct isotp_wolfssl_ctx *ctx)
 {
     int ret;
+    int waited;
     enum isotp_frame_type type;
     enum isotp_flow_control flow_control;
-    ret = ctx->recv_fn(&ctx->frame, ctx->arg, ISOTP_DEFAULT_TIMEOUT);
+    /* Wait up to N_Bs for flow control rather than a single 100ms poll: a peer
+     * that is momentarily late is normal, and every other ISO-TP receive here
+     * retries. Treating the first miss as fatal aborts healthy transfers. */
+    waited = 0;
+    do {
+        ret = ctx->recv_fn(&ctx->frame, ctx->arg, ISOTP_DEFAULT_TIMEOUT);
+        if (ret != 0) {
+            break;
+        }
+        waited += ISOTP_DEFAULT_TIMEOUT;
+    } while (waited < ISOTP_FLOW_CONTROL_TIMEOUT);
+
     if (ret == 0) {
         return WOLFSSL_CBIO_ERR_TIMEOUT;
     } else if (ret < 0) {

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -906,6 +906,8 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
 #endif
 #ifdef WOLFSSL_ISOTP
     #define ISOTP_DEFAULT_TIMEOUT 100
+    /* ISO 15765-2 N_Bs: how long a sender waits for flow control */
+    #define ISOTP_FLOW_CONTROL_TIMEOUT 1000
     #define ISOTP_DEFAULT_WAIT_COUNT 3
     #define ISOTP_FIRST_FRAME_DATA_SIZE 6
     #define ISOTP_SINGLE_FRAME_DATA_SIZE 7


### PR DESCRIPTION
`isotp_receive_flow_control()` waits for flow control with a single 100ms `recv_fn` call and treats a miss as fatal, while every other ISO-TP receive in the same file retries (`ISOTP_Receive` loops `do { ... } while (ret == 0)`). A peer that is a few milliseconds late aborts an otherwise healthy transfer.

ISO 15765-2 calls this timeout N_Bs and puts it around 1000ms, so this retries to that deadline instead of giving up after one poll. Still bounded, no behaviour change when flow control arrives promptly.

Honest scope: I found this while investigating a `can-bus` stall in wolfSSL/wolfssl-examples#598 and initially believed it was the cause. It is not — building that example against this branch still fails the same way, so the stall has a different root cause I have not yet identified. This change stands on its own as a correctness fix to the flow control wait, but it does not close that issue.
