### PR TITLE
Fix link failure with NO_SESSION_CACHE and session tickets

### DIFF
--- a/.github/configs/os-check-linux.json
+++ b/.github/configs/os-check-linux.json
@@ -378,5 +378,14 @@
 {"name": "pkcs12-pbkdf-mp-api", "minutes": 1.0,
  "comment": "WC_PKCS12_PBKDF_USING_MP_API selects a second wc_PKCS12_PBKDF_ex implementation that no configure option reaches.",
  "configure": ["--enable-pkcs12", "--enable-des3", "--enable-opensslextra",
-  "CPPFLAGS=-DWC_PKCS12_PBKDF_USING_MP_API"]}
+  "CPPFLAGS=-DWC_PKCS12_PBKDF_USING_MP_API"]},
+{"name": "no-session-cache-session-ticket", "minutes": 0.8,
+ "comment": "Session tickets with the internal session cache compiled out, over TLS 1.3 and DTLS 1.3. This is what a Zephyr build produces from CONFIG_WOLFSSL_SESSION_CACHE=n with tickets left on, and it used to fail to link. HAVE_EXT_CACHE is set because NO_SESSION_CACHE with an external cache is the one combination where the ticket-session free path keeps its external-cache branch, and --enable-wpas with --enable-lowresource reaches it. Examples are off because tests/unit.test calls the session APIs that NO_SESSION_CACHE removes, so this entry is compile coverage for the library.",
+ "configure": ["--enable-session-ticket", "--enable-dtls", "--enable-dtls13",
+  "--disable-examples",
+  "CPPFLAGS=-DNO_SESSION_CACHE -DWOLFSSL_DTLS_NO_HVR_ON_RESUME -DHAVE_EXT_CACHE"]},
+{"name": "lowresource-tls13-session-ticket", "minutes": 0.8,
+ "comment": "--enable-lowresource defines NO_SESSION_CACHE, so this reaches the src/internal.c no-cache ticket paths purely through configure options, with no CPPFLAGS to get wrong. It does not cover src/dtls.c, whose TlsSessionIdIsValid needs WOLFSSL_DTLS_NO_HVR_ON_RESUME, so no-session-cache-session-ticket is the entry for that and the two are not interchangeable. Examples are off for the same reason as that entry.",
+ "configure": ["--enable-lowresource", "--enable-tls13", "--enable-session-ticket",
+  "--disable-examples"]}
 ]

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -437,9 +437,11 @@ static int TlsTicketIsValid(const WOLFSSL* ssl, WolfSSL_ConstVector exts,
 static int TlsSessionIdIsValid(const WOLFSSL* ssl, WolfSSL_ConstVector sessionID,
                                int* resume)
 {
+#ifndef NO_SESSION_CACHE
     const WOLFSSL_SESSION* sess;
     word32 sessRow;
     int ret;
+#endif
 #ifdef HAVE_EXT_CACHE
     int copy;
 #endif
@@ -474,6 +476,7 @@ static int TlsSessionIdIsValid(const WOLFSSL* ssl, WolfSSL_ConstVector sessionID
 #endif
 
 
+#ifndef NO_SESSION_CACHE
     ret = TlsSessionCacheGetAndRdLock(sessionID.elements, &sess, &sessRow,
             ssl->options.side);
     if (ret == 0 && sess != NULL) {
@@ -486,6 +489,7 @@ static int TlsSessionIdIsValid(const WOLFSSL* ssl, WolfSSL_ConstVector sessionID
             *resume = TRUE;
         TlsSessionCacheUnlockRow(sessRow);
     }
+#endif /* !NO_SESSION_CACHE */
 
     return 0;
 }

--- a/src/internal.c
+++ b/src/internal.c
@@ -42905,7 +42905,13 @@ static int AddPSKtoPreMasterSecret(WOLFSSL* ssl)
             const byte* id, psk_sess_free_cb_ctx* freeCtx)
     {
         const WOLFSSL_SESSION* sess = NULL;
+#ifndef NO_SESSION_CACHE
         int ret;
+#endif
+
+        (void)ssl;
+        (void)id;
+
         XMEMSET(freeCtx, 0, sizeof(*freeCtx));
 #ifdef HAVE_EXT_CACHE
         if (ssl->ctx->get_sess_cb != NULL) {
@@ -42920,12 +42926,14 @@ static int AddPSKtoPreMasterSecret(WOLFSSL* ssl)
             }
         }
 #endif
+#ifndef NO_SESSION_CACHE
         if (sess == NULL) {
             ret = TlsSessionCacheGetAndRdLock(id, &sess, &freeCtx->row,
                     (byte)ssl->options.side);
             if (ret != 0)
                 sess = NULL;
         }
+#endif /* !NO_SESSION_CACHE */
         return sess;
     }
 
@@ -42934,16 +42942,19 @@ static int AddPSKtoPreMasterSecret(WOLFSSL* ssl)
     {
         (void)ssl;
         (void)sess;
+        (void)freeCtx;
 #ifdef HAVE_EXT_CACHE
         if (freeCtx->extCache) {
             if (freeCtx->freeSess)
                 /* In this case sess is not longer const and the external cache
                  * wants us to free it. */
                 wolfSSL_FreeSession(ssl->ctx, (WOLFSSL_SESSION*)sess);
+            return;
         }
-        else
 #endif
-            TlsSessionCacheUnlockRow(freeCtx->row);
+#ifndef NO_SESSION_CACHE
+        TlsSessionCacheUnlockRow(freeCtx->row);
+#endif /* !NO_SESSION_CACHE */
     }
 
     /* Parse ticket sent by client, returns callback return value. Doesn't


### PR DESCRIPTION
### Problem

`TlsSessionCacheGetAndRdLock()` and `TlsSessionCacheUnlockRow()` are defined only inside the `#ifndef NO_SESSION_CACHE` block in `src/ssl_sess.c`, but three call sites used them without that guard: `GetSesionFromCacheOrExt()` and `FreeSessionFromCacheOrExt()` in `src/internal.c`, and `TlsSessionIdIsValid()` in `src/dtls.c`. Building with `NO_SESSION_CACHE` while session tickets and TLS 1.3 are enabled compiles cleanly and fails at link time.

The combination is what a Zephyr build produces from `CONFIG_WOLFSSL_SESSION_CACHE=n` with tickets left on, and it is reachable from plain configure options:

```sh
./configure --enable-lowresource --enable-tls13 --enable-session-ticket
```

Broken since commit `1106e5ff0` (#5960), first released in v5.6.2-stable. Plain `NO_SESSION_CACHE` and TLS 1.2 tickets are unaffected; only the TLS 1.3 stateful ticket path and the DTLS `WOLFSSL_DTLS_NO_HVR_ON_RESUME` path fail.

### Fix

Guard each internal cache use on `NO_SESSION_CACHE`. This is the correct behaviour, not only a build fix: both call sites handle state that cannot exist without a cache. The `src/internal.c` pair serves the stateful TLS 1.3 ticket path, where the ticket is only a session ID needing a lookup, while stateless tickets go through `DoDecryptTicket()` and were never affected. `TlsSessionIdIsValid()` serves DTLS session ID resumption, which already bails out at run time on `sessionCacheOff`. With no internal and no external cache the lookup returns NULL and the peer falls back to a full handshake.

`FreeSessionFromCacheOrExt()` returns early from the external cache branch instead of using an `else`, so the unlock can carry its own guard. The rewrite is behaviourally identical in all four combinations of `HAVE_EXT_CACHE` and `NO_SESSION_CACHE`.

### CI

The matrix had one `NO_SESSION_CACHE` entry, `dtls13-client-minimal`, which is client only with no tickets, so nothing covered these server side paths. Two entries are added:

- `no-session-cache-session-ticket`: sets the macro directly plus DTLS 1.3 and `WOLFSSL_DTLS_NO_HVR_ON_RESUME`, covering all three call sites. It also sets `HAVE_EXT_CACHE`, the only configuration in which the external cache branch of `FreeSessionFromCacheOrExt()` survives the preprocessor.
- `lowresource-tls13-session-ticket`: reaches the `src/internal.c` paths through configure options alone. It does not cover `src/dtls.c`, so both entries are needed.

Both disable the examples, because `tests/unit.test` calls `wolfSSL_get1_session()` and `wolfSSL_set_session()`, which `NO_SESSION_CACHE` compiles out. They are compile coverage for the library.

### Out of scope

`NO_SESSION_CACHE` also removes the public session API, so a cacheless client can negotiate tickets but has no supported way to reuse one. That is the same reason the test suite cannot build in this configuration. Separating the two concerns is a larger change and is left for later.
