### PR TITLE
XMALLOC_OVERRIDE for uITRON4

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1560,7 +1560,9 @@
 #endif
 
 #if defined(WOLFSSL_uITRON4)
-    #define XMALLOC_USER
+
+    #define XMALLOC_OVERRIDE
+
     #include <stddef.h>
     #define ITRON_POOL_SIZE 1024*20
     extern int uITRON4_minit(size_t poolsz) ;


### PR DESCRIPTION
# Description

Conflict XMALLOC define with XMALLOC_USER and WOLFSSL_uITRON4.

Fixes zd#22126

# Testing

Local build test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
