### PR TITLE
fix: signed-shift UB in SLH-DSA base_2b digest accumulator

### DIFF
--- a/wolfcrypt/src/wc_slhdsa.c
+++ b/wolfcrypt/src/wc_slhdsa.c
@@ -1709,7 +1709,10 @@ static void slhdsakey_base_2b(const byte* x, byte b, byte outLen, word16* baseb)
     int j;
     int i = 0;
     int bits = 0;
-    int total = 0;
+    /* total accumulates unmasked via << 8 and must be unsigned: a signed
+     * type overflows from the 4th consumed byte (UB). High bits are
+     * discarded by mask, so the output is unaffected. */
+    word32 total = 0;
     word16 mask = (word16)((1 << b) - 1);
 
     for (j = 0; j < outLen; j++) {


### PR DESCRIPTION
`slhdsakey_base_2b()` accumulates the FORS message digest into a signed `int` that is never masked down; from the fourth consumed byte onward `total << 8` exceeds `INT32_MAX`, which is undefined behavior (CWE-190, C11 6.5.7p4). It sits on the sign and verify path of every SLH-DSA parameter set.

Fix: declare `total` as `word32`. Output is identical: the overflowed high bits were always discarded by the mask. SLH-DSA KATs pass unchanged.

Verified with `-fsanitize=shift` (with `-fwrapv` removed from CFLAGS): pre-fix, `wc_slhdsa.c:1717: left shift of 609481888 by 8 places cannot be represented in type 'int'` fires during the standard KAT test; post-fix the run is clean.

Exposure note: autotools builds get `-fwrapv` from the hardening macros, which gives this defined wrapping semantics, but embedded users compiling wolfCrypt sources with their own flags have no such guarantee. `-fwrapv` also suppresses the sanitizer's shift-base check, which is why nightly sanitizer runs never caught it.

Credit: found by Dominik Blain of Qreative Lab (qreativelab.io) using their Z3-based formal analysis engine, reported with a machine-checked witness. Same bug class as the earlier fix in this file from PR #10104, which addressed a different site.

Related: #10918 (ML-DSA gamma1_19 encoder), #10919 (ML-DSA slow-multiply reductions) — same bug class, found in the same report.
