### PR TITLE
Set label and ID on PKCS11 EC public key

### DIFF
--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -3949,7 +3949,7 @@ static int Pkcs11ECDSA_Verify(Pkcs11Session* session, wc_CryptoInfo* info)
                 ret = Pkcs11GetEccParams(session, publicKey, key);
             }
         }
-        else if (!mp_iszero(key->pubkey.x)) {
+        else if (!mp_iszero(key->pubkey.x) || !mp_iszero(key->pubkey.y)) {
             ret = Pkcs11CreateEccPublicKey(&publicKey, session, key,
                                            CKA_VERIFY);
             sessionKey = 1;
@@ -3957,6 +3957,14 @@ static int Pkcs11ECDSA_Verify(Pkcs11Session* session, wc_CryptoInfo* info)
         else
             ret = Pkcs11FindEccKey(&publicKey, CKO_PUBLIC_KEY, session,
                                    info->pk.eccsign.key, CKA_VERIFY);
+
+        /* keygen destroys the token public key, so fall back to the point. */
+        if (ret != 0 && (key->labelLen > 0 || key->idLen > 0) &&
+                (!mp_iszero(key->pubkey.x) || !mp_iszero(key->pubkey.y))) {
+            ret = Pkcs11CreateEccPublicKey(&publicKey, session, key,
+                                           CKA_VERIFY);
+            sessionKey = 1;
+        }
     }
 
     if (ret == 0) {


### PR DESCRIPTION
- Fixes wc_ecc_verify_hash returning WC_HW_E on a label/ID-generated PKCS#11 EC key — Pkcs11EcKeyGen set the label/ID only on the private key, so verify couldn't find the public key object. Now sets them on the public key template too.
- Caught here: https://github.com/aidangarske/wolfssl-examples/blob/cb15c8dec3cbf8e7d9ada7f6edb3d0301c5cfe3e/.github/examples-manifest.yml#L1415 checked here https://github.com/wolfSSL/wolfssl-examples/actions/runs/29779301218/job/88477936034?pr=598 currently suppressed till merged 