### PR TITLE
DTLS: clear dtls_tx_msg cursor when its record is freed

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -9926,8 +9926,11 @@ void DtlsTxMsgListClean(WOLFSSL* ssl)
     WOLFSSL_ENTER("DtlsTxMsgListClean");
     while (head) {
         next = head->next;
-        if (VerifyForTxDtlsMsgDelete(ssl, head))
+        if (VerifyForTxDtlsMsgDelete(ssl, head)) {
+            if (ssl->dtls_tx_msg == head)
+                ssl->dtls_tx_msg = NULL;
             DtlsMsgDelete(head, ssl->heap);
+        }
         else
             /* Stored packets should be in order so break on first failed
              * verify */


### PR DESCRIPTION
## Summary
- \`DtlsTxMsgListClean()\` could free the record pointed to by \`ssl->dtls_tx_msg\` without clearing the cursor, leaving a dangling pointer.

## Test plan
- [ ] \`./commit-tests.sh\`