### PR TITLE
fix: signed-shift UB in ML-DSA gamma1_19 encoder (32-bit path)

### DIFF
--- a/wolfcrypt/src/wc_mldsa.c
+++ b/wolfcrypt/src/wc_mldsa.c
@@ -1829,10 +1829,10 @@ static void mldsa_encode_gamma1_19_bits_c(const sword32* z, byte* s)
 
     /* Step 3. Get 20 bits as a number. */
     for (j = 0; j < MLDSA_N; j += 4) {
-        sword32 z0 = MLDSA_GAMMA1_19 - z[j + 0];
-        sword32 z1 = MLDSA_GAMMA1_19 - z[j + 1];
-        sword32 z2 = MLDSA_GAMMA1_19 - z[j + 2];
-        sword32 z3 = MLDSA_GAMMA1_19 - z[j + 3];
+        word32 z0 = (word32)(MLDSA_GAMMA1_19 - z[j + 0]);
+        word32 z1 = (word32)(MLDSA_GAMMA1_19 - z[j + 1]);
+        word32 z2 = (word32)(MLDSA_GAMMA1_19 - z[j + 2]);
+        word32 z3 = (word32)(MLDSA_GAMMA1_19 - z[j + 3]);
 
         /* 20 bits per number.
          * 4 numbers become 10 bytes. (4 * 20 bits = 10 * 8 bits) */


### PR DESCRIPTION
The 32-bit little-endian path of `mldsa_encode_gamma1_19_bits_c()` (compiled when `WC_64BIT_CPU` is not set and `WOLFSSL_MLDSA_ALIGNMENT <= 2`) shifts `sword32` operands whose values reach 2^20-1: `z1 << 20` and `z3 << 28` both overflow `INT32_MAX`, which is undefined behavior (CWE-190, C11 6.5.7p4). The sibling encoders (gamma1_17, w1) already declare these locals as `word32` with an explicit cast; this encoder was missed.

Fix: same idiom as the siblings, `word32 zN = (word32)(MLDSA_GAMMA1_19 - z[j + N]);`. Output bits are unchanged. ML-DSA KATs pass on both the 32-bit and 64-bit paths.

Verified with `-fsanitize=shift -DWC_32BIT_CPU -DWOLFSSL_MLDSA_ALIGNMENT=0` (and `-fwrapv` removed, since it suppresses the check): pre-fix, `left shift of 1034459 by 20` and `left shift of 325275 by 28` fire at the two lines during the standard KAT test; post-fix the run is clean.

Credit: found by Dominik Blain of Qreative Lab (qreativelab.io) using their Z3-based formal analysis engine, reported with a machine-checked witness.

Related: #10917 (same bug class in SLH-DSA base_2b).
