### PR TITLE
openssh CI: add 10.4p1 to the matrix

### DIFF
--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -80,6 +80,11 @@ jobs:
             SKIP_LTESTS: >-
               exit-status rekey multiplex forward-control channel-timeout
               connection-timeout
+          - git_ref: 'V_10_4_P1'
+            osp_ver: '10.4p1'
+            SKIP_LTESTS: >-
+              exit-status rekey multiplex forward-control channel-timeout
+              connection-timeout
     name: ${{ matrix.osp_ver }}
     if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -83,6 +83,11 @@ jobs:
             SKIP_LTESTS: >-
               exit-status rekey multiplex forward-control channel-timeout
               connection-timeout
+          - git_ref: 'V_10_4_P1'
+            osp_ver: '10.4p1'
+            SKIP_LTESTS: >-
+              exit-status rekey multiplex forward-control channel-timeout
+              connection-timeout
     name: ${{ matrix.osp_ver }}
     if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Adds OpenSSH 10.4p1 (`V_10_4_P1` / osp `10.4p1`) to the OpenSSH CI matrix,
with the same `SKIP_LTESTS` set as the existing entries.

Depends on wolfSSL/osp#350, which adds the corresponding patch. Keeping this
in draft until that merges, since the job pulls the patch from osp.
