### PR TITLE
Add separate client cookie enable config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,7 +712,7 @@ endif()
 
 # Hello Retry Request Cookie
 add_option("WOLFSSL_HRR_COOKIE"
-    "Enable the server to send Cookie Extension in HRR with state (default: disabled)"
+    "Enable the server to send Cookie Extension in HRR with state. A client always echoes back a cookie it is sent (default: disabled)"
     "undefined" "yes;no;undefined")
 
 if("${WOLFSSL_HRR_COOKIE}" STREQUAL "yes")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,7 +703,7 @@ endif()
 
 # Hello Retry Request Cookie
 add_option("WOLFSSL_HRR_COOKIE"
-    "Enable the server to send Cookie Extension in HRR with state (default: disabled)"
+    "Enable the server to send Cookie Extension in HRR with state. A client always echoes back a cookie it is sent (default: disabled)"
     "undefined" "yes;no;undefined")
 
 if("${WOLFSSL_HRR_COOKIE}" STREQUAL "yes")

--- a/configure.ac
+++ b/configure.ac
@@ -2673,7 +2673,7 @@ fi
 
 # Hello Retry Request Cookie
 AC_ARG_ENABLE([hrrcookie],
-    [AS_HELP_STRING([--enable-hrrcookie],[Enable the server to send Cookie Extension in HRR with state (default: disabled)])],
+    [AS_HELP_STRING([--enable-hrrcookie],[Enable the server to send Cookie Extension in HRR with state. A client always echoes back a cookie it is sent (default: disabled)])],
     [ ENABLED_SEND_HRR_COOKIE=$enableval ],
     [ ENABLED_SEND_HRR_COOKIE=undefined ]
     )

--- a/configure.ac
+++ b/configure.ac
@@ -2680,7 +2680,7 @@ fi
 
 # Hello Retry Request Cookie
 AC_ARG_ENABLE([hrrcookie],
-    [AS_HELP_STRING([--enable-hrrcookie],[Enable the server to send Cookie Extension in HRR with state (default: disabled)])],
+    [AS_HELP_STRING([--enable-hrrcookie],[Enable the server to send Cookie Extension in HRR with state. A client always echoes back a cookie it is sent (default: disabled)])],
     [ ENABLED_SEND_HRR_COOKIE=$enableval ],
     [ ENABLED_SEND_HRR_COOKIE=undefined ]
     )

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5695,7 +5695,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         ssl->options.tls = 0;
         ssl->options.tls1_1 = 0;
     #ifdef WOLFSSL_TLS13
-    #ifdef WOLFSSL_SEND_HRR_COOKIE
+    #ifdef WOLFSSL_TLS13_COOKIE
         ssl->options.hrrSentCookie = 0;
     #endif
         ssl->options.hrrSentKeyShare = 0;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5694,7 +5694,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         ssl->options.tls = 0;
         ssl->options.tls1_1 = 0;
     #ifdef WOLFSSL_TLS13
-    #ifdef WOLFSSL_SEND_HRR_COOKIE
+    #ifdef WOLFSSL_TLS13_COOKIE
         ssl->options.hrrSentCookie = 0;
     #endif
         ssl->options.hrrSentKeyShare = 0;

--- a/src/tls.c
+++ b/src/tls.c
@@ -7546,7 +7546,7 @@ static int TLSX_SetSupportedVersions(TLSX** extensions, const void* data,
 
 #endif /* WOLFSSL_TLS13 */
 
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_SEND_HRR_COOKIE)
+#ifdef WOLFSSL_TLS13_COOKIE
 
 /******************************************************************************/
 /* Cookie                                                                     */
@@ -7622,8 +7622,6 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 {
     word16  len;
     word16  idx = 0;
-    TLSX*   extension;
-    Cookie* cookie;
 
     if (msgType != client_hello && msgType != hello_retry_request) {
         WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
@@ -7646,32 +7644,40 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
                                &ssl->extensions);
     }
 
-    /* client_hello */
-    extension = TLSX_Find(ssl->extensions, TLSX_COOKIE);
-    if (extension == NULL) {
-#ifdef WOLFSSL_DTLS13
-        if (ssl->options.dtls && IsAtLeastTLSv1_3(ssl->version))
-            /* Allow a cookie extension with DTLS 1.3 because it is possible
-             * that a different SSL instance sent the cookie but we are now
-             * receiving it. */
-            return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 0,
-                                   &ssl->extensions);
-        else
-#endif
-        {
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    /* client_hello - only a server that sends cookies has one to check the
+     * echoed cookie against. Otherwise ignore it. */
+    {
+        TLSX*   extension = TLSX_Find(ssl->extensions, TLSX_COOKIE);
+        Cookie* cookie;
+
+        if (extension == NULL) {
+    #ifdef WOLFSSL_DTLS13
+            if (ssl->options.dtls && IsAtLeastTLSv1_3(ssl->version))
+                /* Allow a cookie extension with DTLS 1.3 because it is
+                 * possible that a different SSL instance sent the cookie but
+                 * we are now receiving it. */
+                return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 0,
+                                       &ssl->extensions);
+            else
+    #endif
+            {
+                WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
+                return HRR_COOKIE_ERROR;
+            }
+        }
+
+        cookie = (Cookie*)extension->data;
+        if (cookie->len != len ||
+                XMEMCMP(cookie->data, input + idx, len) != 0) {
             WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
             return HRR_COOKIE_ERROR;
         }
-    }
 
-    cookie = (Cookie*)extension->data;
-    if (cookie->len != len || XMEMCMP(cookie->data, input + idx, len) != 0) {
-        WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
-        return HRR_COOKIE_ERROR;
+        /* Request seen. */
+        extension->resp = 0;
     }
-
-    /* Request seen. */
-    extension->resp = 0;
+#endif
 
     return 0;
 }
@@ -17603,7 +17609,7 @@ int TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType, word32* pLength)
         #ifdef WOLFSSL_EARLY_DATA
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_EARLY_DATA));
         #endif
-        #ifdef WOLFSSL_SEND_HRR_COOKIE
+        #ifdef WOLFSSL_TLS13_COOKIE
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_COOKIE));
         #endif
         #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
@@ -17839,7 +17845,7 @@ int TLSX_WriteRequest(WOLFSSL* ssl, byte* output, byte msgType, word32* pOffset)
         #ifdef WOLFSSL_EARLY_DATA
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_EARLY_DATA));
         #endif
-        #ifdef WOLFSSL_SEND_HRR_COOKIE
+        #ifdef WOLFSSL_TLS13_COOKIE
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_COOKIE));
         #endif
         #ifdef WOLFSSL_POST_HANDSHAKE_AUTH

--- a/src/tls.c
+++ b/src/tls.c
@@ -7622,6 +7622,10 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 {
     word16  len;
     word16  idx = 0;
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    TLSX*   extension;
+    Cookie* cookie;
+#endif
 
     if (msgType != client_hello && msgType != hello_retry_request) {
         WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
@@ -7639,44 +7643,47 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
         return BUFFER_E;
 
     if (msgType == hello_retry_request) {
+        /* RFC 8446 4.2.2 puts no upper bound on the cookie. Limit how much a
+         * server can make us hold and echo back. */
+        if (len > WOLFSSL_MAX_TLS13_COOKIE_SZ) {
+            WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
+            return HRR_COOKIE_ERROR;
+        }
+
         ssl->options.hrrSentCookie = 1;
         return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 1,
                                &ssl->extensions);
     }
 
+    /* client_hello - the encoding is checked above in every build. Only a
+     * server that sends cookies holds one to compare the echoed cookie
+     * against, so otherwise the value is accepted and ignored. */
 #ifdef WOLFSSL_SEND_HRR_COOKIE
-    /* client_hello - only a server that sends cookies has one to check the
-     * echoed cookie against. Otherwise ignore it. */
-    {
-        TLSX*   extension = TLSX_Find(ssl->extensions, TLSX_COOKIE);
-        Cookie* cookie;
-
-        if (extension == NULL) {
-    #ifdef WOLFSSL_DTLS13
-            if (ssl->options.dtls && IsAtLeastTLSv1_3(ssl->version))
-                /* Allow a cookie extension with DTLS 1.3 because it is
-                 * possible that a different SSL instance sent the cookie but
-                 * we are now receiving it. */
-                return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 0,
-                                       &ssl->extensions);
-            else
-    #endif
-            {
-                WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
-                return HRR_COOKIE_ERROR;
-            }
-        }
-
-        cookie = (Cookie*)extension->data;
-        if (cookie->len != len ||
-                XMEMCMP(cookie->data, input + idx, len) != 0) {
+    extension = TLSX_Find(ssl->extensions, TLSX_COOKIE);
+    if (extension == NULL) {
+#ifdef WOLFSSL_DTLS13
+        if (ssl->options.dtls && IsAtLeastTLSv1_3(ssl->version))
+            /* Allow a cookie extension with DTLS 1.3 because it is possible
+             * that a different SSL instance sent the cookie but we are now
+             * receiving it. */
+            return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 0,
+                                   &ssl->extensions);
+        else
+#endif
+        {
             WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
             return HRR_COOKIE_ERROR;
         }
-
-        /* Request seen. */
-        extension->resp = 0;
     }
+
+    cookie = (Cookie*)extension->data;
+    if (cookie->len != len || XMEMCMP(cookie->data, input + idx, len) != 0) {
+        WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
+        return HRR_COOKIE_ERROR;
+    }
+
+    /* Request seen. */
+    extension->resp = 0;
 #endif
 
     return 0;

--- a/src/tls.c
+++ b/src/tls.c
@@ -7496,7 +7496,7 @@ static int TLSX_SetSupportedVersions(TLSX** extensions, const void* data,
 
 #endif /* WOLFSSL_TLS13 */
 
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_SEND_HRR_COOKIE)
+#ifdef WOLFSSL_TLS13_COOKIE
 
 /******************************************************************************/
 /* Cookie                                                                     */
@@ -7572,8 +7572,6 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 {
     word16  len;
     word16  idx = 0;
-    TLSX*   extension;
-    Cookie* cookie;
 
     if (msgType != client_hello && msgType != hello_retry_request) {
         WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
@@ -7596,32 +7594,40 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
                                &ssl->extensions);
     }
 
-    /* client_hello */
-    extension = TLSX_Find(ssl->extensions, TLSX_COOKIE);
-    if (extension == NULL) {
-#ifdef WOLFSSL_DTLS13
-        if (ssl->options.dtls && IsAtLeastTLSv1_3(ssl->version))
-            /* Allow a cookie extension with DTLS 1.3 because it is possible
-             * that a different SSL instance sent the cookie but we are now
-             * receiving it. */
-            return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 0,
-                                   &ssl->extensions);
-        else
-#endif
-        {
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    /* client_hello - only a server that sends cookies has one to check the
+     * echoed cookie against. Otherwise ignore it. */
+    {
+        TLSX*   extension = TLSX_Find(ssl->extensions, TLSX_COOKIE);
+        Cookie* cookie;
+
+        if (extension == NULL) {
+    #ifdef WOLFSSL_DTLS13
+            if (ssl->options.dtls && IsAtLeastTLSv1_3(ssl->version))
+                /* Allow a cookie extension with DTLS 1.3 because it is
+                 * possible that a different SSL instance sent the cookie but
+                 * we are now receiving it. */
+                return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 0,
+                                       &ssl->extensions);
+            else
+    #endif
+            {
+                WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
+                return HRR_COOKIE_ERROR;
+            }
+        }
+
+        cookie = (Cookie*)extension->data;
+        if (cookie->len != len ||
+                XMEMCMP(cookie->data, input + idx, len) != 0) {
             WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
             return HRR_COOKIE_ERROR;
         }
-    }
 
-    cookie = (Cookie*)extension->data;
-    if (cookie->len != len || XMEMCMP(cookie->data, input + idx, len) != 0) {
-        WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
-        return HRR_COOKIE_ERROR;
+        /* Request seen. */
+        extension->resp = 0;
     }
-
-    /* Request seen. */
-    extension->resp = 0;
+#endif
 
     return 0;
 }
@@ -17496,7 +17502,7 @@ int TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType, word32* pLength)
         #ifdef WOLFSSL_EARLY_DATA
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_EARLY_DATA));
         #endif
-        #ifdef WOLFSSL_SEND_HRR_COOKIE
+        #ifdef WOLFSSL_TLS13_COOKIE
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_COOKIE));
         #endif
         #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
@@ -17732,7 +17738,7 @@ int TLSX_WriteRequest(WOLFSSL* ssl, byte* output, byte msgType, word32* pOffset)
         #ifdef WOLFSSL_EARLY_DATA
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_EARLY_DATA));
         #endif
-        #ifdef WOLFSSL_SEND_HRR_COOKIE
+        #ifdef WOLFSSL_TLS13_COOKIE
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_COOKIE));
         #endif
         #ifdef WOLFSSL_POST_HANDSHAKE_AUTH

--- a/src/tls.c
+++ b/src/tls.c
@@ -7643,8 +7643,8 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
         return BUFFER_E;
 
     if (msgType == hello_retry_request) {
-        /* RFC 8446 4.2.2 puts no upper bound on the cookie. Limit how much a
-         * server can make us hold and echo back. */
+        /* RFC 8446 4.2.2 allows up to 2^16-1 bytes. Cap it lower to limit
+         * how much a server can make us hold and echo back. */
         if (len > WOLFSSL_MAX_TLS13_COOKIE_SZ) {
             WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
             return HRR_COOKIE_ERROR;

--- a/src/tls.c
+++ b/src/tls.c
@@ -7572,6 +7572,10 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 {
     word16  len;
     word16  idx = 0;
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    TLSX*   extension;
+    Cookie* cookie;
+#endif
 
     if (msgType != client_hello && msgType != hello_retry_request) {
         WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
@@ -7589,44 +7593,47 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
         return BUFFER_E;
 
     if (msgType == hello_retry_request) {
+        /* RFC 8446 4.2.2 puts no upper bound on the cookie. Limit how much a
+         * server can make us hold and echo back. */
+        if (len > WOLFSSL_MAX_TLS13_COOKIE_SZ) {
+            WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
+            return HRR_COOKIE_ERROR;
+        }
+
         ssl->options.hrrSentCookie = 1;
         return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 1,
                                &ssl->extensions);
     }
 
+    /* client_hello - the encoding is checked above in every build. Only a
+     * server that sends cookies holds one to compare the echoed cookie
+     * against, so otherwise the value is accepted and ignored. */
 #ifdef WOLFSSL_SEND_HRR_COOKIE
-    /* client_hello - only a server that sends cookies has one to check the
-     * echoed cookie against. Otherwise ignore it. */
-    {
-        TLSX*   extension = TLSX_Find(ssl->extensions, TLSX_COOKIE);
-        Cookie* cookie;
-
-        if (extension == NULL) {
-    #ifdef WOLFSSL_DTLS13
-            if (ssl->options.dtls && IsAtLeastTLSv1_3(ssl->version))
-                /* Allow a cookie extension with DTLS 1.3 because it is
-                 * possible that a different SSL instance sent the cookie but
-                 * we are now receiving it. */
-                return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 0,
-                                       &ssl->extensions);
-            else
-    #endif
-            {
-                WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
-                return HRR_COOKIE_ERROR;
-            }
-        }
-
-        cookie = (Cookie*)extension->data;
-        if (cookie->len != len ||
-                XMEMCMP(cookie->data, input + idx, len) != 0) {
+    extension = TLSX_Find(ssl->extensions, TLSX_COOKIE);
+    if (extension == NULL) {
+#ifdef WOLFSSL_DTLS13
+        if (ssl->options.dtls && IsAtLeastTLSv1_3(ssl->version))
+            /* Allow a cookie extension with DTLS 1.3 because it is possible
+             * that a different SSL instance sent the cookie but we are now
+             * receiving it. */
+            return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 0,
+                                   &ssl->extensions);
+        else
+#endif
+        {
             WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
             return HRR_COOKIE_ERROR;
         }
-
-        /* Request seen. */
-        extension->resp = 0;
     }
+
+    cookie = (Cookie*)extension->data;
+    if (cookie->len != len || XMEMCMP(cookie->data, input + idx, len) != 0) {
+        WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
+        return HRR_COOKIE_ERROR;
+    }
+
+    /* Request seen. */
+    extension->resp = 0;
 #endif
 
     return 0;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -36,7 +36,8 @@
  * WOLFSSL_TLS13_MIDDLEBOX_COMPAT: Enable middlebox compatibility  default: on
  *                            Sends ChangeCipherSpec and includes session id
  * WOLFSSL_SEND_HRR_COOKIE:  Send cookie in HelloRetryRequest     default: off
- *                            for stateless ClientHello tracking
+ *                            for stateless ClientHello tracking. A client
+ *                            always echoes back a cookie it is sent.
  * WOLFSSL_EARLY_DATA:       Allow 0-RTT early data                default: off
  * WOLFSSL_EARLY_DATA_GROUP: Group early data with ClientHello     default: off
  * WOLFSSL_POST_HANDSHAKE_AUTH: Post-handshake client auth         default: off
@@ -6104,7 +6105,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
          */
         /* Check if the HRR contained a cookie or a keyshare */
         if (!ssl->options.hrrSentKeyShare
-#ifdef WOLFSSL_SEND_HRR_COOKIE
+#ifdef WOLFSSL_TLS13_COOKIE
                 && !ssl->options.hrrSentCookie
 #endif
                 ) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -38,6 +38,8 @@
  * WOLFSSL_SEND_HRR_COOKIE:  Send cookie in HelloRetryRequest     default: off
  *                            for stateless ClientHello tracking. A client
  *                            always echoes back a cookie it is sent.
+ * WOLFSSL_MAX_TLS13_COOKIE_SZ: Largest cookie a client accepts  default: 4096
+ *                            in a HelloRetryRequest.
  * WOLFSSL_EARLY_DATA:       Allow 0-RTT early data                default: off
  * WOLFSSL_EARLY_DATA_GROUP: Group early data with ClientHello     default: off
  * WOLFSSL_POST_HANDSHAKE_AUTH: Post-handshake client auth         default: off

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -36,7 +36,8 @@
  * WOLFSSL_TLS13_MIDDLEBOX_COMPAT: Enable middlebox compatibility  default: on
  *                            Sends ChangeCipherSpec and includes session id
  * WOLFSSL_SEND_HRR_COOKIE:  Send cookie in HelloRetryRequest     default: off
- *                            for stateless ClientHello tracking
+ *                            for stateless ClientHello tracking. A client
+ *                            always echoes back a cookie it is sent.
  * WOLFSSL_EARLY_DATA:       Allow 0-RTT early data                default: off
  * WOLFSSL_EARLY_DATA_GROUP: Group early data with ClientHello     default: off
  * WOLFSSL_POST_HANDSHAKE_AUTH: Post-handshake client auth         default: off
@@ -6051,7 +6052,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
          */
         /* Check if the HRR contained a cookie or a keyshare */
         if (!ssl->options.hrrSentKeyShare
-#ifdef WOLFSSL_SEND_HRR_COOKIE
+#ifdef WOLFSSL_TLS13_COOKIE
                 && !ssl->options.hrrSentCookie
 #endif
                 ) {

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -8063,6 +8063,126 @@ int test_tls13_hrr_bad_cookie(void)
     return EXPECT_RESULT();
 }
 
+/* Run a handshake where the server sends a cookie in its HelloRetryRequest:
+ * the client must echo it back for the server to accept the second
+ * ClientHello. With noKeyShares the retry also asks for a different group,
+ * without it the cookie is the only thing the retry changes. */
+static int test_tls13_hrr_cookie_handshake_once(int noKeyShares)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && \
+    defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(WOLFSSL_SEND_HRR_COOKIE) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL;
+    WOLFSSL *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+
+    ExpectIntEQ(wolfSSL_send_hrr_cookie(ssl_s, NULL, 0), WOLFSSL_SUCCESS);
+    if (noKeyShares) {
+        ExpectIntEQ(wolfSSL_NoKeyShares(ssl_c), WOLFSSL_SUCCESS);
+    }
+
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+
+    /* Client saw a cookie and the server accepted the one echoed back. */
+    ExpectIntEQ(ssl_c->options.hrrSentCookie, 1);
+    ExpectIntEQ(ssl_s->options.cookieGood, 1);
+    ExpectIntEQ(ssl_c->options.hrrSentKeyShare, noKeyShares ? 1 : 0);
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_s);
+#else
+    (void)noKeyShares;
+#endif
+    return EXPECT_RESULT();
+}
+
+/* HelloRetryRequest carrying both a key share and a cookie. */
+int test_tls13_hrr_cookie_handshake(void)
+{
+    return test_tls13_hrr_cookie_handshake_once(1);
+}
+
+/* HelloRetryRequest whose only change is the cookie. This is what a server
+ * sends when it wants the client's address confirmed and the offered key
+ * share was already usable. */
+int test_tls13_hrr_cookie_only_handshake(void)
+{
+    return test_tls13_hrr_cookie_handshake_once(0);
+}
+
+/* Test that a client stores a cookie received in a HelloRetryRequest and
+ * writes it back out in the second ClientHello. Required of every TLS 1.3
+ * client by RFC 8446 4.2.2, so it must hold without WOLFSSL_SEND_HRR_COOKIE,
+ * which only controls a server creating cookies. */
+int test_tls13_client_cookie_echo(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_CLIENT)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    TLSX* ext = NULL;
+    Cookie* cookie = NULL;
+    word32 length = 0;
+    word32 offset = 0;
+    byte out[128];
+    /* Cookie extension of a HelloRetryRequest: type, extension length,
+     * cookie length, cookie. */
+    static const byte hrrExt[] = {
+        0x00, 0x2c, 0x00, 0x08, 0x00, 0x06, 'w', 'o', 'l', 'f', 'S', 'L'
+    };
+
+    XMEMSET(out, 0, sizeof(out));
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+
+    ExpectIntEQ(TLSX_Parse(ssl, hrrExt, (word16)sizeof(hrrExt),
+        hello_retry_request, NULL), 0);
+
+    ExpectNotNull(ext = TLSX_Find(ssl->extensions, TLSX_COOKIE));
+    if (EXPECT_SUCCESS()) {
+        ExpectNotNull(cookie = (Cookie*)ext->data);
+    }
+    if (EXPECT_SUCCESS()) {
+        ExpectIntEQ(cookie->len, sizeof(hrrExt) - 6);
+        ExpectBufEQ(cookie->data, hrrExt + 6, sizeof(hrrExt) - 6);
+    }
+
+    ExpectIntEQ(TLSX_GetRequestSize(ssl, client_hello, &length), 0);
+    ExpectIntGT(length, 0);
+    ExpectIntLE(length, (word32)sizeof(out));
+    if (EXPECT_SUCCESS()) {
+        ExpectIntEQ(TLSX_WriteRequest(ssl, out, client_hello, &offset), 0);
+    }
+    if (EXPECT_SUCCESS()) {
+        int found = 0;
+        word32 i;
+
+        for (i = 0; i + sizeof(hrrExt) <= offset; i++) {
+            if (XMEMCMP(out + i, hrrExt, sizeof(hrrExt)) == 0) {
+                found = 1;
+                break;
+            }
+        }
+        ExpectIntEQ(found, 1);
+    }
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 /* Test that a TLS 1.3 encrypted record whose inner content type resolves to
  * zero is rejected in removeMsgInnerPadding() with PARSE_ERROR and an
  * unexpected_message alert. */

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -8183,6 +8183,88 @@ int test_tls13_client_cookie_echo(void)
     return EXPECT_RESULT();
 }
 
+/* Test that a client rejects a HelloRetryRequest cookie larger than it is
+ * willing to store and echo back. RFC 8446 4.2.2 sets no upper bound. */
+int test_tls13_client_cookie_too_big(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_CLIENT) && \
+    WOLFSSL_MAX_TLS13_COOKIE_SZ < 65535
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    byte* hrrExt = NULL;
+    const word16 cookieLen = WOLFSSL_MAX_TLS13_COOKIE_SZ + 1;
+    const word16 extLen = cookieLen + OPAQUE16_LEN;
+    const word32 totalLen = (word32)extLen + OPAQUE16_LEN * 2;
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+
+    ExpectNotNull(hrrExt = (byte*)XMALLOC(totalLen, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    if (EXPECT_SUCCESS()) {
+        XMEMSET(hrrExt, 0, totalLen);
+        c16toa(TLSX_COOKIE, hrrExt);
+        c16toa(extLen, hrrExt + OPAQUE16_LEN);
+        c16toa(cookieLen, hrrExt + OPAQUE16_LEN * 2);
+    }
+
+    ExpectIntEQ(TLSX_Parse(ssl, hrrExt, (word16)totalLen, hello_retry_request,
+        NULL), WC_NO_ERR_TRACE(HRR_COOKIE_ERROR));
+    ExpectNull(TLSX_Find(ssl->extensions, TLSX_COOKIE));
+
+    XFREE(hrrExt, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* Test the cookie extension of a ClientHello on the server. The encoding is
+ * validated in every build, so a malformed one is always rejected. Only a
+ * build that sends cookies has a stored cookie to compare the echoed value
+ * against; without one the value is accepted and ignored. */
+int test_tls13_server_cookie_parse(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_SERVER) && \
+    defined(HAVE_ECC) && !defined(NO_FILESYSTEM)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    int expected = 0;
+    /* Cookie extension of a ClientHello: type, extension length, cookie
+     * length, cookie. */
+    static const byte goodExt[] = {
+        0x00, 0x2c, 0x00, 0x08, 0x00, 0x06, 'w', 'o', 'l', 'f', 'S', 'L'
+    };
+    /* Same, with a cookie length that disagrees with the extension length. */
+    static const byte badExt[] = {
+        0x00, 0x2c, 0x00, 0x08, 0x00, 0x07, 'w', 'o', 'l', 'f', 'S', 'L'
+    };
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx, eccCertFile,
+        CERT_FILETYPE));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, eccKeyFile,
+        CERT_FILETYPE));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+
+    ExpectIntEQ(TLSX_Parse(ssl, badExt, (word16)sizeof(badExt), client_hello,
+        (Suites*)WOLFSSL_SUITES(ssl)), WC_NO_ERR_TRACE(BUFFER_E));
+
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    /* No cookie was sent, so there is nothing for the echo to match. */
+    expected = WC_NO_ERR_TRACE(HRR_COOKIE_ERROR);
+#endif
+    ExpectIntEQ(TLSX_Parse(ssl, goodExt, (word16)sizeof(goodExt), client_hello,
+        (Suites*)WOLFSSL_SUITES(ssl)), expected);
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 /* Test that a TLS 1.3 encrypted record whose inner content type resolves to
  * zero is rejected in removeMsgInnerPadding() with PARSE_ERROR and an
  * unexpected_message alert. */

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -7984,6 +7984,88 @@ int test_tls13_client_cookie_echo(void)
     return EXPECT_RESULT();
 }
 
+/* Test that a client rejects a HelloRetryRequest cookie larger than it is
+ * willing to store and echo back. RFC 8446 4.2.2 sets no upper bound. */
+int test_tls13_client_cookie_too_big(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_CLIENT) && \
+    WOLFSSL_MAX_TLS13_COOKIE_SZ < 65535
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    byte* hrrExt = NULL;
+    const word16 cookieLen = WOLFSSL_MAX_TLS13_COOKIE_SZ + 1;
+    const word16 extLen = cookieLen + OPAQUE16_LEN;
+    const word32 totalLen = (word32)extLen + OPAQUE16_LEN * 2;
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+
+    ExpectNotNull(hrrExt = (byte*)XMALLOC(totalLen, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    if (EXPECT_SUCCESS()) {
+        XMEMSET(hrrExt, 0, totalLen);
+        c16toa(TLSX_COOKIE, hrrExt);
+        c16toa(extLen, hrrExt + OPAQUE16_LEN);
+        c16toa(cookieLen, hrrExt + OPAQUE16_LEN * 2);
+    }
+
+    ExpectIntEQ(TLSX_Parse(ssl, hrrExt, (word16)totalLen, hello_retry_request,
+        NULL), WC_NO_ERR_TRACE(HRR_COOKIE_ERROR));
+    ExpectNull(TLSX_Find(ssl->extensions, TLSX_COOKIE));
+
+    XFREE(hrrExt, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* Test the cookie extension of a ClientHello on the server. The encoding is
+ * validated in every build, so a malformed one is always rejected. Only a
+ * build that sends cookies has a stored cookie to compare the echoed value
+ * against; without one the value is accepted and ignored. */
+int test_tls13_server_cookie_parse(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_SERVER) && \
+    defined(HAVE_ECC) && !defined(NO_FILESYSTEM)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    int expected = 0;
+    /* Cookie extension of a ClientHello: type, extension length, cookie
+     * length, cookie. */
+    static const byte goodExt[] = {
+        0x00, 0x2c, 0x00, 0x08, 0x00, 0x06, 'w', 'o', 'l', 'f', 'S', 'L'
+    };
+    /* Same, with a cookie length that disagrees with the extension length. */
+    static const byte badExt[] = {
+        0x00, 0x2c, 0x00, 0x08, 0x00, 0x07, 'w', 'o', 'l', 'f', 'S', 'L'
+    };
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx, eccCertFile,
+        CERT_FILETYPE));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, eccKeyFile,
+        CERT_FILETYPE));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+
+    ExpectIntEQ(TLSX_Parse(ssl, badExt, (word16)sizeof(badExt), client_hello,
+        (Suites*)WOLFSSL_SUITES(ssl)), WC_NO_ERR_TRACE(BUFFER_E));
+
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    /* No cookie was sent, so there is nothing for the echo to match. */
+    expected = WC_NO_ERR_TRACE(HRR_COOKIE_ERROR);
+#endif
+    ExpectIntEQ(TLSX_Parse(ssl, goodExt, (word16)sizeof(goodExt), client_hello,
+        (Suites*)WOLFSSL_SUITES(ssl)), expected);
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 /* Test that a TLS 1.3 encrypted record whose inner content type resolves to
  * zero is rejected in removeMsgInnerPadding() with PARSE_ERROR and an
  * unexpected_message alert. */

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -7864,6 +7864,126 @@ int test_tls13_hrr_bad_cookie(void)
     return EXPECT_RESULT();
 }
 
+/* Run a handshake where the server sends a cookie in its HelloRetryRequest:
+ * the client must echo it back for the server to accept the second
+ * ClientHello. With noKeyShares the retry also asks for a different group,
+ * without it the cookie is the only thing the retry changes. */
+static int test_tls13_hrr_cookie_handshake_once(int noKeyShares)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && \
+    defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(WOLFSSL_SEND_HRR_COOKIE) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL;
+    WOLFSSL *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+
+    ExpectIntEQ(wolfSSL_send_hrr_cookie(ssl_s, NULL, 0), WOLFSSL_SUCCESS);
+    if (noKeyShares) {
+        ExpectIntEQ(wolfSSL_NoKeyShares(ssl_c), WOLFSSL_SUCCESS);
+    }
+
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+
+    /* Client saw a cookie and the server accepted the one echoed back. */
+    ExpectIntEQ(ssl_c->options.hrrSentCookie, 1);
+    ExpectIntEQ(ssl_s->options.cookieGood, 1);
+    ExpectIntEQ(ssl_c->options.hrrSentKeyShare, noKeyShares ? 1 : 0);
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_s);
+#else
+    (void)noKeyShares;
+#endif
+    return EXPECT_RESULT();
+}
+
+/* HelloRetryRequest carrying both a key share and a cookie. */
+int test_tls13_hrr_cookie_handshake(void)
+{
+    return test_tls13_hrr_cookie_handshake_once(1);
+}
+
+/* HelloRetryRequest whose only change is the cookie. This is what a server
+ * sends when it wants the client's address confirmed and the offered key
+ * share was already usable. */
+int test_tls13_hrr_cookie_only_handshake(void)
+{
+    return test_tls13_hrr_cookie_handshake_once(0);
+}
+
+/* Test that a client stores a cookie received in a HelloRetryRequest and
+ * writes it back out in the second ClientHello. Required of every TLS 1.3
+ * client by RFC 8446 4.2.2, so it must hold without WOLFSSL_SEND_HRR_COOKIE,
+ * which only controls a server creating cookies. */
+int test_tls13_client_cookie_echo(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_CLIENT)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    TLSX* ext = NULL;
+    Cookie* cookie = NULL;
+    word32 length = 0;
+    word32 offset = 0;
+    byte out[128];
+    /* Cookie extension of a HelloRetryRequest: type, extension length,
+     * cookie length, cookie. */
+    static const byte hrrExt[] = {
+        0x00, 0x2c, 0x00, 0x08, 0x00, 0x06, 'w', 'o', 'l', 'f', 'S', 'L'
+    };
+
+    XMEMSET(out, 0, sizeof(out));
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+
+    ExpectIntEQ(TLSX_Parse(ssl, hrrExt, (word16)sizeof(hrrExt),
+        hello_retry_request, NULL), 0);
+
+    ExpectNotNull(ext = TLSX_Find(ssl->extensions, TLSX_COOKIE));
+    if (EXPECT_SUCCESS()) {
+        ExpectNotNull(cookie = (Cookie*)ext->data);
+    }
+    if (EXPECT_SUCCESS()) {
+        ExpectIntEQ(cookie->len, sizeof(hrrExt) - 6);
+        ExpectBufEQ(cookie->data, hrrExt + 6, sizeof(hrrExt) - 6);
+    }
+
+    ExpectIntEQ(TLSX_GetRequestSize(ssl, client_hello, &length), 0);
+    ExpectIntGT(length, 0);
+    ExpectIntLE(length, (word32)sizeof(out));
+    if (EXPECT_SUCCESS()) {
+        ExpectIntEQ(TLSX_WriteRequest(ssl, out, client_hello, &offset), 0);
+    }
+    if (EXPECT_SUCCESS()) {
+        int found = 0;
+        word32 i;
+
+        for (i = 0; i + sizeof(hrrExt) <= offset; i++) {
+            if (XMEMCMP(out + i, hrrExt, sizeof(hrrExt)) == 0) {
+                found = 1;
+                break;
+            }
+        }
+        ExpectIntEQ(found, 1);
+    }
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 /* Test that a TLS 1.3 encrypted record whose inner content type resolves to
  * zero is rejected in removeMsgInnerPadding() with PARSE_ERROR and an
  * unexpected_message alert. */

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -8184,12 +8184,15 @@ int test_tls13_client_cookie_echo(void)
 }
 
 /* Test that a client rejects a HelloRetryRequest cookie larger than it is
- * willing to store and echo back. RFC 8446 4.2.2 sets no upper bound. */
+ * willing to store and echo back. RFC 8446 4.2.2 allows up to 2^16-1 bytes;
+ * WOLFSSL_MAX_TLS13_COOKIE_SZ is the smaller local cap tested here.
+ * One byte over the cap plus the six bytes of extension headers must still
+ * fit the word16 length TLSX_Parse() takes: 65535 - 1 - 6 = 65528. */
 int test_tls13_client_cookie_too_big(void)
 {
     EXPECT_DECLS;
 #if defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_CLIENT) && \
-    WOLFSSL_MAX_TLS13_COOKIE_SZ < 65535
+    WOLFSSL_MAX_TLS13_COOKIE_SZ <= 65528
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
     byte* hrrExt = NULL;
@@ -8220,10 +8223,14 @@ int test_tls13_client_cookie_too_big(void)
     return EXPECT_RESULT();
 }
 
-/* Test the cookie extension of a ClientHello on the server. The encoding is
- * validated in every build, so a malformed one is always rejected. Only a
- * build that sends cookies has a stored cookie to compare the echoed value
- * against; without one the value is accepted and ignored. */
+/* Test the cookie extension of a ClientHello on the server. How much of it a
+ * server checks depends on the build:
+ *  - without WOLFSSL_TLS13_COOKIE there is no cookie code, so the extension
+ *    is skipped without being looked at;
+ *  - with WOLFSSL_TLS13_COOKIE, which any build holding a client has, the
+ *    extension is parsed and so its encoding is checked;
+ *  - with WOLFSSL_SEND_HRR_COOKIE the server also kept the cookie it sent,
+ *    and the echoed value has to match it. */
 int test_tls13_server_cookie_parse(void)
 {
     EXPECT_DECLS;
@@ -8231,16 +8238,31 @@ int test_tls13_server_cookie_parse(void)
     defined(HAVE_ECC) && !defined(NO_FILESYSTEM)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
-    int expected = 0;
-    /* Cookie extension of a ClientHello: type, extension length, cookie
-     * length, cookie. */
-    static const byte goodExt[] = {
+    int expectBad = 0;
+    int expectUnsent = 0;
+    /* Cookie extension: type, extension length, cookie length, cookie. */
+    static const byte cookieExt[] = {
         0x00, 0x2c, 0x00, 0x08, 0x00, 0x06, 'w', 'o', 'l', 'f', 'S', 'L'
     };
     /* Same, with a cookie length that disagrees with the extension length. */
     static const byte badExt[] = {
         0x00, 0x2c, 0x00, 0x08, 0x00, 0x07, 'w', 'o', 'l', 'f', 'S', 'L'
     };
+    /* Well formed, same length as the cookie the server sent, but not it. */
+    static const byte otherExt[] = {
+        0x00, 0x2c, 0x00, 0x08, 0x00, 0x06, 'w', 'o', 'l', 'f', 'S', 'S'
+    };
+    /* Well formed, and not even the length of the cookie sent. */
+    static const byte longerExt[] = {
+        0x00, 0x2c, 0x00, 0x09, 0x00, 0x07, 'w', 'o', 'l', 'f', 'S', 'S', 'L'
+    };
+
+#ifdef WOLFSSL_TLS13_COOKIE
+    expectBad = WC_NO_ERR_TRACE(BUFFER_E);
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    expectUnsent = WC_NO_ERR_TRACE(HRR_COOKIE_ERROR);
+#endif
+#endif
 
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
     ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx, eccCertFile,
@@ -8250,14 +8272,34 @@ int test_tls13_server_cookie_parse(void)
     ExpectNotNull(ssl = wolfSSL_new(ctx));
 
     ExpectIntEQ(TLSX_Parse(ssl, badExt, (word16)sizeof(badExt), client_hello,
-        (Suites*)WOLFSSL_SUITES(ssl)), WC_NO_ERR_TRACE(BUFFER_E));
+        (Suites*)WOLFSSL_SUITES(ssl)), expectBad);
+
+    /* Nothing has been sent yet, so there is no cookie to echo. */
+    ExpectIntEQ(TLSX_Parse(ssl, cookieExt, (word16)sizeof(cookieExt),
+        client_hello, (Suites*)WOLFSSL_SUITES(ssl)), expectUnsent);
 
 #ifdef WOLFSSL_SEND_HRR_COOKIE
-    /* No cookie was sent, so there is nothing for the echo to match. */
-    expected = WC_NO_ERR_TRACE(HRR_COOKIE_ERROR);
+    /* Give the server the cookie it sends in a HelloRetryRequest. Parsing the
+     * extension as one leaves it stored the way the server stores it. */
+    ExpectIntEQ(TLSX_Parse(ssl, cookieExt, (word16)sizeof(cookieExt),
+        hello_retry_request, NULL), 0);
 #endif
-    ExpectIntEQ(TLSX_Parse(ssl, goodExt, (word16)sizeof(goodExt), client_hello,
-        (Suites*)WOLFSSL_SUITES(ssl)), expected);
+
+    /* The cookie the server sent, echoed back unchanged. */
+    ExpectIntEQ(TLSX_Parse(ssl, cookieExt, (word16)sizeof(cookieExt),
+        client_hello, (Suites*)WOLFSSL_SUITES(ssl)), 0);
+
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    ExpectIntEQ(TLSX_Parse(ssl, otherExt, (word16)sizeof(otherExt),
+        client_hello, (Suites*)WOLFSSL_SUITES(ssl)),
+        WC_NO_ERR_TRACE(HRR_COOKIE_ERROR));
+    ExpectIntEQ(TLSX_Parse(ssl, longerExt, (word16)sizeof(longerExt),
+        client_hello, (Suites*)WOLFSSL_SUITES(ssl)),
+        WC_NO_ERR_TRACE(HRR_COOKIE_ERROR));
+#else
+    (void)otherExt;
+    (void)longerExt;
+#endif
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -8021,10 +8021,14 @@ int test_tls13_client_cookie_too_big(void)
     return EXPECT_RESULT();
 }
 
-/* Test the cookie extension of a ClientHello on the server. The encoding is
- * validated in every build, so a malformed one is always rejected. Only a
- * build that sends cookies has a stored cookie to compare the echoed value
- * against; without one the value is accepted and ignored. */
+/* Test the cookie extension of a ClientHello on the server. How much of it a
+ * server checks depends on the build:
+ *  - without WOLFSSL_TLS13_COOKIE there is no cookie code, so the extension
+ *    is skipped without being looked at;
+ *  - with WOLFSSL_TLS13_COOKIE, which any build holding a client has, the
+ *    extension is parsed and so its encoding is checked;
+ *  - with WOLFSSL_SEND_HRR_COOKIE the server also kept the cookie it sent,
+ *    and the echoed value has to match it. */
 int test_tls13_server_cookie_parse(void)
 {
     EXPECT_DECLS;
@@ -8032,16 +8036,31 @@ int test_tls13_server_cookie_parse(void)
     defined(HAVE_ECC) && !defined(NO_FILESYSTEM)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL* ssl = NULL;
-    int expected = 0;
-    /* Cookie extension of a ClientHello: type, extension length, cookie
-     * length, cookie. */
-    static const byte goodExt[] = {
+    int expectBad = 0;
+    int expectUnsent = 0;
+    /* Cookie extension: type, extension length, cookie length, cookie. */
+    static const byte cookieExt[] = {
         0x00, 0x2c, 0x00, 0x08, 0x00, 0x06, 'w', 'o', 'l', 'f', 'S', 'L'
     };
     /* Same, with a cookie length that disagrees with the extension length. */
     static const byte badExt[] = {
         0x00, 0x2c, 0x00, 0x08, 0x00, 0x07, 'w', 'o', 'l', 'f', 'S', 'L'
     };
+    /* Well formed, same length as the cookie the server sent, but not it. */
+    static const byte otherExt[] = {
+        0x00, 0x2c, 0x00, 0x08, 0x00, 0x06, 'w', 'o', 'l', 'f', 'S', 'S'
+    };
+    /* Well formed, and not even the length of the cookie sent. */
+    static const byte longerExt[] = {
+        0x00, 0x2c, 0x00, 0x09, 0x00, 0x07, 'w', 'o', 'l', 'f', 'S', 'S', 'L'
+    };
+
+#ifdef WOLFSSL_TLS13_COOKIE
+    expectBad = WC_NO_ERR_TRACE(BUFFER_E);
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    expectUnsent = WC_NO_ERR_TRACE(HRR_COOKIE_ERROR);
+#endif
+#endif
 
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
     ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx, eccCertFile,
@@ -8051,14 +8070,34 @@ int test_tls13_server_cookie_parse(void)
     ExpectNotNull(ssl = wolfSSL_new(ctx));
 
     ExpectIntEQ(TLSX_Parse(ssl, badExt, (word16)sizeof(badExt), client_hello,
-        (Suites*)WOLFSSL_SUITES(ssl)), WC_NO_ERR_TRACE(BUFFER_E));
+        (Suites*)WOLFSSL_SUITES(ssl)), expectBad);
+
+    /* Nothing has been sent yet, so there is no cookie to echo. */
+    ExpectIntEQ(TLSX_Parse(ssl, cookieExt, (word16)sizeof(cookieExt),
+        client_hello, (Suites*)WOLFSSL_SUITES(ssl)), expectUnsent);
 
 #ifdef WOLFSSL_SEND_HRR_COOKIE
-    /* No cookie was sent, so there is nothing for the echo to match. */
-    expected = WC_NO_ERR_TRACE(HRR_COOKIE_ERROR);
+    /* Give the server the cookie it sends in a HelloRetryRequest. Parsing the
+     * extension as one leaves it stored the way the server stores it. */
+    ExpectIntEQ(TLSX_Parse(ssl, cookieExt, (word16)sizeof(cookieExt),
+        hello_retry_request, NULL), 0);
 #endif
-    ExpectIntEQ(TLSX_Parse(ssl, goodExt, (word16)sizeof(goodExt), client_hello,
-        (Suites*)WOLFSSL_SUITES(ssl)), expected);
+
+    /* The cookie the server sent, echoed back unchanged. */
+    ExpectIntEQ(TLSX_Parse(ssl, cookieExt, (word16)sizeof(cookieExt),
+        client_hello, (Suites*)WOLFSSL_SUITES(ssl)), 0);
+
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+    ExpectIntEQ(TLSX_Parse(ssl, otherExt, (word16)sizeof(otherExt),
+        client_hello, (Suites*)WOLFSSL_SUITES(ssl)),
+        WC_NO_ERR_TRACE(HRR_COOKIE_ERROR));
+    ExpectIntEQ(TLSX_Parse(ssl, longerExt, (word16)sizeof(longerExt),
+        client_hello, (Suites*)WOLFSSL_SUITES(ssl)),
+        WC_NO_ERR_TRACE(HRR_COOKIE_ERROR));
+#else
+    (void)otherExt;
+    (void)longerExt;
+#endif
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -65,6 +65,9 @@ int test_tls13_corrupted_finished(void);
 int test_tls13_certificate_verify_bad_sigalgo(void);
 int test_tls13_peerauth_failsafe(void);
 int test_tls13_hrr_bad_cookie(void);
+int test_tls13_hrr_cookie_handshake(void);
+int test_tls13_hrr_cookie_only_handshake(void);
+int test_tls13_client_cookie_echo(void);
 int test_tls13_zero_inner_content_type(void);
 int test_tls13_post_handshake_auth_no_ext(void);
 int test_tls13_post_handshake_auth_late_allow(void);
@@ -149,6 +152,9 @@ int test_tls13_pha_status_request(void);
     TEST_DECL_GROUP("tls13", test_tls13_certificate_verify_bad_sigalgo), \
     TEST_DECL_GROUP("tls13", test_tls13_peerauth_failsafe),    \
     TEST_DECL_GROUP("tls13", test_tls13_hrr_bad_cookie), \
+    TEST_DECL_GROUP("tls13", test_tls13_hrr_cookie_handshake), \
+    TEST_DECL_GROUP("tls13", test_tls13_hrr_cookie_only_handshake), \
+    TEST_DECL_GROUP("tls13", test_tls13_client_cookie_echo), \
     TEST_DECL_GROUP("tls13", test_tls13_zero_inner_content_type), \
     TEST_DECL_GROUP("tls13", test_tls13_post_handshake_auth_no_ext), \
     TEST_DECL_GROUP("tls13", test_tls13_post_handshake_auth_late_allow), \

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -68,6 +68,8 @@ int test_tls13_hrr_bad_cookie(void);
 int test_tls13_hrr_cookie_handshake(void);
 int test_tls13_hrr_cookie_only_handshake(void);
 int test_tls13_client_cookie_echo(void);
+int test_tls13_client_cookie_too_big(void);
+int test_tls13_server_cookie_parse(void);
 int test_tls13_zero_inner_content_type(void);
 int test_tls13_post_handshake_auth_no_ext(void);
 int test_tls13_post_handshake_auth_late_allow(void);
@@ -155,6 +157,8 @@ int test_tls13_pha_status_request(void);
     TEST_DECL_GROUP("tls13", test_tls13_hrr_cookie_handshake), \
     TEST_DECL_GROUP("tls13", test_tls13_hrr_cookie_only_handshake), \
     TEST_DECL_GROUP("tls13", test_tls13_client_cookie_echo), \
+    TEST_DECL_GROUP("tls13", test_tls13_client_cookie_too_big), \
+    TEST_DECL_GROUP("tls13", test_tls13_server_cookie_parse), \
     TEST_DECL_GROUP("tls13", test_tls13_zero_inner_content_type), \
     TEST_DECL_GROUP("tls13", test_tls13_post_handshake_auth_no_ext), \
     TEST_DECL_GROUP("tls13", test_tls13_post_handshake_auth_late_allow), \

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -71,6 +71,8 @@ int test_tls13_hrr_bad_cookie(void);
 int test_tls13_hrr_cookie_handshake(void);
 int test_tls13_hrr_cookie_only_handshake(void);
 int test_tls13_client_cookie_echo(void);
+int test_tls13_client_cookie_too_big(void);
+int test_tls13_server_cookie_parse(void);
 int test_tls13_zero_inner_content_type(void);
 int test_tls13_post_handshake_auth_no_ext(void);
 int test_tls13_post_handshake_auth_late_allow(void);
@@ -161,6 +163,8 @@ int test_tls13_pha_status_request(void);
     TEST_DECL_GROUP("tls13", test_tls13_hrr_cookie_handshake), \
     TEST_DECL_GROUP("tls13", test_tls13_hrr_cookie_only_handshake), \
     TEST_DECL_GROUP("tls13", test_tls13_client_cookie_echo), \
+    TEST_DECL_GROUP("tls13", test_tls13_client_cookie_too_big), \
+    TEST_DECL_GROUP("tls13", test_tls13_server_cookie_parse), \
     TEST_DECL_GROUP("tls13", test_tls13_zero_inner_content_type), \
     TEST_DECL_GROUP("tls13", test_tls13_post_handshake_auth_no_ext), \
     TEST_DECL_GROUP("tls13", test_tls13_post_handshake_auth_late_allow), \

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -68,6 +68,9 @@ int test_tls13_corrupted_finished(void);
 int test_tls13_certificate_verify_bad_sigalgo(void);
 int test_tls13_peerauth_failsafe(void);
 int test_tls13_hrr_bad_cookie(void);
+int test_tls13_hrr_cookie_handshake(void);
+int test_tls13_hrr_cookie_only_handshake(void);
+int test_tls13_client_cookie_echo(void);
 int test_tls13_zero_inner_content_type(void);
 int test_tls13_post_handshake_auth_no_ext(void);
 int test_tls13_post_handshake_auth_late_allow(void);
@@ -155,6 +158,9 @@ int test_tls13_pha_status_request(void);
     TEST_DECL_GROUP("tls13", test_tls13_certificate_verify_bad_sigalgo), \
     TEST_DECL_GROUP("tls13", test_tls13_peerauth_failsafe),    \
     TEST_DECL_GROUP("tls13", test_tls13_hrr_bad_cookie), \
+    TEST_DECL_GROUP("tls13", test_tls13_hrr_cookie_handshake), \
+    TEST_DECL_GROUP("tls13", test_tls13_hrr_cookie_only_handshake), \
+    TEST_DECL_GROUP("tls13", test_tls13_client_cookie_echo), \
     TEST_DECL_GROUP("tls13", test_tls13_zero_inner_content_type), \
     TEST_DECL_GROUP("tls13", test_tls13_post_handshake_auth_no_ext), \
     TEST_DECL_GROUP("tls13", test_tls13_post_handshake_auth_late_allow), \

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3898,6 +3898,12 @@ int TLSX_EncryptThenMac_Respond(WOLFSSL* ssl);
 #endif
 
 #ifdef WOLFSSL_TLS13
+
+/* Cookie support is mandatory per RFC 8446 9.2 */
+#if !defined(NO_WOLFSSL_CLIENT) || defined(WOLFSSL_SEND_HRR_COOKIE)
+    #define WOLFSSL_TLS13_COOKIE
+#endif
+
 /* Cookie extension information - cookie data. */
 typedef struct Cookie {
     word16 len;
@@ -5557,7 +5563,7 @@ struct Options {
     word16            cookieGood:1;
 #endif
 #ifdef WOLFSSL_TLS13
-#ifdef WOLFSSL_SEND_HRR_COOKIE
+#ifdef WOLFSSL_TLS13_COOKIE
     word16            hrrSentCookie:1;    /* HRR sent with cookie */
 #endif
     word16            hrrSentKeyShare:1;  /* HRR sent with key share */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3896,6 +3896,12 @@ int TLSX_EncryptThenMac_Respond(WOLFSSL* ssl);
 #endif
 
 #ifdef WOLFSSL_TLS13
+
+/* Cookie support is mandatory per RFC 8446 9.2 */
+#if !defined(NO_WOLFSSL_CLIENT) || defined(WOLFSSL_SEND_HRR_COOKIE)
+    #define WOLFSSL_TLS13_COOKIE
+#endif
+
 /* Cookie extension information - cookie data. */
 typedef struct Cookie {
     word16 len;
@@ -5544,7 +5550,7 @@ struct Options {
     word16            cookieGood:1;
 #endif
 #ifdef WOLFSSL_TLS13
-#ifdef WOLFSSL_SEND_HRR_COOKIE
+#ifdef WOLFSSL_TLS13_COOKIE
     word16            hrrSentCookie:1;    /* HRR sent with cookie */
 #endif
     word16            hrrSentKeyShare:1;  /* HRR sent with key share */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3904,6 +3904,15 @@ int TLSX_EncryptThenMac_Respond(WOLFSSL* ssl);
     #define WOLFSSL_TLS13_COOKIE
 #endif
 
+/* Largest cookie a client stores from a HelloRetryRequest to echo back in the
+ * second ClientHello. RFC 8446 4.2.2 allows up to 2^16-1. */
+#ifndef WOLFSSL_MAX_TLS13_COOKIE_SZ
+    #define WOLFSSL_MAX_TLS13_COOKIE_SZ 4096
+#endif
+#if WOLFSSL_MAX_TLS13_COOKIE_SZ > 65535
+    #error "WOLFSSL_MAX_TLS13_COOKIE_SZ must be <= 65535 per RFC 8446 4.2.2"
+#endif
+
 /* Cookie extension information - cookie data. */
 typedef struct Cookie {
     word16 len;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3902,6 +3902,15 @@ int TLSX_EncryptThenMac_Respond(WOLFSSL* ssl);
     #define WOLFSSL_TLS13_COOKIE
 #endif
 
+/* Largest cookie a client stores from a HelloRetryRequest to echo back in the
+ * second ClientHello. RFC 8446 4.2.2 allows up to 2^16-1. */
+#ifndef WOLFSSL_MAX_TLS13_COOKIE_SZ
+    #define WOLFSSL_MAX_TLS13_COOKIE_SZ 4096
+#endif
+#if WOLFSSL_MAX_TLS13_COOKIE_SZ > 65535
+    #error "WOLFSSL_MAX_TLS13_COOKIE_SZ must be <= 65535 per RFC 8446 4.2.2"
+#endif
+
 /* Cookie extension information - cookie data. */
 typedef struct Cookie {
     word16 len;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3905,12 +3905,14 @@ int TLSX_EncryptThenMac_Respond(WOLFSSL* ssl);
 #endif
 
 /* Largest cookie a client stores from a HelloRetryRequest to echo back in the
- * second ClientHello. RFC 8446 4.2.2 allows up to 2^16-1. */
+ * second ClientHello. RFC 8446 4.2.2 allows up to 2^16-1 bytes, but the cookie
+ * sits inside an extension body of that same size, so its own two byte length
+ * prefix leaves 65533. */
 #ifndef WOLFSSL_MAX_TLS13_COOKIE_SZ
     #define WOLFSSL_MAX_TLS13_COOKIE_SZ 4096
 #endif
-#if WOLFSSL_MAX_TLS13_COOKIE_SZ > 65535
-    #error "WOLFSSL_MAX_TLS13_COOKIE_SZ must be <= 65535 per RFC 8446 4.2.2"
+#if WOLFSSL_MAX_TLS13_COOKIE_SZ > 65533
+    #error "WOLFSSL_MAX_TLS13_COOKIE_SZ must be <= 65533"
 #endif
 
 /* Cookie extension information - cookie data. */


### PR DESCRIPTION
# Description

Split the existing flag which enables TLS cookie support `WOLFSSL_SEND_HRR_COOKIE` into a smaller portion `WOLFSSL_TLS13_COOKIE` which enables *replying* with a cookie echo'ed from the HelloClientResponse (HRR). This is enabled by default for clients.

Fixes #11074 

# Testing

New unit test

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
