### PR TITLE
fix(tests): avoid unsigned underflow in DH group loop

### DIFF
--- a/tests/api/test_dh.c
+++ b/tests/api/test_dh.c
@@ -566,7 +566,7 @@ int test_wc_DhGenerateKeyPair_and_Agree(void)
 
     ExpectIntEQ(wc_InitRng(&rng), 0);
 
-    for (i = 0; i < sizeof(groups) / sizeof(groups[0]) - 1; i++) {
+    for (i = 0; i + 1 < sizeof(groups) / sizeof(groups[0]); i++) {
         XMEMSET(&aliceKey, 0, sizeof(aliceKey));
         XMEMSET(&bobKey, 0, sizeof(bobKey));
         ExpectIntEQ(wc_InitDhKey(&aliceKey), 0);


### PR DESCRIPTION
Fixes jenkins issue `#558` — https://jenkins-supervisor.wolfssl.com/#/open-issues/558
(root-cause task `#556`: https://jenkins-supervisor.wolfssl.com/#/open-issues/556)

---

### Problem

`test_wc_DhGenerateKeyPair_and_Agree` builds a `groups[]` array from the enabled `HAVE_FFDHE_*` macros, with a trailing `0` sentinel so the array is never empty, and then subtracts that sentinel back off in the loop bound:

```c
static const int groups[] = {
#ifdef HAVE_FFDHE_2048
    WC_FFDHE_2048,
#endif
    ...
    0 /* keep the array non-empty when no HAVE_FFDHE_* is enabled */
};
size_t i;
for (i = 0; i < sizeof(groups) / sizeof(groups[0]) - 1; i++) {
```

When no `HAVE_FFDHE_*` is defined the count is 1, so the bound constant-folds to `size_t i < 0` — an unsigned value compared against zero. GCC flags it under `-Wtype-limits`, and since configure enables `-Werror` for any VCS checkout (`m4/ax_harden_compiler_flags.m4`), the build fails outright:

```
tests/api/test_dh.c:569:19: error: comparison of unsigned expression < 0 is always false [-Werror=type-limits]
  569 |     for (i = 0; i < sizeof(groups) / sizeof(groups[0]) - 1; i++) {
      |                   ^
```

This is not hypothetical — it has been breaking a nightly small-footprint build for 11 consecutive runs. The configuration that trips it enables `dh` and `rsa` with all curves disabled, so `HAVE_FFDHE_2048` is never defined (`configure.ac` gates it behind TLS 1.3 or supported-curves).

### Fix

Compare `i + 1` against the element count rather than `i` against `count - 1`. The subtraction can no longer underflow.

### Verification

Arithmetically identical for every array size. Iteration counts measured before and after on gcc 9.4.0:

| `groups[]` | before | after |
|---|---|---|
| `{0}` | 0 | 0 |
| `{g,0}` | 1 | 1 |
| `{g,g,0}` | 2 | 2 |
| `{g,g,g,0}` | 3 | 3 |

The pre-patch form fails to compile at size 1 under `-Werror -Wtype-limits`; the patched form compiles clean and behaves identically everywhere else.

### Worth noting separately

The loop body is already dead in the no-FFDHE configuration — that build runs no DH group exchange at all, and passes. This PR only fixes the build break; whether such a configuration should skip the test loudly is a separate coverage question I'm happy to follow up on.
