### PR TITLE
Remove dead/unreachable code

### DIFF
--- a/tests/api/test_ed448.c
+++ b/tests/api/test_ed448.c
@@ -1286,7 +1286,8 @@ int test_wc_ed448_import_private_only(void)
  * (the is_small_order VALUE operand's independence is already shown by
  * test_wc_ed448_reject_small_order_keys()), the (ret == 0 &&
  * XMEMCMP(...) != 0) recomputed-vs-stored public key mismatch check in the
- * have-private-key branch, and the deep Y-range check's final byte compare.
+ * have-private-key branch, and both decisions of the Y-range walk: the
+ * top-byte loop and the 0xFE compare that follows it.
  */
 int test_wc_ed448_check_key_decisions(void)
 {
@@ -1336,15 +1337,15 @@ int test_wc_ed448_check_key_decisions(void)
     key.p[0] = (byte)(key.p[0] ^ 0xff);
 
     /* Deep Y-range check: a Y value that is not one of
-     * ed448_is_small_order()'s tabulated points but still forces both
-     * range-check loops all the way down to the final byte compare (every
-     * byte except p[0] matches the encoded field prime p). Only reachable
-     * via a trusted import, which skips wc_ed448_check_key() at import
-     * time so the crafted (curve-invalid) point can be handed to a
-     * *direct* wc_ed448_check_key() call below -- same technique as
-     * test_wc_ed448_reject_small_order_keys(). Whatever the later
-     * curve-decode step decides is fine; the range-check decision itself
-     * is what's targeted here. */
+     * ed448_is_small_order()'s tabulated points but still runs the top-byte
+     * loop to exhaustion (every byte above the 0xFE position is 0xff), so
+     * the loop's index operand goes false and the 0xFE compare below it is
+     * reached and taken. Only reachable via a trusted import, which skips
+     * wc_ed448_check_key() at import time so the crafted (curve-invalid)
+     * point can be handed to a *direct* wc_ed448_check_key() call below --
+     * same technique as test_wc_ed448_reject_small_order_keys(). Whatever
+     * the later curve-decode step decides is fine; the range-check decision
+     * itself is what's targeted here. */
     XMEMSET(near_p, 0xff, sizeof(near_p));
     near_p[28] = 0xfe;
     near_p[0]  = 0x00;
@@ -1355,16 +1356,28 @@ int test_wc_ed448_check_key_decisions(void)
     ExpectTrue((rc == 0) || (rc == WC_NO_ERR_TRACE(PUBLIC_KEY_E)));
     wc_ed448_free(&freshKey);
 
-    /* Same construction but with an extra byte (p[1]) perturbed so the
-     * second range-check loop exits early with ret == 0 before the final
-     * byte compare runs -- closes that compare's PUBLIC_KEY_E
-     * guard operand's FALSE side. */
-    near_p[1] = 0x00;
+    /* Same construction with a byte inside the walked range cleared, so the
+     * loop breaks with ret == 0 instead of running out: closes the byte
+     * compare's TRUE side and the following (ret == PUBLIC_KEY_E) guard's
+     * FALSE side. */
+    near_p[29] = 0x00;
     ExpectIntEQ(wc_ed448_init(&freshKey), 0);
     ExpectIntEQ(wc_ed448_import_public_ex(near_p, ED448_PUB_KEY_SIZE,
         &freshKey, 1), 0);
     rc = wc_ed448_check_key(&freshKey);
     ExpectTrue((rc == 0) || (rc == WC_NO_ERR_TRACE(PUBLIC_KEY_E)));
+    wc_ed448_free(&freshKey);
+
+    /* Every byte 0xff, including the 0xFE position: not a tabulated
+     * small-order encoding, the walk finds no byte below 0xff and the 0xFE
+     * compare is false, so the Y value is out of range. Closes that
+     * compare's FALSE side. */
+    XMEMSET(near_p, 0xff, sizeof(near_p));
+    ExpectIntEQ(wc_ed448_init(&freshKey), 0);
+    ExpectIntEQ(wc_ed448_import_public_ex(near_p, ED448_PUB_KEY_SIZE,
+        &freshKey, 1), 0);
+    ExpectIntEQ(wc_ed448_check_key(&freshKey),
+        WC_NO_ERR_TRACE(PUBLIC_KEY_E));
     wc_ed448_free(&freshKey);
 
     DoExpectIntEQ(wc_FreeRng(&rng), 0);

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -16504,7 +16504,7 @@ static WARN_UNUSED_RESULT int wc_AesFeedbackCFB1(
     }
 
     if (ret == 0) {
-        if (bit >= 0 && bit < 7) {
+        if (bit < 7) {
             out[0] = cur;
         }
     }

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -278,7 +278,7 @@ int Base64_Decode_nonCT(const byte* in, word32 inLen, byte* out, word32* outLen)
     }
 
     /* If the output buffer has a room for an extra byte, add a null terminator */
-    if (out && *outLen > i)
+    if (*outLen > i)
         out[i]= '\0';
 
     /* Note, *outLen won't reflect the optional terminating null. */
@@ -392,7 +392,7 @@ int Base64_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
     }
 
     /* If the output buffer has a room for an extra byte, add a null terminator */
-    if (out && *outLen > i)
+    if (*outLen > i)
         out[i]= '\0';
 
     /* Note, *outLen won't reflect the optional terminating null. */

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -134,7 +134,7 @@ int Base64_SkipNewline(const byte* in, word32 *inLen,
         curChar = in[++j];
         len--;
     }
-    if (len && (curChar == '\r' || curChar == '\n')) {
+    if (curChar == '\r' || curChar == '\n') {
         j++;
         len--;
         if (curChar == '\r') {

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -660,7 +660,7 @@ int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
     if (in == NULL || out == NULL || outLen == NULL)
         return BAD_FUNC_ARG;
 
-    if (inLen == 1 && *outLen && in) {
+    if (inLen == 1 && *outLen) {
         byte b = (byte)(in[inIdx++] - BASE16_MIN);  /* 0 starts at 0x30 */
 
         /* sanity check */

--- a/wolfcrypt/src/ed448.c
+++ b/wolfcrypt/src/ed448.c
@@ -1521,40 +1521,38 @@ int wc_ed448_check_key(ed448_key* key)
         }
     }
     /* No private key, check Y is valid. */
-    else if ((ret == 0) && (!key->privKeySet)) {
+    else if (ret == 0) {
         /* Verify that xQ and yQ are integers in the interval [0, p - 1].
          * Only have yQ so check that ordinate.
          * p = 2^448-2^224-1 = 0xff..fe..ff
          */
-        if (ret == 0) {
-            int i;
-            ret = PUBLIC_KEY_E;
+        int i;
+        ret = PUBLIC_KEY_E;
 
-            /* Check top part before 0xFE. */
-            for (i = ED448_PUB_KEY_SIZE - 1; i > ED448_PUB_KEY_SIZE/2; i--) {
-                if (key->p[i] < 0xff) {
-                    ret = 0;
-                    break;
-                }
+        /* Check top part before 0xFE. */
+        for (i = ED448_PUB_KEY_SIZE - 1; i > ED448_PUB_KEY_SIZE/2; i--) {
+            if (key->p[i] < 0xff) {
+                ret = 0;
+                break;
             }
-            if (ret == WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
-                /* Check against 0xFE. */
-                if (key->p[ED448_PUB_KEY_SIZE/2] < 0xfe) {
-                    ret = 0;
-                }
-                else if (key->p[ED448_PUB_KEY_SIZE/2] == 0xfe) {
-                    /* Check bottom part before last byte. */
-                    for (i = ED448_PUB_KEY_SIZE/2 - 1; i > 0; i--) {
-                        if (key->p[i] != 0xff) {
-                            ret = 0;
-                            break;
-                        }
-                    }
-                    /* Check last byte. */
-                    if ((ret == WC_NO_ERR_TRACE(PUBLIC_KEY_E)) &&
-                        (key->p[0] < 0xff)) {
+        }
+        if (ret == WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
+            /* Check against 0xFE. */
+            if (key->p[ED448_PUB_KEY_SIZE/2] < 0xfe) {
+                ret = 0;
+            }
+            else if (key->p[ED448_PUB_KEY_SIZE/2] == 0xfe) {
+                /* Check bottom part before last byte. */
+                for (i = ED448_PUB_KEY_SIZE/2 - 1; i > 0; i--) {
+                    if (key->p[i] != 0xff) {
                         ret = 0;
+                        break;
                     }
+                }
+                /* Check last byte. */
+                if ((ret == WC_NO_ERR_TRACE(PUBLIC_KEY_E)) &&
+                    (key->p[0] < 0xff)) {
+                    ret = 0;
                 }
             }
         }

--- a/wolfcrypt/src/ed448.c
+++ b/wolfcrypt/src/ed448.c
@@ -251,7 +251,10 @@ static int ed448_is_small_order(const byte p[ED448_PUB_KEY_SIZE])
      * (fe448_from_bytes) reads bytes 0-55 modulo p with no canonical-form
      * check, so y = p decodes to 0 and y = p+1 decodes to 1; both must
      * be rejected here. Only {y, y + p} fits in 56 bytes (2p overflows),
-     * so listing y and y + p exhausts the reachable encodings. */
+     * so listing y and y + p exhausts the reachable encodings.
+     * wc_ed448_check_key() depends on the y = p row: its Y-range test
+     * accepts that encoding, so dropping the row would let a y outside
+     * [0, p - 1] through. */
     static const byte small_order_y[][ED448_PUB_KEY_SIZE] = {
         /* order 1: identity y = 1, x = 0 */
         {0x01,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
@@ -1537,23 +1540,13 @@ int wc_ed448_check_key(ed448_key* key)
             }
         }
         if (ret == WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
-            /* Check against 0xFE. */
-            if (key->p[ED448_PUB_KEY_SIZE/2] < 0xfe) {
+            /* Every byte above this one is 0xff here, so y > p whenever this
+             * byte is 0xff, and y == p is then the only remaining encoding
+             * outside [0, p - 1]. It is already rejected by
+             * ed448_is_small_order() above, whose table carries y == p as a
+             * non-canonical encoding, so the low bytes need no check. */
+            if (key->p[ED448_PUB_KEY_SIZE/2] <= 0xfe) {
                 ret = 0;
-            }
-            else if (key->p[ED448_PUB_KEY_SIZE/2] == 0xfe) {
-                /* Check bottom part before last byte. */
-                for (i = ED448_PUB_KEY_SIZE/2 - 1; i > 0; i--) {
-                    if (key->p[i] != 0xff) {
-                        ret = 0;
-                        break;
-                    }
-                }
-                /* Check last byte. */
-                if ((ret == WC_NO_ERR_TRACE(PUBLIC_KEY_E)) &&
-                    (key->p[0] < 0xff)) {
-                    ret = 0;
-                }
             }
         }
 

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -98,12 +98,10 @@ word32 CheckRunTimeSettings(void)
 }
 
 
-/* handle up to 6 inits */
+/* handle up to 6 inits; returns MP_OKAY */
 int mp_init_multi(mp_int* a, mp_int* b, mp_int* c, mp_int* d, mp_int* e,
                   mp_int* f)
 {
-    int res = MP_OKAY;
-
     if (a) XMEMSET(a, 0, sizeof(mp_int));
     if (b) XMEMSET(b, 0, sizeof(mp_int));
     if (c) XMEMSET(c, 0, sizeof(mp_int));
@@ -111,35 +109,18 @@ int mp_init_multi(mp_int* a, mp_int* b, mp_int* c, mp_int* d, mp_int* e,
     if (e) XMEMSET(e, 0, sizeof(mp_int));
     if (f) XMEMSET(f, 0, sizeof(mp_int));
 
-    if (a && ((res = mp_init(a)) != MP_OKAY))
-        return res;
+    /* mp_init() has exactly one failure mode, a NULL argument, and the guard
+     * on each call excludes it, so every one of these returns MP_OKAY and the
+     * result is discarded. Same shape as sp_init_multi() and tfm.c's
+     * mp_init_multi(), which also return MP_OKAY unconditionally. */
+    if (a) (void)mp_init(a);
+    if (b) (void)mp_init(b);
+    if (c) (void)mp_init(c);
+    if (d) (void)mp_init(d);
+    if (e) (void)mp_init(e);
+    if (f) (void)mp_init(f);
 
-    if (b && ((res = mp_init(b)) != MP_OKAY)) {
-        mp_clear(a);
-        return res;
-    }
-
-    if (c && ((res = mp_init(c)) != MP_OKAY)) {
-        mp_clear(a); mp_clear(b);
-        return res;
-    }
-
-    if (d && ((res = mp_init(d)) != MP_OKAY)) {
-        mp_clear(a); mp_clear(b); mp_clear(c);
-        return res;
-    }
-
-    if (e && ((res = mp_init(e)) != MP_OKAY)) {
-        mp_clear(a); mp_clear(b); mp_clear(c); mp_clear(d);
-        return res;
-    }
-
-    if (f && ((res = mp_init(f)) != MP_OKAY)) {
-        mp_clear(a); mp_clear(b); mp_clear(c); mp_clear(d); mp_clear(e);
-        return res;
-    }
-
-    return res;
+    return MP_OKAY;
 }
 
 

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -1792,8 +1792,7 @@ int s_mp_add (mp_int * a, mp_int * b, mp_int * c)
     tmpc = c->dp;
 
     /* sanity-check dp pointers. */
-    if ((min_ab > 0) &&
-        ((tmpa == NULL) || (tmpb == NULL) || (tmpc == NULL)))
+    if ((min_ab > 0) && ((tmpa == NULL) || (tmpb == NULL)))
     {
         return MP_VAL;
     }

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -1633,7 +1633,7 @@ int wc_KDA_KDF_PRF_cmac(const byte* Kin, word32 KinSz,
     }
     #endif
 
-    while (ret == 0 && len_rem >= WC_AES_BLOCK_SIZE) {
+    while (len_rem >= WC_AES_BLOCK_SIZE) {
         /* cmac in place in block size increments */
         c32toa(counter, counterBuf);
         #ifdef WOLFSSL_DEBUG_KDF

--- a/wolfcrypt/src/md5.c
+++ b/wolfcrypt/src/md5.c
@@ -358,8 +358,8 @@ int wc_Md5Update(wc_Md5* md5, const byte* data, word32 len)
     if (md5->buffLen >= WC_MD5_BLOCK_SIZE)
         return BUFFER_E;
 
-    if (data == NULL && len == 0) {
-        /* valid, but do nothing */
+    if (data == NULL) {
+        /* len is 0 here: valid, but do nothing */
         return 0;
     }
 

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -1411,7 +1411,7 @@ void* wolfSSL_Realloc(void *ptr, size_t size, void* heap, int type)
                 }
             }
 
-            if (pt != NULL && res == NULL) {
+            if (pt != NULL) {
                 word32 prvSz;
 
                 res = pt->buffer;

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -365,17 +365,15 @@ int wc_PBKDF2(byte* output, const byte* passwd, int pLen, const byte* salt,
 
 #ifdef HAVE_PKCS12
 
-/* helper for PKCS12_PBKDF(), does hash operation */
+/* helper for PKCS12_PBKDF(), does hash operation.
+ * buffer and Ai are guaranteed non-NULL by the caller: each is either a stack
+ * array or an XMALLOC result whose failure returns MEMORY_E before the call. */
 static int DoPKCS12Hash(enum wc_HashType hashT, byte* buffer, word32 totalLen,
     byte* Ai, word32 u, int iterations)
 {
     int i;
     int ret = 0;
     WC_DECLARE_VAR(hash, wc_HashAlg, 1, 0);
-
-    if ((buffer == NULL) || (Ai == NULL)) {
-        return BAD_FUNC_ARG;
-    }
 
     /* initialize hash */
     WC_ALLOC_VAR_EX(hash, wc_HashAlg, 1, NULL, DYNAMIC_TYPE_HASHCTX,

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -1186,8 +1186,8 @@ static int wc_Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, word32 p)
         return BAD_FUNC_ARG;
     }
 
-    if (data == NULL && len == 0) {
-        /* valid, but do nothing */
+    if (data == NULL) {
+        /* len is 0 here: valid, but do nothing */
         return 0;
     }
 
@@ -1865,8 +1865,8 @@ int wc_Shake128_Update(wc_Shake* shake, const byte* data, word32 len)
          return BAD_FUNC_ARG;
     }
 
-    if (data == NULL && len == 0) {
-        /* valid, but do nothing */
+    if (data == NULL) {
+        /* len is 0 here: valid, but do nothing */
         return 0;
     }
 
@@ -2163,8 +2163,8 @@ int wc_Shake256_Update(wc_Shake* shake, const byte* data, word32 len)
          return BAD_FUNC_ARG;
     }
 
-    if (data == NULL && len == 0) {
-        /* valid, but do nothing */
+    if (data == NULL) {
+        /* len is 0 here: valid, but do nothing */
         return 0;
     }
 

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -19948,10 +19948,8 @@ static int _sp_lcm(const sp_int* a, const sp_int* b, sp_int* r)
         _sp_init_size(t[0], used);
         _sp_init_size(t[1], used);
 
-        if (err == MP_OKAY) {
-            /* 1. t0 = gcd(a, b) */
-            err = sp_gcd(a, b, t[0]);
-        }
+        /* 1. t0 = gcd(a, b) */
+        err = sp_gcd(a, b, t[0]);
 
         if (err == MP_OKAY) {
             /* Divide the greater by the common divisor and multiply by other

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -18906,13 +18906,11 @@ int sp_todecimal(const sp_int* a, char* str)
             /* Terminate string. */
             str[i] = '\0';
 
-            if (err == MP_OKAY) {
-                /* Reverse string to big endian. */
-                for (j = 0; j <= (i - 1) / 2; j++) {
-                    int c = (unsigned char)str[j];
-                    str[j] = str[i - 1 - j];
-                    str[i - 1 - j] = (char)c;
-                }
+            /* Reverse string to big endian. */
+            for (j = 0; j <= (i - 1) / 2; j++) {
+                int c = (unsigned char)str[j];
+                str[j] = str[i - 1 - j];
+                str[i - 1 - j] = (char)c;
             }
         }
 

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5511,20 +5511,12 @@ int fp_gcd(fp_int *a, fp_int *b, fp_int *c)
    }
 
    /* either zero than gcd is the largest */
-   if (fp_iszero (a) == FP_YES && fp_iszero (b) == FP_NO) {
+   if (fp_iszero (a) == FP_YES) {
      fp_abs (b, c);
      return FP_OKAY;
    }
-   if (fp_iszero (a) == FP_NO && fp_iszero (b) == FP_YES) {
+   if (fp_iszero (b) == FP_YES) {
      fp_abs (a, c);
-     return FP_OKAY;
-   }
-
-   /* optimized.  At this point if a == 0 then
-    * b must equal zero too
-    */
-   if (fp_iszero (a) == FP_YES) {
-     fp_zero(c);
      return FP_OKAY;
    }
 

--- a/wolfcrypt/src/wc_lms_impl.c
+++ b/wolfcrypt/src/wc_lms_impl.c
@@ -3589,9 +3589,6 @@ int wc_hss_reload_key(LmsState* state, const byte* priv_raw,
 #endif
 
     wc_hss_priv_data_load(state->params, priv_key, priv_data);
-#ifndef WOLFSSL_WC_LMS_SMALL
-    priv_key->inited = 0;
-#endif
 
 #ifdef WOLFSSL_WC_LMS_SERIALIZE_STATE
     if (pub_root != NULL)
@@ -3600,7 +3597,7 @@ int wc_hss_reload_key(LmsState* state, const byte* priv_raw,
         /* Expand the raw private key into the private key data. */
         ret = wc_hss_expand_private_key(state, priv_key->priv, priv_raw, 0);
     #ifndef WOLFSSL_WC_LMS_SMALL
-        if ((ret == 0) && (!priv_key->inited)) {
+        if (ret == 0) {
             /* Initialize the authentication paths and caches for all trees. */
             ret = wc_hss_init_auth_path(state, priv_key, pub_root);
         #ifndef WOLFSSL_LMS_NO_SIGN_SMOOTHING

--- a/wolfcrypt/src/wc_mldsa.c
+++ b/wolfcrypt/src/wc_mldsa.c
@@ -5063,7 +5063,7 @@ static int mldsa_vec_check_low_c(const sword32* a, byte l, sword32 hi)
     unsigned int i;
 
     /* For each polynomial of vector. */
-    for (i = 0; (ret == 1) && (i < l); i++) {
+    for (i = 0; i < l; i++) {
         ret = mldsa_check_low(a, hi);
         if (ret == 0) {
             break;

--- a/wolfcrypt/src/wc_mldsa.c
+++ b/wolfcrypt/src/wc_mldsa.c
@@ -8100,7 +8100,7 @@ static int mldsa_make_key_from_seed(wc_MlDsaKey* key, const byte* seed)
 
             /* Put r/i into buffer to be hashed. */
             aseed[MLDSA_PUB_SEED_SZ + 1] = (byte)r;
-            for (s = 0; (ret == 0) && (s < params->l); s++) {
+            for (s = 0; s < params->l; s++) {
                 /* Put s into buffer to be hashed. */
                 aseed[MLDSA_PUB_SEED_SZ + 0] = (byte)s;
                 /* Step 3: Expand public seed into a matrix of polynomials. */
@@ -8892,7 +8892,7 @@ static int mldsa_sign_with_seed_mu(wc_MlDsaKey* key,
                 /* Put r/i into buffer to be hashed. */
                 aseed[MLDSA_PUB_SEED_SZ + 1] = r;
                 /* Alg 26. Step 2: Loop over second dimension of matrix. */
-                for (s = 0; (ret == 0) && (s < params->l); s++) {
+                for (s = 0; s < params->l; s++) {
                     /* Put s into buffer to be hashed. */
                     aseed[MLDSA_PUB_SEED_SZ + 0] = s;
                     /* Alg 26. Step 3: Create polynomial from hashing seed. */

--- a/wolfcrypt/src/wc_mldsa.c
+++ b/wolfcrypt/src/wc_mldsa.c
@@ -11586,7 +11586,7 @@ int wc_MlDsaKey_CheckKey(wc_MlDsaKey* key)
             x |= key->p[i] ^ key->k[i];
         }
 
-        if ((ret == 0) && (x != 0)) {
+        if (x != 0) {
             ret = PUBLIC_KEY_E;
         }
     }

--- a/wolfcrypt/src/wc_mldsa.c
+++ b/wolfcrypt/src/wc_mldsa.c
@@ -8727,7 +8727,7 @@ static int mldsa_sign_with_seed_mu(wc_MlDsaKey* key,
         sizeof(priv_rand_seed));
 #endif
     /* Check the signature buffer isn't too small. */
-    if ((ret == 0) && (*sigLen < params->sigSz)) {
+    if (*sigLen < params->sigSz) {
         ret = BUFFER_E;
     }
     if (ret == 0) {

--- a/wolfcrypt/src/wc_mlkem.c
+++ b/wolfcrypt/src/wc_mlkem.c
@@ -1425,10 +1425,6 @@ static int wc_mlkemkey_check_h(MlKemKey* key)
         XFREE(pubKey, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     #endif
     }
-    if ((ret == 0) && ((key->flags & MLKEM_FLAG_H_SET) == 0)) {
-        /* Implementation issue if h not cached and flag not set. */
-        ret = BAD_STATE_E;
-    }
 
     return ret;
 }
@@ -2794,7 +2790,9 @@ int wc_MlKemKey_EncodePublicKey(MlKemKey* key, unsigned char* out, word32 len)
         }
     }
     if (ret == 0) {
-        /* Public hash is set. */
+        /* Public hash is set. wc_mlkemkey_check_h() relies on this happening on
+         * every successful path: it calls this function to establish the flag
+         * and does not test it again afterwards. */
         key->flags |= MLKEM_FLAG_H_SET;
     }
 


### PR DESCRIPTION
# Description

Eliminates all conditions that are impossible to reach from the existing wolfcrypt code. 

Each dead condition is self-containerd and documented in a separate commit, with proof of death through object code comparison vs. gcc -O2:

# Testing

These are leftover (uncoverable) conditions discovered during the the first four phases of MC/DC campaign

## Proven by gcc -O2 object equivalence (15)

The optimiser had already folded the condition — compiling the file before and after the commit yields byte-identical code, so the removal is provably behaviour-preserving.

- 00f098e6e coding.c: Base64_SkipNewline, the len operand at :137. Entry check rejects len==0; the loop decrements only under len>1.
- 03e40fdc2 coding.c : the out operand at :281 and :395 in both Base64 decoders; entry checks already reject out==NULL.
- 413fcc550 coding.c : the in operand at :663 in Base16_Decode; :660 rejects in==NULL unconditionally.
- 4acfa9984 sp_int.c : nested if (err == MP_OKAY) in sp_todecimal, dominated by :18887; only char writes and a discarded sp_div_d between.
- d851828e0 sp_int.c : same pattern in _sp_lcm; only two void _sp_init_size() calls between.
- 738454dc4 memory.c : res == NULL in wolfSSL_Realloc; both writes to res are on branches mutually exclusive with this one.
- 04774352f wc_mldsa.c : (ret == 1) loop guard in mldsa_vec_check_low_c; callee returns only 0 or 1 and the body breaks on 0.
- 5aecf75c7 wc_mldsa.c : (ret == 0) in wc_MlDsaKey_CheckKey; every call in the dominated span returns void.
- cd1324ff1 wc_mldsa.c : (ret == 0) at the small-mem sign entry; ret unwritten between declaration and its only evaluation.
- 5cd3ba0b8 wc_mldsa.c : (ret == 0) in two inner loops whose every ret write is followed by an unconditional break.
- 23b3a7afc integer.c : the six mp_init() != MP_OKAY guards and their mp_clear cascades in mp_init_multi; mp_init fails only on NULL, already excluded. (Confirmed under --enable-heapmath, the config that compiles the file.)
- 5cdce9689 aes.c : bit >= 0 in wc_AesFeedbackCFB1; bit is normalised back to 7 on every decrement. bit < 7 kept — it's live.
- c62fad325 ed448.c : !key->privKeySet in wc_ed448_check_key, plus the nested always-true if (ret == 0); both follow from the sibling if's short-circuit.
- 7a07129d5 kdf.c : ret == 0 in the KDA-KDF CMAC while; the body's only exit is an unconditional if (ret != 0) break.
- 25ca23099 pwdbased.c : DoPKCS12Hash's NULL check; static, two call sites, all four paths (× WOLFSSL_SMALL_STACK) NULL-check and return first.

### Proved by exhaustive enumeration [no optimizer can reach these]  (6) 

- fc72ef83f md5.c : len == 0 in wc_Md5Update. With data == NULL held true, all 2³² word32 values of len enumerated: every one passing the :345 guard has len == 0. Zero counterexamples. (gcc won't correlate the entry guard's two operands across the branch.)
- f04324101 tfm.c : fp_gcd's two redundant operands plus the unreachable fp_iszero(a) block. fp_iszero is side-effect-free over ->used and neither operand is written in the span, so the chain depends on exactly two booleans: all 4 (Za,Zb) states enumerated, 0 counterexamples.
- e11b5e1e4 integer.c : tmpc == NULL in s_mp_add. mp_grow has exactly three exits, enumerated in full; the only MP_OKAY one is reached after a->dp = tmp (NULL-checked) or through the else if (a->dp == NULL) return MP_VAL filter. Hence MP_OKAY ⇒ dp != NULL.
- aeb153c46 wc_mlkem.c : the BAD_STATE_E re-check. All 9 writes to key->flags in the TU enumerated (:453, 621, 852, 1001, 1003, 2283, 2327, 2430, 2794); check_h calls only 4 functions, of which just EncodePublicKey touches flags — and it sets H_SET on ret == 0. No reachable path clears it.
- 7283dc884 wc_lms_impl.c : !priv_key->inited. HssPrivKey declares byte* priv as a pointer member (wc_lms.h:726) alongside word8 inited:1 (:741); the callee receives the pointer value, so reaching inited through it would be an out-of-bounds write. (gcc must conservatively assume aliasing.)
- 0e18af6fb ed448.c : the Y == p case. The byte walk pins 56 of 57 key bytes, leaving p[0] as the only free variable: all 256 values enumerated against the real ed448_is_small_order(). Two (0xff = y=p, 0xfe = y=p−1) are rejected early by the table; the other 254 satisfy the operand. Zero counterexamples over the complete state space.

### Compile-gated, no host evidence (1)

- 0090560d3 sha3.c  the same len == 0 idiom at :1189/:1868/:2166, all inside PSOC6_HASH_SHA3, which needs the Cypress SDK. Proof is textual (nothing executes between guard and site); the commit says plainly it is not compile-verified. Deliberately does not touch the four look-alikes at :1123/:1285/:1967/:2263, where len == 0 is load-bearing.