### PR TITLE
pkcs7 fix: retain certificates after SignedData encode

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -4124,8 +4124,6 @@ static int PKCS7_EncodeSigned(wc_PKCS7* pkcs7,
         }
     }
 
-    wc_PKCS7_FreeCertSet(pkcs7);
-
     wc_PKCS7_WriteOut(pkcs7, (output2)? (output2 + idx) : NULL,
                 esd->signerInfoSet, esd->signerInfoSetSz);
     idx += (int)esd->signerInfoSetSz;


### PR DESCRIPTION
# Description

PKCS7_EncodeSigned() freed the object's certificate-list nodes after a successful encode while leaving the signer fields populated. Reusing the object then emitted SignedData without certificates, requiring external signature verification.

Keep the list until wc_PKCS7_Free(), which already handles its cleanup.

# Testing

Discovered in MC/DC campaign part 5 #11039 


