### PR TITLE
AES-GCM ASM crypto: restore tmp pointer

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-32-aes-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-32-aes-asm.S
@@ -26670,6 +26670,7 @@ L_aes_gcm_encrypt_arm32_crypto_192_out_start_byte:
 	strb	lr, [r1], #1
 	bne	L_aes_gcm_encrypt_arm32_crypto_192_out_start_byte
 L_aes_gcm_encrypt_arm32_crypto_192_out_end_bytes:
+	sub	r9, r9, r11
 L_aes_gcm_encrypt_arm32_crypto_192_partial_done:
 	# Finish
 	add	r8, r2, #15
@@ -26922,6 +26923,7 @@ L_aes_gcm_encrypt_arm32_crypto_256_out_start_byte:
 	strb	lr, [r1], #1
 	bne	L_aes_gcm_encrypt_arm32_crypto_256_out_start_byte
 L_aes_gcm_encrypt_arm32_crypto_256_out_end_bytes:
+	sub	r9, r9, r11
 L_aes_gcm_encrypt_arm32_crypto_256_partial_done:
 	# Finish
 	add	r8, r2, #15
@@ -27133,6 +27135,7 @@ L_aes_gcm_encrypt_arm32_crypto_128_out_start_byte:
 	strb	lr, [r1], #1
 	bne	L_aes_gcm_encrypt_arm32_crypto_128_out_start_byte
 L_aes_gcm_encrypt_arm32_crypto_128_out_end_bytes:
+	sub	r9, r9, r11
 L_aes_gcm_encrypt_arm32_crypto_128_partial_done:
 	# Finish
 	add	r8, r2, #15
@@ -28624,6 +28627,7 @@ L_aes_gcm_decrypt_arm32_crypto_192_out_start_byte:
 	strb	lr, [r1], #1
 	bne	L_aes_gcm_decrypt_arm32_crypto_192_out_start_byte
 L_aes_gcm_decrypt_arm32_crypto_192_out_end_bytes:
+	sub	r9, r9, r11
 L_aes_gcm_decrypt_arm32_crypto_192_partial_done:
 	# Finish
 	add	r8, r2, #15
@@ -28876,6 +28880,7 @@ L_aes_gcm_decrypt_arm32_crypto_256_out_start_byte:
 	strb	lr, [r1], #1
 	bne	L_aes_gcm_decrypt_arm32_crypto_256_out_start_byte
 L_aes_gcm_decrypt_arm32_crypto_256_out_end_bytes:
+	sub	r9, r9, r11
 L_aes_gcm_decrypt_arm32_crypto_256_partial_done:
 	# Finish
 	add	r8, r2, #15
@@ -29087,6 +29092,7 @@ L_aes_gcm_decrypt_arm32_crypto_128_out_start_byte:
 	strb	lr, [r1], #1
 	bne	L_aes_gcm_decrypt_arm32_crypto_128_out_start_byte
 L_aes_gcm_decrypt_arm32_crypto_128_out_end_bytes:
+	sub	r9, r9, r11
 L_aes_gcm_decrypt_arm32_crypto_128_partial_done:
 	# Finish
 	add	r8, r2, #15

--- a/wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
@@ -27356,6 +27356,7 @@ WC_OMIT_FRAME_POINTER void AES_GCM_encrypt_AARCH32(const byte* in, byte* out,
         "bne	L_aes_gcm_encrypt_arm32_crypto_192_out_start_byte_%=\n\t"
         "\n"
     "L_aes_gcm_encrypt_arm32_crypto_192_out_end_bytes_%=:\n\t"
+        "sub	r9, r9, r11\n\t"
         "\n"
     "L_aes_gcm_encrypt_arm32_crypto_192_partial_done_%=:\n\t"
         /* Finish */
@@ -27621,6 +27622,7 @@ WC_OMIT_FRAME_POINTER void AES_GCM_encrypt_AARCH32(const byte* in, byte* out,
         "bne	L_aes_gcm_encrypt_arm32_crypto_256_out_start_byte_%=\n\t"
         "\n"
     "L_aes_gcm_encrypt_arm32_crypto_256_out_end_bytes_%=:\n\t"
+        "sub	r9, r9, r11\n\t"
         "\n"
     "L_aes_gcm_encrypt_arm32_crypto_256_partial_done_%=:\n\t"
         /* Finish */
@@ -27845,6 +27847,7 @@ WC_OMIT_FRAME_POINTER void AES_GCM_encrypt_AARCH32(const byte* in, byte* out,
         "bne	L_aes_gcm_encrypt_arm32_crypto_128_out_start_byte_%=\n\t"
         "\n"
     "L_aes_gcm_encrypt_arm32_crypto_128_out_end_bytes_%=:\n\t"
+        "sub	r9, r9, r11\n\t"
         "\n"
     "L_aes_gcm_encrypt_arm32_crypto_128_partial_done_%=:\n\t"
         /* Finish */
@@ -29447,6 +29450,7 @@ WC_OMIT_FRAME_POINTER int AES_GCM_decrypt_AARCH32(const byte* in, byte* out,
         "bne	L_aes_gcm_decrypt_arm32_crypto_192_out_start_byte_%=\n\t"
         "\n"
     "L_aes_gcm_decrypt_arm32_crypto_192_out_end_bytes_%=:\n\t"
+        "sub	r9, r9, r11\n\t"
         "\n"
     "L_aes_gcm_decrypt_arm32_crypto_192_partial_done_%=:\n\t"
         /* Finish */
@@ -29712,6 +29716,7 @@ WC_OMIT_FRAME_POINTER int AES_GCM_decrypt_AARCH32(const byte* in, byte* out,
         "bne	L_aes_gcm_decrypt_arm32_crypto_256_out_start_byte_%=\n\t"
         "\n"
     "L_aes_gcm_decrypt_arm32_crypto_256_out_end_bytes_%=:\n\t"
+        "sub	r9, r9, r11\n\t"
         "\n"
     "L_aes_gcm_decrypt_arm32_crypto_256_partial_done_%=:\n\t"
         /* Finish */
@@ -29936,6 +29941,7 @@ WC_OMIT_FRAME_POINTER int AES_GCM_decrypt_AARCH32(const byte* in, byte* out,
         "bne	L_aes_gcm_decrypt_arm32_crypto_128_out_start_byte_%=\n\t"
         "\n"
     "L_aes_gcm_decrypt_arm32_crypto_128_out_end_bytes_%=:\n\t"
+        "sub	r9, r9, r11\n\t"
         "\n"
     "L_aes_gcm_decrypt_arm32_crypto_128_partial_done_%=:\n\t"
         /* Finish */


### PR DESCRIPTION
# Description

Assembly code for AES-GCM was not restoring tmp pointer and writing over fields of the AES structure.

# Testing

./configure --disable-shared LDFLAGS=--static --host=armv8 CC=arm-linux-gnueabihf-gcc --enable-all --disable-crl-monitor