### PR TITLE
fix(build): probe positive form of -Wdeprecated-enum-enum-conversion

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13024,14 +13024,12 @@ fi
 # our use of enum constructs to define fungible constants.
 if test "$KERNEL_MODE_DEFAULTS" != "yes"
 then
-    # Probe with ac_c_werror_flag (fail on any stderr output), not -Werror:
-    # ccache reorders -Werror after the -Wno- option, so gcc accepts it with
-    # only a warning.
-    ax_save_c_werror_flag=$ac_c_werror_flag
-    ac_c_werror_flag=yes
-    AX_CHECK_COMPILE_FLAG([-Wno-deprecated-enum-enum-conversion],
+    # Probe the positive form: gcc rejects an unknown -Wfoo outright, but
+    # only reports an unknown -Wno-foo if some other diagnostic is emitted,
+    # which a trivial conftest never produces.  Probing -Wno- therefore
+    # succeeds on compilers that do not support the option at all.
+    AX_CHECK_COMPILE_FLAG([-Wdeprecated-enum-enum-conversion],
       [AX_APPEND_FLAG([-Wno-deprecated-enum-enum-conversion], [AM_CFLAGS])])
-    ac_c_werror_flag=$ax_save_c_werror_flag
 fi
 
 case $host_os in


### PR DESCRIPTION
Fixes jenkins issue `#559` — https://jenkins-supervisor.wolfssl.com/#/open-issues/559
(root-cause task `#556`: https://jenkins-supervisor.wolfssl.com/#/open-issues/556)

---

### Problem

The probe added in 627f51632b intends to add `-Wno-deprecated-enum-enum-conversion` only "if applicable". It does not achieve that: the flag is accepted on compilers that have never heard of it.

```m4
ax_save_c_werror_flag=$ac_c_werror_flag
ac_c_werror_flag=yes
AX_CHECK_COMPILE_FLAG([-Wno-deprecated-enum-enum-conversion],
  [AX_APPEND_FLAG([-Wno-deprecated-enum-enum-conversion], [AM_CFLAGS])])
ac_c_werror_flag=$ax_save_c_werror_flag
```

GCC reports an unrecognized `-Wno-foo` **only if some other diagnostic is emitted in the same translation unit**. `AX_CHECK_COMPILE_FLAG`'s conftest is trivial and emits nothing, so there is no stderr for `ac_c_werror_flag=yes` to catch, and the probe returns yes. The flag is then appended to `AM_CFLAGS`, reaching every C translation unit in the tree.

It causes no trouble at all until an unrelated warning shows up. Then the deferred complaint fires and `-Werror` converts a single warning into two hard errors:

```
tests/api/test_dh.c:569:19: error: comparison of unsigned expression < 0 is always false [-Werror=type-limits]
tests/api/test_dh.c: At top level:
cc1: error: unrecognized command line option '-Wno-deprecated-enum-enum-conversion' [-Werror]
cc1: all warnings being treated as errors
```

The second error is pure noise that sends you looking in the wrong place — it appears and disappears purely as a function of whether anything else in the file warned.

### Fix

Probe the **positive** `-Wdeprecated-enum-enum-conversion`, which GCC rejects immediately and unconditionally when unknown, then append the `-Wno-` form on success. The `ac_c_werror_flag` juggling is no longer needed.

### Verification

Measured on gcc 9.4.0 (Ubuntu 20.04), the compiler where this actually bites:

| probe | result |
|---|---|
| clean conftest + `-Werror -Wno-deprecated-enum-enum-conversion` (current) | exit 0, no output — **flag wrongly accepted** |
| clean conftest + `-Wdeprecated-enum-enum-conversion` (this PR) | exit 1, `gcc: error: unrecognized command line option` — **correctly skipped** |

Behaviour after this change:

- pre-GCC-11 C compiler — unknown option, probe fails, flag not added
- GCC 11+ compiling C — "valid for C++/ObjC++ but not for C", probe fails, flag not added (C never needed it)
- C++20 compiler — accepted, `-Wno-` form added, original intent preserved

Also confirmed the flag really does land in C flags today: `AM_CFLAGS` in a generated `Makefile` contains it, and `config.log` shows it baked in at configure time.

### Question for the original author

`configure.ac` has no `AC_PROG_CXX`, no `AM_CXXFLAGS`, and compiles no C++, so it isn't obvious which build path was meant to receive this. `.github/workflows/multi-compiler.yml` passes `CXX=g++-9..12` / `clang++-14,19` to configure. If the intended target is genuinely C++ compilation, `AM_CXXFLAGS` under `AC_LANG_PUSH([C++])` would be the more precise home and I'm glad to redo it that way.

Independent of #11050, which fixes the `-Wtype-limits` warning that exposed this. Either PR alone makes the observed failure go away; only this one disarms it for the next warning.
