### PR TITLE
wolfCrypt Fenrir fixes

### DIFF
--- a/.github/configs/os-check-linux.json
+++ b/.github/configs/os-check-linux.json
@@ -336,5 +336,9 @@
 {"name": "opensslextra-no-filesystem-no-bio", "minutes": 0.9,
  "configure": ["--enable-opensslextra", "--disable-filesystem", "CPPFLAGS=-DNO_BIO"]},
 {"name": "no-examples-no-malloc", "minutes": 0.8,
- "configure": ["--disable-examples", "CPPFLAGS=-DWOLFSSL_NO_MALLOC"]}
+ "configure": ["--disable-examples", "CPPFLAGS=-DWOLFSSL_NO_MALLOC"]},
+{"name": "cryptonly-no-asn-rsa", "minutes": 0.2, "check": false,
+ "comment": "RSA with ASN.1 disabled. Build only, since wolfcrypt test and benchmark do not support this combination.",
+ "configure": ["--enable-cryptonly", "--disable-asn", "--enable-lowresource",
+  "--disable-crypttests", "--disable-examples"]}
 ]

--- a/.github/configs/os-check-linux.json
+++ b/.github/configs/os-check-linux.json
@@ -340,5 +340,9 @@
 {"name": "cryptonly-no-asn-rsa", "minutes": 0.2, "check": false,
  "comment": "RSA with ASN.1 disabled. Build only, since wolfcrypt test and benchmark do not support this combination.",
  "configure": ["--enable-cryptonly", "--disable-asn", "--enable-lowresource",
-  "--disable-crypttests", "--disable-examples"]}
+  "--disable-crypttests", "--disable-examples"]},
+{"name": "pkcs12-pbkdf-mp-api", "minutes": 1.0,
+ "comment": "WC_PKCS12_PBKDF_USING_MP_API selects a second wc_PKCS12_PBKDF_ex implementation that no configure option reaches.",
+ "configure": ["--enable-pkcs12", "--enable-des3", "--enable-opensslextra",
+  "CPPFLAGS=-DWC_PKCS12_PBKDF_USING_MP_API"]}
 ]

--- a/tests/api/test_evp.c
+++ b/tests/api/test_evp.c
@@ -584,6 +584,33 @@ int test_wolfSSL_EVP_DecodeUpdate(void)
             0);
     }
 
+    /* decode input holding a NUL byte at the start of a 4 byte group, followed
+     * by more data than the context buffer can hold */
+
+    {
+        unsigned char enc5[64];
+
+        XMEMSET(enc5, 'A', sizeof(enc5));
+        enc5[0] = '\0';
+
+        EVP_DecodeInit(ctx);
+
+        ExpectIntEQ(
+            EVP_DecodeUpdate(
+                ctx,
+                decOutBuff,
+                &outl,
+                enc5,
+                (int)sizeof(enc5)),
+            1                    /* expected result code 1: success */
+            );
+        ExpectIntEQ(outl, 0);
+        /* Before the fix all 64 input bytes were buffered into the 48 byte
+         * ctx->data. The NUL byte ends the input, so nothing may be buffered
+         * at all. */
+        ExpectIntEQ(ctx->remaining, 0);
+    }
+
     EVP_ENCODE_CTX_free(ctx);
 #endif /* OPENSSL && WOLFSSL_BASE_DECODE */
     return EXPECT_RESULT();

--- a/tests/api/test_lms_xmss.c
+++ b/tests/api/test_lms_xmss.c
@@ -71,10 +71,19 @@ static const char* lms_test_priv_key_file(void)
 }
 #define LMS_TEST_PRIV_KEY_FILE lms_test_priv_key_file()
 
+/* Set to 1 to make test_lms_write_key() simulate a non-volatile storage write
+ * that never completes. */
+static int lms_write_key_fail = 0;
+
 static int test_lms_write_key(const byte* priv, word32 privSz, void* context)
 {
-    FILE* f = fopen((const char*)context, "wb");
+    FILE* f;
     int ret = WC_LMS_RC_SAVED_TO_NV_MEMORY;
+
+    if (lms_write_key_fail)
+        return -1;
+
+    f = fopen((const char*)context, "wb");
     if (f == NULL)
         return -1;
     if (fwrite(priv, 1, privSz, f) != privSz)
@@ -169,6 +178,80 @@ int test_wc_LmsKey_sign_verify(void)
         ExpectIntEQ(wc_LmsKey_Sign(&key, sig, &sigSz, msg, sizeof(msg)), 0);
         ExpectIntEQ(wc_LmsKey_Verify(&key, sig, sigSz, msg, sizeof(msg)), 0);
     }
+
+    wc_LmsKey_Free(&key);
+    wc_FreeRng(&rng);
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
+#endif
+    return EXPECT_RESULT();
+}
+
+/*
+ * Test that a failed private key write permanently invalidates the key.
+ *
+ * RFC 8554 section 5.4.1 requires the advanced leaf index to be stored before
+ * the signature is released. The signature is computed with the one-time key
+ * at the current leaf and only then is the index advanced and written out, so
+ * a failed write leaves storage pointing at a leaf that has already been used.
+ * The key must refuse to sign again rather than hand out a second signature
+ * from the same one-time key.
+ */
+int test_wc_LmsKey_write_fail(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_HAVE_LMS) && !defined(WOLFSSL_LMS_VERIFY_ONLY)
+    LmsKey  key;
+    WC_RNG  rng;
+    byte    msg[] = "test message for LMS signing";
+    byte    sig[2048];
+    word32  sigSz;
+    word32  goodSigSz = 0;
+    word32  i;
+    int     nonZero;
+
+    /* Zero so cleanup is safe if an early alloc failure skips init. */
+    XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(&rng, 0, sizeof(rng));
+
+    ExpectIntEQ(wc_InitRng(&rng), 0);
+
+    (void)remove(LMS_TEST_PRIV_KEY_FILE);
+    ExpectIntEQ(test_lms_init_key(&key, &rng), 0);
+    ExpectIntEQ(wc_LmsKey_MakeKey(&key, &rng), 0);
+
+    sigSz = sizeof(sig);
+    ExpectIntEQ(wc_LmsKey_Sign(&key, sig, &sigSz, msg, sizeof(msg)), 0);
+    goodSigSz = sigSz;
+
+    /* A signature was really produced, so the check below is not vacuous. */
+    nonZero = 0;
+    for (i = 0; i < goodSigSz; i++) {
+        if (sig[i] != 0)
+            nonZero++;
+    }
+    ExpectIntGT(nonZero, 0);
+
+    /* Fail the write of the advanced private key. */
+    lms_write_key_fail = 1;
+    sigSz = sizeof(sig);
+    ExpectIntEQ(wc_LmsKey_Sign(&key, sig, &sigSz, msg, sizeof(msg)),
+        WC_NO_ERR_TRACE(IO_FAILED_E));
+    lms_write_key_fail = 0;
+
+    /* The signature has to be erased as well, not just reported as failed.
+     * The leaf index was never stored, so releasing it would allow the same
+     * one-time key to sign twice. */
+    nonZero = 0;
+    for (i = 0; i < goodSigSz; i++) {
+        if (sig[i] != 0)
+            nonZero++;
+    }
+    ExpectIntEQ(nonZero, 0);
+
+    /* Storage works again but the key must stay unusable. */
+    sigSz = sizeof(sig);
+    ExpectIntEQ(wc_LmsKey_Sign(&key, sig, &sigSz, msg, sizeof(msg)),
+        WC_NO_ERR_TRACE(BAD_STATE_E));
 
     wc_LmsKey_Free(&key);
     wc_FreeRng(&rng);

--- a/tests/api/test_lms_xmss.h
+++ b/tests/api/test_lms_xmss.h
@@ -25,6 +25,7 @@
 #include <tests/api/api_decl.h>
 
 int test_wc_LmsKey_sign_verify(void);
+int test_wc_LmsKey_write_fail(void);
 int test_wc_LmsKey_reload_cache(void);
 int test_wc_LmsKey_reload_devid(void);
 int test_wc_XmssKey_reload_devid(void);
@@ -40,6 +41,7 @@ int test_wc_XmssFeatureCoverage(void);
 /* LMS, and RFC 9802 (HSS/LMS and XMSS/XMSS^MT in X.509). */
 #define TEST_LMS_XMSS_DECLS                                                  \
     TEST_DECL_GROUP("lms", test_wc_LmsKey_sign_verify),                 \
+    TEST_DECL_GROUP("lms", test_wc_LmsKey_write_fail),                  \
     TEST_DECL_GROUP("lms", test_wc_LmsKey_reload_cache),                \
     TEST_DECL_GROUP("lms", test_wc_LmsKey_reload_devid),                \
     TEST_DECL_GROUP("xmss", test_wc_XmssKey_reload_devid),              \

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -13925,6 +13925,8 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
         }
         e[0] = in[j++];
         if (e[0] == '\0') {
+            /* a NUL byte ends the input, nothing is left to buffer */
+            inLen = 0;
             break;
         }
         inLen--;
@@ -14004,6 +14006,15 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
             }
             if (c == '=') {
                 pad = 1;
+            }
+            if (i >= BASE64_DECODE_BLOCK_SIZE) {
+                /* More leftover data than one decode block can hold. The loops
+                 * above leave at most a partial block behind, so this is a
+                 * bound on the buffer and not a reachable input error. */
+                XMEMSET(ctx->data, 0, sizeof(ctx->data));
+                ctx->remaining = 0;
+                *outl = 0;
+                return -1;
             }
             ctx->data[i++] = c;
             ctx->remaining++;

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -67,7 +67,6 @@
 #define INITIAL_DEVID 7890
 
 uint32_t   g_CAscm_Idx = (uint32_t)-1; /* index of CM table    */
-static int gdevId = INITIAL_DEVID;     /* initial dev Id for Crypt Callback */
 
 #ifdef WOLF_CRYPTO_CB
 
@@ -76,17 +75,59 @@ FSPSM_ST    *gCbCtx[MAX_FSPSM_CBINDEX];
 
 #include <wolfssl/wolfcrypt/cryptocb.h>
 
+/* Release a callback context slot.
+ *
+ * The hardware lock guards the search for a free slot, so it is taken here as
+ * well. A slot that cannot be locked is still released, since losing it would
+ * make the devId unusable for the rest of the run.
+ *
+ * idx : index into gCbCtx of the slot to release
+ */
+static void cmn_release_cb_slot(int idx)
+{
+    int locked = (cmn_hw_lock() == 0);
+
+    gCbCtx[idx] = NULL;
+
+    if (locked)
+        cmn_hw_unlock();
+    else
+        WOLFSSL_MSG("Failed to lock hw while releasing callback context");
+}
 
 WOLFSSL_LOCAL int Renesas_cmn_Cleanup(struct WOLFSSL* ssl)
 {
     int ret = 0;
+#if defined(WOLFSSL_RENESAS_TSIP_TLS) || defined(WOLFSSL_RENESAS_FSPSM_TLS)
+    FSPSM_ST* cbInfo = NULL;
+    int devId = INVALID_DEVID;
+#endif
+
     WOLFSSL_ENTER("Renesas_cmn_Cleanup");
     (void) ssl;
+
+#if defined(WOLFSSL_RENESAS_TSIP_TLS) || defined(WOLFSSL_RENESAS_FSPSM_TLS)
+    /* The session holds a callback context slot claimed by
+     * wc_CryptoCb_CryptInitRenesasCmn. Remember its devId before the cleanup
+     * below zeroes the user context. */
+    if (ssl != NULL) {
+        cbInfo = (FSPSM_ST*)ssl->RenesasUserCtx;
+        if (cbInfo != NULL)
+            devId = cbInfo->devId;
+    }
+#endif
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_TlsCleanup(ssl);
 #elif defined(WOLFSSL_RENESAS_FSPSM_TLS)
     ret = wc_fspsm_TlsCleanup(ssl);
+#endif
+
+#if defined(WOLFSSL_RENESAS_TSIP_TLS) || defined(WOLFSSL_RENESAS_FSPSM_TLS)
+    /* Give the slot back so that later sessions can use it. The internal
+     * instance was already freed by the cleanup above. */
+    if (devId != INVALID_DEVID)
+        wc_CryptoCb_CleanupRenesasCmn(&devId);
 #endif
 
     WOLFSSL_LEAVE("Renesas_cmn_Cleanup", ret);
@@ -393,7 +434,7 @@ int Renesas_cmn_usable(const struct WOLFSSL* ssl, byte session_key_generated)
  */
 WOLFSSL_LOCAL void *Renesas_cmn_GetCbCtxBydevId(int devId)
 {
-    if (devId >= INITIAL_DEVID && devId <= (MAX_FSPSM_CBINDEX + INITIAL_DEVID))
+    if (devId >= INITIAL_DEVID && devId < (MAX_FSPSM_CBINDEX + INITIAL_DEVID))
         return gCbCtx[devId - INITIAL_DEVID];
     else
         return NULL;
@@ -405,8 +446,9 @@ WOLFSSL_LOCAL void *Renesas_cmn_GetCbCtxBydevId(int devId)
  * ssl     : a pointer to WOLFSSL object
  * ctx     : callback context
  * return  valid device Id on success, otherwise INVALID_DEVIID
- *         device Id starts from 7890, and increases + 1 its number
- *         when the method is successfully called.
+ *         device Id starts from 7890 and is derived from the context slot
+ *         the callback context is stored in. At most MAX_FSPSM_CBINDEX
+ *         contexts can be registered at the same time.
  */
 int wc_CryptoCb_CryptInitRenesasCmn(struct WOLFSSL* ssl, void* ctx)
 {
@@ -415,6 +457,9 @@ int wc_CryptoCb_CryptInitRenesasCmn(struct WOLFSSL* ssl, void* ctx)
 
     FSPSM_ST* cbInfo = (FSPSM_ST*)ctx;
     size_t internal_sz = sizeof(FSPSM_ST_Internal);
+    int idx = 0;
+    int devId = INVALID_DEVID;
+    int allocedInternal = 0;
 
     if (cbInfo == NULL
    #if (!defined(WOLFSSL_RENESAS_FSPSM_CRYPTONLY) && \
@@ -440,6 +485,7 @@ int wc_CryptoCb_CryptInitRenesasCmn(struct WOLFSSL* ssl, void* ctx)
         if (cbInfo->internal == NULL) {
             return MEMORY_E;
         }
+        allocedInternal = 1;
         ForceZero(cbInfo->internal, internal_sz);
        #if defined(WOLFSSL_RENESAS_FSPSM_TLS) ||\
             defined(WOLFSSL_RENESAS_TSIP_TLS)
@@ -449,22 +495,44 @@ int wc_CryptoCb_CryptInitRenesasCmn(struct WOLFSSL* ssl, void* ctx)
     }
     /* need exclusive control because of static variable */
     if ((cmn_hw_lock()) == 0) {
-        /* sanity check for overflow */
-        if (gdevId < 0) {
-            gdevId = INITIAL_DEVID;
+        /* look for a free context slot and derive the devId from it */
+        for (idx = 0; idx < MAX_FSPSM_CBINDEX; idx++) {
+            if (gCbCtx[idx] == NULL)
+                break;
         }
-        cbInfo->devId = gdevId++;
+        if (idx < MAX_FSPSM_CBINDEX) {
+            devId = INITIAL_DEVID + idx;
+            /* claim the slot while the lock is still held */
+            gCbCtx[idx] = cbInfo;
+        }
+        else {
+            WOLFSSL_MSG("No free crypt callback context slot");
+        }
         cmn_hw_unlock();
     }
     else {
         WOLFSSL_MSG("Failed to lock tsip hw");
-        return INVALID_DEVID;
     }
 
-    if (wc_CryptoCb_RegisterDevice(cbInfo->devId,
-                            Renesas_cmn_CryptoDevCb, cbInfo) < 0) {
-        /* undo devId number */
-        gdevId--;
+    if (devId != INVALID_DEVID) {
+        cbInfo->devId = devId;
+
+        if (wc_CryptoCb_RegisterDevice(devId,
+                                Renesas_cmn_CryptoDevCb, cbInfo) < 0) {
+            /* release the context slot again */
+            cmn_release_cb_slot(idx);
+            cbInfo->devId = INVALID_DEVID;
+            devId = INVALID_DEVID;
+        }
+    }
+
+    if (devId == INVALID_DEVID) {
+        /* only release what this call allocated */
+        if (allocedInternal) {
+            XFREE(cbInfo->internal, (ssl != NULL) ? ssl->heap : NULL,
+                                        DYNAMIC_TYPE_TMP_BUFFER);
+            cbInfo->internal = NULL;
+        }
         return INVALID_DEVID;
     }
 
@@ -472,12 +540,10 @@ int wc_CryptoCb_CryptInitRenesasCmn(struct WOLFSSL* ssl, void* ctx)
        !defined(WOLFSSL_RENESAS_TSIP_CRYPTONLY) && \
        !defined(HAVE_RENESAS_SYNC)
     if (ssl)
-        wolfSSL_SetDevId(ssl, cbInfo->devId);
+        wolfSSL_SetDevId(ssl, devId);
    #endif
 
-    gCbCtx[cbInfo->devId - INITIAL_DEVID] = (void*)cbInfo;
-
-    return cbInfo->devId;
+    return devId;
 }
 
 /* Renesas Security Library Common Method
@@ -490,12 +556,18 @@ void wc_CryptoCb_CleanupRenesasCmn(int* id)
 {
 
     FSPSM_ST* cbInfo = NULL;
+    int idx;
+
+    if (id == NULL)
+        return;
 
     if (*id < INITIAL_DEVID ||
-       (*id  - INITIAL_DEVID) > MAX_FSPSM_CBINDEX)
+       (*id  - INITIAL_DEVID) >= MAX_FSPSM_CBINDEX)
         return;
+
+    idx = *id - INITIAL_DEVID;
     /* retrieve internal instance */
-    cbInfo = (FSPSM_ST*)gCbCtx[*id - INITIAL_DEVID];
+    cbInfo = (FSPSM_ST*)gCbCtx[idx];
 
     if (cbInfo != NULL && cbInfo->internal != NULL) {
      #if defined(WOLFSSL_RENESAS_FSPSM_TLS) && \
@@ -507,7 +579,16 @@ void wc_CryptoCb_CleanupRenesasCmn(int* id)
      #endif
         cbInfo->internal = NULL;
     }
+
+    /* Unregister before the slot is released. A new registration that claims
+     * the slot in between would otherwise be torn down here. */
     wc_CryptoCb_UnRegisterDevice(*id);
+
+    if (cbInfo != NULL)
+        cbInfo->devId = INVALID_DEVID;
+
+    /* release the slot so that it can be used by a new registration */
+    cmn_release_cb_slot(idx);
 }
 
 #endif /* WOLF_CRYPTO_CB */

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -470,6 +470,9 @@ int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
     if (ret == 0)
         return BAD_STATE_E;
     v = (word32)ret;
+    /* the block size must not be mistaken for a result when kLen is 0 and the
+     * derivation loop below never runs */
+    ret = 0;
 
 #ifdef WOLFSSL_SMALL_STACK
     Ai = (byte*)XMALLOC(WC_MAX_DIGEST_SIZE, heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -499,7 +502,8 @@ int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
         return BAD_FUNC_ARG;
     }
 
-    if (! WC_SAFE_SUM_UNSIGNED(word32, dLen, sLen, totalLen)) {
+    /* the working buffer holds D || S || P, so totalLen is dLen + iLen */
+    if (! WC_SAFE_SUM_UNSIGNED(word32, dLen, iLen, totalLen)) {
         WC_FREE_VAR_EX(Ai, heap, DYNAMIC_TYPE_TMP_BUFFER);
         WC_FREE_VAR_EX(B, heap, DYNAMIC_TYPE_TMP_BUFFER);
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -203,7 +203,7 @@ int wc_SignatureVerifyHash(
         return ret;
     }
 
-#if !defined(NO_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)
+#if !defined(NO_RSA) && !defined(NO_ASN)
     /* For WC_SIGNATURE_TYPE_RSA_W_ENC, we need to extract the actual size of
      * the ASN.1-encoded hash.
      */

--- a/wolfcrypt/src/wc_lms.c
+++ b/wolfcrypt/src/wc_lms.c
@@ -1421,6 +1421,10 @@ int wc_LmsKey_GetPrivLen(const LmsKey* key, word32* len)
 
 /* Sign a message.
  *
+ * The one-time key at the current leaf is consumed before the advanced private
+ * key is written to storage. If either step fails then the key state is left
+ * bad and no further signatures can be created with this key.
+ *
  * @param [in, out] key    LMS key to sign with.
  * @param [out]     sig    Signature data. Buffer must be big enough to hold
  *                         signature data.
@@ -1434,6 +1438,7 @@ int wc_LmsKey_GetPrivLen(const LmsKey* key, word32* len)
  * @return  BAD_FUNC_ARG when a read/write private key context is not set.
  * @return  BUFFER_E when sigSz is too small.
  * @return  BAD_STATE_E when wrong state for operation.
+ * @return  KEY_EXHAUSTED_E when no signatures are left in the key.
  * @return  IO_FAILED_E when reading or writing private key failed.
  */
 int wc_LmsKey_Sign(LmsKey* key, byte* sig, word32* sigSz, const byte* msg,
@@ -1475,6 +1480,16 @@ int wc_LmsKey_Sign(LmsKey* key, byte* sig, word32* sigSz, const byte* msg,
         ret = wc_CryptoCb_PqcStatefulSigSign(msg, (word32)msgSz, sig, sigSz,
             WC_PQC_STATEFUL_SIG_TYPE_LMS, key);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
+            if (ret == WC_NO_ERR_TRACE(KEY_EXHAUSTED_E)) {
+                /* Signature space exhausted. */
+                WOLFSSL_MSG("error: no LMS signatures remaining");
+                key->state = WC_LMS_STATE_NOSIGS;
+            }
+            else if (ret != 0) {
+                /* The device may have consumed the one-time key without
+                 * committing the advanced state, so presume the key is bad. */
+                key->state = WC_LMS_STATE_BAD;
+            }
             return ret;
         }
         ret = 0; /* fall through to software path */
@@ -1498,6 +1513,9 @@ int wc_LmsKey_Sign(LmsKey* key, byte* sig, word32* sigSz, const byte* msg,
             /* Initialize working state for use. */
             ret = wc_lmskey_state_init(state, key->params);
             if (ret == 0) {
+                /* Set the key state to bad by default. State is presumed bad
+                 * unless a correct sign and write operation happen together. */
+                key->state = WC_LMS_STATE_BAD;
                 /* Sign message. */
                 ret = wc_hss_sign(state, key->priv_raw, &key->priv,
                     key->priv_data, msg, (word32)msgSz, sig);
@@ -1506,6 +1524,11 @@ int wc_LmsKey_Sign(LmsKey* key, byte* sig, word32* sigSz, const byte* msg,
             ForceZero(state, sizeof(LmsState));
             WC_FREE_VAR_EX(state, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
+    }
+    if (ret == WC_NO_ERR_TRACE(KEY_EXHAUSTED_E)) {
+        /* Signature space exhausted. */
+        WOLFSSL_MSG("error: no LMS signatures remaining");
+        key->state = WC_LMS_STATE_NOSIGS;
     }
     if (ret == 0) {
         *sigSz = (word32)key->params->sig_len;
@@ -1532,9 +1555,15 @@ int wc_LmsKey_Sign(LmsKey* key, byte* sig, word32* sigSz, const byte* msg,
         if (rv != WC_LMS_RC_SAVED_TO_NV_MEMORY) {
             /* Write to NV storage failed. Erase the signature from
              * memory to prevent OTS key reuse if state is rolled back. */
+            WOLFSSL_MSG("error: LmsKey write_private_key failed");
             ForceZero(sig, key->params->sig_len);
             ret = IO_FAILED_E;
         }
+    }
+    if (ret == 0) {
+        /* The advanced private key was committed to storage. The key is safe
+         * to sign with again. */
+        key->state = WC_LMS_STATE_OK;
     }
 
     return ret;

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -5162,11 +5162,19 @@ char* wolfSSL_strnstr(const char* s1, const char* s2, size_t n)
 
         XMEMSET(thread, 0, sizeof(*thread));
 
+        thread->tid = (TX_THREAD *)XMALLOC(sizeof(TX_THREAD), NULL,
+                DYNAMIC_TYPE_OS_BUF);
+        if (thread->tid == NULL)
+            return MEMORY_E;
+        XMEMSET(thread->tid, 0, sizeof(TX_THREAD));
+
         thread->threadStack = (void *)XMALLOC(WOLFSSL_NETOS_STACK_SZ, NULL,
                 DYNAMIC_TYPE_OS_BUF);
-        if (thread->threadStack == NULL)
+        if (thread->threadStack == NULL) {
+            XFREE(thread->tid, NULL, DYNAMIC_TYPE_OS_BUF);
+            thread->tid = NULL;
             return MEMORY_E;
-
+        }
 
         /* first create the idle thread:
          * ARGS:
@@ -5177,7 +5185,7 @@ char* wolfSSL_strnstr(const char* s1, const char* s2, size_t n)
          * Param6: stack size
          * Param7 and 8: priority level and preempt threshold
          * Param9 and 10: time slice and auto-start indicator */
-        result = tx_thread_create(&thread->tid,
+        result = tx_thread_create(thread->tid,
                            "wolfSSL thread",
                            (entry_functionType)cb, (ULONG)arg,
                            thread->threadStack,
@@ -5187,6 +5195,8 @@ char* wolfSSL_strnstr(const char* s1, const char* s2, size_t n)
         if (result != TX_SUCCESS) {
             XFREE(thread->threadStack, NULL, DYNAMIC_TYPE_OS_BUF);
             thread->threadStack = NULL;
+            XFREE(thread->tid, NULL, DYNAMIC_TYPE_OS_BUF);
+            thread->tid = NULL;
             return MEMORY_E;
         }
 
@@ -5195,10 +5205,42 @@ char* wolfSSL_strnstr(const char* s1, const char* s2, size_t n)
 
     int wolfSSL_JoinThread(THREAD_TYPE thread)
     {
-        /* TODO: maybe have to use tx_thread_delete? */
+        UINT state = TX_READY;
+        int ret = 0;
+
+        if (thread.tid == NULL)
+            return BAD_FUNC_ARG;
+
+        /* The thread runs on threadStack, so it has to be done with it before
+         * the stack is released. Wait for the entry function to return, or for
+         * the thread to be terminated by someone else. */
+        while (ret == 0 && state != TX_COMPLETED && state != TX_TERMINATED) {
+            if (tx_thread_info_get(thread.tid, TX_NULL, &state, TX_NULL,
+                        TX_NULL, TX_NULL, TX_NULL, TX_NULL, TX_NULL)
+                    != TX_SUCCESS) {
+                /* The control block is not a thread ThreadX knows about, so
+                 * nothing is running on the stack either. */
+                ret = BAD_STATE_E;
+            }
+            else if (state != TX_COMPLETED && state != TX_TERMINATED) {
+                tx_thread_sleep(1);
+            }
+        }
+
+        /* Unregister the thread before its control block and stack go away. */
+        if (ret == 0 && tx_thread_delete(thread.tid) != TX_SUCCESS) {
+            /* ThreadX still owns the control block and the thread may still be
+             * running on the stack, so neither can be released here. */
+            WOLFSSL_MSG("tx_thread_delete failed, leaking thread resources");
+            return BAD_STATE_E;
+        }
+
         XFREE(thread.threadStack, NULL, DYNAMIC_TYPE_OS_BUF);
         thread.threadStack = NULL;
-        return 0;
+        XFREE(thread.tid, NULL, DYNAMIC_TYPE_OS_BUF);
+        thread.tid = NULL;
+
+        return ret;
     }
 
 #elif defined(WOLFSSL_ZEPHYR)

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1987,7 +1987,9 @@ WOLFSSL_API word32 CheckRunTimeSettings(void);
 #elif defined(NETOS)
     typedef UINT        THREAD_RETURN;
     typedef struct {
-        TX_THREAD tid;
+        /* Control block is referenced, not embedded, so that it stays valid
+         * when THREAD_TYPE is passed by value to wolfSSL_JoinThread(). */
+        TX_THREAD* tid;
         void* threadStack;
     } THREAD_TYPE;
     #define WOLFSSL_THREAD


### PR DESCRIPTION
## Description

Six independent wolfCrypt fixes, one commit each, no dependency between them.

**F-7306 - PKCS#12 PBKDF mp variant, undersized buffer** (`pwdbased.c`). The `WC_PKCS12_PBKDF_USING_MP_API` variant sized the `D || S || P` working buffer as `dLen + sLen`, omitting the password block. The fill loop wrote `pLen` bytes past the end, and the hash was fed the short length, so every password over a given salt derived the same key. Sum `dLen + iLen` instead, matching the non-mp variant, which fixes the allocation, hash input length, `I` update bound and `ForceZero` coverage together.

**F-7445 - `EVP_DecodeUpdate()` heap overflow on a NUL byte** (`evp.c`). The decode loop broke out on NUL without clearing the remaining length, so the leftover-buffering block copied the full remaining count into the 48 byte `ctx->data` with an unbounded index, writing attacker-controlled data past the end of the context. Clear the length before breaking and bound the copy at one decode block, which also keeps `ctx->remaining` small enough that a reused context cannot underflow or over-read later.

**F-7438 - Renesas cryptocb slot table, unbounded index** (`renesas_common.c`). The slot index came from a free-running devId counter with no bound check, so the sixth registration in a process wrote past `gCbCtx[]`. Now searches for a free slot under the hardware lock and returns `INVALID_DEVID` when full; `Renesas_cmn_Cleanup()` releases the slot, dropping a stale pointer to a context the app may free. Two off-by-one bounds checks corrected as well.

**F-7411 - LMS key not invalidated on private key write failure** (`wc_lms.c`). The signature is computed at the current leaf before the advanced index is stored. A failed write erased the signature but left the state `OK`, so the key could sign again while storage still pointed at the consumed leaf, and a reload after restart would reuse the same LM-OTS key. Mark the key bad before signing and restore `OK` only after the write succeeds, as XMSS already does.

**F-7413 - NETOS thread stack freed while running** (`wc_port.c`, `types.h`). `wolfSSL_JoinThread()` freed the thread's stack without waiting and never unregistered from ThreadX. Waiting was impossible because `THREAD_TYPE` embedded the `TX_THREAD` by value and is passed by value, so the join saw a stale copy; it now holds a pointer to a heap-allocated control block, like the Zephyr port. The join polls `tx_thread_info_get()` for `TX_COMPLETED`/`TX_TERMINATED`, calls `tx_thread_delete()`, and frees only then. On `tx_thread_delete()` failure the block and stack are leaked deliberately, since freeing would hand ThreadX freed memory.

**F-7412 - `RSA_W_ENC` verify guard** (`signature.c`). The DigestInfo length extraction in `wc_SignatureVerifyHash()` was guarded on `WOLFSSL_RSA_PUBLIC_ONLY`, but it depends on ASN.1, not on private key support. Public-only builds still DER-encode the digest, so every valid signature was rejected with `BAD_LENGTH_E`; the same guard also broke compilation under `NO_ASN` with RSA. Guard on `NO_ASN` instead, matching the encode call site.

## Testing

- `test_wolfSSL_EVP_DecodeUpdate()`: new case feeding a NUL followed by more data than the context buffer holds, asserting `ctx->remaining == 0` (was 64 bytes into a 48 byte buffer).
- `test_wc_LmsKey_write_fail()` (new): fails the write-key callback, checks the signature is erased and that the key then refuses to sign with `BAD_STATE_E`.
- Two new `os-check-linux.json` configs: `cryptonly-no-asn-rsa` (build-only; did not compile before F-7412) and `pkcs12-pbkdf-mp-api` (the mp variant no configure option reaches).

The Renesas and NETOS changes are review-verified only - no vendor SDK, no ThreadX, and no CI job for either port.

