### PR TITLE
Fix unsynchronized globalRNG use in BN_rand, AddSession, ECDH and X25519

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -5187,6 +5187,11 @@ int wolfSSL_EC25519_shared_key(unsigned char *shared, unsigned int *sharedSz,
     int res = 1;
     curve25519_key privkey;
     curve25519_key pubkey;
+#ifdef WOLFSSL_CURVE25519_BLINDING
+    WC_RNG* rng = NULL;
+    WC_DECLARE_VAR(tmpRng, WC_RNG, 1, 0);
+    int initTmpRng = 0;
+#endif
 
     WOLFSSL_ENTER("wolfSSL_EC25519_shared_key");
 
@@ -5206,8 +5211,13 @@ int wolfSSL_EC25519_shared_key(unsigned char *shared, unsigned int *sharedSz,
     }
     if (res) {
     #ifdef WOLFSSL_CURVE25519_BLINDING
-        /* An RNG is needed. */
-        if (wc_curve25519_set_rng(&privkey, wolfssl_make_global_rng()) != 0) {
+        /* An RNG is needed for blinding - create local or get global. */
+        rng = wolfssl_make_rng(tmpRng, &initTmpRng);
+        if (rng == NULL) {
+            WOLFSSL_MSG("wolfSSL_EC25519_shared_key failed to make RNG");
+            res = 0;
+        }
+        else if (wc_curve25519_set_rng(&privkey, rng) != 0) {
             res = 0;
         }
         else
@@ -5249,6 +5259,14 @@ int wolfSSL_EC25519_shared_key(unsigned char *shared, unsigned int *sharedSz,
         }
         wc_curve25519_free(&privkey);
     }
+
+#ifdef WOLFSSL_CURVE25519_BLINDING
+    /* Disposed of after privkey, which references it for blinding. */
+    if (initTmpRng) {
+        wc_FreeRng(rng);
+        WC_FREE_VAR_EX(rng, NULL, DYNAMIC_TYPE_RNG);
+    }
+#endif
 
     return res;
 #else

--- a/src/pk_ec.c
+++ b/src/pk_ec.c
@@ -5489,7 +5489,10 @@ int wolfSSL_ECDH_compute_key(void *out, size_t outLen,
     ecc_key* key = NULL;
 #if defined(ECC_TIMING_RESISTANT) && !defined(HAVE_SELFTEST) && \
     (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,0))
-    int setGlobalRNG = 0;
+    WC_RNG* rng = NULL;
+    WC_DECLARE_VAR(tmpRng, WC_RNG, 1, 0);
+    int initTmpRng = 0;
+    int setKeyRng = 0;
 #endif
 
     /* TODO: support using the KDF. */
@@ -5524,30 +5527,44 @@ int wolfSSL_ECDH_compute_key(void *out, size_t outLen,
 
     #if defined(ECC_TIMING_RESISTANT) && !defined(HAVE_SELFTEST) && \
         (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,0))
-        /* An RNG is needed. */
+        /* An RNG is needed - create local or get global. */
         if (key->rng == NULL) {
-            key->rng = wolfssl_make_global_rng();
-            /* RNG set and needs to be unset. */
-            setGlobalRNG = 1;
+            rng = wolfssl_make_rng(tmpRng, &initTmpRng);
+            if (rng == NULL) {
+                WOLFSSL_MSG("wolfSSL_ECDH_compute_key failed to make RNG");
+                err = 1;
+            }
+            else {
+                key->rng = rng;
+                /* RNG set and needs to be unset. */
+                setKeyRng = 1;
+            }
         }
     #endif
 
-        PRIVATE_KEY_UNLOCK();
-        /* Create secret using wolfSSL. */
-        ret = wc_ecc_shared_secret_ex(key, (ecc_point*)pubKey->internal,
-            (byte *)out, &len);
-        PRIVATE_KEY_LOCK();
-        if (ret != MP_OKAY) {
-            WOLFSSL_MSG("wc_ecc_shared_secret failed");
-            err = 1;
+        if (!err) {
+            PRIVATE_KEY_UNLOCK();
+            /* Create secret using wolfSSL. */
+            ret = wc_ecc_shared_secret_ex(key, (ecc_point*)pubKey->internal,
+                (byte *)out, &len);
+            PRIVATE_KEY_LOCK();
+            if (ret != MP_OKAY) {
+                WOLFSSL_MSG("wc_ecc_shared_secret failed");
+                err = 1;
+            }
         }
     }
 
 #if defined(ECC_TIMING_RESISTANT) && !defined(HAVE_SELFTEST) && \
     (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,0))
-    /* Remove global from key. */
-    if (setGlobalRNG) {
+    /* Clear before the RNG is disposed of - key must not keep a dangling
+     * reference to a local RNG. */
+    if (setKeyRng) {
         key->rng = NULL;
+    }
+    if (initTmpRng) {
+        wc_FreeRng(rng);
+        WC_FREE_VAR_EX(rng, NULL, DYNAMIC_TYPE_RNG);
     }
 #endif
 

--- a/src/ssl_bn.c
+++ b/src/ssl_bn.c
@@ -2146,10 +2146,19 @@ int wolfSSL_BN_rand(WOLFSSL_BIGNUM* bn, int bits, int top, int bottom)
             WOLFSSL_MSG("Failed to allocate buffer.");
             ret = 0;
         }
-        /* Generate bytes to cover bits. */
-        if ((ret == 1) && wc_RNG_GenerateBlock(rng, buff, len) != 0) {
-            WOLFSSL_MSG("wc_RNG_GenerateBlock failed");
+        /* Global RNG is shared, lock it while generating. */
+        if ((ret == 1) && (wc_LockMutex(&globalRNGMutex) != 0)) {
+            WOLFSSL_MSG("Bad Lock Mutex rng");
             ret = 0;
+        }
+
+        /* Generate bytes to cover bits. */
+        if (ret == 1) {
+            if (wc_RNG_GenerateBlock(rng, buff, len) != 0) {
+                WOLFSSL_MSG("wc_RNG_GenerateBlock failed");
+                ret = 0;
+            }
+            wc_UnLockMutex(&globalRNGMutex);
         }
         /* Read bytes in to big number. */
         if ((ret == 1) && mp_read_unsigned_bin((mp_int*)bn->internal, buff, len)

--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -2162,15 +2162,29 @@ void AddSession(WOLFSSL* ssl)
      * this point, it won't on resumption. */
     if (idSz == 0 && ssl->options.side == WOLFSSL_CLIENT_END) {
         WC_RNG* rng = NULL;
+        int genRet;
+#if defined(HAVE_GLOBAL_RNG) && defined(OPENSSL_EXTRA)
+        int rngLocked = 0;
+#endif
         if (ssl->rng != NULL)
             rng = ssl->rng;
 #if defined(HAVE_GLOBAL_RNG) && defined(OPENSSL_EXTRA)
         else if (initGlobalRNG == 1 || wolfSSL_RAND_Init() == WOLFSSL_SUCCESS) {
+            /* Global RNG is shared, lock it while generating. */
+            if (wc_LockMutex(&globalRNGMutex) != 0) {
+                WOLFSSL_MSG("Bad Lock Mutex rng");
+                return;
+            }
             rng = &globalRNG;
+            rngLocked = 1;
         }
 #endif
-        if (wc_RNG_GenerateBlock(rng, ssl->session->altSessionID,
-                ID_LEN) != 0)
+        genRet = wc_RNG_GenerateBlock(rng, ssl->session->altSessionID, ID_LEN);
+#if defined(HAVE_GLOBAL_RNG) && defined(OPENSSL_EXTRA)
+        if (rngLocked)
+            wc_UnLockMutex(&globalRNGMutex);
+#endif
+        if (genRet != 0)
             return;
         ssl->session->haveAltSessionID = 1;
         id = ssl->session->altSessionID;


### PR DESCRIPTION
### Problem

`globalRNG` (`src/ssl.c`) is a single process-wide `WC_RNG` with no internal
per-instance locking; its designated lock is `globalRNGMutex`. The `RAND_*`
family in `src/ssl_crypto.c` takes that mutex at all eleven of its call sites.
Four OpenSSL-compat entry points using `globalRNG` as their primary RNG took no
lock at all, so two threads could interleave DRBG generation on the same V/C
state and produce torn or duplicate output used directly as key material.

Closes f-7543.

### Fix

Two remedies, depending on whether the site can cheaply own its RNG:

| Site | File | Fix |
|---|---|---|
| `wolfSSL_BN_rand` | `src/ssl_bn.c` | hold `globalRNGMutex` across `wc_RNG_GenerateBlock` |
| `AddSession` | `src/ssl_sess.c` | hold `globalRNGMutex` across `wc_RNG_GenerateBlock`, global path only |
| `wolfSSL_ECDH_compute_key` | `src/pk_ec.c` | `wolfssl_make_rng()` in place of `wolfssl_make_global_rng()` |
| `wolfSSL_EC25519_shared_key` | `src/pk.c` | same, for the `WOLFSSL_CURVE25519_BLINDING` RNG |

The two lock sites are open-coded in the style already used in those files, so
no new locking convention is introduced.

The two shared-secret paths instead take a **per-call RNG** via
`wolfssl_make_rng()` — the helper the rest of `pk.c`/`pk_ec.c` already uses —
removing the sharing rather than serializing on it. Holding `globalRNGMutex`
across the whole shared-secret operation (the first version of this PR) would
have serialized all ECDH process-wide, including keys that carry their own RNG.
Both sites now NULL-check the RNG; `wolfSSL_ECDH_compute_key` additionally
guards the shared-secret call on `!err` and clears `key->rng` before the local
RNG is freed, so no dangling reference is left behind.

### Known trade-off

ECDH and X25519 now init and seed a fresh DRBG per call instead of reusing the
global one, which costs performance on those paths. Accepted as an interim
state — still better than the unsynchronized global.

### Intentionally not in this PR

- Roughly eighteen further sites reach the global only through
  `wolfssl_make_rng()`'s fallback, after a local `wc_InitRng()` has already
  failed. Same defect, far lower reachability.
- A concurrently shared `EC_KEY` is unsafe independent of the RNG
  (`wc_ecc_shared_secret_ex` writes `private_key->state` and dispatches on it).
  That needs per-key locking, which neither wolfSSL nor OpenSSL provides.

### Verification

- Builds clean, no new warnings, across `opensslall+keygen`, `opensslextra+all`,
  `dh+ecc` (no `OPENSSL_EXTRA`), `singlethreaded` and `wpas`, plus a
  `-DWOLFSSL_CURVE25519_BLINDING` build for the Curve25519 path.
- `make check`: 17/17 on `--enable-all`, 6/6 on `opensslall`, 0 failures.
- ThreadSanitizer clean: 32 threads x 150 iterations hammering `BN_rand`,
  `ECDH_compute_key`, `EC25519_shared_key` and `RAND_bytes`, 0 races.
  Negative control: reverting the `BN_rand` lock reports races in
  `Hash512_DRBG_Generate`.

No regression test is added: a threaded test is nondeterministic and there is no
ThreadSanitizer job in CI, so it would add flake without signal.