### PR TITLE
Fix mem-fail nightly crashes (jenkins-supervisor #501)

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -16325,7 +16325,7 @@ static int test_wolfSSL_Tls13_ECH_wire_sni_ex(int accept, int useCtx)
     wolfSSL_SNI_GetRequest(test_ctx.s_ssl, WOLFSSL_SNI_HOST_NAME, &sniName);
     ExpectStrEQ((const char*)sniName, expectedSni);
     /* verify the ctx always has the private SNI */
-    if (useCtx) {
+    if (useCtx && EXPECT_SUCCESS() && (test_ctx.c_ctx != NULL)) {
         sniName = NULL;
         TLSX_SNI_GetRequest(test_ctx.c_ctx->extensions, WOLFSSL_SNI_HOST_NAME,
             &sniName, 1);

--- a/tests/api/test_ossl_x509_vp.c
+++ b/tests/api/test_ossl_x509_vp.c
@@ -155,8 +155,10 @@ int test_wolfSSL_X509_VERIFY_PARAM(void)
     ExpectIntEQ(X509_VERIFY_PARAM_set1_host(paramTo, testhostName2,
         (int)XSTRLEN(testhostName2)), 1);
     ExpectIntEQ(X509_VERIFY_PARAM_set1_ip_asc(paramTo, testIPv4), 1);
-    paramTo->inherit_flags = X509_VP_FLAG_ONCE;
-    paramFrom->inherit_flags = 0;
+    if ((paramTo != NULL) && (paramFrom != NULL)) {
+        paramTo->inherit_flags = X509_VP_FLAG_ONCE;
+        paramFrom->inherit_flags = 0;
+    }
     ExpectIntEQ(X509_VERIFY_PARAM_inherit(paramTo, paramFrom), 1);
     ExpectIntEQ(paramTo->inherit_flags, 0);
     ExpectIntEQ(0, XSTRNCMP(paramTo->hostName, testhostName2,
@@ -164,17 +166,21 @@ int test_wolfSSL_X509_VERIFY_PARAM(void)
     ExpectIntEQ(0, XSTRNCMP(paramTo->ipasc, testIPv4, WOLFSSL_MAX_IPSTR));
 
     /* check_time should not be copied when already set unless overwrite */
-    XMEMSET(paramTo, 0, sizeof(X509_VERIFY_PARAM));
-    XMEMSET(paramFrom, 0, sizeof(X509_VERIFY_PARAM));
-    paramTo->check_time = 11;
-    paramTo->flags = WOLFSSL_USE_CHECK_TIME;
-    paramFrom->check_time = 22;
+    if ((paramTo != NULL) && (paramFrom != NULL)) {
+        XMEMSET(paramTo, 0, sizeof(X509_VERIFY_PARAM));
+        XMEMSET(paramFrom, 0, sizeof(X509_VERIFY_PARAM));
+        paramTo->check_time = 11;
+        paramTo->flags = WOLFSSL_USE_CHECK_TIME;
+        paramFrom->check_time = 22;
+    }
     ExpectIntEQ(X509_VERIFY_PARAM_inherit(paramTo, paramFrom), 1);
     ExpectTrue(paramTo->check_time == 11);
     ExpectIntEQ(paramTo->flags & WOLFSSL_USE_CHECK_TIME,
         WOLFSSL_USE_CHECK_TIME);
 
-    paramTo->inherit_flags = X509_VP_FLAG_OVERWRITE;
+    if (paramTo != NULL) {
+        paramTo->inherit_flags = X509_VP_FLAG_OVERWRITE;
+    }
     ExpectIntEQ(X509_VERIFY_PARAM_inherit(paramTo, paramFrom), 1);
     ExpectTrue(paramTo->check_time == 22);
     ExpectIntEQ(paramTo->flags & WOLFSSL_USE_CHECK_TIME, 0);

--- a/tests/api/test_sakke.c
+++ b/tests/api/test_sakke.c
@@ -158,6 +158,9 @@ int test_wc_Sakke_DecisionCoverage(void)
     byte encSsv[16];
     int valid = 0;
 
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(&key2, 0, sizeof(key2));
     /* idMax is used only to exercise the idSz == SAKKE_ID_MAX_SIZE boundary
      * (byte *length*, not magnitude) -- keep it numerically small so the
      * real EC scalar multiply it drives (in wc_MakeSakkePointI()/
@@ -676,6 +679,7 @@ int test_wc_Sakke_FeatureCoverage(void)
     word32 pubKeySz2 = sizeof(pubKeyData2);
     int i;
 
+    XMEMSET(&rng, 0, sizeof(rng));
     XMEMSET(&key, 0, sizeof(key));
     XMEMSET(&key2, 0, sizeof(key2));
     XMEMSET(ssvOrig, 0, sizeof(ssvOrig));

--- a/wolfcrypt/src/sakke.c
+++ b/wolfcrypt/src/sakke.c
@@ -202,26 +202,33 @@ void wc_FreeSakkeKey(SakkeKey* key)
 #ifdef WOLFCRYPT_SAKKE_CLIENT
             mp_free(&key->tmp.m2);
 #endif
+            key->mpInit = 0;
         }
 #ifdef WOLFCRYPT_SAKKE_CLIENT
         if (key->i.i != NULL) {
             wc_ecc_del_point_h(key->i.i, key->ecc.heap);
+            key->i.i = NULL;
         }
         if (key->rsk.rsk != NULL) {
             wc_ecc_del_point_h(key->rsk.rsk, key->ecc.heap);
+            key->rsk.rsk = NULL;
         }
         if (key->tmp.p3 != NULL) {
             wc_ecc_del_point_h(key->tmp.p3, key->ecc.heap);
+            key->tmp.p3 = NULL;
         }
         if (key->tmp.p2 != NULL) {
             wc_ecc_del_point_h(key->tmp.p2, key->ecc.heap);
+            key->tmp.p2 = NULL;
         }
         if (key->tmp.p1 != NULL) {
             wc_ecc_del_point_h(key->tmp.p1, key->ecc.heap);
+            key->tmp.p1 = NULL;
         }
 #endif
         if (params->base != NULL) {
             wc_ecc_del_point_h(params->base, key->ecc.heap);
+            params->base = NULL;
         }
         wc_ecc_free(&key->ecc);
     }


### PR DESCRIPTION
# Description

Fixes crashes found by the mem-fail Jenkins nightly
([open issue 501].

That job fails the Nth allocation via `MEM_FAIL_CNT` and treats segfault
(139) / abort (134) as product findings. In these cases the library often
returned a clean error (e.g. NULL from `XMALLOC`), but the unit tests kept
running bare statements after an `Expect*` failure and touched NULL or
uninitialised state.

- **`test_wolfSSL_X509_VERIFY_PARAM`** (shard 2, fail at 2/3 and 3/3):
  After `X509_VERIFY_PARAM_new()` returns NULL, guard bare
  `paramTo` / `paramFrom` writes (`inherit_flags`, `XMEMSET`, etc.).

- **`test_wc_Sakke_FeatureCoverage` / `test_wc_Sakke_DecisionCoverage`**
  (shards 0 and 3): Zero-init `rng` / `key` / `key2` so `wc_FreeSakkeKey`
  is not called on stack garbage when init fails. Also make
  `wc_FreeSakkeKey` clear freed pointers / `mpInit` so a second free after
  a failed init path is a no-op.

- **`test_wolfSSL_Tls13_ECH_wire_sni`** (shard 0, fail around 3147/6295):
  Do not dereference `test_ctx.c_ctx` when `test_ssl_memio_setup` failed.

Fixes zd#

# Testing

Built with the mem-fail configure line (`--enable-memorylog`,
`WOLFSSL_MEM_FAIL_COUNT`).

- Baseline (no `MEM_FAIL_CNT`): all four tests pass; alloc/free counts
  balance.
- `test_wolfSSL_X509_VERIFY_PARAM`: `MEM_FAIL_CNT=1..3` → exit 1 (was
  139 at 2 and 3).
- SAKKE Feature + Decision: full injection sweeps (820 and 818) → no
  crash / abort; alloc/free balance OK.
- `test_wolfSSL_Tls13_ECH_wire_sni`: all 484 previously crashing indices
  (locally 3166–4628) → exit 1; A/B at 3166: without fix 139, with fix 1.

Left for later (not mem-fail NULL-deref class): RPK baseline failures,
LMS Linux-only SIGILL at baseline.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation