### PR TITLE
tls13: reject zero length session ticket, and add test.

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -13630,6 +13630,10 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
     *inOutIdx += LENGTH_SZ;
     if ((*inOutIdx - begin) + length > size)
         return BUFFER_ERROR;
+    /* note: we reject zero length ticket here, and not in SetTicket(),
+     * because zero length is valid for TLS 1.2 */
+    if (length == 0)
+        return BUFFER_ERROR;
 
     if ((ret = SetTicket(ssl, input + *inOutIdx, length)) != 0)
         return ret;

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -7354,8 +7354,8 @@ int test_tls13_zero_length_session_ticket(void)
     byte rec[256];
     byte ticketMsg[18];
     int  recSz = 0;
-    size_t i = 0;
-    size_t idx = 0;
+    int  i = 0;
+    int  idx = 0;
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
     ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -7280,7 +7280,6 @@ int test_tls13_empty_record_limit(void)
  * (32 bytes) does not cause an unsigned integer underflow / OOB read in
  * SetTicket. Uses a full memio handshake, then injects a crafted
  * NewSessionTicket with a 5-byte ticket into the client's read path. */
-
 int test_tls13_short_session_ticket(void)
 {
     EXPECT_DECLS;
@@ -7341,6 +7340,74 @@ int test_tls13_short_session_ticket(void)
     return EXPECT_RESULT();
 }
 
+/* Test valid looking session ticket, but with zero length ticket.
+ *  */
+int test_tls13_zero_length_session_ticket(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)
+    struct test_memio_ctx test_ctx;
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    char buf[64];
+    byte rec[256];
+    byte ticketMsg[18];
+    int  recSz = 0;
+    size_t i = 0;
+    size_t idx = 0;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+                    wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+
+    /* Complete a TLS 1.3 handshake. The server will send a
+     * NewSessionTicket as part of post-handshake messages. */
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    /* Read on client to consume the server's NewSessionTicket. */
+    ExpectIntEQ(wolfSSL_read(ssl_c, buf, sizeof(buf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+
+    /* Encode a valid looking session ticket but with zero length. */
+    if (EXPECT_SUCCESS()) {
+        idx = 0;
+        ticketMsg[idx++] = session_ticket;            /* handshake msg type */
+        ticketMsg[idx++] = 0x00;                       /* 24-bit body length */
+        ticketMsg[idx++] = 0x00;
+        ticketMsg[idx++] = 0x0E;                       /* = 14 */
+        ticketMsg[idx++] = 0x00; ticketMsg[idx++] = 0x00; /* lifetime = 3600 */
+        ticketMsg[idx++] = 0x0E; ticketMsg[idx++] = 0x10;
+        ticketMsg[idx++] = 0x01; ticketMsg[idx++] = 0x02; /* ticket_age_add */
+        ticketMsg[idx++] = 0x03; ticketMsg[idx++] = 0x04;
+        ticketMsg[idx++] = 0x01;                       /* nonce length */
+        for (i = 0; i < 1; i++)
+            ticketMsg[idx++] = (byte)(0xA0 + i);       /* nonce */
+        ticketMsg[idx++] = 0x00; ticketMsg[idx++] = 0x00; /* ticket length=0 */
+        /* zero ticket data to add */
+        ticketMsg[idx++] = 0x00; ticketMsg[idx++] = 0x00; /* extensions: none */
+        ExpectIntEQ(idx, (int)sizeof(ticketMsg));
+    }
+
+    if (EXPECT_SUCCESS()) {
+        recSz = BuildTls13Message(ssl_s, rec, (int)sizeof(rec), ticketMsg,
+                                  idx, handshake, 0, 0, 0);
+        ExpectIntGT(recSz, 0);
+        ExpectIntEQ(test_memio_inject_message(&test_ctx, 1, (const char*)rec,
+                                              recSz), 0);
+    }
+
+    /* Read on client to consume the server's NewSessionTicket.
+     * The zero length ticket should return BUFFER_ERROR. */
+    ExpectIntEQ(wolfSSL_read(ssl_c, buf, sizeof(buf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), BUFFER_ERROR);
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
 
 #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
     defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -54,6 +54,7 @@ int test_tls13_pqc_hybrid_truncated_keyshare(void);
 int test_tls13_pqc_hybrid_malformed_ecdh(void);
 int test_tls13_empty_record_limit(void);
 int test_tls13_short_session_ticket(void);
+int test_tls13_zero_length_session_ticket(void);
 int test_tls13_new_session_ticket_max_lifetime(void);
 int test_tls13_fragmented_session_ticket(void);
 int test_tls13_early_data_0rtt_replay(void);
@@ -136,6 +137,7 @@ int test_tls13_pha_status_request(void);
     TEST_DECL_GROUP("tls13", test_tls13_pqc_hybrid_malformed_ecdh), \
     TEST_DECL_GROUP("tls13", test_tls13_empty_record_limit),    \
     TEST_DECL_GROUP("tls13", test_tls13_short_session_ticket),  \
+    TEST_DECL_GROUP("tls13", test_tls13_zero_length_session_ticket),  \
     TEST_DECL_GROUP("tls13", test_tls13_new_session_ticket_max_lifetime), \
     TEST_DECL_GROUP("tls13", test_tls13_fragmented_session_ticket), \
     TEST_DECL_GROUP("tls13", test_tls13_early_data_0rtt_replay), \


### PR DESCRIPTION
# Description

- `tls13.c`, `DoTls13NewSessionTicket`: reject a zero-length session ticket.

# Testing

Added unit test:
- `test_tls13_zero_length_session_ticket`

```sh
./configure --enable-tls13 --enable-session-ticket --enable-debug && make
./tests/unit.test -test_tls13_zero_length_session_ticket
```

