### PR TITLE
ssl: fix miscellaneous issues found in review.

### DIFF
--- a/src/ssl_api_cert.c
+++ b/src/ssl_api_cert.c
@@ -2836,6 +2836,11 @@ static WOLF_STACK_OF(WOLFSSL_X509)* CreatePeerCertChain(const WOLFSSL* ssl,
         return NULL;
 
     sk = wolfSSL_sk_X509_new_null();
+    if (sk == NULL) {
+        WOLFSSL_MSG("Error Creating sk");
+        return NULL;
+    }
+
     for (i = 0; i < ssl->session->chain.count; i++) {
         x509 = wolfSSL_X509_new_ex(ssl->heap);
         if (x509 == NULL) {

--- a/src/ssl_api_cert.c
+++ b/src/ssl_api_cert.c
@@ -2867,9 +2867,6 @@ static WOLF_STACK_OF(WOLFSSL_X509)* CreatePeerCertChain(const WOLFSSL* ssl,
         }
     }
 
-    if (sk == NULL) {
-        WOLFSSL_MSG("Null session chain");
-    }
     return sk;
 }
 

--- a/src/ssl_api_pk.c
+++ b/src/ssl_api_pk.c
@@ -2858,7 +2858,7 @@ int wolfSSL_CTX_set_dh_auto(WOLFSSL_CTX* ctx, int onoff)
                 WOLFSSL_MSG("wc_SrpSetPassword failed.");
                 return WOLFSSL_FAILURE;
             }
-            XFREE(ctx->srp_password, NULL, DYNAMIC_TYPE_SRP);
+            XFREE(ctx->srp_password, ctx->heap, DYNAMIC_TYPE_SRP);
             ctx->srp_password = NULL;
         } else {
             /* save password for wolfSSL_set_srp_username */

--- a/src/ssl_api_rw.c
+++ b/src/ssl_api_rw.c
@@ -583,7 +583,7 @@ int wolfSSL_recv(WOLFSSL* ssl, void* data, int sz, int flags)
 int wolfSSL_SendUserCanceled(WOLFSSL* ssl)
 {
     int ret = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
-    WOLFSSL_ENTER("wolfSSL_recv");
+    WOLFSSL_ENTER("wolfSSL_SendUserCanceled");
 
     if (ssl != NULL) {
         ssl->error = SendAlert(ssl, alert_warning, user_canceled);

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -5855,7 +5855,7 @@ int wc_OBJ_sn2nid(const char *sn)
     static int wolfssl_obj2txt_numeric(char *buf, int bufLen,
                                        const WOLFSSL_ASN1_OBJECT *a)
     {
-        int bufSz;
+        int    bufSz;
         int    length;
         word32 idx = 0;
         byte   tag;
@@ -5874,11 +5874,12 @@ int wc_OBJ_sn2nid(const char *sn)
             return ASN_PARSE_E;
         }
 
+        /* save an extra byte for null term. */
         if (bufLen < MAX_OID_STRING_SZ) {
             bufSz = bufLen - 1;
         }
         else {
-            bufSz = MAX_OID_STRING_SZ;
+            bufSz = MAX_OID_STRING_SZ - 1;
         }
 
         if ((bufSz = DecodePolicyOID(buf, (word32)bufSz, a->obj + idx,

--- a/src/ssl_crypto.c
+++ b/src/ssl_crypto.c
@@ -4015,6 +4015,8 @@ int wolfSSL_RAND_pseudo_bytes(unsigned char* buf, int num)
     hash = WC_SHA;
     #elif !defined(NO_MD5)
     hash = WC_MD5;
+    #else
+    #error "No PRF hash function available"
     #endif
 
     /* get secret value from source of entropy */
@@ -4029,6 +4031,7 @@ int wolfSSL_RAND_pseudo_bytes(unsigned char* buf, int num)
         PRIVATE_KEY_LOCK();
         ret = (ret == 0) ? WOLFSSL_SUCCESS: WOLFSSL_FAILURE;
     }
+    ForceZero(secret, sizeof(secret));
 #else
     /* fall back to just doing wolfSSL_RAND_bytes if PRF not avialbale */
     ret = wolfSSL_RAND_bytes(buf, num);
@@ -4202,6 +4205,7 @@ int wolfSSL_RAND_poll(void)
     }
 
     wc_UnLockMutex(&globalRNGMutex);
+    ForceZero(entropy, sizeof(entropy));
 
     return ret;
 }


### PR DESCRIPTION
## Description

Fixes some pre-existing issues found by copilot while reviewing another PR (https://github.com/wolfSSL/wolfssl/pull/10926).

- src/ssl_api_cert.c: add missing NULL check.
- src/ssl_api_pk.c: add missing heap hint pointer.
- src/ssl_api_rw.c: correct WOLFSSL_ENTER message.
- src/ssl_asn1.c: save byte for nul term (relevant when `bufLen == MAX_OID_STRING_SZ`).
- src/ssl_crypto.c:
  -  add `#else #error` clause if no hash function available.
  - add missing ForceZero for `secret` and `entropy`.

## Testing
multi-test:
  - all-c89-clang-tidy
  - linuxkm-fips-*-intelasm-LKCAPI-insmod

