### PR TITLE
Use atomics for write-dup mailbox state

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -879,6 +879,12 @@ static int DupSSL(WOLFSSL* dup, WOLFSSL* ssl)
         ssl->dupWrite = NULL;
         return BAD_MUTEX_E;
     }
+#ifdef WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX
+    wolfSSL_Atomic_Int_Init(&ssl->dupWrite->dupErr, 0);
+#ifdef WOLFSSL_TLS13
+    wolfSSL_Atomic_Int_Init(&ssl->dupWrite->keyUpdateRespond, 0);
+#endif
+#endif
 
     /* Pre-allocate any objects that can fail BEFORE performing destructive
      * state mutations on ssl, so an allocation failure cannot leave ssl
@@ -1042,6 +1048,12 @@ WOLFSSL* wolfSSL_write_dup(WOLFSSL* ssl)
 */
 int NotifyWriteSide(WOLFSSL* ssl, int err)
 {
+#ifdef WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX
+    WOLFSSL_ENTER("NotifyWriteSide");
+
+    WriteDupStoreError(ssl->dupWrite, err);
+    return 0;
+#else
     int ret;
 
     WOLFSSL_ENTER("NotifyWriteSide");
@@ -1053,6 +1065,7 @@ int NotifyWriteSide(WOLFSSL* ssl, int err)
     }
 
     return ret;
+#endif
 }
 
 

--- a/src/ssl_api_rw.c
+++ b/src/ssl_api_rw.c
@@ -70,6 +70,15 @@ static int wolfSSL_write_internal(WOLFSSL* ssl, const void* data, size_t sz)
      * with handling async data and other edge case errors. */
     if (ssl->dupWrite != NULL && ssl->error == 0) {
         int dupErr = 0;   /* local copy */
+#ifdef WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX
+        dupErr = WriteDupLoadError(ssl->dupWrite);
+#ifdef WOLFSSL_TLS13
+        if (IsAtLeastTLSv1_3(ssl->version)) {
+            ssl->keys.keyUpdateRespond |=
+                WriteDupTakeKeyUpdate(ssl->dupWrite);
+        }
+#endif /* WOLFSSL_TLS13 */
+#else
         /* Lock ssl->dupWrite to gather what needs to be done. */
         if (wc_LockMutex(&ssl->dupWrite->dupMutex) != 0)
             return BAD_MUTEX_E;
@@ -145,6 +154,7 @@ static int wolfSSL_write_internal(WOLFSSL* ssl, const void* data, size_t sz)
         }
 #endif /* WOLFSSL_TLS13 */
         wc_UnLockMutex(&ssl->dupWrite->dupMutex);
+#endif /* WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX */
 
         if (dupErr != 0) {
             WOLFSSL_MSG("Write dup error from other side");

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -12612,10 +12612,14 @@ static int DoTls13KeyUpdate(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #if defined(HAVE_WRITE_DUP) && defined(WOLFSSL_TLS13)
         /* Read side cannot write; delegate the response to the write side. */
         if (ssl->dupWrite != NULL && ssl->dupSide == READ_DUP_SIDE) {
+#ifdef WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX
+            WriteDupPostKeyUpdate(ssl->dupWrite);
+#else
             if (wc_LockMutex(&ssl->dupWrite->dupMutex) != 0)
                 return BAD_MUTEX_E;
             ssl->dupWrite->keyUpdateRespond = 1;
             wc_UnLockMutex(&ssl->dupWrite->dupMutex);
+#endif
             ssl->keys.keyUpdateRespond = 0;
             return 0;
         }

--- a/tests/api.c
+++ b/tests/api.c
@@ -35677,6 +35677,87 @@ static int test_write_dup_oom(void)
     return EXPECT_RESULT();
 }
 
+#if defined(WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX) && defined(WOLFSSL_TLS13)
+#define WRITE_DUP_ATOMIC_TEST_ITERATIONS 100000
+
+typedef struct WriteDupAtomicTestCtx {
+    WriteDup mailbox;
+    wolfSSL_Atomic_Int ready;
+    wolfSSL_Atomic_Int start;
+    wolfSSL_Atomic_Int done;
+    int finalError;
+    int sawKeyUpdate;
+} WriteDupAtomicTestCtx;
+
+static THREAD_RETURN WOLFSSL_THREAD write_dup_atomic_producer(void* arg)
+{
+    WriteDupAtomicTestCtx* ctx = (WriteDupAtomicTestCtx*)arg;
+    int i;
+
+    (void)wolfSSL_Atomic_Int_FetchAdd(&ctx->ready, 1);
+    while (WOLFSSL_ATOMIC_LOAD(ctx->start) == 0) {
+    }
+
+    for (i = 1; i <= WRITE_DUP_ATOMIC_TEST_ITERATIONS; i++) {
+        WriteDupStoreError(&ctx->mailbox, i);
+        WriteDupPostKeyUpdate(&ctx->mailbox);
+    }
+    WOLFSSL_ATOMIC_STORE(ctx->done, 1);
+
+    WOLFSSL_RETURN_FROM_THREAD(0);
+}
+
+static THREAD_RETURN WOLFSSL_THREAD write_dup_atomic_consumer(void* arg)
+{
+    WriteDupAtomicTestCtx* ctx = (WriteDupAtomicTestCtx*)arg;
+    int sawKeyUpdate = 0;
+
+    (void)wolfSSL_Atomic_Int_FetchAdd(&ctx->ready, 1);
+    while (WOLFSSL_ATOMIC_LOAD(ctx->start) == 0) {
+    }
+
+    while (WOLFSSL_ATOMIC_LOAD(ctx->done) == 0) {
+        ctx->finalError = WriteDupLoadError(&ctx->mailbox);
+        sawKeyUpdate |= WriteDupTakeKeyUpdate(&ctx->mailbox);
+    }
+    ctx->finalError = WriteDupLoadError(&ctx->mailbox);
+    sawKeyUpdate |= WriteDupTakeKeyUpdate(&ctx->mailbox);
+    ctx->sawKeyUpdate = sawKeyUpdate;
+
+    WOLFSSL_RETURN_FROM_THREAD(0);
+}
+#endif
+
+static int test_write_dup_atomic_mailbox(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX) && defined(WOLFSSL_TLS13)
+    WriteDupAtomicTestCtx ctx;
+    THREAD_TYPE producer;
+    THREAD_TYPE consumer;
+
+    XMEMSET(&ctx, 0, sizeof(ctx));
+    wolfSSL_Atomic_Int_Init(&ctx.mailbox.dupErr, 0);
+    wolfSSL_Atomic_Int_Init(&ctx.mailbox.keyUpdateRespond, 0);
+    wolfSSL_Atomic_Int_Init(&ctx.ready, 0);
+    wolfSSL_Atomic_Int_Init(&ctx.start, 0);
+    wolfSSL_Atomic_Int_Init(&ctx.done, 0);
+
+    start_thread(write_dup_atomic_producer, (func_args*)&ctx, &producer);
+    start_thread(write_dup_atomic_consumer, (func_args*)&ctx, &consumer);
+    while (WOLFSSL_ATOMIC_LOAD(ctx.ready) != 2) {
+    }
+    WOLFSSL_ATOMIC_STORE(ctx.start, 1);
+
+    join_thread(producer);
+    join_thread(consumer);
+
+    ExpectIntEQ(ctx.finalError, WRITE_DUP_ATOMIC_TEST_ITERATIONS);
+    ExpectIntEQ(ctx.sawKeyUpdate, 1);
+#endif
+    return EXPECT_RESULT();
+}
+
 static int test_read_write_hs(void)
 {
 
@@ -38823,6 +38904,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_write_dup_want_write),
     TEST_DECL(test_write_dup_want_write_simul),
     TEST_DECL(test_write_dup_oom),
+    TEST_DECL(test_write_dup_atomic_mailbox),
     TEST_DECL(test_read_write_hs),
     TEST_DECL(test_get_signature_nid),
 #ifndef WOLFSSL_TEST_APPLE_NATIVE_CERT_VALIDATION

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5995,10 +5995,23 @@ typedef struct BuildMsgArgs {
     #define WRITE_DUP_SIDE 1
     #define READ_DUP_SIDE 2
 
+    /* The simple TLS write-dup mailbox has no pointer ownership to transfer.
+     * Use wolfSSL's portable atomics when available. Configurations with
+     * additional shared DTLS 1.3 or post-handshake authentication state keep
+     * the mutex path below. */
+#if defined(WOLFSSL_ATOMIC_OPS) && !defined(SINGLE_THREADED) && \
+    !defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+    #define WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX
+#endif
+
     typedef struct WriteDup {
         wolfSSL_Mutex   dupMutex;       /* field access mutex */
         int             dupCount;       /* reference count */
+#ifdef WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX
+        wolfSSL_Atomic_Int dupErr;       /* fatal state for the write side */
+#else
         int             dupErr;         /* under dupMutex, pass to other side */
+#endif
 #ifdef WOLFSSL_DTLS13
         struct Dtls13RecordNumber* sendAckList; /* ownership transferred */
         /* Key update ACK tracking: write side stores the (epoch, seq) of its
@@ -6032,12 +6045,43 @@ typedef struct BuildMsgArgs {
 #ifdef WOLFSSL_TLS13
         /* TLS 1.3 (and DTLS 1.3): read side received a KeyUpdate(update_requested)
          * but cannot send the response; write side handles it. */
+#ifdef WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX
+        wolfSSL_Atomic_Int keyUpdateRespond; /* read-to-write mailbox */
+#else
         WC_BITFIELD keyUpdateRespond:1; /* write side must send a KeyUpdate response */
+#endif
 #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
         WC_BITFIELD postHandshakeAuthPending:1; /* write side must respond */
 #endif /* WOLFSSL_POST_HANDSHAKE_AUTH */
 #endif /* WOLFSSL_TLS13 */
     } WriteDup;
+
+#ifdef WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX
+    static WC_INLINE int WriteDupLoadError(const WriteDup* state)
+    {
+        return WOLFSSL_ATOMIC_LOAD(state->dupErr);
+    }
+
+    static WC_INLINE void WriteDupStoreError(WriteDup* state, int error)
+    {
+        WOLFSSL_ATOMIC_STORE(state->dupErr, error);
+    }
+
+#ifdef WOLFSSL_TLS13
+    static WC_INLINE int WriteDupTakeKeyUpdate(WriteDup* state)
+    {
+        if (WOLFSSL_ATOMIC_LOAD(state->keyUpdateRespond) == 0)
+            return 0;
+
+        return wolfSSL_Atomic_Int_Exchange(&state->keyUpdateRespond, 0);
+    }
+
+    static WC_INLINE void WriteDupPostKeyUpdate(WriteDup* state)
+    {
+        WOLFSSL_ATOMIC_STORE(state->keyUpdateRespond, 1);
+    }
+#endif /* WOLFSSL_TLS13 */
+#endif /* WOLFSSL_WRITE_DUP_ATOMIC_MAILBOX */
 
     WOLFSSL_LOCAL void FreeWriteDup(WOLFSSL* ssl);
     WOLFSSL_LOCAL int  NotifyWriteSide(WOLFSSL* ssl, int err);


### PR DESCRIPTION
# Description

Use wolfSSL's portable atomic integer operations for the simple TLS write-dup error and KeyUpdate mailbox state when atomic operations are available.

The mutex remains responsible for lifetime and reference-count state. Configurations with DTLS 1.3 or post-handshake authentication retain the existing mutex mailbox path because they carry additional compound state and ownership.

This removes the explicit per-write mailbox mutex on the supported atomic path without changing the public API or the mailbox's level-triggered semantics.

# Testing

- GCC RelWithDebInfo: write-dup API tests passed.
- Clang RelWithDebInfo: write-dup API tests passed.
- GCC with atomic operations disabled: existing write-dup tests passed and the atomic-only test was skipped.
- ASan and UBSan: write-dup API tests passed.
- DTLS 1.2 and DTLS 1.3 configuration: write-dup API tests passed on the retained mutex path.
- Post-handshake authentication configuration: library and unit-test binary built on the retained mutex path; the existing certificate-chain assertions fail identically on unmodified `master`.
- Full GCC unit suite: passed.
- Added a concurrent producer/consumer regression test for error publication and KeyUpdate take/post behavior.
- Ran the source-text hygiene check on all changed files.

ThreadSanitizer builds successfully after demoting its existing `atomic_thread_fence` warning, but its runtime exits before test execution in this WSL environment with `unexpected memory mapping`.

# Checklist

 - [x] added tests
 - [x] updated/added doxygen: not applicable; internal-only change
 - [x] updated appropriate READMEs: not applicable
 - [x] Updated manual and documentation: not applicable
