### PR TITLE
cross-library: recover the break-check scan base when the PR merge ref moves

### DIFF
--- a/.github/workflows/cross-library.yml
+++ b/.github/workflows/cross-library.yml
@@ -195,6 +195,24 @@ jobs:
           rel="$(git tag --merged HEAD --sort=-v:refname --list 'v*-stable')"
           base="$(printf '%s\n' "$rel" | sed -n '2p')"
           echo "Deepened to $(git rev-list --count HEAD) commits; scan base='${base}'"
+
+          # The fetch above deepens whatever "$GITHUB_REF" resolves to NOW, but
+          # actions/checkout pinned a SHA when the job started. GitHub can
+          # regenerate refs/pull/N/merge in between -- a new commit object with
+          # the same parents -- and then FETCH_HEAD is not HEAD, HEAD keeps its
+          # depth-1 graft, and no tag is reachable from it. Deepen the ref we are
+          # actually on before giving up. Re-running the job cannot clear this:
+          # a re-run replays the same pinned SHA.
+          if [ -z "$base" ]; then
+            echo "Scan base empty (merge ref moved under the checkout?);" \
+                 "retrying with a full deepen."
+            git fetch --unshallow --filter=tree:0 --tags origin
+            rel="$(git tag --merged HEAD --sort=-v:refname --list 'v*-stable')"
+            base="$(printf '%s\n' "$rel" | sed -n '2p')"
+            echo "Re-deepened to $(git rev-list --count HEAD) commits;" \
+                 "scan base='${base}'"
+          fi
+
           if [ -z "$base" ]; then
             echo "::error::Deepen produced no usable scan base; check-break.sh would scan the wrong window."
             printf 'Release tags merged into HEAD: %s\n' "${rel:-<none>}"


### PR DESCRIPTION
All six `cross-library / Compile <product> (latest)` jobs can fail on a PR with:

```
Newest release tags: v5.9.2-stable v5.9.1-stable v5.9.0-stable
From https://github.com/wolfSSL/wolfssl
 * branch            refs/pull/10970/merge -> FETCH_HEAD
 * [new tag]         v5.9.2-stable -> v5.9.2-stable
 * [new tag]         v5.9.1-stable -> v5.9.1-stable
Deepened to 1 commits; scan base=''
Error: Deepen produced no usable scan base; check-break.sh would scan the wrong window.
Release tags merged into HEAD: <none>
```

The branch is fine. `v5.9.0/1/2-stable` really are ancestors of the PR merge ref, and `git tag --merged` returns `v5.9.1-stable` when run against it locally.

## Cause

`actions/checkout` pins a **SHA** when the job starts:

```
git ... fetch --depth=1 origin +a2bb62120f...:refs/remotes/pull/10970/merge
git checkout --force refs/remotes/pull/10970/merge
```

The "Deepen wolfSSL history for the break check" step then re-resolves the **symbolic** ref:

```
git fetch --no-tags --filter=tree:0 --shallow-exclude="${T[2]}" origin "$GITHUB_REF" ...
```

GitHub can regenerate `refs/pull/N/merge` in between. In the observed case it produced a new commit object with **identical parents**:

| | commit | parents |
|---|---|---|
| checked out | `a2bb62120f` | `77da93945b 649cd91bd4` |
| fetched by the deepen | `d4292518d8` | `77da93945b 649cd91bd4` |

Same content, different object. So `FETCH_HEAD` is not `HEAD`, `HEAD` keeps its depth-1 graft, nothing is reachable from it, and the assertion fires.

Two consequences worth calling out:

- **Re-running the job cannot clear it.** A re-run replays the original pinned SHA, so it reproduces deterministically and looks like a branch defect rather than a race. Confirmed by re-running and getting a byte-identical failure.
- It is most likely to bite PRs pushed while `master` is moving, which is exactly when the cross-library check matters.

## Fix

If the scan base comes back empty, deepen the ref we are actually on and retry before failing:

```bash
if [ -z "$base" ]; then
  echo "Scan base empty (merge ref moved under the checkout?);" \
       "retrying with a full deepen."
  git fetch --unshallow --filter=tree:0 --tags origin
  rel="$(git tag --merged HEAD --sort=-v:refname --list 'v*-stable')"
  base="$(printf '%s\n' "$rel" | sed -n '2p')"
  echo "Re-deepened to $(git rev-list --count HEAD) commits;" \
       "scan base='${base}'"
fi
```

The original hard failure is kept as the second gate, so a genuinely missing scan base still errors out loudly and `check-break.sh` never scans the wrong window. Behaviour is unchanged on the happy path.

`--unshallow --filter=tree:0` costs a commit-graph-only fetch, and only in the rare race, so the `--shallow-exclude` fast path still carries normal traffic. This mirrors the existing `--unshallow --filter=tree:0 --tags` fallback already used a few lines above when there are fewer than three release tags.