### PR TITLE
Reject zero modulus in mulmod/sqrmod

### DIFF
--- a/wolfcrypt/src/port/maxim/max3266x.c
+++ b/wolfcrypt/src/port/maxim/max3266x.c
@@ -2495,6 +2495,10 @@ int hw_mulmod(mp_int* multiplier, mp_int* multiplicand, mp_int* mod,
         return MP_VAL;
     }
     if ((multiplier->used == 0) || (multiplicand->used == 0)) {
+        /* A zero modulus is invalid whatever the operands are. */
+        if (mod->used == 0) {
+            return MP_VAL;
+        }
         mp_zero(result);
         return 0;
     }
@@ -2591,6 +2595,10 @@ int hw_sqrmod(mp_int* base, mp_int* mod, mp_int* result)
         return MP_VAL;
     }
     if (base->used == 0) {
+        /* A zero modulus is invalid whatever the base is. */
+        if (mod->used == 0) {
+            return MP_VAL;
+        }
         mp_zero(result);
         return 0;
     }

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -12292,6 +12292,7 @@ int sp_mul(const sp_int* a, const sp_int* b, sp_int* r)
  * @param [out] r  SP integer result.
  *
  * @return  MP_OKAY on success.
+ * @return  MP_VAL when m is 0.
  * @return  MP_MEM when dynamic memory allocation fails.
  */
 static int _sp_mulmod_tmp(const sp_int* a, const sp_int* b, const sp_int* m,
@@ -12300,7 +12301,15 @@ static int _sp_mulmod_tmp(const sp_int* a, const sp_int* b, const sp_int* m,
     int err = MP_OKAY;
 
     if (sp_iszero(a) || sp_iszero(b)) {
-        _sp_zero(r);
+        /* Only reached from sp_mulmod() when the result aliases the modulus.
+         * The zero-operand short-circuit would otherwise bypass the sp_mod()
+         * validation that the non-zero operand path relies on. */
+        if (sp_iszero(m)) {
+            err = MP_VAL;
+        }
+        else {
+            _sp_zero(r);
+        }
     }
     else {
         /* Create temporary for multiplication result. */
@@ -12334,6 +12343,7 @@ static int _sp_mulmod_tmp(const sp_int* a, const sp_int* b, const sp_int* m,
  * @param [out] r  SP integer result.
  *
  * @return  MP_OKAY on success.
+ * @return  MP_VAL when m is 0.
  * @return  MP_MEM when dynamic memory allocation fails.
  */
 static int _sp_mulmod(const sp_int* a, const sp_int* b, const sp_int* m,
@@ -17501,6 +17511,7 @@ int sp_sqr(const sp_int* a, sp_int* r)
  * @param [out] r  SP integer result.
  *
  * @return  MP_OKAY on success.
+ * @return  MP_VAL when m is 0.
  * @return  MP_MEM when dynamic memory allocation fails.
  */
 static int _sp_sqrmod(const sp_int* a, const sp_int* m, sp_int* r)
@@ -17508,7 +17519,15 @@ static int _sp_sqrmod(const sp_int* a, const sp_int* m, sp_int* r)
     int err = MP_OKAY;
 
     if (sp_iszero(a)) {
-        _sp_zero(r);
+        /* Only reached from sp_sqrmod() when the result aliases the modulus.
+         * The zero-operand short-circuit would otherwise bypass the sp_mod()
+         * validation that the non-zero operand path relies on. */
+        if (sp_iszero(m)) {
+            err = MP_VAL;
+        }
+        else {
+            _sp_zero(r);
+        }
     }
     else {
         /* Create temporary for multiplication result. */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -76044,6 +76044,39 @@ static wc_test_ret_t mp_test_mulmod_sqrmod(mp_int* a, mp_int* b, mp_int* m,
     if (!mp_iszero(m))
         return WC_TEST_RET_ENC_NC;
 
+    /* A zero modulus is invalid whether or not the result aliases it. The
+     * zero-operand short-circuits must not hide it. */
+    ret = mp_set(a, 0);
+    if (ret == MP_OKAY)
+        ret = mp_set(b, 0x5);
+    if (ret == MP_OKAY)
+        ret = mp_set(m, 0);
+    if (ret != MP_OKAY)
+        return WC_TEST_RET_ENC_EC(ret);
+    if (mp_sqrmod(a, m, r) != WC_NO_ERR_TRACE(MP_VAL))
+        return WC_TEST_RET_ENC_NC;
+    if (mp_sqrmod(a, m, m) != WC_NO_ERR_TRACE(MP_VAL))
+        return WC_TEST_RET_ENC_NC;
+    ret = mp_set(m, 0);
+    if (ret != MP_OKAY)
+        return WC_TEST_RET_ENC_EC(ret);
+    if (mp_mulmod(a, b, m, r) != WC_NO_ERR_TRACE(MP_VAL))
+        return WC_TEST_RET_ENC_NC;
+    if (mp_mulmod(a, b, m, m) != WC_NO_ERR_TRACE(MP_VAL))
+        return WC_TEST_RET_ENC_NC;
+    /* Cover the other half of the zero-operand test in _sp_mulmod_tmp. */
+    ret = mp_set(a, 0x5);
+    if (ret == MP_OKAY)
+        ret = mp_set(b, 0);
+    if (ret == MP_OKAY)
+        ret = mp_set(m, 0);
+    if (ret != MP_OKAY)
+        return WC_TEST_RET_ENC_EC(ret);
+    if (mp_mulmod(a, b, m, r) != WC_NO_ERR_TRACE(MP_VAL))
+        return WC_TEST_RET_ENC_NC;
+    if (mp_mulmod(a, b, m, m) != WC_NO_ERR_TRACE(MP_VAL))
+        return WC_TEST_RET_ENC_NC;
+
     return 0;
 }
 


### PR DESCRIPTION
Fixes #11063.

`_sp_sqrmod()` and `_sp_mulmod_tmp()` short-circuit on a zero operand and store zero without checking the modulus, while the non-aliased paths reject a zero modulus through `sp_mod()`. So the return value depended on whether the caller aliased the result onto the modulus:

```
mp_sqrmod(a, m, r)  a=0, m=0, r distinct  ->  MP_VAL
mp_sqrmod(a, m, m)  a=0, m=0              ->  MP_OKAY, result 0
```

`mp_mulmod` behaves the same way through `_sp_mulmod_tmp()`. Both public wrappers already document `MP_VAL` for a zero modulus (`sp_sqrmod` and `sp_mulmod`), so the aliased path did not match its documented contract.

The check goes in the zero-operand branch of each helper rather than in the public wrappers, so the non-zero path keeps getting it from `sp_mod()` as before.

### Other backends

- `tfm.c` (`fp_mulmod`, `fp_sqrmod`) and `integer.c` (`mp_mulmod`, `mp_sqrmod`) have no zero-operand short-circuit and always reduce through `fp_div`/`mp_div`, which reject a zero divisor. Already correct in both aliasings, unchanged here.
- `hw_mulmod()` and `hw_sqrmod()` in `port/maxim/max3266x.c` carry the identical pattern, and `wolfmath.h` maps `mp_mulmod`/`mp_sqrmod` onto them when `WOLFSSL_USE_HW_MP` is defined. They get the same check. **That hunk is by inspection only** — building the port needs the Maxim SDK, so it has not been compiled or run. Happy to drop it into a separate PR if you would rather someone with the hardware take it.

### Behavior change

The only production caller reaching the changed branch is `wc_CheckRsaKey()`, at `rsa.c:927` and `rsa.c:950`, which call `mp_mulmod(&key->dP, &key->e, tmp, tmp)` with the result aliased onto the modulus. `tmp` is `p-1`/`q-1`, non-zero for any real key. For a malformed key with `p == 1` the call now returns `MP_VAL` and the key is rejected as `MP_EXPTMOD_E`, where previously it returned `MP_OKAY` with `tmp = 0` and was rejected by the following `!mp_isone(tmp)` check. Same outcome, explicit rather than incidental.

### Testing

Extends the existing aliasing test in `mp_test_mulmod_sqrmod()` to cover a zero modulus in both arrangements, including both halves of the `_sp_mulmod_tmp()` zero-operand disjunction. The test fails before the `sp_int.c` change and passes after.

Note that `mp_test()` is gated behind `WOLFSSL_PUBLIC_MP`, so a default `./configure && make check` skips the whole mp suite. Verified with `CFLAGS=-DWOLFSSL_PUBLIC_MP`. CI covers it via `cmake.yml` and `os-check-linux.json`.

Found via OSS-Fuzz 513887571 (cryptofuzz `BignumCalc SqrMod`).
