### PR TITLE
wolfCrypt and TLS 1.3 correctness fixes (F-1376, F-2653, F-1972, F-4593)

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -36950,6 +36950,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             case WC_NO_ERR_TRACE(BAD_CERTIFICATE_STATUS_ERROR):
                 return bad_certificate_status_response;
             case WC_NO_ERR_TRACE(OUT_OF_ORDER_E):
+            case WC_NO_ERR_TRACE(DUPLICATE_MSG_E):
                 return unexpected_message;
             default:
                 return invalid_alert;

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -8347,8 +8347,8 @@ void wolfSSL_EVP_init(void)
                  * combines them to a new iv. EVP is given exactly *one* iv,
                  * so to pass it into chacha, we have to revert that first.
                  * The counter comes first in little-endian */
-                word32 counter = (word32)iv[0] + (word32)(iv[1] << 8) +
-                    (word32)(iv[2] << 16) + (word32)(iv[3] << 24);
+                word32 counter = (word32)iv[0] | ((word32)iv[1] << 8) |
+                    ((word32)iv[2] << 16) | ((word32)iv[3] << 24);
                 if (wc_Chacha_SetIV(&ctx->cipher.chacha,
                                     iv + sizeof(counter), counter) != 0) {
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -13058,7 +13058,10 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
 
     byte    buff[WOLFSSL_EVP_EXPONENT_PRINT_MAX] = { 0 };
     int     res = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
-    word32  length;
+    /* int (not word32) to match the int* out-parameter of GetSequence/GetLength;
+     * casting &length aliased a word32 and corrupted it on platforms where
+     * sizeof(int) != sizeof(word32). Values are non-negative ASN.1 lengths. */
+    int     length;
     word32  inOutIdx;
     word32  oid;
     byte    tagFound;
@@ -13094,17 +13097,17 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         int idx;
         int wsz;
 
-        if (GetSequence(pkey, &inOutIdx, (int*)&length, (word32)pkeySz) < 0) {
+        if (GetSequence(pkey, &inOutIdx, &length, (word32)pkeySz) < 0) {
             break;
         }
-        if (GetSequence(pkey, &inOutIdx, (int*)&length, (word32)pkeySz) < 0) {
+        if (GetSequence(pkey, &inOutIdx, &length, (word32)pkeySz) < 0) {
             break;
         }
         if (GetObjectId(pkey, &inOutIdx, &oid, oidIgnoreType, (word32)pkeySz) <
                 0) {
             break;
         }
-        if (GetSequence(pkey, &inOutIdx, (int*)&length, (word32)pkeySz) < 0) {
+        if (GetSequence(pkey, &inOutIdx, &length, (word32)pkeySz) < 0) {
             break;
         }
         /* get prime element */
@@ -13114,7 +13117,7 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (tagFound != ASN_INTEGER) {
             break;
         }
-        if (GetLength(pkey, &inOutIdx, (int*)&length, (word32)pkeySz) <= 0) {
+        if (GetLength(pkey, &inOutIdx, &length, (word32)pkeySz) <= 0) {
             break;
         }
         prime     = (byte*)(pkey + inOutIdx);
@@ -13128,7 +13131,7 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (tagFound != ASN_INTEGER) {
             break;
         }
-        if (GetLength(pkey, &inOutIdx, (int*)&length, (word32)pkeySz) <= 0) {
+        if (GetLength(pkey, &inOutIdx, &length, (word32)pkeySz) <= 0) {
             break;
         }
         if (length != 1) {
@@ -13144,7 +13147,7 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (tagFound != ASN_BIT_STRING) {
             break;
         }
-        if (GetLength(pkey, &inOutIdx, (int*)&length, (word32)pkeySz) <= 0) {
+        if (GetLength(pkey, &inOutIdx, &length, (word32)pkeySz) <= 0) {
             break;
         }
         inOutIdx ++;
@@ -13154,7 +13157,7 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (tagFound != ASN_INTEGER) {
             break;
         }
-        if (GetLength(pkey, &inOutIdx, (int*)&length, (word32)pkeySz) <= 0) {
+        if (GetLength(pkey, &inOutIdx, &length, (word32)pkeySz) <= 0) {
             break;
         }
         publicKeySz = (int)length;

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -74,6 +74,10 @@ int wc_AesCbcEncryptWithKey(byte* out, const byte* in, word32 inSz,
     int  ret = 0;
     WC_DECLARE_VAR(aes, Aes, 1, 0);
 
+    if (out == NULL || in == NULL || key == NULL || iv == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
     WC_ALLOC_VAR_EX(aes, Aes, 1, NULL, DYNAMIC_TYPE_TMP_BUFFER,
         return MEMORY_E);
 


### PR DESCRIPTION
Four independent fixes in wolfCrypt and the TLS 1.3 handshake. Each is self-contained and reviewable on its own commit.

### `wc_AesCbcEncryptWithKey`: validate NULL parameters (F-1376)
The function did not check `out`/`in`/`key`/`iv` for NULL before calling `wc_AesSetKey`/`wc_AesCbcEncrypt`, unlike its counterpart `wc_AesCbcDecryptWithKey`. A NULL `key` reaches `wc_AesSetKey` implementations that `XMEMCPY` `userKey` without a NULL guard (e.g. the STM32 path), crashing at the API boundary instead of returning `BAD_FUNC_ARG`.

Adds the same guard `wc_AesCbcDecryptWithKey` already uses.

### ChaCha20 EVP: fix counter reconstruction shift UB (F-2653)
`wolfSSL_EVP_CipherInit` rebuilt the 32-bit ChaCha20 counter with `(word32)(iv[1] << 8)` and friends. The cast applies *after* the shift, so each `unsigned char` promotes to `int` and shifts as a signed value: on 16-bit `int` platforms `iv[1] << 8` is signed-overflow UB and `iv[2] << 16`/`iv[3] << 24` are UB unconditionally (shift >= int width). Even with 32-bit `int`, `iv[3] << 24` with the high bit set is signed overflow.

Casts each byte to `word32` before shifting, and uses `|` rather than `+` to compose the bytes.

### `PrintPubKeyDH`: fix strict-aliasing violation in length (F-1972)
`length` was declared `word32` but passed as `(int*)&length` to `GetSequence`/`GetLength`, which write through an `int*`. Where `sizeof(int) != sizeof(word32)` this updates only part of the object and leaves stale bytes behind.

Declares `length` as `int` to match the callee out-parameter type and drops the casts. The values are non-negative ASN.1 lengths, already consumed via `(int)` casts and pointer arithmetic.

### TLS 1.3: send `unexpected_message` on a duplicate handshake message (F-4593)
When a TLS 1.3 client received a second HelloRetryRequest, `DoTls13ServerHello` returned `DUPLICATE_MSG_E` without sending an alert: `TranslateErrorToAlert` had no mapping for it, so it returned `invalid_alert` and the dispatch tail skipped `SendAlert`. The connection aborted silently rather than with the alert [RFC 8446](https://www.rfc-editor.org/rfc/rfc8446#section-4.1.4) mandates.

Maps `DUPLICATE_MSG_E` to `unexpected_message` alongside `OUT_OF_ORDER_E`, mirroring the sanity-check path and covering any TLS 1.3 handler that returns `DUPLICATE_MSG_E` to the dispatch loop.

---

No regression tests here: three of the four only misbehave on platforms where `sizeof(int) != sizeof(word32)` or `int` is 16-bit, and the fourth needs a server that replies with a second HelloRetryRequest. Happy to add a unit test for the alert path if reviewers want one.
