### PR TITLE
OpenSSL compat with ML-DSA

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -6590,6 +6590,18 @@ WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PrivateKey(WOLFSSL_BIO* bio,
                 type = WC_EVP_PKEY_ED448;
                 break;
         #endif
+        #ifdef WOLFSSL_HAVE_MLDSA
+            case ML_DSA_44k:
+            case ML_DSA_65k:
+            case ML_DSA_87k:
+            #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
+            case DILITHIUM_LEVEL2k:
+            case DILITHIUM_LEVEL3k:
+            case DILITHIUM_LEVEL5k:
+            #endif
+                type = WC_EVP_PKEY_DILITHIUM;
+                break;
+        #endif
             default:
                 type = WOLFSSL_FATAL_ERROR;
                 break;
@@ -6745,6 +6757,18 @@ WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_PrivateKey(XFILE fp, WOLFSSL_EVP_PKEY **key,
         #ifdef HAVE_ED448
             case ED448k:
                 type = WC_EVP_PKEY_ED448;
+                break;
+        #endif
+        #ifdef WOLFSSL_HAVE_MLDSA
+            case ML_DSA_44k:
+            case ML_DSA_65k:
+            case ML_DSA_87k:
+            #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
+            case DILITHIUM_LEVEL2k:
+            case DILITHIUM_LEVEL3k:
+            case DILITHIUM_LEVEL5k:
+            #endif
+                type = WC_EVP_PKEY_DILITHIUM;
                 break;
         #endif
             default:

--- a/src/x509.c
+++ b/src/x509.c
@@ -12996,13 +12996,21 @@ cleanup:
 
 #ifndef WC_MAX_X509_GEN
     /* able to override max size until dynamic buffer created */
-    #ifdef WOLFSSL_HAVE_MLDSA
+    #define WC_MAX_X509_GEN 4096
+#endif
+#ifdef WOLFSSL_HAVE_MLDSA
+    #ifndef WC_MAX_X509_GEN_MLDSA
         /* ML-DSA public keys and signatures are large (ML-DSA-87:
          * 2592 byte public key, 4627 byte signature). */
-        #define WC_MAX_X509_GEN 20480
-    #else
-        #define WC_MAX_X509_GEN 4096
+        #define WC_MAX_X509_GEN_MLDSA 20480
     #endif
+    /* DER buffer size for certificate/CSR signing, chosen from the signing
+     * key type so that only ML-DSA keys pay for the large buffer. */
+    #define X509_GEN_BUF_SZ(pkey) \
+        (((pkey) != NULL && (pkey)->type == WC_EVP_PKEY_DILITHIUM) ? \
+            WC_MAX_X509_GEN_MLDSA : WC_MAX_X509_GEN)
+#else
+    #define X509_GEN_BUF_SZ(pkey) WC_MAX_X509_GEN
 #endif
 
 /* returns the size of signature on success */
@@ -13010,13 +13018,21 @@ int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
         const WOLFSSL_EVP_MD* md)
 {
     int  ret;
-    /* @TODO dynamic set based on expected cert size */
-    byte *der = (byte *)XMALLOC(WC_MAX_X509_GEN, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    int  derSz = WC_MAX_X509_GEN;
+    byte *der = NULL;
+    int  bufSz = 0;
+    int  derSz = 0;
 
     WOLFSSL_ENTER("wolfSSL_X509_sign");
 
     if (x509 == NULL || pkey == NULL || md == NULL) {
+        ret = WOLFSSL_FAILURE;
+        goto out;
+    }
+
+    bufSz = X509_GEN_BUF_SZ(pkey);
+    derSz = bufSz;
+    der = (byte *)XMALLOC((size_t)bufSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (der == NULL) {
         ret = WOLFSSL_FAILURE;
         goto out;
     }
@@ -13031,7 +13047,7 @@ int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
         goto out;
     }
 
-    ret = wolfSSL_X509_resign_cert(x509, 0, der, WC_MAX_X509_GEN, derSz,
+    ret = wolfSSL_X509_resign_cert(x509, 0, der, bufSz, derSz,
             (WOLFSSL_EVP_MD*)md, pkey);
     if (ret <= 0) {
         WOLFSSL_LEAVE("wolfSSL_X509_sign", ret);
@@ -16968,33 +16984,38 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
                           const WOLFSSL_EVP_MD *md)
 {
     int ret;
-    WC_DECLARE_VAR(der, byte, WC_MAX_X509_GEN, 0);
-    int derSz = WC_MAX_X509_GEN;
+    byte* der = NULL;
+    int bufSz;
+    int derSz;
 
     if (req == NULL || pkey == NULL || md == NULL) {
         WOLFSSL_LEAVE("wolfSSL_X509_REQ_sign", BAD_FUNC_ARG);
         return WOLFSSL_FAILURE;
     }
 
-    WC_ALLOC_VAR_EX(der, byte, derSz, NULL, DYNAMIC_TYPE_TMP_BUFFER,
-        return WOLFSSL_FAILURE);
+    bufSz = X509_GEN_BUF_SZ(pkey);
+    derSz = bufSz;
+    der = (byte*)XMALLOC((size_t)bufSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (der == NULL) {
+        return WOLFSSL_FAILURE;
+    }
 
     /* Create a Cert that has the certificate request fields. */
     req->sigOID = wolfSSL_sigTypeFromPKEY((WOLFSSL_EVP_MD*)md, pkey);
     ret = wolfssl_x509_make_der(req, 1, der, &derSz, 0);
     if (ret != WOLFSSL_SUCCESS) {
-        WC_FREE_VAR_EX(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         WOLFSSL_MSG("Unable to make DER for X509");
         WOLFSSL_LEAVE("wolfSSL_X509_REQ_sign", ret);
         return WOLFSSL_FAILURE;
     }
 
-    if (wolfSSL_X509_resign_cert(req, 1, der, WC_MAX_X509_GEN, derSz,
+    if (wolfSSL_X509_resign_cert(req, 1, der, bufSz, derSz,
             (WOLFSSL_EVP_MD*)md, pkey) <= 0) {
-        WC_FREE_VAR_EX(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return WOLFSSL_FAILURE;
     }
-    WC_FREE_VAR_EX(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     return WOLFSSL_SUCCESS;
 }
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -16600,6 +16600,16 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
             PRIVATE_KEY_LOCK();
         #endif
             if (!decodeOk) {
+            #ifdef WOLFSSL_MLDSA_PRIVATE_KEY
+                /* A failed PrivateKeyDecode may leave the level pinned;
+                 * reset the key so PublicKeyDecode auto-detects it from
+                 * the SPKI OID. */
+                wc_MlDsaKey_Free(mldsa);
+                if (wc_MlDsaKey_Init(mldsa, NULL, INVALID_DEVID) != 0) {
+                    XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
+                    return WOLFSSL_FAILURE;
+                }
+            #endif
                 idx = 0;
                 if (wc_MlDsaKey_PublicKeyDecode(mldsa,
                         (const byte*)pkey->pkey.ptr, (word32)pkey->pkey_sz,

--- a/src/x509.c
+++ b/src/x509.c
@@ -12863,7 +12863,7 @@ cleanup:
         if (pkey->type == WC_EVP_PKEY_DILITHIUM) {
             /* Decode the ML-DSA private key held as DER in pkey.ptr. */
             word32 idx = 0;
-            byte level = 0;
+            int oidSum = 0;
             int decRet;
 
             mldsa = (MlDsaKey*)XMALLOC(sizeof(MlDsaKey), NULL,
@@ -12879,30 +12879,33 @@ cleanup:
                     (const byte*)pkey->pkey.ptr, (word32)pkey->pkey_sz,
                     &idx);
             PRIVATE_KEY_LOCK();
+            /* Map the parameter set to its OID with mldsa_get_oid_sum():
+             * unlike wc_MlDsaKey_GetParams() it distinguishes FIPS204-draft
+             * levels. */
             if (decRet != 0 ||
-                    wc_MlDsaKey_GetParams(mldsa, &level) != 0) {
+                    mldsa_get_oid_sum(mldsa, &oidSum) != 0) {
                 wc_MlDsaKey_Free(mldsa);
                 XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
                 return WOLFSSL_FATAL_ERROR;
             }
-            switch (level) {
-                case WC_ML_DSA_44:
+            switch (oidSum) {
+                case ML_DSA_44k:
                     type = ML_DSA_LEVEL2_TYPE;
                     break;
-                case WC_ML_DSA_65:
+                case ML_DSA_65k:
                     type = ML_DSA_LEVEL3_TYPE;
                     break;
-                case WC_ML_DSA_87:
+                case ML_DSA_87k:
                     type = ML_DSA_LEVEL5_TYPE;
                     break;
             #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
-                case WC_ML_DSA_44_DRAFT:
+                case DILITHIUM_LEVEL2k:
                     type = DILITHIUM_LEVEL2_TYPE;
                     break;
-                case WC_ML_DSA_65_DRAFT:
+                case DILITHIUM_LEVEL3k:
                     type = DILITHIUM_LEVEL3_TYPE;
                     break;
-                case WC_ML_DSA_87_DRAFT:
+                case DILITHIUM_LEVEL5k:
                     type = DILITHIUM_LEVEL5_TYPE;
                     break;
             #endif
@@ -16579,7 +16582,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
             /* Decode key DER (private or public) and export public part. */
             MlDsaKey* mldsa;
             word32 idx = 0;
-            byte level = 0;
+            int oidSum = 0;
             int decodeOk = 0;
 
             mldsa = (MlDsaKey*)XMALLOC(sizeof(MlDsaKey), cert->heap,
@@ -16619,7 +16622,11 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
                     return WOLFSSL_FAILURE;
                 }
             }
-            if (wc_MlDsaKey_GetParams(mldsa, &level) != 0) {
+            /* Map the parameter set to its OID with mldsa_get_oid_sum():
+             * unlike wc_MlDsaKey_GetParams() it distinguishes FIPS204-draft
+             * levels, keeping pubKeyOID consistent with the SPKI encoded
+             * by wc_MlDsaKey_PublicKeyToDer(). */
+            if (mldsa_get_oid_sum(mldsa, &oidSum) != 0) {
                 wc_MlDsaKey_Free(mldsa);
                 XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
                 return WOLFSSL_FAILURE;
@@ -16639,31 +16646,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
                 XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                 return WOLFSSL_FAILURE;
             }
-            switch (level) {
-                case WC_ML_DSA_44:
-                    cert->pubKeyOID = ML_DSA_44k;
-                    break;
-                case WC_ML_DSA_65:
-                    cert->pubKeyOID = ML_DSA_65k;
-                    break;
-                case WC_ML_DSA_87:
-                    cert->pubKeyOID = ML_DSA_87k;
-                    break;
-            #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
-                case WC_ML_DSA_44_DRAFT:
-                    cert->pubKeyOID = DILITHIUM_LEVEL2k;
-                    break;
-                case WC_ML_DSA_65_DRAFT:
-                    cert->pubKeyOID = DILITHIUM_LEVEL3k;
-                    break;
-                case WC_ML_DSA_87_DRAFT:
-                    cert->pubKeyOID = DILITHIUM_LEVEL5k;
-                    break;
-            #endif
-                default:
-                    XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-                    return WOLFSSL_FAILURE;
-            }
+            cert->pubKeyOID = oidSum;
         }
         break;
 #endif /* WOLFSSL_HAVE_MLDSA && WOLFSSL_MLDSA_PUBLIC_KEY &&

--- a/src/x509.c
+++ b/src/x509.c
@@ -13026,25 +13026,31 @@ cleanup:
     /* able to override max size until dynamic buffer created */
     #define WC_MAX_X509_GEN 4096
 #endif
-#ifdef WOLFSSL_HAVE_MLDSA
-    #ifndef WC_MAX_X509_GEN_MLDSA
-        /* Base size plus the largest compiled-in ML-DSA signature and its
-         * ASN.1 overhead; the subject key is added in X509_GEN_BUF_SZ(). */
-        #define WC_MAX_X509_GEN_MLDSA \
-            (WC_MAX_X509_GEN + MLDSA_MAX_SIG_SIZE + MAX_ALGO_SZ + \
-             MAX_SEQ_SZ * 2)
-    #endif
-    /* DER buffer size for certificate/CSR signing: chosen from the signing
-     * key type, plus the subject public key held in the x509 so that a
-     * large (e.g. ML-DSA) SPKI fits under a classic signing key too. */
-    #define X509_GEN_BUF_SZ(x509, pkey) \
-        ((((pkey) != NULL && (pkey)->type == WC_EVP_PKEY_DILITHIUM) ? \
-            WC_MAX_X509_GEN_MLDSA : WC_MAX_X509_GEN) + \
-            (int)(x509)->pubKey.length)
-#else
-    #define X509_GEN_BUF_SZ(x509, pkey) \
-        (WC_MAX_X509_GEN + (int)(x509)->pubKey.length)
+#if defined(WOLFSSL_HAVE_MLDSA) && !defined(WC_MAX_X509_GEN_MLDSA)
+    /* Base size plus the largest compiled-in ML-DSA signature and its
+     * ASN.1 overhead; the subject key is added in x509_gen_buf_sz(). */
+    #define WC_MAX_X509_GEN_MLDSA \
+        (WC_MAX_X509_GEN + MLDSA_MAX_SIG_SIZE + MAX_ALGO_SZ + \
+         MAX_SEQ_SZ * 2)
 #endif
+
+/* DER buffer size for certificate/CSR signing: chosen from the signing
+ * key type, plus the subject public key held in the x509 so that a
+ * large (e.g. ML-DSA) SPKI fits under a classic signing key too. */
+static int x509_gen_buf_sz(const WOLFSSL_X509* x509,
+    const WOLFSSL_EVP_PKEY* pkey)
+{
+    int sz = WC_MAX_X509_GEN;
+
+#ifdef WOLFSSL_HAVE_MLDSA
+    if (pkey != NULL && pkey->type == WC_EVP_PKEY_DILITHIUM) {
+        sz = WC_MAX_X509_GEN_MLDSA;
+    }
+#else
+    (void)pkey;
+#endif
+    return sz + (int)x509->pubKey.length;
+}
 
 /* returns the size of signature on success */
 int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
@@ -13073,7 +13079,7 @@ int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
         goto out;
     }
 
-    bufSz = X509_GEN_BUF_SZ(x509, pkey);
+    bufSz = x509_gen_buf_sz(x509, pkey);
     derSz = bufSz;
     der = (byte *)XMALLOC((size_t)bufSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {
@@ -17050,7 +17056,7 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
         return WOLFSSL_FAILURE;
     }
 
-    bufSz = X509_GEN_BUF_SZ(req, pkey);
+    bufSz = x509_gen_buf_sz(req, pkey);
     derSz = bufSz;
     der = (byte*)XMALLOC((size_t)bufSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {

--- a/src/x509.c
+++ b/src/x509.c
@@ -12244,8 +12244,13 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
 
     #ifdef WOLFSSL_MLDSA_X509_SIGN
         if (pkey->type == WC_EVP_PKEY_DILITHIUM) {
-            /* ML-DSA does not use a separate hash; md (may be NULL, as in
-             * OpenSSL's X509_sign(x, pkey, NULL)) is ignored. */
+            /* ML-DSA does not use a separate hash. A NULL md matches
+             * OpenSSL's X509_sign(x, pkey, NULL); unlike OpenSSL, a
+             * non-NULL md is deliberately ignored rather than rejected to
+             * keep hash-passing callers working. */
+            if (md != NULL) {
+                WOLFSSL_MSG("Ignoring md for ML-DSA signing");
+            }
             switch (WOLFSSL_ATOMIC_LOAD(pkey->mldsaOID)) {
                 case ML_DSA_44k:
                     sigType = CTC_ML_DSA_44;

--- a/src/x509.c
+++ b/src/x509.c
@@ -13004,13 +13004,16 @@ cleanup:
          * 2592 byte public key, 4627 byte signature). */
         #define WC_MAX_X509_GEN_MLDSA 20480
     #endif
-    /* DER buffer size for certificate/CSR signing, chosen from the signing
-     * key type so that only ML-DSA keys pay for the large buffer. */
-    #define X509_GEN_BUF_SZ(pkey) \
-        (((pkey) != NULL && (pkey)->type == WC_EVP_PKEY_DILITHIUM) ? \
-            WC_MAX_X509_GEN_MLDSA : WC_MAX_X509_GEN)
+    /* DER buffer size for certificate/CSR signing: chosen from the signing
+     * key type, plus the subject public key held in the x509 so that a
+     * large (e.g. ML-DSA) SPKI fits under a classic signing key too. */
+    #define X509_GEN_BUF_SZ(x509, pkey) \
+        ((((pkey) != NULL && (pkey)->type == WC_EVP_PKEY_DILITHIUM) ? \
+            WC_MAX_X509_GEN_MLDSA : WC_MAX_X509_GEN) + \
+            (int)(x509)->pubKey.length)
 #else
-    #define X509_GEN_BUF_SZ(pkey) WC_MAX_X509_GEN
+    #define X509_GEN_BUF_SZ(x509, pkey) \
+        (WC_MAX_X509_GEN + (int)(x509)->pubKey.length)
 #endif
 
 /* returns the size of signature on success */
@@ -13029,7 +13032,7 @@ int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
         goto out;
     }
 
-    bufSz = X509_GEN_BUF_SZ(pkey);
+    bufSz = X509_GEN_BUF_SZ(x509, pkey);
     derSz = bufSz;
     der = (byte *)XMALLOC((size_t)bufSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {
@@ -16993,7 +16996,7 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
         return WOLFSSL_FAILURE;
     }
 
-    bufSz = X509_GEN_BUF_SZ(pkey);
+    bufSz = X509_GEN_BUF_SZ(req, pkey);
     derSz = bufSz;
     der = (byte*)XMALLOC((size_t)bufSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {

--- a/src/x509.c
+++ b/src/x509.c
@@ -12234,6 +12234,38 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
         int hashType;
         int sigType = WOLFSSL_FAILURE;
 
+    #ifdef WOLFSSL_HAVE_MLDSA
+        if (pkey->type == WC_EVP_PKEY_DILITHIUM) {
+            /* ML-DSA does not use a separate hash; md (may be NULL, as in
+             * OpenSSL's X509_sign(x, pkey, NULL)) is ignored. */
+            switch (WOLFSSL_ATOMIC_LOAD(pkey->mldsaOID)) {
+                case ML_DSA_44k:
+                    sigType = CTC_ML_DSA_LEVEL2;
+                    break;
+                case ML_DSA_65k:
+                    sigType = CTC_ML_DSA_LEVEL3;
+                    break;
+                case ML_DSA_87k:
+                    sigType = CTC_ML_DSA_LEVEL5;
+                    break;
+            #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
+                case DILITHIUM_LEVEL2k:
+                    sigType = CTC_DILITHIUM_LEVEL2;
+                    break;
+                case DILITHIUM_LEVEL3k:
+                    sigType = CTC_DILITHIUM_LEVEL3;
+                    break;
+                case DILITHIUM_LEVEL5k:
+                    sigType = CTC_DILITHIUM_LEVEL5;
+                    break;
+            #endif
+                default:
+                    return WOLFSSL_FAILURE;
+            }
+            return sigType;
+        }
+    #endif /* WOLFSSL_HAVE_MLDSA */
+
         /* Convert key type and hash algorithm to a signature algorithm */
         if (wolfSSL_EVP_get_hashinfo(md, &hashType, NULL)
             == WC_NO_ERR_TRACE(WOLFSSL_FAILURE))
@@ -12311,35 +12343,6 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
                     return WOLFSSL_FAILURE;
             }
         }
-    #ifdef WOLFSSL_HAVE_MLDSA
-        else if (pkey->type == WC_EVP_PKEY_DILITHIUM) {
-            /* ML-DSA does not use a separate hash; ignore md. */
-            switch (WOLFSSL_ATOMIC_LOAD(pkey->mldsaOID)) {
-                case ML_DSA_44k:
-                    sigType = CTC_ML_DSA_LEVEL2;
-                    break;
-                case ML_DSA_65k:
-                    sigType = CTC_ML_DSA_LEVEL3;
-                    break;
-                case ML_DSA_87k:
-                    sigType = CTC_ML_DSA_LEVEL5;
-                    break;
-            #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
-                case DILITHIUM_LEVEL2k:
-                    sigType = CTC_DILITHIUM_LEVEL2;
-                    break;
-                case DILITHIUM_LEVEL3k:
-                    sigType = CTC_DILITHIUM_LEVEL3;
-                    break;
-                case DILITHIUM_LEVEL5k:
-                    sigType = CTC_DILITHIUM_LEVEL5;
-                    break;
-            #endif
-                default:
-                    return WOLFSSL_FAILURE;
-            }
-        }
-    #endif /* WOLFSSL_HAVE_MLDSA */
         else
             return WOLFSSL_FAILURE;
         return sigType;
@@ -13027,7 +13030,17 @@ int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
 
     WOLFSSL_ENTER("wolfSSL_X509_sign");
 
-    if (x509 == NULL || pkey == NULL || md == NULL) {
+    if (x509 == NULL || pkey == NULL) {
+        ret = WOLFSSL_FAILURE;
+        goto out;
+    }
+    /* md may be NULL for hash-free algorithms (ML-DSA), as in OpenSSL's
+     * X509_sign(x, pkey, NULL). */
+    if (md == NULL
+#ifdef WOLFSSL_HAVE_MLDSA
+        && pkey->type != WC_EVP_PKEY_DILITHIUM
+#endif
+        ) {
         ret = WOLFSSL_FAILURE;
         goto out;
     }
@@ -16991,7 +17004,13 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
     int bufSz;
     int derSz;
 
-    if (req == NULL || pkey == NULL || md == NULL) {
+    /* md may be NULL for hash-free algorithms (ML-DSA), as in OpenSSL's
+     * X509_REQ_sign(req, pkey, NULL). */
+    if (req == NULL || pkey == NULL || (md == NULL
+#ifdef WOLFSSL_HAVE_MLDSA
+        && pkey->type != WC_EVP_PKEY_DILITHIUM
+#endif
+        )) {
         WOLFSSL_LEAVE("wolfSSL_X509_REQ_sign", BAD_FUNC_ARG);
         return WOLFSSL_FAILURE;
     }

--- a/src/x509.c
+++ b/src/x509.c
@@ -12248,13 +12248,13 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
              * OpenSSL's X509_sign(x, pkey, NULL)) is ignored. */
             switch (WOLFSSL_ATOMIC_LOAD(pkey->mldsaOID)) {
                 case ML_DSA_44k:
-                    sigType = CTC_ML_DSA_LEVEL2;
+                    sigType = CTC_ML_DSA_44;
                     break;
                 case ML_DSA_65k:
-                    sigType = CTC_ML_DSA_LEVEL3;
+                    sigType = CTC_ML_DSA_65;
                     break;
                 case ML_DSA_87k:
-                    sigType = CTC_ML_DSA_LEVEL5;
+                    sigType = CTC_ML_DSA_87;
                     break;
             #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
                 case DILITHIUM_LEVEL2k:
@@ -12894,13 +12894,13 @@ cleanup:
             }
             switch (oidSum) {
                 case ML_DSA_44k:
-                    type = ML_DSA_LEVEL2_TYPE;
+                    type = ML_DSA_44_TYPE;
                     break;
                 case ML_DSA_65k:
-                    type = ML_DSA_LEVEL3_TYPE;
+                    type = ML_DSA_65_TYPE;
                     break;
                 case ML_DSA_87k:
-                    type = ML_DSA_LEVEL5_TYPE;
+                    type = ML_DSA_87_TYPE;
                     break;
             #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
                 case DILITHIUM_LEVEL2k:

--- a/src/x509.c
+++ b/src/x509.c
@@ -12833,7 +12833,7 @@ cleanup:
         int sigType;
         WC_RNG rng;
     #ifdef WOLFSSL_MLDSA_X509_SIGN
-        MlDsaKey* mldsa = NULL;
+        wc_MlDsaKey* mldsa = NULL;
     #endif
 
         (void)req;
@@ -12866,12 +12866,15 @@ cleanup:
             int oidSum = 0;
             int decRet;
 
-            mldsa = (MlDsaKey*)XMALLOC(sizeof(MlDsaKey), NULL,
+            mldsa = (wc_MlDsaKey*)XMALLOC(sizeof(wc_MlDsaKey), x509->heap,
                     DYNAMIC_TYPE_MLDSA);
-            if (mldsa == NULL)
+            if (mldsa == NULL) {
+                WOLFSSL_MSG("Failed to allocate memory for wc_MlDsaKey");
                 return WOLFSSL_FATAL_ERROR;
-            if (wc_MlDsaKey_Init(mldsa, NULL, INVALID_DEVID) != 0) {
-                XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
+            }
+            if (wc_MlDsaKey_Init(mldsa, x509->heap, INVALID_DEVID) != 0) {
+                WOLFSSL_MSG("wc_MlDsaKey_Init error");
+                XFREE(mldsa, x509->heap, DYNAMIC_TYPE_MLDSA);
                 return WOLFSSL_FATAL_ERROR;
             }
             PRIVATE_KEY_UNLOCK();
@@ -12884,8 +12887,9 @@ cleanup:
              * levels. */
             if (decRet != 0 ||
                     mldsa_get_oid_sum(mldsa, &oidSum) != 0) {
+                WOLFSSL_MSG("Error decoding ML-DSA private key");
                 wc_MlDsaKey_Free(mldsa);
-                XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
+                XFREE(mldsa, x509->heap, DYNAMIC_TYPE_MLDSA);
                 return WOLFSSL_FATAL_ERROR;
             }
             switch (oidSum) {
@@ -12910,8 +12914,9 @@ cleanup:
                     break;
             #endif
                 default:
+                    WOLFSSL_MSG("Unsupported ML-DSA parameter set");
                     wc_MlDsaKey_Free(mldsa);
-                    XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
+                    XFREE(mldsa, x509->heap, DYNAMIC_TYPE_MLDSA);
                     return WOLFSSL_FATAL_ERROR;
             }
             key = mldsa;
@@ -12924,7 +12929,7 @@ cleanup:
         #ifdef WOLFSSL_MLDSA_X509_SIGN
             if (mldsa != NULL) {
                 wc_MlDsaKey_Free(mldsa);
-                XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
+                XFREE(mldsa, x509->heap, DYNAMIC_TYPE_MLDSA);
             }
         #endif
             return ret;
@@ -12935,7 +12940,7 @@ cleanup:
     #ifdef WOLFSSL_MLDSA_X509_SIGN
         if (mldsa != NULL) {
             wc_MlDsaKey_Free(mldsa);
-            XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
+            XFREE(mldsa, x509->heap, DYNAMIC_TYPE_MLDSA);
         }
     #endif
         if (ret < 0) {
@@ -16580,16 +16585,19 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
     case WC_EVP_PKEY_DILITHIUM:
         {
             /* Decode key DER (private or public) and export public part. */
-            MlDsaKey* mldsa;
+            wc_MlDsaKey* mldsa;
             word32 idx = 0;
             int oidSum = 0;
             int decodeOk = 0;
 
-            mldsa = (MlDsaKey*)XMALLOC(sizeof(MlDsaKey), cert->heap,
+            mldsa = (wc_MlDsaKey*)XMALLOC(sizeof(wc_MlDsaKey), cert->heap,
                     DYNAMIC_TYPE_MLDSA);
-            if (mldsa == NULL)
+            if (mldsa == NULL) {
+                WOLFSSL_MSG("Failed to allocate memory for wc_MlDsaKey");
                 return WOLFSSL_FAILURE;
-            if (wc_MlDsaKey_Init(mldsa, NULL, INVALID_DEVID) != 0) {
+            }
+            if (wc_MlDsaKey_Init(mldsa, cert->heap, INVALID_DEVID) != 0) {
+                WOLFSSL_MSG("wc_MlDsaKey_Init error");
                 XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
                 return WOLFSSL_FAILURE;
             }
@@ -16608,7 +16616,8 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
                  * reset the key so PublicKeyDecode auto-detects it from
                  * the SPKI OID. */
                 wc_MlDsaKey_Free(mldsa);
-                if (wc_MlDsaKey_Init(mldsa, NULL, INVALID_DEVID) != 0) {
+                if (wc_MlDsaKey_Init(mldsa, cert->heap, INVALID_DEVID) != 0) {
+                    WOLFSSL_MSG("wc_MlDsaKey_Init error");
                     XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
                     return WOLFSSL_FAILURE;
                 }
@@ -16617,6 +16626,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
                 if (wc_MlDsaKey_PublicKeyDecode(mldsa,
                         (const byte*)pkey->pkey.ptr, (word32)pkey->pkey_sz,
                         &idx) != 0) {
+                    WOLFSSL_MSG("Error decoding ML-DSA public key");
                     wc_MlDsaKey_Free(mldsa);
                     XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
                     return WOLFSSL_FAILURE;
@@ -16627,6 +16637,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
              * levels, keeping pubKeyOID consistent with the SPKI encoded
              * by wc_MlDsaKey_PublicKeyToDer(). */
             if (mldsa_get_oid_sum(mldsa, &oidSum) != 0) {
+                WOLFSSL_MSG("Error getting ML-DSA OID");
                 wc_MlDsaKey_Free(mldsa);
                 XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
                 return WOLFSSL_FAILURE;
@@ -16635,6 +16646,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
             derSz = MLDSA_MAX_PUB_KEY_SIZE + MAX_ALGO_SZ + MAX_SEQ_SZ * 2;
             p = (byte*)XMALLOC(derSz, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
             if (p == NULL) {
+                WOLFSSL_MSG("malloc error");
                 wc_MlDsaKey_Free(mldsa);
                 XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
                 return WOLFSSL_FAILURE;
@@ -16643,6 +16655,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
             wc_MlDsaKey_Free(mldsa);
             XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
             if (derSz <= 0) {
+                WOLFSSL_MSG("Error making ML-DSA public key DER");
                 XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                 return WOLFSSL_FAILURE;
             }

--- a/src/x509.c
+++ b/src/x509.c
@@ -12897,6 +12897,16 @@ cleanup:
                 XFREE(mldsa, x509->heap, DYNAMIC_TYPE_MLDSA);
                 return WOLFSSL_FATAL_ERROR;
             }
+            /* sigType above came from the cached pkey->mldsaOID; require
+             * the decoded key to agree so a stale cache cannot emit a
+             * certificate whose signatureAlgorithm disagrees with the
+             * actual signature. */
+            if (oidSum != WOLFSSL_ATOMIC_LOAD(pkey->mldsaOID)) {
+                WOLFSSL_MSG("ML-DSA key does not match cached pkey OID");
+                wc_MlDsaKey_Free(mldsa);
+                XFREE(mldsa, x509->heap, DYNAMIC_TYPE_MLDSA);
+                return WOLFSSL_FATAL_ERROR;
+            }
             switch (oidSum) {
                 case ML_DSA_44k:
                     type = ML_DSA_44_TYPE;

--- a/src/x509.c
+++ b/src/x509.c
@@ -12855,6 +12855,7 @@ cleanup:
             /* Decode the ML-DSA private key held as DER in pkey.ptr. */
             word32 idx = 0;
             byte level = 0;
+            int decRet;
 
             mldsa = (MlDsaKey*)XMALLOC(sizeof(MlDsaKey), NULL,
                     DYNAMIC_TYPE_MLDSA);
@@ -12864,9 +12865,12 @@ cleanup:
                 XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
                 return WOLFSSL_FATAL_ERROR;
             }
-            if (wc_MlDsaKey_PrivateKeyDecode(mldsa,
+            PRIVATE_KEY_UNLOCK();
+            decRet = wc_MlDsaKey_PrivateKeyDecode(mldsa,
                     (const byte*)pkey->pkey.ptr, (word32)pkey->pkey_sz,
-                    &idx) != 0 ||
+                    &idx);
+            PRIVATE_KEY_LOCK();
+            if (decRet != 0 ||
                     wc_MlDsaKey_GetParams(mldsa, &level) != 0) {
                 wc_MlDsaKey_Free(mldsa);
                 XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
@@ -16548,11 +16552,13 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
                 return WOLFSSL_FAILURE;
             }
         #ifdef WOLFSSL_MLDSA_PRIVATE_KEY
+            PRIVATE_KEY_UNLOCK();
             if (wc_MlDsaKey_PrivateKeyDecode(mldsa,
                     (const byte*)pkey->pkey.ptr, (word32)pkey->pkey_sz,
                     &idx) == 0) {
                 decodeOk = 1;
             }
+            PRIVATE_KEY_LOCK();
         #endif
             if (!decodeOk) {
                 idx = 0;

--- a/src/x509.c
+++ b/src/x509.c
@@ -16654,7 +16654,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
                 return WOLFSSL_FAILURE;
             }
 
-            derSz = MLDSA_MAX_PUB_KEY_SIZE + MAX_ALGO_SZ + MAX_SEQ_SZ * 2;
+            derSz = MLDSA_MAX_PUB_KEY_DER_SIZE;
             p = (byte*)XMALLOC(derSz, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
             if (p == NULL) {
                 WOLFSSL_MSG("malloc error");

--- a/src/x509.c
+++ b/src/x509.c
@@ -12311,6 +12311,35 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
                     return WOLFSSL_FAILURE;
             }
         }
+    #ifdef WOLFSSL_HAVE_MLDSA
+        else if (pkey->type == WC_EVP_PKEY_DILITHIUM) {
+            /* ML-DSA does not use a separate hash; ignore md. */
+            switch (WOLFSSL_ATOMIC_LOAD(pkey->mldsaOID)) {
+                case ML_DSA_44k:
+                    sigType = CTC_ML_DSA_LEVEL2;
+                    break;
+                case ML_DSA_65k:
+                    sigType = CTC_ML_DSA_LEVEL3;
+                    break;
+                case ML_DSA_87k:
+                    sigType = CTC_ML_DSA_LEVEL5;
+                    break;
+            #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
+                case DILITHIUM_LEVEL2k:
+                    sigType = CTC_DILITHIUM_LEVEL2;
+                    break;
+                case DILITHIUM_LEVEL3k:
+                    sigType = CTC_DILITHIUM_LEVEL3;
+                    break;
+                case DILITHIUM_LEVEL5k:
+                    sigType = CTC_DILITHIUM_LEVEL5;
+                    break;
+            #endif
+                default:
+                    return WOLFSSL_FAILURE;
+            }
+        }
+    #endif /* WOLFSSL_HAVE_MLDSA */
         else
             return WOLFSSL_FAILURE;
         return sigType;
@@ -12792,6 +12821,10 @@ cleanup:
         int type = -1;
         int sigType;
         WC_RNG rng;
+    #if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+        !defined(WOLFSSL_MLDSA_NO_ASN1) && !defined(WOLFSSL_MLDSA_NO_SIGN)
+        MlDsaKey* mldsa = NULL;
+    #endif
 
         (void)req;
         WOLFSSL_ENTER("wolfSSL_X509_resign_cert");
@@ -12816,14 +12849,83 @@ cleanup:
             key = pkey->ecc->internal;
         }
     #endif
+    #if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+        !defined(WOLFSSL_MLDSA_NO_ASN1) && !defined(WOLFSSL_MLDSA_NO_SIGN)
+        if (pkey->type == WC_EVP_PKEY_DILITHIUM) {
+            /* Decode the ML-DSA private key held as DER in pkey.ptr. */
+            word32 idx = 0;
+            byte level = 0;
+
+            mldsa = (MlDsaKey*)XMALLOC(sizeof(MlDsaKey), NULL,
+                    DYNAMIC_TYPE_MLDSA);
+            if (mldsa == NULL)
+                return WOLFSSL_FATAL_ERROR;
+            if (wc_MlDsaKey_Init(mldsa, NULL, INVALID_DEVID) != 0) {
+                XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
+                return WOLFSSL_FATAL_ERROR;
+            }
+            if (wc_MlDsaKey_PrivateKeyDecode(mldsa,
+                    (const byte*)pkey->pkey.ptr, (word32)pkey->pkey_sz,
+                    &idx) != 0 ||
+                    wc_MlDsaKey_GetParams(mldsa, &level) != 0) {
+                wc_MlDsaKey_Free(mldsa);
+                XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
+                return WOLFSSL_FATAL_ERROR;
+            }
+            switch (level) {
+                case WC_ML_DSA_44:
+                    type = ML_DSA_LEVEL2_TYPE;
+                    break;
+                case WC_ML_DSA_65:
+                    type = ML_DSA_LEVEL3_TYPE;
+                    break;
+                case WC_ML_DSA_87:
+                    type = ML_DSA_LEVEL5_TYPE;
+                    break;
+            #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
+                case WC_ML_DSA_44_DRAFT:
+                    type = DILITHIUM_LEVEL2_TYPE;
+                    break;
+                case WC_ML_DSA_65_DRAFT:
+                    type = DILITHIUM_LEVEL3_TYPE;
+                    break;
+                case WC_ML_DSA_87_DRAFT:
+                    type = DILITHIUM_LEVEL5_TYPE;
+                    break;
+            #endif
+                default:
+                    wc_MlDsaKey_Free(mldsa);
+                    XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
+                    return WOLFSSL_FATAL_ERROR;
+            }
+            key = mldsa;
+        }
+    #endif /* WOLFSSL_HAVE_MLDSA && WOLFSSL_MLDSA_PRIVATE_KEY &&
+            * !WOLFSSL_MLDSA_NO_ASN1 && !WOLFSSL_MLDSA_NO_SIGN */
 
         /* Sign the certificate (request) body. */
         ret = wc_InitRng(&rng);
-        if (ret != 0)
+        if (ret != 0) {
+        #if defined(WOLFSSL_HAVE_MLDSA) && \
+            defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+            !defined(WOLFSSL_MLDSA_NO_ASN1) && !defined(WOLFSSL_MLDSA_NO_SIGN)
+            if (mldsa != NULL) {
+                wc_MlDsaKey_Free(mldsa);
+                XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
+            }
+        #endif
             return ret;
+        }
         ret = wc_SignCert_ex(certBodySz, sigType, der, (word32)derSz, type, key,
             &rng);
         wc_FreeRng(&rng);
+    #if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+        !defined(WOLFSSL_MLDSA_NO_ASN1) && !defined(WOLFSSL_MLDSA_NO_SIGN)
+        if (mldsa != NULL) {
+            wc_MlDsaKey_Free(mldsa);
+            XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
+        }
+    #endif
         if (ret < 0) {
             WOLFSSL_LEAVE("wolfSSL_X509_resign_cert", ret);
             return ret;
@@ -12890,7 +12992,13 @@ cleanup:
 
 #ifndef WC_MAX_X509_GEN
     /* able to override max size until dynamic buffer created */
-    #define WC_MAX_X509_GEN 4096
+    #ifdef WOLFSSL_HAVE_MLDSA
+        /* ML-DSA public keys and signatures are large (ML-DSA-87:
+         * 2592 byte public key, 4627 byte signature). */
+        #define WC_MAX_X509_GEN 20480
+    #else
+        #define WC_MAX_X509_GEN 4096
+    #endif
 #endif
 
 /* returns the size of signature on success */
@@ -16421,6 +16529,90 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
         }
         break;
 #endif
+#if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PUBLIC_KEY) && \
+    !defined(WOLFSSL_MLDSA_NO_ASN1) && defined(WC_ENABLE_ASYM_KEY_EXPORT)
+    case WC_EVP_PKEY_DILITHIUM:
+        {
+            /* Decode key DER (private or public) and export public part. */
+            MlDsaKey* mldsa;
+            word32 idx = 0;
+            byte level = 0;
+            int decodeOk = 0;
+
+            mldsa = (MlDsaKey*)XMALLOC(sizeof(MlDsaKey), cert->heap,
+                    DYNAMIC_TYPE_MLDSA);
+            if (mldsa == NULL)
+                return WOLFSSL_FAILURE;
+            if (wc_MlDsaKey_Init(mldsa, NULL, INVALID_DEVID) != 0) {
+                XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
+                return WOLFSSL_FAILURE;
+            }
+        #ifdef WOLFSSL_MLDSA_PRIVATE_KEY
+            if (wc_MlDsaKey_PrivateKeyDecode(mldsa,
+                    (const byte*)pkey->pkey.ptr, (word32)pkey->pkey_sz,
+                    &idx) == 0) {
+                decodeOk = 1;
+            }
+        #endif
+            if (!decodeOk) {
+                idx = 0;
+                if (wc_MlDsaKey_PublicKeyDecode(mldsa,
+                        (const byte*)pkey->pkey.ptr, (word32)pkey->pkey_sz,
+                        &idx) != 0) {
+                    wc_MlDsaKey_Free(mldsa);
+                    XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
+                    return WOLFSSL_FAILURE;
+                }
+            }
+            if (wc_MlDsaKey_GetParams(mldsa, &level) != 0) {
+                wc_MlDsaKey_Free(mldsa);
+                XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
+                return WOLFSSL_FAILURE;
+            }
+
+            derSz = MLDSA_MAX_PUB_KEY_SIZE + MAX_ALGO_SZ + MAX_SEQ_SZ * 2;
+            p = (byte*)XMALLOC(derSz, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+            if (p == NULL) {
+                wc_MlDsaKey_Free(mldsa);
+                XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
+                return WOLFSSL_FAILURE;
+            }
+            derSz = wc_MlDsaKey_PublicKeyToDer(mldsa, p, (word32)derSz, 1);
+            wc_MlDsaKey_Free(mldsa);
+            XFREE(mldsa, cert->heap, DYNAMIC_TYPE_MLDSA);
+            if (derSz <= 0) {
+                XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+                return WOLFSSL_FAILURE;
+            }
+            switch (level) {
+                case WC_ML_DSA_44:
+                    cert->pubKeyOID = ML_DSA_44k;
+                    break;
+                case WC_ML_DSA_65:
+                    cert->pubKeyOID = ML_DSA_65k;
+                    break;
+                case WC_ML_DSA_87:
+                    cert->pubKeyOID = ML_DSA_87k;
+                    break;
+            #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
+                case WC_ML_DSA_44_DRAFT:
+                    cert->pubKeyOID = DILITHIUM_LEVEL2k;
+                    break;
+                case WC_ML_DSA_65_DRAFT:
+                    cert->pubKeyOID = DILITHIUM_LEVEL3k;
+                    break;
+                case WC_ML_DSA_87_DRAFT:
+                    cert->pubKeyOID = DILITHIUM_LEVEL5k;
+                    break;
+            #endif
+                default:
+                    XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+                    return WOLFSSL_FAILURE;
+            }
+        }
+        break;
+#endif /* WOLFSSL_HAVE_MLDSA && WOLFSSL_MLDSA_PUBLIC_KEY &&
+        * !WOLFSSL_MLDSA_NO_ASN1 && WC_ENABLE_ASYM_KEY_EXPORT */
     default:
         return WOLFSSL_FAILURE;
     }
@@ -16770,8 +16962,8 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
                           const WOLFSSL_EVP_MD *md)
 {
     int ret;
-    WC_DECLARE_VAR(der, byte, 2048, 0);
-    int derSz = 2048;
+    WC_DECLARE_VAR(der, byte, WC_MAX_X509_GEN, 0);
+    int derSz = WC_MAX_X509_GEN;
 
     if (req == NULL || pkey == NULL || md == NULL) {
         WOLFSSL_LEAVE("wolfSSL_X509_REQ_sign", BAD_FUNC_ARG);
@@ -16791,7 +16983,7 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
         return WOLFSSL_FAILURE;
     }
 
-    if (wolfSSL_X509_resign_cert(req, 1, der, 2048, derSz,
+    if (wolfSSL_X509_resign_cert(req, 1, der, WC_MAX_X509_GEN, derSz,
             (WOLFSSL_EVP_MD*)md, pkey) <= 0) {
         WC_FREE_VAR_EX(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return WOLFSSL_FAILURE;

--- a/src/x509.c
+++ b/src/x509.c
@@ -13039,6 +13039,7 @@ int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
     byte *der = NULL;
     int  bufSz = 0;
     int  derSz = 0;
+    int  sigType;
 
     WOLFSSL_ENTER("wolfSSL_X509_sign");
 
@@ -13065,12 +13066,15 @@ int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
         goto out;
     }
 
-    x509->sigOID = wolfSSL_sigTypeFromPKEY((WOLFSSL_EVP_MD*)md, pkey);
-    if (x509->sigOID == WC_NO_ERR_TRACE(WOLFSSL_FAILURE)) {
+    /* Only update sigOID on success to keep the object unmodified on a
+     * rejected key/md combination. */
+    sigType = wolfSSL_sigTypeFromPKEY((WOLFSSL_EVP_MD*)md, pkey);
+    if (sigType == WC_NO_ERR_TRACE(WOLFSSL_FAILURE)) {
         WOLFSSL_MSG("Unsupported key/md combination for signing");
         ret = WOLFSSL_FAILURE;
         goto out;
     }
+    x509->sigOID = sigType;
     if ((ret = wolfssl_x509_make_der(x509, 0, der, &derSz, 0)) !=
             WOLFSSL_SUCCESS) {
         WOLFSSL_MSG("Unable to make DER for X509");
@@ -17018,6 +17022,7 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
     byte* der = NULL;
     int bufSz;
     int derSz;
+    int sigType;
 
     /* md may be NULL for hash-free algorithms (ML-DSA), as in OpenSSL's
      * X509_REQ_sign(req, pkey, NULL). */
@@ -17037,13 +17042,16 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
         return WOLFSSL_FAILURE;
     }
 
-    /* Create a Cert that has the certificate request fields. */
-    req->sigOID = wolfSSL_sigTypeFromPKEY((WOLFSSL_EVP_MD*)md, pkey);
-    if (req->sigOID == WC_NO_ERR_TRACE(WOLFSSL_FAILURE)) {
+    /* Create a Cert that has the certificate request fields. Only update
+     * sigOID on success to keep the object unmodified on a rejected
+     * key/md combination. */
+    sigType = wolfSSL_sigTypeFromPKEY((WOLFSSL_EVP_MD*)md, pkey);
+    if (sigType == WC_NO_ERR_TRACE(WOLFSSL_FAILURE)) {
         WOLFSSL_MSG("Unsupported key/md combination for signing");
         XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return WOLFSSL_FAILURE;
     }
+    req->sigOID = sigType;
     ret = wolfssl_x509_make_der(req, 1, der, &derSz, 0);
     if (ret != WOLFSSL_SUCCESS) {
         XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/src/x509.c
+++ b/src/x509.c
@@ -12225,6 +12225,14 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
 }
 
 
+#if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+    !defined(WOLFSSL_MLDSA_NO_ASN1) && !defined(WOLFSSL_MLDSA_NO_SIGN)
+    /* ML-DSA X.509 signing needs private key decode and sign support; keep
+     * every gate that decides "can we sign with ML-DSA" identical so that
+     * verify-only builds reject the key type up front. */
+    #define WOLFSSL_MLDSA_X509_SIGN
+#endif
+
     /* returns the sig type to use on success i.e CTC_SHAwRSA and WOLFSSL_FALURE
      * on fail case */
     static int wolfSSL_sigTypeFromPKEY(WOLFSSL_EVP_MD* md,
@@ -12234,7 +12242,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
         int hashType;
         int sigType = WOLFSSL_FAILURE;
 
-    #ifdef WOLFSSL_HAVE_MLDSA
+    #ifdef WOLFSSL_MLDSA_X509_SIGN
         if (pkey->type == WC_EVP_PKEY_DILITHIUM) {
             /* ML-DSA does not use a separate hash; md (may be NULL, as in
              * OpenSSL's X509_sign(x, pkey, NULL)) is ignored. */
@@ -12264,7 +12272,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
             }
             return sigType;
         }
-    #endif /* WOLFSSL_HAVE_MLDSA */
+    #endif /* WOLFSSL_MLDSA_X509_SIGN */
 
         /* Convert key type and hash algorithm to a signature algorithm */
         if (wolfSSL_EVP_get_hashinfo(md, &hashType, NULL)
@@ -12824,8 +12832,7 @@ cleanup:
         int type = -1;
         int sigType;
         WC_RNG rng;
-    #if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
-        !defined(WOLFSSL_MLDSA_NO_ASN1) && !defined(WOLFSSL_MLDSA_NO_SIGN)
+    #ifdef WOLFSSL_MLDSA_X509_SIGN
         MlDsaKey* mldsa = NULL;
     #endif
 
@@ -12852,8 +12859,7 @@ cleanup:
             key = pkey->ecc->internal;
         }
     #endif
-    #if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
-        !defined(WOLFSSL_MLDSA_NO_ASN1) && !defined(WOLFSSL_MLDSA_NO_SIGN)
+    #ifdef WOLFSSL_MLDSA_X509_SIGN
         if (pkey->type == WC_EVP_PKEY_DILITHIUM) {
             /* Decode the ML-DSA private key held as DER in pkey.ptr. */
             word32 idx = 0;
@@ -12907,15 +12913,12 @@ cleanup:
             }
             key = mldsa;
         }
-    #endif /* WOLFSSL_HAVE_MLDSA && WOLFSSL_MLDSA_PRIVATE_KEY &&
-            * !WOLFSSL_MLDSA_NO_ASN1 && !WOLFSSL_MLDSA_NO_SIGN */
+    #endif /* WOLFSSL_MLDSA_X509_SIGN */
 
         /* Sign the certificate (request) body. */
         ret = wc_InitRng(&rng);
         if (ret != 0) {
-        #if defined(WOLFSSL_HAVE_MLDSA) && \
-            defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
-            !defined(WOLFSSL_MLDSA_NO_ASN1) && !defined(WOLFSSL_MLDSA_NO_SIGN)
+        #ifdef WOLFSSL_MLDSA_X509_SIGN
             if (mldsa != NULL) {
                 wc_MlDsaKey_Free(mldsa);
                 XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
@@ -12926,8 +12929,7 @@ cleanup:
         ret = wc_SignCert_ex(certBodySz, sigType, der, (word32)derSz, type, key,
             &rng);
         wc_FreeRng(&rng);
-    #if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
-        !defined(WOLFSSL_MLDSA_NO_ASN1) && !defined(WOLFSSL_MLDSA_NO_SIGN)
+    #ifdef WOLFSSL_MLDSA_X509_SIGN
         if (mldsa != NULL) {
             wc_MlDsaKey_Free(mldsa);
             XFREE(mldsa, NULL, DYNAMIC_TYPE_MLDSA);
@@ -13037,7 +13039,7 @@ int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
     /* md may be NULL for hash-free algorithms (ML-DSA), as in OpenSSL's
      * X509_sign(x, pkey, NULL). */
     if (md == NULL
-#ifdef WOLFSSL_HAVE_MLDSA
+#ifdef WOLFSSL_MLDSA_X509_SIGN
         && pkey->type != WC_EVP_PKEY_DILITHIUM
 #endif
         ) {
@@ -13054,6 +13056,11 @@ int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
     }
 
     x509->sigOID = wolfSSL_sigTypeFromPKEY((WOLFSSL_EVP_MD*)md, pkey);
+    if (x509->sigOID == WC_NO_ERR_TRACE(WOLFSSL_FAILURE)) {
+        WOLFSSL_MSG("Unsupported key/md combination for signing");
+        ret = WOLFSSL_FAILURE;
+        goto out;
+    }
     if ((ret = wolfssl_x509_make_der(x509, 0, der, &derSz, 0)) !=
             WOLFSSL_SUCCESS) {
         WOLFSSL_MSG("Unable to make DER for X509");
@@ -17007,7 +17014,7 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
     /* md may be NULL for hash-free algorithms (ML-DSA), as in OpenSSL's
      * X509_REQ_sign(req, pkey, NULL). */
     if (req == NULL || pkey == NULL || (md == NULL
-#ifdef WOLFSSL_HAVE_MLDSA
+#ifdef WOLFSSL_MLDSA_X509_SIGN
         && pkey->type != WC_EVP_PKEY_DILITHIUM
 #endif
         )) {
@@ -17024,6 +17031,11 @@ int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
 
     /* Create a Cert that has the certificate request fields. */
     req->sigOID = wolfSSL_sigTypeFromPKEY((WOLFSSL_EVP_MD*)md, pkey);
+    if (req->sigOID == WC_NO_ERR_TRACE(WOLFSSL_FAILURE)) {
+        WOLFSSL_MSG("Unsupported key/md combination for signing");
+        XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        return WOLFSSL_FAILURE;
+    }
     ret = wolfssl_x509_make_der(req, 1, der, &derSz, 0);
     if (ret != WOLFSSL_SUCCESS) {
         XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/src/x509.c
+++ b/src/x509.c
@@ -13013,9 +13013,11 @@ cleanup:
 #endif
 #ifdef WOLFSSL_HAVE_MLDSA
     #ifndef WC_MAX_X509_GEN_MLDSA
-        /* ML-DSA public keys and signatures are large (ML-DSA-87:
-         * 2592 byte public key, 4627 byte signature). */
-        #define WC_MAX_X509_GEN_MLDSA 20480
+        /* Base size plus the largest compiled-in ML-DSA signature and its
+         * ASN.1 overhead; the subject key is added in X509_GEN_BUF_SZ(). */
+        #define WC_MAX_X509_GEN_MLDSA \
+            (WC_MAX_X509_GEN + MLDSA_MAX_SIG_SIZE + MAX_ALGO_SZ + \
+             MAX_SEQ_SZ * 2)
     #endif
     /* DER buffer size for certificate/CSR signing: chosen from the signing
      * key type, plus the subject public key held in the x509 so that a

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -30,6 +30,9 @@
 
 #include <wolfssl/openssl/evp.h>
 #include <wolfssl/openssl/kdf.h>
+#ifdef WOLFSSL_HAVE_MLDSA
+    #include <wolfssl/wolfcrypt/wc_mldsa.h>
+#endif
 #include <tests/api/api.h>
 #include <tests/api/test_evp_pkey.h>
 
@@ -3123,6 +3126,75 @@ int test_wolfSSL_d2i_PUBKEY_mldsa_reuse(void)
     }
 
     wolfSSL_EVP_PKEY_free(pkey);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* Typed d2i entry points for ML-DSA: a PKCS#8 key of another algorithm
+ * and raw (non-DER) bytes must both be rejected; a matching PKCS#8
+ * ML-DSA key must decode. */
+int test_wolfSSL_d2i_PrivateKey_mldsa(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_EXTRA) && defined(WOLFSSL_HAVE_MLDSA) && \
+    defined(WOLFSSL_MLDSA_PRIVATE_KEY) && !defined(WOLFSSL_MLDSA_NO_ASN1) && \
+    !defined(WOLFSSL_NO_ML_DSA_44) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM)
+    WOLFSSL_EVP_PKEY* pkey = NULL;
+    const unsigned char* p;
+    unsigned char mldsaDer[4096];
+    unsigned char rsaDer[2048];
+    unsigned char rawBlob[2560]; /* ML-DSA-44 raw private key size */
+    int mldsaSz = 0;
+    int rsaSz = 0;
+    XFILE f = XBADFILE;
+
+    ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44-key.der", "rb"))
+        != XBADFILE);
+    ExpectIntGT(mldsaSz = (int)XFREAD(mldsaDer, 1, sizeof(mldsaDer), f), 0);
+    if (f != XBADFILE) {
+        XFCLOSE(f);
+        f = XBADFILE;
+    }
+    ExpectTrue((f = XFOPEN("./certs/server-keyPkcs8.der", "rb")) != XBADFILE);
+    ExpectIntGT(rsaSz = (int)XFREAD(rsaDer, 1, sizeof(rsaDer), f), 0);
+    if (f != XBADFILE) {
+        XFCLOSE(f);
+    }
+
+    /* PKCS#8 ML-DSA private key decodes with the matching type. */
+    p = mldsaDer;
+    ExpectNotNull(pkey = wolfSSL_d2i_PrivateKey(WC_EVP_PKEY_DILITHIUM, NULL,
+        &p, (long)mldsaSz));
+    ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), WC_EVP_PKEY_DILITHIUM);
+    wolfSSL_EVP_PKEY_free(pkey);
+    pkey = NULL;
+
+    /* PKCS#8 RSA key requested as ML-DSA is rejected by the algId check. */
+    p = rsaDer;
+    ExpectNull(wolfSSL_d2i_PrivateKey(WC_EVP_PKEY_DILITHIUM, NULL, &p,
+        (long)rsaSz));
+
+    /* Raw (non-DER) private key bytes are rejected: d2i is a DER API, the
+     * size-keyed raw import is for the auto-detect path only. Use genuine
+     * raw bytes so the rejection is due to the format, not the contents. */
+    {
+        MlDsaKey mldsa;
+        word32 idx = 0;
+        word32 rawSz = (word32)sizeof(rawBlob);
+
+        ExpectIntEQ(wc_MlDsaKey_Init(&mldsa, NULL, INVALID_DEVID), 0);
+        PRIVATE_KEY_UNLOCK();
+        ExpectIntEQ(wc_MlDsaKey_PrivateKeyDecode(&mldsa, mldsaDer,
+            (word32)mldsaSz, &idx), 0);
+        ExpectIntEQ(wc_MlDsaKey_ExportPrivRaw(&mldsa, rawBlob, &rawSz), 0);
+        PRIVATE_KEY_LOCK();
+        wc_MlDsaKey_Free(&mldsa);
+
+        p = rawBlob;
+        ExpectNull(wolfSSL_d2i_PrivateKey(WC_EVP_PKEY_DILITHIUM, NULL, &p,
+            (long)rawSz));
+    }
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -3105,13 +3105,9 @@ int test_wolfSSL_d2i_PUBKEY_mldsa_reuse(void)
         if (pkey->pkey.ptr != NULL) {
             ExpectIntEQ(XMEMCMP(pkey->pkey.ptr, der44, (size_t)der44Sz), 0);
         }
-        /* EVP_PKEY_free() releases the per-algorithm object only for the
-         * final type, so drop the RSA object left from the first decode
-         * to keep this test leak-free. */
-        if (pkey->rsa != NULL && pkey->ownRsa == 1) {
-            wolfSSL_RSA_free(pkey->rsa);
-            pkey->rsa = NULL;
-        }
+        /* The RSA object from the first decode must have been released
+         * and detached when the key was repurposed. */
+        ExpectNull(wolfSSL_EVP_PKEY_get0_RSA(pkey));
     }
 
     /* Reuse again with a different ML-DSA level: same type, new key data. */

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -2962,6 +2962,28 @@ int test_wolfSSL_EVP_PKEY_ed25519(void)
     wolfSSL_EVP_PKEY_free(pkey);
     pkey = NULL;
 
+#if !defined(NO_RSA) && defined(USE_CERT_BUFFERS_2048)
+    {
+        /* Reuse: after decoding an RSA key, reusing the same EVP_PKEY for
+         * an Ed25519 PKCS#8 must re-populate type and DER and release the
+         * RSA object. */
+        unsigned char* dp = (unsigned char*)client_key_der_2048;
+        ExpectNotNull(wolfSSL_d2i_PrivateKey_EVP(&pkey, &dp,
+            (long)sizeof_client_key_der_2048));
+        ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), EVP_PKEY_RSA);
+        dp = (unsigned char*)server_ed25519_key;
+        ExpectNotNull(wolfSSL_d2i_PrivateKey_EVP(&pkey, &dp,
+            (long)sizeof_server_ed25519_key));
+        ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), EVP_PKEY_ED25519);
+        if (pkey != NULL) {
+            ExpectIntEQ(pkey->pkey_sz, (int)sizeof_server_ed25519_key);
+            ExpectNull(wolfSSL_EVP_PKEY_get0_RSA(pkey));
+        }
+        wolfSSL_EVP_PKEY_free(pkey);
+        pkey = NULL;
+    }
+#endif
+
     {
         static const unsigned char junk[16] = { 0 };
         const unsigned char* jp = junk;

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -3137,7 +3137,8 @@ int test_wolfSSL_d2i_PrivateKey_mldsa(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && defined(WOLFSSL_HAVE_MLDSA) && \
-    defined(WOLFSSL_MLDSA_PRIVATE_KEY) && !defined(WOLFSSL_MLDSA_NO_ASN1) && \
+    defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+    defined(WOLFSSL_MLDSA_PUBLIC_KEY) && !defined(WOLFSSL_MLDSA_NO_ASN1) && \
     !defined(WOLFSSL_NO_ML_DSA_44) && !defined(NO_RSA) && \
     !defined(NO_FILESYSTEM)
     WOLFSSL_EVP_PKEY* pkey = NULL;
@@ -3194,6 +3195,25 @@ int test_wolfSSL_d2i_PrivateKey_mldsa(void)
         p = rawBlob;
         ExpectNull(wolfSSL_d2i_PrivateKey(WC_EVP_PKEY_DILITHIUM, NULL, &p,
             (long)rawSz));
+    }
+
+    /* Typed public-key entry point decodes an ML-DSA SPKI. */
+    {
+        unsigned char spki[2048];
+        int spkiSz = 0;
+
+        ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44_pub-spki.der", "rb"))
+            != XBADFILE);
+        ExpectIntGT(spkiSz = (int)XFREAD(spki, 1, sizeof(spki), f), 0);
+        if (f != XBADFILE) {
+            XFCLOSE(f);
+        }
+        p = spki;
+        ExpectNotNull(pkey = wolfSSL_d2i_PublicKey(WC_EVP_PKEY_DILITHIUM,
+            NULL, &p, (long)spkiSz));
+        ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), WC_EVP_PKEY_DILITHIUM);
+        wolfSSL_EVP_PKEY_free(pkey);
+        pkey = NULL;
     }
 #endif
     return EXPECT_RESULT();

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -33,6 +33,9 @@
 #ifdef WOLFSSL_HAVE_MLDSA
     #include <wolfssl/wolfcrypt/wc_mldsa.h>
 #endif
+#ifdef HAVE_CURVE25519
+    #include <wolfssl/wolfcrypt/curve25519.h>
+#endif
 #include <tests/api/api.h>
 #include <tests/api/test_evp_pkey.h>
 
@@ -3088,11 +3091,30 @@ int test_wolfSSL_d2i_PUBKEY_mldsa_reuse(void)
         f = XBADFILE;
     }
 
+#ifdef HAVE_CURVE25519
+    {
+        /* Start from a raw X25519 key: the RSA decode below repurposes the
+         * EVP_PKEY and must release the curve25519 object too. */
+        static const unsigned char x25519Base[CURVE25519_PUB_KEY_SIZE] =
+            { 9 };
+        ExpectNotNull(pkey = wolfSSL_EVP_PKEY_new_raw_public_key(
+            WC_EVP_PKEY_X25519, NULL, x25519Base, sizeof(x25519Base)));
+        ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), WC_EVP_PKEY_X25519);
+    }
+#endif
+
     /* Decode an RSA SPKI first so pkey holds a non-ML-DSA key. */
     p = client_keypub_der_2048;
     ExpectNotNull(wolfSSL_d2i_PUBKEY(&pkey, &p,
         (long)sizeof_client_keypub_der_2048));
     ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), EVP_PKEY_RSA);
+#ifdef HAVE_CURVE25519
+    if (pkey != NULL) {
+        /* The X25519 object must have been released and detached when the
+         * key was repurposed to RSA. */
+        ExpectNull(pkey->curve25519);
+    }
+#endif
 
     /* Reuse the same EVP_PKEY for an ML-DSA SPKI and check the object was
      * re-populated with the new key. */

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -3092,22 +3092,26 @@ int test_wolfSSL_d2i_PUBKEY_mldsa_reuse(void)
     !defined(NO_FILESYSTEM)
     WOLFSSL_EVP_PKEY* pkey = NULL;
     const unsigned char* p;
-    unsigned char der44[2048];
-    unsigned char der65[2600];
+    unsigned char* der44 = NULL;
+    unsigned char* der65 = NULL;
     int der44Sz = 0;
     int der65Sz = 0;
     XFILE f = XBADFILE;
 
+    ExpectNotNull(der44 = (unsigned char*)XMALLOC(2048, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    ExpectNotNull(der65 = (unsigned char*)XMALLOC(2600, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER));
     ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44_pub-spki.der", "rb"))
         != XBADFILE);
-    ExpectIntGT(der44Sz = (int)XFREAD(der44, 1, sizeof(der44), f), 0);
+    ExpectIntGT(der44Sz = (int)XFREAD(der44, 1, 2048, f), 0);
     if (f != XBADFILE) {
         XFCLOSE(f);
         f = XBADFILE;
     }
     ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa65_pub-spki.der", "rb"))
         != XBADFILE);
-    ExpectIntGT(der65Sz = (int)XFREAD(der65, 1, sizeof(der65), f), 0);
+    ExpectIntGT(der65Sz = (int)XFREAD(der65, 1, 2600, f), 0);
     if (f != XBADFILE) {
         XFCLOSE(f);
         f = XBADFILE;
@@ -3167,6 +3171,8 @@ int test_wolfSSL_d2i_PUBKEY_mldsa_reuse(void)
     }
 
     wolfSSL_EVP_PKEY_free(pkey);
+    XFREE(der65, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(der44, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
     return EXPECT_RESULT();
 }
@@ -3184,22 +3190,29 @@ int test_wolfSSL_d2i_PrivateKey_mldsa(void)
     !defined(NO_FILESYSTEM)
     WOLFSSL_EVP_PKEY* pkey = NULL;
     const unsigned char* p;
-    unsigned char mldsaDer[4096];
-    unsigned char rsaDer[2048];
-    unsigned char rawBlob[2560]; /* ML-DSA-44 raw private key size */
+    unsigned char* mldsaDer = NULL;
+    unsigned char* rsaDer = NULL;
+    unsigned char* rawBlob = NULL;
     int mldsaSz = 0;
     int rsaSz = 0;
     XFILE f = XBADFILE;
 
+    ExpectNotNull(mldsaDer = (unsigned char*)XMALLOC(4096, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    ExpectNotNull(rsaDer = (unsigned char*)XMALLOC(2048, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    /* 2560 = ML-DSA-44 raw private key size */
+    ExpectNotNull(rawBlob = (unsigned char*)XMALLOC(2560, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER));
     ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44-key.der", "rb"))
         != XBADFILE);
-    ExpectIntGT(mldsaSz = (int)XFREAD(mldsaDer, 1, sizeof(mldsaDer), f), 0);
+    ExpectIntGT(mldsaSz = (int)XFREAD(mldsaDer, 1, 4096, f), 0);
     if (f != XBADFILE) {
         XFCLOSE(f);
         f = XBADFILE;
     }
     ExpectTrue((f = XFOPEN("./certs/server-keyPkcs8.der", "rb")) != XBADFILE);
-    ExpectIntGT(rsaSz = (int)XFREAD(rsaDer, 1, sizeof(rsaDer), f), 0);
+    ExpectIntGT(rsaSz = (int)XFREAD(rsaDer, 1, 2048, f), 0);
     if (f != XBADFILE) {
         XFCLOSE(f);
         f = XBADFILE;
@@ -3224,7 +3237,7 @@ int test_wolfSSL_d2i_PrivateKey_mldsa(void)
     {
         wc_MlDsaKey* mldsa = NULL;
         word32 idx = 0;
-        word32 rawSz = (word32)sizeof(rawBlob);
+        word32 rawSz = 2560;
         int keyRet = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
         ExpectNotNull(mldsa = (wc_MlDsaKey*)XMALLOC(sizeof(*mldsa), NULL,
@@ -3245,25 +3258,29 @@ int test_wolfSSL_d2i_PrivateKey_mldsa(void)
             (long)rawSz));
     }
 
-    /* Typed public-key entry point decodes an ML-DSA SPKI. */
+    /* Typed public-key entry point decodes an ML-DSA SPKI. Reuse the
+     * mldsaDer buffer for the SPKI bytes. */
     {
-        unsigned char spki[2048];
         int spkiSz = 0;
 
         ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44_pub-spki.der", "rb"))
             != XBADFILE);
-        ExpectIntGT(spkiSz = (int)XFREAD(spki, 1, sizeof(spki), f), 0);
+        ExpectIntGT(spkiSz = (int)XFREAD(mldsaDer, 1, 4096, f), 0);
         if (f != XBADFILE) {
             XFCLOSE(f);
             f = XBADFILE;
         }
-        p = spki;
+        p = mldsaDer;
         ExpectNotNull(pkey = wolfSSL_d2i_PublicKey(WC_EVP_PKEY_DILITHIUM,
             NULL, &p, (long)spkiSz));
         ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), WC_EVP_PKEY_DILITHIUM);
         wolfSSL_EVP_PKEY_free(pkey);
         pkey = NULL;
     }
+
+    XFREE(rawBlob, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(rsaDer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(mldsaDer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -2965,18 +2965,22 @@ int test_wolfSSL_EVP_PKEY_ed25519(void)
 #if !defined(NO_RSA) && defined(USE_CERT_BUFFERS_2048)
     {
         /* Reuse: after decoding an RSA key, reusing the same EVP_PKEY for
-         * an Ed25519 PKCS#8 must re-populate type and DER and release the
+         * an Ed25519 SPKI must re-populate type and DER and release the
          * RSA object. */
-        unsigned char* dp = (unsigned char*)client_key_der_2048;
-        ExpectNotNull(wolfSSL_d2i_PrivateKey_EVP(&pkey, &dp,
-            (long)sizeof_client_key_der_2048));
+        p = client_keypub_der_2048;
+        ExpectNotNull(wolfSSL_d2i_PUBKEY(&pkey, &p,
+            (long)sizeof_client_keypub_der_2048));
         ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), EVP_PKEY_RSA);
-        dp = (unsigned char*)server_ed25519_key;
-        ExpectNotNull(wolfSSL_d2i_PrivateKey_EVP(&pkey, &dp,
-            (long)sizeof_server_ed25519_key));
+        p = spkiPub;
+        ExpectNotNull(wolfSSL_d2i_PUBKEY(&pkey, &p, (long)sizeof(spkiPub)));
         ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), EVP_PKEY_ED25519);
         if (pkey != NULL) {
-            ExpectIntEQ(pkey->pkey_sz, (int)sizeof_server_ed25519_key);
+            /* The stored DER length is how far the Ed25519 decoder advanced
+             * its index, which differs between the ASN template and
+             * original implementations - only require that the previous RSA
+             * DER (larger than the whole SPKI) was replaced. */
+            ExpectIntGT(pkey->pkey_sz, 0);
+            ExpectIntLE(pkey->pkey_sz, (int)sizeof(spkiPub));
             ExpectNull(wolfSSL_EVP_PKEY_get0_RSA(pkey));
         }
         wolfSSL_EVP_PKEY_free(pkey);

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -3050,6 +3050,83 @@ int test_wolfSSL_EVP_PKEY_ed448(void)
     return EXPECT_RESULT();
 }
 
+/* Decoding into a caller-supplied EVP_PKEY must re-populate the object
+ * (documented OpenSSL reuse semantics). An ML-DSA decode into a key that
+ * previously held another key must not return success while leaving the
+ * old key data in place. */
+int test_wolfSSL_d2i_PUBKEY_mldsa_reuse(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_EXTRA) && defined(WOLFSSL_HAVE_MLDSA) && \
+    defined(WOLFSSL_MLDSA_PUBLIC_KEY) && !defined(WOLFSSL_MLDSA_NO_ASN1) && \
+    !defined(WOLFSSL_NO_ML_DSA_44) && !defined(WOLFSSL_NO_ML_DSA_65) && \
+    !defined(NO_RSA) && defined(USE_CERT_BUFFERS_2048) && \
+    !defined(NO_FILESYSTEM)
+    WOLFSSL_EVP_PKEY* pkey = NULL;
+    const unsigned char* p;
+    unsigned char der44[2048];
+    unsigned char der65[2600];
+    int der44Sz = 0;
+    int der65Sz = 0;
+    XFILE f = XBADFILE;
+
+    ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44_pub-spki.der", "rb"))
+        != XBADFILE);
+    ExpectIntGT(der44Sz = (int)XFREAD(der44, 1, sizeof(der44), f), 0);
+    if (f != XBADFILE) {
+        XFCLOSE(f);
+        f = XBADFILE;
+    }
+    ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa65_pub-spki.der", "rb"))
+        != XBADFILE);
+    ExpectIntGT(der65Sz = (int)XFREAD(der65, 1, sizeof(der65), f), 0);
+    if (f != XBADFILE) {
+        XFCLOSE(f);
+    }
+
+    /* Decode an RSA SPKI first so pkey holds a non-ML-DSA key. */
+    p = client_keypub_der_2048;
+    ExpectNotNull(wolfSSL_d2i_PUBKEY(&pkey, &p,
+        (long)sizeof_client_keypub_der_2048));
+    ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), EVP_PKEY_RSA);
+
+    /* Reuse the same EVP_PKEY for an ML-DSA SPKI and check the object was
+     * re-populated with the new key. */
+    p = der44;
+    ExpectNotNull(wolfSSL_d2i_PUBKEY(&pkey, &p, (long)der44Sz));
+    ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), WC_EVP_PKEY_DILITHIUM);
+    if (pkey != NULL) {
+        ExpectIntEQ(pkey->pkey_sz, der44Sz);
+        ExpectNotNull(pkey->pkey.ptr);
+        if (pkey->pkey.ptr != NULL) {
+            ExpectIntEQ(XMEMCMP(pkey->pkey.ptr, der44, (size_t)der44Sz), 0);
+        }
+        /* EVP_PKEY_free() releases the per-algorithm object only for the
+         * final type, so drop the RSA object left from the first decode
+         * to keep this test leak-free. */
+        if (pkey->rsa != NULL && pkey->ownRsa == 1) {
+            wolfSSL_RSA_free(pkey->rsa);
+            pkey->rsa = NULL;
+        }
+    }
+
+    /* Reuse again with a different ML-DSA level: same type, new key data. */
+    p = der65;
+    ExpectNotNull(wolfSSL_d2i_PUBKEY(&pkey, &p, (long)der65Sz));
+    ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), WC_EVP_PKEY_DILITHIUM);
+    if (pkey != NULL) {
+        ExpectIntEQ(pkey->pkey_sz, der65Sz);
+        ExpectNotNull(pkey->pkey.ptr);
+        if (pkey->pkey.ptr != NULL) {
+            ExpectIntEQ(XMEMCMP(pkey->pkey.ptr, der65, (size_t)der65Sz), 0);
+        }
+    }
+
+    wolfSSL_EVP_PKEY_free(pkey);
+#endif
+    return EXPECT_RESULT();
+}
+
 int test_wolfSSL_EVP_PKEY_x25519(void)
 {
     EXPECT_DECLS;

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -3227,6 +3227,24 @@ int test_wolfSSL_d2i_PrivateKey_mldsa(void)
     ExpectNotNull(pkey = wolfSSL_d2i_PrivateKey(WC_EVP_PKEY_DILITHIUM, NULL,
         &p, (long)mldsaSz));
     ExpectIntEQ(wolfSSL_EVP_PKEY_id(pkey), WC_EVP_PKEY_DILITHIUM);
+
+    /* i2d must emit the full PKCS#8 wrapper (the parameter set only exists
+     * in the AlgorithmIdentifier) so the output round-trips through d2i. */
+    {
+        WOLFSSL_EVP_PKEY* pkey2 = NULL;
+        unsigned char* out = NULL;
+
+        ExpectIntEQ(wolfSSL_i2d_PrivateKey(pkey, &out), mldsaSz);
+        ExpectNotNull(out);
+        if (out != NULL) {
+            ExpectIntEQ(XMEMCMP(out, mldsaDer, (size_t)mldsaSz), 0);
+            p = out;
+            ExpectNotNull(pkey2 = wolfSSL_d2i_PrivateKey(
+                WC_EVP_PKEY_DILITHIUM, NULL, &p, (long)mldsaSz));
+            wolfSSL_EVP_PKEY_free(pkey2);
+        }
+        XFREE(out, NULL, DYNAMIC_TYPE_OPENSSL);
+    }
     wolfSSL_EVP_PKEY_free(pkey);
     pkey = NULL;
 

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -3085,6 +3085,7 @@ int test_wolfSSL_d2i_PUBKEY_mldsa_reuse(void)
     ExpectIntGT(der65Sz = (int)XFREAD(der65, 1, sizeof(der65), f), 0);
     if (f != XBADFILE) {
         XFCLOSE(f);
+        f = XBADFILE;
     }
 
     /* Decode an RSA SPKI first so pkey holds a non-ML-DSA key. */
@@ -3161,6 +3162,7 @@ int test_wolfSSL_d2i_PrivateKey_mldsa(void)
     ExpectIntGT(rsaSz = (int)XFREAD(rsaDer, 1, sizeof(rsaDer), f), 0);
     if (f != XBADFILE) {
         XFCLOSE(f);
+        f = XBADFILE;
     }
 
     /* PKCS#8 ML-DSA private key decodes with the matching type. */
@@ -3213,6 +3215,7 @@ int test_wolfSSL_d2i_PrivateKey_mldsa(void)
         ExpectIntGT(spkiSz = (int)XFREAD(spki, 1, sizeof(spki), f), 0);
         if (f != XBADFILE) {
             XFCLOSE(f);
+            f = XBADFILE;
         }
         p = spki;
         ExpectNotNull(pkey = wolfSSL_d2i_PublicKey(WC_EVP_PKEY_DILITHIUM,

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -3180,17 +3180,23 @@ int test_wolfSSL_d2i_PrivateKey_mldsa(void)
      * size-keyed raw import is for the auto-detect path only. Use genuine
      * raw bytes so the rejection is due to the format, not the contents. */
     {
-        MlDsaKey mldsa;
+        wc_MlDsaKey* mldsa = NULL;
         word32 idx = 0;
         word32 rawSz = (word32)sizeof(rawBlob);
+        int keyRet = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
-        ExpectIntEQ(wc_MlDsaKey_Init(&mldsa, NULL, INVALID_DEVID), 0);
+        ExpectNotNull(mldsa = (wc_MlDsaKey*)XMALLOC(sizeof(*mldsa), NULL,
+            DYNAMIC_TYPE_TMP_BUFFER));
+        ExpectIntEQ(keyRet = wc_MlDsaKey_Init(mldsa, NULL, INVALID_DEVID), 0);
         PRIVATE_KEY_UNLOCK();
-        ExpectIntEQ(wc_MlDsaKey_PrivateKeyDecode(&mldsa, mldsaDer,
+        ExpectIntEQ(wc_MlDsaKey_PrivateKeyDecode(mldsa, mldsaDer,
             (word32)mldsaSz, &idx), 0);
-        ExpectIntEQ(wc_MlDsaKey_ExportPrivRaw(&mldsa, rawBlob, &rawSz), 0);
+        ExpectIntEQ(wc_MlDsaKey_ExportPrivRaw(mldsa, rawBlob, &rawSz), 0);
         PRIVATE_KEY_LOCK();
-        wc_MlDsaKey_Free(&mldsa);
+        if (keyRet == 0) {
+            wc_MlDsaKey_Free(mldsa);
+        }
+        XFREE(mldsa, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
         p = rawBlob;
         ExpectNull(wolfSSL_d2i_PrivateKey(WC_EVP_PKEY_DILITHIUM, NULL, &p,

--- a/tests/api/test_evp_pkey.h
+++ b/tests/api/test_evp_pkey.h
@@ -71,6 +71,7 @@ int test_wolfSSL_EVP_PKEY_print_public(void);
 int test_wolfSSL_EVP_PKEY_ed25519(void);
 int test_wolfSSL_CTX_use_PrivateKey_ed25519(void);
 int test_wolfSSL_EVP_PKEY_ed448(void);
+int test_wolfSSL_d2i_PUBKEY_mldsa_reuse(void);
 int test_wolfSSL_EVP_PKEY_x25519(void);
 int test_wolfSSL_EVP_PKEY_x448(void);
 int test_wolfSSL_EVP_PKEY_encoded_public_key(void);
@@ -125,6 +126,7 @@ int test_wolfSSL_d2i_PrivateKey_reuse_resets_state(void);
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_ed25519),                \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_CTX_use_PrivateKey_ed25519),      \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_ed448),                  \
+    TEST_DECL_GROUP("evp_pkey", test_wolfSSL_d2i_PUBKEY_mldsa_reuse),          \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_x25519),                 \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_x448),                   \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_encoded_public_key),     \

--- a/tests/api/test_evp_pkey.h
+++ b/tests/api/test_evp_pkey.h
@@ -72,6 +72,7 @@ int test_wolfSSL_EVP_PKEY_ed25519(void);
 int test_wolfSSL_CTX_use_PrivateKey_ed25519(void);
 int test_wolfSSL_EVP_PKEY_ed448(void);
 int test_wolfSSL_d2i_PUBKEY_mldsa_reuse(void);
+int test_wolfSSL_d2i_PrivateKey_mldsa(void);
 int test_wolfSSL_EVP_PKEY_x25519(void);
 int test_wolfSSL_EVP_PKEY_x448(void);
 int test_wolfSSL_EVP_PKEY_encoded_public_key(void);
@@ -127,6 +128,7 @@ int test_wolfSSL_d2i_PrivateKey_reuse_resets_state(void);
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_CTX_use_PrivateKey_ed25519),      \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_ed448),                  \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_d2i_PUBKEY_mldsa_reuse),          \
+    TEST_DECL_GROUP("evp_pkey", test_wolfSSL_d2i_PrivateKey_mldsa),            \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_x25519),                 \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_x448),                   \
     TEST_DECL_GROUP("evp_pkey", test_wolfSSL_EVP_PKEY_encoded_public_key),     \

--- a/tests/api/test_ossl_pem.c
+++ b/tests/api/test_ossl_pem.c
@@ -603,6 +603,58 @@ int test_wolfSSL_PEM_PrivateKey_dh(void)
     return EXPECT_RESULT();
 }
 
+/* test loading ML-DSA keys with PEM_read_bio_PrivateKey and
+ * PEM_read_PrivateKey */
+int test_wolfSSL_PEM_PrivateKey_mldsa(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
+    defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+    !defined(WOLFSSL_MLDSA_NO_ASN1) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_BIO)
+    const char* fnames[] = {
+    #ifndef WOLFSSL_NO_ML_DSA_44
+        "./certs/mldsa/mldsa44-key.pem",
+    #endif
+    #ifndef WOLFSSL_NO_ML_DSA_65
+        "./certs/mldsa/mldsa65-key.pem",
+    #endif
+    #ifndef WOLFSSL_NO_ML_DSA_87
+        "./certs/mldsa/mldsa87-key.pem",
+    #endif
+    };
+    BIO*      bio  = NULL;
+    EVP_PKEY* pkey = NULL;
+    XFILE     file = XBADFILE;
+    word32    i;
+
+    for (i = 0; i < (word32)(sizeof(fnames) / sizeof(*fnames)); i++) {
+        /* BIO variant */
+        ExpectNotNull(bio = BIO_new_file(fnames[i], "rb"));
+        ExpectNotNull(pkey = wolfSSL_PEM_read_bio_PrivateKey(bio, NULL, NULL,
+            NULL));
+        ExpectIntEQ(EVP_PKEY_id(pkey), EVP_PKEY_DILITHIUM);
+        BIO_free(bio);
+        bio = NULL;
+        EVP_PKEY_free(pkey);
+        pkey = NULL;
+
+        /* XFILE variant */
+        ExpectTrue((file = XFOPEN(fnames[i], "rb")) != XBADFILE);
+        ExpectNotNull(pkey = wolfSSL_PEM_read_PrivateKey(file, NULL, NULL,
+            NULL));
+        ExpectIntEQ(EVP_PKEY_id(pkey), EVP_PKEY_DILITHIUM);
+        if (file != XBADFILE) {
+            XFCLOSE(file);
+            file = XBADFILE;
+        }
+        EVP_PKEY_free(pkey);
+        pkey = NULL;
+    }
+#endif
+    return EXPECT_RESULT();
+}
+
 int test_wolfSSL_PEM_PrivateKey(void)
 {
     EXPECT_DECLS;

--- a/tests/api/test_ossl_pem.c
+++ b/tests/api/test_ossl_pem.c
@@ -651,6 +651,37 @@ int test_wolfSSL_PEM_PrivateKey_mldsa(void)
         EVP_PKEY_free(pkey);
         pkey = NULL;
     }
+
+    /* Out-parameter reuse form (documented OpenSSL semantics): a second
+     * read into the same non-NULL EVP_PKEY must re-populate the object. */
+    {
+        word32 last = (word32)(sizeof(fnames) / sizeof(*fnames)) - 1;
+        int firstSz = 0;
+
+        ExpectNotNull(bio = BIO_new_file(fnames[0], "rb"));
+        ExpectNotNull(wolfSSL_PEM_read_bio_PrivateKey(bio, &pkey, NULL,
+            NULL));
+        ExpectIntEQ(EVP_PKEY_id(pkey), EVP_PKEY_DILITHIUM);
+        if (pkey != NULL) {
+            firstSz = pkey->pkey_sz;
+        }
+        BIO_free(bio);
+        bio = NULL;
+
+        ExpectNotNull(bio = BIO_new_file(fnames[last], "rb"));
+        ExpectNotNull(wolfSSL_PEM_read_bio_PrivateKey(bio, &pkey, NULL,
+            NULL));
+        ExpectIntEQ(EVP_PKEY_id(pkey), EVP_PKEY_DILITHIUM);
+        if ((last > 0) && (pkey != NULL)) {
+            /* A different level was read: the held key must have been
+             * replaced, not left stale. */
+            ExpectIntNE(pkey->pkey_sz, firstSz);
+        }
+        BIO_free(bio);
+        bio = NULL;
+        EVP_PKEY_free(pkey);
+        pkey = NULL;
+    }
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_ossl_pem.c
+++ b/tests/api/test_ossl_pem.c
@@ -679,6 +679,34 @@ int test_wolfSSL_PEM_PrivateKey_mldsa(void)
         }
         BIO_free(bio);
         bio = NULL;
+
+        /* A failed read into the same pointer must leave the held key
+         * untouched, not freed (the caller would otherwise be left with
+         * a dangling pointer and a later double free). */
+        {
+            static const char badPem[] =
+                "-----BEGIN PRIVATE KEY-----\n"
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                "-----END PRIVATE KEY-----\n";
+            static const unsigned char junk[8] =
+                { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+            const unsigned char* jp = junk;
+
+            ExpectNull(wolfSSL_d2i_PrivateKey(WC_EVP_PKEY_DILITHIUM, &pkey,
+                &jp, (long)sizeof(junk)));
+            ExpectNotNull(pkey);
+            ExpectIntEQ(EVP_PKEY_id(pkey), EVP_PKEY_DILITHIUM);
+
+            ExpectNotNull(bio = BIO_new_mem_buf(badPem,
+                (int)sizeof(badPem) - 1));
+            ExpectNull(wolfSSL_PEM_read_bio_PrivateKey(bio, &pkey, NULL,
+                NULL));
+            ExpectNotNull(pkey);
+            ExpectIntEQ(EVP_PKEY_id(pkey), EVP_PKEY_DILITHIUM);
+            BIO_free(bio);
+            bio = NULL;
+        }
+
         EVP_PKEY_free(pkey);
         pkey = NULL;
     }

--- a/tests/api/test_ossl_pem.h
+++ b/tests/api/test_ossl_pem.h
@@ -31,6 +31,7 @@ int test_wolfSSL_PEM_PrivateKey_rsa(void);
 int test_wolfSSL_PEM_PrivateKey_ecc(void);
 int test_wolfSSL_PEM_PrivateKey_dsa(void);
 int test_wolfSSL_PEM_PrivateKey_dh(void);
+int test_wolfSSL_PEM_PrivateKey_mldsa(void);
 int test_wolfSSL_PEM_PrivateKey(void);
 int test_wolfSSL_PEM_write_PrivateKey(void);
 int test_wolfSSL_PEM_write_PUBKEY(void);
@@ -53,6 +54,7 @@ int test_wolfSSL_PEM_PUBKEY(void);
     TEST_DECL_GROUP("ossl_pem", test_wolfSSL_PEM_PrivateKey_ecc),       \
     TEST_DECL_GROUP("ossl_pem", test_wolfSSL_PEM_PrivateKey_dsa),       \
     TEST_DECL_GROUP("ossl_pem", test_wolfSSL_PEM_PrivateKey_dh),        \
+    TEST_DECL_GROUP("ossl_pem", test_wolfSSL_PEM_PrivateKey_mldsa),     \
     TEST_DECL_GROUP("ossl_pem", test_wolfSSL_PEM_PrivateKey),           \
     TEST_DECL_GROUP("ossl_pem", test_wolfSSL_PEM_write_PrivateKey),     \
     TEST_DECL_GROUP("ossl_pem", test_wolfSSL_PEM_write_PUBKEY),         \

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -342,6 +342,66 @@ int test_wolfSSL_X509_set_pubkey(void)
     wolfSSL_EVP_PKEY_free(pkey);
     pkey = NULL;
 #endif
+#if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+    defined(WOLFSSL_MLDSA_PUBLIC_KEY) && !defined(WOLFSSL_MLDSA_NO_ASN1) && \
+    defined(WC_ENABLE_ASYM_KEY_EXPORT) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_BIO) && !defined(WOLFSSL_NO_ML_DSA_44)
+    {
+        WOLFSSL_BIO* bio = NULL;
+        WOLFSSL_EVP_PKEY* pubkey = NULL;
+
+        /* EVP_PKEY with no key data */
+        ExpectNotNull(pkey = wolfSSL_EVP_PKEY_new());
+        if (pkey != NULL) {
+            pkey->type = WC_EVP_PKEY_DILITHIUM;
+        }
+        ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, pkey), WOLFSSL_FAILURE);
+        wolfSSL_EVP_PKEY_free(pkey);
+        pkey = NULL;
+
+        /* ML-DSA key loaded from file */
+        ExpectNotNull(bio = wolfSSL_BIO_new_file(
+            "./certs/mldsa/mldsa44-key.pem", "rb"));
+        ExpectNotNull(pkey = wolfSSL_PEM_read_bio_PrivateKey(bio, NULL, NULL,
+            NULL));
+        wolfSSL_BIO_free(bio);
+        bio = NULL;
+        ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, pkey), WOLFSSL_SUCCESS);
+
+        /* public key can be retrieved and has the right type */
+        ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
+        ExpectIntEQ(wolfSSL_EVP_PKEY_id(pubkey), WC_EVP_PKEY_DILITHIUM);
+        wolfSSL_EVP_PKEY_free(pubkey);
+        pubkey = NULL;
+
+    #if defined(WOLFSSL_CERT_GEN) && !defined(NO_PWDBASED) && \
+        !defined(WOLFSSL_MLDSA_NO_SIGN) && !defined(WOLFSSL_MLDSA_NO_VERIFY)
+        /* sign and verify round trip with the ML-DSA key */
+        {
+            WOLFSSL_X509_NAME* name = NULL;
+
+            ExpectNotNull(name = wolfSSL_X509_NAME_new());
+            ExpectIntEQ(wolfSSL_X509_NAME_add_entry_by_txt(name, "CN",
+                MBSTRING_UTF8, (const byte*)"mldsa-test", -1, -1, 0),
+                WOLFSSL_SUCCESS);
+            ExpectIntEQ(wolfSSL_X509_set_subject_name(x509, name),
+                WOLFSSL_SUCCESS);
+            ExpectIntEQ(wolfSSL_X509_set_issuer_name(x509, name),
+                WOLFSSL_SUCCESS);
+            wolfSSL_X509_NAME_free(name);
+
+            ExpectIntGT(wolfSSL_X509_sign(x509, pkey, wolfSSL_EVP_sha256()),
+                0);
+            ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
+            ExpectIntEQ(wolfSSL_X509_verify(x509, pubkey), WOLFSSL_SUCCESS);
+            wolfSSL_EVP_PKEY_free(pubkey);
+            pubkey = NULL;
+        }
+    #endif
+        wolfSSL_EVP_PKEY_free(pkey);
+        pkey = NULL;
+    }
+#endif /* WOLFSSL_HAVE_MLDSA */
 
     wolfSSL_X509_free(x509);
 #endif

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -494,22 +494,29 @@ int test_wolfSSL_X509_set_pubkey(void)
                 XFCLOSE(f);
             }
             {
-                wc_MlDsaKey rawKey;
+                wc_MlDsaKey* rawKey = NULL;
                 byte pubDer[MLDSA_MAX_PUB_KEY_SIZE + 64];
                 word32 kidx = 0;
                 int expected = WOLFSSL_FAILURE;
+                int keyRet = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
-                ExpectIntEQ(wc_MlDsaKey_Init(&rawKey, NULL, INVALID_DEVID),
-                    0);
+                ExpectNotNull(rawKey = (wc_MlDsaKey*)XMALLOC(sizeof(*rawKey),
+                    NULL, DYNAMIC_TYPE_TMP_BUFFER));
+                ExpectIntEQ(keyRet = wc_MlDsaKey_Init(rawKey, NULL,
+                    INVALID_DEVID), 0);
                 PRIVATE_KEY_UNLOCK();
-                ExpectIntEQ(wc_MlDsaKey_PrivateKeyDecode(&rawKey, der,
+                ExpectIntEQ(wc_MlDsaKey_PrivateKeyDecode(rawKey, der,
                     (word32)derSz, &kidx), 0);
-                if (wc_MlDsaKey_PublicKeyToDer(&rawKey, pubDer,
-                        (word32)sizeof(pubDer), 1) > 0) {
+                if (EXPECT_SUCCESS() &&
+                        wc_MlDsaKey_PublicKeyToDer(rawKey, pubDer,
+                            (word32)sizeof(pubDer), 1) > 0) {
                     expected = WOLFSSL_SUCCESS;
                 }
                 PRIVATE_KEY_LOCK();
-                wc_MlDsaKey_Free(&rawKey);
+                if (keyRet == 0) {
+                    wc_MlDsaKey_Free(rawKey);
+                }
+                XFREE(rawKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
                 pp = der;
                 ExpectNotNull(pkey = wolfSSL_d2i_PrivateKey(
@@ -528,25 +535,35 @@ int test_wolfSSL_X509_set_pubkey(void)
          * consistent with the draft-OID SPKI emitted by
          * wc_MlDsaKey_PublicKeyToDer(), or the subsequent sign fails. */
         {
-            MlDsaKey draftKey;
+            wc_MlDsaKey* draftKey = NULL;
             WC_RNG rng;
             byte draftDer[4096];
             int draftDerSz = 0;
             const unsigned char* dp = draftDer;
+            int rngRet = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
+            int keyRet = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
-            ExpectIntEQ(wc_InitRng(&rng), 0);
-            ExpectIntEQ(wc_MlDsaKey_Init(&draftKey, NULL, INVALID_DEVID), 0);
-            ExpectIntEQ(wc_MlDsaKey_SetParams(&draftKey, WC_ML_DSA_44_DRAFT),
+            ExpectNotNull(draftKey = (wc_MlDsaKey*)XMALLOC(sizeof(*draftKey),
+                NULL, DYNAMIC_TYPE_TMP_BUFFER));
+            ExpectIntEQ(rngRet = wc_InitRng(&rng), 0);
+            ExpectIntEQ(keyRet = wc_MlDsaKey_Init(draftKey, NULL,
+                INVALID_DEVID), 0);
+            ExpectIntEQ(wc_MlDsaKey_SetParams(draftKey, WC_ML_DSA_44_DRAFT),
                 0);
-            ExpectIntEQ(wc_MlDsaKey_MakeKey(&draftKey, &rng), 0);
+            ExpectIntEQ(wc_MlDsaKey_MakeKey(draftKey, &rng), 0);
             /* KeyToDer (priv+pub): the decode of a priv-only PKCS#8 does
              * not derive the public part needed by PublicKeyToDer. */
             PRIVATE_KEY_UNLOCK();
-            ExpectIntGT(draftDerSz = wc_MlDsaKey_KeyToDer(&draftKey,
+            ExpectIntGT(draftDerSz = wc_MlDsaKey_KeyToDer(draftKey,
                 draftDer, (word32)sizeof(draftDer)), 0);
             PRIVATE_KEY_LOCK();
-            wc_MlDsaKey_Free(&draftKey);
-            wc_FreeRng(&rng);
+            if (keyRet == 0) {
+                wc_MlDsaKey_Free(draftKey);
+            }
+            XFREE(draftKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            if (rngRet == 0) {
+                wc_FreeRng(&rng);
+            }
 
             ExpectNotNull(pkey = wolfSSL_d2i_PrivateKey(
                 WC_EVP_PKEY_DILITHIUM, NULL, &dp, (long)draftDerSz));

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -29,6 +29,9 @@
 #endif
 
 #include <wolfssl/ssl.h>
+#ifdef WOLFSSL_HAVE_MLDSA
+    #include <wolfssl/wolfcrypt/wc_mldsa.h>
+#endif
 #include <tests/utils.h>
 #include <tests/api/api.h>
 #include <tests/api/test_ossl_x509_pk.h>
@@ -456,6 +459,48 @@ int test_wolfSSL_X509_set_pubkey(void)
 
         wolfSSL_EVP_PKEY_free(pkey);
         pkey = NULL;
+
+    #if defined(WOLFSSL_MLDSA_FIPS204_DRAFT) && \
+        !defined(WOLFSSL_MLDSA_VERIFY_ONLY) && defined(WOLFSSL_CERT_GEN) && \
+        !defined(NO_PWDBASED) && !defined(WOLFSSL_MLDSA_NO_SIGN) && \
+        !defined(WOLFSSL_MLDSA_NO_VERIFY) && !defined(WOLFSSL_NO_ML_DSA_44)
+        /* FIPS204-draft Dilithium key: set_pubkey must keep pubKeyOID
+         * consistent with the draft-OID SPKI emitted by
+         * wc_MlDsaKey_PublicKeyToDer(), or the subsequent sign fails. */
+        {
+            MlDsaKey draftKey;
+            WC_RNG rng;
+            byte draftDer[4096];
+            int draftDerSz = 0;
+            const unsigned char* dp = draftDer;
+
+            ExpectIntEQ(wc_InitRng(&rng), 0);
+            ExpectIntEQ(wc_MlDsaKey_Init(&draftKey, NULL, INVALID_DEVID), 0);
+            ExpectIntEQ(wc_MlDsaKey_SetParams(&draftKey, WC_ML_DSA_44_DRAFT),
+                0);
+            ExpectIntEQ(wc_MlDsaKey_MakeKey(&draftKey, &rng), 0);
+            /* KeyToDer (priv+pub): the decode of a priv-only PKCS#8 does
+             * not derive the public part needed by PublicKeyToDer. */
+            PRIVATE_KEY_UNLOCK();
+            ExpectIntGT(draftDerSz = wc_MlDsaKey_KeyToDer(&draftKey,
+                draftDer, (word32)sizeof(draftDer)), 0);
+            PRIVATE_KEY_LOCK();
+            wc_MlDsaKey_Free(&draftKey);
+            wc_FreeRng(&rng);
+
+            ExpectNotNull(pkey = wolfSSL_d2i_PrivateKey(
+                WC_EVP_PKEY_DILITHIUM, NULL, &dp, (long)draftDerSz));
+            ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, pkey),
+                WOLFSSL_SUCCESS);
+            ExpectIntGT(wolfSSL_X509_sign(x509, pkey, NULL), 0);
+            ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
+            ExpectIntEQ(wolfSSL_X509_verify(x509, pubkey), WOLFSSL_SUCCESS);
+            wolfSSL_EVP_PKEY_free(pubkey);
+            pubkey = NULL;
+            wolfSSL_EVP_PKEY_free(pkey);
+            pkey = NULL;
+        }
+    #endif /* WOLFSSL_MLDSA_FIPS204_DRAFT */
     }
 #endif /* WOLFSSL_HAVE_MLDSA */
 

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -446,8 +446,10 @@ int test_wolfSSL_X509_set_pubkey(void)
             ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44_pub-spki.der",
                 "rb")) != XBADFILE);
             ExpectIntGT(derSz = (int)XFREAD(der, 1, sizeof(der), f), 0);
-            if (f != XBADFILE)
+            if (f != XBADFILE) {
                 XFCLOSE(f);
+                f = XBADFILE;
+            }
             ExpectNotNull(spki = wolfSSL_d2i_PUBKEY(NULL, &pp, (long)derSz));
             ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, spki), WOLFSSL_SUCCESS);
             ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
@@ -492,6 +494,7 @@ int test_wolfSSL_X509_set_pubkey(void)
             ExpectIntGT(derSz = (int)XFREAD(der, 1, sizeof(der), f), 0);
             if (f != XBADFILE) {
                 XFCLOSE(f);
+                f = XBADFILE;
             }
             {
                 wc_MlDsaKey* rawKey = NULL;

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -425,6 +425,19 @@ int test_wolfSSL_X509_set_pubkey(void)
                         WOLFSSL_SUCCESS);
                     wolfSSL_EVP_PKEY_free(pubkey);
                     pubkey = NULL;
+
+                    /* A stale/tampered mldsaOID cache must fail the sign
+                     * rather than emit a certificate whose
+                     * signatureAlgorithm disagrees with the actual key. */
+                    if (EXPECT_SUCCESS() && pkey != NULL) {
+                        int realOID = WOLFSSL_ATOMIC_LOAD(pkey->mldsaOID);
+                        int wrongOID = (realOID == ML_DSA_44k) ?
+                            ML_DSA_65k : ML_DSA_44k;
+                        WOLFSSL_ATOMIC_STORE(pkey->mldsaOID, wrongOID);
+                        ExpectIntEQ(wolfSSL_X509_sign(x509, pkey, NULL),
+                            WC_NO_ERR_TRACE(WOLFSSL_FAILURE));
+                        WOLFSSL_ATOMIC_STORE(pkey->mldsaOID, realOID);
+                    }
                 }
             #endif
                 if (ki + 1 < sizeof(keyFiles) / sizeof(keyFiles[0])) {

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -359,52 +359,77 @@ int test_wolfSSL_X509_set_pubkey(void)
         wolfSSL_EVP_PKEY_free(pkey);
         pkey = NULL;
 
-        /* ML-DSA key loaded from file */
-        ExpectNotNull(bio = wolfSSL_BIO_new_file(
-            "./certs/mldsa/mldsa44-key.pem", "rb"));
-        ExpectNotNull(pkey = wolfSSL_PEM_read_bio_PrivateKey(bio, NULL, NULL,
-            NULL));
-        wolfSSL_BIO_free(bio);
-        bio = NULL;
-        ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, pkey), WOLFSSL_SUCCESS);
-
-        /* public key can be retrieved and has the right type */
-        ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
-        ExpectIntEQ(wolfSSL_EVP_PKEY_id(pubkey), WC_EVP_PKEY_DILITHIUM);
-        wolfSSL_EVP_PKEY_free(pubkey);
-        pubkey = NULL;
-
-    #if defined(WOLFSSL_CERT_GEN) && !defined(NO_PWDBASED) && \
-        !defined(WOLFSSL_MLDSA_NO_SIGN) && !defined(WOLFSSL_MLDSA_NO_VERIFY)
-        /* sign and verify round trip with the ML-DSA key */
+        /* ML-DSA keys loaded from file: cover every compiled-in level.
+         * ML-DSA-87 (2592-byte public key, 4627-byte signature) is what
+         * motivates the enlarged DER buffers. */
         {
-            WOLFSSL_X509_NAME* name = NULL;
+            static const char* keyFiles[] = {
+                "./certs/mldsa/mldsa44-key.pem",
+            #ifndef WOLFSSL_NO_ML_DSA_65
+                "./certs/mldsa/mldsa65-key.pem",
+            #endif
+            #ifndef WOLFSSL_NO_ML_DSA_87
+                "./certs/mldsa/mldsa87-key.pem",
+            #endif
+            };
+            size_t ki;
 
-            ExpectNotNull(name = wolfSSL_X509_NAME_new());
-            ExpectIntEQ(wolfSSL_X509_NAME_add_entry_by_txt(name, "CN",
-                MBSTRING_UTF8, (const byte*)"mldsa-test", -1, -1, 0),
-                WOLFSSL_SUCCESS);
-            ExpectIntEQ(wolfSSL_X509_set_subject_name(x509, name),
-                WOLFSSL_SUCCESS);
-            ExpectIntEQ(wolfSSL_X509_set_issuer_name(x509, name),
-                WOLFSSL_SUCCESS);
-            wolfSSL_X509_NAME_free(name);
+            for (ki = 0; ki < sizeof(keyFiles) / sizeof(keyFiles[0]); ki++) {
+                ExpectNotNull(bio = wolfSSL_BIO_new_file(keyFiles[ki], "rb"));
+                ExpectNotNull(pkey = wolfSSL_PEM_read_bio_PrivateKey(bio,
+                    NULL, NULL, NULL));
+                wolfSSL_BIO_free(bio);
+                bio = NULL;
+                ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, pkey),
+                    WOLFSSL_SUCCESS);
 
-            ExpectIntGT(wolfSSL_X509_sign(x509, pkey, wolfSSL_EVP_sha256()),
-                0);
-            ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
-            ExpectIntEQ(wolfSSL_X509_verify(x509, pubkey), WOLFSSL_SUCCESS);
-            wolfSSL_EVP_PKEY_free(pubkey);
-            pubkey = NULL;
+                /* public key can be retrieved and has the right type */
+                ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
+                ExpectIntEQ(wolfSSL_EVP_PKEY_id(pubkey),
+                    WC_EVP_PKEY_DILITHIUM);
+                wolfSSL_EVP_PKEY_free(pubkey);
+                pubkey = NULL;
 
-            /* OpenSSL semantics: NULL md is valid for ML-DSA. */
-            ExpectIntGT(wolfSSL_X509_sign(x509, pkey, NULL), 0);
-            ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
-            ExpectIntEQ(wolfSSL_X509_verify(x509, pubkey), WOLFSSL_SUCCESS);
-            wolfSSL_EVP_PKEY_free(pubkey);
-            pubkey = NULL;
+            #if defined(WOLFSSL_CERT_GEN) && !defined(NO_PWDBASED) && \
+                !defined(WOLFSSL_MLDSA_NO_SIGN) && \
+                !defined(WOLFSSL_MLDSA_NO_VERIFY)
+                /* sign and verify round trip with the ML-DSA key */
+                {
+                    WOLFSSL_X509_NAME* name = NULL;
+
+                    ExpectNotNull(name = wolfSSL_X509_NAME_new());
+                    ExpectIntEQ(wolfSSL_X509_NAME_add_entry_by_txt(name,
+                        "CN", MBSTRING_UTF8, (const byte*)"mldsa-test", -1,
+                        -1, 0), WOLFSSL_SUCCESS);
+                    ExpectIntEQ(wolfSSL_X509_set_subject_name(x509, name),
+                        WOLFSSL_SUCCESS);
+                    ExpectIntEQ(wolfSSL_X509_set_issuer_name(x509, name),
+                        WOLFSSL_SUCCESS);
+                    wolfSSL_X509_NAME_free(name);
+
+                    ExpectIntGT(wolfSSL_X509_sign(x509, pkey,
+                        wolfSSL_EVP_sha256()), 0);
+                    ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
+                    ExpectIntEQ(wolfSSL_X509_verify(x509, pubkey),
+                        WOLFSSL_SUCCESS);
+                    wolfSSL_EVP_PKEY_free(pubkey);
+                    pubkey = NULL;
+
+                    /* OpenSSL semantics: NULL md is valid for ML-DSA. */
+                    ExpectIntGT(wolfSSL_X509_sign(x509, pkey, NULL), 0);
+                    ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
+                    ExpectIntEQ(wolfSSL_X509_verify(x509, pubkey),
+                        WOLFSSL_SUCCESS);
+                    wolfSSL_EVP_PKEY_free(pubkey);
+                    pubkey = NULL;
+                }
+            #endif
+                if (ki + 1 < sizeof(keyFiles) / sizeof(keyFiles[0])) {
+                    wolfSSL_EVP_PKEY_free(pkey);
+                    pkey = NULL;
+                }
+            }
         }
-    #endif
 
         /* Public-only EVP_PKEY holding an SPKI: the private-key decode
          * fails and the fallback public decode must work on a reset key. */

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -460,6 +460,66 @@ int test_wolfSSL_X509_set_pubkey(void)
         wolfSSL_EVP_PKEY_free(pkey);
         pkey = NULL;
 
+        /* PKCS#8 shapes: a seed-carrying key derives the public half so
+         * set_pubkey succeeds. For a private-only blob the outcome tracks
+         * whether wolfCrypt can derive the public half on demand in
+         * wc_MlDsaKey_PublicKeyToDer() (added by PR #10985). */
+        {
+            unsigned char der[4096];
+            int derSz = 0;
+            const unsigned char* pp;
+            XFILE f = XBADFILE;
+
+        #ifndef WOLFSSL_MLDSA_VERIFY_ONLY
+            ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44_seed-priv.der",
+                "rb")) != XBADFILE);
+            ExpectIntGT(derSz = (int)XFREAD(der, 1, sizeof(der), f), 0);
+            if (f != XBADFILE) {
+                XFCLOSE(f);
+                f = XBADFILE;
+            }
+            pp = der;
+            ExpectNotNull(pkey = wolfSSL_d2i_PrivateKey(
+                WC_EVP_PKEY_DILITHIUM, NULL, &pp, (long)derSz));
+            ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, pkey),
+                WOLFSSL_SUCCESS);
+            wolfSSL_EVP_PKEY_free(pkey);
+            pkey = NULL;
+        #endif
+
+            ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44_priv-only.der",
+                "rb")) != XBADFILE);
+            ExpectIntGT(derSz = (int)XFREAD(der, 1, sizeof(der), f), 0);
+            if (f != XBADFILE) {
+                XFCLOSE(f);
+            }
+            {
+                wc_MlDsaKey rawKey;
+                byte pubDer[MLDSA_MAX_PUB_KEY_SIZE + 64];
+                word32 kidx = 0;
+                int expected = WOLFSSL_FAILURE;
+
+                ExpectIntEQ(wc_MlDsaKey_Init(&rawKey, NULL, INVALID_DEVID),
+                    0);
+                PRIVATE_KEY_UNLOCK();
+                ExpectIntEQ(wc_MlDsaKey_PrivateKeyDecode(&rawKey, der,
+                    (word32)derSz, &kidx), 0);
+                if (wc_MlDsaKey_PublicKeyToDer(&rawKey, pubDer,
+                        (word32)sizeof(pubDer), 1) > 0) {
+                    expected = WOLFSSL_SUCCESS;
+                }
+                PRIVATE_KEY_LOCK();
+                wc_MlDsaKey_Free(&rawKey);
+
+                pp = der;
+                ExpectNotNull(pkey = wolfSSL_d2i_PrivateKey(
+                    WC_EVP_PKEY_DILITHIUM, NULL, &pp, (long)derSz));
+                ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, pkey), expected);
+                wolfSSL_EVP_PKEY_free(pkey);
+                pkey = NULL;
+            }
+        }
+
     #if defined(WOLFSSL_MLDSA_FIPS204_DRAFT) && \
         !defined(WOLFSSL_MLDSA_VERIFY_ONLY) && defined(WOLFSSL_CERT_GEN) && \
         !defined(NO_PWDBASED) && !defined(WOLFSSL_MLDSA_NO_SIGN) && \

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -405,6 +405,30 @@ int test_wolfSSL_X509_set_pubkey(void)
             pubkey = NULL;
         }
     #endif
+
+        /* Public-only EVP_PKEY holding an SPKI: the private-key decode
+         * fails and the fallback public decode must work on a reset key. */
+        {
+            WOLFSSL_EVP_PKEY* spki = NULL;
+            unsigned char der[2048];
+            int derSz = 0;
+            const unsigned char* pp = der;
+            XFILE f = XBADFILE;
+
+            ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44_pub-spki.der",
+                "rb")) != XBADFILE);
+            ExpectIntGT(derSz = (int)XFREAD(der, 1, sizeof(der), f), 0);
+            if (f != XBADFILE)
+                XFCLOSE(f);
+            ExpectNotNull(spki = wolfSSL_d2i_PUBKEY(NULL, &pp, (long)derSz));
+            ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, spki), WOLFSSL_SUCCESS);
+            ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
+            ExpectIntEQ(wolfSSL_EVP_PKEY_id(pubkey), WC_EVP_PKEY_DILITHIUM);
+            wolfSSL_EVP_PKEY_free(pubkey);
+            pubkey = NULL;
+            wolfSSL_EVP_PKEY_free(spki);
+        }
+
         wolfSSL_EVP_PKEY_free(pkey);
         pkey = NULL;
     }

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -500,7 +500,7 @@ int test_wolfSSL_X509_set_pubkey(void)
                 wc_MlDsaKey* rawKey = NULL;
                 byte pubDer[MLDSA_MAX_PUB_KEY_SIZE + 64];
                 word32 kidx = 0;
-                int expected = WOLFSSL_FAILURE;
+                int expected = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
                 int keyRet = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
                 ExpectNotNull(rawKey = (wc_MlDsaKey*)XMALLOC(sizeof(*rawKey),

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -438,18 +438,21 @@ int test_wolfSSL_X509_set_pubkey(void)
          * fails and the fallback public decode must work on a reset key. */
         {
             WOLFSSL_EVP_PKEY* spki = NULL;
-            unsigned char der[2048];
+            unsigned char* der = NULL;
             int derSz = 0;
-            const unsigned char* pp = der;
+            const unsigned char* pp;
             XFILE f = XBADFILE;
 
+            ExpectNotNull(der = (unsigned char*)XMALLOC(2048, NULL,
+                DYNAMIC_TYPE_TMP_BUFFER));
             ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44_pub-spki.der",
                 "rb")) != XBADFILE);
-            ExpectIntGT(derSz = (int)XFREAD(der, 1, sizeof(der), f), 0);
+            ExpectIntGT(derSz = (int)XFREAD(der, 1, 2048, f), 0);
             if (f != XBADFILE) {
                 XFCLOSE(f);
                 f = XBADFILE;
             }
+            pp = der;
             ExpectNotNull(spki = wolfSSL_d2i_PUBKEY(NULL, &pp, (long)derSz));
             ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, spki), WOLFSSL_SUCCESS);
             ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
@@ -457,6 +460,7 @@ int test_wolfSSL_X509_set_pubkey(void)
             wolfSSL_EVP_PKEY_free(pubkey);
             pubkey = NULL;
             wolfSSL_EVP_PKEY_free(spki);
+            XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
 
         wolfSSL_EVP_PKEY_free(pkey);
@@ -467,15 +471,17 @@ int test_wolfSSL_X509_set_pubkey(void)
          * whether wolfCrypt can derive the public half on demand in
          * wc_MlDsaKey_PublicKeyToDer() (added by PR #10985). */
         {
-            unsigned char der[4096];
+            unsigned char* der = NULL;
             int derSz = 0;
             const unsigned char* pp;
             XFILE f = XBADFILE;
 
+            ExpectNotNull(der = (unsigned char*)XMALLOC(4096, NULL,
+                DYNAMIC_TYPE_TMP_BUFFER));
         #ifndef WOLFSSL_MLDSA_VERIFY_ONLY
             ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44_seed-priv.der",
                 "rb")) != XBADFILE);
-            ExpectIntGT(derSz = (int)XFREAD(der, 1, sizeof(der), f), 0);
+            ExpectIntGT(derSz = (int)XFREAD(der, 1, 4096, f), 0);
             if (f != XBADFILE) {
                 XFCLOSE(f);
                 f = XBADFILE;
@@ -491,18 +497,21 @@ int test_wolfSSL_X509_set_pubkey(void)
 
             ExpectTrue((f = XFOPEN("./certs/mldsa/mldsa44_priv-only.der",
                 "rb")) != XBADFILE);
-            ExpectIntGT(derSz = (int)XFREAD(der, 1, sizeof(der), f), 0);
+            ExpectIntGT(derSz = (int)XFREAD(der, 1, 4096, f), 0);
             if (f != XBADFILE) {
                 XFCLOSE(f);
                 f = XBADFILE;
             }
             {
                 wc_MlDsaKey* rawKey = NULL;
-                byte pubDer[MLDSA_MAX_PUB_KEY_SIZE + 64];
+                byte* pubDer = NULL;
                 word32 kidx = 0;
                 int expected = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
                 int keyRet = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
+                ExpectNotNull(pubDer = (byte*)XMALLOC(
+                    MLDSA_MAX_PUB_KEY_SIZE + 64, NULL,
+                    DYNAMIC_TYPE_TMP_BUFFER));
                 ExpectNotNull(rawKey = (wc_MlDsaKey*)XMALLOC(sizeof(*rawKey),
                     NULL, DYNAMIC_TYPE_TMP_BUFFER));
                 ExpectIntEQ(keyRet = wc_MlDsaKey_Init(rawKey, NULL,
@@ -512,7 +521,7 @@ int test_wolfSSL_X509_set_pubkey(void)
                     (word32)derSz, &kidx), 0);
                 if (EXPECT_SUCCESS() &&
                         wc_MlDsaKey_PublicKeyToDer(rawKey, pubDer,
-                            (word32)sizeof(pubDer), 1) > 0) {
+                            MLDSA_MAX_PUB_KEY_SIZE + 64, 1) > 0) {
                     expected = WOLFSSL_SUCCESS;
                 }
                 PRIVATE_KEY_LOCK();
@@ -520,6 +529,7 @@ int test_wolfSSL_X509_set_pubkey(void)
                     wc_MlDsaKey_Free(rawKey);
                 }
                 XFREE(rawKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(pubDer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
                 pp = der;
                 ExpectNotNull(pkey = wolfSSL_d2i_PrivateKey(
@@ -528,6 +538,7 @@ int test_wolfSSL_X509_set_pubkey(void)
                 wolfSSL_EVP_PKEY_free(pkey);
                 pkey = NULL;
             }
+            XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
 
     #if defined(WOLFSSL_MLDSA_FIPS204_DRAFT) && \
@@ -540,12 +551,14 @@ int test_wolfSSL_X509_set_pubkey(void)
         {
             wc_MlDsaKey* draftKey = NULL;
             WC_RNG rng;
-            byte draftDer[4096];
+            byte* draftDer = NULL;
             int draftDerSz = 0;
-            const unsigned char* dp = draftDer;
+            const unsigned char* dp;
             int rngRet = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
             int keyRet = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
+            ExpectNotNull(draftDer = (byte*)XMALLOC(4096, NULL,
+                DYNAMIC_TYPE_TMP_BUFFER));
             ExpectNotNull(draftKey = (wc_MlDsaKey*)XMALLOC(sizeof(*draftKey),
                 NULL, DYNAMIC_TYPE_TMP_BUFFER));
             ExpectIntEQ(rngRet = wc_InitRng(&rng), 0);
@@ -558,7 +571,7 @@ int test_wolfSSL_X509_set_pubkey(void)
              * not derive the public part needed by PublicKeyToDer. */
             PRIVATE_KEY_UNLOCK();
             ExpectIntGT(draftDerSz = wc_MlDsaKey_KeyToDer(draftKey,
-                draftDer, (word32)sizeof(draftDer)), 0);
+                draftDer, 4096), 0);
             PRIVATE_KEY_LOCK();
             if (keyRet == 0) {
                 wc_MlDsaKey_Free(draftKey);
@@ -568,6 +581,7 @@ int test_wolfSSL_X509_set_pubkey(void)
                 wc_FreeRng(&rng);
             }
 
+            dp = draftDer;
             ExpectNotNull(pkey = wolfSSL_d2i_PrivateKey(
                 WC_EVP_PKEY_DILITHIUM, NULL, &dp, (long)draftDerSz));
             ExpectIntEQ(wolfSSL_X509_set_pubkey(x509, pkey),
@@ -579,6 +593,7 @@ int test_wolfSSL_X509_set_pubkey(void)
             pubkey = NULL;
             wolfSSL_EVP_PKEY_free(pkey);
             pkey = NULL;
+            XFREE(draftDer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
     #endif /* WOLFSSL_MLDSA_FIPS204_DRAFT */
     }

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -403,6 +403,66 @@ int test_wolfSSL_X509_set_pubkey(void)
     }
 #endif /* WOLFSSL_HAVE_MLDSA */
 
+#if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+    defined(WOLFSSL_MLDSA_PUBLIC_KEY) && !defined(WOLFSSL_MLDSA_NO_ASN1) && \
+    defined(WC_ENABLE_ASYM_KEY_EXPORT) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_BIO) && !defined(WOLFSSL_NO_ML_DSA_87) && \
+    !defined(NO_RSA) && defined(USE_CERT_BUFFERS_2048) && \
+    defined(WOLFSSL_CERT_GEN) && !defined(NO_PWDBASED)
+    {
+        /* Classic-signed certificate carrying a large ML-DSA-87 subject
+         * public key: the DER buffer must be sized for the subject SPKI
+         * even though the signing key is RSA. */
+        WOLFSSL_X509* cx = NULL;
+        WOLFSSL_EVP_PKEY* mldsaKey = NULL;
+        WOLFSSL_EVP_PKEY* rsaKey = NULL;
+        WOLFSSL_EVP_PKEY* pub = NULL;
+        WOLFSSL_X509_NAME* name = NULL;
+        WOLFSSL_BIO* bio = NULL;
+        const unsigned char* p = client_key_der_2048;
+
+        ExpectNotNull(bio = wolfSSL_BIO_new_file(
+            "./certs/mldsa/mldsa87-key.pem", "rb"));
+        ExpectNotNull(mldsaKey = wolfSSL_PEM_read_bio_PrivateKey(bio, NULL,
+            NULL, NULL));
+        wolfSSL_BIO_free(bio);
+        bio = NULL;
+        ExpectNotNull(rsaKey = wolfSSL_d2i_PrivateKey(EVP_PKEY_RSA, NULL, &p,
+            (long)sizeof_client_key_der_2048));
+
+        ExpectNotNull(cx = wolfSSL_X509_new());
+        ExpectNotNull(name = wolfSSL_X509_NAME_new());
+        ExpectIntEQ(wolfSSL_X509_NAME_add_entry_by_txt(name, "CN",
+            MBSTRING_UTF8, (const byte*)"mldsa87-subject", -1, -1, 0),
+            WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_X509_set_subject_name(cx, name), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_X509_set_issuer_name(cx, name), WOLFSSL_SUCCESS);
+        wolfSSL_X509_NAME_free(name);
+        ExpectIntEQ(wolfSSL_X509_set_pubkey(cx, mldsaKey), WOLFSSL_SUCCESS);
+
+        ExpectIntGT(wolfSSL_X509_sign(cx, rsaKey, wolfSSL_EVP_sha256()), 0);
+
+        /* Subject public key kept its type; signature checks out with the
+         * RSA issuer key. */
+        ExpectNotNull(pub = wolfSSL_X509_get_pubkey(cx));
+        ExpectIntEQ(wolfSSL_EVP_PKEY_id(pub), WC_EVP_PKEY_DILITHIUM);
+        wolfSSL_EVP_PKEY_free(pub);
+        pub = NULL;
+        {
+            const unsigned char* pp = client_keypub_der_2048;
+            ExpectNotNull(pub = wolfSSL_d2i_PUBKEY(NULL, &pp,
+                (long)sizeof_client_keypub_der_2048));
+            ExpectIntEQ(wolfSSL_X509_verify(cx, pub), WOLFSSL_SUCCESS);
+            wolfSSL_EVP_PKEY_free(pub);
+            pub = NULL;
+        }
+
+        wolfSSL_EVP_PKEY_free(rsaKey);
+        wolfSSL_EVP_PKEY_free(mldsaKey);
+        wolfSSL_X509_free(cx);
+    }
+#endif /* classic-signed cert with ML-DSA-87 subject key */
+
     wolfSSL_X509_free(x509);
 #endif
     return EXPECT_RESULT();

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -510,7 +510,7 @@ int test_wolfSSL_X509_set_pubkey(void)
                 int keyRet = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
                 ExpectNotNull(pubDer = (byte*)XMALLOC(
-                    MLDSA_MAX_PUB_KEY_SIZE + 64, NULL,
+                    MLDSA_MAX_PUB_KEY_DER_SIZE, NULL,
                     DYNAMIC_TYPE_TMP_BUFFER));
                 ExpectNotNull(rawKey = (wc_MlDsaKey*)XMALLOC(sizeof(*rawKey),
                     NULL, DYNAMIC_TYPE_TMP_BUFFER));
@@ -521,7 +521,7 @@ int test_wolfSSL_X509_set_pubkey(void)
                     (word32)derSz, &kidx), 0);
                 if (EXPECT_SUCCESS() &&
                         wc_MlDsaKey_PublicKeyToDer(rawKey, pubDer,
-                            MLDSA_MAX_PUB_KEY_SIZE + 64, 1) > 0) {
+                            MLDSA_MAX_PUB_KEY_DER_SIZE, 1) > 0) {
                     expected = WOLFSSL_SUCCESS;
                 }
                 PRIVATE_KEY_LOCK();

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -396,6 +396,13 @@ int test_wolfSSL_X509_set_pubkey(void)
             ExpectIntEQ(wolfSSL_X509_verify(x509, pubkey), WOLFSSL_SUCCESS);
             wolfSSL_EVP_PKEY_free(pubkey);
             pubkey = NULL;
+
+            /* OpenSSL semantics: NULL md is valid for ML-DSA. */
+            ExpectIntGT(wolfSSL_X509_sign(x509, pkey, NULL), 0);
+            ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(x509));
+            ExpectIntEQ(wolfSSL_X509_verify(x509, pubkey), WOLFSSL_SUCCESS);
+            wolfSSL_EVP_PKEY_free(pubkey);
+            pubkey = NULL;
         }
     #endif
         wolfSSL_EVP_PKEY_free(pkey);
@@ -439,6 +446,9 @@ int test_wolfSSL_X509_set_pubkey(void)
         ExpectIntEQ(wolfSSL_X509_set_issuer_name(cx, name), WOLFSSL_SUCCESS);
         wolfSSL_X509_NAME_free(name);
         ExpectIntEQ(wolfSSL_X509_set_pubkey(cx, mldsaKey), WOLFSSL_SUCCESS);
+
+        /* NULL md is still rejected for a hash-based signing key. */
+        ExpectIntEQ(wolfSSL_X509_sign(cx, rsaKey, NULL), WOLFSSL_FAILURE);
 
         ExpectIntGT(wolfSSL_X509_sign(cx, rsaKey, wolfSSL_EVP_sha256()), 0);
 

--- a/tests/api/test_x509.c
+++ b/tests/api/test_x509.c
@@ -1146,3 +1146,67 @@ int test_x509_ReqCertFromX509_ext_critical(void)
 #endif
     return EXPECT_RESULT();
 }
+
+/* Sign a certificate request with an ML-DSA key through the compat layer
+ * (wolfSSL_X509_REQ_sign), round-trip it through DER and verify the
+ * signature with the public key recovered from the parsed request. The
+ * REQ path sizes its DER buffer with WC_DECLARE_VAR/WC_MAX_X509_GEN,
+ * separately from wolfSSL_X509_sign, so it needs its own coverage. */
+int test_x509_REQ_sign_mldsa(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_CERT_REQ) && defined(WOLFSSL_CERT_GEN) && \
+    (defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)) && \
+    defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+    defined(WOLFSSL_MLDSA_PUBLIC_KEY) && !defined(WOLFSSL_MLDSA_NO_ASN1) && \
+    !defined(WOLFSSL_MLDSA_NO_SIGN) && !defined(WOLFSSL_MLDSA_NO_VERIFY) && \
+    defined(WC_ENABLE_ASYM_KEY_EXPORT) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_BIO) && !defined(NO_PWDBASED) && !defined(WOLFSSL_NO_ML_DSA_44)
+
+    WOLFSSL_BIO*       bio    = NULL;
+    WOLFSSL_EVP_PKEY*  pkey   = NULL;
+    WOLFSSL_EVP_PKEY*  pubkey = NULL;
+    WOLFSSL_X509*      req    = NULL;
+    WOLFSSL_X509*      parsed = NULL;
+    WOLFSSL_X509_NAME* name   = NULL;
+    unsigned char*     der    = NULL;
+    int                derSz  = 0;
+
+    ExpectNotNull(bio = wolfSSL_BIO_new_file(
+        "./certs/mldsa/mldsa44-key.pem", "rb"));
+    ExpectNotNull(pkey = wolfSSL_PEM_read_bio_PrivateKey(bio, NULL, NULL,
+        NULL));
+    wolfSSL_BIO_free(bio);
+    bio = NULL;
+
+    ExpectNotNull(req = wolfSSL_X509_REQ_new());
+    ExpectNotNull(name = wolfSSL_X509_NAME_new());
+    ExpectIntEQ(wolfSSL_X509_NAME_add_entry_by_txt(name, "commonName",
+        MBSTRING_UTF8, (const byte*)"mldsa-req", -1, -1, 0), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_X509_REQ_set_subject_name(req, name), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_X509_REQ_set_pubkey(req, pkey), WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(wolfSSL_X509_REQ_sign(req, pkey, wolfSSL_EVP_sha256()),
+        WOLFSSL_SUCCESS);
+
+    /* Round-trip the signed request through DER to prove the encoding is a
+     * complete, parseable CSR (an ML-DSA signature does not fit the old
+     * fixed 2048-byte buffer). */
+    ExpectIntGT((derSz = wolfSSL_i2d_X509_REQ(req, &der)), 0);
+    ExpectNotNull(der);
+    ExpectNotNull(parsed = wolfSSL_X509_REQ_d2i(NULL, der, derSz));
+
+    /* Verify the signature with the public key from the parsed request. */
+    ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(parsed));
+    ExpectIntEQ(wolfSSL_EVP_PKEY_id(pubkey), WC_EVP_PKEY_DILITHIUM);
+    ExpectIntEQ(wolfSSL_X509_REQ_verify(parsed, pubkey), WOLFSSL_SUCCESS);
+
+    wolfSSL_EVP_PKEY_free(pubkey);
+    wolfSSL_X509_free(parsed);
+    XFREE(der, NULL, DYNAMIC_TYPE_OPENSSL);
+    wolfSSL_X509_NAME_free(name);
+    wolfSSL_X509_free(req);
+    wolfSSL_EVP_PKEY_free(pkey);
+#endif
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_x509.c
+++ b/tests/api/test_x509.c
@@ -1202,6 +1202,9 @@ int test_x509_REQ_sign_mldsa(void)
     ExpectIntEQ(wolfSSL_EVP_PKEY_id(pubkey), WC_EVP_PKEY_DILITHIUM);
     ExpectIntEQ(wolfSSL_X509_REQ_verify(parsed, pubkey), WOLFSSL_SUCCESS);
 
+    /* OpenSSL semantics: NULL md is valid for ML-DSA. */
+    ExpectIntEQ(wolfSSL_X509_REQ_sign(req, pkey, NULL), WOLFSSL_SUCCESS);
+
     wolfSSL_EVP_PKEY_free(pubkey);
     wolfSSL_X509_free(parsed);
     XFREE(der, NULL, DYNAMIC_TYPE_OPENSSL);

--- a/tests/api/test_x509.c
+++ b/tests/api/test_x509.c
@@ -1172,45 +1172,68 @@ int test_x509_REQ_sign_mldsa(void)
     WOLFSSL_X509_NAME* name   = NULL;
     unsigned char*     der    = NULL;
     int                derSz  = 0;
+    /* ML-DSA-87 (4627-byte signature) is what motivates the enlarged DER
+     * buffers; cover every compiled-in level. */
+    static const char* keyFiles[] = {
+        "./certs/mldsa/mldsa44-key.pem",
+    #ifndef WOLFSSL_NO_ML_DSA_65
+        "./certs/mldsa/mldsa65-key.pem",
+    #endif
+    #ifndef WOLFSSL_NO_ML_DSA_87
+        "./certs/mldsa/mldsa87-key.pem",
+    #endif
+    };
+    size_t i;
 
-    ExpectNotNull(bio = wolfSSL_BIO_new_file(
-        "./certs/mldsa/mldsa44-key.pem", "rb"));
-    ExpectNotNull(pkey = wolfSSL_PEM_read_bio_PrivateKey(bio, NULL, NULL,
-        NULL));
-    wolfSSL_BIO_free(bio);
-    bio = NULL;
+    for (i = 0; i < sizeof(keyFiles) / sizeof(keyFiles[0]); i++) {
+        ExpectNotNull(bio = wolfSSL_BIO_new_file(keyFiles[i], "rb"));
+        ExpectNotNull(pkey = wolfSSL_PEM_read_bio_PrivateKey(bio, NULL, NULL,
+            NULL));
+        wolfSSL_BIO_free(bio);
+        bio = NULL;
 
-    ExpectNotNull(req = wolfSSL_X509_REQ_new());
-    ExpectNotNull(name = wolfSSL_X509_NAME_new());
-    ExpectIntEQ(wolfSSL_X509_NAME_add_entry_by_txt(name, "commonName",
-        MBSTRING_UTF8, (const byte*)"mldsa-req", -1, -1, 0), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_X509_REQ_set_subject_name(req, name), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_X509_REQ_set_pubkey(req, pkey), WOLFSSL_SUCCESS);
+        ExpectNotNull(req = wolfSSL_X509_REQ_new());
+        ExpectNotNull(name = wolfSSL_X509_NAME_new());
+        ExpectIntEQ(wolfSSL_X509_NAME_add_entry_by_txt(name, "commonName",
+            MBSTRING_UTF8, (const byte*)"mldsa-req", -1, -1, 0),
+            WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_X509_REQ_set_subject_name(req, name),
+            WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_X509_REQ_set_pubkey(req, pkey), WOLFSSL_SUCCESS);
 
-    ExpectIntEQ(wolfSSL_X509_REQ_sign(req, pkey, wolfSSL_EVP_sha256()),
-        WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_X509_REQ_sign(req, pkey, wolfSSL_EVP_sha256()),
+            WOLFSSL_SUCCESS);
 
-    /* Round-trip the signed request through DER to prove the encoding is a
-     * complete, parseable CSR (an ML-DSA signature does not fit the old
-     * fixed 2048-byte buffer). */
-    ExpectIntGT((derSz = wolfSSL_i2d_X509_REQ(req, &der)), 0);
-    ExpectNotNull(der);
-    ExpectNotNull(parsed = wolfSSL_X509_REQ_d2i(NULL, der, derSz));
+        /* Round-trip the signed request through DER to prove the encoding
+         * is a complete, parseable CSR (an ML-DSA signature does not fit
+         * the old fixed 2048-byte buffer). */
+        ExpectIntGT((derSz = wolfSSL_i2d_X509_REQ(req, &der)), 0);
+        ExpectNotNull(der);
+        ExpectNotNull(parsed = wolfSSL_X509_REQ_d2i(NULL, der, derSz));
 
-    /* Verify the signature with the public key from the parsed request. */
-    ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(parsed));
-    ExpectIntEQ(wolfSSL_EVP_PKEY_id(pubkey), WC_EVP_PKEY_DILITHIUM);
-    ExpectIntEQ(wolfSSL_X509_REQ_verify(parsed, pubkey), WOLFSSL_SUCCESS);
+        /* Verify the signature with the public key from the parsed
+         * request. */
+        ExpectNotNull(pubkey = wolfSSL_X509_get_pubkey(parsed));
+        ExpectIntEQ(wolfSSL_EVP_PKEY_id(pubkey), WC_EVP_PKEY_DILITHIUM);
+        ExpectIntEQ(wolfSSL_X509_REQ_verify(parsed, pubkey), WOLFSSL_SUCCESS);
 
-    /* OpenSSL semantics: NULL md is valid for ML-DSA. */
-    ExpectIntEQ(wolfSSL_X509_REQ_sign(req, pkey, NULL), WOLFSSL_SUCCESS);
+        /* OpenSSL semantics: NULL md is valid for ML-DSA. */
+        ExpectIntEQ(wolfSSL_X509_REQ_sign(req, pkey, NULL), WOLFSSL_SUCCESS);
 
-    wolfSSL_EVP_PKEY_free(pubkey);
-    wolfSSL_X509_free(parsed);
-    XFREE(der, NULL, DYNAMIC_TYPE_OPENSSL);
-    wolfSSL_X509_NAME_free(name);
-    wolfSSL_X509_free(req);
-    wolfSSL_EVP_PKEY_free(pkey);
+        wolfSSL_EVP_PKEY_free(pubkey);
+        pubkey = NULL;
+        wolfSSL_X509_free(parsed);
+        parsed = NULL;
+        XFREE(der, NULL, DYNAMIC_TYPE_OPENSSL);
+        der = NULL;
+        derSz = 0;
+        wolfSSL_X509_NAME_free(name);
+        name = NULL;
+        wolfSSL_X509_free(req);
+        req = NULL;
+        wolfSSL_EVP_PKEY_free(pkey);
+        pkey = NULL;
+    }
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_x509.c
+++ b/tests/api/test_x509.c
@@ -35,6 +35,7 @@
 #include <wolfssl/openssl/ssl.h>
 #include <wolfssl/openssl/x509.h>
 #include <wolfssl/openssl/x509v3.h>
+#include <wolfssl/openssl/pem.h>
 
 #include <wolfssl/internal.h>
 #include <wolfssl/wolfcrypt/asn.h>
@@ -1150,8 +1151,8 @@ int test_x509_ReqCertFromX509_ext_critical(void)
 /* Sign a certificate request with an ML-DSA key through the compat layer
  * (wolfSSL_X509_REQ_sign), round-trip it through DER and verify the
  * signature with the public key recovered from the parsed request. The
- * REQ path sizes its DER buffer with WC_DECLARE_VAR/WC_MAX_X509_GEN,
- * separately from wolfSSL_X509_sign, so it needs its own coverage. */
+ * REQ path sizes and allocates its DER buffer separately from
+ * wolfSSL_X509_sign, so it needs its own coverage. */
 int test_x509_REQ_sign_mldsa(void)
 {
     EXPECT_DECLS;

--- a/tests/api/test_x509.h
+++ b/tests/api/test_x509.h
@@ -31,6 +31,7 @@ int test_x509_CertFromX509_akid_overflow(void);
 int test_x509_ReqCertFromX509_skid_overflow(void);
 int test_x509_ReqCertFromX509_skid_boundary(void);
 int test_x509_ReqCertFromX509_ext_critical(void);
+int test_x509_REQ_sign_mldsa(void);
 
 #define TEST_X509_DECLS                                                        \
     TEST_DECL_GROUP("x509", test_x509_rfc2818_verification_callback),          \
@@ -41,6 +42,7 @@ int test_x509_ReqCertFromX509_ext_critical(void);
     TEST_DECL_GROUP("x509", test_x509_CertFromX509_akid_overflow),             \
     TEST_DECL_GROUP("x509", test_x509_ReqCertFromX509_skid_overflow),          \
     TEST_DECL_GROUP("x509", test_x509_ReqCertFromX509_skid_boundary),          \
-    TEST_DECL_GROUP("x509", test_x509_ReqCertFromX509_ext_critical)
+    TEST_DECL_GROUP("x509", test_x509_ReqCertFromX509_ext_critical),           \
+    TEST_DECL_GROUP("x509", test_x509_REQ_sign_mldsa)
 
 #endif /* WOLFCRYPT_TEST_X509_H */

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -9425,6 +9425,7 @@ static int PopulateRSAEvpPkeyDer(WOLFSSL_EVP_PKEY *pkey)
                     ForceZero(keyBuf, (word32)keySz);
                     XFREE(keyBuf, pkey->heap, DYNAMIC_TYPE_DER);
                     pkey->pkey.ptr = (char*)derBuf;
+                    pkey->pkey_sz  = (int)pkcs8Sz;
                 }
                 else {
                     /* The encoding is abandoned but keyBuf stays on the pkey,

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -9256,6 +9256,59 @@ static void clearEVPPkeyKeys(WOLFSSL_EVP_PKEY *pkey)
     }
     pkey->ownEcc = 0;
 #endif
+#ifdef HAVE_ED25519
+    if (pkey->ed25519 != NULL && pkey->ownEd25519 == 1) {
+        wc_ed25519_free(pkey->ed25519);
+        XFREE(pkey->ed25519, pkey->heap, DYNAMIC_TYPE_ED25519);
+        pkey->ed25519 = NULL;
+    }
+    pkey->ownEd25519 = 0;
+#endif
+#ifdef HAVE_ED448
+    if (pkey->ed448 != NULL && pkey->ownEd448 == 1) {
+        wc_ed448_free(pkey->ed448);
+        XFREE(pkey->ed448, pkey->heap, DYNAMIC_TYPE_ED448);
+        pkey->ed448 = NULL;
+    }
+    pkey->ownEd448 = 0;
+#endif
+#ifdef HAVE_CURVE25519
+    if (pkey->curve25519 != NULL && pkey->ownCurve25519 == 1) {
+        wc_curve25519_free(pkey->curve25519);
+        XFREE(pkey->curve25519, pkey->heap, DYNAMIC_TYPE_CURVE25519);
+        pkey->curve25519 = NULL;
+    }
+    pkey->ownCurve25519 = 0;
+#endif
+#ifdef HAVE_CURVE448
+    if (pkey->curve448 != NULL && pkey->ownCurve448 == 1) {
+        wc_curve448_free(pkey->curve448);
+        XFREE(pkey->curve448, pkey->heap, DYNAMIC_TYPE_CURVE448);
+        pkey->curve448 = NULL;
+    }
+    pkey->ownCurve448 = 0;
+#endif
+#ifdef HAVE_HKDF
+    XFREE(pkey->hkdfSalt, NULL, DYNAMIC_TYPE_SALT);
+    pkey->hkdfSalt = NULL;
+    if (pkey->hkdfKey != NULL && pkey->hkdfKeySz > 0) {
+        ForceZero(pkey->hkdfKey, pkey->hkdfKeySz);
+    }
+    XFREE(pkey->hkdfKey, NULL, DYNAMIC_TYPE_KEY);
+    pkey->hkdfKey = NULL;
+    XFREE(pkey->hkdfInfo, NULL, DYNAMIC_TYPE_INFO);
+    pkey->hkdfInfo = NULL;
+    pkey->hkdfSaltSz = 0;
+    pkey->hkdfKeySz = 0;
+    pkey->hkdfInfoSz = 0;
+#endif
+#if defined(WOLFSSL_CMAC) && defined(OPENSSL_EXTRA) && \
+    defined(WOLFSSL_AES_DIRECT)
+    if (pkey->cmacCtx != NULL) {
+        wolfSSL_CMAC_CTX_free(pkey->cmacCtx);
+        pkey->cmacCtx = NULL;
+    }
+#endif
 }
 
 #ifndef NO_RSA

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -1501,12 +1501,8 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey(int type, WOLFSSL_EVP_PKEY** out,
         }
     }
 
-    /* Dispose of any WOLFSSL_EVP_PKEY passed in. */
-    if (out != NULL && *out != NULL) {
-        wolfSSL_EVP_PKEY_free(*out);
-        *out = NULL;
-    }
-    /* Create a new WOLFSSL_EVP_PKEY and populate. */
+    /* Create a new WOLFSSL_EVP_PKEY and populate. Any WOLFSSL_EVP_PKEY
+     * passed in is replaced only on success. */
     local = wolfSSL_EVP_PKEY_new();
     if (local == NULL) {
         return NULL;
@@ -1631,6 +1627,8 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey(int type, WOLFSSL_EVP_PKEY** out,
             *in += local->pkey_sz;
         }
         if (out != NULL) {
+            /* Dispose of any WOLFSSL_EVP_PKEY passed in. */
+            wolfSSL_EVP_PKEY_free(*out);
             *out = local;
         }
     }

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -1490,6 +1490,14 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey(int type, WOLFSSL_EVP_PKEY** out,
                 return NULL;
             }
 
+        #ifdef WOLFSSL_HAVE_MLDSA
+            /* Keep the full PKCS#8 wrapper for ML-DSA so i2d retains the
+             * parameter set held in the AlgorithmIdentifier. */
+            if (type == WC_EVP_PKEY_DILITHIUM) {
+                pkcs8HeaderSz = 0;
+            }
+        #endif
+
             (void)idx; /* not used */
         }
         /* Ensure no error occurred try to remove any PKCS#8 header. */

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -1977,9 +1977,9 @@ WOLFSSL_PKCS8_PRIV_KEY_INFO* wolfSSL_d2i_PKCS8_PKEY(
                 (algId == DILITHIUM_LEVEL3k) ||
                 (algId == DILITHIUM_LEVEL5k) ||
             #endif
-                (algId == ML_DSA_LEVEL2k) ||
-                (algId == ML_DSA_LEVEL3k) ||
-                (algId == ML_DSA_LEVEL5k)) {
+                (algId == ML_DSA_44k) ||
+                (algId == ML_DSA_65k) ||
+                (algId == ML_DSA_87k)) {
 
                 /* Keep full PKCS#8 wrapper for level recovery from
                  * AlgorithmIdentifier parameters */

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -1032,13 +1032,15 @@ static int d2iTryFalconKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
  * @param [in]      priv   1 means private key, 0 means public key.
  * @param [in]      prePopulated  1 means *out already holds the input bytes
  *                         so the d2i_make_pkey allocate/copy is skipped.
+ * @param [in]      allowRaw  1 means size-keyed raw key bytes are accepted
+ *                         in addition to DER (auto-detect path only).
  * @return  1 on success.
  * @return  0 when input was recognized as this key type but
  *            object creation/import failed.
  * @return  WOLFSSL_FATAL_ERROR when input is not this key type.
  */
 static int d2iTryMlDsaKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
-    long memSz, int priv, int prePopulated)
+    long memSz, int priv, int prePopulated, int allowRaw)
 {
     static const byte levels[] = { WC_ML_DSA_44, WC_ML_DSA_65, WC_ML_DSA_87 };
     word32 inSz = (word32)memSz;
@@ -1063,8 +1065,9 @@ static int d2iTryMlDsaKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         return 0;
     }
 
-    /* Raw key bytes are size-keyed, try each level */
-    numLevels = (int)(sizeof(levels) / sizeof(levels[0]));
+    /* Raw key bytes are size-keyed, try each level. Only the auto-detect
+     * path accepts raw bytes; the typed d2i entry points are DER APIs. */
+    numLevels = allowRaw ? (int)(sizeof(levels) / sizeof(levels[0])) : 0;
     for (i = 0; i < numLevels && !isMlDsa; i++) {
         if (wc_MlDsaKey_SetParams(mldsa, levels[i]) != 0) {
             continue;
@@ -1226,7 +1229,7 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey_try(WOLFSSL_EVP_PKEY** out,
     else
 #endif /* HAVE_FALCON */
 #ifdef WOLFSSL_HAVE_MLDSA
-    if (d2iTryMlDsaKey(&pkey, *in, inSz, priv, 0) >= 0) {
+    if (d2iTryMlDsaKey(&pkey, *in, inSz, priv, 0, 1) >= 0) {
         found = 1;
     }
     else
@@ -1464,6 +1467,17 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey(int type, WOLFSSL_EVP_PKEY** out,
             #ifdef HAVE_ED448
                 || (type == WC_EVP_PKEY_ED448 && algId != ED448k)
             #endif
+            #ifdef WOLFSSL_HAVE_MLDSA
+                || (type == WC_EVP_PKEY_DILITHIUM &&
+                    algId != ML_DSA_44k && algId != ML_DSA_65k &&
+                    algId != ML_DSA_87k
+                #ifdef WOLFSSL_MLDSA_FIPS204_DRAFT
+                    && algId != DILITHIUM_LEVEL2k
+                    && algId != DILITHIUM_LEVEL3k
+                    && algId != DILITHIUM_LEVEL5k
+                #endif
+                   )
+            #endif
                 ) {
                 WOLFSSL_MSG("PKCS8 does not match EVP key type");
                 return NULL;
@@ -1592,7 +1606,7 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey(int type, WOLFSSL_EVP_PKEY** out,
 #if defined(WOLFSSL_HAVE_MLDSA)
         case WC_EVP_PKEY_DILITHIUM:
             /* local already holds the input bytes: prePopulated=1. */
-            if (d2iTryMlDsaKey(&local, p, local->pkey_sz, priv, 1) != 1) {
+            if (d2iTryMlDsaKey(&local, p, local->pkey_sz, priv, 1, 0) != 1) {
                 wolfSSL_EVP_PKEY_free(local);
                 return NULL;
             }

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -55,6 +55,8 @@ static int d2i_make_pkey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
     int prevSz = 0;
     int ret = 1;
 
+    (void)priv;
+
     /* Get or create the EVP PKEY object. */
     if (*out != NULL) {
         pkey = *out;
@@ -92,21 +94,12 @@ static int d2i_make_pkey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         }
     }
 
-    /* Release key data held from a previous decode when the caller reuses
-     * an EVP PKEY object. It may hold private key material. */
-    if (pkey->pkey.ptr != NULL) {
-        if (pkey->pkey_sz > 0) {
-            ForceZero(pkey->pkey.ptr, (word32)pkey->pkey_sz);
-        }
-        XFREE(pkey->pkey.ptr, pkey->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-        pkey->pkey.ptr = NULL;
-    }
-
-    /* Set the size and allocate memory for key data to be copied into. */
+    /* Set the size and allocate memory for key data to be copied into.
+     * Heap hint and DYNAMIC_TYPE must match the frees of pkey.ptr. */
     pkey->pkey_sz = (int)memSz;
     if (memSz > 0) {
         pkey->pkey.ptr = (char*)XMALLOC((size_t)memSz, pkey->heap,
-            priv ? DYNAMIC_TYPE_PRIVATE_KEY : DYNAMIC_TYPE_PUBLIC_KEY);
+            DYNAMIC_TYPE_PUBLIC_KEY);
         if (pkey->pkey.ptr == NULL) {
             /* No encoding held - do not describe one. */
             pkey->pkey_sz = 0;
@@ -122,8 +115,7 @@ static int d2i_make_pkey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         if (prevSz > 0) {
             ForceZero(prevData, (word32)prevSz);
         }
-        XFREE(prevData, pkey->heap,
-            priv ? DYNAMIC_TYPE_PRIVATE_KEY : DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(prevData, pkey->heap, DYNAMIC_TYPE_PUBLIC_KEY);
     }
     if (ret == 1) {
         /* Set key type passed in and return object. */
@@ -707,7 +699,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_raw_private_key(int type,
         return NULL;
     }
 
-    pkey->pkey.ptr = (char*)XMALLOC(len, pkey->heap, DYNAMIC_TYPE_PRIVATE_KEY);
+    pkey->pkey.ptr = (char*)XMALLOC(len, pkey->heap, DYNAMIC_TYPE_PUBLIC_KEY);
     if (pkey->pkey.ptr == NULL) {
         wolfSSL_EVP_PKEY_free(pkey);
         return NULL;

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -292,10 +292,12 @@ static int d2iTryEccKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
  * @return  1 on success.
  * @return  0 when input was recognized as this key type but object
  *            creation/import failed.
+ * @param [in]      prePopulated  1 means *out already holds the input bytes
+ *                         so the d2i_make_pkey allocate/copy is skipped.
  * @return  WOLFSSL_FATAL_ERROR when input is not this key type.
  */
 static int d2iTryEd25519Key(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
-    long memSz, int priv)
+    long memSz, int priv, int prePopulated)
 {
     ed25519_key* edKey = NULL;
     word32 keyIdx = 0;
@@ -328,10 +330,10 @@ static int d2iTryEd25519Key(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         return WOLFSSL_FATAL_ERROR;
     }
 
-    /* Create an EVP PKEY object holding the input DER bytes. If the caller
-     * already populated the EVP PKEY with the input bytes (pkey.ptr set),
-     * skip the allocate/copy. */
-    if (*out == NULL || (*out)->pkey.ptr == NULL) {
+    /* Copy the consumed DER into pkey->pkey.ptr, unless the caller
+     * pre-filled the EVP PKEY with the input bytes (d2i_evp_pkey()).
+     * A reused key must be re-populated here. */
+    if (!prePopulated) {
         ret = d2i_make_pkey(out, mem, keyIdx, priv, WC_EVP_PKEY_ED25519);
     }
     if (ret == 1) {
@@ -358,10 +360,12 @@ static int d2iTryEd25519Key(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
  * @return  1 on success.
  * @return  0 when input was recognized as this key type but object
  *            creation/import failed.
+ * @param [in]      prePopulated  1 means *out already holds the input bytes
+ *                         so the d2i_make_pkey allocate/copy is skipped.
  * @return  WOLFSSL_FATAL_ERROR when input is not this key type.
  */
 static int d2iTryEd448Key(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
-    long memSz, int priv)
+    long memSz, int priv, int prePopulated)
 {
     ed448_key* edKey = NULL;
     word32 keyIdx = 0;
@@ -394,10 +398,10 @@ static int d2iTryEd448Key(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         return WOLFSSL_FATAL_ERROR;
     }
 
-    /* Create an EVP PKEY object holding the input DER bytes. If the caller
-     * already populated the EVP PKEY with the input bytes (pkey.ptr set),
-     * skip the allocate/copy. */
-    if (*out == NULL || (*out)->pkey.ptr == NULL) {
+    /* Copy the consumed DER into pkey->pkey.ptr, unless the caller
+     * pre-filled the EVP PKEY with the input bytes (d2i_evp_pkey()).
+     * A reused key must be re-populated here. */
+    if (!prePopulated) {
         ret = d2i_make_pkey(out, mem, keyIdx, priv, WC_EVP_PKEY_ED448);
     }
     if (ret == 1) {
@@ -1214,13 +1218,13 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey_try(WOLFSSL_EVP_PKEY** out,
 #endif /* !NO_DH &&  OPENSSL_EXTRA && WOLFSSL_DH_EXTRA */
 
 #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
-    if (d2iTryEd25519Key(&pkey, *in, inSz, priv) >= 0) {
+    if (d2iTryEd25519Key(&pkey, *in, inSz, priv, 0) >= 0) {
         found = 1;
     }
     else
 #endif /* HAVE_ED25519 && HAVE_ED25519_KEY_IMPORT */
 #if defined(HAVE_ED448) && defined(HAVE_ED448_KEY_IMPORT)
-    if (d2iTryEd448Key(&pkey, *in, inSz, priv) >= 0) {
+    if (d2iTryEd448Key(&pkey, *in, inSz, priv, 0) >= 0) {
         found = 1;
     }
     else
@@ -1588,10 +1592,8 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey(int type, WOLFSSL_EVP_PKEY** out,
 #endif /* WOLFSSL_QT || OPENSSL_ALL || WOLFSSL_OPENSSH */
 #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
         case WC_EVP_PKEY_ED25519:
-            /* local->pkey.ptr already holds the input bytes, so
-             * d2iTryEd25519Key will skip the d2i_make_pkey allocate/copy
-             * and just decode into local->ed25519. */
-            if (d2iTryEd25519Key(&local, p, local->pkey_sz, priv) != 1) {
+            /* local already holds the input bytes: prePopulated=1. */
+            if (d2iTryEd25519Key(&local, p, local->pkey_sz, priv, 1) != 1) {
                 wolfSSL_EVP_PKEY_free(local);
                 return NULL;
             }
@@ -1600,7 +1602,7 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey(int type, WOLFSSL_EVP_PKEY** out,
 #if defined(HAVE_ED448) && defined(HAVE_ED448_KEY_IMPORT)
         case WC_EVP_PKEY_ED448:
             /* See WC_EVP_PKEY_ED25519 case above. */
-            if (d2iTryEd448Key(&local, p, local->pkey_sz, priv) != 1) {
+            if (d2iTryEd448Key(&local, p, local->pkey_sz, priv, 1) != 1) {
                 wolfSSL_EVP_PKEY_free(local);
                 return NULL;
             }

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -72,7 +72,9 @@ static int d2i_make_pkey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         clearEVPPkeyKeys(pkey);
     #endif
         /* Drop metadata describing the key this object held before, so a
-         * reused object decodes to the same state as a new one. */
+         * reused object decodes to the same state as a new one. A failure
+         * below must not leave the object advertising the old type. */
+        pkey->type = WC_EVP_PKEY_NONE;
         pkey->pkcs8HeaderSz = 0;
         pkey->save_type = 0;
     #ifdef HAVE_ECC

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -1118,8 +1118,13 @@ static int d2iTryMlDsaKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         return WOLFSSL_FATAL_ERROR;
     }
 
-    /* Copy the consumed DER into pkey->pkey.ptr when the input was DER */
-    ret = d2i_make_pkey(out, mem, keyIdx, priv, WC_EVP_PKEY_DILITHIUM);
+    /* Copy the consumed DER into pkey->pkey.ptr when the input was DER.
+     * If the caller already populated the EVP PKEY with the input bytes
+     * (pkey.ptr set), skip the allocate/copy. */
+    ret = 1;
+    if ((out == NULL) || (*out == NULL) || ((*out)->pkey.ptr == NULL)) {
+        ret = d2i_make_pkey(out, mem, keyIdx, priv, WC_EVP_PKEY_DILITHIUM);
+    }
     if ((ret == 1) && (out != NULL) && (*out != NULL) && (oidSum != 0)) {
         WOLFSSL_ATOMIC_STORE((*out)->mldsaOID, oidSum);
     }
@@ -1575,6 +1580,15 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey(int type, WOLFSSL_EVP_PKEY** out,
             }
             break;
 #endif /* HAVE_ED448 */
+#if defined(WOLFSSL_HAVE_MLDSA)
+        case WC_EVP_PKEY_DILITHIUM:
+            /* See WC_EVP_PKEY_ED25519 case above. */
+            if (d2iTryMlDsaKey(&local, p, local->pkey_sz, priv) != 1) {
+                wolfSSL_EVP_PKEY_free(local);
+                return NULL;
+            }
+            break;
+#endif /* WOLFSSL_HAVE_MLDSA */
         default:
             WOLFSSL_MSG("Unsupported key type");
             wolfSSL_EVP_PKEY_free(local);

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -90,6 +90,13 @@ static int d2i_make_pkey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         }
     }
 
+    /* Release key data held from a previous decode when the caller reuses
+     * an EVP PKEY object. */
+    if (pkey->pkey.ptr != NULL) {
+        XFREE(pkey->pkey.ptr, pkey->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        pkey->pkey.ptr = NULL;
+    }
+
     /* Set the size and allocate memory for key data to be copied into. */
     pkey->pkey_sz = (int)memSz;
     if (memSz > 0) {
@@ -1023,13 +1030,15 @@ static int d2iTryFalconKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
  * @param [in]      mem    Memory containing key data.
  * @param [in]      memSz  Size of key data in bytes.
  * @param [in]      priv   1 means private key, 0 means public key.
+ * @param [in]      prePopulated  1 means *out already holds the input bytes
+ *                         so the d2i_make_pkey allocate/copy is skipped.
  * @return  1 on success.
  * @return  0 when input was recognized as this key type but
  *            object creation/import failed.
  * @return  WOLFSSL_FATAL_ERROR when input is not this key type.
  */
 static int d2iTryMlDsaKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
-    long memSz, int priv)
+    long memSz, int priv, int prePopulated)
 {
     static const byte levels[] = { WC_ML_DSA_44, WC_ML_DSA_65, WC_ML_DSA_87 };
     word32 inSz = (word32)memSz;
@@ -1118,11 +1127,11 @@ static int d2iTryMlDsaKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         return WOLFSSL_FATAL_ERROR;
     }
 
-    /* Copy the consumed DER into pkey->pkey.ptr when the input was DER.
-     * If the caller already populated the EVP PKEY with the input bytes
-     * (pkey.ptr set), skip the allocate/copy. */
+    /* Copy the consumed DER into pkey->pkey.ptr, unless the caller
+     * pre-filled the EVP PKEY with the input bytes (d2i_evp_pkey()).
+     * A reused key must be re-populated here. */
     ret = 1;
-    if ((out == NULL) || (*out == NULL) || ((*out)->pkey.ptr == NULL)) {
+    if (!prePopulated) {
         ret = d2i_make_pkey(out, mem, keyIdx, priv, WC_EVP_PKEY_DILITHIUM);
     }
     if ((ret == 1) && (out != NULL) && (*out != NULL) && (oidSum != 0)) {
@@ -1217,7 +1226,7 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey_try(WOLFSSL_EVP_PKEY** out,
     else
 #endif /* HAVE_FALCON */
 #ifdef WOLFSSL_HAVE_MLDSA
-    if (d2iTryMlDsaKey(&pkey, *in, inSz, priv) >= 0) {
+    if (d2iTryMlDsaKey(&pkey, *in, inSz, priv, 0) >= 0) {
         found = 1;
     }
     else
@@ -1582,8 +1591,8 @@ static WOLFSSL_EVP_PKEY* d2i_evp_pkey(int type, WOLFSSL_EVP_PKEY** out,
 #endif /* HAVE_ED448 */
 #if defined(WOLFSSL_HAVE_MLDSA)
         case WC_EVP_PKEY_DILITHIUM:
-            /* See WC_EVP_PKEY_ED25519 case above. */
-            if (d2iTryMlDsaKey(&local, p, local->pkey_sz, priv) != 1) {
+            /* local already holds the input bytes: prePopulated=1. */
+            if (d2iTryMlDsaKey(&local, p, local->pkey_sz, priv, 1) != 1) {
                 wolfSSL_EVP_PKEY_free(local);
                 return NULL;
             }

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -289,11 +289,11 @@ static int d2iTryEccKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
  * @param [in]      mem    Memory containing key data.
  * @param [in]      memSz  Size of key data in bytes.
  * @param [in]      priv   1 means private key, 0 means public key.
+ * @param [in]      prePopulated  1 means *out already holds the input bytes
+ *                         so the d2i_make_pkey allocate/copy is skipped.
  * @return  1 on success.
  * @return  0 when input was recognized as this key type but object
  *            creation/import failed.
- * @param [in]      prePopulated  1 means *out already holds the input bytes
- *                         so the d2i_make_pkey allocate/copy is skipped.
  * @return  WOLFSSL_FATAL_ERROR when input is not this key type.
  */
 static int d2iTryEd25519Key(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
@@ -357,11 +357,11 @@ static int d2iTryEd25519Key(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
  * @param [in]      mem    Memory containing key data.
  * @param [in]      memSz  Size of key data in bytes.
  * @param [in]      priv   1 means private key, 0 means public key.
+ * @param [in]      prePopulated  1 means *out already holds the input bytes
+ *                         so the d2i_make_pkey allocate/copy is skipped.
  * @return  1 on success.
  * @return  0 when input was recognized as this key type but object
  *            creation/import failed.
- * @param [in]      prePopulated  1 means *out already holds the input bytes
- *                         so the d2i_make_pkey allocate/copy is skipped.
  * @return  WOLFSSL_FATAL_ERROR when input is not this key type.
  */
 static int d2iTryEd448Key(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -91,8 +91,11 @@ static int d2i_make_pkey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
     }
 
     /* Release key data held from a previous decode when the caller reuses
-     * an EVP PKEY object. */
+     * an EVP PKEY object. It may hold private key material. */
     if (pkey->pkey.ptr != NULL) {
+        if (pkey->pkey_sz > 0) {
+            ForceZero(pkey->pkey.ptr, (word32)pkey->pkey_sz);
+        }
         XFREE(pkey->pkey.ptr, pkey->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         pkey->pkey.ptr = NULL;
     }


### PR DESCRIPTION
# Description

 wolfSSL_PEM_read_bio_PrivateKey
 wolfSSL_PEM_read_PrivateKey
wolfSSL_d2i_PrivateKey, wolfSSL_d2i_PublicKey
 wolfSSL_X509_sign
wolfSSL_X509_REQ_sign
wolfSSL_X509_set_pubkey

Fixes zd#22151

# Testing

Added test_wolfSSL_PEM_PrivateKey_mldsa
Added ML-DSA cases in test_wolfSSL_X509_set_pubkey

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
