### PR TITLE
add cryptocb only flag for turning on support of all WOLF_CRYPTO_CB_ONLY_* flags

### DIFF
--- a/.github/workflows/cryptocb-only.yml
+++ b/.github/workflows/cryptocb-only.yml
@@ -133,6 +133,9 @@ jobs:
           {"name": "all", "minutes": 4.3,
            "comment": "All eight ONLY_* macros at once: every supported software primitive is stripped and dispatched through cryptocb. Catches any cross-algorithm call that a single-strip entry would still resolve via the remaining software paths.",
            "configure": ["CPPFLAGS=-DWOLF_CRYPTO_CB_ONLY_ECC -DWOLF_CRYPTO_CB_ONLY_RSA -DWOLF_CRYPTO_CB_ONLY_SHA256 -DWOLF_CRYPTO_CB_ONLY_SHA512 -DWOLF_CRYPTO_CB_ONLY_AES -DWOLF_CRYPTO_CB_ONLY_ED25519 -DWOLF_CRYPTO_CB_ONLY_CURVE25519 -DWOLF_CRYPTO_CB_ONLY_CURVE448"]}
+          {"name": "only",
+           "comment": "Same coverage as the \"all\" entry above, but driven by ./configure --enable-cryptocb=only instead of a hand-written CPPFLAGS list. This is the regression test for the configure option: it must emit exactly the WOLF_CRYPTO_CB_ONLY_* set that \"all\" passes by hand, for the algorithms this base enables. The \"all\" entry deliberately stays on explicit CPPFLAGS so a bug in the configure logic cannot silently weaken both. Note the base already passes --enable-cryptocb; this entry's flags are appended after the base, so --enable-cryptocb=only wins.",
+           "configure": ["--enable-cryptocb=only"]}
           ]}
           EOF
           .github/scripts/parallel-make-check.py \

--- a/.github/workflows/cryptocb-only.yml
+++ b/.github/workflows/cryptocb-only.yml
@@ -119,7 +119,10 @@ jobs:
            "configure": ["CPPFLAGS=-DWOLF_CRYPTO_CB_ONLY_CURVE25519"]},
           {"name": "all",
            "comment": "All seven ONLY_* macros at once: every supported software primitive is stripped and dispatched through cryptocb. Catches any cross-algorithm call that a single-strip entry would still resolve via the remaining software paths.",
-           "configure": ["CPPFLAGS=-DWOLF_CRYPTO_CB_ONLY_ECC -DWOLF_CRYPTO_CB_ONLY_RSA -DWOLF_CRYPTO_CB_ONLY_SHA256 -DWOLF_CRYPTO_CB_ONLY_SHA512 -DWOLF_CRYPTO_CB_ONLY_AES -DWOLF_CRYPTO_CB_ONLY_ED25519 -DWOLF_CRYPTO_CB_ONLY_CURVE25519"]}
+           "configure": ["CPPFLAGS=-DWOLF_CRYPTO_CB_ONLY_ECC -DWOLF_CRYPTO_CB_ONLY_RSA -DWOLF_CRYPTO_CB_ONLY_SHA256 -DWOLF_CRYPTO_CB_ONLY_SHA512 -DWOLF_CRYPTO_CB_ONLY_AES -DWOLF_CRYPTO_CB_ONLY_ED25519 -DWOLF_CRYPTO_CB_ONLY_CURVE25519"]},
+          {"name": "only",
+           "comment": "Same coverage as the \"all\" entry above, but driven by ./configure --enable-cryptocb=only instead of a hand-written CPPFLAGS list. This is the regression test for the configure option: it must emit exactly the WOLF_CRYPTO_CB_ONLY_* set that \"all\" passes by hand, for the algorithms this base enables. The \"all\" entry deliberately stays on explicit CPPFLAGS so a bug in the configure logic cannot silently weaken both. Note the base already passes --enable-cryptocb; this entry's flags are appended after the base, so --enable-cryptocb=only wins.",
+           "configure": ["--enable-cryptocb=only"]}
           ]}
           EOF
           .github/scripts/parallel-make-check.py \

--- a/.github/workflows/cryptocb-only.yml
+++ b/.github/workflows/cryptocb-only.yml
@@ -132,8 +132,8 @@ jobs:
            "configure": ["--disable-swdev", "--enable-cryptonly", "CPPFLAGS=-DWOLF_CRYPTO_CB_ONLY_CURVE448"]},
           {"name": "all", "minutes": 4.3,
            "comment": "All eight ONLY_* macros at once: every supported software primitive is stripped and dispatched through cryptocb. Catches any cross-algorithm call that a single-strip entry would still resolve via the remaining software paths.",
-           "configure": ["CPPFLAGS=-DWOLF_CRYPTO_CB_ONLY_ECC -DWOLF_CRYPTO_CB_ONLY_RSA -DWOLF_CRYPTO_CB_ONLY_SHA256 -DWOLF_CRYPTO_CB_ONLY_SHA512 -DWOLF_CRYPTO_CB_ONLY_AES -DWOLF_CRYPTO_CB_ONLY_ED25519 -DWOLF_CRYPTO_CB_ONLY_CURVE25519 -DWOLF_CRYPTO_CB_ONLY_CURVE448"]}
-          {"name": "only",
+           "configure": ["CPPFLAGS=-DWOLF_CRYPTO_CB_ONLY_ECC -DWOLF_CRYPTO_CB_ONLY_RSA -DWOLF_CRYPTO_CB_ONLY_SHA256 -DWOLF_CRYPTO_CB_ONLY_SHA512 -DWOLF_CRYPTO_CB_ONLY_AES -DWOLF_CRYPTO_CB_ONLY_ED25519 -DWOLF_CRYPTO_CB_ONLY_CURVE25519 -DWOLF_CRYPTO_CB_ONLY_CURVE448"]},
+          {"name": "only", "minutes": 4.0,
            "comment": "Same coverage as the \"all\" entry above, but driven by ./configure --enable-cryptocb=only instead of a hand-written CPPFLAGS list. This is the regression test for the configure option: it must emit exactly the WOLF_CRYPTO_CB_ONLY_* set that \"all\" passes by hand, for the algorithms this base enables. The \"all\" entry deliberately stays on explicit CPPFLAGS so a bug in the configure logic cannot silently weaken both. Note the base already passes --enable-cryptocb; this entry's flags are appended after the base, so --enable-cryptocb=only wins.",
            "configure": ["--enable-cryptocb=only"]}
           ]}

--- a/configure.ac
+++ b/configure.ac
@@ -11269,19 +11269,31 @@ AC_ARG_ENABLE([cryptodev],
 # Support for crypto callbacks
 AC_ARG_ENABLE([cryptocb],
     [AS_HELP_STRING([--enable-cryptocb],
-        [Enable crypto callbacks (default: disabled). Use 'no-default-devid' to enable without a platform-specific default device ID])],
-[
-    case "$enableval" in
+        [Enable crypto callbacks (default: disabled). Use 'only' to also strip the software implementation of every algorithm that has a crypto callback only mode, so all crypto operations are offloaded. Use 'no-default-devid' to enable without a platform-specific default device ID])],
+    [ ENABLED_CRYPTOCB=$enableval ],
+    [ ENABLED_CRYPTOCB=no ])
+
+ENABLED_CRYPTOCB_ONLY=no
+if test "$ENABLED_CRYPTOCB" != "no"
+then
+    for v in `echo $ENABLED_CRYPTOCB | tr "," " "`
+    do
+        case $v in
+        yes)
+            ;;
+        only)
+            ENABLED_CRYPTOCB_ONLY=yes
+            ;;
         no-default-devid)
-            ENABLED_CRYPTOCB=yes
             AM_CPPFLAGS="$AM_CPPFLAGS -DWC_NO_DEFAULT_DEVID"
             ;;
         *)
-            ENABLED_CRYPTOCB="$enableval"
-            ;;
-    esac
-],
-[ ENABLED_CRYPTOCB=no ])
+            AC_MSG_ERROR([Invalid cryptocb option. Valid are: yes, only, no-default-devid or no. Seen: $ENABLED_CRYPTOCB.])
+            break;;
+        esac
+    done
+    ENABLED_CRYPTOCB=yes
+fi
 
 # Enable testing of cryptoCb using software crypto. On platforms where wolfCrypt tests
 # are used to test a custom cryptoCb, it may be desired to disable this so wolfCrypt tests
@@ -11303,6 +11315,38 @@ fi
 if test "$ENABLED_CRYPTOCB" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB"
+fi
+
+# Crypto callback only: strip the software implementation of every algorithm
+# that has a crypto callback only mode, so all crypto operations are offloaded.
+# A flag is added only when its algorithm is enabled; the requirement and
+# conflict checks live in wolfssl/wolfcrypt/settings.h, not here.
+if test "$ENABLED_CRYPTOCB_ONLY" = "yes"
+then
+    if test "$ENABLED_SHA256" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_SHA256"
+    fi
+    if test "$ENABLED_SHA512" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_SHA512"
+    fi
+    if test "$ENABLED_AES" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_AES"
+    fi
+    if test "$ENABLED_RSA" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_RSA"
+    fi
+    if test "$ENABLED_ECC" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_ECC"
+    fi
+    if test "$ENABLED_ED25519" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_ED25519"
+    fi
+    if test "$ENABLED_CURVE25519" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_CURVE25519"
+    fi
+    if test "$ENABLED_FALCON" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_FALCON"
+    fi
 fi
 
 if test "$ENABLED_CRYPTOCB_SW_TEST" = "no"
@@ -13721,6 +13765,7 @@ echo "   * Linux KCAPI:                $ENABLED_KCAPI"
 echo "   * Linux devcrypto:            $ENABLED_DEVCRYPTO"
 echo "   * PK callbacks:               $ENABLED_PKCALLBACKS"
 echo "   * Crypto callbacks:           $ENABLED_CRYPTOCB"
+echo "   * Crypto callbacks only:      $ENABLED_CRYPTOCB_ONLY"
 echo "   * i.MX CAAM:                  $ENABLED_CAAM"
 echo "   * IoT-Safe:                   $ENABLED_IOTSAFE"
 echo "   * IoT-Safe HWRNG:             $ENABLED_IOTSAFE_HWRNG"

--- a/configure.ac
+++ b/configure.ac
@@ -11553,19 +11553,31 @@ AC_ARG_ENABLE([cryptodev],
 # Support for crypto callbacks
 AC_ARG_ENABLE([cryptocb],
     [AS_HELP_STRING([--enable-cryptocb],
-        [Enable crypto callbacks (default: disabled). Use 'no-default-devid' to enable without a platform-specific default device ID])],
-[
-    case "$enableval" in
+        [Enable crypto callbacks (default: disabled). Use 'only' to also strip the software implementation of every algorithm that has a crypto callback only mode, so all crypto operations are offloaded. Use 'no-default-devid' to enable without a platform-specific default device ID])],
+    [ ENABLED_CRYPTOCB=$enableval ],
+    [ ENABLED_CRYPTOCB=no ])
+
+ENABLED_CRYPTOCB_ONLY=no
+if test "$ENABLED_CRYPTOCB" != "no"
+then
+    for v in `echo $ENABLED_CRYPTOCB | tr "," " "`
+    do
+        case $v in
+        yes)
+            ;;
+        only)
+            ENABLED_CRYPTOCB_ONLY=yes
+            ;;
         no-default-devid)
-            ENABLED_CRYPTOCB=yes
             AM_CPPFLAGS="$AM_CPPFLAGS -DWC_NO_DEFAULT_DEVID"
             ;;
         *)
-            ENABLED_CRYPTOCB="$enableval"
-            ;;
-    esac
-],
-[ ENABLED_CRYPTOCB=no ])
+            AC_MSG_ERROR([Invalid cryptocb option. Valid are: yes, only, no-default-devid or no. Seen: $ENABLED_CRYPTOCB.])
+            break;;
+        esac
+    done
+    ENABLED_CRYPTOCB=yes
+fi
 
 # Enable testing of cryptoCb using software crypto. On platforms where wolfCrypt tests
 # are used to test a custom cryptoCb, it may be desired to disable this so wolfCrypt tests
@@ -11609,6 +11621,41 @@ fi
 if test "$ENABLED_CRYPTOCB" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB"
+fi
+
+# Crypto callback only: strip the software implementation of every algorithm
+# that has a crypto callback only mode, so all crypto operations are offloaded.
+# A flag is added only when its algorithm is enabled; the requirement and
+# conflict checks live in wolfssl/wolfcrypt/settings.h, not here.
+if test "$ENABLED_CRYPTOCB_ONLY" = "yes"
+then
+    if test "$ENABLED_SHA256" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_SHA256"
+    fi
+    if test "$ENABLED_SHA512" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_SHA512"
+    fi
+    if test "$ENABLED_AES" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_AES"
+    fi
+    if test "$ENABLED_RSA" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_RSA"
+    fi
+    if test "$ENABLED_ECC" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_ECC"
+    fi
+    if test "$ENABLED_ED25519" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_ED25519"
+    fi
+    if test "$ENABLED_CURVE25519" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_CURVE25519"
+    fi
+    if test "$ENABLED_CURVE448" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_CURVE448"
+    fi
+    if test "$ENABLED_FALCON" != "no"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB_ONLY_FALCON"
+    fi
 fi
 
 if test "$ENABLED_CRYPTOCB_SW_TEST" = "no"
@@ -14071,6 +14118,7 @@ echo "   * Linux KCAPI:                $ENABLED_KCAPI"
 echo "   * Linux devcrypto:            $ENABLED_DEVCRYPTO"
 echo "   * PK callbacks:               $ENABLED_PKCALLBACKS"
 echo "   * Crypto callbacks:           $ENABLED_CRYPTOCB"
+echo "   * Crypto callbacks only:      $ENABLED_CRYPTOCB_ONLY"
 echo "   * i.MX CAAM:                  $ENABLED_CAAM"
 echo "   * IoT-Safe:                   $ENABLED_IOTSAFE"
 echo "   * WISeKey/SealSQ VaultIC:     $ENABLED_VAULTIC"


### PR DESCRIPTION
Adds the flag --enable-cryptocb=only to turn on all WOLF_CRYPTO_CB_ONLY_* flags