### PR TITLE
Send illegal_parameter for bad ServerHello supported_versions

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -7431,15 +7431,20 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
         major = input[0];
         minor = input[OPAQUE8_LEN];
 
+        /* RFC 8446 4.2.1: a version in the ServerHello supported_versions that
+         * the client did not offer, or one prior to TLS 1.3, must be rejected
+         * with illegal_parameter, so return INVALID_PARAMETER rather than
+         * VERSION_ERROR (which maps to protocol_version). */
+
         if (major != ssl->ctx->method->version.major) {
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
+            return INVALID_PARAMETER;
         }
 
         /* Can't downgrade with this extension below TLS v1.3. */
         if (versionIsLesser(isDtls, minor, tls13minor)) {
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
+            return INVALID_PARAMETER;
         }
 
         /* Version is TLS v1.2 to handle downgrading from TLS v1.3+. */
@@ -7450,21 +7455,21 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
 
         /* No upgrade allowed. */
         if (versionIsLesser(isDtls, ssl->version.minor, minor)) {
-            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-            return VERSION_ERROR;
+            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
+            return INVALID_PARAMETER;
         }
 
         /* Check downgrade. */
         if (versionIsGreater(isDtls, ssl->version.minor, minor)) {
             if (!ssl->options.downgrade) {
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
+                return INVALID_PARAMETER;
             }
 
             if (versionIsLesser(
                     isDtls, minor, ssl->options.minDowngrade)) {
-                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
-                return VERSION_ERROR;
+                WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
+                return INVALID_PARAMETER;
             }
 
             /* Downgrade the version. */

--- a/tests/api.c
+++ b/tests/api.c
@@ -33876,12 +33876,112 @@ static int test_tls13_trunc_ext_sh_alert(void)
     return test_tls13_sh_expect_alert(test_tls13_trunc_ext_sh,
         (int)sizeof(test_tls13_trunc_ext_sh), decode_error);
 }
+
+/* A well-formed ServerHello that DOES carry a supported_versions extension,
+ * but selects TLS 1.2 in it - a version prior to TLS 1.3. Unlike the absent
+ * extension case above (RFC 8446 6.2, protocol_version), sending the extension
+ * at all means the server has spoken TLS 1.3, so a bad value in it is a
+ * malformed parameter and RFC 8446 4.2.1 requires illegal_parameter (47).
+ *
+ * Layout: legacy_version = 0x0303, 32-byte random, 32-byte session id,
+ * cipher_suite = TLS_AES_128_GCM_SHA256 (0x1301), null compression, and a
+ * 6-byte extensions block holding only supported_versions (type 0x002b). */
+static const byte test_tls13_sv_old_sh[] = {
+    /* record: handshake, TLS 1.2, len 82 */
+    0x16, 0x03, 0x03, 0x00, 0x52,
+    /* server_hello, body len 78 */
+    0x02, 0x00, 0x00, 0x4e,
+    /* legacy_version = TLS 1.2 */
+    0x03, 0x03,
+    /* 32-byte random (not the HelloRetryRequest magic) */
+    0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+    0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+    0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+    0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+    /* legacy_session_id length = 32 */
+    0x20,
+    /* 32-byte session id */
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+    /* cipher_suite =TLS_AES_128_GCM_SHA256 */
+    0x13, 0x01,
+    /* compression = null */
+    0x00,
+    /* extensions length = 6 */
+    0x00, 0x06,
+    /* supported_versions, length 2 */
+    0x00, 0x2b, 0x00, 0x02,
+    /* selected_version = TLS 1.2 */
+    0x03, 0x03
+};
+
+/* RFC 8446 4.2.1: a supported_versions in the ServerHello holding a version
+ * prior to TLS 1.3 must be rejected with illegal_parameter (47), not
+ * protocol_version (70). */
+static int test_tls13_sv_old_sh_alert(void)
+{
+    return test_tls13_sh_expect_alert(test_tls13_sv_old_sh,
+        (int)sizeof(test_tls13_sv_old_sh), illegal_parameter);
+}
+
+/* Identical to test_tls13_sv_old_sh but selecting 0x0305, an undefined version
+ * above TLS 1.3 that the client never offered, which reaches the "No upgrade
+ * allowed" check rather than the pre-TLS-1.3 one. */
+static const byte test_tls13_sv_unoffered_sh[] = {
+    /* record: handshake, TLS 1.2, len 82 */
+    0x16, 0x03, 0x03, 0x00, 0x52,
+    /* server_hello, body len 78 */
+    0x02, 0x00, 0x00, 0x4e,
+    /* legacy_version = TLS 1.2 */
+    0x03, 0x03,
+    /* 32-byte random (not the HelloRetryRequest magic) */
+    0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+    0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+    0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+    0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+    /* legacy_session_id length = 32 */
+    0x20,
+    /* 32-byte session id */
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+    0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5, 0xa5,
+    /* cipher_suite =TLS_AES_128_GCM_SHA256 */
+    0x13, 0x01,
+    /* compression = null */
+    0x00,
+    /* extensions length = 6 */
+    0x00, 0x06,
+    /* supported_versions, length 2 */
+    0x00, 0x2b, 0x00, 0x02,
+    /* selected_version = 0x0305, not offered by the client */
+    0x03, 0x05
+};
+
+/* RFC 8446 4.2.1: a supported_versions in the ServerHello holding a version
+ * the client did not offer must be rejected with illegal_parameter (47), not
+ * protocol_version (70). */
+static int test_tls13_sv_unoffered_sh_alert(void)
+{
+    return test_tls13_sh_expect_alert(test_tls13_sv_unoffered_sh,
+        (int)sizeof(test_tls13_sv_unoffered_sh), illegal_parameter);
+}
 #else
 static int test_tls13_no_ext_sh_alert(void)
 {
     return TEST_SKIPPED;
 }
 static int test_tls13_trunc_ext_sh_alert(void)
+{
+    return TEST_SKIPPED;
+}
+static int test_tls13_sv_old_sh_alert(void)
+{
+    return TEST_SKIPPED;
+}
+static int test_tls13_sv_unoffered_sh_alert(void)
 {
     return TEST_SKIPPED;
 }
@@ -39431,6 +39531,8 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wrong_cs_downgrade),
     TEST_DECL(test_tls13_no_ext_sh_alert),
     TEST_DECL(test_tls13_trunc_ext_sh_alert),
+    TEST_DECL(test_tls13_sv_old_sh_alert),
+    TEST_DECL(test_tls13_sv_unoffered_sh_alert),
     TEST_DECL(test_extra_alerts_wrong_cs),
     TEST_DECL(test_extra_alerts_skip_hs),
     TEST_DECL(test_extra_alerts_bad_psk),


### PR DESCRIPTION
# Description

RFC 8446 (in particularr section 4.2.1) requires illegal_parameter to be sent when the ServerHello's supported_versions holds a version the client did not offer or one priort to TLS 1.3.
Return INVALID_PARAMETER instead of VERSION_ERROR.

Fixes https://github.com/wolfSSL/wolfssl/issues/11088

# Testing

Added two regression tests with their associated ServerHellos to reproduce the behaviour, where each drives a TLS 1.3-only client through its ClientHello, then feeds it a canned ServerHello whose supported_versions extension selects TLS 1.2 (prior to TLS 1.3) in one, and 0x0305 (not offered by the client) in the other.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
