### PR TITLE
SSL_get_cipher_list: enumerate the configured cipher list

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9305,12 +9305,9 @@ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
         if (ssl->suitesStack == NULL)
             return NULL;
 
-        /* higher priority of cipher suite will be on top of stack */
-#if defined(OPENSSL_ALL)
-        for (i = suites->suiteSz - 2; i >=0; i-=2)
-#else
-        for (i = 0; i < suites->suiteSz; i+=2)
-#endif
+        /* Walk lowest priority first: each suite is inserted at index 0, so
+         * the highest priority suite ends up on top of the stack. */
+        for (i = suites->suiteSz - 2; i >= 0; i -= 2)
         {
             struct WOLFSSL_CIPHER cipher;
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9355,6 +9355,49 @@ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
     }
     return ssl->suitesStack;
 }
+
+/* Get the name of the cipher at index priority in the cipher list configured
+ * on this SSL. Index 0 is the highest priority suite. Returns NULL once
+ * priority is past the end of the list. Matches OpenSSL SSL_get_cipher_list().
+ */
+const char* wolfSSL_get_cipher_list_compat(const WOLFSSL* ssl, int priority)
+{
+    const Suites* suites;
+    int i;
+    int idx = 0;
+
+    WOLFSSL_ENTER("wolfSSL_get_cipher_list_compat");
+
+    if (ssl == NULL || priority < 0)
+        return NULL;
+
+    suites = WOLFSSL_SUITES(ssl);
+    if (suites == NULL)
+        return NULL;
+
+    for (i = 0; i < suites->suiteSz; i += 2) {
+        /* A couple of suites are placeholders for special options, skip
+         * those. */
+        if (SCSV_Check(suites->suites[i], suites->suites[i+1])
+                || sslCipherMinMaxCheck(ssl, suites->suites[i],
+                                        suites->suites[i+1])) {
+            continue;
+        }
+
+        if (idx++ == priority) {
+            /* Report the same name that SSL_CIPHER_get_name() would. */
+        #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && \
+            !defined(NO_ERROR_STRINGS) && !defined(WOLFSSL_QT)
+            return GetCipherNameIana(suites->suites[i], suites->suites[i+1]);
+        #else
+            return wolfSSL_get_cipher_name_from_suite(suites->suites[i],
+                    suites->suites[i+1]);
+        #endif
+        }
+    }
+
+    return NULL;
+}
 #endif /* OPENSSL_EXTRA || OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY */
 #ifdef OPENSSL_ALL
 /* returned pointer is to an internal element in WOLFSSL struct and should not

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9029,6 +9029,49 @@ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
     }
     return ssl->suitesStack;
 }
+
+/* Get the name of the cipher at index priority in the cipher list configured
+ * on this SSL. Index 0 is the highest priority suite. Returns NULL once
+ * priority is past the end of the list. Matches OpenSSL SSL_get_cipher_list().
+ */
+const char* wolfSSL_get_cipher_list_compat(const WOLFSSL* ssl, int priority)
+{
+    const Suites* suites;
+    int i;
+    int idx = 0;
+
+    WOLFSSL_ENTER("wolfSSL_get_cipher_list_compat");
+
+    if (ssl == NULL || priority < 0)
+        return NULL;
+
+    suites = WOLFSSL_SUITES(ssl);
+    if (suites == NULL)
+        return NULL;
+
+    for (i = 0; i < suites->suiteSz; i += 2) {
+        /* A couple of suites are placeholders for special options, skip
+         * those. */
+        if (SCSV_Check(suites->suites[i], suites->suites[i+1])
+                || sslCipherMinMaxCheck(ssl, suites->suites[i],
+                                        suites->suites[i+1])) {
+            continue;
+        }
+
+        if (idx++ == priority) {
+            /* Report the same name that SSL_CIPHER_get_name() would. */
+        #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && \
+            !defined(NO_ERROR_STRINGS) && !defined(WOLFSSL_QT)
+            return GetCipherNameIana(suites->suites[i], suites->suites[i+1]);
+        #else
+            return wolfSSL_get_cipher_name_from_suite(suites->suites[i],
+                    suites->suites[i+1]);
+        #endif
+        }
+    }
+
+    return NULL;
+}
 #endif /* OPENSSL_EXTRA || OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY */
 #ifdef OPENSSL_ALL
 /* returned pointer is to an internal element in WOLFSSL struct and should not

--- a/tests/api.c
+++ b/tests/api.c
@@ -23082,6 +23082,46 @@ static int test_wolfSSL_get_ciphers_compat_empty(void)
     return EXPECT_RESULT();
 }
 
+/* SSL_get_cipher_list() walks the cipher list configured on the SSL, highest
+ * priority first, and returns NULL once past the end. No handshake has run
+ * here, so there is no negotiated suite to report. */
+static int test_wolfSSL_get_cipher_list_compat(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_TLS) && !defined(NO_WOLFSSL_CLIENT)
+    SSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    STACK_OF(SSL_CIPHER)* ciphers = NULL;
+    const char* name = NULL;
+    int num = 0;
+    int i;
+
+    ExpectNotNull(ctx = SSL_CTX_new(SSLv23_client_method()));
+    ExpectNotNull(ssl = SSL_new(ctx));
+
+    ExpectNull(SSL_get_cipher_list(NULL, 0));
+    ExpectNull(SSL_get_cipher_list(ssl, -1));
+
+    ExpectNotNull(name = SSL_get_cipher_list(ssl, 0));
+    ExpectStrNE(name, "None");
+
+    /* Must agree with the stack SSL_get_ciphers() returns, entry for entry. */
+    ExpectNotNull(ciphers = SSL_get_ciphers(ssl));
+    ExpectIntGT(num = sk_SSL_CIPHER_num(ciphers), 0);
+    for (i = 0; i < num; i++) {
+        ExpectNotNull(name = SSL_get_cipher_list(ssl, i));
+        ExpectStrEQ(name,
+            SSL_CIPHER_get_name(sk_SSL_CIPHER_value(ciphers, i)));
+    }
+
+    ExpectNull(SSL_get_cipher_list(ssl, num));
+
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 static int test_wolfSSL_CTX_ctrl(void)
 {
     EXPECT_DECLS;
@@ -40222,6 +40262,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_sk_CIPHER_description),
     TEST_DECL(test_wolfSSL_get_ciphers_compat),
     TEST_DECL(test_wolfSSL_get_ciphers_compat_empty),
+    TEST_DECL(test_wolfSSL_get_cipher_list_compat),
 
     TEST_DECL(test_wolfSSL_CTX_ctrl),
 #endif /* OPENSSL_ALL */

--- a/tests/api.c
+++ b/tests/api.c
@@ -18354,76 +18354,94 @@ static int test_wolfSSL_SSL_CIPHER_find(void)
     if (EXPECT_SUCCESS() && (wolfSSL_sk_SSL_CIPHER_num(sk) > 1)) {
         WOLFSSL* sslLtd = NULL;
         WOLF_STACK_OF(WOLFSSL_CIPHER)* skLtd = NULL;
-        const WOLFSSL_CIPHER* keep = wolfSSL_sk_SSL_CIPHER_value(sk, 0);
         const WOLFSSL_CIPHER* absent = NULL;
         unsigned char absentId[2] = { 0, 0 };
         int i;
 
-        ExpectNotNull(keep);
-        ExpectNotNull(sslLtd = wolfSSL_new(ctx));
-        if (keep != NULL) {
-            ExpectIntEQ(wolfSSL_set_cipher_list(sslLtd,
-                wolfSSL_CIPHER_get_name(keep)), WOLFSSL_SUCCESS);
-        }
-        ExpectNotNull(skLtd = wolfSSL_get_ciphers_compat(sslLtd));
         /* Restricting must really drop suites or the check below would be
-         * satisfied by the SSL's own list instead of the fallback. */
-        ExpectIntLT(wolfSSL_sk_SSL_CIPHER_num(skLtd),
-                    wolfSSL_sk_SSL_CIPHER_num(sk));
-
-        /* Find a suite the restricted SSL dropped. */
-        for (i = 0; EXPECT_SUCCESS() &&
+         * satisfied by the SSL's own list instead of the fallback. Naming a
+         * TLS 1.3 suite leaves the TLS 1.2 list alone, so the first suite is
+         * not always one that narrows anything - keep the first that does. */
+        for (i = 0; EXPECT_SUCCESS() && (skLtd == NULL) &&
                 (i < wolfSSL_sk_SSL_CIPHER_num(sk)); i++) {
-            const WOLFSSL_CIPHER* full = wolfSSL_sk_SSL_CIPHER_value(sk, i);
-            int inLtd = 0;
-            int j;
+            const WOLFSSL_CIPHER* keep = wolfSSL_sk_SSL_CIPHER_value(sk, i);
+            WOLF_STACK_OF(WOLFSSL_CIPHER)* skTry = NULL;
+            WOLFSSL* sslTry = NULL;
 
-            if (full == NULL)
+            if (keep == NULL)
                 continue;
-            for (j = 0; j < wolfSSL_sk_SSL_CIPHER_num(skLtd); j++) {
-                const WOLFSSL_CIPHER* ltd =
-                    wolfSSL_sk_SSL_CIPHER_value(skLtd, j);
+            ExpectNotNull(sslTry = wolfSSL_new(ctx));
+            ExpectIntEQ(wolfSSL_set_cipher_list(sslTry,
+                wolfSSL_CIPHER_get_name(keep)), WOLFSSL_SUCCESS);
+            ExpectNotNull(skTry = wolfSSL_get_ciphers_compat(sslTry));
+            if (EXPECT_SUCCESS() && (wolfSSL_sk_SSL_CIPHER_num(skTry) <
+                    wolfSSL_sk_SSL_CIPHER_num(sk))) {
+                sslLtd = sslTry;
+                skLtd = skTry;
+            }
+            else {
+                wolfSSL_free(sslTry);
+            }
+        }
 
-                if ((ltd != NULL) &&
-                        (ltd->cipherSuite0 == full->cipherSuite0) &&
-                        (ltd->cipherSuite == full->cipherSuite)) {
-                    inLtd = 1;
+        /* Builds whose whole suite list shares one name cannot express a
+         * narrower list, so there is nothing to look up here. */
+        if (EXPECT_SUCCESS() && (skLtd != NULL)) {
+            /* Find a suite the restricted SSL dropped. */
+            for (i = 0; EXPECT_SUCCESS() &&
+                    (i < wolfSSL_sk_SSL_CIPHER_num(sk)); i++) {
+                const WOLFSSL_CIPHER* full =
+                    wolfSSL_sk_SSL_CIPHER_value(sk, i);
+                int inLtd = 0;
+                int j;
+
+                if (full == NULL)
+                    continue;
+                for (j = 0; j < wolfSSL_sk_SSL_CIPHER_num(skLtd); j++) {
+                    const WOLFSSL_CIPHER* ltd =
+                        wolfSSL_sk_SSL_CIPHER_value(skLtd, j);
+
+                    if ((ltd != NULL) &&
+                            (ltd->cipherSuite0 == full->cipherSuite0) &&
+                            (ltd->cipherSuite == full->cipherSuite)) {
+                        inLtd = 1;
+                        break;
+                    }
+                }
+                if (!inLtd) {
+                    absentId[0] = full->cipherSuite0;
+                    absentId[1] = full->cipherSuite;
+                    absent = full;
                     break;
                 }
             }
-            if (!inLtd) {
-                absentId[0] = full->cipherSuite0;
-                absentId[1] = full->cipherSuite;
-                absent = full;
-                break;
-            }
-        }
-        ExpectNotNull(absent);
+            ExpectNotNull(absent);
 
-        ExpectNotNull(found = SSL_CIPHER_find(sslLtd, absentId));
-        if (found != NULL) {
-            ExpectIntEQ(found->cipherSuite0, absentId[0]);
-            ExpectIntEQ(found->cipherSuite,  absentId[1]);
-        }
+            ExpectNotNull(found = SSL_CIPHER_find(sslLtd, absentId));
+            if (found != NULL) {
+                ExpectIntEQ(found->cipherSuite0, absentId[0]);
+                ExpectIntEQ(found->cipherSuite,  absentId[1]);
+            }
 
 #ifdef OPENSSL_ALL
-        /* SSL_CIPHER_description(SSL_CIPHER_find(...)) must describe the suite
-         * that was looked up. Nothing has been negotiated, so a description
-         * taken from the session state would be empty. */
-        if ((found != NULL) && (absent != NULL)) {
-            char descFind[MAX_DESCRIPTION_SZ];
-            char descStack[MAX_DESCRIPTION_SZ];
+            /* SSL_CIPHER_description(SSL_CIPHER_find(...)) must describe the
+             * suite that was looked up. Nothing has been negotiated, so a
+             * description taken from the session state would be empty. */
+            if ((found != NULL) && (absent != NULL)) {
+                char descFind[MAX_DESCRIPTION_SZ];
+                char descStack[MAX_DESCRIPTION_SZ];
 
-            XMEMSET(descFind, 0, sizeof(descFind));
-            XMEMSET(descStack, 0, sizeof(descStack));
-            ExpectNotNull(SSL_CIPHER_description(absent, descStack,
-                (int)sizeof(descStack)));
-            ExpectNotNull(SSL_CIPHER_description(found, descFind,
-                (int)sizeof(descFind)));
-            ExpectStrEQ(descFind, descStack);
-            ExpectNull(XSTRSTR(descFind, "unknown"));
-        }
+                XMEMSET(descFind, 0, sizeof(descFind));
+                XMEMSET(descStack, 0, sizeof(descStack));
+                ExpectNotNull(SSL_CIPHER_description(absent, descStack,
+                    (int)sizeof(descStack)));
+                ExpectNotNull(SSL_CIPHER_description(found, descFind,
+                    (int)sizeof(descFind)));
+                ExpectStrEQ(descFind, descStack);
+                ExpectNull(XSTRSTR(descFind, "unknown"));
+            }
 #endif
+        }
 
         wolfSSL_free(sslLtd);
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -21877,6 +21877,46 @@ static int test_wolfSSL_get_ciphers_compat_empty(void)
     return EXPECT_RESULT();
 }
 
+/* SSL_get_cipher_list() walks the cipher list configured on the SSL, highest
+ * priority first, and returns NULL once past the end. No handshake has run
+ * here, so there is no negotiated suite to report. */
+static int test_wolfSSL_get_cipher_list_compat(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_TLS) && !defined(NO_WOLFSSL_CLIENT)
+    SSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    STACK_OF(SSL_CIPHER)* ciphers = NULL;
+    const char* name = NULL;
+    int num = 0;
+    int i;
+
+    ExpectNotNull(ctx = SSL_CTX_new(SSLv23_client_method()));
+    ExpectNotNull(ssl = SSL_new(ctx));
+
+    ExpectNull(SSL_get_cipher_list(NULL, 0));
+    ExpectNull(SSL_get_cipher_list(ssl, -1));
+
+    ExpectNotNull(name = SSL_get_cipher_list(ssl, 0));
+    ExpectStrNE(name, "None");
+
+    /* Must agree with the stack SSL_get_ciphers() returns, entry for entry. */
+    ExpectNotNull(ciphers = SSL_get_ciphers(ssl));
+    ExpectIntGT(num = sk_SSL_CIPHER_num(ciphers), 0);
+    for (i = 0; i < num; i++) {
+        ExpectNotNull(name = SSL_get_cipher_list(ssl, i));
+        ExpectStrEQ(name,
+            SSL_CIPHER_get_name(sk_SSL_CIPHER_value(ciphers, i)));
+    }
+
+    ExpectNull(SSL_get_cipher_list(ssl, num));
+
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 static int test_wolfSSL_CTX_ctrl(void)
 {
     EXPECT_DECLS;
@@ -38412,6 +38452,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_sk_CIPHER_description),
     TEST_DECL(test_wolfSSL_get_ciphers_compat),
     TEST_DECL(test_wolfSSL_get_ciphers_compat_empty),
+    TEST_DECL(test_wolfSSL_get_cipher_list_compat),
 
     TEST_DECL(test_wolfSSL_CTX_ctrl),
 #endif /* OPENSSL_ALL */

--- a/tests/api.c
+++ b/tests/api.c
@@ -23082,45 +23082,6 @@ static int test_wolfSSL_get_ciphers_compat_empty(void)
     return EXPECT_RESULT();
 }
 
-/* SSL_get_cipher_list() walks the cipher list configured on the SSL, highest
- * priority first, and returns NULL once past the end. No handshake has run
- * here, so there is no negotiated suite to report. */
-static int test_wolfSSL_get_cipher_list_compat(void)
-{
-    EXPECT_DECLS;
-#if !defined(NO_TLS) && !defined(NO_WOLFSSL_CLIENT)
-    SSL_CTX* ctx = NULL;
-    WOLFSSL* ssl = NULL;
-    STACK_OF(SSL_CIPHER)* ciphers = NULL;
-    const char* name = NULL;
-    int num = 0;
-    int i;
-
-    ExpectNotNull(ctx = SSL_CTX_new(SSLv23_client_method()));
-    ExpectNotNull(ssl = SSL_new(ctx));
-
-    ExpectNull(SSL_get_cipher_list(NULL, 0));
-    ExpectNull(SSL_get_cipher_list(ssl, -1));
-
-    ExpectNotNull(name = SSL_get_cipher_list(ssl, 0));
-    ExpectStrNE(name, "None");
-
-    /* Must agree with the stack SSL_get_ciphers() returns, entry for entry. */
-    ExpectNotNull(ciphers = SSL_get_ciphers(ssl));
-    ExpectIntGT(num = sk_SSL_CIPHER_num(ciphers), 0);
-    for (i = 0; i < num; i++) {
-        ExpectNotNull(name = SSL_get_cipher_list(ssl, i));
-        ExpectStrEQ(name,
-            SSL_CIPHER_get_name(sk_SSL_CIPHER_value(ciphers, i)));
-    }
-
-    ExpectNull(SSL_get_cipher_list(ssl, num));
-
-    SSL_free(ssl);
-    SSL_CTX_free(ctx);
-#endif
-    return EXPECT_RESULT();
-}
 
 static int test_wolfSSL_CTX_ctrl(void)
 {
@@ -23428,6 +23389,103 @@ static int test_wolfSSL_NCONF_negative_paths(void)
     return EXPECT_RESULT();
 }
 #endif /* OPENSSL_ALL */
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) || \
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+/* SSL_get_cipher_list() walks the cipher list configured on the SSL, highest
+ * priority first, and returns NULL once past the end. No handshake has run
+ * here, so there is no negotiated suite to report. */
+static int test_wolfSSL_get_cipher_list_compat(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_TLS) && !defined(NO_WOLFSSL_CLIENT)
+    SSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    const char* name = NULL;
+    int count = 0;
+
+    ExpectNotNull(ctx = SSL_CTX_new(SSLv23_client_method()));
+    ExpectNotNull(ssl = SSL_new(ctx));
+
+    ExpectNull(SSL_get_cipher_list(NULL, 0));
+    ExpectNull(SSL_get_cipher_list(ssl, -1));
+
+    ExpectNotNull(name = SSL_get_cipher_list(ssl, 0));
+    /* Sentinel differs between the IANA and short-name builds. */
+    ExpectStrNE(name, "None");
+    ExpectStrNE(name, "NONE");
+
+    /* Walk to the end of the list. */
+    while (EXPECT_SUCCESS() && SSL_get_cipher_list(ssl, count) != NULL)
+        count++;
+    ExpectIntGT(count, 0);
+    ExpectNull(SSL_get_cipher_list(ssl, count));
+
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY)
+    /* Must agree with the stack SSL_get_ciphers() returns, entry for entry. */
+    {
+        STACK_OF(SSL_CIPHER)* ciphers = NULL;
+        int num = 0;
+        int i;
+
+        ExpectNotNull(ciphers = SSL_get_ciphers(ssl));
+        ExpectIntEQ(num = sk_SSL_CIPHER_num(ciphers), count);
+        for (i = 0; i < num; i++) {
+            ExpectNotNull(name = SSL_get_cipher_list(ssl, i));
+            ExpectStrEQ(name,
+                SSL_CIPHER_get_name(sk_SSL_CIPHER_value(ciphers, i)));
+        }
+    }
+#endif
+
+    SSL_free(ssl);
+    ssl = NULL;
+
+    /* Masking every version filters out all suites, so priority 0 is NULL. */
+    ExpectNotNull(ssl = SSL_new(ctx));
+    wolfSSL_set_options(ssl, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 |
+        SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3);
+    ExpectNull(SSL_get_cipher_list(ssl, 0));
+
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* The list stays the configured suites after a handshake. The old
+ * SSL_get_cipher_list() reported the negotiated suite at priority 0. */
+static int test_wolfSSL_get_cipher_list_compat_after_handshake(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && !defined(NO_TLS) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
+    struct test_memio_ctx test_ctx;
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    const char* before = NULL;
+    const char* after = NULL;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+                    wolfSSLv23_client_method, wolfSSLv23_server_method), 0);
+
+    ExpectNotNull(before = SSL_get_cipher_list(ssl_c, 0));
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    ExpectNotNull(after = SSL_get_cipher_list(ssl_c, 0));
+    ExpectStrEQ(before, after);
+
+    /* More than one suite is still reachable after the handshake. */
+    ExpectNotNull(SSL_get_cipher_list(ssl_c, 1));
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
+#endif /* OPENSSL_EXTRA || OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY */
 
 static int test_wolfSSL_d2i_and_i2d_PublicKey(void)
 {
@@ -40262,10 +40320,14 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_sk_CIPHER_description),
     TEST_DECL(test_wolfSSL_get_ciphers_compat),
     TEST_DECL(test_wolfSSL_get_ciphers_compat_empty),
-    TEST_DECL(test_wolfSSL_get_cipher_list_compat),
 
     TEST_DECL(test_wolfSSL_CTX_ctrl),
 #endif /* OPENSSL_ALL */
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) || \
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+    TEST_DECL(test_wolfSSL_get_cipher_list_compat),
+    TEST_DECL(test_wolfSSL_get_cipher_list_compat_after_handshake),
+#endif
 #if (defined(OPENSSL_ALL) || defined(WOLFSSL_ASIO)) && !defined(NO_RSA)
     TEST_DECL(test_wolfSSL_CTX_use_certificate_ASN1),
 #endif /* (OPENSSL_ALL || WOLFSSL_ASIO) && !NO_RSA */

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -247,7 +247,8 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 
 #define SSL_get_client_random(ssl,out,outSz) \
                                   wolfSSL_get_client_random((ssl),(out),(outSz))
-#define SSL_get_cipher_list(ctx,i)         wolfSSL_get_cipher_list_ex((ctx),(i))
+#define SSL_get_cipher_list(ssl,i) \
+                                       wolfSSL_get_cipher_list_compat((ssl),(i))
 #define SSL_get_cipher_name(ctx)           wolfSSL_get_cipher((ctx))
 #define SSL_get_shared_ciphers(ctx,buf,len) \
                                    wolfSSL_get_shared_ciphers((ctx),(buf),(len))

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -247,8 +247,15 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 
 #define SSL_get_client_random(ssl,out,outSz) \
                                   wolfSSL_get_client_random((ssl),(out),(outSz))
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) || \
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
 #define SSL_get_cipher_list(ssl,i) \
                                        wolfSSL_get_cipher_list_compat((ssl),(i))
+#else
+/* wolfSSL_get_cipher_list_compat is only declared with the compat layer;
+ * fall back to the always-declared _ex form otherwise. */
+#define SSL_get_cipher_list(ssl,i)         wolfSSL_get_cipher_list_ex((ssl),(i))
+#endif
 #define SSL_get_cipher_name(ctx)           wolfSSL_get_cipher((ctx))
 #define SSL_get_shared_ciphers(ctx,buf,len) \
                                    wolfSSL_get_shared_ciphers((ctx),(buf),(len))

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -254,8 +254,15 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 
 #define SSL_get_client_random(ssl,out,outSz) \
                                   wolfSSL_get_client_random((ssl),(out),(outSz))
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) || \
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
 #define SSL_get_cipher_list(ssl,i) \
                                        wolfSSL_get_cipher_list_compat((ssl),(i))
+#else
+/* wolfSSL_get_cipher_list_compat is only declared with the compat layer;
+ * fall back to the always-declared _ex form otherwise. */
+#define SSL_get_cipher_list(ssl,i)         wolfSSL_get_cipher_list_ex((ssl),(i))
+#endif
 #define SSL_get_cipher_name(ctx)           wolfSSL_get_cipher((ctx))
 #define SSL_get_shared_ciphers(ctx,buf,len) \
                                    wolfSSL_get_shared_ciphers((ctx),(buf),(len))

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -254,7 +254,8 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 
 #define SSL_get_client_random(ssl,out,outSz) \
                                   wolfSSL_get_client_random((ssl),(out),(outSz))
-#define SSL_get_cipher_list(ctx,i)         wolfSSL_get_cipher_list_ex((ctx),(i))
+#define SSL_get_cipher_list(ssl,i) \
+                                       wolfSSL_get_cipher_list_compat((ssl),(i))
 #define SSL_get_cipher_name(ctx)           wolfSSL_get_cipher((ctx))
 #define SSL_get_shared_ciphers(ctx,buf,len) \
                                    wolfSSL_get_shared_ciphers((ctx),(buf),(len))

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1463,6 +1463,11 @@ WOLFSSL_API int  wolfSSL_set_write_fd (WOLFSSL* ssl, int fd);
 WOLFSSL_API int  wolfSSL_set_read_fd (WOLFSSL* ssl, int fd);
 WOLFSSL_API char* wolfSSL_get_cipher_list(int priority);
 WOLFSSL_API char* wolfSSL_get_cipher_list_ex(WOLFSSL* ssl, int priority);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) || \
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+WOLFSSL_API const char* wolfSSL_get_cipher_list_compat(const WOLFSSL* ssl,
+    int priority);
+#endif
 WOLFSSL_API int  wolfSSL_get_ciphers(char* buf, int len);
 WOLFSSL_API int wolfSSL_get_ciphers_iana(char* buf, int len);
 WOLFSSL_API const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1458,6 +1458,11 @@ WOLFSSL_API int  wolfSSL_set_write_fd (WOLFSSL* ssl, int fd);
 WOLFSSL_API int  wolfSSL_set_read_fd (WOLFSSL* ssl, int fd);
 WOLFSSL_API char* wolfSSL_get_cipher_list(int priority);
 WOLFSSL_API char* wolfSSL_get_cipher_list_ex(WOLFSSL* ssl, int priority);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) || \
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+WOLFSSL_API const char* wolfSSL_get_cipher_list_compat(const WOLFSSL* ssl,
+    int priority);
+#endif
 WOLFSSL_API int  wolfSSL_get_ciphers(char* buf, int len);
 WOLFSSL_API int wolfSSL_get_ciphers_iana(char* buf, int len);
 WOLFSSL_API const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);


### PR DESCRIPTION
`SSL_get_cipher_list()` was mapped to `wolfSSL_get_cipher_list_ex()`, which
only returned the negotiated cipher at index 0 and NULL for every other
index, so callers walking the list saw a single entry instead of the full
configured list as OpenSSL does.

`wolfSSL_get_cipher_list_ex()` had a fallback meant to enumerate the list,
but it was unreachable (it only triggers when the internal cipher name
lookup returns NULL, which hasn't happened since the lookup started
returning the literal "None" instead). Even if reached, it indexed the
global `cipher_names[]` table rather than the suites actually configured on
the SSL, so it wouldn't have matched OpenSSL's behavior anyway.

Add `wolfSSL_get_cipher_list_compat()` and point the `SSL_get_cipher_list`
macro at it instead. It walks `WOLFSSL_SUITES(ssl)` with the same SCSV and
min/max version filtering used by `wolfSSL_get_ciphers_compat()`, so
`SSL_get_cipher_list()` and `SSL_get_ciphers()` now report the same suites
in the same order, named the way `SSL_CIPHER_get_name()` does.
`wolfSSL_get_cipher_list_ex()` itself is left unchanged for direct callers.