### PR TITLE
Hash: consistent error code for uninitialized wc_Hash ops under DEBUG_WOLFSSL

### DIFF
--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -1143,7 +1143,7 @@ int wc_HashUpdate(wc_HashAlg* hash, enum wc_HashType type, const byte* data,
         return BAD_FUNC_ARG;
 
 #ifdef DEBUG_WOLFSSL
-    if (hash->type != type) {
+    if (hash->type != WC_HASH_TYPE_NONE && hash->type != type) {
         WOLFSSL_MSG("Hash update type mismatch!");
         return BAD_FUNC_ARG;
     }
@@ -1292,7 +1292,7 @@ int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type, byte* out)
         return BAD_FUNC_ARG;
 
 #ifdef DEBUG_WOLFSSL
-    if (hash->type != type) {
+    if (hash->type != WC_HASH_TYPE_NONE && hash->type != type) {
         WOLFSSL_MSG("Hash final type mismatch!");
         return BAD_FUNC_ARG;
     }
@@ -1443,7 +1443,7 @@ int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
         return BAD_FUNC_ARG;
 
 #ifdef DEBUG_WOLFSSL
-    if (hash->type != type) {
+    if (hash->type != WC_HASH_TYPE_NONE && hash->type != type) {
         WOLFSSL_MSG("Hash free type mismatch!");
         return BAD_FUNC_ARG;
     }


### PR DESCRIPTION

# Description

Under DEBUG_WOLFSSL the hash->type != type check in wc_HashUpdate, wc_HashFinal and wc_HashFree fired for an uninitialized hash (hash->type == WC_HASH_TYPE_NONE), returning BAD_FUNC_ARG where a non-debug build returns HASH_TYPE_E from the type switch, so the returned error code depended on whether DEBUG_WOLFSSL was defined. Only apply the mismatch check to initialized hashes; the genuine init-then-wrong-type misuse check is preserved.


# Testing

Discovered via MC/DC campaign part 3 #10912 

