### PR TITLE
Remove stale NO_PWDBASED guards from OpenSSL compat layer

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -293,8 +293,7 @@ static int der_write_to_bio_as_pem(const unsigned char* der, int derSz,
 #endif
 
 #if !defined(NO_FILESYSTEM) && \
-    ((defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_ASN) && \
-      !defined(NO_PWDBASED)) || \
+    ((defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_ASN)) || \
      defined(WOLFSSL_DH_EXTRA))
 /* Write the DER data as PEM into file pointer.
  *
@@ -326,8 +325,7 @@ static int der_write_to_file_as_pem(const unsigned char* der, int derSz,
     return ret;
 }
 #endif /* !NO_FILESYSTEM &&
-        * ((OPENSSL_EXTRA && !NO_CERTS && !NO_ASN && !NO_PWDBASED) ||
-        *  WOLFSSL_DH_EXTRA) */
+        * ((OPENSSL_EXTRA && !NO_CERTS && !NO_ASN) || WOLFSSL_DH_EXTRA) */
 
 #if defined(OPENSSL_EXTRA) && defined(WOLFSSL_KEY_GEN) && \
     defined(WOLFSSL_PEM_TO_DER)
@@ -6314,7 +6312,7 @@ int wolfSSL_PEM_write_bio_PrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key,
 #endif /* !NO_BIO */
 
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && defined(OPENSSL_EXTRA) && \
-    !defined(NO_ASN) && !defined(NO_PWDBASED)
+    !defined(NO_ASN)
 /* Writes a public key to a file pointer encoded in PEM format.
  *
  * @param [in] fp   File pointer to write to.
@@ -6470,8 +6468,7 @@ int wolfSSL_PEM_write_PrivateKey(XFILE fp, WOLFSSL_EVP_PKEY* key,
     WOLFSSL_LEAVE("wolfSSL_PEM_write_PrivateKey", err);
     return !err;
 }
-#endif /* !NO_FILESYSTEM && !NO_CERTS && OPENSSL_EXTRA && !NO_ASN &&
-        * !NO_PWDBASED */
+#endif /* !NO_FILESYSTEM && !NO_CERTS && OPENSSL_EXTRA && !NO_ASN */
 
 #ifndef NO_BIO
 /* Create a private key object from the data in the BIO.
@@ -7389,7 +7386,9 @@ int pkcs8_encrypt(WOLFSSL_EVP_PKEY* pkey,
 
     return ret;
 }
+#endif /* !NO_PWDBASED && HAVE_PKCS8 */
 
+#ifdef HAVE_PKCS8
 /* Encode private key in PKCS#8 format.
  *
  * @param [in]      pkey   Private key.
@@ -7464,7 +7463,9 @@ int pkcs8_encode(WOLFSSL_EVP_PKEY* pkey, byte* key, word32* keySz)
 
     return ret;
 }
+#endif /* HAVE_PKCS8 */
 
+#if !defined(NO_PWDBASED) && defined(HAVE_PKCS8)
 #if !defined(NO_BIO) || (!defined(NO_FILESYSTEM) && \
     !defined(NO_STDIO_FILESYSTEM))
 /* Write PEM encoded, PKCS#8 formatted private key to BIO.

--- a/src/x509.c
+++ b/src/x509.c
@@ -3786,7 +3786,6 @@ int wolfSSL_X509_EXTENSION_set_data(WOLFSSL_X509_EXTENSION* ext,
     return wolfSSL_ASN1_STRING_copy(&ext->value, data);
 }
 
-#if !defined(NO_PWDBASED)
 int wolfSSL_X509_digest(const WOLFSSL_X509* x509, const WOLFSSL_EVP_MD* digest,
         unsigned char* buf, unsigned int* len)
 {
@@ -3832,7 +3831,6 @@ int wolfSSL_X509_pubkey_digest(const WOLFSSL_X509 *x509,
     WOLFSSL_LEAVE("wolfSSL_X509_pubkey_digest", ret);
     return ret;
 }
-#endif
 
 #endif /* OPENSSL_EXTRA */
 
@@ -11612,8 +11610,7 @@ error:
 #endif /* OPENSSL_ALL || OPENSSL_EXTRA || WOLFSSL_APACHE_HTTPD ||
         * WOLFSSL_HAPROXY || WOLFSSL_WPAS */
 
-#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_ASN) && \
-    !defined(NO_PWDBASED)
+#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_ASN)
 
 int wolfSSL_i2d_X509_PUBKEY(WOLFSSL_X509_PUBKEY* x509_PubKey,
     unsigned char** der)
@@ -11623,7 +11620,7 @@ int wolfSSL_i2d_X509_PUBKEY(WOLFSSL_X509_PUBKEY* x509_PubKey,
     return wolfSSL_i2d_PublicKey(x509_PubKey->pkey, der);
 }
 
-#endif /* OPENSSL_EXTRA && !NO_CERTS && !NO_ASN && !NO_PWDBASED */
+#endif /* OPENSSL_EXTRA && !NO_CERTS && !NO_ASN */
 
 #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
@@ -12229,7 +12226,7 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
     static int wolfSSL_sigTypeFromPKEY(WOLFSSL_EVP_MD* md,
             WOLFSSL_EVP_PKEY* pkey)
     {
-    #if !defined(NO_PWDBASED) && defined(OPENSSL_EXTRA)
+    #if defined(OPENSSL_EXTRA)
         int hashType;
         int sigType = WOLFSSL_FAILURE;
 
@@ -12353,9 +12350,9 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
 #else
         (void)md;
         (void)pkey;
-        WOLFSSL_MSG("Cannot get hashinfo when NO_PWDBASED is defined");
+        WOLFSSL_MSG("Cannot get signature type without OPENSSL_EXTRA");
         return WOLFSSL_FAILURE;
-#endif /* !NO_PWDBASED && OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA */
     }
 
 
@@ -16084,7 +16081,8 @@ int wolfSSL_X509_NAME_digest(const WOLFSSL_X509_NAME *name,
     if (name == NULL || type == NULL)
         return WOLFSSL_FAILURE;
 
-#if !defined(NO_FILESYSTEM) && !defined(NO_PWDBASED)
+/* wolfSSL_EVP_Digest() is only compiled with these defines. */
+#if defined(OPENSSL_EXTRA) || defined(HAVE_CURL)
     return wolfSSL_EVP_Digest((unsigned char*)name->name,
                               name->sz, md, len, type, NULL);
 #else

--- a/tests/api.c
+++ b/tests/api.c
@@ -23079,7 +23079,7 @@ static int test_wolfSSL_d2i_and_i2d_PublicKey_ecc(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && defined(HAVE_ECC) && !defined(NO_CERTS) && \
-    !defined(NO_ASN) && !defined(NO_PWDBASED)
+    !defined(NO_ASN)
     EVP_PKEY* pkey = NULL;
     const unsigned char* p;
     unsigned char *der = NULL;
@@ -23215,7 +23215,7 @@ static int test_wolfSSL_i2d_PrivateKey(void)
 {
     EXPECT_DECLS;
 #if (!defined(NO_RSA) || defined(HAVE_ECC)) && defined(OPENSSL_EXTRA) && \
-    !defined(NO_ASN) && !defined(NO_PWDBASED)
+    !defined(NO_ASN)
 
 #if !defined(NO_RSA) && defined(USE_CERT_BUFFERS_2048)
     {

--- a/tests/api/test_evp_cipher.c
+++ b/tests/api/test_evp_cipher.c
@@ -677,7 +677,8 @@ int test_wolfSSL_EVP_CIPHER_type_string(void)
 int test_wolfSSL_EVP_BytesToKey(void)
 {
     EXPECT_DECLS;
-#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(OPENSSL_ALL)
+#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(OPENSSL_ALL) && \
+    defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_PWDBASED)
     byte                key[AES_BLOCK_SIZE] = {0};
     byte                iv[AES_BLOCK_SIZE] = {0};
     int                 count = 0;

--- a/tests/api/test_evp_digest.c
+++ b/tests/api/test_evp_digest.c
@@ -222,7 +222,7 @@ int test_wolfSSL_EVP_get_digestbynid(void)
 int test_wolfSSL_EVP_Digest(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_EXTRA) && !defined(NO_SHA256) && !defined(NO_PWDBASED)
+#if defined(OPENSSL_EXTRA) && !defined(NO_SHA256)
     const char* in = "abc";
     int   inLen = (int)XSTRLEN(in);
     byte  out[WC_SHA256_DIGEST_SIZE];

--- a/tests/api/test_evp_pkey.c
+++ b/tests/api/test_evp_pkey.c
@@ -1447,11 +1447,11 @@ int test_wolfSSL_EVP_PKEY_keygen(void)
 int test_wolfSSL_EVP_PKEY_keygen_reuse(void)
 {
     EXPECT_DECLS;
-/* wolfSSL_i2d_PrivateKey() needs OPENSSL_EXTRA plus !NO_ASN and !NO_PWDBASED,
- * and nothing here is OPENSSL_ALL only. */
+/* wolfSSL_i2d_PrivateKey() needs OPENSSL_EXTRA plus !NO_ASN, and nothing here
+ * is OPENSSL_ALL only. */
 #if defined(OPENSSL_EXTRA) && !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN) && \
     defined(USE_CERT_BUFFERS_2048) && !defined(HAVE_SELFTEST) && \
-    !defined(NO_ASN) && !defined(NO_PWDBASED)
+    !defined(NO_ASN)
     WOLFSSL_EVP_PKEY* pkey = NULL;
     WOLFSSL_EVP_PKEY* decoded = NULL;
     EVP_PKEY_CTX*     ctx = NULL;
@@ -1545,7 +1545,7 @@ int test_wolfSSL_EVP_PKEY_set1_EC_KEY_no_pkcs8(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && defined(HAVE_ECC) && !defined(NO_FILESYSTEM) && \
-    !defined(NO_CERTS) && !defined(NO_ASN) && !defined(NO_PWDBASED)
+    !defined(NO_CERTS) && !defined(NO_ASN)
     WOLFSSL_EVP_PKEY* wrapped = NULL;
     WOLFSSL_EVP_PKEY* fresh = NULL;
     WOLFSSL_EC_KEY*   ec = NULL;
@@ -1610,7 +1610,7 @@ int test_wolfSSL_EVP_PKEY_set1_shrinking_der(void)
  * that half is the only coverage for the ECC_populate_EVP_PKEY() over-copy.
  * Gate on the union and keep the per-algorithm guards inside. */
 #if defined(OPENSSL_EXTRA) && !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && \
-    !defined(NO_ASN) && !defined(NO_PWDBASED) && \
+    !defined(NO_ASN) && \
     ((!defined(NO_RSA) && defined(WOLFSSL_KEY_TO_DER)) || defined(HAVE_ECC))
     const unsigned char* in;
     byte*             buf = NULL;
@@ -1701,7 +1701,7 @@ int test_wolfSSL_EVP_PKEY_get1_EC_KEY_reuse(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && defined(HAVE_ECC) && !defined(NO_FILESYSTEM) && \
-    !defined(NO_CERTS) && !defined(NO_ASN) && !defined(NO_PWDBASED)
+    !defined(NO_CERTS) && !defined(NO_ASN)
     WOLFSSL_EVP_PKEY* pkey = NULL;
     WOLFSSL_EC_KEY*   ec1 = NULL;
     WOLFSSL_EC_KEY*   ec2 = NULL;

--- a/tests/api/test_ossl_x509_name.c
+++ b/tests/api/test_ossl_x509_name.c
@@ -124,7 +124,7 @@ int test_wolfSSL_X509_NAME(void)
         0x01, 0x16, 0x00
     };
 #endif
-#if defined(OPENSSL_EXTRA) && !defined(NO_PWDBASED)
+#ifdef OPENSSL_EXTRA
     byte   digest[64]; /* max digest size */
     word32 digestSz;
 #endif
@@ -181,7 +181,6 @@ int test_wolfSSL_X509_NAME(void)
     ExpectIntEQ(X509_NAME_cmp(a, NULL), -2);
     ExpectIntEQ(X509_NAME_cmp(a, b), 0); /* self signed should be 0 */
 
-#if !defined(NO_PWDBASED)
     ExpectIntEQ(wolfSSL_X509_NAME_digest(NULL, NULL, NULL, NULL), 0);
     ExpectIntEQ(wolfSSL_X509_NAME_digest(a, NULL, NULL, NULL), 0);
 #ifndef NO_SHA256
@@ -202,10 +201,6 @@ int test_wolfSSL_X509_NAME(void)
     ExpectIntEQ(wolfSSL_X509_NAME_digest(a, wolfSSL_EVP_sha256(), digest,
         &digestSz), 1);
     ExpectTrue(digestSz == 32);
-#endif
-#else
-    ExpectIntEQ(wolfSSL_X509_NAME_digest(NULL, NULL, NULL, NULL),
-        NOT_COMPILED_IN);
 #endif
 #endif /* OPENSSL_EXTRA */
 

--- a/tests/api/test_ossl_x509_pk.c
+++ b/tests/api/test_ossl_x509_pk.c
@@ -393,7 +393,7 @@ int test_wolfSSL_X509_set_pubkey(void)
                 wolfSSL_EVP_PKEY_free(pubkey);
                 pubkey = NULL;
 
-            #if defined(WOLFSSL_CERT_GEN) && !defined(NO_PWDBASED) && \
+            #if defined(WOLFSSL_CERT_GEN) && \
                 !defined(WOLFSSL_MLDSA_NO_SIGN) && \
                 !defined(WOLFSSL_MLDSA_NO_VERIFY)
                 /* sign and verify round trip with the ML-DSA key */
@@ -556,7 +556,7 @@ int test_wolfSSL_X509_set_pubkey(void)
 
     #if defined(WOLFSSL_MLDSA_FIPS204_DRAFT) && \
         !defined(WOLFSSL_MLDSA_VERIFY_ONLY) && defined(WOLFSSL_CERT_GEN) && \
-        !defined(NO_PWDBASED) && !defined(WOLFSSL_MLDSA_NO_SIGN) && \
+        !defined(WOLFSSL_MLDSA_NO_SIGN) && \
         !defined(WOLFSSL_MLDSA_NO_VERIFY) && !defined(WOLFSSL_NO_ML_DSA_44)
         /* FIPS204-draft Dilithium key: set_pubkey must keep pubKeyOID
          * consistent with the draft-OID SPKI emitted by
@@ -617,7 +617,7 @@ int test_wolfSSL_X509_set_pubkey(void)
     defined(WC_ENABLE_ASYM_KEY_EXPORT) && !defined(NO_FILESYSTEM) && \
     !defined(NO_BIO) && !defined(WOLFSSL_NO_ML_DSA_87) && \
     !defined(NO_RSA) && defined(USE_CERT_BUFFERS_2048) && \
-    defined(WOLFSSL_CERT_GEN) && !defined(NO_PWDBASED)
+    defined(WOLFSSL_CERT_GEN)
     {
         /* Classic-signed certificate carrying a large ML-DSA-87 subject
          * public key: the DER buffer must be sized for the subject SPKI

--- a/wolfcrypt/src/evp_pk.c
+++ b/wolfcrypt/src/evp_pk.c
@@ -2195,7 +2195,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_id(int type, WOLFSSL_EVP_PKEY** out,
  * START OF i2d APIs
  ******************************************************************************/
 
-#ifdef OPENSSL_ALL
+#if defined(OPENSSL_ALL) && defined(HAVE_PKCS8)
 /* Encode PKCS#8 key as DER data.
  *
  * @param [in]  key  PKCS#8 private key to encode.
@@ -2257,11 +2257,11 @@ int wolfSSL_i2d_PKCS8_PKEY(WOLFSSL_PKCS8_PRIV_KEY_INFO* key, unsigned char** pp)
 
     return len;
 }
-#endif
+#endif /* OPENSSL_ALL && HAVE_PKCS8 */
 
 #ifdef OPENSSL_EXTRA
 
-#if !defined(NO_ASN) && !defined(NO_PWDBASED)
+#if !defined(NO_ASN)
 /* Get raw pointer to DER buffer from WOLFSSL_EVP_PKEY.
  *
  * Assumes der is large enough if passed in.
@@ -2585,7 +2585,7 @@ cleanup:
 }
 #endif /* !NO_BIO */
 
-#endif /* !NO_ASN && !NO_PWDBASED */
+#endif /* !NO_ASN */
 
 #endif /* OPENSSL_EXTRA */
 


### PR DESCRIPTION
# Description

wolfSSL_sigTypeFromPKEY() was guarded by !NO_PWDBASED because
wolfSSL_EVP_get_hashinfo() originally lived inside the PBE section of
evp.c. The function now only requires OPENSSL_EXTRA, but the
caller-side guard was left behind, so X509_sign()/X509_REQ_sign()
fail at runtime when NO_PWDBASED is defined. The same stale condition
spread to other compat functions whose callees never depended on
password-based crypto; this PR removes those guards as well.

Fixes zd#22275

# Testing

- --enable-opensslextra --enable-certgen --enable-certreq
  --enable-keygen CPPFLAGS=-DNO_PWDBASED: CSR generation via
  X509_REQ_sign() succeeds (previously returned failure)
- make check passes with --enable-opensslall both with and without
  NO_PWDBASED (the NO_PWDBASED variant did not even link before)

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
