### PR TITLE
Document that raw ECC import does not validate the point

### DIFF
--- a/doc/dox_comments/header_files/ecc.h
+++ b/doc/dox_comments/header_files/ecc.h
@@ -1453,7 +1453,11 @@ int wc_ecc_rs_to_sig(const char* r, const char* s, byte* out, word32* outlen);
     \ingroup ECC
 
     \brief This function fills an ecc_key structure with the raw components
-    of an ECC signature.
+    of an ECC key.
+
+    \note This function does not check that the imported public point lies on
+    the curve. Define WOLFSSL_VALIDATE_ECC_IMPORT to validate the point on
+    import, or call wc_ecc_check_key before the key is used.
 
     \return 0 Returned upon successfully importing into the ecc_key structure
     \return ECC_BAD_ARG_E Returned if any of the input values evaluate to NULL
@@ -3038,6 +3042,10 @@ int wc_ecc_sig_to_rs(const byte* sig, word32 sigLen, byte* r,
     \ingroup ECC
     \brief Imports raw key with curve ID.
 
+    \note This function does not check that the imported public point lies on
+    the curve. Define WOLFSSL_VALIDATE_ECC_IMPORT to validate the point on
+    import, or call wc_ecc_check_key before the key is used.
+
     \return 0 on success
     \return negative on error
 
@@ -3062,6 +3070,10 @@ int wc_ecc_import_raw_ex(ecc_key* key, const char* qx,
 /*!
     \ingroup ECC
     \brief Imports unsigned key with curve ID.
+
+    \note This function does not check that the imported public point lies on
+    the curve. Define WOLFSSL_VALIDATE_ECC_IMPORT to validate the point on
+    import, or call wc_ecc_check_key before the key is used.
 
     \return 0 on success
     \return negative on error


### PR DESCRIPTION
### Description

`wc_ecc_import_raw`, `wc_ecc_import_raw_ex` and `wc_ecc_import_unsigned` all reach `wc_ecc_import_raw_private`, which validates that the imported public point lies on the curve only when `WOLFSSL_VALIDATE_ECC_IMPORT` is defined (`wolfcrypt/src/ecc.c`). That flag is off in default builds and set in FIPS builds.

The x963 and ASN.1 import paths validate unconditionally, so the raw importers are the one public entry point where the caller has to know to validate. Neither the function names nor the existing documentation said so. This adds a `\note` to each of the three saying the check is not performed, and pointing at both ways to get it.

Documentation only. No functional change, no behavior change, no ABI change.

This is a documentation change rather than a code change on purpose. Raw import is trusted-input-only by design, which is the intended contract; the gap was that the contract was not written down anywhere a caller would see it.

### Pre-existing issue corrected in the same block

The `\brief` for `wc_ecc_import_raw` described the function as filling an `ecc_key` with "the raw components of an ECC signature". It fills it with the components of a key. Corrected here since it is the same doc block. Happy to drop that hunk if you would rather keep this to a single concern.

### Testing

Documentation only, so no test changes. The touched file is `doc/dox_comments/header_files/ecc.h`, which is Doxygen input and is not compiled.

### Checklist

- [x] added tests: N/A, documentation only
- [x] added documentation
- [ ] ChangeLog entry: omitted, no user-visible behavior change
