### PR TITLE
Deep copy revoked cert entry extensions in DupCRL_Entry()

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -1411,6 +1411,37 @@ static CRL_Entry* DupCRL_Entry(const CRL_Entry* ent, void* heap)
         CRL_Entry_free(dupl, heap);
         return NULL;
     }
+#elif defined(OPENSSL_EXTRA)
+    {
+        int i;
+
+        /* certs is an in-struct array living after verifyMutex, so the bulk
+         * copy above aliased every extensions pointer with the original's.
+         * Cleaning the whole array first. */
+        for (i = 0; i < CRL_MAX_REVOKED_CERTS; i++) {
+            dupl->certs[i].extensions = NULL;
+            dupl->certs[i].extensionsSz = 0;
+        }
+
+        /* Deep copy the entry extensions, as DupRevokedCertList() does for the
+         * linked-list build. */
+        for (i = 0; i < ent->totalCerts; i++) {
+            if (ent->certs[i].extensions == NULL ||
+                    ent->certs[i].extensionsSz == 0) {
+                continue;
+            }
+            dupl->certs[i].extensions = (byte*)XMALLOC(
+                    ent->certs[i].extensionsSz, heap, DYNAMIC_TYPE_REVOKED);
+            if (dupl->certs[i].extensions == NULL) {
+                WOLFSSL_MSG("Failed to allocate revoked cert extensions");
+                CRL_Entry_free(dupl, heap);
+                return NULL;
+            }
+            XMEMCPY(dupl->certs[i].extensions, ent->certs[i].extensions,
+                    ent->certs[i].extensionsSz);
+            dupl->certs[i].extensionsSz = ent->certs[i].extensionsSz;
+        }
+    }
 #endif
 #ifdef OPENSSL_EXTRA
     dupl->issuer = wolfSSL_X509_NAME_dup(ent->issuer);

--- a/src/crl.c
+++ b/src/crl.c
@@ -1326,65 +1326,77 @@ static WOLFSSL_X509_CRL* wolfSSL_X509_crl_new(WOLFSSL_CERT_MANAGER* cm)
     return ret;
 }
 
-#ifndef CRL_STATIC_REVOKED_LIST
-/* returns head of copied list that was alloc'd */
-static RevokedCert *DupRevokedCertList(RevokedCert* in, void* heap)
+/* Copy a single revoked cert, deep copying any entry extensions.
+ * returns 0 on success and MEMORY_E on fail */
+static int DupRevokedCert(RevokedCert* out, const RevokedCert* in, void* heap)
 {
-    RevokedCert* head = NULL;
-    RevokedCert* current = in;
-    RevokedCert* prev = NULL;
-    while (current) {
-        RevokedCert* tmp = (RevokedCert*)XMALLOC(sizeof(RevokedCert), heap,
-                DYNAMIC_TYPE_REVOKED);
-        if (tmp != NULL) {
-            XMEMCPY(tmp->serialNumber, current->serialNumber,
-                    EXTERNAL_SERIAL_SIZE);
-            tmp->serialSz = current->serialSz;
-            XMEMCPY(tmp->revDate, current->revDate,
-                    MAX_DATE_SIZE);
-            tmp->revDateFormat = current->revDateFormat;
-            tmp->reasonCode = current->reasonCode;
+    XMEMCPY(out->serialNumber, in->serialNumber, EXTERNAL_SERIAL_SIZE);
+    out->serialSz = in->serialSz;
+    XMEMCPY(out->revDate, in->revDate, MAX_DATE_SIZE);
+    out->revDateFormat = in->revDateFormat;
+    out->reasonCode = in->reasonCode;
+    out->next = NULL;
 #if defined(OPENSSL_EXTRA)
-            tmp->extensions = NULL;
-            tmp->extensionsSz = 0;
-            if (current->extensions != NULL && current->extensionsSz > 0) {
-                tmp->extensions = (byte*)XMALLOC(current->extensionsSz, heap,
-                                                 DYNAMIC_TYPE_REVOKED);
-                if (tmp->extensions != NULL) {
-                    XMEMCPY(tmp->extensions, current->extensions,
-                            current->extensionsSz);
-                    tmp->extensionsSz = current->extensionsSz;
-                }
-            }
-#endif
-            tmp->next = NULL;
-            if (prev != NULL)
-                prev->next = tmp;
-            if (head == NULL)
-                head = tmp;
-            prev = tmp;
+    out->extensions = NULL;
+    out->extensionsSz = 0;
+    if (in->extensions != NULL && in->extensionsSz > 0) {
+        out->extensions = (byte*)XMALLOC(in->extensionsSz, heap,
+                                         DYNAMIC_TYPE_REVOKED);
+        if (out->extensions == NULL) {
+            WOLFSSL_MSG("Failed to allocate revoked cert extensions");
+            return MEMORY_E;
         }
-        else {
-            WOLFSSL_MSG("Failed to allocate new RevokedCert structure");
-            /* free up any existing list */
-            while (head != NULL) {
-                current = head;
-                head = head->next;
-#if defined(OPENSSL_EXTRA)
-                XFREE(current->extensions, heap, DYNAMIC_TYPE_REVOKED);
-#endif
-                XFREE(current, heap, DYNAMIC_TYPE_REVOKED);
-            }
-            return NULL;
-        }
-        current = current->next;
+        XMEMCPY(out->extensions, in->extensions, in->extensionsSz);
+        out->extensionsSz = in->extensionsSz;
     }
+#endif
 
     (void)heap;
-    return head;
+    return 0;
 }
 
-#endif /* CRL_STATIC_REVOKED_LIST */
+/* Copy the revoked certs of ent into dupl. On fail the certs copied so far are
+ * left owned by dupl, for CRL_Entry_free() to release.
+ * returns 0 on success and MEMORY_E on fail */
+static int DupRevokedCertList(CRL_Entry* dupl, const CRL_Entry* ent, void* heap)
+{
+#ifdef CRL_STATIC_REVOKED_LIST
+    int i;
+
+    /* CRL_Entry_new() zeroed the array, so only the used entries need to be
+     * filled in. */
+    for (i = 0; i < ent->totalCerts; i++) {
+        if (DupRevokedCert(&dupl->certs[i], &ent->certs[i], heap) != 0)
+            return MEMORY_E;
+    }
+#else
+    RevokedCert* current;
+    RevokedCert* prev = NULL;
+
+    for (current = ent->certs; current != NULL; current = current->next) {
+        RevokedCert* tmp = (RevokedCert*)XMALLOC(sizeof(RevokedCert), heap,
+                DYNAMIC_TYPE_REVOKED);
+        if (tmp == NULL) {
+            WOLFSSL_MSG("Failed to allocate new RevokedCert structure");
+            return MEMORY_E;
+        }
+        if (DupRevokedCert(tmp, current, heap) != 0) {
+            XFREE(tmp, heap, DYNAMIC_TYPE_REVOKED);
+            return MEMORY_E;
+        }
+        /* link it in before copying the next one so that a later failure
+         * doesn't leak it */
+        if (prev != NULL)
+            prev->next = tmp;
+        else
+            dupl->certs = tmp;
+        prev = tmp;
+    }
+#endif
+
+    return 0;
+}
+
 /* returns a deep copy of ent on success and null on fail */
 static CRL_Entry* DupCRL_Entry(const CRL_Entry* ent, void* heap)
 {
@@ -1405,13 +1417,11 @@ static CRL_Entry* DupCRL_Entry(const CRL_Entry* ent, void* heap)
     XMEMCPY((byte*)dupl + copyOffset, (byte*)ent + copyOffset,
             sizeof(CRL_Entry) - copyOffset);
 
-#ifndef CRL_STATIC_REVOKED_LIST
-    dupl->certs = DupRevokedCertList(ent->certs, heap);
-    if (ent->certs != NULL && dupl->certs == NULL) {
+    /* certs is not part of the bulk copy above so we copy it explicitly */
+    if (DupRevokedCertList(dupl, ent, heap) != 0) {
         CRL_Entry_free(dupl, heap);
         return NULL;
     }
-#endif
 #ifdef OPENSSL_EXTRA
     dupl->issuer = wolfSSL_X509_NAME_dup(ent->issuer);
     if (ent->issuer != NULL && dupl->issuer == NULL) {

--- a/tests/api/test_certman.c
+++ b/tests/api/test_certman.c
@@ -29,6 +29,7 @@
 #endif
 
 #include <wolfssl/ssl.h>
+#include <wolfssl/internal.h>
 #include <wolfssl/ocsp.h>
 #include <tests/api/api.h>
 #include <tests/api/test_certman.h>
@@ -2598,6 +2599,54 @@ int test_wolfSSL_CRL_static_revoked_list(void)
         sizeof_server_cert_der_2048), WC_NO_ERR_TRACE(CRL_CERT_REVOKED));
 
     wolfSSL_CertManagerFree(cm);
+#endif
+    return EXPECT_RESULT();
+}
+
+int test_wolfSSL_CRL_static_revoked_list_dup(void)
+{
+    EXPECT_DECLS;
+#if defined(CRL_STATIC_REVOKED_LIST) && defined(HAVE_CRL) && \
+    defined(OPENSSL_EXTRA) && !defined(NO_RSA) && !defined(NO_CERTS) && \
+    defined(WOLFSSL_PEM_TO_DER) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_STDIO_FILESYSTEM)
+    /* certs/crl/crl_reason.pem revokes serial 01 and carries a
+     * crlEntryExtensions (CRL Reason Code) for that entry.
+     * Under OPENSSL_EXTRA GetRevoked() heap-allocates
+     * RevokedCert.extensions to hold the raw DER of those extensions. */
+    const char* crlReasonFile = "./certs/crl/crl_reason.pem";
+    XFILE fp = XBADFILE;
+    WOLFSSL_X509_CRL* crl = NULL;
+    WOLFSSL_X509_CRL* dupl = NULL;
+
+    ExpectTrue((fp = XFOPEN(crlReasonFile, "rb")) != XBADFILE);
+    ExpectNotNull(crl = wolfSSL_PEM_read_X509_CRL(fp, NULL, NULL, NULL));
+    if (fp != XBADFILE)
+        XFCLOSE(fp);
+
+    ExpectNotNull(crl != NULL ? crl->crlList : NULL);
+    ExpectIntGT((crl != NULL && crl->crlList != NULL) ?
+        crl->crlList->totalCerts : 0, 0);
+    ExpectNotNull((crl != NULL && crl->crlList != NULL) ?
+        crl->crlList->certs[0].extensions : NULL);
+
+    ExpectNotNull(dupl = wolfSSL_X509_CRL_dup(crl));
+
+    /* Every duplicated revoked cert must own its own extensions buffer. This
+     * fails when the bulk copy aliased them. */
+    if (crl != NULL && dupl != NULL && crl->crlList != NULL &&
+            dupl->crlList != NULL) {
+        int i;
+        for (i = 0; i < crl->crlList->totalCerts; i++) {
+            if (crl->crlList->certs[i].extensions != NULL) {
+                ExpectPtrNE(dupl->crlList->certs[i].extensions,
+                            crl->crlList->certs[i].extensions);
+            }
+        }
+    }
+
+    wolfSSL_X509_CRL_free(dupl);
+    wolfSSL_X509_CRL_free(crl);
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_certman.c
+++ b/tests/api/test_certman.c
@@ -29,6 +29,7 @@
 #endif
 
 #include <wolfssl/ssl.h>
+#include <wolfssl/internal.h>
 #include <wolfssl/ocsp.h>
 #include <tests/api/api.h>
 #include <tests/api/test_certman.h>
@@ -2598,6 +2599,59 @@ int test_wolfSSL_CRL_static_revoked_list(void)
         sizeof_server_cert_der_2048), WC_NO_ERR_TRACE(CRL_CERT_REVOKED));
 
     wolfSSL_CertManagerFree(cm);
+#endif
+    return EXPECT_RESULT();
+}
+
+int test_wolfSSL_CRL_static_revoked_list_dup(void)
+{
+    EXPECT_DECLS;
+#if defined(CRL_STATIC_REVOKED_LIST) && defined(HAVE_CRL) && \
+    defined(OPENSSL_EXTRA) && !defined(NO_RSA) && !defined(NO_CERTS) && \
+    defined(WOLFSSL_PEM_TO_DER) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_STDIO_FILESYSTEM)
+    /* certs/crl/crl_reason.pem revokes serial 01 and carries a
+     * crlEntryExtensions (CRL Reason Code) for that entry.
+     * Under OPENSSL_EXTRA GetRevoked() heap-allocates
+     * RevokedCert.extensions to hold the raw DER of those extensions. */
+    const char* crlReasonFile = "./certs/crl/crl_reason.pem";
+    XFILE fp = XBADFILE;
+    WOLFSSL_X509_CRL* crl = NULL;
+    WOLFSSL_X509_CRL* dupl = NULL;
+
+    ExpectTrue((fp = XFOPEN(crlReasonFile, "rb")) != XBADFILE);
+    ExpectNotNull(crl = wolfSSL_PEM_read_X509_CRL(fp, NULL, NULL, NULL));
+    if (fp != XBADFILE)
+        XFCLOSE(fp);
+
+    ExpectNotNull(crl != NULL ? crl->crlList : NULL);
+    ExpectIntGT((crl != NULL && crl->crlList != NULL) ?
+        crl->crlList->totalCerts : 0, 0);
+    ExpectNotNull((crl != NULL && crl->crlList != NULL) ?
+        crl->crlList->certs[0].extensions : NULL);
+
+    ExpectNotNull(dupl = wolfSSL_X509_CRL_dup(crl));
+
+    /* Every duplicated revoked cert must own its own copy of the extensions.
+     * A shallow copy shares the pointer, a dropped copy leaves it NULL. */
+    if (crl != NULL && dupl != NULL && crl->crlList != NULL &&
+            dupl->crlList != NULL) {
+        int i;
+        for (i = 0; i < crl->crlList->totalCerts; i++) {
+            const RevokedCert* o = &crl->crlList->certs[i];
+            const RevokedCert* d = &dupl->crlList->certs[i];
+
+            if (o->extensions != NULL) {
+                ExpectNotNull(d->extensions);
+                ExpectPtrNE(d->extensions, o->extensions);
+                ExpectIntEQ(d->extensionsSz, o->extensionsSz);
+                ExpectBufEQ(d->extensions, o->extensions, o->extensionsSz);
+            }
+        }
+    }
+
+    wolfSSL_X509_CRL_free(dupl);
+    wolfSSL_X509_CRL_free(crl);
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_certman.h
+++ b/tests/api/test_certman.h
@@ -44,6 +44,7 @@ int test_wolfSSL_X509_check_host_URI_SAN_not_DNS_match(void);
 int test_wolfSSL_CertManagerCRL(void);
 int test_wolfSSL_CRL_reason_extensions_cleanup(void);
 int test_wolfSSL_CRL_static_revoked_list(void);
+int test_wolfSSL_CRL_static_revoked_list_dup(void);
 int test_wolfSSL_CRL_duplicate_extensions(void);
 int test_wolfSSL_CRL_critical_idp(void);
 int test_wolfSSL_CRL_unknown_critical_ext(void);
@@ -82,6 +83,7 @@ int test_wolfSSL_CertManagerNameConstraint_skid_disambiguates(void);
     TEST_DECL_GROUP("certman", test_wolfSSL_CertManagerCRL),                \
     TEST_DECL_GROUP("certman", test_wolfSSL_CRL_reason_extensions_cleanup), \
     TEST_DECL_GROUP("certman", test_wolfSSL_CRL_static_revoked_list),      \
+    TEST_DECL_GROUP("certman", test_wolfSSL_CRL_static_revoked_list_dup),  \
     TEST_DECL_GROUP("certman", test_wolfSSL_CRL_duplicate_extensions),      \
     TEST_DECL_GROUP("certman", test_wolfSSL_CRL_critical_idp),             \
     TEST_DECL_GROUP("certman", test_wolfSSL_CRL_unknown_critical_ext),     \

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2554,9 +2554,16 @@ struct CRL_Entry {
     WOLFSSL_X509_NAME*    issuer;     /* X509_NAME type issuer */
 #endif
     CRL_Entry* next;                      /* next entry */
+#ifdef CRL_STATIC_REVOKED_LIST
+    RevokedCert certs[CRL_MAX_REVOKED_CERTS];
+#else
+    RevokedCert* certs;             /* revoked cert list  */
+#endif
     wolfSSL_Mutex verifyMutex;
-    /* DupCRL_Entry copies data after the `verifyMutex` member. Using the mutex
-     * as the marker because clang-tidy doesn't like taking the sizeof a
+    /* DupCRL_Entry bulk copies the data after the `verifyMutex` member, so
+     * only self-contained value data belongs below it. Anything holding a
+     * pointer goes above, where DupCRL_Entry copies it explicitly. Using the
+     * mutex as the marker because clang-tidy doesn't like taking the sizeof a
      * pointer. */
     char    crlNumber[CRL_MAX_NUM_HEX_STR_SZ];    /* CRL number extension */
     byte    issuerHash[CRL_DIGEST_SIZE];  /* issuer hash                 */
@@ -2569,11 +2576,6 @@ struct CRL_Entry {
 #if defined(OPENSSL_EXTRA)
     WOLFSSL_ASN1_TIME lastDateAsn1;  /* last date updated  */
     WOLFSSL_ASN1_TIME nextDateAsn1;  /* next update date   */
-#endif
-#ifdef CRL_STATIC_REVOKED_LIST
-    RevokedCert certs[CRL_MAX_REVOKED_CERTS];
-#else
-    RevokedCert* certs;             /* revoked cert list  */
 #endif
     int     totalCerts;             /* number on list     */
     int     version;                /* version of certificate */


### PR DESCRIPTION
# Description

Deep copy revoked cert entry extensions in DupCRL_Entry() when CRL_STATIC_REVOKED_LIST and OPENSSL_EXTRA are enabled, and add a regression test for the X509_CRL_dup path.

# Testing

Added regression test test_wolfSSL_CRL_static_revoked_list_dup in the testsuite;

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
