### PR TITLE
Check ctx extensions before rejecting a TLS1.3 certificate message extension

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -18044,10 +18044,14 @@ WOLFSSL_TEST_VIS int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 #ifdef WOLFSSL_TLS13
         /* RFC 8446 4.4.2: extensions in a Certificate message MUST
          * correspond to ones offered in our prior ClientHello (client) or
-         * CertificateRequest (server). Reject anything we did not offer. */
+         * CertificateRequest (server). Reject anything we did not offer, but a
+         * CTX-level API leaves the extension on ctx->extensions, so look there
+         * too before concluding it was never offered. */
         if (msgType == certificate &&
             IsAtLeastTLSv1_3(ssl->version) &&
-            TLSX_Find(ssl->extensions, (TLSX_Type)type) == NULL) {
+            TLSX_Find(ssl->extensions, (TLSX_Type)type) == NULL &&
+            (ssl->ctx == NULL ||
+             TLSX_Find(ssl->ctx->extensions, (TLSX_Type)type) == NULL)) {
             WOLFSSL_MSG("Cert-msg extension not offered in CH/CR");
             SendAlert(ssl, alert_fatal, unsupported_extension);
             WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_EXTENSION);


### PR DESCRIPTION
`wolfSSL_CTX_UseOCSPStapling()` stores status_request on `ctx->extensions`, and nothing copies it to `ssl->extensions`. The ClientHello is written from the CTX, so the extension *is* offered, but the RFC 8446 4.4.2 check in `TLSX_Parse()` only searched `ssl->extensions` and killed the server's staple:

```
Parsing 1836 bytes of cert extensions
Cert-msg extension not offered in CH/CR
SendAlert: 110 unsupported_extension   -> -429
```

So OCSP stapling over TLS 1.3 fails for any client that uses the CTX-level API. TLS 1.2 takes a different path and is unaffected. `TLSX_CheckUnsupportedExtension()` already does this ssl-then-ctx lookup; this call site now matches it.

Found by wolfssl-examples `ocsp/stapling`, which uses the documented CTX API. Currently pointing OCSP testing here till merged