### PR TITLE
GPLv2 license exception for Cisco Systems, Inc. use of wolfCrypt in U-Boot only

### DIFF
--- a/LICENSING
+++ b/LICENSING
@@ -23,6 +23,9 @@ RPCS3
 
 VDE - Virtual Distributed Ethernet
 
+U-Boot (from Cisco Systems, Inc. only)
+
+
 For our users who cannot use wolfSSL under GPLv3, a commercial license to
 wolfSSL and wolfCrypt is available.
 


### PR DESCRIPTION
Pairs with https://github.com/wolfSSL/wolfTPM/pull/557