### PR TITLE
Release sniffer static ephemeral lock on all SetupKeys exits

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -3055,8 +3055,11 @@ static int SetupKeys(const byte* input, int* sslBytes, SnifferSession* session,
     #endif /* HAVE_CURVE448 */
 
     #if defined(WOLFSSL_STATIC_EPHEMERAL) && !defined(SINGLE_THREADED)
+        /* release early so the lock is not held during key agreement,
+         * the exit path below covers the error cases */
         if (args->keyLocked) {
             wc_UnLockMutex(&ctx->staticKELock);
+            args->keyLocked = 0;
         }
     #endif
 
@@ -3277,7 +3280,22 @@ static int SetupKeys(const byte* input, int* sslBytes, SnifferSession* session,
 
 #ifdef WOLFSSL_ASYNC_CRYPT
 exit_sk:
+#endif
 
+#if defined(WOLFSSL_STATIC_EPHEMERAL) && !defined(SINGLE_THREADED)
+    /* release the lock if an error path left the key state locked */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if ((args != NULL) && (args->keyLocked))
+#else
+    if (args->keyLocked)
+#endif
+    {
+        wc_UnLockMutex(&ctx->staticKELock);
+        args->keyLocked = 0;
+    }
+#endif
+
+#ifdef WOLFSSL_ASYNC_CRYPT
     /* Handle async pending response */
     if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         return ret;


### PR DESCRIPTION
### Problem

`SetupKeys()` acquires the CTX-wide static-ephemeral mutex at the top of
`case TLS_ASYNC_BEGIN` (`src/sniffer.c:2588`) and releases it only at the bottom of
that case (`src/sniffer.c:3057`). Three error paths execute a bare `break;`, which
exits the enclosing `switch (ssl->options.asyncState)` and jumps past the release:

| Line | Path | Trigger |
|---|---|---|
| 2615 | `wc_RsaPrivateKeyDecode` failure, `#ifndef HAVE_ECC` | malformed static RSA key on a non-ECC build |
| 2915 | Curve25519 `KeyCb` failure | configured key callback returns an error |
| 3000 | Curve448 `KeyCb` failure | configured key callback returns an error |

The common exit at `exit_sk:` frees `args` but never touches the mutex.
`ctx->staticKELock` is a plain non-recursive `wolfSSL_Mutex` on the `WOLFSSL_CTX`
shared by every `SnifferSession` for that server, so one hit leaves it held forever:
the next packet reaching `SetupKeys` for any session on that context blocks in
`wc_LockMutex()` indefinitely. The trigger is remote-influenced. Closes f-7544.

### Fix (`src/sniffer.c`)

- **The existing release now clears `args->keyLocked`**, making the flag authoritative.
- **A matching release was added on the common exit path**, between the `exit_sk:`
  label and the `WC_PENDING_E` early `return`, so the async pending path is covered too.
- The early release is kept deliberately: it bounds lock-hold time by dropping the
  mutex before the shared-secret and derivation work in `TLS_ASYNC_DO`/`VERIFY`/
  `FINALIZE`. A comment records that intent.
- The `args != NULL` guard is `#ifdef`-split because `args` is an array in the
  non-async build (`-Waddress`) but a legitimately NULL pointer under
  `WOLFSSL_ASYNC_CRYPT`.

### Verification

- `./scripts/sniffer-testsuite.test`: all 9 cases pass. The two `Fatal Error State on
  packet 24` lines are pre-existing, reproduced identically on an unmodified build.
- Compile sweeps clean under `-Werror`: default sniffer, `--enable-singlethreaded`,
  `--enable-curve448 --enable-curve25519`, and `--disable-ecc --disable-curve25519`,
  covering every preprocessor combination the new block sits in.
- Deadlock reproduced and fixed with a temporary instrumented build (forced `break`
  after the lock): unfixed, the process hung in `SetupKeys` -> `wc_LockMutex` on the
  second of three `SetupKeys` calls in `sniffer-tls13-ecc.pcap`, confirmed by
  `sample(1)`; fixed, all three complete and a follow-up re-lock succeeds.

### Not in this PR

No regression test. `ssl_SetKeyCallback()` has no in-tree caller, so the `KeyCb`
branches never execute under test; `sniffer-tls13-x25519{,-resume}.pcap` are 24-byte
empty captures; and the RSA path needs a `--disable-ecc` build plus the SNI named-key
route, since `wolfSSL_CTX_use_PrivateKey_file()` validates the key at load time.
Committing the harness above would mean permanent fault injection in `sniffer.c`.
The empty x25519 captures are a separate pre-existing coverage gap.