### PR TITLE
CI: set ccache path so settings are saved on initial seed

### DIFF
--- a/.github/actions/ccache-setup/action.yml
+++ b/.github/actions/ccache-setup/action.yml
@@ -83,6 +83,13 @@ runs:
     - name: Configure ccache and PATH
       shell: bash
       run: |
+        # Set CCACHE_DIR for the commands below too, not only via
+        # GITHUB_ENV (which applies to later steps): without it the
+        # settings land in a different default dir on runs where
+        # ~/.ccache does not exist yet, and seed runs then compile
+        # with mismatched hash settings that later runs cannot reuse.
+        export CCACHE_DIR="$HOME/.ccache"
+        mkdir -p "$CCACHE_DIR"
         ccache -M "${{ inputs.max-size }}"
         # base_dir lets ccache reuse hits across different workspace
         # checkout paths (different runs use different /home/.../work/ dirs).

--- a/.github/actions/ccache-setup/action.yml
+++ b/.github/actions/ccache-setup/action.yml
@@ -108,7 +108,7 @@ runs:
           CCACHE_LIBEXEC="/usr/lib/ccache"
         fi
         echo "$CCACHE_LIBEXEC" >> "$GITHUB_PATH"
-        echo "CCACHE_DIR=$HOME/.ccache" >> "$GITHUB_ENV"
+        echo "CCACHE_DIR=$CCACHE_DIR" >> "$GITHUB_ENV"
 
     # On the scheduled (cron) refresh, force every compile to miss the
     # cache and re-store a fresh result (CCACHE_RECACHE still writes, it


### PR DESCRIPTION
# Description

Set the path prior to running `ccache --set-config` so that the settings end up in the right path on the first run (or after the weekly re-seed).

Prior to this change, the settings are saved to a different directory. Cache keys contain the settings, so the first run has incorrect keys. On subsequent loads, the cache is already restored and the keys are correct, but there are cache misses on this run unnecessarily.

Note this does not impact existing caches.

Found while adding `ccache` to wolfHSM.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
