### PR TITLE
Honor WC_SIG_MIN_HASH_TYPE override in signature decision test

### DIFF
--- a/tests/api/test_signature.c
+++ b/tests/api/test_signature.c
@@ -41,6 +41,13 @@
 #include <tests/api/api.h>
 #include <tests/api/test_signature.h>
 
+/* Effective hash floor used by wc_SignatureVerify/Generate; mirrors the
+ * default in wolfcrypt/src/signature.c. A build may lower it (e.g.
+ * --enable-wolfclu defines WC_SIG_MIN_HASH_TYPE=WC_HASH_TYPE_MD5). */
+#ifndef WC_SIG_MIN_HASH_TYPE
+    #define WC_SIG_MIN_HASH_TYPE WC_HASH_TYPE_SHA256
+#endif
+
 /* Testing wc_SignatureGetSize() for signature type ECC */
 int test_wc_SignatureGetSize_ecc(void)
 {
@@ -337,10 +344,14 @@ int test_wc_SignatureDecisionCoverage(void)
 
 #ifndef NO_SHA
             /* Hash weaker than WC_SIG_MIN_HASH_TYPE (default SHA-256)
-             * rejected by wc_SignatureCheckHashStrength() */
-            ExpectIntEQ(wc_SignatureVerify(WC_HASH_TYPE_SHA, sig_type,
-                data, data_len, sig, sig_len, &ecc, key_len),
-                WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+             * rejected by wc_SignatureCheckHashStrength(). Only assert
+             * when SHA-1 is below the effective floor of this build. */
+            if (wc_HashGetDigestSize(WC_SIG_MIN_HASH_TYPE) >
+                    wc_HashGetDigestSize(WC_HASH_TYPE_SHA)) {
+                ExpectIntEQ(wc_SignatureVerify(WC_HASH_TYPE_SHA, sig_type,
+                    data, data_len, sig, sig_len, &ecc, key_len),
+                    WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+            }
 #endif
 
             /* Real signature that fails verification: SIG_VERIFY_E.
@@ -518,8 +529,11 @@ int test_wc_SignatureDecisionCoverage(void)
             }
 
 #ifndef NO_SHA
-            /* Weak hash rejected before any hashing/signing occurs */
-            {
+            /* Weak hash rejected before any hashing/signing occurs. Only
+             * assert when SHA-1 is below the effective floor of this
+             * build. */
+            if (wc_HashGetDigestSize(WC_SIG_MIN_HASH_TYPE) >
+                    wc_HashGetDigestSize(WC_HASH_TYPE_SHA)) {
                 word32 lenCopy = (word32)eccSigMax;
                 ExpectIntEQ(wc_SignatureGenerate(WC_HASH_TYPE_SHA, sig_type,
                     data, data_len, genSig, &lenCopy, &ecc, key_len, &rng),

--- a/tests/api/test_signature.c
+++ b/tests/api/test_signature.c
@@ -41,13 +41,6 @@
 #include <tests/api/api.h>
 #include <tests/api/test_signature.h>
 
-/* Effective hash floor used by wc_SignatureVerify/Generate; mirrors the
- * default in wolfcrypt/src/signature.c. A build may lower it (e.g.
- * --enable-wolfclu defines WC_SIG_MIN_HASH_TYPE=WC_HASH_TYPE_MD5). */
-#ifndef WC_SIG_MIN_HASH_TYPE
-    #define WC_SIG_MIN_HASH_TYPE WC_HASH_TYPE_SHA256
-#endif
-
 /* Testing wc_SignatureGetSize() for signature type ECC */
 int test_wc_SignatureGetSize_ecc(void)
 {

--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -53,16 +53,6 @@
     #endif
 #endif
 
-/* Minimum hash strength accepted by the wc_SignatureVerify/Generate
- * convenience APIs. Default is SHA-256 to keep MD5 and SHA-1 (both with
- * known collision attacks) out of new code. Define WC_SIG_MIN_HASH_TYPE
- * to a weaker wc_HashType (e.g. WC_HASH_TYPE_SHA) to opt back into legacy
- * behavior. The lower-level wc_SignatureVerifyHash/wc_SignatureGenerateHash
- * APIs are unaffected. */
-#ifndef WC_SIG_MIN_HASH_TYPE
-    #define WC_SIG_MIN_HASH_TYPE WC_HASH_TYPE_SHA256
-#endif
-
 static int wc_SignatureCheckHashStrength(enum wc_HashType hash_type)
 {
     int min_sz, this_sz;

--- a/wolfssl/wolfcrypt/signature.h
+++ b/wolfssl/wolfcrypt/signature.h
@@ -35,6 +35,16 @@
     extern "C" {
 #endif
 
+/* Minimum hash strength accepted by the wc_SignatureVerify/Generate
+ * convenience APIs. Default is SHA-256 to keep MD5 and SHA-1 (both with
+ * known collision attacks) out of new code. Define WC_SIG_MIN_HASH_TYPE
+ * to a weaker wc_HashType (e.g. WC_HASH_TYPE_SHA) to opt back into legacy
+ * behavior. The lower-level wc_SignatureVerifyHash/wc_SignatureGenerateHash
+ * APIs are unaffected. */
+#ifndef WC_SIG_MIN_HASH_TYPE
+    #define WC_SIG_MIN_HASH_TYPE WC_HASH_TYPE_SHA256
+#endif
+
 enum wc_SignatureType {
     WC_SIGNATURE_TYPE_NONE = 0,
     WC_SIGNATURE_TYPE_ECC = 1,


### PR DESCRIPTION
# Description

test_wc_SignatureDecisionCoverage asserts that SHA-1 input is rejected
by wc_SignatureVerify/Generate, assuming the default
SHA-256 hash strength floor. A build may lower the floor - configuring
with --enable-wolfclu.

Fixes zd#22151

# Testing

fixed test_wc_SignatureGetSize_ecc

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
