### PR TITLE
Fix TI port AES-CTR streaming and hashCopy correctness bugs

### DIFF
--- a/wolfcrypt/src/port/ti/ti-aes.c
+++ b/wolfcrypt/src/port/ti/ti-aes.c
@@ -251,6 +251,17 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
             aes->left = 0;
             XMEMSET(tmp, 0x0, WC_AES_BLOCK_SIZE);
         }
+        else if (odd > 0) {
+            /* buffered bytes do not fill a block: encrypt the partial block
+             * without advancing the counter, emit the new bytes, and keep
+             * the remaining buffered bytes for the next call */
+            ret = AesProcess(aes, (byte*)out_block, (byte const *)tmp, WC_AES_BLOCK_SIZE,
+                        AES_CFG_DIR_ENCRYPT, AES_CFG_MODE_CTR_NOCTR);
+            if (ret != 0)
+                return ret;
+            XMEMCPY(out, out_block+aes->left, odd);
+            aes->left += odd;
+        }
         in += odd;
         out+= odd;
         sz -= odd;

--- a/wolfcrypt/src/port/ti/ti-hash.c
+++ b/wolfcrypt/src/port/ti/ti-hash.c
@@ -127,10 +127,24 @@ static int hashCopy(wolfssl_TI_Hash *src, wolfssl_TI_Hash *dst)
 {
     if (src == NULL || dst == NULL)
         return BAD_FUNC_ARG;
-    /* only copy hash, zero the rest of the struct to avoid double-free */
+    if (src == dst)
+        return 0;
+    /* release any buffer dst already owns, then copy the accumulated message
+     * into a fresh buffer so each descriptor owns its own allocation and can
+     * be freed independently */
+    XFREE(dst->msg, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     dst->msg = NULL;
-    dst->used = 0;
-    dst->len = 0;
+    if ((src->msg != NULL) && (src->len > 0)) {
+        dst->msg = (byte*)XMALLOC(src->len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (dst->msg == NULL) {
+            dst->used = 0;
+            dst->len  = 0;
+            return MEMORY_E;
+        }
+        XMEMCPY(dst->msg, src->msg, src->len);
+    }
+    dst->used = src->used;
+    dst->len  = src->len;
     XMEMCPY(dst->hash, src->hash, sizeof(dst->hash));
     return 0;
 }


### PR DESCRIPTION
## Description

Fixes two bugs in the TI (TivaWare TM4C129 AES/SHA-MD5 hardware) port. Both silently produce wrong output rather than failing, and both trace to PR #7018.

### F-3078 - `wc_AesCtrEncrypt` drops partial streaming input (`wolfcrypt/src/port/ti/ti-aes.c`)

When AES-CTR is called in streaming fashion and a follow-up chunk does not complete the buffered block (`aes->left + sz < WC_AES_BLOCK_SIZE`), the leading carry-over branch buffered the new plaintext but never encrypted it, never wrote the caller's output, and never advanced `aes->left`. The caller saw uninitialized/stale output, and the next call overwrote the still-buffered bytes, silently losing plaintext. Fixed by adding the `else` path that mirrors the existing tail-handling block: encrypt the partial block with `AES_CFG_MODE_CTR_NOCTR` (no counter advance), emit the new bytes, and do `aes->left += odd`.

### F-2646 - `hashCopy` discards accumulated message (`wolfcrypt/src/port/ti/ti-hash.c`)

`hashCopy` zeroed `msg`/`used`/`len` and copied only the never-populated `hash` field, so a copied context finalized to the hash of an empty message instead of the source data. Affects `wc_Md5Copy`, `wc_ShaCopy`, `wc_Sha224Copy`, and `wc_Sha256Copy`. Fixed by allocating a fresh `dst->msg` and copying `src->len` bytes (independent allocation preserves the original anti-double-free intent), matching the reference `wc_Sha256Copy` in `devcrypto_hash.c`.
