### PR TITLE
Fully clear ECC k when calling wc_ecc_sign_hash_ex with SP math.  Avoid aliasing the ticket in wolfSSL_GetSessionAtIndex.  Fix IAR warnings.

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -2828,7 +2828,10 @@ int wolfSSL_GetSessionIndex(WOLFSSL* ssl);
 
     \brief This function gets the session at specified index of the session
     cache and copies it into memory. The WOLFSSL_SESSION structure holds
-    the session information.
+    the session information. The copy is independent of the cache entry: it
+    does not share the ticket buffer, peer certificate or ex_data with the
+    cache, and it stays valid after the cache entry is overwritten or evicted.
+    The caller owns the copy and releases it with wolfSSL_SESSION_free().
 
     \return SSL_SUCCESS returned if the function executed successfully and
     no errors were thrown.
@@ -2836,16 +2839,19 @@ int wolfSSL_GetSessionIndex(WOLFSSL* ssl);
     \return SSL_FAILURE returned if the function did not execute successfully.
 
     \param index an int type representing the session index.
-    \param session a pointer to the WOLFSSL_SESSION structure.
+    \param session a pointer to a WOLFSSL_SESSION structure to copy into,
+    obtained from wolfSSL_SESSION_new().
 
     _Example_
     \code
     int idx; // The index to locate the session.
-    WOLFSSL_SESSION* session;  // Buffer to copy to.
+    WOLFSSL_SESSION* session = wolfSSL_SESSION_new();  // Buffer to copy to.
     ...
     if(wolfSSL_GetSessionAtIndex(idx, session) != SSL_SUCCESS){
     	// Failure case.
     }
+    ...
+    wolfSSL_SESSION_free(session);
     \endcode
 
     \sa UnLockMutex

--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -23,6 +23,10 @@
 
 #include <wolfssl/internal.h>
 
+#if defined(WOLFSSL_RENESAS_TSIP_TLS) || defined(WOLFSSL_RENESAS_FSPSM_TLS)
+#include <wolfssl/wolfcrypt/port/Renesas/renesas_cmn.h>
+#endif
+
 #if !defined(WOLFSSL_SSL_CERTMAN_INCLUDED)
     #ifndef WOLFSSL_IGNORE_FILE_WARN
         #warning ssl_certman.c not to be compiled separately from ssl.c

--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -2271,8 +2271,18 @@ int wolfSSL_GetSessionAtIndex(int idx, WOLFSSL_SESSION* session)
     cacheSession = &sessRow->Sessions[col];
 #endif
     if (cacheSession) {
-        XMEMCPY(session, cacheSession, sizeof(WOLFSSL_SESSION));
-        result = WOLFSSL_SUCCESS;
+#ifdef HAVE_EX_DATA
+        /* The copy keeps its own ex_data. The struct copy below carries over
+         * the cache's pointers, which the cache frees when the entry goes. */
+        WOLFSSL_CRYPTO_EX_DATA exData;
+        XMEMCPY(&exData, &session->ex_data, sizeof(exData));
+#endif
+        /* Must not alias the ticket, peer cert and ex_data the cache owns and
+         * frees on overwrite or eviction. */
+        result = wolfSSL_DupSession(cacheSession, session, 0);
+#ifdef HAVE_EX_DATA
+        XMEMCPY(&session->ex_data, &exData, sizeof(exData));
+#endif
     }
     else {
         result = WOLFSSL_FAILURE;

--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -1121,8 +1121,8 @@ static int SessionTicketNoncePrealloc(byte** buf, byte* len, void *heap)
 #endif /* HAVE_SESSION_TICKET && WOLFSSL_TLS13 */
 
 static int wolfSSL_DupSessionEx(const WOLFSSL_SESSION* input,
-    WOLFSSL_SESSION* output, int avoidSysCalls, byte* ticketNonceBuf,
-    byte* ticketNonceLen, byte* preallocUsed);
+    WOLFSSL_SESSION* output, int avoidSysCalls, int transferExData,
+    byte* ticketNonceBuf, byte* ticketNonceLen, byte* preallocUsed);
 
 void TlsSessionCacheUnlockRow(word32 row)
 {
@@ -1406,7 +1406,7 @@ int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output)
 
     if (error == WOLFSSL_SUCCESS) {
 #if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13)
-        error = wolfSSL_DupSessionEx(sess, output, 1,
+        error = wolfSSL_DupSessionEx(sess, output, 1, 1,
             preallocNonce, &preallocNonceLen, &preallocNonceUsed);
 #else
         error = wolfSSL_DupSession(sess, output, 1);
@@ -2046,7 +2046,7 @@ int AddSessionToCache(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* addSession,
 #if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13) &&                  \
     defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                                   \
     (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    ret = (wolfSSL_DupSessionEx(addSession, cacheSession, 1, preallocNonce,
+    ret = (wolfSSL_DupSessionEx(addSession, cacheSession, 1, 1, preallocNonce,
                                 &preallocNonceLen, &preallocNonceUsed)
            == WC_NO_ERR_TRACE(WOLFSSL_FAILURE));
 #else
@@ -2271,18 +2271,11 @@ int wolfSSL_GetSessionAtIndex(int idx, WOLFSSL_SESSION* session)
     cacheSession = &sessRow->Sessions[col];
 #endif
     if (cacheSession) {
-#ifdef HAVE_EX_DATA
-        /* The copy keeps its own ex_data. The struct copy below carries over
-         * the cache's pointers, which the cache frees when the entry goes. */
-        WOLFSSL_CRYPTO_EX_DATA exData;
-        XMEMCPY(&exData, &session->ex_data, sizeof(exData));
-#endif
         /* Must not alias the ticket, peer cert and ex_data the cache owns and
-         * frees on overwrite or eviction. */
-        result = wolfSSL_DupSession(cacheSession, session, 0);
-#ifdef HAVE_EX_DATA
-        XMEMCPY(&session->ex_data, &exData, sizeof(exData));
-#endif
+         * frees on overwrite or eviction. The caller keeps this copy, so it
+         * does not take over the cache's ex_data either. */
+        result = wolfSSL_DupSessionEx(cacheSession, session, 0, 0, NULL, NULL,
+            NULL);
     }
     else {
         result = WOLFSSL_FAILURE;
@@ -3889,6 +3882,9 @@ int wolfSSL_SESSION_up_ref(WOLFSSL_SESSION* session)
  *                      sessions from cache. When a cache row is locked, we
  *                      don't want to block other threads with long running
  *                      system calls.
+ * @param transferExData If true, the output takes over the input's ex_data.
+ *                      Set false when the caller keeps the output and the
+ *                      input's ex_data stays owned elsewhere, e.g. the cache.
  * @param ticketNonceBuf If not null and @avoidSysCalls is true, the copy of the
  *                      ticketNonce will happen in this pre allocated buffer
  * @param ticketNonceLen @ticketNonceBuf len as input, used length on output
@@ -3897,18 +3893,22 @@ int wolfSSL_SESSION_up_ref(WOLFSSL_SESSION* session)
  *                      WOLFSSL_FAILURE on failure
  */
 static int wolfSSL_DupSessionEx(const WOLFSSL_SESSION* input,
-    WOLFSSL_SESSION* output, int avoidSysCalls, byte* ticketNonceBuf,
-    byte* ticketNonceLen, byte* preallocUsed)
+    WOLFSSL_SESSION* output, int avoidSysCalls, int transferExData,
+    byte* ticketNonceBuf, byte* ticketNonceLen, byte* preallocUsed)
 {
 #ifdef HAVE_SESSION_TICKET
     word16 ticLenAlloc = 0;
     byte *ticBuff = NULL;
+#endif
+#ifdef HAVE_EX_DATA
+    WOLFSSL_CRYPTO_EX_DATA exData;
 #endif
     const size_t copyOffset = WC_OFFSETOF(WOLFSSL_SESSION, heap) +
         sizeof(input->heap);
     int ret = WOLFSSL_SUCCESS;
 
     (void)avoidSysCalls;
+    (void)transferExData;
     (void)ticketNonceBuf;
     (void)ticketNonceLen;
     (void)preallocUsed;
@@ -3957,6 +3957,13 @@ static int wolfSSL_DupSessionEx(const WOLFSSL_SESSION* input,
         wolfSSL_X509_free(output->peer);
         output->peer = NULL;
     }
+#endif
+
+#ifdef HAVE_EX_DATA
+    /* ex_data sits after the heap member so the copy below carries over the
+     * input's pointers. Stash the output's to put them back. */
+    if (!transferExData)
+        XMEMCPY(&exData, &output->ex_data, sizeof(exData));
 #endif
 
     XMEMCPY((byte*)output + copyOffset, (byte*)input + copyOffset,
@@ -4118,12 +4125,17 @@ static int wolfSSL_DupSessionEx(const WOLFSSL_SESSION* input,
 #endif /* HAVE_SESSION_TICKET */
 
 #ifdef HAVE_EX_DATA_CRYPTO
-    if (input->type != WOLFSSL_SESSION_TYPE_CACHE &&
+    if (transferExData && input->type != WOLFSSL_SESSION_TYPE_CACHE &&
             output->type != WOLFSSL_SESSION_TYPE_CACHE) {
         /* Not called with cache as that passes ownership of ex_data */
         ret = crypto_ex_cb_dup_data(&input->ex_data, &output->ex_data,
                                     crypto_ex_cb_ctx_session);
     }
+#endif
+
+#ifdef HAVE_EX_DATA
+    if (!transferExData)
+        XMEMCPY(&output->ex_data, &exData, sizeof(exData));
 #endif
 
     return ret;
@@ -4145,7 +4157,8 @@ static int wolfSSL_DupSessionEx(const WOLFSSL_SESSION* input,
 int wolfSSL_DupSession(const WOLFSSL_SESSION* input, WOLFSSL_SESSION* output,
         int avoidSysCalls)
 {
-    return wolfSSL_DupSessionEx(input, output, avoidSysCalls, NULL, NULL, NULL);
+    return wolfSSL_DupSessionEx(input, output, avoidSysCalls, 1, NULL, NULL,
+        NULL);
 }
 
 WOLFSSL_SESSION* wolfSSL_SESSION_dup(WOLFSSL_SESSION* session)

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5393,6 +5393,11 @@ typedef struct Dsh13Args {
 #endif
 } Dsh13Args;
 
+/* sessIdSz below bounds both the copy into arrays->sessionID and the comparison
+ * against arrays->clientRandom, so one check only covers both while these
+ * match. */
+wc_static_assert(ID_LEN == RAN_LEN);
+
 int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                        word32 helloSz, byte* extMsgType)
 {
@@ -5554,7 +5559,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     /* Session id */
     args->sessIdSz = input[args->idx++];
-    if (args->sessIdSz > ID_LEN || args->sessIdSz > RAN_LEN ||
+    if (args->sessIdSz > ID_LEN ||
         ((args->idx - args->begin) + args->sessIdSz > helloSz))
         return BUFFER_ERROR;
     args->sessId = input + args->idx;

--- a/tests/api/test_session.c
+++ b/tests/api/test_session.c
@@ -1614,3 +1614,128 @@ int test_wolfSSL_SESSION_get_ex_new_index(void)
     return TEST_SKIPPED;
 }
 #endif
+
+/*----------------------------------------------------------------------------*/
+/* wolfSSL_GetSessionAtIndex                                                  */
+/*----------------------------------------------------------------------------*/
+
+#if defined(SESSION_INDEX) && defined(HAVE_SESSION_TICKET) && \
+    !defined(NO_SESSION_CACHE) && !defined(NO_WOLFSSL_CLIENT) && \
+    !defined(NO_TLS)
+
+/* Cache a client session under id with a ticLen byte ticket of fill bytes.
+ * ticLen over SESSION_TICKET_LEN makes the cache allocate a ticket buffer. */
+static int test_session_at_index_add(WOLFSSL_CTX* ctx, const byte* id,
+    word16 ticLen, byte fill, int* idx)
+{
+    EXPECT_DECLS;
+    WOLFSSL_SESSION* sess = NULL;
+    byte* tic = NULL;
+
+    ExpectNotNull(tic = (byte*)XMALLOC(ticLen, NULL, DYNAMIC_TYPE_TMP_BUFFER));
+    ExpectNotNull(sess = wolfSSL_SESSION_new());
+    if (EXPECT_SUCCESS()) {
+        XMEMSET(tic, fill, ticLen);
+        XMEMCPY(sess->sessionID, id, ID_LEN);
+        sess->sessionIDSz = ID_LEN;
+        sess->side = WOLFSSL_CLIENT_END;
+        sess->isSetup = 1;
+        /* Borrowed buffer - ticketLenAlloc stays 0 so sess does not free it. */
+        sess->ticket = tic;
+        sess->ticketLen = ticLen;
+    }
+    ExpectIntEQ(AddSessionToCache(ctx, sess, id, ID_LEN, idx,
+        WOLFSSL_CLIENT_END, 1, NULL), 0);
+
+    if (sess != NULL) {
+        sess->ticket = sess->staticTicket;
+        sess->ticketLen = 0;
+        wolfSSL_SESSION_free(sess);
+    }
+    XFREE(tic, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+
+    return EXPECT_RESULT();
+}
+
+static int test_session_at_index_ticket_is(const WOLFSSL_SESSION* sess,
+    word16 ticLen, byte fill)
+{
+    word16 i;
+
+    if ((sess == NULL) || (sess->ticket == NULL) || (sess->ticketLen != ticLen))
+        return 0;
+    for (i = 0; i < ticLen; i++) {
+        if (sess->ticket[i] != fill)
+            return 0;
+    }
+    return 1;
+}
+
+int test_wolfSSL_GetSessionAtIndex(void)
+{
+    EXPECT_DECLS;
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL_SESSION* copy = NULL;
+    WOLFSSL_SESSION* copy2 = NULL;
+    byte id[ID_LEN];
+    word16 ticLen = (word16)(SESSION_TICKET_LEN + 128);
+    int idx = -1;
+
+    XMEMSET(id, 0x5A, sizeof(id));
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
+    ExpectIntEQ(test_session_at_index_add(ctx, id, ticLen, 0xA1, &idx),
+        TEST_SUCCESS);
+    ExpectIntGE(idx, 0);
+
+    ExpectNotNull(copy = wolfSSL_SESSION_new());
+#ifdef HAVE_EX_DATA
+    if (copy != NULL) {
+        copy->ex_data.ex_data[0] = (void*)copy;
+    }
+#endif
+    ExpectIntEQ(wolfSSL_GetSessionAtIndex(idx, copy), WOLFSSL_SUCCESS);
+    ExpectIntEQ(test_session_at_index_ticket_is(copy, ticLen, 0xA1), 1);
+#ifdef HAVE_EX_DATA
+    /* The copy keeps its own ex_data and the right to free it. */
+    if (copy != NULL) {
+        ExpectPtrEq(copy->ex_data.ex_data[0], (void*)copy);
+        ExpectIntEQ(copy->ownExData, 1);
+    }
+#endif
+
+    /* Each copy owns its ticket rather than pointing into the cache. */
+    ExpectNotNull(copy2 = wolfSSL_SESSION_new());
+    ExpectIntEQ(wolfSSL_GetSessionAtIndex(idx, copy2), WOLFSSL_SUCCESS);
+    if ((copy != NULL) && (copy2 != NULL)) {
+        ExpectPtrNE(copy->ticket, copy2->ticket);
+    }
+
+    /* Same length overwrite reuses the cache buffer - copies keep their
+     * bytes. */
+    ExpectIntEQ(test_session_at_index_add(ctx, id, ticLen, 0xB2, NULL),
+        TEST_SUCCESS);
+    ExpectIntEQ(test_session_at_index_ticket_is(copy, ticLen, 0xA1), 1);
+    ExpectIntEQ(test_session_at_index_ticket_is(copy2, ticLen, 0xA1), 1);
+
+    /* Longer ticket makes the cache free its buffer, and releasing a copy must
+     * not free a buffer the cache still uses. */
+    wolfSSL_SESSION_free(copy2);
+    copy2 = NULL;
+    ExpectIntEQ(test_session_at_index_add(ctx, id, (word16)(ticLen + 512),
+        0xC3, NULL), TEST_SUCCESS);
+    ExpectIntEQ(test_session_at_index_ticket_is(copy, ticLen, 0xA1), 1);
+
+    wolfSSL_SESSION_free(copy);
+    wolfSSL_CTX_free(ctx);
+    return EXPECT_RESULT();
+}
+
+#else
+
+int test_wolfSSL_GetSessionAtIndex(void)
+{
+    return TEST_SKIPPED;
+}
+
+#endif /* SESSION_INDEX && HAVE_SESSION_TICKET && !NO_SESSION_CACHE &&
+        * !NO_WOLFSSL_CLIENT && !NO_TLS */

--- a/tests/api/test_session.h
+++ b/tests/api/test_session.h
@@ -36,6 +36,7 @@ int test_wolfSSL_SESSION_expire_downgrade(void);
 int test_wolfSSL_CTX_sess_set_remove_cb(void);
 int test_wolfSSL_ticket_keys(void);
 int test_wolfSSL_SESSION_get_ex_new_index(void);
+int test_wolfSSL_GetSessionAtIndex(void);
 
 #define TEST_SESSION_DECLS                                                     \
     TEST_DECL_GROUP("session", test_wolfSSL_CTX_add_session),                  \
@@ -49,6 +50,7 @@ int test_wolfSSL_SESSION_get_ex_new_index(void);
     TEST_DECL_GROUP("session", test_wolfSSL_SESSION_expire_downgrade),         \
     TEST_DECL_GROUP("session", test_wolfSSL_CTX_sess_set_remove_cb),           \
     TEST_DECL_GROUP("session", test_wolfSSL_ticket_keys),                      \
-    TEST_DECL_GROUP("session", test_wolfSSL_SESSION_get_ex_new_index)
+    TEST_DECL_GROUP("session", test_wolfSSL_SESSION_get_ex_new_index),         \
+    TEST_DECL_GROUP("session", test_wolfSSL_GetSessionAtIndex)
 
 #endif /* WOLFCRYPT_TEST_SESSION_H */

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7473,6 +7473,29 @@ static int ecc_sign_hash_sw(ecc_key* key, ecc_key* pubkey, WC_RNG* rng,
 #endif
 
 #ifdef WOLFSSL_HAVE_SP_ECC
+#if defined(WOLFSSL_ECDSA_SET_K) || defined(WOLFSSL_ECDSA_SET_K_ONE_LOOP) || \
+    defined(WOLFSSL_ECDSA_DETERMINISTIC_K) || \
+    defined(WOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT)
+/* SP only resets the logical length of k, leaving its digits in the backing
+ * store. Clear it the way the software path does. */
+static void ecc_sign_k_forcezero(ecc_key* key)
+{
+#ifndef WOLFSSL_NO_MALLOC
+    if (key->sign_k != NULL) {
+        mp_forcezero(key->sign_k);
+        mp_free(key->sign_k);
+        XFREE(key->sign_k, key->heap, DYNAMIC_TYPE_ECC);
+        key->sign_k = NULL;
+    }
+#else
+    if (key->sign_k_set) {
+        mp_forcezero(key->sign_k);
+        key->sign_k_set = 0;
+    }
+#endif
+}
+#endif
+
 static int ecc_sign_hash_sp(const byte* in, word32 inlen, WC_RNG* rng,
     ecc_key* key, mp_int *r, mp_int *s)
 {
@@ -7702,7 +7725,20 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 
 #if defined(WOLFSSL_HAVE_SP_ECC)
    err = ecc_sign_hash_sp(in, inlen, rng, key, r, s);
+   /* WC_KEY_SIZE_E only means SP left this curve to the software path below,
+    * which needs k and clears it itself. Every other result consumed k. */
    if (err != WC_NO_ERR_TRACE(WC_KEY_SIZE_E)) {
+   #if defined(WOLFSSL_ECDSA_SET_K) || defined(WOLFSSL_ECDSA_SET_K_ONE_LOOP) || \
+       defined(WOLFSSL_ECDSA_DETERMINISTIC_K) || \
+       defined(WOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT)
+       #ifdef WC_ECC_NONBLOCK
+       /* An incomplete operation still needs k. */
+       if (err != FP_WOULDBLOCK)
+       #endif
+       {
+           ecc_sign_k_forcezero(key);
+       }
+   #endif
        return err;
    }
 #else


### PR DESCRIPTION
# Description

Fixes zd#22232, zd#22242, zd#22263

# Testing

Built in tests, provided reproducers

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [X] Updated manual and documentation
