### PR TITLE
SP ECC P-256 x64 asm: fix carry in triple and rsb_sub_dbl

### DIFF
--- a/wolfcrypt/src/sp_x86_64_asm.S
+++ b/wolfcrypt/src/sp_x86_64_asm.S
@@ -45182,7 +45182,7 @@ _sp_256_mont_tpl_4:
         movq	$0xffffffff00000001, %r10
         adcq	16(%rsi), %rcx
         adcq	24(%rsi), %r8
-        sbbq	$0x00, %r11
+        sbbq	%r11, %r11
         movl	%r11d, %r9d
         andq	%r11, %r10
         subq	%r11, %rdx
@@ -45361,7 +45361,7 @@ _sp_256_mont_rsb_sub_dbl_4:
         movq	$0xffffffff00000001, %r15
         sbbq	%r12, %r8
         sbbq	%r13, %r9
-        sbbq	$0x00, %rsi
+        sbbq	%rsi, %rsi
         movl	%esi, %r14d
         andq	%rsi, %r15
         addq	%rsi, %rax

--- a/wolfcrypt/src/sp_x86_64_asm.asm
+++ b/wolfcrypt/src/sp_x86_64_asm.asm
@@ -43757,7 +43757,7 @@ sp_256_mont_tpl_4 PROC
         mov	r12, 18446744069414584321
         adc	r9, QWORD PTR [rdx+16]
         adc	r10, QWORD PTR [rdx+24]
-        sbb	r13, 0
+        sbb	r13, r13
         mov	r11d, r13d
         and	r12, r13
         sub	rax, r13
@@ -43909,7 +43909,7 @@ sp_256_mont_rsb_sub_dbl_4 PROC
         mov	rsi, 18446744069414584321
         sbb	r10, r14
         sbb	r11, r15
-        sbb	rdx, 0
+        sbb	rdx, rdx
         mov	edi, edx
         and	rsi, rdx
         add	rax, rdx


### PR DESCRIPTION
# Description

Subtracted 0 assuming register was 0.
Changed to subtract register from register to ensure 0.

Fixes zd#22300

# Testing

./configure --disable-shared --enable-intelasm --enable-sp --enable-sp-asm
Used customers reproducer which is very rare case.