### PR TITLE
tls 1.3: respect advertised psk_key_exchange modes for tickets and PSKs

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8308,6 +8308,7 @@ static void InitSSL_Tls13Options(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
     #endif
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
         ssl->options.noPskDheKe = ctx->noPskDheKe;
+        ssl->options.noPskDheKeCfg = ctx->noPskDheKe;
     #ifdef HAVE_SUPPORTED_CURVES
         ssl->options.onlyPskDheKe = ctx->onlyPskDheKe;
     #endif /* HAVE_SUPPORTED_CURVES */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5705,9 +5705,14 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     #ifdef WOLFSSL_TLS13
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
         ssl->options.noPskDheKe = ssl->ctx->noPskDheKe;
+        ssl->options.noPskDheKeCfg = ssl->ctx->noPskDheKe;
         #ifdef HAVE_SUPPORTED_CURVES
         ssl->options.onlyPskDheKe = ssl->ctx->onlyPskDheKe;
         #endif
+        /* Modes advertised on the previous handshake must not carry over. */
+        ssl->options.pskKeModesRecvd = 0;
+        ssl->options.pskKeModeKe = 0;
+        ssl->options.pskKeModeDheKe = 0;
     #endif
     #endif
     #ifdef HAVE_SESSION_TICKET

--- a/src/tls.c
+++ b/src/tls.c
@@ -12911,8 +12911,15 @@ static int TLSX_PskKeModes_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     byte modes;
 
     ret = TLSX_PskKeyModes_Parse_Modes(input, length, msgType, &modes);
-    if (ret == 0)
+    if (ret == 0) {
+        /* Keep the modes in the options: the extension list may be freed
+         * before a post-handshake ticket is sent. */
+        ssl->options.pskKeModesRecvd = 1;
+        ssl->options.pskKeModeKe = ((modes & (1 << PSK_KE)) != 0);
+        ssl->options.pskKeModeDheKe = ((modes & (1 << PSK_DHE_KE)) != 0);
+
         ret = TLSX_PskKeyModes_Use(ssl, modes);
+    }
 
     if (ret != 0) {
         WOLFSSL_ERROR_VERBOSE(ret);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -6790,6 +6790,39 @@ cleanup:
     return ret;
 }
 
+/* Check whether a PSK can be used with a key exchange mode the client
+ * advertised in psk_key_exchange_modes.
+ *
+ * RFC 8446 Section 4.2.9: the advertised modes restrict both the PSKs offered
+ * in this ClientHello and any the server later sends in a NewSessionTicket.
+ *
+ * Modes come from the options, not ssl->extensions, which
+ * FreeHandshakeResources() may free before a post-handshake ticket is sent.
+ * Policy comes from noPskDheKeCfg, not noPskDheKe, which is cleared when the
+ * handshake ends up using no PSK.
+ *
+ * ssl  The SSL/TLS object.
+ * returns 1 when a PSK is usable and 0 when no advertised mode is acceptable.
+ */
+static int PskKeyModesUsable(const WOLFSSL* ssl)
+{
+    /* Modes unknown without the extension, so impose no restriction. */
+    if (!ssl->options.pskKeModesRecvd)
+        return 1;
+
+#ifdef HAVE_SUPPORTED_CURVES
+    if (ssl->options.pskKeModeDheKe && !ssl->options.noPskDheKeCfg)
+        return 1;
+    if (ssl->options.pskKeModeKe && !ssl->options.onlyPskDheKe)
+        return 1;
+
+    return 0;
+#else
+    /* Without (EC)DHE support only psk_ke can be negotiated. */
+    return ssl->options.pskKeModeKe != 0;
+#endif
+}
+
 /* Handle any Pre-Shared Key (PSK) extension.
  * Must do this in ClientHello as it requires a hash of the truncated message.
  * Don't know size of binders until Pre-Shared Key extension has been parsed.
@@ -6807,6 +6840,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
     TLSX*  ext;
     word16 bindersLen;
     int    first = 0;
+    int    modesUsable;
 #ifndef WOLFSSL_PSK_ONE_ID
     int    i;
     const Suites* suites;
@@ -6844,6 +6878,12 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
      * prepend new entries to ssl->extensions before this point and would
      * otherwise trip a head-of-list check here. */
 
+    /* RFC 8446 Section 4.2.11: an unusable PSK is ignored and a non-PSK
+     * handshake performed instead, so leave the offered keys untried. */
+    modesUsable = PskKeyModesUsable(ssl);
+    if (!modesUsable)
+        WOLFSSL_MSG("No advertised PSK mode is usable; ignoring offered PSKs");
+
     /* Assume we are going to resume with a pre-shared key. */
     ssl->options.resuming = 1;
 
@@ -6867,7 +6907,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
     suites = WOLFSSL_SUITES(ssl);
     /* Server list has only common suites from refining in server or client
      * order. */
-    for (i = 0; !(*usingPSK) && i < suites->suiteSz; i += 2) {
+    for (i = 0; modesUsable && !(*usingPSK) && i < suites->suiteSz; i += 2) {
         ret = DoPreSharedKeys(ssl, input, helloSz - bindersLen,
                 suites->suites + i, usingPSK, &first);
         if (ret != 0) {
@@ -6885,11 +6925,13 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
     CleanupClientTickets((PreSharedKey*)ext->data);
 #endif
 #else
-    ret = DoPreSharedKeys(ssl, input, helloSz - bindersLen, suite, usingPSK,
-        &first);
-    if (ret != 0) {
-        WOLFSSL_MSG_EX("DoPreSharedKeys: %d", ret);
-        return ret;
+    if (modesUsable) {
+        ret = DoPreSharedKeys(ssl, input, helloSz - bindersLen, suite, usingPSK,
+            &first);
+        if (ret != 0) {
+            WOLFSSL_MSG_EX("DoPreSharedKeys: %d", ret);
+            return ret;
+        }
     }
 #endif
 
@@ -13846,6 +13888,14 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
         return 0;
     }
 
+    /* RFC 8446 Section 4.2.9: don't send a ticket that no advertised mode
+     * could resume with. */
+    if (!PskKeyModesUsable(ssl)) {
+        WOLFSSL_MSG("Ticket not usable with advertised PSK modes; "
+                    "skipping ticket");
+        return 0;
+    }
+
 #ifdef WOLFSSL_DTLS13
     if (ssl->options.dtls)
         idx = Dtls13GetRlHeaderLength(ssl, 1) + DTLS_HANDSHAKE_HEADER_SZ;
@@ -15964,6 +16014,7 @@ int wolfSSL_no_dhe_psk(WOLFSSL* ssl)
 
 #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
     ssl->options.noPskDheKe = 1;
+    ssl->options.noPskDheKeCfg = 1;
 #endif
 
     return 0;

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -2254,6 +2254,329 @@ int test_tls13_fail_if_no_psk_dtls13_rejects_no_psk(void)
 }
 
 #if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET) && \
+    defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(HAVE_SUPPORTED_CURVES) && \
+    !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_CERTS) && !defined(NO_FILESYSTEM) && \
+    (defined(HAVE_ECC) || !defined(NO_RSA))
+/* Counts the NewSessionTicket messages the client accepted. */
+static int test_tls13_psk_mode_ticket_cb(WOLFSSL* ssl,
+    const unsigned char* ticket, int ticketSz, void* ctx)
+{
+    (void)ssl;
+    (void)ticket;
+    (void)ticketSz;
+
+    (*(int*)ctx)++;
+
+    return 0;
+}
+#endif
+
+/* A server that only allows psk_dhe_ke must not send a NewSessionTicket to a
+ * client that advertised psk_ke as its only PSK mode. */
+int test_tls13_psk_mode_no_incompatible_ticket(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET) && \
+    defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(HAVE_SUPPORTED_CURVES) && \
+    !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_CERTS) && !defined(NO_FILESYSTEM) && \
+    (defined(HAVE_ECC) || !defined(NO_RSA))
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL;
+    WOLFSSL *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+    int ticketCnt = 0;
+    byte readBuf[16];
+
+    /* Control: client also advertises psk_dhe_ke, so a ticket must be sent. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, NULL);
+    ExpectIntEQ(wolfSSL_set_SessionTicket_cb(ssl_c,
+        test_tls13_psk_mode_ticket_cb, &ticketCnt), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_only_dhe_psk(ssl_s), 0);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    /* Drain the post-handshake NewSessionTicket. */
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(ticketCnt, 1);
+    wolfSSL_free(ssl_c);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_s);
+    ssl_c = NULL; ssl_s = NULL; ctx_c = NULL; ctx_s = NULL;
+
+    /* Client advertises psk_ke only, the one mode the server refuses, so no
+     * ticket may be sent. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, NULL);
+    ticketCnt = 0;
+    ExpectIntEQ(wolfSSL_set_SessionTicket_cb(ssl_c,
+        test_tls13_psk_mode_ticket_cb, &ticketCnt), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_no_dhe_psk(ssl_c), 0);
+    ExpectIntEQ(wolfSSL_only_dhe_psk(ssl_s), 0);
+    /* The certificate handshake must still pass. */
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    /* Let any NewSessionTicket arrive before counting. */
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(ticketCnt, 0);
+    wolfSSL_free(ssl_c);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_s);
+    ssl_c = NULL; ssl_s = NULL; ctx_c = NULL; ctx_s = NULL;
+
+    /* Mirror case: psk_dhe_ke only, refused by the server. The handshake uses
+     * no PSK, clearing noPskDheKe, so this only holds while the ticket check
+     * reads the configured policy. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, NULL);
+    ticketCnt = 0;
+    ExpectIntEQ(wolfSSL_set_SessionTicket_cb(ssl_c,
+        test_tls13_psk_mode_ticket_cb, &ticketCnt), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_only_dhe_psk(ssl_c), 0);
+    ExpectIntEQ(wolfSSL_no_dhe_psk(ssl_s), 0);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(ticketCnt, 0);
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* A server that only allows psk_dhe_ke must decline a psk_ke-only resumption
+ * attempt and complete a full handshake instead of aborting. */
+int test_tls13_psk_mode_incompatible_falls_back(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET) && \
+    defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(HAVE_SUPPORTED_CURVES) && \
+    !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_CERTS) && !defined(NO_FILESYSTEM) && \
+    (defined(HAVE_ECC) || !defined(NO_RSA))
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL;
+    WOLFSSL *ssl_s = NULL;
+    WOLFSSL_SESSION *sess = NULL;
+    struct test_memio_ctx test_ctx;
+    byte readBuf[16];
+
+    /* Step 1: full handshake with compatible modes to obtain a ticket. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, NULL);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    /* Drain the post-handshake NewSessionTicket. */
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectNotNull(sess = wolfSSL_get1_session(ssl_c));
+    wolfSSL_free(ssl_c); ssl_c = NULL;
+    wolfSSL_free(ssl_s); ssl_s = NULL;
+
+    /* Step 2: offer that ticket with psk_ke only to a server requiring
+     * psk_dhe_ke. The client sent a key_share, so the server must decline the
+     * PSK and complete a certificate handshake instead of aborting. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, NULL);
+    ExpectIntEQ(wolfSSL_no_dhe_psk(ssl_c), 0);
+    ExpectIntEQ(wolfSSL_only_dhe_psk(ssl_s), 0);
+    ExpectIntEQ(wolfSSL_set_session(ssl_c, sess), WOLFSSL_SUCCESS);
+
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 20, NULL), 0);
+    /* Neither side may believe the offered PSK was used. */
+    ExpectIntEQ(wolfSSL_session_reused(ssl_c), 0);
+    ExpectIntEQ(ssl_s->options.pskNegotiated, 0);
+
+    wolfSSL_SESSION_free(sess);
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* The configured PSK mode policy must survive a HelloRetryRequest: declining
+ * the PSK in the first ClientHello clears ssl->options.noPskDheKe, yet the
+ * second ClientHello must decline the same PSK. */
+int test_tls13_psk_mode_policy_survives_hrr(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET) && \
+    defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(HAVE_SUPPORTED_CURVES) && \
+    !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_CERTS) && !defined(NO_FILESYSTEM) && \
+    (defined(HAVE_ECC) || !defined(NO_RSA))
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL;
+    WOLFSSL *ssl_s = NULL;
+    WOLFSSL_SESSION *sess = NULL;
+    struct test_memio_ctx test_ctx;
+    byte readBuf[16];
+
+    /* Step 1: full handshake with compatible modes to obtain a ticket. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, NULL);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    /* Drain the post-handshake NewSessionTicket. */
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectNotNull(sess = wolfSSL_get1_session(ssl_c));
+    wolfSSL_free(ssl_c); ssl_c = NULL;
+    wolfSSL_free(ssl_s); ssl_s = NULL;
+
+    /* Step 2: offer that ticket with psk_dhe_ke only to a server refusing it,
+     * and omit the key shares so the server sends a HelloRetryRequest and
+     * parses a second ClientHello carrying the same PSK. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, NULL);
+    ExpectIntEQ(wolfSSL_only_dhe_psk(ssl_c), 0);
+    ExpectIntEQ(wolfSSL_no_dhe_psk(ssl_s), 0);
+    ExpectIntEQ(wolfSSL_set_session(ssl_c, sess), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_NoKeyShares(ssl_c), WOLFSSL_SUCCESS);
+
+    /* CH1: client -> server (no key_share). */
+    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+    /* Server declines the PSK and asks for a key share instead. */
+    ExpectIntNE(wolfSSL_accept(ssl_s), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(ssl_s->options.serverState,
+        SERVER_HELLO_RETRY_REQUEST_COMPLETE);
+
+    /* CH2 carries the same unusable PSK, so the handshake must still complete
+     * with a certificate and no resumption. */
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 20, NULL), 0);
+    ExpectIntEQ(wolfSSL_session_reused(ssl_c), 0);
+    ExpectIntEQ(ssl_s->options.pskNegotiated, 0);
+
+    wolfSSL_SESSION_free(sess);
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* Tickets sent with wolfSSL_send_SessionTicket() must obey the advertised
+ * modes too. FreeHandshakeResources() may have freed ssl->extensions by then,
+ * so the check has to work off the modes recorded in the options. */
+int test_tls13_psk_mode_post_handshake_ticket(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET) && \
+    defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(HAVE_SUPPORTED_CURVES) && \
+    !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_CERTS) && !defined(NO_FILESYSTEM) && \
+    (defined(HAVE_ECC) || !defined(NO_RSA))
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL;
+    WOLFSSL *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+    int ticketCnt = 0;
+    byte readBuf[16];
+
+    /* Control: compatible modes, so the second, application-requested ticket
+     * must reach the client. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, NULL);
+    ExpectIntEQ(wolfSSL_set_SessionTicket_cb(ssl_c,
+        test_tls13_psk_mode_ticket_cb, &ticketCnt), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_only_dhe_psk(ssl_s), 0);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(ticketCnt, 1);
+    ExpectIntEQ(wolfSSL_send_SessionTicket(ssl_s), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(ticketCnt, 2);
+    wolfSSL_free(ssl_c);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_s);
+    ssl_c = NULL; ssl_s = NULL; ctx_c = NULL; ctx_s = NULL;
+
+    /* Client advertises psk_ke only and the server refuses it, so neither
+     * ticket may be sent. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, NULL);
+    ticketCnt = 0;
+    ExpectIntEQ(wolfSSL_set_SessionTicket_cb(ssl_c,
+        test_tls13_psk_mode_ticket_cb, &ticketCnt), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_no_dhe_psk(ssl_c), 0);
+    ExpectIntEQ(wolfSSL_only_dhe_psk(ssl_s), 0);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    /* Modes are kept in the options, not only in the extension list. */
+    ExpectIntEQ(ssl_s->options.pskKeModesRecvd, 1);
+    ExpectIntEQ(ssl_s->options.pskKeModeKe, 1);
+    ExpectIntEQ(ssl_s->options.pskKeModeDheKe, 0);
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(ticketCnt, 0);
+    ExpectIntEQ(wolfSSL_send_SessionTicket(ssl_s), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(ticketCnt, 0);
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
+
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET) && \
     !defined(NO_WOLFSSL_SERVER) && defined(HAVE_ECC) && \
     defined(BUILD_TLS_AES_128_GCM_SHA256) && \
     defined(BUILD_TLS_AES_256_GCM_SHA384)
@@ -8368,11 +8691,13 @@ int test_tls13_clear_preserves_psk_dhe(void)
     ExpectIntEQ(wolfSSL_CTX_no_dhe_psk(ctx), 0);
     ExpectNotNull(ssl = wolfSSL_new(ctx));
     ExpectIntEQ(ssl->options.noPskDheKe, 1);
+    ExpectIntEQ(ssl->options.noPskDheKeCfg, 1);
 
     /* SSL reuse must preserve the CTX-level noPskDheKe; resetting to 0
      * would silently re-enable psk_dhe_ke for the next handshake. */
     ExpectIntEQ(wolfSSL_clear(ssl), WOLFSSL_SUCCESS);
     ExpectIntEQ(ssl->options.noPskDheKe, 1);
+    ExpectIntEQ(ssl->options.noPskDheKeCfg, 1);
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -91,6 +91,10 @@ int test_tls13_fail_if_no_psk_server_rejects_offered_psk(void);
 int test_tls13_fail_if_no_psk_no_cert_server(void);
 int test_tls13_fail_if_no_psk_dtls13_handshake(void);
 int test_tls13_fail_if_no_psk_dtls13_rejects_no_psk(void);
+int test_tls13_psk_mode_no_incompatible_ticket(void);
+int test_tls13_psk_mode_incompatible_falls_back(void);
+int test_tls13_psk_mode_policy_survives_hrr(void);
+int test_tls13_psk_mode_post_handshake_ticket(void);
 int test_tls13_ticket_peer_cert_reverify(void);
 int test_tls13_clear_preserves_psk_dhe(void);
 int test_tls13_cipher_fuzz_aes128_gcm_sha256(void);
@@ -175,6 +179,10 @@ int test_tls13_pha_status_request(void);
     TEST_DECL_GROUP("tls13", test_tls13_fail_if_no_psk_no_cert_server), \
     TEST_DECL_GROUP("tls13", test_tls13_fail_if_no_psk_dtls13_handshake), \
     TEST_DECL_GROUP("tls13", test_tls13_fail_if_no_psk_dtls13_rejects_no_psk), \
+    TEST_DECL_GROUP("tls13", test_tls13_psk_mode_no_incompatible_ticket), \
+    TEST_DECL_GROUP("tls13", test_tls13_psk_mode_incompatible_falls_back), \
+    TEST_DECL_GROUP("tls13", test_tls13_psk_mode_policy_survives_hrr), \
+    TEST_DECL_GROUP("tls13", test_tls13_psk_mode_post_handshake_ticket), \
     TEST_DECL_GROUP("tls13", test_tls13_ticket_peer_cert_reverify), \
     TEST_DECL_GROUP("tls13", test_tls13_clear_preserves_psk_dhe), \
     TEST_DECL_GROUP("tls13", test_tls13_cipher_fuzz_aes128_gcm_sha256), \

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5426,11 +5426,21 @@ struct Options {
     word16            usingAnon_cipher:1; /* are we using an anon cipher */
 #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
     word16            noPskDheKe:1;       /* Don't use (EC)DHE with PSK */
+    word16            noPskDheKeCfg:1;    /* noPskDheKe as configured, since
+                                           * noPskDheKe is cleared when the
+                                           * handshake uses no PSK */
 #ifdef HAVE_SUPPORTED_CURVES
     word16            onlyPskDheKe:1;     /* Only use (EC)DHE with PSK */
 #endif
 #if defined(WOLFSSL_CERT_WITH_EXTERN_PSK)
     word16            certWithExternPsk:1; /* Cert auth with external PSK */
+#endif
+#ifdef WOLFSSL_TLS13
+    /* psk_key_exchange_modes advertised in the ClientHello. Kept here as
+     * ssl->extensions may be freed before a post-handshake ticket is sent. */
+    word16            pskKeModesRecvd:1;  /* extension was received */
+    word16            pskKeModeKe:1;      /* psk_ke advertised */
+    word16            pskKeModeDheKe:1;   /* psk_dhe_ke advertised */
 #endif
 #endif
     word16            partialWrite:1;     /* only one msg per write call */


### PR DESCRIPTION
# Description

A wolfSSL server ignored the client's advertised psk_key_exchange_modes when issuing a NewSessionTicket, handing out  tickets it would never accept , and then aborted the resuption attempt with PSK_KEY_ERROR instead of falling back to a full handshake.
This skips tickets no advertised mode can use (as mentioned in RFC 8446, around section 4.2.9) and declines unusuable PSKs rather than failing the connection (section 4.2.11).

Fixes https://github.com/wolfSSL/wolfssl/issues/11087.

# Testing

Added two regression tests: test_tls13_psk_mode_no_incompatible_ticket test_tls13_psk_mode_incompatible_falls_back. The first one asserts no ticket is sent to a psk_ke-only client when the server requires psk_dhe_ke, with a compatible-client control that still gets one.
The second offers a valid ticket under that same mode mismatch and asserts the handshake completes unresumed instead of aborting.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
