### PR TITLE
Bsdkm cleanup

### DIFF
--- a/bsdkm/bsdkm_wc_port.h
+++ b/bsdkm/bsdkm_wc_port.h
@@ -63,10 +63,11 @@ static inline time_t wolfkmod_time(time_t * tloc) {
 
 /* str and char utility functions */
 #define XATOI(s) ({                                                          \
-      char * endptr = NULL;                                                  \
-      long   _xatoi_ret = strtol(s, &endptr, 10);                            \
-      if ((s) == endptr || *endptr != '\0') {                                \
-        _xatoi_ret = 0;                                                      \
+      const char * _str = (s);                                               \
+      char *       _endptr = NULL;                                           \
+      long         _xatoi_ret = strtol(_str, &_endptr, 10);                  \
+      if ((_str) == _endptr || *_endptr != '\0') {                           \
+          _xatoi_ret = 0;                                                    \
       }                                                                      \
       (int)_xatoi_ret;                                                       \
 })

--- a/bsdkm/bsdkm_wc_port.h
+++ b/bsdkm/bsdkm_wc_port.h
@@ -80,27 +80,53 @@ static inline time_t wolfkmod_time(time_t * tloc) {
 extern struct malloc_type M_WOLFSSL[1];
 
 #if defined(WOLFSSL_BSDKM_MEMORY_DEBUG)
-    #define XMALLOC(s, h, t) ({                                              \
-        (void)(h); (void)(t);                                                \
-        size_t _sz = (size_t)(s);                                            \
-        int _wait_flag = curthread->td_critnest == 0 ? M_WAITOK : M_NOWAIT;  \
-        void * _ptr = malloc(_sz, M_WOLFSSL, _wait_flag | M_ZERO);           \
-        printf("info: malloc: %p, M_WOLFSSL, %zu\n", _ptr, _sz);             \
-        (void *)_ptr;                                                        \
-    })
+    #if defined(BSDKM_CRYPTO_REGISTER)
+        /* cryptodev work functions must not sleep.see man CRYPTO_DRIVER(9) */
+        #define XMALLOC(s, h, t) ({                                          \
+            (void)(h); (void)(t);                                            \
+            size_t _sz; void * _ptr;                                         \
+            _sz = (size_t)(s);                                               \
+            _ptr = malloc(_sz, M_WOLFSSL, M_NOWAIT | M_ZERO);                \
+            printf("info: malloc: %p, M_WOLFSSL, %zu, 0x%02x\n", _ptr, _sz,  \
+                   M_NOWAIT | M_ZERO);                                       \
+            (void *)_ptr;                                                    \
+        })
+    #else
+        #define XMALLOC(s, h, t) ({                                          \
+            (void)(h); (void)(t);                                            \
+            size_t _sz; int _wait_flag; void * _ptr;                         \
+            _sz = (size_t)(s);                                               \
+            _wait_flag = curthread->td_critnest == 0 ? M_WAITOK : M_NOWAIT;  \
+            _ptr = malloc(_sz, M_WOLFSSL, _wait_flag | M_ZERO);              \
+            printf("info: malloc: %p, M_WOLFSSL, %zu, 0x%02x\n", _ptr, _sz,  \
+                   _wait_flag);                                              \
+            (void *)_ptr;                                                    \
+        })
+    #endif /* BSDKM_CRYPTO_REGISTER */
 
-    #define XFREE(p, h, t) ({                                                \
-        void* _xp; (void)(h); (void)(t); _xp = (p);                          \
-        printf("info: free: %p, M_WOLFSSL\n", _xp);                          \
-        if(_xp) free(_xp, M_WOLFSSL);                                        \
+    #define XFREE(p, h, t) ({                                            \
+        void* _xp; (void)(h); (void)(t); _xp = (p);                      \
+        printf("info: free: %p, M_WOLFSSL\n", _xp);                      \
+        if(_xp) free(_xp, M_WOLFSSL);                                    \
     })
 #else
-    #define XMALLOC(s, h, t) ({                                              \
-        (void)(h); (void)(t);                                                \
-        int _wait_flag = curthread->td_critnest == 0 ? M_WAITOK : M_NOWAIT;  \
-        void * _ptr = malloc((s), M_WOLFSSL, _wait_flag | M_ZERO);           \
-        (void *)_ptr;                                                        \
-    })
+    #if defined(BSDKM_CRYPTO_REGISTER)
+        /* cryptodev work functions must not sleep.see man CRYPTO_DRIVER(9) */
+        #define XMALLOC(s, h, t) ({                                          \
+            (void)(h); (void)(t);                                            \
+            void * _ptr;                                                     \
+            _ptr = malloc((s), M_WOLFSSL, M_NOWAIT | M_ZERO);                \
+            (void *)_ptr;                                                    \
+        })
+    #else
+        #define XMALLOC(s, h, t) ({                                          \
+            (void)(h); (void)(t);                                            \
+            int _wait_flag; void * _ptr;                                     \
+            _wait_flag = curthread->td_critnest == 0 ? M_WAITOK : M_NOWAIT;  \
+            _ptr = malloc((s), M_WOLFSSL, _wait_flag | M_ZERO);              \
+            (void *)_ptr;                                                    \
+        })
+    #endif /* BSDKM_CRYPTO_REGISTER */
 
     #define XFREE(p, h, t) ({                                                \
         void* _xp; (void)(h); (void)(t); _xp = (p);                          \

--- a/bsdkm/wolfkmod.c
+++ b/bsdkm/wolfkmod.c
@@ -383,16 +383,19 @@ static void km_AesFree(Aes * aes) {
     #endif
 }
 
-static void wolfkdriv_aes_ctx_clear(km_aes_ctx * ctx)
+/* clean up allocated km_aes_ctx struct.
+ *   - cbc allocates both encrypt and decrypt, and frees both.
+ *   - gcm uses only aes_encrypt.
+ * */
+static void wolfkdriv_aes_ctx_clear(km_aes_ctx * ctx, int free_decrypt)
 {
     if (ctx != NULL) {
         km_AesFree(&ctx->aes_encrypt);
-        km_AesFree(&ctx->aes_decrypt);
-    }
 
-    #ifdef WOLFKM_DEBUG_AES
-    printf("info: exiting km_AesExitCommon\n");
-    #endif /* WOLFKM_DEBUG_AES */
+        if (free_decrypt) {
+            km_AesFree(&ctx->aes_decrypt);
+        }
+    }
 }
 
 static void wolfkdriv_identify(driver_t * driver, device_t parent)
@@ -671,7 +674,16 @@ static int wolfkdriv_newsession_aes(device_t dev,
 
 newsession_cipher_out:
     if (error != 0) {
-        wolfkdriv_aes_ctx_clear(&session->aes_ctx);
+        switch (csp->csp_cipher_alg) {
+        case CRYPTO_AES_NIST_GCM_16:
+            wolfkdriv_aes_ctx_clear(&session->aes_ctx, 0);
+            break;
+        case CRYPTO_AES_CBC:
+            wolfkdriv_aes_ctx_clear(&session->aes_ctx, 1);
+        default:
+            break;
+        }
+
         return (EINVAL);
     }
 
@@ -713,13 +725,27 @@ static void
 wolfkdriv_freesession(device_t dev, crypto_session_t cses)
 {
     wolfkdriv_session_t * session = NULL;
+    const struct crypto_session_params * csp = NULL;
     (void)dev;
 
     /* get the wolfkdriv_session_t context */
     session = crypto_get_driver_session(cses);
+    csp = crypto_get_params(cses);
 
     /* clean it up */
-    wolfkdriv_aes_ctx_clear(&session->aes_ctx);
+    switch (csp->csp_mode) {
+    case CSP_MODE_CIPHER:
+        wolfkdriv_aes_ctx_clear(&session->aes_ctx, 1);
+        break;
+    case CSP_MODE_DIGEST:
+    case CSP_MODE_ETA:
+        break;
+    case CSP_MODE_AEAD:
+        wolfkdriv_aes_ctx_clear(&session->aes_ctx, 0);
+        break;
+    default:
+        __assert_unreachable();
+    }
 
     #if defined(WOLFSSL_BSDKM_VERBOSE_DEBUG)
     device_printf(dev, "info: exiting freesession\n");

--- a/bsdkm/wolfkmod.c
+++ b/bsdkm/wolfkmod.c
@@ -763,6 +763,19 @@ static int wolfkdriv_cbc_work(device_t dev, wolfkdriv_session_t * session,
         is_encrypt = 0;
         memcpy(&aes, &session->aes_ctx.aes_decrypt, sizeof(aes));
     }
+#if defined(WOLFSSL_AESGCM_STREAM) && defined(WOLFSSL_SMALL_STACK) && \
+   !defined(WOLFSSL_AESNI)
+    aes.streamData = NULL;
+#endif
+#ifdef WC_DEBUG_CIPHER_LIFECYCLE
+    {
+        error = wc_debug_CipherLifecycleInit(&aes.CipherLifecycleTag, NULL);
+        if (error) {
+            error = EINVAL;
+            goto cbc_work_out;
+        }
+    }
+#endif
 
     /* must be multiple of block size */
     if (data_len % WC_AES_BLOCK_SIZE) {
@@ -910,6 +923,15 @@ static int wolfkdriv_gcm_work(device_t dev, wolfkdriv_session_t * session,
 #if defined(WOLFSSL_AESGCM_STREAM) && defined(WOLFSSL_SMALL_STACK) && \
    !defined(WOLFSSL_AESNI)
     aes.streamData = NULL;
+#endif
+#ifdef WC_DEBUG_CIPHER_LIFECYCLE
+    {
+        error = wc_debug_CipherLifecycleInit(&aes.CipherLifecycleTag, NULL);
+        if (error) {
+            error = EINVAL;
+            goto gcm_work_out;
+        }
+    }
 #endif
 
     data_len = crp->crp_payload_length;

--- a/bsdkm/x86_vecreg.c
+++ b/bsdkm/x86_vecreg.c
@@ -129,11 +129,13 @@ void wolfkmod_vecreg_exit(void)
         fpu_kern_leave(curthread, NULL);                                     \
     } while (0)
 #else
-    #define wolfkmod_fpu_kern_enter()                                        \
-        fpu_kern_enter(curthread, NULL, FPU_KERN_NOCTX);
+    #define wolfkmod_fpu_kern_enter() do {                                   \
+        fpu_kern_enter(curthread, NULL, FPU_KERN_NOCTX);                     \
+    } while (0)
 
-    #define wolfkmod_fpu_kern_leave()                                        \
-        fpu_kern_leave(curthread, NULL);
+    #define wolfkmod_fpu_kern_leave() do {                                   \
+        fpu_kern_leave(curthread, NULL);                                     \
+    } while (0)
 #endif /* WOLFSSL_BSDKM_FPU_DEBUG */
 
 int wolfkmod_vecreg_save(int flags_unused)


### PR DESCRIPTION
## Description

bsdkm cleanup:
- F-7721: wrap wolfkmod_fpu_kern_enter / leave macros.
- F-7711: missing wc_debug_CipherLifecycleInit.
- F-6855: don't free a never-initialized aes_decrypt context.
- F-7715: don't use M_WAITOK with bsdkm driver.
- F-1233: XATOI macro cleanup.

## Testing

```
#!/bin/sh                                                                       
BSDKM_CFLAGS="-DWC_DEBUG_CIPHER_LIFECYCLE -DWOLFSSL_BSDKM_VERBOSE_DEBUG -DWOLFSSL_BSDKM_FPU_DEBUG -DWOLFSSL_BSDKM_MEMORY_DEBUG"
                                                                                
./configure --enable-freebsdkm --enable-freebsdkm-crypto-register \
  --enable-cryptonly --enable-crypttests \
  --enable-kernel-benchmarks --enable-all-crypto --enable-aesni \ 
  --enable-aesni-with-avx \ 
  CFLAGS="$BSDKM_CFLAGS" && make \
  || exit 1
                      
file bsdkm/libwolfssl.ko && sudo kldload bsdkm/libwolfssl.ko || exit 1
```

```
BSDKM_CFLAGS="-DWOLFSSL_BSDKM_VERBOSE_DEBUG"
./configure --enable-freebsdkm --enable-cryptonly --enable-crypttests \
  --enable-kernel-benchmarks --enable-all-crypto --enable-aesni \
  --enable-aesni-with-avx --enable-sp-asm \
  CFLAGS="$BSDKM_CFLAGS" && make \
  || exit 1
file bsdkm/libwolfssl.ko && sudo kldload bsdkm/libwolfssl.ko || exit 1
```

