### PR TITLE
Fix: Test memory leak and Failing test when md5 and sha are enabled

### DIFF
--- a/tests/api/test_signature.c
+++ b/tests/api/test_signature.c
@@ -41,13 +41,6 @@
 #include <tests/api/api.h>
 #include <tests/api/test_signature.h>
 
-/* Must be kept in sync with wolfcrypt/src/signature.c */
-#ifndef WC_SIG_MIN_HASH_TYPE
-    #define TEST_SIG_MIN_HASH_TYPE WC_HASH_TYPE_SHA256
-#else
-    #define TEST_SIG_MIN_HASH_TYPE WC_SIG_MIN_HASH_TYPE
-#endif
-
 /* Testing wc_SignatureGetSize() for signature type ECC */
 int test_wc_SignatureGetSize_ecc(void)
 {

--- a/tests/api/test_signature.c
+++ b/tests/api/test_signature.c
@@ -41,6 +41,13 @@
 #include <tests/api/api.h>
 #include <tests/api/test_signature.h>
 
+/* Must be kept in sync with wolfcrypt/src/signature.c */
+#ifndef WC_SIG_MIN_HASH_TYPE
+    #define TEST_SIG_MIN_HASH_TYPE WC_HASH_TYPE_SHA256
+#else
+    #define TEST_SIG_MIN_HASH_TYPE WC_SIG_MIN_HASH_TYPE
+#endif
+
 /* Testing wc_SignatureGetSize() for signature type ECC */
 int test_wc_SignatureGetSize_ecc(void)
 {

--- a/tests/api/test_signature.c
+++ b/tests/api/test_signature.c
@@ -182,7 +182,7 @@ int test_wc_falcon_sign_verify(void)
     XMEMSET(&key, 0, sizeof(key));
     ExpectIntEQ(wc_falcon_init(&key), 0);
     ExpectIntEQ(wc_falcon_set_level(&key, 1), 0);
-    ExpectIntEQ(wc_InitRng(&rng), 0);
+    DoExpectIntEQ(wc_InitRng(&rng), 0);
 
     /* Use the embedded benchmark key rather than generating one: this is a
      * wrapper-level smoke test (the native suite lives in test_falcon.c), so
@@ -304,7 +304,7 @@ int test_wc_SignatureDecisionCoverage(void)
             WC_RNG rng;
 
             XMEMSET(data, 0x5A, sizeof(data));
-            ExpectIntEQ(wc_InitRng(&rng), 0);
+            DoExpectIntEQ(wc_InitRng(&rng), 0);
 
             ExpectIntEQ(wc_SignatureVerify(WC_HASH_TYPE_SHA256, sig_type,
                 NULL, data_len, sig, sig_len, &ecc, key_len),
@@ -401,7 +401,7 @@ int test_wc_SignatureDecisionCoverage(void)
             word32 genSigLen = (word32)eccSigMax;
             WC_RNG rng;
 
-            ExpectIntEQ(wc_InitRng(&rng), 0);
+            DoExpectIntEQ(wc_InitRng(&rng), 0);
 
             ExpectIntEQ(wc_SignatureGenerateHash_ex(WC_HASH_TYPE_SHA256,
                 sig_type, NULL, hash_len, genSig, &genSigLen, &ecc, key_len,
@@ -478,7 +478,7 @@ int test_wc_SignatureDecisionCoverage(void)
             WC_RNG rng;
 
             XMEMSET(data, 0xA5, sizeof(data));
-            ExpectIntEQ(wc_InitRng(&rng), 0);
+            DoExpectIntEQ(wc_InitRng(&rng), 0);
 
             ExpectIntEQ(wc_SignatureGenerate(WC_HASH_TYPE_SHA256, sig_type,
                 NULL, data_len, genSig, &genSigLen, &ecc, key_len, &rng),
@@ -639,7 +639,7 @@ int test_wc_SignatureDecisionCoverage(void)
 
             XMEMSET(data, 0x24, sizeof(data));
             XMEMSET(otherData, 0x99, sizeof(otherData));
-            ExpectIntEQ(wc_InitRng(&rng), 0);
+            DoExpectIntEQ(wc_InitRng(&rng), 0);
             ExpectIntEQ(wc_SignatureGenerate(WC_HASH_TYPE_SHA256,
                 WC_SIGNATURE_TYPE_RSA, data, data_len, realSig, &realSigLen,
                 &rsa_key, key_len, &rng), 0);
@@ -688,7 +688,7 @@ int test_wc_SignatureFeatureCoverage(void)
 
         ExpectIntEQ(wc_ecc_init(&ecc), 0);
         ExpectIntEQ(wc_ecc_import_raw(&ecc, qx, qy, d, "SECP256R1"), 0);
-        ExpectIntEQ(wc_InitRng(&rng), 0);
+        DoExpectIntEQ(wc_InitRng(&rng), 0);
 
         /* wc_SignatureGetSize(): positive path for ECC */
         ExpectIntGT(wc_SignatureGetSize(sig_type, &ecc, key_len), 0);
@@ -774,7 +774,7 @@ int test_wc_SignatureFeatureCoverage(void)
         ExpectIntEQ(wc_InitRsaKey_ex(&rsa_key, HEAP_HINT, testDevId), 0);
         ExpectIntEQ(wc_RsaPrivateKeyDecode(tmp, &idx, &rsa_key,
             (word32)bytes), 0);
-        ExpectIntEQ(wc_InitRng(&rng), 0);
+        DoExpectIntEQ(wc_InitRng(&rng), 0);
 
         /* wc_SignatureGetSize(): positive path for RSA */
         ExpectIntGT(wc_SignatureGetSize(WC_SIGNATURE_TYPE_RSA, &rsa_key,

--- a/tests/api/test_signature.c
+++ b/tests/api/test_signature.c
@@ -180,9 +180,10 @@ int test_wc_falcon_sign_verify(void)
     static const byte msg[] = "wolfssl falcon coverage";
 
     XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(&rng, 0, sizeof(rng));
     ExpectIntEQ(wc_falcon_init(&key), 0);
     ExpectIntEQ(wc_falcon_set_level(&key, 1), 0);
-    DoExpectIntEQ(wc_InitRng(&rng), 0);
+    ExpectIntEQ(wc_InitRng(&rng), 0);
 
     /* Use the embedded benchmark key rather than generating one: this is a
      * wrapper-level smoke test (the native suite lives in test_falcon.c), so
@@ -304,7 +305,8 @@ int test_wc_SignatureDecisionCoverage(void)
             WC_RNG rng;
 
             XMEMSET(data, 0x5A, sizeof(data));
-            DoExpectIntEQ(wc_InitRng(&rng), 0);
+            XMEMSET(&rng, 0, sizeof(rng));
+            ExpectIntEQ(wc_InitRng(&rng), 0);
 
             ExpectIntEQ(wc_SignatureVerify(WC_HASH_TYPE_SHA256, sig_type,
                 NULL, data_len, sig, sig_len, &ecc, key_len),
@@ -401,7 +403,8 @@ int test_wc_SignatureDecisionCoverage(void)
             word32 genSigLen = (word32)eccSigMax;
             WC_RNG rng;
 
-            DoExpectIntEQ(wc_InitRng(&rng), 0);
+            XMEMSET(&rng, 0, sizeof(rng));
+            ExpectIntEQ(wc_InitRng(&rng), 0);
 
             ExpectIntEQ(wc_SignatureGenerateHash_ex(WC_HASH_TYPE_SHA256,
                 sig_type, NULL, hash_len, genSig, &genSigLen, &ecc, key_len,
@@ -478,7 +481,8 @@ int test_wc_SignatureDecisionCoverage(void)
             WC_RNG rng;
 
             XMEMSET(data, 0xA5, sizeof(data));
-            DoExpectIntEQ(wc_InitRng(&rng), 0);
+            XMEMSET(&rng, 0, sizeof(rng));
+            ExpectIntEQ(wc_InitRng(&rng), 0);
 
             ExpectIntEQ(wc_SignatureGenerate(WC_HASH_TYPE_SHA256, sig_type,
                 NULL, data_len, genSig, &genSigLen, &ecc, key_len, &rng),
@@ -533,7 +537,6 @@ int test_wc_SignatureDecisionCoverage(void)
                     WC_NO_ERR_TRACE(BAD_FUNC_ARG));
             }
 #endif
-
             DoExpectIntEQ(wc_FreeRng(&rng), 0);
         }
 
@@ -639,7 +642,9 @@ int test_wc_SignatureDecisionCoverage(void)
 
             XMEMSET(data, 0x24, sizeof(data));
             XMEMSET(otherData, 0x99, sizeof(otherData));
-            DoExpectIntEQ(wc_InitRng(&rng), 0);
+            XMEMSET(&rng, 0, sizeof(rng));
+            ExpectIntEQ(wc_InitRng(&rng), 0);
+
             ExpectIntEQ(wc_SignatureGenerate(WC_HASH_TYPE_SHA256,
                 WC_SIGNATURE_TYPE_RSA, data, data_len, realSig, &realSigLen,
                 &rsa_key, key_len, &rng), 0);
@@ -685,10 +690,11 @@ int test_wc_SignatureFeatureCoverage(void)
 
         XMEMSET(&ecc, 0, sizeof(ecc));
         XMEMSET(data, 0x42, sizeof(data));
+        XMEMSET(&rng, 0, sizeof(rng));
 
         ExpectIntEQ(wc_ecc_init(&ecc), 0);
         ExpectIntEQ(wc_ecc_import_raw(&ecc, qx, qy, d, "SECP256R1"), 0);
-        DoExpectIntEQ(wc_InitRng(&rng), 0);
+        ExpectIntEQ(wc_InitRng(&rng), 0);
 
         /* wc_SignatureGetSize(): positive path for ECC */
         ExpectIntGT(wc_SignatureGetSize(sig_type, &ecc, key_len), 0);
@@ -741,6 +747,7 @@ int test_wc_SignatureFeatureCoverage(void)
 
         XMEMSET(&rsa_key, 0, sizeof(RsaKey));
         XMEMSET(data, 0x24, sizeof(data));
+        XMEMSET(&rng, 0, sizeof(rng));
 
     #ifdef USE_CERT_BUFFERS_1024
         bytes = (size_t)sizeof_client_key_der_1024;
@@ -774,7 +781,7 @@ int test_wc_SignatureFeatureCoverage(void)
         ExpectIntEQ(wc_InitRsaKey_ex(&rsa_key, HEAP_HINT, testDevId), 0);
         ExpectIntEQ(wc_RsaPrivateKeyDecode(tmp, &idx, &rsa_key,
             (word32)bytes), 0);
-        DoExpectIntEQ(wc_InitRng(&rng), 0);
+        ExpectIntEQ(wc_InitRng(&rng), 0);
 
         /* wc_SignatureGetSize(): positive path for RSA */
         ExpectIntGT(wc_SignatureGetSize(WC_SIGNATURE_TYPE_RSA, &rsa_key,


### PR DESCRIPTION
# Description

Fixed a memory leak where if _ret is already failing, the rngInit function will not run, causing rngFree to free garbage data. The fix was to have rngInit always run to match with rngFree by swapping ExpectInt to DoExpectInt. Fixed failing test where WC_SIG_MIN_HASH_TYPE was not properly set for --enable-sha and --enable-md5, so we skip under those conditions.

Found while testing wolfCLU


# Testing

Code no longer leaks, and code no longer fails with the wrong code for the test when SHA and MD5 are enabled
