### PR TITLE
Testing: AES GCM opps with IV < 96-bits now returns WC_FIPS_NOT_APPROVED with FIPS

### DIFF
--- a/.wolfssl_known_macro_extras
+++ b/.wolfssl_known_macro_extras
@@ -1078,8 +1078,6 @@ XGETPASSWD
 XMSS_CALL_PRF_KEYGEN
 XPAR_VERSAL_CIPS_0_PSPMC_0_PSV_CORTEXA72_0_TIMESTAMP_CLK_FREQ
 XSECURE_CACHE_DISABLE
-fipsCastStatus_get
-wc_Des3_SetKey
 _ABI64
 _ABIO64
 _ARCH_PPC64
@@ -1262,8 +1260,10 @@ __xtensa__
 byte
 configTICK_RATE_HZ
 fallthrough
+fipsCastStatus_get
 noinline
 ssize_t
 sun
 versal
+wc_Des3_SetKey
 wc_Tls13_HKDF_Expand_Label

--- a/tests/api/test_aes.c
+++ b/tests/api/test_aes.c
@@ -9239,11 +9239,11 @@ int test_wc_AesGcmArgMcdc(void)
          * self-contained demonstration). */
         ExpectIntEQ(wc_AesGcmSetIV(&aes, 10, NULL, 0, &rng),
             WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-        ExpectIntEQ(wc_AesGcmSetIV(&aes, GCM_NONCE_MIN_SZ, NULL, 0, &rng),
 #if defined(HAVE_FIPS) && FIPS_VERSION3_GE(7,0,0)
+        ExpectIntEQ(wc_AesGcmSetIV(&aes, GCM_NONCE_MIN_SZ, NULL, 0, &rng),
             WC_FIPS_NOT_APPROVED);
 #else
-            0);
+        ExpectIntEQ(wc_AesGcmSetIV(&aes, GCM_NONCE_MIN_SZ, NULL, 0, &rng), 0);
 #endif
         ExpectIntEQ(wc_AesGcmSetIV(&aes, GCM_NONCE_MID_SZ, NULL, 0, &rng),
             0);

--- a/tests/api/test_aes.c
+++ b/tests/api/test_aes.c
@@ -9240,7 +9240,11 @@ int test_wc_AesGcmArgMcdc(void)
         ExpectIntEQ(wc_AesGcmSetIV(&aes, 10, NULL, 0, &rng),
             WC_NO_ERR_TRACE(BAD_FUNC_ARG));
         ExpectIntEQ(wc_AesGcmSetIV(&aes, GCM_NONCE_MIN_SZ, NULL, 0, &rng),
+#if defined(HAVE_FIPS) && FIPS_VERSION3_GE(7,0,0)
+            WC_FIPS_NOT_APPROVED);
+#else
             0);
+#endif
         ExpectIntEQ(wc_AesGcmSetIV(&aes, GCM_NONCE_MID_SZ, NULL, 0, &rng),
             0);
         ExpectIntEQ(wc_AesGcmSetIV(&aes, GCM_NONCE_MAX_SZ, NULL, 0, &rng),


### PR DESCRIPTION
# Description

Accounts for the new functionality in https://github.com/wolfSSL/fips/pull/405 and needs the fixes in https://github.com/wolfSSL/fips/pull/407

# Testing

./fips-check.sh ready keep

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
