### PR TITLE
fix: bound ECDSA r/s before copy in PSoC6 verify (stack overflow)

### DIFF
--- a/tests/api/test_ecc.c
+++ b/tests/api/test_ecc.c
@@ -2385,6 +2385,31 @@ int test_wc_EccDecisionCoverage2(void)
         mp_clear(&s);
         mp_clear(&bigVal);
     }
+
+    /* r/s with MORE bytes than the curve size (keySz + 1). This is the
+     * byte-length overshoot that overflows the fixed signature_buf on hardware
+     * ports; the software path rejects it in wc_ecc_check_r_s_range() (value >=
+     * order) and the PSoC6 port rejects it via the rSz/sSz > keySz guard.
+     * Assert path-agnostically: a failure return with verify == 0. */
+    if (key.dp != NULL)
+    {
+        mp_int r, s;
+        int    verify = 0;
+        byte   oversized[MAX_ECC_BYTES + 1];
+        word32 osSz = (word32)key.dp->size + 1;
+        byte   digest[] = TEST_STRING;
+
+        XMEMSET(oversized, 0xFF, sizeof(oversized));
+        ExpectIntEQ(mp_init(&r), MP_OKAY);
+        ExpectIntEQ(mp_init(&s), MP_OKAY);
+        ExpectIntEQ(mp_read_unsigned_bin(&r, oversized, osSz), MP_OKAY);
+        ExpectIntEQ(mp_read_unsigned_bin(&s, oversized, osSz), MP_OKAY);
+        ExpectIntNE(ret = wc_ecc_verify_hash_ex(&r, &s, digest,
+            (word32)TEST_STRING_SZ, &verify, &key), 0);
+        ExpectIntEQ(verify, 0);
+        mp_clear(&r);
+        mp_clear(&s);
+    }
 #endif
 
     /* ---- wc_ecc_import_point_der_ex / wc_ecc_export_point_der{,_compressed}:

--- a/wolfcrypt/src/port/cypress/psoc6_crypto.c
+++ b/wolfcrypt/src/port/cypress/psoc6_crypto.c
@@ -2093,7 +2093,7 @@ int psoc6_ecc_verify_hash_ex(MATH_INT_T* r, MATH_INT_T* s, const byte* hash,
     uint8_t k[MAX_ECC_KEYSIZE] = { 0 };
 
     if (!key || !verif_res || !r || !s || !hash)
-        return -BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
 
     /* Enable CRYPTO block if not enabled */
     if (!Cy_Crypto_Core_IsEnabled(crypto_base)) {
@@ -2105,7 +2105,15 @@ int psoc6_ecc_verify_hash_ex(MATH_INT_T* r, MATH_INT_T* s, const byte* hash,
     sSz   = mp_unsigned_bin_size(s);
 
     if (keySz > MAX_ECC_KEYSIZE)
-        return -BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
+
+    /* r and s come from the (untrusted) signature. A valid ECDSA r,s is in
+     * [1, order-1], so each fits in keySz bytes. Reject anything larger before
+     * it is copied into the fixed-size signature_buf, which would otherwise
+     * overflow. The software path enforces this via wc_ecc_check_r_s_range(),
+     * which is compiled out for the PSoC6 port. */
+    if (rSz > keySz || sSz > keySz)
+        return BAD_FUNC_ARG;
 
     /* Prepare ECC key */
     ecc_key.type     = PK_PUBLIC;


### PR DESCRIPTION
`psoc6_ecc_verify_hash_ex()` copies the signature's r and s components into a fixed 132-byte stack buffer sized for the largest supported curve:

```c
uint8_t signature_buf[MAX_ECC_KEYSIZE * 2] = { 0 };   /* 66 * 2 */
...
rSz = mp_unsigned_bin_size(r);   /* from the untrusted signature */
sSz = mp_unsigned_bin_size(s);
...
mp_to_unsigned_bin(r, signature_buf);          /* writes rSz bytes at [0]   */
mp_to_unsigned_bin(s, signature_buf + keySz);  /* writes sSz bytes at [keySz] */
```

`keySz` is bounded (`keySz > MAX_ECC_KEYSIZE` is rejected), but `rSz`/`sSz` are not. In a verify operation r and s come straight from the attacker-supplied signature, so an oversized r or s overflows `signature_buf` on the stack.

The generic path guards this with `wc_ecc_check_r_s_range()` (rejects r,s outside `[1, order-1]`), but that function is `#if !defined(WOLFSSL_PSOC6_CRYPTO)` — compiled out for this port — and `wc_ecc_verify_hash_ex()` returns early into `psoc6_ecc_verify_hash_ex()` before the check would run.

Fix: reject `rSz > keySz || sSz > keySz` before the copies, mirroring the adjacent `keySz` guard. A valid ECDSA r,s is in `[1, order-1]` and always fits in `keySz` bytes, so this rejects nothing legitimate.

**Verification.** The PSoC6 port needs Cypress PDL headers/hardware and can't be built or run here, so this is a code-read fix. I modeled the exact buffer arithmetic in a standalone harness under AddressSanitizer: pre-fix, an oversized r (200 bytes, secp256r1 keySz=32) triggers `stack-buffer-overflow` in the r/s copy; post-fix it's rejected and a valid signature (rSz/sSz ≤ keySz) still passes. Runtime confirmation on real PSoC6 hardware would be welcome.

**Scope note.** The STM32 PKA path (`WOLFSSL_STM32_PKA`) has the same early-return-before-check structure; I left it untouched since I only verified the PSoC6 buffer arithmetic. Worth a look by someone with that hardware.

Found by Fenrir (finding 6778).

---
**Update after Skoll self-review:** also corrected three inverted error returns in this function (`return -BAD_FUNC_ARG` returned +173, since `BAD_FUNC_ARG` is already -173 — two predate this change), and added a path-agnostic negative test (oversized r/s of keySz+1 bytes) to `test_wc_EccDecisionCoverage2` that exercises `wc_ecc_check_r_s_range()` on software builds and the new guard on-device. Verified: the test passes on a software build and fails under a negative control (asserting the oversized signature must not verify).
