### PR TITLE
Reset the ready-file wait counter on each server start

### DIFF
--- a/scripts/crl-revoked.test
+++ b/scripts/crl-revoked.test
@@ -111,6 +111,7 @@ run_test() {
                              -k ${CERT_DIR}/server-revoked-key.pem &
     server_pid=$!
 
+    counter=0
     while [ ! -s "$ready_file" -a "$counter" -lt 20 ]; do
         echo -e "waiting for ready file..."
         sleep 0.1
@@ -187,6 +188,7 @@ run_hashdir_test() {
                              -c ${CERT_DIR}/server-revoked-cert.pem \
                              -k ${CERT_DIR}/server-revoked-key.pem &
   server_pid=$!
+  counter=0
   while [ ! -s "$ready_file" -a "$counter" -lt 20 ]; do
         echo -e "waiting for ready file..."
         sleep 0.1

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -303,6 +303,7 @@ start_wolfssl_server() {
 check_server_ready() {
     # server should be ready, let's make sure
     server_ready=0
+    counter=0
     while [ "$counter" -lt 20 ]; do
         echo -e "waiting for $server_name ready..."
         echo -e Checking | nc -4 -w 1 -z localhost "$server_port"

--- a/scripts/pkcallbacks.test
+++ b/scripts/pkcallbacks.test
@@ -111,6 +111,7 @@ run_test() {
     timeout -s KILL 2m ./examples/server/server -P -R "$ready_file" -p $pk_port &
     server_pid=$!
 
+    counter=0
     while [ ! -s "$ready_file" -a "$counter" -lt 20 ]; do
         echo -e "waiting for ready file..."
         sleep 0.1

--- a/scripts/psk.test
+++ b/scripts/psk.test
@@ -33,6 +33,7 @@ ready_file=`pwd`/wolfssl_psk_ready$$
 echo "ready file \"$ready_file\""
 
 create_port() {
+    counter=0
     while [ ! -s "$ready_file" -a "$counter" -lt 20 ]; do
         echo -e "waiting for ready file..."
         sleep 0.1

--- a/scripts/resume.test
+++ b/scripts/resume.test
@@ -87,6 +87,7 @@ do_test() {
     timeout -s KILL 2m ./examples/server/server -r -R "$ready_file" -p $resume_port &
     server_pid=$!
 
+    counter=0
     while [ ! -s "$ready_file" -a "$counter" -lt 20 ]; do
         echo -e "waiting for ready file..."
         sleep 0.1

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -48,6 +48,7 @@ client_out_file="$(pwd)/wolfssl_tls13_client_out$$"
 echo "ready file \"$ready_file\""
 
 create_port() {
+    counter=0
     while [ ! -s "$ready_file" ]; do
         if [ "$counter" -gt 50 ]; then
             break

--- a/scripts/trusted_peer.test
+++ b/scripts/trusted_peer.test
@@ -57,6 +57,7 @@ wrong_cert=`pwd`/certs/server-revoked-cert.pem
 echo "ready file \"$ready_file\""
 
 create_port() {
+    counter=0
     while [ ! -s "$ready_file" -a "$counter" -lt 20 ]; do
         echo -e "waiting for ready file..."
         sleep 0.1


### PR DESCRIPTION
## Description

Seven test scripts wait for the example server to publish its ready file, but they declare `counter` at file scope and never reset it. The retry budget (20 waits of 0.1s, 50 in `tls13.test`) is therefore shared across every server start in the script instead of applying to each one. Once the early cases have consumed it, every later `create_port()` / `run_test()` falls straight through to `NO ready file ending test`, kills a server that was starting up normally, and the client then fails with `port number cannot be 0`. Retry loops around the failing case do not help, because the budget is already spent by the time they run.

This only needs a build whose server start-up is slow enough to burn a few tenths of a second per case. It surfaced in the FIPS `dev-no-POST` `kernel-settings-all-pqc-asm` job (introduced in #11031), where the server pays for the CASTs, the PQC algorithms and the vector-register fallback fuzzer. The signature is unmistakable: `psk.test` gave up after exactly 20 waits and `tls13.test` after exactly 51 — the whole script budget, not a per-case one.

The fix is to reset `counter` where the wait begins, which is what `scripts/ocsp-stapling*.test` already does in its `wait_for_readyFile()` helper.

## Changes

| File | Change |
|---|---|
| `scripts/crl-revoked.test` | reset in `run_test()` and `run_hashdir_test()` |
| `scripts/openssl.test` | reset in `check_server_ready()` |
| `scripts/pkcallbacks.test` | reset in `run_test()` |
| `scripts/psk.test` | reset in `create_port()` |
| `scripts/resume.test` | reset in `do_test()` |
| `scripts/tls13.test` | reset in `create_port()` |
| `scripts/trusted_peer.test` | reset in `create_port()` |

Test-script only — no library code is touched, and the retry limits themselves are unchanged.

## Testing

Reproduced with a wrapper that delays the example server by one second on start-up, so each case eats the full budget:

- Before the change, `psk.test` fails on its third case with `NO ready file ending test` / `port number cannot be 0`.
- After the change, the same run passes.