### PR TITLE
socat CI: prevent rare shard hang in inverted OPENSSL tests

### DIFF
--- a/.github/workflows/socat.yml
+++ b/.github/workflows/socat.yml
@@ -127,17 +127,12 @@ jobs:
           # (|| true), errors left visible so a runner without IPv6 still runs the
           # IPv4 tests and any failure stays diagnosable in the log.
           #
-          # The inverted OPENSSL testserversec tests (OPENSSLCERTCLIENT etc.)
-          # run a foreground one-shot SSL listener with no port-wait; their
-          # background connector gives up after 2s (retry=2, 1s apart). On a
-          # loaded runner the listener can bind after the connector is gone
-          # and then blocks in accept() forever. retry=30 widens that window;
-          # a healthy run still connects on the first or second attempt, and
-          # testserversec kills the connector right after the client returns,
-          # so passing runs pay nothing. timeout(1) bounds each shard
-          # (normally ~2 min) so any remaining hang fails fast with the
-          # culprit test named in the shard output instead of stalling the
-          # job into the 15-min kill, which discards all output.
+          # The inverted OPENSSL testserversec tests run a one-shot foreground
+          # listener with no port-wait; the background connector quits after
+          # 2s (retry=2), and a later listener then hangs in accept() forever.
+          # retry=30 widens the window at no cost to passing runs. timeout
+          # makes any remaining hang fail fast with the culprit test named in
+          # the shard output instead of stalling into the 15-min job kill.
           cat > socat-configs.json <<'EOF'
           [{
             "name": "socat", "build": false, "netns": true, "shards": __SHARDS__,

--- a/.github/workflows/socat.yml
+++ b/.github/workflows/socat.yml
@@ -126,10 +126,22 @@ jobs:
           # numeric non-loopback addresses (e.g. the multicast tests). Best-effort
           # (|| true), errors left visible so a runner without IPv6 still runs the
           # IPv4 tests and any failure stays diagnosable in the log.
+          #
+          # The inverted OPENSSL testserversec tests (OPENSSLCERTCLIENT etc.)
+          # run a foreground one-shot SSL listener with no port-wait; their
+          # background connector gives up after 2s (retry=2, 1s apart). On a
+          # loaded runner the listener can bind after the connector is gone
+          # and then blocks in accept() forever. retry=30 widens that window;
+          # a healthy run still connects on the first or second attempt, and
+          # testserversec kills the connector right after the client returns,
+          # so passing runs pay nothing. timeout(1) bounds each shard
+          # (normally ~2 min) so any remaining hang fails fast with the
+          # culprit test named in the shard output instead of stalling the
+          # job into the 15-min kill, which discards all output.
           cat > socat-configs.json <<'EOF'
           [{
             "name": "socat", "build": false, "netns": true, "shards": __SHARDS__,
-            "run": [["bash", "-c", "set -e; ip link set lo up || true; sysctl -wq net.ipv6.conf.lo.disable_ipv6=0 || true; ip addr add ::1/128 dev lo || true; ip addr add fc00::1/128 dev lo || true; ip addr add 192.0.2.1/32 dev lo || true; sysctl -wq net.ipv6.bindv6only=0 || true; cp -a \"$SOCAT_SRC/.\" .; tests=$(seq \"$SHARD\" \"$SHARDS\" 999); SOCAT=\"$PWD/socat\" SHELL=/bin/bash ./test.sh -t 1.0 --expect-fail \"$EXPECT_FAIL\" ${tests:-0}"]]
+            "run": [["bash", "-c", "set -e; ip link set lo up || true; sysctl -wq net.ipv6.conf.lo.disable_ipv6=0 || true; ip addr add ::1/128 dev lo || true; ip addr add fc00::1/128 dev lo || true; ip addr add 192.0.2.1/32 dev lo || true; sysctl -wq net.ipv6.bindv6only=0 || true; cp -a \"$SOCAT_SRC/.\" .; sed -i 's/fork,retry=2,/fork,retry=30,/' test.sh; tests=$(seq \"$SHARD\" \"$SHARDS\" 999); SOCAT=\"$PWD/socat\" SHELL=/bin/bash timeout -k 10 600 ./test.sh -t 1.0 --expect-fail \"$EXPECT_FAIL\" ${tests:-0}"]]
           }]
           EOF
           sed -i "s/__SHARDS__/$(( 6 * $(nproc) ))/" socat-configs.json

--- a/.github/workflows/socat.yml
+++ b/.github/workflows/socat.yml
@@ -133,10 +133,13 @@ jobs:
           # retry=30 widens the window at no cost to passing runs. timeout
           # makes any remaining hang fail fast with the culprit test named in
           # the shard output instead of stalling into the 15-min job kill.
+          # Assert the retry=2 pattern is present first: a silent sed no-op
+          # (upstream test.sh changed) would otherwise reintroduce the hang
+          # while the run still looked green.
           cat > socat-configs.json <<'EOF'
           [{
             "name": "socat", "build": false, "netns": true, "shards": __SHARDS__,
-            "run": [["bash", "-c", "set -e; ip link set lo up || true; sysctl -wq net.ipv6.conf.lo.disable_ipv6=0 || true; ip addr add ::1/128 dev lo || true; ip addr add fc00::1/128 dev lo || true; ip addr add 192.0.2.1/32 dev lo || true; sysctl -wq net.ipv6.bindv6only=0 || true; cp -a \"$SOCAT_SRC/.\" .; sed -i 's/fork,retry=2,/fork,retry=30,/' test.sh; tests=$(seq \"$SHARD\" \"$SHARDS\" 999); SOCAT=\"$PWD/socat\" SHELL=/bin/bash timeout -k 10 600 ./test.sh -t 1.0 --expect-fail \"$EXPECT_FAIL\" ${tests:-0}"]]
+            "run": [["bash", "-c", "set -e; ip link set lo up || true; sysctl -wq net.ipv6.conf.lo.disable_ipv6=0 || true; ip addr add ::1/128 dev lo || true; ip addr add fc00::1/128 dev lo || true; ip addr add 192.0.2.1/32 dev lo || true; sysctl -wq net.ipv6.bindv6only=0 || true; cp -a \"$SOCAT_SRC/.\" .; grep -q 'fork,retry=2,' test.sh || { echo 'socat test.sh: fork,retry=2 pattern gone, retry-widen would silently no-op (upstream changed?)' >&2; exit 1; }; sed -i 's/fork,retry=2,/fork,retry=30,/' test.sh; tests=$(seq \"$SHARD\" \"$SHARDS\" 999); SOCAT=\"$PWD/socat\" SHELL=/bin/bash timeout -k 10 600 ./test.sh -t 1.0 --expect-fail \"$EXPECT_FAIL\" ${tests:-0}"]]
           }]
           EOF
           sed -i "s/__SHARDS__/$(( 6 * $(nproc) ))/" socat-configs.json


### PR DESCRIPTION
Fixes a rare socat shard hang that stalls the job until the 15-minute timeout kills it with no diagnosable output. Seen once on a run whose re-run passed; reproduced deterministically by delaying the listener past the retry budget.

### Root cause
The inverted `testserversec` OPENSSL tests (`OPENSSLCERTCLIENT`, the commonname test and the fips test) run a foreground one-shot SSL listener with no port-wait, while their background connector exits after ~2s (`retry=2`, 1s apart). On a loaded runner the listener can bind *after* the connector is already gone, then block in `accept()` forever. Nothing bounds the shard, so it stalls until the job-level timeout fires and the log says nothing about which test was running.

### Fix
- **Widen the connector budget to `retry=30`.** Retries only happen while the listener is not yet up, and `testserversec` kills the connector as soon as the client returns, so passing runs are unaffected — this only buys the listener a wider window to win the race.
- **Bound each shard with `timeout(1)` at 10 minutes** (normal shard time is ~2 min). Any future hang then fails fast, and the shard output names the test that was running instead of dying to the opaque job-level kill.
