### PR TITLE
Append injected data at the end of the input buffer

### DIFF
--- a/doc/dox_comments/header_files-ja/ssl.h
+++ b/doc/dox_comments/header_files-ja/ssl.h
@@ -12950,7 +12950,8 @@ int  wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz,
     \param [in] sz 注入するデータのバイト数。
 
     \return BAD_FUNC_ARG いずれかのポインタパラメータがNULLまたはsz <= 0の場合。
-    \return APP_DATA_READY 読み取るべきアプリケーションデータが残っている場合。
+    \return BUFFER_ERROR 入力バッファの長さに矛盾がある場合。
+    \return APP_DATA_READY 読み取るべきアプリケーションデータが残っている状態で入力バッファの拡張が必要になった場合。
     \return MEMORY_E 割り当てが失敗した場合。
     \return WOLFSSL_SUCCESS 成功時。
 

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -15723,7 +15723,9 @@ int  wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz,
     \param [in] sz number of bytes of data to inject.
 
     \return BAD_FUNC_ARG if any pointer parameter is NULL or sz <= 0
-    \return APP_DATA_READY if there is application data left to read
+    \return BUFFER_ERROR if the input buffer lengths are inconsistent
+    \return APP_DATA_READY if the input buffer must be grown while there is
+            application data left to read
     \return MEMORY_E if allocation fails
     \return WOLFSSL_SUCCESS on success
 

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -15629,7 +15629,9 @@ int  wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz,
     \param [in] sz number of bytes of data to inject.
 
     \return BAD_FUNC_ARG if any pointer parameter is NULL or sz <= 0
-    \return APP_DATA_READY if there is application data left to read
+    \return BUFFER_ERROR if the input buffer lengths are inconsistent
+    \return APP_DATA_READY if the input buffer must be grown while there is
+            application data left to read
     \return MEMORY_E if allocation fails
     \return WOLFSSL_SUCCESS on success
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -12467,19 +12467,27 @@ int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength)
         tmp += align - hdrSz;
 #endif
 
-#ifdef WOLFSSL_STATIC_MEMORY
-    /* can be from IO memory pool which does not need copy if same buffer */
-    if (usedLength && tmp == ssl->buffers.inputBuffer.buffer) {
-        ssl->buffers.inputBuffer.bufferSize = size + usedLength;
+    /* Move the retained data to the front of the new buffer. A pooled
+     * allocator can hand back the buffer still in use, so the two regions may
+     * overlap and this has to be a move, not a copy. */
+    if (usedLength > 0) {
+        XMEMMOVE(tmp, ssl->buffers.inputBuffer.buffer +
+                 ssl->buffers.inputBuffer.idx, (size_t)usedLength);
+    }
+
+    /* Same buffer back: the data is already in place, so it must not be freed
+     * or zeroed here, only the consumed bytes left behind it. */
+    if (tmp == ssl->buffers.inputBuffer.buffer) {
+        if (IsEncryptionOn(ssl, 1) &&
+                ssl->buffers.inputBuffer.length > (word32)usedLength) {
+            ForceZero(tmp + usedLength,
+                      ssl->buffers.inputBuffer.length - (word32)usedLength);
+        }
+        ssl->buffers.inputBuffer.bufferSize = (word32)(size + usedLength);
         ssl->buffers.inputBuffer.idx    = 0;
-        ssl->buffers.inputBuffer.length = usedLength;
+        ssl->buffers.inputBuffer.length = (word32)usedLength;
         return 0;
     }
-#endif
-
-    if (usedLength)
-        XMEMCPY(tmp, ssl->buffers.inputBuffer.buffer +
-                    ssl->buffers.inputBuffer.idx, (size_t)(usedLength));
 
     if (ssl->buffers.inputBuffer.dynamicFlag) {
         if (IsEncryptionOn(ssl, 1)) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -12556,10 +12556,60 @@ static WC_INLINE int GrowOutputBuffer(WOLFSSL* ssl, int size)
 }
 
 
+/* Resize the input buffer's storage, leaving retainedLength bytes from
+ * cur->idx at offset zero of *out. A pooled allocator can hand back the block
+ * still in use; a capacity it cannot serve must come back as NULL. */
+static int ResizeInputBufferStorage(void* heap, const bufferStatic* cur,
+                                    word32 retainedLength,
+                                    word32 requestedSize, byte padSz,
+                                    byte frontOffset, int secureClear,
+                                    byte** out)
+{
+    int   ret = 0;
+    byte* tmp;
+
+    tmp = (byte*)XMALLOC((size_t)requestedSize + padSz, heap,
+                         DYNAMIC_TYPE_IN_BUFFER);
+    if (tmp == NULL) {
+        ret = MEMORY_E;
+    }
+
+    if (ret == 0) {
+        tmp += frontOffset;
+
+        /* Source and destination can be the same block, so this is a move. */
+        if (retainedLength > 0) {
+            XMEMMOVE(tmp, cur->buffer + cur->idx, retainedLength);
+        }
+
+        if (tmp == cur->buffer) {
+            /* Storage reused in place: clear only what is left behind the
+             * retained bytes, and do not free the block. */
+            if (secureClear && (cur->length > retainedLength)) {
+                ForceZero(tmp + retainedLength, cur->length - retainedLength);
+            }
+        }
+        else if (cur->dynamicFlag) {
+            if (secureClear) {
+                ForceZero(cur->buffer, cur->length);
+            }
+            XFREE(cur->buffer - cur->offset, heap, DYNAMIC_TYPE_IN_BUFFER);
+        }
+
+        *out = tmp;
+    }
+
+    return ret;
+}
+
+
 /* Grow the input buffer, should only be to read cert or big app data */
 int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength)
 {
-    byte* tmp;
+    bufferStatic* in = &ssl->buffers.inputBuffer;
+    byte* tmp = NULL;
+    byte  frontOffset = 0;
+    int   ret;
 #if defined(WOLFSSL_DTLS) || WOLFSSL_GENERAL_ALIGNMENT > 0
     byte  align = ssl->options.dtls ? WOLFSSL_GENERAL_ALIGNMENT : 0;
     byte  hdrSz = DTLS_RECORD_HEADER_SZ;
@@ -12576,6 +12626,7 @@ int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength)
     if (align) {
        while (align < hdrSz)
            align *= 2;
+       frontOffset = (byte)(align - hdrSz);
     }
 #endif
 
@@ -12584,53 +12635,20 @@ int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength)
         return BAD_FUNC_ARG;
     }
 
-    tmp = (byte*)XMALLOC((size_t)(size + usedLength + align),
-                             ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
     WOLFSSL_MSG("growing input buffer");
 
-    if (tmp == NULL)
-        return MEMORY_E;
+    ret = ResizeInputBufferStorage(ssl->heap, in, (word32)usedLength,
+            (word32)(size + usedLength), align, frontOffset,
+            IsEncryptionOn(ssl, 1), &tmp);
+    if (ret != 0)
+        return ret;
 
-#if defined(WOLFSSL_DTLS) || WOLFSSL_GENERAL_ALIGNMENT > 0
-    if (align)
-        tmp += align - hdrSz;
-#endif
-
-#ifdef WOLFSSL_STATIC_MEMORY
-    /* can be from IO memory pool which does not need copy if same buffer */
-    if (usedLength && tmp == ssl->buffers.inputBuffer.buffer) {
-        ssl->buffers.inputBuffer.bufferSize = size + usedLength;
-        ssl->buffers.inputBuffer.idx    = 0;
-        ssl->buffers.inputBuffer.length = usedLength;
-        return 0;
-    }
-#endif
-
-    if (usedLength)
-        XMEMCPY(tmp, ssl->buffers.inputBuffer.buffer +
-                    ssl->buffers.inputBuffer.idx, (size_t)(usedLength));
-
-    if (ssl->buffers.inputBuffer.dynamicFlag) {
-        if (IsEncryptionOn(ssl, 1)) {
-            ForceZero(ssl->buffers.inputBuffer.buffer,
-                ssl->buffers.inputBuffer.length);
-        }
-        XFREE(ssl->buffers.inputBuffer.buffer - ssl->buffers.inputBuffer.offset,
-              ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
-    }
-
-    ssl->buffers.inputBuffer.dynamicFlag = 1;
-#if defined(WOLFSSL_DTLS) || WOLFSSL_GENERAL_ALIGNMENT > 0
-    if (align)
-        ssl->buffers.inputBuffer.offset = align - hdrSz;
-    else
-#endif
-        ssl->buffers.inputBuffer.offset = 0;
-
-    ssl->buffers.inputBuffer.buffer = tmp;
-    ssl->buffers.inputBuffer.bufferSize = (word32)(size + usedLength);
-    ssl->buffers.inputBuffer.idx    = 0;
-    ssl->buffers.inputBuffer.length = (word32)usedLength;
+    in->buffer      = tmp;
+    in->bufferSize  = (word32)(size + usedLength);
+    in->offset      = frontOffset;
+    in->dynamicFlag = 1;
+    in->idx         = 0;
+    in->length      = (word32)usedLength;
 
     return 0;
 }

--- a/src/ssl_api_rw.c
+++ b/src/ssl_api_rw.c
@@ -381,6 +381,7 @@ int wolfSSL_write(WOLFSSL* ssl, const void* data, int sz)
  * @param [in]      sz    Length of data in bytes.
  * @return  WOLFSSL_SUCCESS on success.
  * @return  BAD_FUNC_ARG when ssl or data is NULL, or sz is not positive.
+ * @return  BUFFER_ERROR when the input buffer lengths are inconsistent.
  * @return  APP_DATA_READY when there is application data still to be read,
  *          as growing the buffer would invalidate it.
  * @return  Negative error code from growing the input buffer, such as
@@ -389,6 +390,8 @@ int wolfSSL_write(WOLFSSL* ssl, const void* data, int sz)
 int wolfSSL_inject(WOLFSSL* ssl, const void* data, int sz)
 {
     int ret = WOLFSSL_SUCCESS;
+    int usedLength = 0;
+    int maxLength = 0;
 
     WOLFSSL_ENTER("wolfSSL_inject");
 
@@ -398,34 +401,41 @@ int wolfSSL_inject(WOLFSSL* ssl, const void* data, int sz)
     }
 
     if (ret == WOLFSSL_SUCCESS) {
-        int usedLength = (int)(ssl->buffers.inputBuffer.length -
-                               ssl->buffers.inputBuffer.idx);
-        int maxLength  = (int)(ssl->buffers.inputBuffer.bufferSize -
-                               (word32)usedLength);
+        usedLength = (int)(ssl->buffers.inputBuffer.length -
+                           ssl->buffers.inputBuffer.idx);
+        /* Free space past everything buffered, where new data is appended. */
+        maxLength  = (int)(ssl->buffers.inputBuffer.bufferSize -
+                           ssl->buffers.inputBuffer.length);
 
-        if (sz > maxLength) {
-            /* Need to make space */
-            if (ssl->buffers.clearOutputBuffer.length > 0) {
-                /* clearOutputBuffer points into so reallocating inputBuffer
-                 * will invalidate clearOutputBuffer and lose app data */
-                WOLFSSL_MSG(
-                    "Can't inject while there is application data to read");
-                ret = APP_DATA_READY;
-            }
-            else {
-                int growRet = GrowInputBuffer(ssl, sz, usedLength);
+        if ((usedLength < 0) || (maxLength < 0)) {
+            ret = BUFFER_ERROR;
+        }
+    }
 
-                if (growRet < 0) {
-                    ret = growRet;
-                }
+    if ((ret == WOLFSSL_SUCCESS) && (sz > maxLength)) {
+        /* Need to make space */
+        if (ssl->buffers.clearOutputBuffer.length > 0) {
+            /* clearOutputBuffer points into so reallocating inputBuffer
+             * will invalidate clearOutputBuffer and lose app data */
+            WOLFSSL_MSG(
+                "Can't inject while there is application data to read");
+            ret = APP_DATA_READY;
+        }
+        else {
+            /* Compacts the unconsumed data, leaving idx 0 and length
+             * usedLength. */
+            int growRet = GrowInputBuffer(ssl, sz, usedLength);
+
+            if (growRet < 0) {
+                ret = growRet;
             }
         }
     }
 
     if (ret == WOLFSSL_SUCCESS) {
-        XMEMCPY(ssl->buffers.inputBuffer.buffer + ssl->buffers.inputBuffer.idx,
-                data, sz);
-        ssl->buffers.inputBuffer.length += sz;
+        XMEMCPY(ssl->buffers.inputBuffer.buffer +
+                ssl->buffers.inputBuffer.length, data, (size_t)sz);
+        ssl->buffers.inputBuffer.length += (word32)sz;
     }
 
     return ret;

--- a/src/ssl_api_rw.c
+++ b/src/ssl_api_rw.c
@@ -381,14 +381,18 @@ int wolfSSL_write(WOLFSSL* ssl, const void* data, int sz)
  * @param [in]      sz    Length of data in bytes.
  * @return  WOLFSSL_SUCCESS on success.
  * @return  BAD_FUNC_ARG when ssl or data is NULL, or sz is not positive.
- * @return  APP_DATA_READY when there is application data still to be read,
- *          as growing the buffer would invalidate it.
+ * @return  BUFFER_ERROR when the input buffer lengths are inconsistent.
+ * @return  APP_DATA_READY when the input buffer must be grown while there is
+ *          application data left to read.
  * @return  Negative error code from growing the input buffer, such as
  *          MEMORY_E.
  */
 int wolfSSL_inject(WOLFSSL* ssl, const void* data, int sz)
 {
     int ret = WOLFSSL_SUCCESS;
+    int usedLength = 0;
+    int maxLength = 0;
+    bufferStatic* in = NULL;
 
     WOLFSSL_ENTER("wolfSSL_inject");
 
@@ -398,34 +402,47 @@ int wolfSSL_inject(WOLFSSL* ssl, const void* data, int sz)
     }
 
     if (ret == WOLFSSL_SUCCESS) {
-        int usedLength = (int)(ssl->buffers.inputBuffer.length -
-                               ssl->buffers.inputBuffer.idx);
-        int maxLength  = (int)(ssl->buffers.inputBuffer.bufferSize -
-                               (word32)usedLength);
+        in = &ssl->buffers.inputBuffer;
 
-        if (sz > maxLength) {
-            /* Need to make space */
-            if (ssl->buffers.clearOutputBuffer.length > 0) {
-                /* clearOutputBuffer points into so reallocating inputBuffer
-                 * will invalidate clearOutputBuffer and lose app data */
-                WOLFSSL_MSG(
-                    "Can't inject while there is application data to read");
-                ret = APP_DATA_READY;
+        /* Order the unsigned fields first. Subtracting a larger value wraps
+         * and can land back in the positive int range. */
+        if ((in->idx > in->length) || (in->length > in->bufferSize)) {
+            ret = BUFFER_ERROR;
+        }
+        else {
+            usedLength = (int)(in->length - in->idx);
+            /* Free space past all buffered data, where new data is appended. */
+            maxLength  = (int)(in->bufferSize - in->length);
+
+            if ((usedLength < 0) || (maxLength < 0)) {
+                ret = BUFFER_ERROR;
             }
-            else {
-                int growRet = GrowInputBuffer(ssl, sz, usedLength);
+        }
+    }
 
-                if (growRet < 0) {
-                    ret = growRet;
-                }
+    if ((ret == WOLFSSL_SUCCESS) && (sz > maxLength)) {
+        /* Need to make space */
+        if (ssl->buffers.clearOutputBuffer.length > 0) {
+            /* clearOutputBuffer points into so reallocating inputBuffer
+             * will invalidate clearOutputBuffer and lose app data */
+            WOLFSSL_MSG(
+                "Can't inject while there is application data to read");
+            ret = APP_DATA_READY;
+        }
+        else {
+            /* Compacts the unconsumed data, leaving idx 0 and length
+             * usedLength. */
+            int growRet = GrowInputBuffer(ssl, sz, usedLength);
+
+            if (growRet < 0) {
+                ret = growRet;
             }
         }
     }
 
     if (ret == WOLFSSL_SUCCESS) {
-        XMEMCPY(ssl->buffers.inputBuffer.buffer + ssl->buffers.inputBuffer.idx,
-                data, sz);
-        ssl->buffers.inputBuffer.length += sz;
+        XMEMCPY(in->buffer + in->length, data, (size_t)sz);
+        in->length += (word32)sz;
     }
 
     return ret;

--- a/tests/api.c
+++ b/tests/api.c
@@ -37500,6 +37500,169 @@ static int test_wolfSSL_inject(void)
     return EXPECT_RESULT();
 }
 
+/* Kept under one TLS record: injecting several records at once is a separate
+ * (unrelated) code path. */
+#define TEST_INJECT_BIG_SZ 8192
+
+/* Injected bytes must land after the data buffered but not yet consumed.
+ * Writing them at inputBuffer.idx overwrote a retained partial record, so a
+ * record fed in over several calls never reassembled. */
+static int test_wolfSSL_inject_partial_record(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && !defined(NO_SHA256) && \
+    !defined(WOLFSSL_NO_TLS12)
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL;
+    WOLFSSL *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+    const char msg[] = "wolfSSL inject partial record";
+    byte* bigData = NULL;
+    byte* record = NULL;
+    char* readBuf = NULL;
+    word32 savedIdx = 0;
+    word32 savedLength = 0;
+    int msgSz = (int)sizeof(msg) - 1;
+    int recordSz = 0;
+    int rounds = 0;
+    int injectSz = 0;
+    int off;
+    int chunk;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+
+    /* sized from the transport buffer the records are copied out of */
+    record = (byte*)XMALLOC(TEST_MEMIO_BUF_SZ, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    bigData = (byte*)XMALLOC(TEST_INJECT_BIG_SZ, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    readBuf = (char*)XMALLOC(TEST_INJECT_BIG_SZ, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    ExpectNotNull(record);
+    ExpectNotNull(bigData);
+    ExpectNotNull(readBuf);
+    /* non-repeating, so the readback also catches reordered chunks */
+    if (bigData != NULL) {
+        for (off = 0; off < TEST_INJECT_BIG_SZ; off++)
+            bigData[off] = (byte)(off ^ (off >> 8));
+    }
+
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+            wolfTLSv1_2_client_method, wolfTLSv1_2_server_method), 0);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, &rounds), 0);
+
+    /* Draining the transport leaves injected bytes as the server's only input. */
+    ExpectIntEQ(wolfSSL_write(ssl_c, msg, msgSz), msgSz);
+    ExpectIntGT(test_ctx.s_len, 0);
+    if (EXPECT_SUCCESS()) {
+        recordSz = test_ctx.s_len;
+        XMEMCPY(record, test_ctx.s_buff, (size_t)recordSz);
+        test_memio_clear_buffer(&test_ctx, 0);
+    }
+
+    /* Every chunk but the last leaves a partial record buffered. */
+    for (off = 0; off < recordSz && EXPECT_SUCCESS(); off += chunk) {
+        chunk = recordSz - off;
+        if (chunk > 7)
+            chunk = 7;
+        ExpectIntEQ(wolfSSL_inject(ssl_s, record + off, chunk),
+                WOLFSSL_SUCCESS);
+        if (off + chunk < recordSz) {
+            ExpectIntEQ(wolfSSL_read(ssl_s, readBuf, msgSz), -1);
+            ExpectIntEQ(wolfSSL_get_error(ssl_s, -1), WOLFSSL_ERROR_WANT_READ);
+        }
+    }
+    ExpectIntEQ(wolfSSL_read(ssl_s, readBuf, msgSz), msgSz);
+    ExpectIntEQ(XMEMCMP(readBuf, msg, (size_t)msgSz), 0);
+
+    /* A first chunk shorter than a record header leaves nothing to pre-grow the
+     * buffer, so the second inject grows it with a partial record held. */
+    ExpectIntEQ(wolfSSL_write(ssl_c, bigData, TEST_INJECT_BIG_SZ),
+            TEST_INJECT_BIG_SZ);
+    ExpectIntGT(test_ctx.s_len, TEST_INJECT_BIG_SZ);
+    if (EXPECT_SUCCESS()) {
+        recordSz = test_ctx.s_len;
+        XMEMCPY(record, test_ctx.s_buff, (size_t)recordSz);
+        test_memio_clear_buffer(&test_ctx, 0);
+    }
+
+    ExpectIntEQ(wolfSSL_inject(ssl_s, record, 3), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_read(ssl_s, readBuf, TEST_INJECT_BIG_SZ), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(wolfSSL_inject(ssl_s, record + 3, recordSz - 3),
+            WOLFSSL_SUCCESS);
+    /* Configurations whose static buffer already holds a whole record cover the
+     * no-grow path here instead. */
+    if (ssl_s != NULL && STATIC_BUFFER_LEN < TEST_INJECT_BIG_SZ) {
+        ExpectIntGT(ssl_s->buffers.inputBuffer.bufferSize,
+                (word32)STATIC_BUFFER_LEN);
+    }
+
+    /* The payload may arrive as several records, so read until it is drained. */
+    for (off = 0; off < TEST_INJECT_BIG_SZ && EXPECT_SUCCESS(); off += chunk) {
+        chunk = wolfSSL_read(ssl_s, readBuf, TEST_INJECT_BIG_SZ - off);
+        ExpectIntGT(chunk, 0);
+        if (chunk <= 0)
+            break;
+        ExpectIntEQ(XMEMCMP(readBuf, bigData + off, (size_t)chunk), 0);
+    }
+    ExpectIntEQ(off, TEST_INJECT_BIG_SZ);
+
+    /* Reading a single byte leaves the rest of the plaintext pending. */
+    ExpectIntEQ(wolfSSL_write(ssl_c, msg, msgSz), msgSz);
+    ExpectIntGT(test_ctx.s_len, 0);
+    if (EXPECT_SUCCESS()) {
+        recordSz = test_ctx.s_len;
+        XMEMCPY(record, test_ctx.s_buff, (size_t)recordSz);
+        test_memio_clear_buffer(&test_ctx, 0);
+    }
+    ExpectIntEQ(wolfSSL_inject(ssl_s, record, recordSz), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_read(ssl_s, readBuf, 1), 1);
+    ExpectIntEQ(wolfSSL_pending(ssl_s), msgSz - 1);
+
+    /* clearOutputBuffer points into the input buffer, so a grow has to be
+     * refused instead of invalidating that pending plaintext. Size the inject
+     * past the free space so it needs a grow whatever the buffer size is. */
+    if (ssl_s != NULL) {
+        injectSz = (int)(ssl_s->buffers.inputBuffer.bufferSize -
+                ssl_s->buffers.inputBuffer.length) + 1;
+    }
+    ExpectIntGT(injectSz, 0);
+    ExpectIntLE(injectSz, TEST_MEMIO_BUF_SZ);
+    ExpectIntEQ(wolfSSL_inject(ssl_s, record, injectSz),
+            WC_NO_ERR_TRACE(APP_DATA_READY));
+    ExpectIntEQ(wolfSSL_read(ssl_s, readBuf, msgSz - 1), msgSz - 1);
+    ExpectIntEQ(XMEMCMP(readBuf, msg + 1, (size_t)(msgSz - 1)), 0);
+
+    /* A broken buffer invariant must fail closed: both lengths are unsigned
+     * differences, so idx > length or length > bufferSize goes negative. The
+     * call returns before it writes, so restoring the field is enough. */
+    if (ssl_s != NULL) {
+        savedIdx = ssl_s->buffers.inputBuffer.idx;
+        ssl_s->buffers.inputBuffer.idx = ssl_s->buffers.inputBuffer.length + 1;
+    }
+    ExpectIntEQ(wolfSSL_inject(ssl_s, record, 1),
+            WC_NO_ERR_TRACE(BUFFER_ERROR));
+    if (ssl_s != NULL) {
+        ssl_s->buffers.inputBuffer.idx = savedIdx;
+        savedLength = ssl_s->buffers.inputBuffer.length;
+        ssl_s->buffers.inputBuffer.length =
+                ssl_s->buffers.inputBuffer.bufferSize + 1;
+    }
+    ExpectIntEQ(wolfSSL_inject(ssl_s, record, 1),
+            WC_NO_ERR_TRACE(BUFFER_ERROR));
+    if (ssl_s != NULL)
+        ssl_s->buffers.inputBuffer.length = savedLength;
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+    XFREE(record, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(bigData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(readBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+    return EXPECT_RESULT();
+}
+
 /*----------------------------------------------------------------------------*
  | Main
  *----------------------------------------------------------------------------*/
@@ -39475,6 +39638,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_read_ahead_buffer_len),
     TEST_DECL(test_wolfSSL_read_ahead_ctx_inherit),
     TEST_DECL(test_wolfSSL_inject),
+    TEST_DECL(test_wolfSSL_inject_partial_record),
     TEST_DECL(test_ocsp_status_callback),
     TEST_DECL(test_ocsp_basic_verify),
     TEST_DECL(test_ocsp_ancestor_responder_rejected),

--- a/tests/api.c
+++ b/tests/api.c
@@ -38395,6 +38395,177 @@ static int test_wolfSSL_inject(void)
     return EXPECT_RESULT();
 }
 
+/* Kept under one TLS record: injecting several records at once is a separate
+ * (unrelated) code path. */
+#define TEST_INJECT_BIG_SZ 8192
+
+/* Injected bytes must land after the data buffered but not yet consumed.
+ * Writing them at inputBuffer.idx overwrote a retained partial record, so a
+ * record fed in over several calls never reassembled. */
+static int test_wolfSSL_inject_partial_record(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && !defined(NO_SHA256) && \
+    !defined(WOLFSSL_NO_TLS12)
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL;
+    WOLFSSL *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+    const char msg[] = "wolfSSL inject partial record";
+    byte* bigData = NULL;
+    byte* record = NULL;
+    char* readBuf = NULL;
+    word32 savedIdx = 0;
+    word32 savedLength = 0;
+    word32 overshoot;
+    int msgSz = (int)sizeof(msg) - 1;
+    int recordSz = 0;
+    int rounds = 0;
+    int injectSz = 0;
+    int off;
+    int chunk;
+    int i;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+
+    /* sized from the transport buffer the records are copied out of */
+    record = (byte*)XMALLOC(TEST_MEMIO_BUF_SZ, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    bigData = (byte*)XMALLOC(TEST_INJECT_BIG_SZ, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    readBuf = (char*)XMALLOC(TEST_INJECT_BIG_SZ, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    ExpectNotNull(record);
+    ExpectNotNull(bigData);
+    ExpectNotNull(readBuf);
+    /* non-repeating, so the readback also catches reordered chunks */
+    if (bigData != NULL) {
+        for (off = 0; off < TEST_INJECT_BIG_SZ; off++)
+            bigData[off] = (byte)(off ^ (off >> 8));
+    }
+
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+            wolfTLSv1_2_client_method, wolfTLSv1_2_server_method), 0);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, &rounds), 0);
+
+    /* Draining the transport leaves injected bytes as the server's only
+     * input. */
+    ExpectIntEQ(wolfSSL_write(ssl_c, msg, msgSz), msgSz);
+    ExpectIntGT(test_ctx.s_len, 0);
+    if (EXPECT_SUCCESS()) {
+        recordSz = test_ctx.s_len;
+        XMEMCPY(record, test_ctx.s_buff, (size_t)recordSz);
+        test_memio_clear_buffer(&test_ctx, 0);
+    }
+
+    /* Every chunk but the last leaves a partial record buffered. */
+    for (off = 0; off < recordSz && EXPECT_SUCCESS(); off += chunk) {
+        chunk = recordSz - off;
+        if (chunk > 7)
+            chunk = 7;
+        ExpectIntEQ(wolfSSL_inject(ssl_s, record + off, chunk),
+                WOLFSSL_SUCCESS);
+        if (off + chunk < recordSz) {
+            ExpectIntEQ(wolfSSL_read(ssl_s, readBuf, msgSz), -1);
+            ExpectIntEQ(wolfSSL_get_error(ssl_s, -1), WOLFSSL_ERROR_WANT_READ);
+        }
+    }
+    ExpectIntEQ(wolfSSL_read(ssl_s, readBuf, msgSz), msgSz);
+    ExpectIntEQ(XMEMCMP(readBuf, msg, (size_t)msgSz), 0);
+
+    /* A first chunk shorter than a record header leaves nothing to pre-grow the
+     * buffer, so the second inject grows it with a partial record held. */
+    ExpectIntEQ(wolfSSL_write(ssl_c, bigData, TEST_INJECT_BIG_SZ),
+            TEST_INJECT_BIG_SZ);
+    ExpectIntGT(test_ctx.s_len, TEST_INJECT_BIG_SZ);
+    if (EXPECT_SUCCESS()) {
+        recordSz = test_ctx.s_len;
+        XMEMCPY(record, test_ctx.s_buff, (size_t)recordSz);
+        test_memio_clear_buffer(&test_ctx, 0);
+    }
+
+    ExpectIntEQ(wolfSSL_inject(ssl_s, record, 3), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_read(ssl_s, readBuf, TEST_INJECT_BIG_SZ), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(wolfSSL_inject(ssl_s, record + 3, recordSz - 3),
+            WOLFSSL_SUCCESS);
+    /* Configurations whose static buffer already holds a whole record cover the
+     * no-grow path here instead. */
+    if (ssl_s != NULL && STATIC_BUFFER_LEN < TEST_INJECT_BIG_SZ) {
+        ExpectIntGT(ssl_s->buffers.inputBuffer.bufferSize,
+                (word32)STATIC_BUFFER_LEN);
+    }
+
+    /* The payload may arrive as several records, so read until drained. */
+    for (off = 0; off < TEST_INJECT_BIG_SZ && EXPECT_SUCCESS(); off += chunk) {
+        chunk = wolfSSL_read(ssl_s, readBuf, TEST_INJECT_BIG_SZ - off);
+        ExpectIntGT(chunk, 0);
+        if (chunk <= 0)
+            break;
+        ExpectIntEQ(XMEMCMP(readBuf, bigData + off, (size_t)chunk), 0);
+    }
+    ExpectIntEQ(off, TEST_INJECT_BIG_SZ);
+
+    /* Reading a single byte leaves the rest of the plaintext pending. */
+    ExpectIntEQ(wolfSSL_write(ssl_c, msg, msgSz), msgSz);
+    ExpectIntGT(test_ctx.s_len, 0);
+    if (EXPECT_SUCCESS()) {
+        recordSz = test_ctx.s_len;
+        XMEMCPY(record, test_ctx.s_buff, (size_t)recordSz);
+        test_memio_clear_buffer(&test_ctx, 0);
+    }
+    ExpectIntEQ(wolfSSL_inject(ssl_s, record, recordSz), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_read(ssl_s, readBuf, 1), 1);
+    ExpectIntEQ(wolfSSL_pending(ssl_s), msgSz - 1);
+
+    /* clearOutputBuffer points into the input buffer, so a grow has to be
+     * refused instead of invalidating that pending plaintext. Size the inject
+     * past the free space so it needs a grow whatever the buffer size is. */
+    if (ssl_s != NULL) {
+        injectSz = (int)(ssl_s->buffers.inputBuffer.bufferSize -
+                ssl_s->buffers.inputBuffer.length) + 1;
+    }
+    ExpectIntGT(injectSz, 0);
+    ExpectIntLE(injectSz, TEST_MEMIO_BUF_SZ);
+    ExpectIntEQ(wolfSSL_inject(ssl_s, record, injectSz),
+            WC_NO_ERR_TRACE(APP_DATA_READY));
+    ExpectIntEQ(wolfSSL_read(ssl_s, readBuf, msgSz - 1), msgSz - 1);
+    ExpectIntEQ(XMEMCMP(readBuf, msg + 1, (size_t)(msgSz - 1)), 0);
+
+    /* A broken buffer invariant must fail closed. An overshoot of 0x80000001
+     * wraps back into the positive int range, so only the unsigned ordering
+     * catches it. The call returns before it writes. */
+    for (i = 0; i < 2 && EXPECT_SUCCESS(); i++) {
+        overshoot = (i == 0) ? 1U : 0x80000001U;
+
+        if (ssl_s != NULL) {
+            savedIdx = ssl_s->buffers.inputBuffer.idx;
+            ssl_s->buffers.inputBuffer.idx =
+                    ssl_s->buffers.inputBuffer.length + overshoot;
+        }
+        ExpectIntEQ(wolfSSL_inject(ssl_s, record, 1),
+                WC_NO_ERR_TRACE(BUFFER_ERROR));
+        if (ssl_s != NULL) {
+            ssl_s->buffers.inputBuffer.idx = savedIdx;
+            savedLength = ssl_s->buffers.inputBuffer.length;
+            ssl_s->buffers.inputBuffer.length =
+                    ssl_s->buffers.inputBuffer.bufferSize + overshoot;
+        }
+        ExpectIntEQ(wolfSSL_inject(ssl_s, record, 1),
+                WC_NO_ERR_TRACE(BUFFER_ERROR));
+        if (ssl_s != NULL)
+            ssl_s->buffers.inputBuffer.length = savedLength;
+    }
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+    XFREE(record, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(bigData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(readBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+    return EXPECT_RESULT();
+}
+
 /*----------------------------------------------------------------------------*
  | Main
  *----------------------------------------------------------------------------*/
@@ -40386,6 +40557,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_read_ahead_buffer_len),
     TEST_DECL(test_wolfSSL_read_ahead_ctx_inherit),
     TEST_DECL(test_wolfSSL_inject),
+    TEST_DECL(test_wolfSSL_inject_partial_record),
     TEST_DECL(test_ocsp_status_callback),
     TEST_DECL_GROUP("ocsp", test_ocsp_basic_verify),
     TEST_DECL_GROUP("ocsp", test_ocsp_ancestor_responder_rejected),


### PR DESCRIPTION
### Problem
Two defects, both reached by feeding one TLS record to `wolfSSL_inject()` over
several calls.

**1. Wrong append offset (`src/ssl_api_rw.c`).** New bytes belong at
`inputBuffer.buffer + length`; the copy went to `+ idx`, the start of the
unconsumed region. The two coincide when the buffer is drained, which is why
existing coverage never caught it. Otherwise the injected bytes overwrote a
retained partial record, so a record fed in over several calls never
reassembled. The free-space check compounded this, measuring
`bufferSize - usedLength` while writing at `idx`. Closes f-7521.

**2. `GrowInputBuffer()` destroyed retained data when the allocator aliases
(`src/internal.c`).** `XMALLOC(DYNAMIC_TYPE_IN_BUFFER)` returns the block
already in use under `HAVE_IO_POOL` and under static memory with
`WOLFMEM_IO_POOL_FIXED`. The function copied the retained bytes to the front,
then zeroed that same memory. A `WOLFSSL_STATIC_MEMORY`-only guard existed but
did not cover `HAVE_IO_POOL`, and never moved the data, so it also mis-read
stale bytes whenever `idx > 0`.

### Fix (`src/ssl_api_rw.c`)
- **`maxLength`** measures free space past `inputBuffer.length`.
- **`XMEMCPY`** appends at `inputBuffer.length`.
- **`BUFFER_ERROR`** when `idx`/`length`/`bufferSize` are misordered, checked
  as `word32` before any subtraction can wrap back into positive `int` range.

Also documents `BUFFER_ERROR` and the narrowed `APP_DATA_READY` condition in
the source comment and the EN/JA doxygen.

### Fix (`src/internal.c`)
Storage handling moves into a new static `ResizeInputBufferStorage()`, which
allocates, moves the retained range to offset zero, and — when the allocator
hands back the block in use — clears only the bytes past that range and leaves
the block allocated. `GrowInputBuffer()` keeps the alignment arithmetic and the
metadata update, and no longer reasons about allocator behavior.

The alias test stays a runtime pointer comparison rather than a compile-time
branch: `XMALLOC_USER` lets an application install a pooling allocator with no
macro to key on.

### Tests
`test_wolfSSL_inject_partial_record` in `tests/api.c`:

| Phase | Injection pattern | Path covered |
|---|---|---|
| 1 | one record in 7-byte chunks | partial record retained |
| 2 | 8 KB record split 3 bytes / remainder | grow with a partial record held |
| 3 | oversized inject after a 1-byte read | `APP_DATA_READY` refusal |
| 4 | forced `idx`/`length` overshoot | `BUFFER_ERROR` |

### Verification

| Config | Result |
|---|---|
| default | 0 failed / 488 passed |
| `--enable-iopool` | 0 failed / 488 passed |
| `--enable-staticmemory` | 0 failed / 490 passed |
| `--enable-dtls --enable-dtls13` | 0 failed / 581 passed |
| `--enable-all` | 0 failed / 1922 passed |
| `--enable-iopool` + ASan/UBSan | 0 failed, sanitizer-clean |

All under `-Werror`. Negative control: stubbing out the alias branch fails the
new test under `--enable-iopool` and nothing else.