### PR TITLE
Fix ECC OID cache lock being re-initialized

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -16858,7 +16858,12 @@ int wc_ecc_oid_cache_init(void)
 {
     int ret = 0;
 #if !defined(SINGLE_THREADED) && !defined(WOLFSSL_MUTEX_INITIALIZER)
-    ret = wc_InitMutex(&ecc_oid_cache_lock);
+    if (eccOidLockInit == 0) {
+        ret = wc_InitMutex(&ecc_oid_cache_lock);
+        if (ret == 0) {
+            eccOidLockInit = 1;
+        }
+    }
 #endif
     return ret;
 }
@@ -16867,6 +16872,7 @@ void wc_ecc_oid_cache_free(void)
 {
 #if !defined(SINGLE_THREADED) && !defined(WOLFSSL_MUTEX_INITIALIZER)
     wc_FreeMutex(&ecc_oid_cache_lock);
+    eccOidLockInit = 0;
 #endif
 }
 #endif /* HAVE_OID_ENCODING */


### PR DESCRIPTION
# Description

`wc_ecc_oid_cache_init()` creates `ecc_oid_cache_lock` but never sets `eccOidLockInit`. The "sanity check if wolfCrypt_Init not called" fallback in `wc_ecc_get_oid()` therefore re-runs `wc_InitMutex()` on every call, from every thread, on a mutex others are already holding.

Threads either block indefinitely, or lose exclusion over the OID cache, where `o->oidSz` is briefly the buffer capacity rather than the OID length, so a valid key could returns `ASN_UNKNOWN_OID_E`.

Affects builds without `WOLFSSL_MUTEX_INITIALIZER`, i.e. anything not using pthreads.

# Testing

Tested and reproduced inside wolfcrypt-jni release cycle test scripts.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
