### PR TITLE
Thumb2 ASM: fix out-of-range narrow branches with IAR compiler

### DIFF
--- a/wolfcrypt/src/port/arm/thumb2-chacha-asm.S
+++ b/wolfcrypt/src/port/arm/thumb2-chacha-asm.S
@@ -253,7 +253,7 @@ L_chacha_thumb2_crypt_loop:
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BGT	L_chacha_thumb2_crypt_loop
 #else
-	BGT.N	L_chacha_thumb2_crypt_loop
+	BGT.W	L_chacha_thumb2_crypt_loop
 #endif
 	STM	sp, {r8, r9, r10, r11, r12}
 	LDR	lr, [sp, #32]
@@ -296,7 +296,7 @@ L_chacha_thumb2_crypt_loop:
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BLT	L_chacha_thumb2_crypt_lt_block
 #else
-	BLT.N	L_chacha_thumb2_crypt_lt_block
+	BLT.W	L_chacha_thumb2_crypt_lt_block
 #endif
 	LDR	r12, [sp, #40]
 	LDR	lr, [sp, #36]
@@ -368,7 +368,7 @@ L_chacha_thumb2_crypt_loop:
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_chacha_thumb2_crypt_block
 #else
-	BNE.N	L_chacha_thumb2_crypt_block
+	BNE.W	L_chacha_thumb2_crypt_block
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	B	L_chacha_thumb2_crypt_done

--- a/wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c
@@ -327,9 +327,9 @@ WC_OMIT_FRAME_POINTER void wc_chacha_crypt_bytes(ChaCha* ctx, byte* c,
 #if defined(__GNUC__)
         "BGT	L_chacha_thumb2_crypt_loop_%=\n\t"
 #elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
-        "BGT.N	L_chacha_thumb2_crypt_loop\n\t"
+        "BGT.W	L_chacha_thumb2_crypt_loop\n\t"
 #else
-        "BGT.N	L_chacha_thumb2_crypt_loop_%=\n\t"
+        "BGT.W	L_chacha_thumb2_crypt_loop_%=\n\t"
 #endif
         "STM	sp, {r8, r9, r10, r11, r12}\n\t"
         "LDR	lr, [sp, #32]\n\t"
@@ -372,9 +372,9 @@ WC_OMIT_FRAME_POINTER void wc_chacha_crypt_bytes(ChaCha* ctx, byte* c,
 #if defined(__GNUC__)
         "BLT	L_chacha_thumb2_crypt_lt_block_%=\n\t"
 #elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
-        "BLT.N	L_chacha_thumb2_crypt_lt_block\n\t"
+        "BLT.W	L_chacha_thumb2_crypt_lt_block\n\t"
 #else
-        "BLT.N	L_chacha_thumb2_crypt_lt_block_%=\n\t"
+        "BLT.W	L_chacha_thumb2_crypt_lt_block_%=\n\t"
 #endif
         "LDR	r12, [sp, #40]\n\t"
         "LDR	lr, [sp, #36]\n\t"
@@ -446,9 +446,9 @@ WC_OMIT_FRAME_POINTER void wc_chacha_crypt_bytes(ChaCha* ctx, byte* c,
 #if defined(__GNUC__)
         "BNE	L_chacha_thumb2_crypt_block_%=\n\t"
 #elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
-        "BNE.N	L_chacha_thumb2_crypt_block\n\t"
+        "BNE.W	L_chacha_thumb2_crypt_block\n\t"
 #else
-        "BNE.N	L_chacha_thumb2_crypt_block_%=\n\t"
+        "BNE.W	L_chacha_thumb2_crypt_block_%=\n\t"
 #endif
 #if defined(__GNUC__)
         "B	L_chacha_thumb2_crypt_done_%=\n\t"

--- a/wolfcrypt/src/port/arm/thumb2-curve25519.S
+++ b/wolfcrypt/src/port/arm/thumb2-curve25519.S
@@ -4060,7 +4060,7 @@ L_curve25519_bits:
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BGE	L_curve25519_bits
 #else
-	BGE.N	L_curve25519_bits
+	BGE.W	L_curve25519_bits
 #endif
 	/*   Cycle Count: 171 */
 	LDR	r1, [sp, #184]

--- a/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
@@ -4570,9 +4570,9 @@ WC_OMIT_FRAME_POINTER int curve25519(byte* r, const byte* n, const byte* a)
 #if defined(__GNUC__)
         "BGE	L_curve25519_bits_%=\n\t"
 #elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
-        "BGE.N	L_curve25519_bits\n\t"
+        "BGE.W	L_curve25519_bits\n\t"
 #else
-        "BGE.N	L_curve25519_bits_%=\n\t"
+        "BGE.W	L_curve25519_bits_%=\n\t"
 #endif
         /*   Cycle Count: 166 */
         "LDR	%[n], [sp, #184]\n\t"

--- a/wolfcrypt/src/port/arm/thumb2-mlkem-asm.S
+++ b/wolfcrypt/src/port/arm/thumb2-mlkem-asm.S
@@ -512,7 +512,7 @@ L_mlkem_thumb2_ntt_loop_123:
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_mlkem_thumb2_ntt_loop_123
 #else
-	BNE.N	L_mlkem_thumb2_ntt_loop_123
+	BNE.W	L_mlkem_thumb2_ntt_loop_123
 #endif
 	SUB	r0, r0, #0x40
 	MOV	r3, #0
@@ -1316,7 +1316,7 @@ L_mlkem_thumb2_ntt_loop_567:
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_mlkem_thumb2_ntt_loop_567
 #else
-	BNE.N	L_mlkem_thumb2_ntt_loop_567
+	BNE.W	L_mlkem_thumb2_ntt_loop_567
 #endif
 	ADD	sp, sp, #8
 	POP	{r4, r5, r6, r7, r8, r9, r10, r11, pc}
@@ -1959,7 +1959,7 @@ L_mlkem_invntt_loop_765:
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_mlkem_invntt_loop_765
 #else
-	BNE.N	L_mlkem_invntt_loop_765
+	BNE.W	L_mlkem_invntt_loop_765
 #endif
 	SUB	r0, r0, #0x200
 	MOV	r3, #0
@@ -2972,7 +2972,7 @@ L_mlkem_invntt_loop_321:
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_mlkem_invntt_loop_321
 #else
-	BNE.N	L_mlkem_invntt_loop_321
+	BNE.W	L_mlkem_invntt_loop_321
 #endif
 	ADD	sp, sp, #8
 	POP	{r4, r5, r6, r7, r8, r9, r10, r11, pc}

--- a/wolfcrypt/src/port/arm/thumb2-mlkem-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-mlkem-asm_c.c
@@ -533,9 +533,9 @@ WC_OMIT_FRAME_POINTER void mlkem_thumb2_ntt(sword16* r)
 #if defined(__GNUC__)
         "BNE	L_mlkem_thumb2_ntt_loop_123_%=\n\t"
 #elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
-        "BNE.N	L_mlkem_thumb2_ntt_loop_123\n\t"
+        "BNE.W	L_mlkem_thumb2_ntt_loop_123\n\t"
 #else
-        "BNE.N	L_mlkem_thumb2_ntt_loop_123_%=\n\t"
+        "BNE.W	L_mlkem_thumb2_ntt_loop_123_%=\n\t"
 #endif
         "SUB	%[r], %[r], #0x40\n\t"
         "MOV	r3, #0\n\t"
@@ -1358,9 +1358,9 @@ WC_OMIT_FRAME_POINTER void mlkem_thumb2_ntt(sword16* r)
 #if defined(__GNUC__)
         "BNE	L_mlkem_thumb2_ntt_loop_567_%=\n\t"
 #elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
-        "BNE.N	L_mlkem_thumb2_ntt_loop_567\n\t"
+        "BNE.W	L_mlkem_thumb2_ntt_loop_567\n\t"
 #else
-        "BNE.N	L_mlkem_thumb2_ntt_loop_567_%=\n\t"
+        "BNE.W	L_mlkem_thumb2_ntt_loop_567_%=\n\t"
 #endif
         "ADD	sp, sp, #8\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2018,9 +2018,9 @@ WC_OMIT_FRAME_POINTER void mlkem_thumb2_invntt(sword16* r)
 #if defined(__GNUC__)
         "BNE	L_mlkem_invntt_loop_765_%=\n\t"
 #elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
-        "BNE.N	L_mlkem_invntt_loop_765\n\t"
+        "BNE.W	L_mlkem_invntt_loop_765\n\t"
 #else
-        "BNE.N	L_mlkem_invntt_loop_765_%=\n\t"
+        "BNE.W	L_mlkem_invntt_loop_765_%=\n\t"
 #endif
         "SUB	%[r], %[r], #0x200\n\t"
         "MOV	r3, #0\n\t"
@@ -3052,9 +3052,9 @@ WC_OMIT_FRAME_POINTER void mlkem_thumb2_invntt(sword16* r)
 #if defined(__GNUC__)
         "BNE	L_mlkem_invntt_loop_321_%=\n\t"
 #elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
-        "BNE.N	L_mlkem_invntt_loop_321\n\t"
+        "BNE.W	L_mlkem_invntt_loop_321\n\t"
 #else
-        "BNE.N	L_mlkem_invntt_loop_321_%=\n\t"
+        "BNE.W	L_mlkem_invntt_loop_321_%=\n\t"
 #endif
         "ADD	sp, sp, #8\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/thumb2-poly1305-asm.S
+++ b/wolfcrypt/src/port/arm/thumb2-poly1305-asm.S
@@ -44,7 +44,7 @@ poly1305_blocks_thumb2_16:
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_poly1305_thumb2_16_done
 #else
-	BEQ.N	L_poly1305_thumb2_16_done
+	BEQ.W	L_poly1305_thumb2_16_done
 #endif
 	ADD	lr, sp, #12
 	STM	lr, {r0, r1, r2, r3}

--- a/wolfcrypt/src/port/arm/thumb2-poly1305-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-poly1305-asm_c.c
@@ -71,9 +71,9 @@ WC_OMIT_FRAME_POINTER void poly1305_blocks_thumb2_16(Poly1305* ctx,
 #if defined(__GNUC__)
         "BEQ	L_poly1305_thumb2_16_done_%=\n\t"
 #elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
-        "BEQ.N	L_poly1305_thumb2_16_done\n\t"
+        "BEQ.W	L_poly1305_thumb2_16_done\n\t"
 #else
-        "BEQ.N	L_poly1305_thumb2_16_done_%=\n\t"
+        "BEQ.W	L_poly1305_thumb2_16_done_%=\n\t"
 #endif
         "ADD	lr, sp, #12\n\t"
         "STM	lr, {%[ctx], %[m], %[len], %[notLast]}\n\t"


### PR DESCRIPTION
Applies wolfssl/scripts#629

IAR reports "Branch offset too long" on branches that force the narrow instruction encoding (.N) but whose targets are beyond the byte range of a 16-bit branch.

This uses the .W variant for branches that exceed the limit.

Fixes ZD#22040
