### PR TITLE
Return error code from wc_BufferKey{Encrypt,Decrypt} for unknown cipherType

### DIFF
--- a/doc/dox_comments/header_files/wc_encrypt.h
+++ b/doc/dox_comments/header_files/wc_encrypt.h
@@ -271,6 +271,7 @@ int wc_AesCbcEncryptWithKey(byte* out, const byte* in, word32 inSz,
     \return BAD_FUNC_ARG if info->keySz > WC_MAX_SYM_KEY_SIZE
     \return ALGO_ID_E if info->cipherType is not one of the cipher types
     this function handles
+    \return BUFFER_E if IV buffer is too small
     \return NOT_COMPILED_IN if info->cipherType is a cipher type this
     function handles, but support for it was disabled in this build
     \return Negative value on error

--- a/doc/dox_comments/header_files/wc_encrypt.h
+++ b/doc/dox_comments/header_files/wc_encrypt.h
@@ -358,12 +358,16 @@ int wc_BufferKeyDecrypt(struct EncryptedInfo* info, byte* der,
     // with info.ivSz random bytes; the first PKCS5_SALT_SZ of them are used
     // as the key derivation salt, and the buffer is also used as the
     // cipher IV.
+    WC_RNG rng;
+    wc_InitRng(&rng);
+    wc_RNG_GenerateBlock(&rng, info.iv, info.ivSz);
 
     int ret = wc_BufferKeyEncrypt(&info, key, sizeof(key), password,
                                   sizeof(password)-1, WC_SHA256);
     if (ret != 0) {
         // encryption error
     }
+    wc_FreeRng(&rng);
     \endcode
 
     \sa wc_BufferKeyDecrypt

--- a/doc/dox_comments/header_files/wc_encrypt.h
+++ b/doc/dox_comments/header_files/wc_encrypt.h
@@ -259,11 +259,20 @@ int wc_AesCbcEncryptWithKey(byte* out, const byte* in, word32 inSz,
 /*!
     \ingroup Crypto
     \brief This function decrypts an encrypted key buffer using the
-    provided password. It supports various encryption algorithms
-    including DES, 3DES, and AES. The encryption information is
+    provided password. It supports encryption algorithms
+    DES, 3DES, and AES. The encryption information is
     provided in the EncryptedInfo structure.
 
-    \return Length of decrypted key on success
+    \return 0 on success
+    \return BAD_FUNC_ARG if der is NULL
+    \return BAD_FUNC_ARG if password is NULL
+    \return BAD_FUNC_ARG if info is NULL
+    \return BAD_FUNC_ARG if info->keySz is 0
+    \return BAD_FUNC_ARG if info->keySz > WC_MAX_SYM_KEY_SIZE
+    \return ALGO_ID_E if info->cipherType is not one of the cipher types
+    this function handles
+    \return NOT_COMPILED_IN if info->cipherType is a cipher type this
+    function handles, but support for it was disabled in this build
     \return Negative value on error
 
     \param info pointer to EncryptedInfo structure containing encryption
@@ -277,13 +286,24 @@ int wc_AesCbcEncryptWithKey(byte* out, const byte* in, word32 inSz,
     _Example_
     \code
     EncryptedInfo info;
-    byte encryptedKey[]; // encrypted key data
+    byte encryptedKey[32]; // encrypted key data, decrypted in place
     byte password[] = "mypassword";
+
+    XMEMSET(&info, 0, sizeof(info));
+    info.cipherType = WC_CIPHER_AES_CBC;
+    info.keySz = 16;       // size of the key derived from the password
+
+    // info.iv holds the IV as hex characters, the way it appears in a PEM
+    // DEK-Info header.  It is Base16-decoded in place, and must decode to
+    // at least PKCS5_SALT_SZ bytes.  The decoded bytes are used both as the
+    // key derivation salt and as the cipher IV.
+    XMEMCPY(info.iv, "0123456789ABCDEF0123456789ABCDEF", 32);
+    info.ivSz = 32;        // length of the hex string, not the decoded IV
 
     int ret = wc_BufferKeyDecrypt(&info, encryptedKey,
                                   sizeof(encryptedKey), password,
                                   sizeof(password)-1, WC_SHA256);
-    if (ret < 0) {
+    if (ret != 0) {
         // decryption error
     }
     \endcode
@@ -297,11 +317,21 @@ int wc_BufferKeyDecrypt(struct EncryptedInfo* info, byte* der,
 /*!
     \ingroup Crypto
     \brief This function encrypts a key buffer using the provided
-    password. It supports various encryption algorithms including DES,
+    password. It supports encryption algorithms DES,
     3DES, and AES. The encryption information is provided in the
     EncryptedInfo structure.
 
-    \return Length of encrypted key on success
+    \return 0 on success
+    \return BAD_FUNC_ARG if der is NULL
+    \return BAD_FUNC_ARG if password is NULL
+    \return BAD_FUNC_ARG if info is NULL
+    \return BAD_FUNC_ARG if info->keySz is 0
+    \return BAD_FUNC_ARG if info->keySz > WC_MAX_SYM_KEY_SIZE
+    \return BAD_FUNC_ARG if info->ivSz < PKCS5_SALT_SZ
+    \return ALGO_ID_E if info->cipherType is not one of the cipher types
+    this function handles
+    \return NOT_COMPILED_IN if info->cipherType is a cipher type this
+    function handles, but support for it was disabled in this build
     \return Negative value on error
 
     \param info pointer to EncryptedInfo structure containing encryption
@@ -315,13 +345,22 @@ int wc_BufferKeyDecrypt(struct EncryptedInfo* info, byte* der,
     _Example_
     \code
     EncryptedInfo info;
-    byte key[]; // key data to encrypt
+    byte key[32]; // key data to encrypt, encrypted in place
     byte password[] = "mypassword";
 
-    info.algo = AES256CBCb;
+    XMEMSET(&info, 0, sizeof(info));
+    info.cipherType = WC_CIPHER_AES_CBC;
+    info.keySz = 16;   // size of the key derived from the password
+    info.ivSz  = 16;   // must be at least PKCS5_SALT_SZ
+
+    // Unlike wc_BufferKeyDecrypt, info.iv holds raw bytes here.  Fill it
+    // with info.ivSz random bytes; the first PKCS5_SALT_SZ of them are used
+    // as the key derivation salt, and the buffer is also used as the
+    // cipher IV.
+
     int ret = wc_BufferKeyEncrypt(&info, key, sizeof(key), password,
                                   sizeof(password)-1, WC_SHA256);
-    if (ret < 0) {
+    if (ret != 0) {
         // encryption error
     }
     \endcode

--- a/tests/api/test_wc_encrypt.c
+++ b/tests/api/test_wc_encrypt.c
@@ -253,6 +253,11 @@ int test_wc_BufferKeyEncryptDecryptDecisionCoverage(void)
     ExpectIntEQ(wc_BufferKeyEncrypt(&info, der, (word32)sizeof(der),
                     pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
                 WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    /* info->keySz > WC_MAX_SYM_KEY_SIZE */
+    info.keySz = 128;
+    ExpectIntEQ(wc_BufferKeyEncrypt(&info, der, (word32)sizeof(der),
+                    pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
+                WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     info.keySz = 16;
     /* info->ivSz < PKCS5_SALT_SZ */
     info.ivSz = PKCS5_SALT_SZ - 1;
@@ -272,6 +277,10 @@ int test_wc_BufferKeyEncryptDecryptDecisionCoverage(void)
                     pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
                 WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     info.keySz = 0;
+    ExpectIntEQ(wc_BufferKeyDecrypt(&info, der, (word32)sizeof(der),
+                    pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
+                WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    info.keySz = 128;
     ExpectIntEQ(wc_BufferKeyDecrypt(&info, der, (word32)sizeof(der),
                     pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
                 WC_NO_ERR_TRACE(BAD_FUNC_ARG));
@@ -311,6 +320,28 @@ int test_wc_BufferKeyEncryptDecryptDecisionCoverage(void)
         ExpectIntEQ(wc_BufferKeyEncrypt(&info, der, 24,
                         pw, (int)sizeof(pw), WC_HASH_TYPE_SHA), 0);
     }
+#else
+    {
+        XMEMSET(&info, 0, sizeof(info));
+        info.cipherType = WC_CIPHER_DES3;
+        info.keySz = 16;
+        info.ivSz  = PKCS5_SALT_SZ;
+        XMEMSET(info.iv, 0x25, PKCS5_SALT_SZ);
+        XMEMSET(der, 0x33, 24);
+        ExpectIntEQ(wc_BufferKeyEncrypt(&info, der, 16,
+                    pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
+                WC_NO_ERR_TRACE(NOT_COMPILED_IN));
+
+        XMEMSET(&info, 0, sizeof(info));
+        info.cipherType = WC_CIPHER_DES;
+        info.keySz = 8;
+        info.ivSz  = PKCS5_SALT_SZ;
+        XMEMSET(info.iv, 0x26, PKCS5_SALT_SZ);
+        XMEMSET(der, 0x33, 24);
+        ExpectIntEQ(wc_BufferKeyEncrypt(&info, der, 24,
+                    pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
+                WC_NO_ERR_TRACE(NOT_COMPILED_IN));
+    }
 #endif
 
     /* ---- decrypt dispatch: iv is hex (Base16-decoded to the PBKDF salt) ---- */
@@ -342,7 +373,66 @@ int test_wc_BufferKeyEncryptDecryptDecisionCoverage(void)
                     WC_NO_ERR_TRACE(BUFFER_E));
     }
 #endif
+#if !defined(HAVE_AES_CBC) || !defined(HAVE_AES_DECRYPT)
+    {
+        /* 16 hex chars -> 8-byte salt after Base16_Decode */
+        const byte hexIv[16] = {
+            '1','1','2','2','3','3','4','4',
+            '5','5','6','6','7','7','8','8'
+        };
+        XMEMSET(&info, 0, sizeof(info));
+        info.cipherType = WC_CIPHER_AES_CBC;
+        info.keySz = 16;
+        info.ivSz  = 16;
+        XMEMCPY(info.iv, hexIv, 16);
+        XMEMSET(der, 0x33, 16);
+        ExpectIntEQ(wc_BufferKeyDecrypt(&info, der, 16,
+                    pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
+                WC_NO_ERR_TRACE(NOT_COMPILED_IN));
+    }
+#endif
 #endif
     return EXPECT_RESULT();
 } /* END test_wc_BufferKeyEncryptDecryptDecisionCoverage */
 
+/*
+ * wc_BufferKeyEncrypt / wc_BufferKeyDecrypt: an unknown info->cipherType
+ * value should return ALGO_ID_E.
+ */
+int test_wc_BufferKeyEncryptDecryptUnknownCipher(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_ASN) && defined(WOLFSSL_ENCRYPTED_KEYS) && \
+    !defined(NO_PWDBASED) && !defined(NO_SHA)
+    const byte pw[] = { 'p','a','s','s','w','o','r','d' };
+    /* decrypt Base16-decodes info->iv in place, so it must be hex:
+     * 16 hex chars -> 8-byte salt */
+    const byte hexIv[16] = {
+        '1','1','2','2','3','3','4','4',
+        '5','5','6','6','7','7','8','8'
+    };
+    EncryptedInfo info;
+    byte der[16];
+
+    XMEMSET(&info, 0, sizeof(info));
+    info.cipherType = WC_CIPHER_NONE;
+    info.keySz = 16;
+    info.ivSz  = 16;
+    XMEMSET(info.iv, 0x27, 16);
+    XMEMSET(der, 0x33, sizeof(der));
+    ExpectIntEQ(wc_BufferKeyEncrypt(&info, der, (word32)sizeof(der),
+                    pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
+                WC_NO_ERR_TRACE(ALGO_ID_E));
+
+    XMEMSET(&info, 0, sizeof(info));
+    info.cipherType = WC_CIPHER_NONE;
+    info.keySz = 16;
+    info.ivSz  = 16;
+    XMEMCPY(info.iv, hexIv, 16);
+    XMEMSET(der, 0x33, sizeof(der));
+    ExpectIntEQ(wc_BufferKeyDecrypt(&info, der, (word32)sizeof(der),
+                    pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
+                WC_NO_ERR_TRACE(ALGO_ID_E));
+#endif
+    return EXPECT_RESULT();
+} /* END test_wc_BufferKeyEncryptDecryptUnknownCipher */

--- a/tests/api/test_wc_encrypt.c
+++ b/tests/api/test_wc_encrypt.c
@@ -254,7 +254,7 @@ int test_wc_BufferKeyEncryptDecryptDecisionCoverage(void)
                     pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
                 WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     /* info->keySz > WC_MAX_SYM_KEY_SIZE */
-    info.keySz = 128;
+    info.keySz = WC_MAX_SYM_KEY_SIZE + 1;
     ExpectIntEQ(wc_BufferKeyEncrypt(&info, der, (word32)sizeof(der),
                     pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
                 WC_NO_ERR_TRACE(BAD_FUNC_ARG));
@@ -280,7 +280,7 @@ int test_wc_BufferKeyEncryptDecryptDecisionCoverage(void)
     ExpectIntEQ(wc_BufferKeyDecrypt(&info, der, (word32)sizeof(der),
                     pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
                 WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-    info.keySz = 128;
+    info.keySz = WC_MAX_SYM_KEY_SIZE + 1;
     ExpectIntEQ(wc_BufferKeyDecrypt(&info, der, (word32)sizeof(der),
                     pw, (int)sizeof(pw), WC_HASH_TYPE_SHA),
                 WC_NO_ERR_TRACE(BAD_FUNC_ARG));

--- a/tests/api/test_wc_encrypt.h
+++ b/tests/api/test_wc_encrypt.h
@@ -28,12 +28,15 @@ int test_wc_Des3_CbcEncryptDecryptWithKey(void);
 int test_wc_Des_CbcEncryptDecryptWithKey(void);
 int test_wc_AesCbcEncryptDecryptWithKey(void);
 int test_wc_BufferKeyEncryptDecryptDecisionCoverage(void);
+int test_wc_BufferKeyEncryptDecryptUnknownCipher(void);
 
 #define TEST_WC_ENCRYPT_DECLS                                                   \
     TEST_DECL_GROUP("wc_encrypt", test_wc_Des3_CbcEncryptDecryptWithKey),       \
     TEST_DECL_GROUP("wc_encrypt", test_wc_Des_CbcEncryptDecryptWithKey),        \
     TEST_DECL_GROUP("wc_encrypt", test_wc_AesCbcEncryptDecryptWithKey),         \
     TEST_DECL_GROUP("wc_encrypt",                                               \
-        test_wc_BufferKeyEncryptDecryptDecisionCoverage)
+        test_wc_BufferKeyEncryptDecryptDecisionCoverage),                       \
+    TEST_DECL_GROUP("wc_encrypt",                                               \
+        test_wc_BufferKeyEncryptDecryptUnknownCipher)
 
 #endif /* WOLFCRYPT_TEST_WC_ENCRYPT_H */

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -232,8 +232,7 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
 #endif
 
     if (ret == 0) {
-        switch (info->cipherType)
-        {
+        switch (info->cipherType) {
         case WC_CIPHER_DES:
 #ifndef NO_DES3
             ret = wc_Des_CbcDecryptWithKey(der, der, derSz, key, info->iv);
@@ -302,8 +301,7 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
 #endif
 
     if (ret == 0) {
-        switch (info->cipherType)
-        {
+        switch (info->cipherType) {
         case WC_CIPHER_DES:
 #ifndef NO_DES3
             ret = wc_Des_CbcEncryptWithKey(der, der, derSz, key, info->iv);

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -229,6 +229,7 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
 #ifndef NO_PWDBASED
     if ((ret = wc_PBKDF1(key, password, passwordSz, info->iv, PKCS5_SALT_SZ, 1,
                                         (int)info->keySz, hashType)) != 0) {
+        ForceZero(key, WC_MAX_SYM_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
 #elif defined(WOLFSSL_CHECK_MEM_ZERO)
@@ -305,6 +306,7 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
 #ifndef NO_PWDBASED
     if ((ret = wc_PBKDF1(key, password, passwordSz, info->iv, PKCS5_SALT_SZ, 1,
                                         (int)info->keySz, hashType)) != 0) {
+        ForceZero(key, WC_MAX_SYM_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
 #elif defined(WOLFSSL_CHECK_MEM_ZERO)

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -196,14 +196,15 @@ int wc_Des3_CbcDecryptWithKey(byte* out, const byte* in, word32 sz,
 int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
     const byte* password, int passwordSz, int hashType)
 {
-    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
+    int ret;
     WC_DECLARE_VAR(key, byte, WC_MAX_SYM_KEY_SIZE, 0);
 
     (void)derSz;
     (void)passwordSz;
     (void)hashType;
 
-    if (der == NULL || password == NULL || info == NULL || info->keySz == 0) {
+    if (der == NULL || password == NULL || info == NULL || info->keySz == 0 ||
+            info->keySz > WC_MAX_SYM_KEY_SIZE) {
         return BAD_FUNC_ARG;
     }
 
@@ -237,17 +238,35 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
     }
 #endif
 
+    switch (info->cipherType)
+    {
 #ifndef NO_DES3
-    if (info->cipherType == WC_CIPHER_DES)
+    case WC_CIPHER_DES:
         ret = wc_Des_CbcDecryptWithKey(der, der, derSz, key, info->iv);
-    if (info->cipherType == WC_CIPHER_DES3)
+        break;
+    case WC_CIPHER_DES3:
         ret = wc_Des3_CbcDecryptWithKey(der, der, derSz, key, info->iv);
+        break;
+#else
+    case WC_CIPHER_DES:
+    case WC_CIPHER_DES3:
+        ret = NOT_COMPILED_IN;
+        break;
 #endif /* NO_DES3 */
 #if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(HAVE_AES_DECRYPT)
-    if (info->cipherType == WC_CIPHER_AES_CBC)
+    case WC_CIPHER_AES_CBC:
         ret = wc_AesCbcDecryptWithKey(der, der, derSz, key, info->keySz,
             info->iv);
+        break;
+#else
+    case WC_CIPHER_AES_CBC:
+        ret = NOT_COMPILED_IN;
+        break;
 #endif /* !NO_AES && HAVE_AES_CBC && HAVE_AES_DECRYPT */
+    default:
+        ret = ALGO_ID_E;
+        break;
+    }
 
     ForceZero(key, WC_MAX_SYM_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
@@ -262,7 +281,7 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
 int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
     const byte* password, int passwordSz, int hashType)
 {
-    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
+    int ret;
     WC_DECLARE_VAR(key, byte, WC_MAX_SYM_KEY_SIZE, 0);
 
     (void)derSz;
@@ -270,7 +289,7 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
     (void)hashType;
 
     if (der == NULL || password == NULL || info == NULL || info->keySz == 0 ||
-            info->ivSz < PKCS5_SALT_SZ) {
+            info->keySz > WC_MAX_SYM_KEY_SIZE || info->ivSz < PKCS5_SALT_SZ) {
         return BAD_FUNC_ARG;
     }
 
@@ -278,7 +297,7 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
         DYNAMIC_TYPE_SYMMETRIC_KEY, return MEMORY_E);
 #ifdef WOLFSSL_CHECK_MEM_ZERO
     XMEMSET(key, 0xff, WC_MAX_SYM_KEY_SIZE);
-    wc_MemZero_Add("wc_BufferKeyDecrypt key", key, WC_MAX_SYM_KEY_SIZE);
+    wc_MemZero_Add("wc_BufferKeyEncrypt key", key, WC_MAX_SYM_KEY_SIZE);
 #endif
 
     (void)XMEMSET(key, 0, WC_MAX_SYM_KEY_SIZE);
@@ -295,17 +314,35 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
     }
 #endif
 
+    switch (info->cipherType)
+    {
 #ifndef NO_DES3
-    if (info->cipherType == WC_CIPHER_DES)
+    case WC_CIPHER_DES:
         ret = wc_Des_CbcEncryptWithKey(der, der, derSz, key, info->iv);
-    if (info->cipherType == WC_CIPHER_DES3)
+        break;
+    case WC_CIPHER_DES3:
         ret = wc_Des3_CbcEncryptWithKey(der, der, derSz, key, info->iv);
+        break;
+#else
+    case WC_CIPHER_DES:
+    case WC_CIPHER_DES3:
+        ret = NOT_COMPILED_IN;
+        break;
 #endif /* NO_DES3 */
 #if !defined(NO_AES) && defined(HAVE_AES_CBC)
-    if (info->cipherType == WC_CIPHER_AES_CBC)
+    case WC_CIPHER_AES_CBC:
         ret = wc_AesCbcEncryptWithKey(der, der, derSz, key, info->keySz,
             info->iv);
+        break;
+#else
+    case WC_CIPHER_AES_CBC:
+        ret = NOT_COMPILED_IN;
+        break;
 #endif /* !NO_AES && HAVE_AES_CBC */
+    default:
+        ret = ALGO_ID_E;
+        break;
+    }
 
     ForceZero(key, WC_MAX_SYM_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -227,45 +227,39 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
     (void)XMEMSET(key, 0, WC_MAX_SYM_KEY_SIZE);
 
 #ifndef NO_PWDBASED
-    if ((ret = wc_PBKDF1(key, password, passwordSz, info->iv, PKCS5_SALT_SZ, 1,
-                                        (int)info->keySz, hashType)) != 0) {
-        ForceZero(key, WC_MAX_SYM_KEY_SIZE);
-#ifdef WOLFSSL_SMALL_STACK
-        XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
-#elif defined(WOLFSSL_CHECK_MEM_ZERO)
-        wc_MemZero_Check(key, WC_MAX_SYM_KEY_SIZE);
-#endif
-        return ret;
-    }
+    ret = wc_PBKDF1(key, password, passwordSz, info->iv, PKCS5_SALT_SZ, 1,
+                                        (int)info->keySz, hashType);
 #endif
 
-    switch (info->cipherType)
-    {
-    case WC_CIPHER_DES:
+    if (ret == 0) {
+        switch (info->cipherType)
+        {
+        case WC_CIPHER_DES:
 #ifndef NO_DES3
-        ret = wc_Des_CbcDecryptWithKey(der, der, derSz, key, info->iv);
+            ret = wc_Des_CbcDecryptWithKey(der, der, derSz, key, info->iv);
 #else
-        ret = NOT_COMPILED_IN;
+            ret = NOT_COMPILED_IN;
 #endif
-        break;
-    case WC_CIPHER_DES3:
+            break;
+        case WC_CIPHER_DES3:
 #ifndef NO_DES3
-        ret = wc_Des3_CbcDecryptWithKey(der, der, derSz, key, info->iv);
+            ret = wc_Des3_CbcDecryptWithKey(der, der, derSz, key, info->iv);
 #else
-        ret = NOT_COMPILED_IN;
+            ret = NOT_COMPILED_IN;
 #endif
-        break;
-    case WC_CIPHER_AES_CBC:
+            break;
+        case WC_CIPHER_AES_CBC:
 #if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(HAVE_AES_DECRYPT)
-        ret = wc_AesCbcDecryptWithKey(der, der, derSz, key, info->keySz,
-            info->iv);
+            ret = wc_AesCbcDecryptWithKey(der, der, derSz, key, info->keySz,
+                info->iv);
 #else
-        ret = NOT_COMPILED_IN;
+            ret = NOT_COMPILED_IN;
 #endif /* !NO_AES && HAVE_AES_CBC && HAVE_AES_DECRYPT */
-        break;
-    default:
-        ret = ALGO_ID_E;
-        break;
+            break;
+        default:
+            ret = ALGO_ID_E;
+            break;
+        }
     }
 
     ForceZero(key, WC_MAX_SYM_KEY_SIZE);
@@ -303,45 +297,39 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
     (void)XMEMSET(key, 0, WC_MAX_SYM_KEY_SIZE);
 
 #ifndef NO_PWDBASED
-    if ((ret = wc_PBKDF1(key, password, passwordSz, info->iv, PKCS5_SALT_SZ, 1,
-                                        (int)info->keySz, hashType)) != 0) {
-        ForceZero(key, WC_MAX_SYM_KEY_SIZE);
-#ifdef WOLFSSL_SMALL_STACK
-        XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
-#elif defined(WOLFSSL_CHECK_MEM_ZERO)
-        wc_MemZero_Check(key, WC_MAX_SYM_KEY_SIZE);
-#endif
-        return ret;
-    }
+    ret = wc_PBKDF1(key, password, passwordSz, info->iv, PKCS5_SALT_SZ, 1,
+                                        (int)info->keySz, hashType);
 #endif
 
-    switch (info->cipherType)
-    {
-    case WC_CIPHER_DES:
+    if (ret == 0) {
+        switch (info->cipherType)
+        {
+        case WC_CIPHER_DES:
 #ifndef NO_DES3
-        ret = wc_Des_CbcEncryptWithKey(der, der, derSz, key, info->iv);
+            ret = wc_Des_CbcEncryptWithKey(der, der, derSz, key, info->iv);
 #else
-        ret = NOT_COMPILED_IN;
+            ret = NOT_COMPILED_IN;
 #endif
-        break;
-    case WC_CIPHER_DES3:
+            break;
+        case WC_CIPHER_DES3:
 #ifndef NO_DES3
-        ret = wc_Des3_CbcEncryptWithKey(der, der, derSz, key, info->iv);
+            ret = wc_Des3_CbcEncryptWithKey(der, der, derSz, key, info->iv);
 #else
-        ret = NOT_COMPILED_IN;
+            ret = NOT_COMPILED_IN;
 #endif
-        break;
-    case WC_CIPHER_AES_CBC:
+            break;
+        case WC_CIPHER_AES_CBC:
 #if !defined(NO_AES) && defined(HAVE_AES_CBC)
-        ret = wc_AesCbcEncryptWithKey(der, der, derSz, key, info->keySz,
-            info->iv);
+            ret = wc_AesCbcEncryptWithKey(der, der, derSz, key, info->keySz,
+                info->iv);
 #else
-        ret = NOT_COMPILED_IN;
+            ret = NOT_COMPILED_IN;
 #endif /* !NO_AES && HAVE_AES_CBC */
-        break;
-    default:
-        ret = ALGO_ID_E;
-        break;
+            break;
+        default:
+            ret = ALGO_ID_E;
+            break;
+        }
     }
 
     ForceZero(key, WC_MAX_SYM_KEY_SIZE);

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -196,7 +196,7 @@ int wc_Des3_CbcDecryptWithKey(byte* out, const byte* in, word32 sz,
 int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
     const byte* password, int passwordSz, int hashType)
 {
-    int ret;
+    int ret = 0;
     WC_DECLARE_VAR(key, byte, WC_MAX_SYM_KEY_SIZE, 0);
 
     (void)derSz;
@@ -274,7 +274,7 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
 int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
     const byte* password, int passwordSz, int hashType)
 {
-    int ret;
+    int ret = 0;
     WC_DECLARE_VAR(key, byte, WC_MAX_SYM_KEY_SIZE, 0);
 
     (void)derSz;

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -241,29 +241,28 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
 
     switch (info->cipherType)
     {
+    case WC_CIPHER_DES:
 #ifndef NO_DES3
-    case WC_CIPHER_DES:
         ret = wc_Des_CbcDecryptWithKey(der, der, derSz, key, info->iv);
-        break;
-    case WC_CIPHER_DES3:
-        ret = wc_Des3_CbcDecryptWithKey(der, der, derSz, key, info->iv);
-        break;
 #else
-    case WC_CIPHER_DES:
-    case WC_CIPHER_DES3:
         ret = NOT_COMPILED_IN;
+#endif
         break;
-#endif /* NO_DES3 */
-#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(HAVE_AES_DECRYPT)
+    case WC_CIPHER_DES3:
+#ifndef NO_DES3
+        ret = wc_Des3_CbcDecryptWithKey(der, der, derSz, key, info->iv);
+#else
+        ret = NOT_COMPILED_IN;
+#endif
+        break;
     case WC_CIPHER_AES_CBC:
+#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(HAVE_AES_DECRYPT)
         ret = wc_AesCbcDecryptWithKey(der, der, derSz, key, info->keySz,
             info->iv);
-        break;
 #else
-    case WC_CIPHER_AES_CBC:
         ret = NOT_COMPILED_IN;
-        break;
 #endif /* !NO_AES && HAVE_AES_CBC && HAVE_AES_DECRYPT */
+        break;
     default:
         ret = ALGO_ID_E;
         break;
@@ -318,29 +317,28 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
 
     switch (info->cipherType)
     {
+    case WC_CIPHER_DES:
 #ifndef NO_DES3
-    case WC_CIPHER_DES:
         ret = wc_Des_CbcEncryptWithKey(der, der, derSz, key, info->iv);
-        break;
-    case WC_CIPHER_DES3:
-        ret = wc_Des3_CbcEncryptWithKey(der, der, derSz, key, info->iv);
-        break;
 #else
-    case WC_CIPHER_DES:
-    case WC_CIPHER_DES3:
         ret = NOT_COMPILED_IN;
+#endif
         break;
-#endif /* NO_DES3 */
-#if !defined(NO_AES) && defined(HAVE_AES_CBC)
+    case WC_CIPHER_DES3:
+#ifndef NO_DES3
+        ret = wc_Des3_CbcEncryptWithKey(der, der, derSz, key, info->iv);
+#else
+        ret = NOT_COMPILED_IN;
+#endif
+        break;
     case WC_CIPHER_AES_CBC:
+#if !defined(NO_AES) && defined(HAVE_AES_CBC)
         ret = wc_AesCbcEncryptWithKey(der, der, derSz, key, info->keySz,
             info->iv);
-        break;
 #else
-    case WC_CIPHER_AES_CBC:
         ret = NOT_COMPILED_IN;
-        break;
 #endif /* !NO_AES && HAVE_AES_CBC */
+        break;
     default:
         ret = ALGO_ID_E;
         break;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -12855,7 +12855,7 @@ static wc_test_ret_t des_key_wrap_test(void)
     /* Test invalid hash type - only applies to wc_PBKDF1 call */
     ret = wc_BufferKeyEncrypt(&info, cipher, sizeof(cipher), key,
             sizeof(key), WC_HASH_TYPE_NONE);
-    if (ret == 0)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     /* Same test for wc_BufferKeyDecrypt.  It Base16-decodes info.iv in place
@@ -12869,7 +12869,7 @@ static wc_test_ret_t des_key_wrap_test(void)
 
     ret = wc_BufferKeyDecrypt(&info, cipher, sizeof(cipher), key,
             sizeof(key), WC_HASH_TYPE_NONE);
-    if (ret == 0)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 #endif /* !NO_PWDBASED */
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -12822,6 +12822,14 @@ static wc_test_ret_t des_key_wrap_test(void)
     {
         0x12,0x34,0x56,0x78,0x90,0xab,0xcd,0xef
     };
+#ifndef NO_PWDBASED
+    /* 16 hex characters -> PKCS5_SALT_SZ (8) byte salt once Base16-decoded */
+    WOLFSSL_SMALL_STACK_STATIC const byte hexIv[] =
+    {
+        '1','2','3','4','5','6','7','8',
+        '9','0','a','b','c','d','e','f'
+    };
+#endif
     byte cipher[24] = { 0 };
     EncryptedInfo info;
     wc_test_ret_t ret;
@@ -12846,6 +12854,20 @@ static wc_test_ret_t des_key_wrap_test(void)
 #ifndef NO_PWDBASED
     /* Test invalid hash type - only applies to wc_PBKDF1 call */
     ret = wc_BufferKeyEncrypt(&info, cipher, sizeof(cipher), key,
+            sizeof(key), WC_HASH_TYPE_NONE);
+    if (ret == 0)
+        return WC_TEST_RET_ENC_EC(ret);
+
+    /* Same test for wc_BufferKeyDecrypt.  It Base16-decodes info.iv in place
+     * to get the PBKDF salt, so the IV must hold hex characters to reach the
+     * wc_PBKDF1 call. */
+    XMEMSET(&info, 0, sizeof(EncryptedInfo));
+    XMEMCPY(info.iv, hexIv, sizeof(hexIv));
+    info.ivSz = sizeof(hexIv);
+    info.keySz = sizeof(key);
+    info.cipherType = WC_CIPHER_DES;
+
+    ret = wc_BufferKeyDecrypt(&info, cipher, sizeof(cipher), key,
             sizeof(key), WC_HASH_TYPE_NONE);
     if (ret == 0)
         return WC_TEST_RET_ENC_EC(ret);


### PR DESCRIPTION
# Description

Return error code from wc_BufferKey{Encrypt,Decrypt} for unknown cipherType.

Fixes F-7397.

Also ensure key is zeroized on PBKDF failure.

# Testing

How did you test?

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
