### PR TITLE
Rust wrapper: bump wolfssl-wolfcrypt crate to v2.2.0

### DIFF
--- a/wrapper/rust/wolfssl-wolfcrypt/CHANGELOG.md
+++ b/wrapper/rust/wolfssl-wolfcrypt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # wolfssl-wolfcrypt Change Log
 
-## Unreleased
+## v2.2.0
 
 New features:
 

--- a/wrapper/rust/wolfssl-wolfcrypt/Cargo.lock
+++ b/wrapper/rust/wolfssl-wolfcrypt/Cargo.lock
@@ -420,7 +420,7 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "wolfssl-wolfcrypt"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "aead",
  "bindgen",

--- a/wrapper/rust/wolfssl-wolfcrypt/Cargo.toml
+++ b/wrapper/rust/wolfssl-wolfcrypt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-wolfcrypt"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2024"
 description = "Rust wrapper for wolfssl C library cryptographic functionality"
 license = "GPL-3.0"


### PR DESCRIPTION
# Description

Rust wrapper: bump wolfssl-wolfcrypt crate to v2.2.0

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
