### PR TITLE
Fix UAF in DH buffers

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7624,6 +7624,58 @@ static int SetSSL_CTX_CertsAndKeys(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
 }
 #endif /* NO_CERTS */
 
+#ifndef NO_DH
+/* Give the SSL object its own copy of the context's DH parameters.
+ *
+ * The parameters are plain buffers with no reference count on them, so a
+ * session must not point at the context's: the context is free to replace
+ * them at any time. They are small and only present when the application
+ * asked for them, so a copy per session is the cheap way to keep them safe.
+ *
+ * @param [in, out] ssl  SSL object. Any parameters it owns are let go of.
+ * @param [in]      ctx  SSL context object.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+int CopySSL_CTX_DhParams(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
+{
+    byte* p;
+    byte* g;
+
+    if ((ctx->serverDH_P.buffer == NULL) || (ctx->serverDH_G.buffer == NULL)) {
+        return 0;
+    }
+
+    p = (byte*)XMALLOC(ctx->serverDH_P.length, ssl->heap,
+        DYNAMIC_TYPE_PUBLIC_KEY);
+    g = (byte*)XMALLOC(ctx->serverDH_G.length, ssl->heap,
+        DYNAMIC_TYPE_PUBLIC_KEY);
+    if ((p == NULL) || (g == NULL)) {
+        XFREE(p, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(g, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        return MEMORY_E;
+    }
+
+    /* Let go of any parameters this object already had. */
+    if (ssl->buffers.weOwnDH) {
+        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap,
+            DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap,
+            DYNAMIC_TYPE_PUBLIC_KEY);
+    }
+
+    XMEMCPY(p, ctx->serverDH_P.buffer, ctx->serverDH_P.length);
+    XMEMCPY(g, ctx->serverDH_G.buffer, ctx->serverDH_G.length);
+    ssl->buffers.serverDH_P.buffer = p;
+    ssl->buffers.serverDH_P.length = ctx->serverDH_P.length;
+    ssl->buffers.serverDH_G.buffer = g;
+    ssl->buffers.serverDH_G.length = ctx->serverDH_G.length;
+    ssl->buffers.weOwnDH = 1;
+
+    return 0;
+}
+#endif /* !NO_DH */
+
 int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 {
     int ret = WOLFSSL_SUCCESS; /* set default ret */
@@ -7812,8 +7864,9 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         !defined(HAVE_SELFTEST)
         ssl->options.dhKeyTested = ctx->dhKeyTested;
     #endif
-    ssl->buffers.serverDH_P = ctx->serverDH_P;
-    ssl->buffers.serverDH_G = ctx->serverDH_G;
+    if (CopySSL_CTX_DhParams(ssl, ctx) != 0) {
+        return MEMORY_E;
+    }
 #endif
 
 #if defined(HAVE_RPK)
@@ -9688,7 +9741,6 @@ void wolfSSL_ResourceFree(WOLFSSL* ssl)
     }
     XFREE(ssl->buffers.serverDH_Priv.buffer, ssl->heap, DYNAMIC_TYPE_PRIVATE_KEY);
     XFREE(ssl->buffers.serverDH_Pub.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    /* parameters (p,g) may be owned by ctx */
     if (ssl->buffers.weOwnDH) {
         XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
@@ -10077,11 +10129,15 @@ void FreeHandshakeResources(WOLFSSL* ssl)
     ssl->buffers.serverDH_Priv.buffer = NULL;
     XFREE(ssl->buffers.serverDH_Pub.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
     ssl->buffers.serverDH_Pub.buffer = NULL;
-    /* parameters (p,g) may be owned by ctx */
-    if (ssl->buffers.weOwnDH) {
-        XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+    /* A server keeps the parameters (p,g): a renegotiation or a reused object
+     * needs them again, and they are freed with the object. A client reads new
+     * ones from every ServerKeyExchange, so it lets them go here. */
+    if ((ssl->options.side == WOLFSSL_CLIENT_END) && ssl->buffers.weOwnDH) {
+        XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap,
+            DYNAMIC_TYPE_PUBLIC_KEY);
         ssl->buffers.serverDH_G.buffer = NULL;
-        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap,
+            DYNAMIC_TYPE_PUBLIC_KEY);
         ssl->buffers.serverDH_P.buffer = NULL;
     }
 #endif /* !NO_DH */

--- a/src/internal.c
+++ b/src/internal.c
@@ -7624,6 +7624,58 @@ static int SetSSL_CTX_CertsAndKeys(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
 }
 #endif /* NO_CERTS */
 
+#ifndef NO_DH
+/* Give the SSL object its own copy of the context's DH parameters.
+ *
+ * The parameters are plain buffers with no reference count on them, so a
+ * session must not point at the context's: the context is free to replace
+ * them at any time. They are small and only present when the application
+ * asked for them, so a copy per session is the cheap way to keep them safe.
+ *
+ * @param [in, out] ssl  SSL object. Any parameters it owns are let go of.
+ * @param [in]      ctx  SSL context object.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+int CopySSL_CTX_DhParams(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
+{
+    byte* p;
+    byte* g;
+
+    if ((ctx->serverDH_P.buffer == NULL) || (ctx->serverDH_G.buffer == NULL)) {
+        return 0;
+    }
+
+    p = (byte*)XMALLOC(ctx->serverDH_P.length, ssl->heap,
+        DYNAMIC_TYPE_PUBLIC_KEY);
+    g = (byte*)XMALLOC(ctx->serverDH_G.length, ssl->heap,
+        DYNAMIC_TYPE_PUBLIC_KEY);
+    if ((p == NULL) || (g == NULL)) {
+        XFREE(p, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(g, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        return MEMORY_E;
+    }
+
+    /* Let go of any parameters this object already had. */
+    if (ssl->buffers.weOwnDH) {
+        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap,
+            DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap,
+            DYNAMIC_TYPE_PUBLIC_KEY);
+    }
+
+    XMEMCPY(p, ctx->serverDH_P.buffer, ctx->serverDH_P.length);
+    XMEMCPY(g, ctx->serverDH_G.buffer, ctx->serverDH_G.length);
+    ssl->buffers.serverDH_P.buffer = p;
+    ssl->buffers.serverDH_P.length = ctx->serverDH_P.length;
+    ssl->buffers.serverDH_G.buffer = g;
+    ssl->buffers.serverDH_G.length = ctx->serverDH_G.length;
+    ssl->buffers.weOwnDH = 1;
+
+    return 0;
+}
+#endif /* !NO_DH */
+
 int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 {
     int ret = WOLFSSL_SUCCESS; /* set default ret */
@@ -7812,8 +7864,9 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         !defined(HAVE_SELFTEST)
         ssl->options.dhKeyTested = ctx->dhKeyTested;
     #endif
-    ssl->buffers.serverDH_P = ctx->serverDH_P;
-    ssl->buffers.serverDH_G = ctx->serverDH_G;
+    if (CopySSL_CTX_DhParams(ssl, ctx) != 0) {
+        return MEMORY_E;
+    }
 #endif
 
 #if defined(HAVE_RPK)
@@ -9688,7 +9741,6 @@ void wolfSSL_ResourceFree(WOLFSSL* ssl)
     }
     XFREE(ssl->buffers.serverDH_Priv.buffer, ssl->heap, DYNAMIC_TYPE_PRIVATE_KEY);
     XFREE(ssl->buffers.serverDH_Pub.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    /* parameters (p,g) may be owned by ctx */
     if (ssl->buffers.weOwnDH) {
         XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
@@ -10077,13 +10129,8 @@ void FreeHandshakeResources(WOLFSSL* ssl)
     ssl->buffers.serverDH_Priv.buffer = NULL;
     XFREE(ssl->buffers.serverDH_Pub.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
     ssl->buffers.serverDH_Pub.buffer = NULL;
-    /* parameters (p,g) may be owned by ctx */
-    if (ssl->buffers.weOwnDH) {
-        XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-        ssl->buffers.serverDH_G.buffer = NULL;
-        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-        ssl->buffers.serverDH_P.buffer = NULL;
-    }
+    /* The parameters (p,g) are kept: a renegotiation or a reused object needs
+     * them again, and they are freed with the object. */
 #endif /* !NO_DH */
 
 #if !defined(NO_CERTS) && !defined(OPENSSL_EXTRA) && \

--- a/src/internal.c
+++ b/src/internal.c
@@ -7630,7 +7630,8 @@ static int SetSSL_CTX_CertsAndKeys(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
  * The parameters are plain buffers with no reference count on them, so a
  * session must not point at the context's: the context is free to replace
  * them at any time. They are small and only present when the application
- * asked for them, so a copy per session is the cheap way to keep them safe.
+ * asked for them, so a copy is the cheap way to keep them safe. It is given
+ * back at the end of the handshake and taken again when next needed.
  *
  * @param [in, out] ssl  SSL object. Any parameters it owns are let go of.
  * @param [in]      ctx  SSL context object.
@@ -10129,10 +10130,9 @@ void FreeHandshakeResources(WOLFSSL* ssl)
     ssl->buffers.serverDH_Priv.buffer = NULL;
     XFREE(ssl->buffers.serverDH_Pub.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
     ssl->buffers.serverDH_Pub.buffer = NULL;
-    /* A server keeps the parameters (p,g): a renegotiation or a reused object
-     * needs them again, and they are freed with the object. A client reads new
-     * ones from every ServerKeyExchange, so it lets them go here. */
-    if ((ssl->options.side == WOLFSSL_CLIENT_END) && ssl->buffers.weOwnDH) {
+    /* Release the parameters (p,g) back here rather than hold them for
+     * the life of the connection. */
+    if (ssl->buffers.weOwnDH) {
         XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap,
             DYNAMIC_TYPE_PUBLIC_KEY);
         ssl->buffers.serverDH_G.buffer = NULL;
@@ -39030,6 +39030,14 @@ static int AddPSKtoPreMasterSecret(WOLFSSL* ssl)
 #endif
                     {
                         /* Allocate DH key buffers and generate key */
+                        if (ssl->buffers.serverDH_P.buffer == NULL ||
+                            ssl->buffers.serverDH_G.buffer == NULL) {
+                            /* Buffers freed at the end of the last handshake,
+                             * create a new copy from the context. */
+                            if (CopySSL_CTX_DhParams(ssl, ssl->ctx) != 0) {
+                                ERROR_OUT(MEMORY_E, exit_sske);
+                            }
+                        }
                         if (ssl->buffers.serverDH_P.buffer == NULL ||
                             ssl->buffers.serverDH_G.buffer == NULL) {
                             ERROR_OUT(NO_DH_PARAMS, exit_sske);

--- a/src/ssl_api_hs.c
+++ b/src/ssl_api_hs.c
@@ -1592,9 +1592,14 @@ void wolfSSL_set_accept_state(WOLFSSL* ssl)
 
         #ifndef NO_DH
         if ((!ssl->options.haveDH) && (ssl->ctx->haveDH)) {
-            ssl->buffers.serverDH_P = ssl->ctx->serverDH_P;
-            ssl->buffers.serverDH_G = ssl->ctx->serverDH_G;
-            ssl->options.haveDH = 1;
+            /* Nothing to return the failure through, so leave the object
+             * without DH rather than claim parameters it does not have. */
+            if (CopySSL_CTX_DhParams(ssl, ssl->ctx) == 0) {
+                ssl->options.haveDH = 1;
+            }
+            else {
+                WOLFSSL_MSG("Unable to copy DH parameters from context");
+            }
         }
         #endif
     }

--- a/tests/api/test_ssl_hs.c
+++ b/tests/api/test_ssl_hs.c
@@ -810,10 +810,19 @@ int test_wolfSSL_set_accept_state_reinit(void)
 
     wolfSSL_set_accept_state(ssl);
 
+    /* Picked up as the object's own copy, not the context's buffers. */
     if ((ssl != NULL) && (ctx != NULL)) {
         ExpectIntEQ(ssl->options.haveDH, 1);
-        ExpectPtrEq(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
-        ExpectPtrEq(ssl->buffers.serverDH_G.buffer, ctx->serverDH_G.buffer);
+        ExpectNotNull(ssl->buffers.serverDH_P.buffer);
+        ExpectNotNull(ssl->buffers.serverDH_G.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_G.buffer, ctx->serverDH_G.buffer);
+        ExpectIntEQ(ssl->buffers.serverDH_P.length, ctx->serverDH_P.length);
+        ExpectIntEQ(ssl->buffers.serverDH_G.length, ctx->serverDH_G.length);
+        ExpectBufEQ(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer,
+            ctx->serverDH_P.length);
+        ExpectBufEQ(ssl->buffers.serverDH_G.buffer, ctx->serverDH_G.buffer,
+            ctx->serverDH_G.length);
     }
 
     wolfSSL_free(ssl);
@@ -968,8 +977,8 @@ int test_wolfSSL_SSL_do_handshake_quic(void)
 /* Test that wolfSSL_set_connect_state() discards server DH parameters.
  *
  * A client generates its own DH parameters, so any server ones are dropped.
- * Parameters the object owns are freed; parameters merely borrowed from the
- * context are only unlinked, since the context still owns them.
+ * The object holds its own copy either way, whether set on it directly or
+ * taken from the context, so the context is left untouched.
  *
  * @return  TEST_SUCCESS on success.
  */
@@ -1016,7 +1025,7 @@ int test_wolfSSL_set_connect_state_dh(void)
     wolfSSL_CTX_free(ctx);
     ctx = NULL;
 
-    /* Parameters borrowed from the context are left for the context to free. */
+    /* Parameters taken from the context are a copy the object owns. */
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_server_method()));
     ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
         WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
@@ -1026,10 +1035,14 @@ int test_wolfSSL_set_connect_state_dh(void)
         WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
     ExpectNotNull(ssl = wolfSSL_new(ctx));
 
-    /* Inherited from the context, so not owned here. */
-    if (ssl != NULL) {
-        ExpectPtrEq(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
-        ExpectIntEQ(ssl->buffers.weOwnDH, 0);
+    /* Copied from the context, so owned here. */
+    if ((ssl != NULL) && (ctx != NULL)) {
+        ExpectNotNull(ssl->buffers.serverDH_P.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
+        ExpectIntEQ(ssl->buffers.serverDH_P.length, ctx->serverDH_P.length);
+        ExpectBufEQ(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer,
+            ctx->serverDH_P.length);
+        ExpectIntEQ(ssl->buffers.weOwnDH, 1);
     }
 
     wolfSSL_set_connect_state(ssl);
@@ -1044,11 +1057,266 @@ int test_wolfSSL_set_connect_state_dh(void)
         ExpectNotNull(ctx->serverDH_G.buffer);
     }
     ExpectNotNull(ssl2 = wolfSSL_new(ctx));
-    if (ssl2 != NULL) {
-        ExpectPtrEq(ssl2->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
+    if ((ssl2 != NULL) && (ctx != NULL)) {
+        ExpectNotNull(ssl2->buffers.serverDH_P.buffer);
+        ExpectPtrNE(ssl2->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
+        ExpectIntEQ(ssl2->buffers.serverDH_P.length, ctx->serverDH_P.length);
+        ExpectBufEQ(ssl2->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer,
+            ctx->serverDH_P.length);
     }
 
     wolfSSL_free(ssl2);
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* DH parameters taken from the context are the object's own copy, and they
+ * last as long as the object does.
+ *
+ * The copy is what lets the context replace its parameters while sessions are
+ * running. Since the session then holds the only copy it will ever have, the
+ * end of a handshake must not take it away: a reused object needs it again.
+ *
+ * @return  TEST_SUCCESS on success.
+ */
+int test_wolfSSL_dh_ctx_params_reuse(void)
+{
+    EXPECT_DECLS;
+/* Handing the object a second connection needs its certificate and key to
+ * outlast the first handshake, which only these builds arrange. */
+#if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)) && \
+    defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(BUILD_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256) && \
+    !defined(WOLFSSL_NO_TLS12) && !defined(NO_DH) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_WOLFSSL_CLIENT)
+    struct test_memio_ctx test_ctx;
+    WOLFSSL_CTX* ctx_c = NULL;
+    WOLFSSL_CTX* ctx_s = NULL;
+    WOLFSSL* ssl_c = NULL;
+    WOLFSSL* ssl_s = NULL;
+    const byte* startP = NULL;
+    const byte* startG = NULL;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    test_ctx.c_ciphers = test_ctx.s_ciphers = "DHE-RSA-AES128-GCM-SHA256";
+
+    /* The parameters go on the context before any session takes them. A
+     * context made here is used as-is, so it gets the credentials and the
+     * memio wiring that test_memio_setup would otherwise have given it. */
+    ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_2_server_method()));
+    ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_set_cipher_list(ctx_s, test_ctx.s_ciphers),
+        WOLFSSL_SUCCESS);
+    wolfSSL_SetIORecv(ctx_s, test_memio_read_cb);
+    wolfSSL_SetIOSend(ctx_s, test_memio_write_cb);
+    ExpectIntEQ(wolfSSL_CTX_SetTmpDH_file(ctx_s, dhParamFile, CERT_FILETYPE),
+        WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_2_client_method, wolfTLSv1_2_server_method), 0);
+
+    /* test_memio_setup puts its own parameters on the server session, which
+     * would stand in for the ones under test. Take a fresh session from the
+     * same context so the parameters really are the context's. */
+    wolfSSL_free(ssl_s);
+    ssl_s = NULL;
+    ExpectNotNull(ssl_s = wolfSSL_new(ctx_s));
+    wolfSSL_SetIOWriteCtx(ssl_s, &test_ctx);
+    wolfSSL_SetIOReadCtx(ssl_s, &test_ctx);
+
+    /* Its own copy, matching the context's but not the same buffers. */
+    if ((ssl_s != NULL) && (ctx_s != NULL)) {
+        ExpectNotNull(ssl_s->buffers.serverDH_P.buffer);
+        ExpectNotNull(ssl_s->buffers.serverDH_G.buffer);
+        ExpectPtrNE(ssl_s->buffers.serverDH_P.buffer, ctx_s->serverDH_P.buffer);
+        ExpectPtrNE(ssl_s->buffers.serverDH_G.buffer, ctx_s->serverDH_G.buffer);
+        ExpectIntEQ(ssl_s->buffers.serverDH_P.length, ctx_s->serverDH_P.length);
+        ExpectIntEQ(ssl_s->buffers.serverDH_G.length, ctx_s->serverDH_G.length);
+        ExpectBufEQ(ssl_s->buffers.serverDH_P.buffer, ctx_s->serverDH_P.buffer,
+            ctx_s->serverDH_P.length);
+        ExpectBufEQ(ssl_s->buffers.serverDH_G.buffer, ctx_s->serverDH_G.buffer,
+            ctx_s->serverDH_G.length);
+        ExpectIntEQ(ssl_s->buffers.weOwnDH, 1);
+        startP = ssl_s->buffers.serverDH_P.buffer;
+        startG = ssl_s->buffers.serverDH_G.buffer;
+    }
+
+    /* Offering no FFDHE group keeps the server on the parameters it was
+     * given, rather than switching to a named group and dropping them. A build
+     * without supported curves sends no groups at all, so there is nothing to
+     * narrow down. */
+#ifdef HAVE_SUPPORTED_CURVES
+    ExpectIntEQ(wolfSSL_UseSupportedCurve(ssl_c, WOLFSSL_ECC_SECP256R1),
+        WOLFSSL_SUCCESS);
+#endif
+
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+
+    /* The handshake used them and the cleanup after it left them alone. */
+    if (ssl_s != NULL) {
+        ExpectPtrEq(ssl_s->buffers.serverDH_P.buffer, startP);
+        ExpectPtrEq(ssl_s->buffers.serverDH_G.buffer, startG);
+    }
+
+    /* So the object can be handed a second connection. */
+    ExpectIntEQ(wolfSSL_clear(ssl_s), WOLFSSL_SUCCESS);
+    wolfSSL_free(ssl_c);
+    ssl_c = NULL;
+    ExpectNotNull(ssl_c = wolfSSL_new(ctx_c));
+    wolfSSL_SetIOWriteCtx(ssl_c, &test_ctx);
+    wolfSSL_SetIOReadCtx(ssl_c, &test_ctx);
+#ifdef HAVE_SUPPORTED_CURVES
+    ExpectIntEQ(wolfSSL_UseSupportedCurve(ssl_c, WOLFSSL_ECC_SECP256R1),
+        WOLFSSL_SUCCESS);
+#endif
+    test_memio_clear_buffer(&test_ctx, 0);
+    test_memio_clear_buffer(&test_ctx, 1);
+
+    /* The second handshake ran on the parameters the first one left behind. */
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    if (ssl_s != NULL) {
+        ExpectPtrEq(ssl_s->buffers.serverDH_P.buffer, startP);
+        ExpectPtrEq(ssl_s->buffers.serverDH_G.buffer, startG);
+    }
+
+    /* And the context still has its own to hand out. */
+    if (ctx_s != NULL) {
+        ExpectNotNull(ctx_s->serverDH_P.buffer);
+        ExpectNotNull(ctx_s->serverDH_G.buffer);
+    }
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
+
+
+#if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_EXTRA) || \
+     defined(WOLFSSL_WPAS_SMALL)) && \
+    !defined(NO_DH) && !defined(NO_RSA) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_CERTS) && !defined(NO_TLS) && !defined(WOLFSSL_NO_TLS12) && \
+    !defined(NO_WOLFSSL_CLIENT) && defined(USE_WOLFSSL_MEMORY) && \
+    !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_STATIC_MEMORY)
+#define TEST_DH_OOM
+
+/* Makes every allocation fail, so the DH copy is certain to run out of
+ * memory whichever allocations a build makes. */
+static int dhOomFailAll = 0;
+static int dhOomFailed = 0;
+
+#ifdef WOLFSSL_DEBUG_MEMORY
+static void* dhOomMalloc(size_t size, const char* func, unsigned int line)
+{
+    (void)func;
+    (void)line;
+#else
+static void* dhOomMalloc(size_t size)
+{
+#endif
+    if (dhOomFailAll) {
+        dhOomFailed = 1;
+        return NULL;
+    }
+    return malloc(size);
+}
+
+#ifdef WOLFSSL_DEBUG_MEMORY
+static void dhOomFree(void* ptr, const char* func, unsigned int line)
+{
+    (void)func;
+    (void)line;
+#else
+static void dhOomFree(void* ptr)
+{
+#endif
+    free(ptr);
+}
+
+#ifdef WOLFSSL_DEBUG_MEMORY
+static void* dhOomRealloc(void* ptr, size_t size, const char* func,
+    unsigned int line)
+{
+    (void)func;
+    (void)line;
+#else
+static void* dhOomRealloc(void* ptr, size_t size)
+{
+#endif
+    if (dhOomFailAll) {
+        dhOomFailed = 1;
+        return NULL;
+    }
+    return realloc(ptr, size);
+}
+#endif /* TEST_DH_OOM */
+
+/* Running out of memory while copying the context's DH parameters.
+ *
+ * wolfSSL_set_accept_state has nothing to report a failure through, so it
+ * must leave the object without DH rather than claim parameters it does not
+ * hold. Every allocation fails here rather than a chosen one: the call
+ * reaches the copy whatever else runs out of memory, and only the copy
+ * failing can leave haveDH clear.
+ *
+ * @return  TEST_SUCCESS on success.
+ */
+int test_wolfSSL_dh_ctx_params_oom(void)
+{
+    EXPECT_DECLS;
+#ifdef TEST_DH_OOM
+    wolfSSL_Malloc_cb  prevM = NULL;
+    wolfSSL_Free_cb    prevF = NULL;
+    wolfSSL_Realloc_cb prevR = NULL;
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+
+    /* The parameters reach the context after the object is made, so the
+     * object has none of its own to lose. */
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method()));
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+    ExpectIntEQ(wolfSSL_CTX_SetTmpDH_file(ctx, dhParamFile, CERT_FILETYPE),
+        WOLFSSL_SUCCESS);
+    if (ssl != NULL) {
+        ExpectIntEQ(ssl->options.haveDH, 0);
+        ExpectNull(ssl->buffers.serverDH_P.buffer);
+    }
+
+    ExpectIntEQ(wolfSSL_GetAllocators(&prevM, &prevF, &prevR), 0);
+    if (EXPECT_SUCCESS()) {
+        ExpectIntEQ(wolfSSL_SetAllocators(dhOomMalloc, dhOomFree,
+            dhOomRealloc), 0);
+        dhOomFailed = 0;
+        dhOomFailAll = 1;
+        wolfSSL_set_accept_state(ssl);
+        dhOomFailAll = 0;
+        (void)wolfSSL_SetAllocators(prevM, prevF, prevR);
+    }
+
+    ExpectIntEQ(dhOomFailed, 1);
+    if (ssl != NULL) {
+        ExpectIntEQ(ssl->options.haveDH, 0);
+        ExpectNull(ssl->buffers.serverDH_P.buffer);
+        ExpectNull(ssl->buffers.serverDH_G.buffer);
+    }
+    /* The context kept its own, so a later object still gets them. */
+    if (ctx != NULL) {
+        ExpectNotNull(ctx->serverDH_P.buffer);
+        ExpectNotNull(ctx->serverDH_G.buffer);
+    }
+
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
 #endif

--- a/tests/api/test_ssl_hs.c
+++ b/tests/api/test_ssl_hs.c
@@ -1072,12 +1072,12 @@ int test_wolfSSL_set_connect_state_dh(void)
     return EXPECT_RESULT();
 }
 
-/* DH parameters taken from the context are the object's own copy, and they
- * last as long as the object does.
+/* DH parameters taken from the context are the object's own copy, given back
+ * at the end of the handshake and taken again when next needed.
  *
  * The copy is what lets the context replace its parameters while sessions are
- * running. Since the session then holds the only copy it will ever have, the
- * end of a handshake must not take it away: a reused object needs it again.
+ * running. Holding it only for the handshake keeps the cost off connections
+ * that are established and idle.
  *
  * @return  TEST_SUCCESS on success.
  */
@@ -1097,8 +1097,6 @@ int test_wolfSSL_dh_ctx_params_reuse(void)
     WOLFSSL_CTX* ctx_s = NULL;
     WOLFSSL* ssl_c = NULL;
     WOLFSSL* ssl_s = NULL;
-    const byte* startP = NULL;
-    const byte* startG = NULL;
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
     test_ctx.c_ciphers = test_ctx.s_ciphers = "DHE-RSA-AES128-GCM-SHA256";
@@ -1143,8 +1141,6 @@ int test_wolfSSL_dh_ctx_params_reuse(void)
         ExpectBufEQ(ssl_s->buffers.serverDH_G.buffer, ctx_s->serverDH_G.buffer,
             ctx_s->serverDH_G.length);
         ExpectIntEQ(ssl_s->buffers.weOwnDH, 1);
-        startP = ssl_s->buffers.serverDH_P.buffer;
-        startG = ssl_s->buffers.serverDH_G.buffer;
     }
 
     /* Offering no FFDHE group keeps the server on the parameters it was
@@ -1158,10 +1154,14 @@ int test_wolfSSL_dh_ctx_params_reuse(void)
 
     ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
 
-    /* The handshake used them and the cleanup after it left them alone. */
+    /* The handshake ran on them and then gave them back. A build that may
+     * renegotiate holds on to every handshake resource, parameters included. */
     if (ssl_s != NULL) {
-        ExpectPtrEq(ssl_s->buffers.serverDH_P.buffer, startP);
-        ExpectPtrEq(ssl_s->buffers.serverDH_G.buffer, startG);
+        ExpectIntEQ(ssl_s->specs.kea, diffie_hellman_kea);
+#ifndef HAVE_SECURE_RENEGOTIATION
+        ExpectNull(ssl_s->buffers.serverDH_P.buffer);
+        ExpectNull(ssl_s->buffers.serverDH_G.buffer);
+#endif
     }
 
     /* So the object can be handed a second connection. */
@@ -1178,11 +1178,15 @@ int test_wolfSSL_dh_ctx_params_reuse(void)
     test_memio_clear_buffer(&test_ctx, 0);
     test_memio_clear_buffer(&test_ctx, 1);
 
-    /* The second handshake ran on the parameters the first one left behind. */
+    /* The second handshake took a fresh copy from the context. Without it
+     * there would be no parameters left to send and it would not complete. */
     ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
     if (ssl_s != NULL) {
-        ExpectPtrEq(ssl_s->buffers.serverDH_P.buffer, startP);
-        ExpectPtrEq(ssl_s->buffers.serverDH_G.buffer, startG);
+        ExpectIntEQ(ssl_s->specs.kea, diffie_hellman_kea);
+#ifndef HAVE_SECURE_RENEGOTIATION
+        ExpectNull(ssl_s->buffers.serverDH_P.buffer);
+        ExpectNull(ssl_s->buffers.serverDH_G.buffer);
+#endif
     }
 
     /* And the context still has its own to hand out. */

--- a/tests/api/test_ssl_hs.c
+++ b/tests/api/test_ssl_hs.c
@@ -810,10 +810,15 @@ int test_wolfSSL_set_accept_state_reinit(void)
 
     wolfSSL_set_accept_state(ssl);
 
+    /* Picked up as the object's own copy, not the context's buffers. */
     if ((ssl != NULL) && (ctx != NULL)) {
         ExpectIntEQ(ssl->options.haveDH, 1);
-        ExpectPtrEq(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
-        ExpectPtrEq(ssl->buffers.serverDH_G.buffer, ctx->serverDH_G.buffer);
+        ExpectNotNull(ssl->buffers.serverDH_P.buffer);
+        ExpectNotNull(ssl->buffers.serverDH_G.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_G.buffer, ctx->serverDH_G.buffer);
+        ExpectIntEQ(ssl->buffers.serverDH_P.length, ctx->serverDH_P.length);
+        ExpectIntEQ(ssl->buffers.serverDH_G.length, ctx->serverDH_G.length);
     }
 
     wolfSSL_free(ssl);
@@ -968,8 +973,8 @@ int test_wolfSSL_SSL_do_handshake_quic(void)
 /* Test that wolfSSL_set_connect_state() discards server DH parameters.
  *
  * A client generates its own DH parameters, so any server ones are dropped.
- * Parameters the object owns are freed; parameters merely borrowed from the
- * context are only unlinked, since the context still owns them.
+ * The object holds its own copy either way, whether set on it directly or
+ * taken from the context, so the context is left untouched.
  *
  * @return  TEST_SUCCESS on success.
  */
@@ -1016,7 +1021,7 @@ int test_wolfSSL_set_connect_state_dh(void)
     wolfSSL_CTX_free(ctx);
     ctx = NULL;
 
-    /* Parameters borrowed from the context are left for the context to free. */
+    /* Parameters taken from the context are a copy the object owns. */
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_server_method()));
     ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
         WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
@@ -1026,10 +1031,11 @@ int test_wolfSSL_set_connect_state_dh(void)
         WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
     ExpectNotNull(ssl = wolfSSL_new(ctx));
 
-    /* Inherited from the context, so not owned here. */
-    if (ssl != NULL) {
-        ExpectPtrEq(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
-        ExpectIntEQ(ssl->buffers.weOwnDH, 0);
+    /* Copied from the context, so owned here. */
+    if ((ssl != NULL) && (ctx != NULL)) {
+        ExpectNotNull(ssl->buffers.serverDH_P.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
+        ExpectIntEQ(ssl->buffers.weOwnDH, 1);
     }
 
     wolfSSL_set_connect_state(ssl);
@@ -1044,13 +1050,123 @@ int test_wolfSSL_set_connect_state_dh(void)
         ExpectNotNull(ctx->serverDH_G.buffer);
     }
     ExpectNotNull(ssl2 = wolfSSL_new(ctx));
-    if (ssl2 != NULL) {
-        ExpectPtrEq(ssl2->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
+    if ((ssl2 != NULL) && (ctx != NULL)) {
+        ExpectNotNull(ssl2->buffers.serverDH_P.buffer);
+        ExpectPtrNE(ssl2->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
     }
 
     wolfSSL_free(ssl2);
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* DH parameters taken from the context are the object's own copy, and they
+ * last as long as the object does.
+ *
+ * The copy is what lets the context replace its parameters while sessions are
+ * running. Since the session then holds the only copy it will ever have, the
+ * end of a handshake must not take it away: a reused object needs it again.
+ *
+ * @return  TEST_SUCCESS on success.
+ */
+int test_wolfSSL_dh_ctx_params_reuse(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(BUILD_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256) && \
+    !defined(WOLFSSL_NO_TLS12) && !defined(NO_DH) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_WOLFSSL_CLIENT)
+    struct test_memio_ctx test_ctx;
+    WOLFSSL_CTX* ctx_c = NULL;
+    WOLFSSL_CTX* ctx_s = NULL;
+    WOLFSSL* ssl_c = NULL;
+    WOLFSSL* ssl_s = NULL;
+    const byte* startP = NULL;
+    const byte* startG = NULL;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    test_ctx.c_ciphers = test_ctx.s_ciphers = "DHE-RSA-AES128-GCM-SHA256";
+
+    /* The parameters go on the context before any session takes them. A
+     * context made here is used as-is, so it gets the credentials and the
+     * memio wiring that test_memio_setup would otherwise have given it. */
+    ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_2_server_method()));
+    ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile,
+        WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile,
+        WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_set_cipher_list(ctx_s, test_ctx.s_ciphers),
+        WOLFSSL_SUCCESS);
+    wolfSSL_SetIORecv(ctx_s, test_memio_read_cb);
+    wolfSSL_SetIOSend(ctx_s, test_memio_write_cb);
+    ExpectIntEQ(wolfSSL_CTX_SetTmpDH_file(ctx_s, dhParamFile,
+        WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_2_client_method, wolfTLSv1_2_server_method), 0);
+
+    /* test_memio_setup puts its own parameters on the server session, which
+     * would stand in for the ones under test. Take a fresh session from the
+     * same context so the parameters really are the context's. */
+    wolfSSL_free(ssl_s);
+    ssl_s = NULL;
+    ExpectNotNull(ssl_s = wolfSSL_new(ctx_s));
+    wolfSSL_SetIOWriteCtx(ssl_s, &test_ctx);
+    wolfSSL_SetIOReadCtx(ssl_s, &test_ctx);
+
+    /* Its own copy, matching the context's but not the same buffers. */
+    if ((ssl_s != NULL) && (ctx_s != NULL)) {
+        ExpectNotNull(ssl_s->buffers.serverDH_P.buffer);
+        ExpectNotNull(ssl_s->buffers.serverDH_G.buffer);
+        ExpectPtrNE(ssl_s->buffers.serverDH_P.buffer, ctx_s->serverDH_P.buffer);
+        ExpectPtrNE(ssl_s->buffers.serverDH_G.buffer, ctx_s->serverDH_G.buffer);
+        ExpectIntEQ(ssl_s->buffers.serverDH_P.length, ctx_s->serverDH_P.length);
+        ExpectIntEQ(ssl_s->buffers.serverDH_G.length, ctx_s->serverDH_G.length);
+        ExpectIntEQ(ssl_s->buffers.weOwnDH, 1);
+        startP = ssl_s->buffers.serverDH_P.buffer;
+        startG = ssl_s->buffers.serverDH_G.buffer;
+    }
+
+    /* Offering no FFDHE group keeps the server on the parameters it was
+     * given, rather than switching to a named group and dropping them. */
+    ExpectIntEQ(wolfSSL_UseSupportedCurve(ssl_c, WOLFSSL_ECC_SECP256R1),
+        WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+
+    /* The handshake used them and the cleanup after it left them alone. */
+    if (ssl_s != NULL) {
+        ExpectPtrEq(ssl_s->buffers.serverDH_P.buffer, startP);
+        ExpectPtrEq(ssl_s->buffers.serverDH_G.buffer, startG);
+    }
+
+    /* So the object can be handed a second connection. */
+    ExpectIntEQ(wolfSSL_clear(ssl_s), WOLFSSL_SUCCESS);
+    wolfSSL_free(ssl_c);
+    ssl_c = NULL;
+    ExpectNotNull(ssl_c = wolfSSL_new(ctx_c));
+    wolfSSL_SetIOWriteCtx(ssl_c, &test_ctx);
+    wolfSSL_SetIOReadCtx(ssl_c, &test_ctx);
+    ExpectIntEQ(wolfSSL_UseSupportedCurve(ssl_c, WOLFSSL_ECC_SECP256R1),
+        WOLFSSL_SUCCESS);
+    test_ctx.c_len = test_ctx.s_len = 0;
+
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    ExpectIntNE(wolfSSL_get_error(ssl_s, 0), WC_NO_ERR_TRACE(NO_DH_PARAMS));
+
+    /* And the context still has its own to hand out. */
+    if (ctx_s != NULL) {
+        ExpectNotNull(ctx_s->serverDH_P.buffer);
+        ExpectNotNull(ctx_s->serverDH_G.buffer);
+    }
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_ssl_hs.h
+++ b/tests/api/test_ssl_hs.h
@@ -37,6 +37,7 @@ int test_wolfSSL_set_accept_state_static_ecc(void);
 int test_wolfSSL_negotiate_bad_args(void);
 int test_wolfSSL_SSL_do_handshake_quic(void);
 int test_wolfSSL_set_connect_state_dh(void);
+int test_wolfSSL_dh_ctx_params_reuse(void);
 int test_wolfSSL_connect_bad_args(void);
 int test_wolfSSL_accept_bad_args(void);
 int test_wolfSSL_connect_step_failures(void);
@@ -62,6 +63,7 @@ int test_wolfSSL_hs_info_cb(void);
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_negotiate_bad_args),            \
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_SSL_do_handshake_quic),         \
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_set_connect_state_dh),          \
+        TEST_DECL_GROUP("ssl_hs", test_wolfSSL_dh_ctx_params_reuse),           \
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_connect_bad_args),              \
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_accept_bad_args),               \
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_connect_step_failures),         \

--- a/tests/api/test_ssl_hs.h
+++ b/tests/api/test_ssl_hs.h
@@ -37,6 +37,8 @@ int test_wolfSSL_set_accept_state_static_ecc(void);
 int test_wolfSSL_negotiate_bad_args(void);
 int test_wolfSSL_SSL_do_handshake_quic(void);
 int test_wolfSSL_set_connect_state_dh(void);
+int test_wolfSSL_dh_ctx_params_reuse(void);
+int test_wolfSSL_dh_ctx_params_oom(void);
 int test_wolfSSL_connect_bad_args(void);
 int test_wolfSSL_accept_bad_args(void);
 int test_wolfSSL_connect_step_failures(void);
@@ -62,6 +64,8 @@ int test_wolfSSL_hs_info_cb(void);
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_negotiate_bad_args),            \
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_SSL_do_handshake_quic),         \
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_set_connect_state_dh),          \
+        TEST_DECL_GROUP("ssl_hs", test_wolfSSL_dh_ctx_params_reuse),           \
+        TEST_DECL_GROUP("ssl_hs", test_wolfSSL_dh_ctx_params_oom),             \
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_connect_bad_args),              \
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_accept_bad_args),               \
         TEST_DECL_GROUP("ssl_hs", test_wolfSSL_connect_step_failures),         \

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -3909,6 +3909,121 @@ int test_tls13_pha(void)
     return EXPECT_RESULT();
 }
 
+
+/* DH parameters are not reference counted, so each session takes its own copy
+ * of them and the context is free to replace its own at any time. */
+int test_tls13_ctx_dh_rotation(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && !defined(NO_DH) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && \
+    !defined(NO_WOLFSSL_SERVER)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    const byte* startP = NULL;
+    const byte* startG = NULL;
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_SetTmpDH_file(ctx, dhParamFile, CERT_FILETYPE),
+        WOLFSSL_SUCCESS);
+
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+    if ((ssl != NULL) && (ctx != NULL)) {
+        /* The session took its own copy of the parameters. */
+        ExpectPtrNE(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_G.buffer, ctx->serverDH_G.buffer);
+        ExpectIntEQ(ssl->buffers.serverDH_P.length, ctx->serverDH_P.length);
+        ExpectIntEQ(ssl->buffers.serverDH_G.length, ctx->serverDH_G.length);
+        ExpectBufEQ(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer,
+            ctx->serverDH_P.length);
+        ExpectBufEQ(ssl->buffers.serverDH_G.buffer, ctx->serverDH_G.buffer,
+            ctx->serverDH_G.length);
+        startP = ssl->buffers.serverDH_P.buffer;
+        startG = ssl->buffers.serverDH_G.buffer;
+    }
+
+    /* Replacing them on the context while the session is alive is allowed and
+     * leaves the session's copy where it was. */
+    ExpectIntEQ(wolfSSL_CTX_SetTmpDH_file(ctx, dhParamFile, CERT_FILETYPE),
+        WOLFSSL_SUCCESS);
+    if (ssl != NULL) {
+        ExpectPtrEq(ssl->buffers.serverDH_P.buffer, startP);
+        ExpectPtrEq(ssl->buffers.serverDH_G.buffer, startG);
+        ExpectNotNull(ssl->buffers.serverDH_P.buffer);
+        ExpectNotNull(ssl->buffers.serverDH_G.buffer);
+    }
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
+
+/* A context that gains DH parameters after a session already exists hands the
+ * session its own copy when the session is turned into a server. */
+int test_tls13_accept_state_dh_copy(void)
+{
+    EXPECT_DECLS;
+#if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_EXTRA) || \
+     defined(WOLFSSL_WPAS_SMALL)) && \
+    defined(WOLFSSL_TLS13) && !defined(NO_DH) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && \
+    !defined(NO_WOLFSSL_CLIENT)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    const byte* startP = NULL;
+
+    /* Starts as a client, so that set_accept_state has a side to switch. */
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+
+    /* The session is made before the context has any parameters. */
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+    if (ssl != NULL) {
+        ExpectNull(ssl->buffers.serverDH_P.buffer);
+    }
+
+    ExpectIntEQ(wolfSSL_CTX_SetTmpDH_file(ctx, dhParamFile, CERT_FILETYPE),
+        WOLFSSL_SUCCESS);
+    wolfSSL_set_accept_state(ssl);
+
+    /* It picked them up, as its own copy rather than the context's. */
+    if ((ssl != NULL) && (ctx != NULL)) {
+        ExpectNotNull(ssl->buffers.serverDH_P.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_G.buffer, ctx->serverDH_G.buffer);
+        ExpectIntEQ(ssl->buffers.serverDH_P.length, ctx->serverDH_P.length);
+        ExpectIntEQ(ssl->buffers.serverDH_G.length, ctx->serverDH_G.length);
+        ExpectBufEQ(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer,
+            ctx->serverDH_P.length);
+        ExpectBufEQ(ssl->buffers.serverDH_G.buffer, ctx->serverDH_G.buffer,
+            ctx->serverDH_G.length);
+        startP = ssl->buffers.serverDH_P.buffer;
+    }
+
+    /* So the context may still replace its own. */
+    ExpectIntEQ(wolfSSL_CTX_SetTmpDH_file(ctx, dhParamFile, CERT_FILETYPE),
+        WOLFSSL_SUCCESS);
+    if (ssl != NULL) {
+        ExpectPtrEq(ssl->buffers.serverDH_P.buffer, startP);
+        ExpectNotNull(ssl->buffers.serverDH_P.buffer);
+    }
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
+
 #if defined(HAVE_RPK) && defined(WOLFSSL_TLS13) && \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
     !defined(NO_SHA256)

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -3909,6 +3909,110 @@ int test_tls13_pha(void)
     return EXPECT_RESULT();
 }
 
+
+/* DH parameters are not reference counted, so each session takes its own copy
+ * of them and the context is free to replace its own at any time. */
+int test_tls13_ctx_dh_rotation(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && !defined(NO_DH) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_SERVER)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    const byte* startP = NULL;
+    const byte* startG = NULL;
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_SetTmpDH_file(ctx, dhParamFile, CERT_FILETYPE),
+        WOLFSSL_SUCCESS);
+
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+    if ((ssl != NULL) && (ctx != NULL)) {
+        /* The session took its own copy of the parameters. */
+        ExpectPtrNE(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_G.buffer, ctx->serverDH_G.buffer);
+        ExpectIntEQ(ssl->buffers.serverDH_P.length, ctx->serverDH_P.length);
+        ExpectIntEQ(ssl->buffers.serverDH_G.length, ctx->serverDH_G.length);
+        startP = ssl->buffers.serverDH_P.buffer;
+        startG = ssl->buffers.serverDH_G.buffer;
+    }
+
+    /* Replacing them on the context while the session is alive is allowed and
+     * leaves the session's copy where it was. */
+    ExpectIntEQ(wolfSSL_CTX_SetTmpDH_file(ctx, dhParamFile, CERT_FILETYPE),
+        WOLFSSL_SUCCESS);
+    if (ssl != NULL) {
+        ExpectPtrEq(ssl->buffers.serverDH_P.buffer, startP);
+        ExpectPtrEq(ssl->buffers.serverDH_G.buffer, startG);
+        ExpectNotNull(ssl->buffers.serverDH_P.buffer);
+        ExpectNotNull(ssl->buffers.serverDH_G.buffer);
+    }
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
+
+/* A context that gains DH parameters after a session already exists hands the
+ * session its own copy when the session is turned into a server. */
+int test_tls13_accept_state_dh_copy(void)
+{
+    EXPECT_DECLS;
+#if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_EXTRA) || \
+     defined(WOLFSSL_WPAS_SMALL)) && \
+    defined(WOLFSSL_TLS13) && !defined(NO_DH) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_CLIENT)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    const byte* startP = NULL;
+
+    /* Starts as a client, so that set_accept_state has a side to switch. */
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+        CERT_FILETYPE), WOLFSSL_SUCCESS);
+
+    /* The session is made before the context has any parameters. */
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+    if (ssl != NULL) {
+        ExpectNull(ssl->buffers.serverDH_P.buffer);
+    }
+
+    ExpectIntEQ(wolfSSL_CTX_SetTmpDH_file(ctx, dhParamFile, CERT_FILETYPE),
+        WOLFSSL_SUCCESS);
+    wolfSSL_set_accept_state(ssl);
+
+    /* It picked them up, as its own copy rather than the context's. */
+    if ((ssl != NULL) && (ctx != NULL)) {
+        ExpectNotNull(ssl->buffers.serverDH_P.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_P.buffer, ctx->serverDH_P.buffer);
+        ExpectPtrNE(ssl->buffers.serverDH_G.buffer, ctx->serverDH_G.buffer);
+        ExpectIntEQ(ssl->buffers.serverDH_P.length, ctx->serverDH_P.length);
+        startP = ssl->buffers.serverDH_P.buffer;
+    }
+
+    /* So the context may still replace its own. */
+    ExpectIntEQ(wolfSSL_CTX_SetTmpDH_file(ctx, dhParamFile, CERT_FILETYPE),
+        WOLFSSL_SUCCESS);
+    if (ssl != NULL) {
+        ExpectPtrEq(ssl->buffers.serverDH_P.buffer, startP);
+        ExpectNotNull(ssl->buffers.serverDH_P.buffer);
+    }
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
+
 #if defined(HAVE_RPK) && defined(WOLFSSL_TLS13) && \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
     !defined(NO_SHA256)

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -30,6 +30,8 @@ int test_tls13_bad_psk_binder(void);
 int test_tls13_rpk_handshake(void);
 int test_tls13_rpk_handshake_no_negotiation(void);
 int test_tls13_pha(void);
+int test_tls13_ctx_dh_rotation(void);
+int test_tls13_accept_state_dh_copy(void);
 int test_tls13_rpk_untrusted(void);
 int test_tls13_rpk_trust(void);
 int test_tls13_pq_groups(void);
@@ -114,6 +116,8 @@ int test_tls13_pha_status_request(void);
     TEST_DECL_GROUP("tls13", test_tls13_rpk_handshake),         \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_handshake_no_negotiation), \
     TEST_DECL_GROUP("tls13", test_tls13_pha),                   \
+    TEST_DECL_GROUP("tls13", test_tls13_ctx_dh_rotation),       \
+    TEST_DECL_GROUP("tls13", test_tls13_accept_state_dh_copy),  \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_untrusted),         \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_trust),             \
     TEST_DECL_GROUP("tls13", test_tls13_pq_groups),             \

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5325,6 +5325,12 @@ typedef struct Buffers {
 #endif
 } Buffers;
 
+#ifndef NO_DH
+/* Give the SSL object its own copy of the context's DH parameters. They are
+ * not reference counted, so a session must not point at the context's. */
+WOLFSSL_LOCAL int CopySSL_CTX_DhParams(WOLFSSL* ssl, WOLFSSL_CTX* ctx);
+#endif
+
 /* sub-states for send/do key share (key exchange) */
 enum asyncState {
     TLS_ASYNC_BEGIN = 0,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5258,8 +5258,10 @@ typedef struct Buffers {
 #endif
     byte            weOwnDH;               /* SSL own dh (p,g)  flag */
 #ifndef NO_DH
-    buffer          serverDH_P;            /* WOLFSSL_CTX owns, unless we own */
-    buffer          serverDH_G;            /* WOLFSSL_CTX owns, unless we own */
+    /* SSL owns p and g when weOwnDH is set. Otherwise they point at the
+     * static parameters of a named group, which nothing owns. */
+    buffer          serverDH_P;
+    buffer          serverDH_G;
     buffer          serverDH_Pub;
     buffer          serverDH_Priv;
     DhKey*          serverDH_Key;
@@ -5324,6 +5326,12 @@ typedef struct Buffers {
     buffer          certVerifyMsg;
 #endif
 } Buffers;
+
+#ifndef NO_DH
+/* Give the SSL object its own copy of the context's DH parameters. They are
+ * not reference counted, so a session must not point at the context's. */
+WOLFSSL_LOCAL int CopySSL_CTX_DhParams(WOLFSSL* ssl, WOLFSSL_CTX* ctx);
+#endif
 
 /* sub-states for send/do key share (key exchange) */
 enum asyncState {


### PR DESCRIPTION
# Description

Fixes the case where `SetSSL_CTX` aliases the `serverDH_P` and `serverDH_G` buffers with `weOwnDH` still at 0. A subsequent call to `wolfSSL_CTX_SetTmpDH*` would result in a dangling pointer.

Related to #11109, but with DH buffers. Note that refcounting is not performed here since the API uses plain byte buffers instead of structs/objects.

`weOwnDH == 0` currently means either "CTX heap buffer" or "static named-group params" today. After this change, it only means the static case which removes ambiguity in the free paths.

# Testing

Added unit tests.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
