### PR TITLE
asn.c: guard empty otherName copy to avoid NULL memcpy (UBSan)

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -14981,7 +14981,9 @@ static int SetDNSEntry(void* heap, DNS_entry* pool, word32* poolUsed,
         /* Set tag type, name length, name and NUL terminate name. */
         dnsEntry->type = type;
         dnsEntry->len = strLen;
-        XMEMCPY(dnsEntry_name, str, (size_t)strLen);
+        if (str != NULL && strLen > 0) {
+            XMEMCPY(dnsEntry_name, str, (size_t)strLen);
+        }
         dnsEntry_name[strLen] = '\0';
 
 #ifdef WOLFSSL_RID_ALT_NAME


### PR DESCRIPTION
When a subjectAltName otherName has an empty value, SetDNSEntry() called XMEMCPY(dst, NULL, 0). Passing NULL to memcpy is undefined behavior and aborts under UBSan. Skip the copy unless there is real data to copy.