### PR TITLE
Bound CKS extension allocation in TLSX_CKS_Parse

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -11797,8 +11797,10 @@ int TLSX_CKS_Parse(WOLFSSL* ssl, byte* input, word16 length,
 
     (void) extensions;
 
-    /* Validating the input. */
-    if (length == 0)
+    /* Validating the input. A well-formed CKS list carries at most one of each
+     * valid specifier, so reject anything longer than WOLFSSL_MAX_CKS_SIGSPEC_SZ
+     * to bound the peerSigSpec allocation below. */
+    if (length == 0 || length > WOLFSSL_MAX_CKS_SIGSPEC_SZ)
         return BUFFER_ERROR;
     for (i = 0; i < length; i++) {
         switch (input[i])

--- a/tests/api/test_ssl_ext.c
+++ b/tests/api/test_ssl_ext.c
@@ -811,3 +811,56 @@ int test_wolfSSL_CTX_set_alpn_protos_inval_ext(void)
 #endif
     return EXPECT_RESULT();
 }
+
+int test_wolfSSL_dual_alg_cks_parse_ext(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_DUAL_ALG_CERTS) && defined(WOLFSSL_TLS13) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_TLS)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL*     ssl = NULL;
+    byte         oversized[WOLFSSL_MAX_CKS_SIGSPEC_SZ + 1];
+    byte         huge[64];
+    byte         maxValid[WOLFSSL_MAX_CKS_SIGSPEC_SZ];
+    byte         value;
+
+    /* An oversized list made entirely of valid specifiers still needs to be
+     * rejected, so fill the buffers with a valid value. */
+    XMEMSET(oversized, WOLFSSL_CKS_SIGSPEC_NATIVE, sizeof(oversized));
+    XMEMSET(huge, WOLFSSL_CKS_SIGSPEC_NATIVE, sizeof(huge));
+    maxValid[0] = WOLFSSL_CKS_SIGSPEC_BOTH;
+    maxValid[1] = WOLFSSL_CKS_SIGSPEC_ALTERNATIVE;
+    maxValid[2] = WOLFSSL_CKS_SIGSPEC_NATIVE;
+
+    /* A client reaches the allocation path without needing an alt key. */
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+
+    /* A zero length list is rejected. */
+    value = WOLFSSL_CKS_SIGSPEC_NATIVE;
+    ExpectIntEQ(TLSX_CKS_Parse(ssl, &value, 0, &ssl->extensions),
+        WC_NO_ERR_TRACE(BUFFER_ERROR));
+
+    /* A list of all-valid bytes longer than the semantic maximum is rejected
+     * before any allocation. This is the denial-of-service regression:
+     * previously any length up to 65535 was copied into a fresh heap buffer. */
+    ExpectIntEQ(TLSX_CKS_Parse(ssl, oversized, (word16)sizeof(oversized),
+        &ssl->extensions), WC_NO_ERR_TRACE(BUFFER_ERROR));
+    ExpectIntEQ(TLSX_CKS_Parse(ssl, huge, (word16)sizeof(huge),
+        &ssl->extensions), WC_NO_ERR_TRACE(BUFFER_ERROR));
+
+    /* An invalid specifier value is still rejected. */
+    value = WOLFSSL_CKS_SIGSPEC_EXTERNAL;
+    ExpectIntEQ(TLSX_CKS_Parse(ssl, &value, 1, &ssl->extensions),
+        WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+    /* A well-formed list at the maximum length is accepted, so the cap does not
+     * break legitimate peers (the example client sends all three specifiers). */
+    ExpectIntEQ(TLSX_CKS_Parse(ssl, maxValid, (word16)sizeof(maxValid),
+        &ssl->extensions), 0);
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_ssl_ext.h
+++ b/tests/api/test_ssl_ext.h
@@ -50,6 +50,7 @@ int test_wolfSSL_CTX_set_TicketEncCb_inval_ext(void);
 int test_wolfSSL_SessionTicket_inval_ext(void);
 int test_wolfSSL_CTX_set_servername_arg_inval_ext(void);
 int test_wolfSSL_CTX_set_alpn_protos_inval_ext(void);
+int test_wolfSSL_dual_alg_cks_parse_ext(void);
 
 #define TEST_SSL_EXT_DECLS                                                     \
         TEST_DECL_GROUP("ssl_ext", test_wolfSSL_NoTicketTLSv12_ext),           \
@@ -90,6 +91,8 @@ int test_wolfSSL_CTX_set_alpn_protos_inval_ext(void);
         TEST_DECL_GROUP("ssl_ext",                                            \
             test_wolfSSL_CTX_set_servername_arg_inval_ext),                   \
         TEST_DECL_GROUP("ssl_ext",                                            \
-            test_wolfSSL_CTX_set_alpn_protos_inval_ext)
+            test_wolfSSL_CTX_set_alpn_protos_inval_ext),                      \
+        TEST_DECL_GROUP("ssl_ext",                                            \
+            test_wolfSSL_dual_alg_cks_parse_ext)
 
 #endif /* TESTS_API_SSL_EXT_H */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3800,7 +3800,7 @@ WOLFSSL_LOCAL int TLSX_KeyShare_Parse_ClientHello(const WOLFSSL* ssl,
 WOLFSSL_LOCAL int TLSX_KeyShare_HandlePqcHybridKeyServer(WOLFSSL* ssl,
         KeyShareEntry* keyShareEntry, byte* data, word16 len);
 #ifdef WOLFSSL_DUAL_ALG_CERTS
-WOLFSSL_LOCAL int TLSX_CKS_Parse(WOLFSSL* ssl, byte* input,
+WOLFSSL_TEST_VIS int TLSX_CKS_Parse(WOLFSSL* ssl, byte* input,
                                  word16 length, TLSX** extensions);
 WOLFSSL_LOCAL int TLSX_CKS_Set(WOLFSSL* ssl, TLSX** extensions);
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4935,9 +4935,10 @@ WOLFSSL_API int wolfSSL_NoKeyShares(WOLFSSL* ssl);
 #define WOLFSSL_CKS_SIGSPEC_BOTH        0x0003
 #define WOLFSSL_CKS_SIGSPEC_EXTERNAL    0x0004
 
-/* Maximum length in bytes of a CKS signature specifier list. Only the three
- * specifiers above are valid, so a well-formed preference list is never longer
- * than this. Used to bound the peer allocation in TLSX_CKS_Parse(). */
+/* Maximum length in bytes of a CKS signature specifier list. Only NATIVE,
+ * ALTERNATIVE, and BOTH are valid specifiers (EXTERNAL is rejected), so a
+ * well-formed preference list is never longer than this. Used to bound the
+ * peer allocation in TLSX_CKS_Parse(). */
 #define WOLFSSL_MAX_CKS_SIGSPEC_SZ      3
 
 WOLFSSL_API int wolfSSL_UseCKS(WOLFSSL* ssl, byte *sigSpec, word16 sigSpecSz);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4935,6 +4935,11 @@ WOLFSSL_API int wolfSSL_NoKeyShares(WOLFSSL* ssl);
 #define WOLFSSL_CKS_SIGSPEC_BOTH        0x0003
 #define WOLFSSL_CKS_SIGSPEC_EXTERNAL    0x0004
 
+/* Maximum length in bytes of a CKS signature specifier list. Only the three
+ * specifiers above are valid, so a well-formed preference list is never longer
+ * than this. Used to bound the peer allocation in TLSX_CKS_Parse(). */
+#define WOLFSSL_MAX_CKS_SIGSPEC_SZ      3
+
 WOLFSSL_API int wolfSSL_UseCKS(WOLFSSL* ssl, byte *sigSpec, word16 sigSpecSz);
 WOLFSSL_API int wolfSSL_CTX_UseCKS(WOLFSSL_CTX* ctx, byte *sigSpec,
                                    word16 sigSpecSz);


### PR DESCRIPTION
# Description

The TLS 1.3 CKS (Certificate Key Selection) extension parser allocated a heap buffer sized directly from the attacker-controlled extension length, with no upper bound other than the word16 type limit.

This issue was reported by Pelioro

Fixes zd22167

# Testing

`test_wolfSSL_dual_alg_cks_parse_ext

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
