### PR TITLE
Fix configure.ac so --enable-mldsa=verify-only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1985,6 +1985,16 @@ do
   esac
 done
 
+# If ML-DSA is enabled but no specific level (44/65/87) was requested,
+# default to enabling all levels.
+if test "$ENABLED_MLDSA" != "no" && test "$ENABLED_MLDSA44" = "" && \
+   test "$ENABLED_MLDSA65" = "" && test "$ENABLED_MLDSA87" = ""
+then
+    ENABLED_MLDSA44=yes
+    ENABLED_MLDSA65=yes
+    ENABLED_MLDSA87=yes
+fi
+
 # XMSS
 AC_ARG_ENABLE([xmss],
     [AS_HELP_STRING([--enable-xmss],[Enable stateful XMSS/XMSS^MT signatures (default: disabled)])],


### PR DESCRIPTION
## Summary
- Fix `configure.ac` so `--enable-mldsa=verify-only` (and `verify`/`sign`/`make` used alone) no longer disables all ML-DSA security levels.
- Previously, these sub-options only set the operation flags (`ENABLED_MLDSA_MAKE_KEY`/`SIGN`/`VERIFY`) but never touched the level flags (`ENABLED_MLDSA44`/`65`/`87`), which are otherwise only set by `yes`/`all`/`44`/`65`/`87`. With no level selected, all three levels ended up disabled via `WOLFSSL_NO_ML_DSA_44/65/87`, tripping `#error ML-DSA: All levels disabled.` in `wc_mldsa.h` and failing the build.
- Added a post-loop default: if ML-DSA is enabled but no level (44/65/87) was explicitly requested, enable all three levels by default — consistent with how `--enable-mldsa` (bare `yes`) already behaves.

## Root cause
`configure.ac`'s ML-DSA option-parsing loop (`--enable-mldsa=...`) never defaulted the level flags when only an operation keyword (`verify-only`, `verify`, `sign`, `make`) was given, leaving `ENABLED_MLDSA44/65/87` empty and causing every parameter set to be compiled out.


# Testing

- [x] `./configure --enable-mldsa=verify-only && make check`
- [x] `./autogen.sh && ./configure --enable-mldsa=verify-only && make` completes successfully (previously failed with `#error ML-DSA: All levels disabled.`)
- [x] `./wolfcrypt/test/testwolfcrypt` passes, including the `ML-DSA` test
- [x] Verified `--enable-mldsa=verify`, `--enable-mldsa=sign`, `--enable-mldsa=make` (each used alone) also configure/build correctly with the fix
- [x] Verified `--enable-mldsa` (bare, default `yes`) is unaffected and still enables all levels
- [x] Confirmed resulting `options.h` macros match the intended verify-only configuration (`WOLFSSL_MLDSA_VERIFY_ONLY`, `WOLFSSL_MLDSA_NO_MAKE_KEY`, `WOLFSSL_MLDSA_NO_SIGN`, all three levels enabled)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
