### PR TITLE
ascon: re-initialize the context in Final so it can be reused

### DIFF
--- a/doc/dox_comments/header_files-ja/ascon.h
+++ b/doc/dox_comments/header_files-ja/ascon.h
@@ -60,7 +60,7 @@ int wc_AsconHash256_Update(wc_AsconHash256* a, const byte* data, word32 dataSz);
 
 /*!
     \ingroup ASCON
-    \brief この関数は、ASCONハッシュを完了し、出力を生成します。
+    \brief この関数は、ASCONハッシュを完了し、出力を生成します。ASCONハッシュコンテキストの状態をリセットします。
 
     \return 0 成功時。
     \return BAD_FUNC_ARG コンテキストまたは出力ポインタがNULLの場合。
@@ -314,7 +314,7 @@ int wc_AsconAEAD128_EncryptUpdate(wc_AsconAEAD128* a, byte* out, const byte* in,
 
 /*!
     \ingroup ASCON
-    \brief この関数は、Ascon AEADを使用した暗号化プロセスを完了し、認証タグを生成します。
+    \brief この関数は、Ascon AEADを使用した暗号化プロセスを完了し、認証タグを生成します。Ascon AEADコンテキストの状態をリセットします。
 
     \return 0 成功時。
     \return BAD_FUNC_ARG コンテキストまたは出力ポインタがNULLの場合、または入力サイズが0より大きいのに入力がNULLの場合。
@@ -407,7 +407,7 @@ int wc_AsconAEAD128_DecryptUpdate(wc_AsconAEAD128* a, byte* out, const byte* in,
 
 /*!
     \ingroup ASCON
-    \brief この関数は、Ascon AEADを使用した復号プロセスを完了し、認証タグを検証します。
+    \brief この関数は、Ascon AEADを使用した復号プロセスを完了し、認証タグを検証します。Ascon AEADコンテキストの状態をリセットします。
 
     \return 0 成功時。
     \return BAD_FUNC_ARG コンテキストまたはタグポインタがNULLの場合。

--- a/doc/dox_comments/header_files/ascon.h
+++ b/doc/dox_comments/header_files/ascon.h
@@ -61,6 +61,7 @@ int wc_AsconHash256_Update(wc_AsconHash256* a, const byte* data, word32 dataSz);
 /*!
     \ingroup ASCON
     \brief This function finalizes the ASCON hash and produces the output.
+           Resets state of the ASCON hash context.
 
     \return 0 on success.
     \return BAD_FUNC_ARG if the context or output pointer is NULL.
@@ -321,7 +322,8 @@ int wc_AsconAEAD128_EncryptUpdate(wc_AsconAEAD128* a, byte* out, const byte* in,
 /*!
     \ingroup ASCON
     \brief This function finalizes the encryption process using Ascon AEAD and
-           produces the authentication tag.
+           produces the authentication tag. Resets state of the Ascon AEAD
+           context.
 
     \return 0 on success.
     \return BAD_FUNC_ARG if the context or output pointer is NULL or the input
@@ -421,7 +423,8 @@ int wc_AsconAEAD128_DecryptUpdate(wc_AsconAEAD128* a, byte* out, const byte* in,
 /*!
     \ingroup ASCON
     \brief This function finalizes the decryption process using Ascon AEAD and
-           verifies the authentication tag.
+           verifies the authentication tag. Resets state of the Ascon AEAD
+           context.
 
     \return 0 on success.
     \return BAD_FUNC_ARG if the context or tag pointer is NULL.

--- a/tests/api/test_ascon.c
+++ b/tests/api/test_ascon.c
@@ -413,7 +413,6 @@ int test_ascon_decision_coverage(void)
     byte ptbuf[8] = { 0 };
     byte ctbuf[8] = { 0 };
     byte tag[ASCON_AEAD128_TAG_SZ] = { 0 };
-    byte dummy[1] = { 0 }; /* non-NULL placeholder for 0-length in/ad args */
 
     /* ---------------------------------------------------------------- */
     /* wc_AsconHash256_Update:                                           */
@@ -725,3 +724,161 @@ int test_ascon_decision_coverage(void)
 #endif /* HAVE_ASCON */
     return EXPECT_RESULT();
 } /* END test_ascon_decision_coverage */
+
+/*
+ * Regression coverage for contexts reused after a Final call.
+ *
+ * The Final functions wipe the context with ForceZero(). Before the fix that
+ * also erased the algorithm IV installed by Init(), so a reused context
+ * silently absorbed into an all-zero state and returned 0 while producing a
+ * digest/ciphertext that is not Ascon. Final now re-initializes, so a reused
+ * context must produce exactly the same output as a freshly initialized one.
+ */
+int test_ascon_reuse_after_final(void)
+{
+    EXPECT_DECLS;
+#ifdef HAVE_ASCON
+    static const byte key[ASCON_AEAD128_KEY_SZ] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+    };
+    static const byte nonce[ASCON_AEAD128_NONCE_SZ] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+    };
+    static const byte ad[4] = { 0x00, 0x01, 0x02, 0x03 };
+    static const byte pt[8] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07
+    };
+    /* KAT[0]: PT = "", AD = "" -> tag only */
+    static const byte expTag0[ASCON_AEAD128_TAG_SZ] = {
+        0x44, 0x27, 0xD6, 0x4B, 0x8E, 0x1E, 0x14, 0x51,
+        0xFC, 0x44, 0x59, 0x60, 0xF0, 0x83, 0x9B, 0xB0
+    };
+    wc_AsconHash256 hashCtx;
+    wc_AsconAEAD128 aeadCtx;
+    byte msg[32];
+    byte md1[ASCON_HASH256_SZ];
+    byte md2[ASCON_HASH256_SZ];
+    byte ct1[sizeof(pt)];
+    byte ct2[sizeof(pt)];
+    byte tag1[ASCON_AEAD128_TAG_SZ];
+    byte tag2[ASCON_AEAD128_TAG_SZ];
+    byte ptOut[sizeof(pt)];
+    byte badTag[ASCON_AEAD128_TAG_SZ];
+    byte dummy[1]; /* non-NULL placeholder for 0-length pt/ad args */
+    word32 i;
+
+    for (i = 0; i < (word32)sizeof(msg); i++)
+        msg[i] = (byte)i;
+    dummy[0] = 0;
+
+    /* ------------------------------------------------------------------ */
+    /* 1. Hash256 reused after Final, with no intervening Init            */
+    /* ------------------------------------------------------------------ */
+    XMEMSET(md1, 0, sizeof(md1));
+    ExpectIntEQ(wc_AsconHash256_Init(&hashCtx), 0);
+    ExpectIntEQ(wc_AsconHash256_Update(&hashCtx, msg, (word32)sizeof(msg)), 0);
+    ExpectIntEQ(wc_AsconHash256_Final(&hashCtx, md1), 0);
+    ExpectBufEQ(md1, ascon_hash256_output[sizeof(msg)], ASCON_HASH256_SZ);
+
+    /* Deliberately no Init: Final must leave a usable context behind */
+    XMEMSET(md2, 0, sizeof(md2));
+    ExpectIntEQ(wc_AsconHash256_Update(&hashCtx, msg, (word32)sizeof(msg)), 0);
+    ExpectIntEQ(wc_AsconHash256_Final(&hashCtx, md2), 0);
+    ExpectBufEQ(md2, ascon_hash256_output[sizeof(msg)], ASCON_HASH256_SZ);
+
+    /* A third pass, split across two Updates, must still match */
+    XMEMSET(md2, 0, sizeof(md2));
+    ExpectIntEQ(wc_AsconHash256_Update(&hashCtx, msg, 8), 0);
+    ExpectIntEQ(wc_AsconHash256_Update(&hashCtx, msg + 8,
+        (word32)sizeof(msg) - 8), 0);
+    ExpectIntEQ(wc_AsconHash256_Final(&hashCtx, md2), 0);
+    ExpectBufEQ(md2, ascon_hash256_output[sizeof(msg)], ASCON_HASH256_SZ);
+    wc_AsconHash256_Clear(&hashCtx);
+
+    /* ------------------------------------------------------------------ */
+    /* 2. AEAD128 encrypt reused after EncryptFinal                        */
+    /* ------------------------------------------------------------------ */
+    XMEMSET(ct1, 0, sizeof(ct1));
+    XMEMSET(tag1, 0, sizeof(tag1));
+    ExpectIntEQ(wc_AsconAEAD128_Init(&aeadCtx), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetKey(&aeadCtx, key), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetNonce(&aeadCtx, nonce), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetAD(&aeadCtx, ad, (word32)sizeof(ad)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_EncryptUpdate(&aeadCtx, ct1, pt,
+        (word32)sizeof(pt)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_EncryptFinal(&aeadCtx, tag1), 0);
+
+    /* Deliberately no Init: the same sequence on the reused context must
+     * reproduce the ciphertext and tag of the fresh context above */
+    XMEMSET(ct2, 0, sizeof(ct2));
+    XMEMSET(tag2, 0, sizeof(tag2));
+    ExpectIntEQ(wc_AsconAEAD128_SetKey(&aeadCtx, key), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetNonce(&aeadCtx, nonce), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetAD(&aeadCtx, ad, (word32)sizeof(ad)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_EncryptUpdate(&aeadCtx, ct2, pt,
+        (word32)sizeof(pt)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_EncryptFinal(&aeadCtx, tag2), 0);
+    ExpectBufEQ(ct2, ct1, (word32)sizeof(ct1));
+    ExpectBufEQ(tag2, tag1, ASCON_AEAD128_TAG_SZ);
+
+    /* Absolute anchor: a third pass on the twice-reused context, with the
+     * empty PT/AD KAT, must yield the published tag. This only holds if
+     * state.s64[0] really was restored to ASCON_AEAD128_IV */
+    XMEMSET(tag2, 0, sizeof(tag2));
+    ExpectIntEQ(wc_AsconAEAD128_SetKey(&aeadCtx, key), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetNonce(&aeadCtx, nonce), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetAD(&aeadCtx, dummy, 0), 0);
+    ExpectIntEQ(wc_AsconAEAD128_EncryptUpdate(&aeadCtx, dummy, dummy, 0), 0);
+    ExpectIntEQ(wc_AsconAEAD128_EncryptFinal(&aeadCtx, tag2), 0);
+    ExpectBufEQ(tag2, expTag0, ASCON_AEAD128_TAG_SZ);
+    wc_AsconAEAD128_Clear(&aeadCtx);
+
+    /* ------------------------------------------------------------------ */
+    /* 3. AEAD128 decrypt reused after DecryptFinal                        */
+    /* ------------------------------------------------------------------ */
+    XMEMSET(ptOut, 0, sizeof(ptOut));
+    ExpectIntEQ(wc_AsconAEAD128_Init(&aeadCtx), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetKey(&aeadCtx, key), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetNonce(&aeadCtx, nonce), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetAD(&aeadCtx, ad, (word32)sizeof(ad)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_DecryptUpdate(&aeadCtx, ptOut, ct1,
+        (word32)sizeof(ct1)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_DecryptFinal(&aeadCtx, tag1), 0);
+    ExpectBufEQ(ptOut, pt, (word32)sizeof(pt));
+
+    /* Deliberately no Init: the reused context must authenticate again */
+    XMEMSET(ptOut, 0, sizeof(ptOut));
+    ExpectIntEQ(wc_AsconAEAD128_SetKey(&aeadCtx, key), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetNonce(&aeadCtx, nonce), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetAD(&aeadCtx, ad, (word32)sizeof(ad)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_DecryptUpdate(&aeadCtx, ptOut, ct1,
+        (word32)sizeof(ct1)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_DecryptFinal(&aeadCtx, tag1), 0);
+    ExpectBufEQ(ptOut, pt, (word32)sizeof(pt));
+
+    /* A tag failure must still reset the context for the next message */
+    XMEMCPY(badTag, tag1, ASCON_AEAD128_TAG_SZ);
+    badTag[0] ^= 0xFF;
+    XMEMSET(ptOut, 0, sizeof(ptOut));
+    ExpectIntEQ(wc_AsconAEAD128_SetKey(&aeadCtx, key), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetNonce(&aeadCtx, nonce), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetAD(&aeadCtx, ad, (word32)sizeof(ad)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_DecryptUpdate(&aeadCtx, ptOut, ct1,
+        (word32)sizeof(ct1)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_DecryptFinal(&aeadCtx, badTag),
+        WC_NO_ERR_TRACE(ASCON_AUTH_E));
+
+    XMEMSET(ptOut, 0, sizeof(ptOut));
+    ExpectIntEQ(wc_AsconAEAD128_SetKey(&aeadCtx, key), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetNonce(&aeadCtx, nonce), 0);
+    ExpectIntEQ(wc_AsconAEAD128_SetAD(&aeadCtx, ad, (word32)sizeof(ad)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_DecryptUpdate(&aeadCtx, ptOut, ct1,
+        (word32)sizeof(ct1)), 0);
+    ExpectIntEQ(wc_AsconAEAD128_DecryptFinal(&aeadCtx, tag1), 0);
+    ExpectBufEQ(ptOut, pt, (word32)sizeof(pt));
+    wc_AsconAEAD128_Clear(&aeadCtx);
+#endif /* HAVE_ASCON */
+    return EXPECT_RESULT();
+} /* END test_ascon_reuse_after_final */

--- a/tests/api/test_ascon.h
+++ b/tests/api/test_ascon.h
@@ -28,11 +28,13 @@ int test_ascon_hash256(void);
 int test_ascon_aead128(void);
 int test_ascon_aead128_edge_cases(void);
 int test_ascon_decision_coverage(void);
+int test_ascon_reuse_after_final(void);
 
-#define TEST_ASCON_DECLS                                        \
-    TEST_DECL_GROUP("ascon", test_ascon_hash256),               \
-    TEST_DECL_GROUP("ascon", test_ascon_aead128),               \
-    TEST_DECL_GROUP("ascon", test_ascon_aead128_edge_cases),    \
-    TEST_DECL_GROUP("ascon", test_ascon_decision_coverage)
+#define TEST_ASCON_DECLS                                     \
+    TEST_DECL_GROUP("ascon", test_ascon_hash256),            \
+    TEST_DECL_GROUP("ascon", test_ascon_aead128),            \
+    TEST_DECL_GROUP("ascon", test_ascon_aead128_edge_cases), \
+    TEST_DECL_GROUP("ascon", test_ascon_decision_coverage),  \
+    TEST_DECL_GROUP("ascon", test_ascon_reuse_after_final)
 
 #endif /* TESTS_API_TEST_ASCON_H */

--- a/wolfcrypt/src/ascon.c
+++ b/wolfcrypt/src/ascon.c
@@ -266,9 +266,9 @@ int wc_AsconHash256_Final(wc_AsconHash256* a, byte* hash)
         hash += ASCON_HASH256_RATE;
     }
 
-    /* Clear state as soon as possible */
+    /* Clear state as soon as possible, then reset for reuse */
     wc_AsconHash256_Clear(a);
-    return 0;
+    return wc_AsconHash256_Init(a);
 }
 
 /* AsconAEAD API */
@@ -438,11 +438,10 @@ int wc_AsconAEAD128_EncryptFinal(wc_AsconAEAD128* a, byte* tag)
 
     XMEMCPY(tag, &a->state.s64[3], ASCON_AEAD128_TAG_SZ);
 
-    /* Clear state as soon as possible */
+    /* Clear state as soon as possible, then reset for reuse */
     wc_AsconAEAD128_Clear(a);
 
-    return 0;
-
+    return wc_AsconAEAD128_Init(a);
 }
 
 
@@ -502,6 +501,7 @@ int wc_AsconAEAD128_DecryptUpdate(wc_AsconAEAD128* a, byte* out,
 int wc_AsconAEAD128_DecryptFinal(wc_AsconAEAD128* a, const byte* tag)
 {
     int ret = 0;
+    int initRet;
 
     if (a == NULL || tag == NULL)
         return BAD_FUNC_ARG;
@@ -525,8 +525,11 @@ int wc_AsconAEAD128_DecryptFinal(wc_AsconAEAD128* a, const byte* tag)
         ret = ASCON_AUTH_E;
     }
 
-    /* Clear state as soon as possible */
+    /* Clear state as soon as possible, then reset for reuse */
     wc_AsconAEAD128_Clear(a);
+    initRet = wc_AsconAEAD128_Init(a);
+    if (ret == 0)
+        ret = initRet;
 
     return ret;
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -12527,14 +12527,42 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ascon_hash256_test(void)
         wc_AsconHash256_Clear(&asconHash);
     }
 
+    /* Test context reuse. Final re-initializes the context, so Init is
+     * called only once for the whole loop below. */
+    err = wc_AsconHash256_Init(&asconHash);
+    if (err != 0)
+        return WC_TEST_RET_ENC_EC(err);
+    for (i = 0; i < XELEM_CNT(hash_output); i++) {
+        XMEMSET(mdOut, 0, sizeof(mdOut));
+        err = wc_AsconHash256_Update(&asconHash, msg, i);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconHash256_Final(&asconHash, mdOut);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        if (XMEMCMP(mdOut, hash_output[i], ASCON_HASH256_SZ) != 0)
+            return WC_TEST_RET_ENC_NC;
+    }
+    wc_AsconHash256_Clear(&asconHash);
+
     return 0;
 }
 
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ascon_aead128_test(void)
 {
     word32 i;
+    word32 k;
+    word32 m;
     wc_AsconAEAD128 asconAEAD;
     int err;
+    byte rkey[ASCON_AEAD128_KEY_SZ];
+    byte rnonce[ASCON_AEAD128_NONCE_SZ];
+    byte rad[32];
+    word32 radSz;
+    byte rct[48];
+    byte rtag[ASCON_AEAD128_TAG_SZ];
+    byte rbadtag[ASCON_AEAD128_TAG_SZ];
+    byte rbuf[1]; /* non-NULL placeholder for the 0-length plaintext */
 
     /* KATs taken from https://github.com/ascon/ascon-c.
      * Testing only a subset of KATs here. The rest are tested in
@@ -12707,6 +12735,114 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ascon_aead128_test(void)
             wc_AsconAEAD128_Clear(&asconAEAD);
         }
     }
+
+    /* Test context reuse. Both Final calls re-initialize the context, so Init
+     * is called only once for the whole loop below. Every vector in the table
+     * has an empty plaintext, so the ciphertext is the tag alone. */
+    err = wc_AsconAEAD128_Init(&asconAEAD);
+    if (err != 0)
+        return WC_TEST_RET_ENC_EC(err);
+    for (k = 0; k < XELEM_CNT(aead_kat); k++) {
+        XMEMSET(rkey, 0, sizeof(rkey));
+        XMEMSET(rnonce, 0, sizeof(rnonce));
+        XMEMSET(rad, 0, sizeof(rad));
+        XMEMSET(rct, 0, sizeof(rct));
+        XMEMSET(rtag, 0, sizeof(rtag));
+        rbuf[0] = 0;
+
+        for (m = 0; aead_kat[k][0][m] != '\0'; m += 2) {
+            rkey[m/2] = HexCharToByte(aead_kat[k][0][m]) << 4 |
+                        HexCharToByte(aead_kat[k][0][m+1]);
+        }
+        for (m = 0; aead_kat[k][1][m] != '\0'; m += 2) {
+            rnonce[m/2] = HexCharToByte(aead_kat[k][1][m]) << 4 |
+                          HexCharToByte(aead_kat[k][1][m+1]);
+        }
+        for (m = 0; aead_kat[k][3][m] != '\0'; m += 2) {
+            rad[m/2] = HexCharToByte(aead_kat[k][3][m]) << 4 |
+                       HexCharToByte(aead_kat[k][3][m+1]);
+        }
+        radSz = m/2;
+        for (m = 0; aead_kat[k][4][m] != '\0'; m += 2) {
+            rct[m/2] = HexCharToByte(aead_kat[k][4][m]) << 4 |
+                       HexCharToByte(aead_kat[k][4][m+1]);
+        }
+
+        err = wc_AsconAEAD128_SetKey(&asconAEAD, rkey);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_SetNonce(&asconAEAD, rnonce);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_SetAD(&asconAEAD, rad, radSz);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_EncryptUpdate(&asconAEAD, rbuf, rbuf, 0);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_EncryptFinal(&asconAEAD, rtag);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        if (XMEMCMP(rtag, rct, ASCON_AEAD128_TAG_SZ) != 0)
+            return WC_TEST_RET_ENC_NC;
+
+        /* Decrypt on the context EncryptFinal just reset */
+        err = wc_AsconAEAD128_SetKey(&asconAEAD, rkey);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_SetNonce(&asconAEAD, rnonce);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_SetAD(&asconAEAD, rad, radSz);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_DecryptUpdate(&asconAEAD, rbuf, rbuf, 0);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_DecryptFinal(&asconAEAD, rct);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+
+        /* A rejected tag must still leave the context ready for reuse. The
+         * next loop iteration verifies that recovery. */
+        XMEMCPY(rbadtag, rct, ASCON_AEAD128_TAG_SZ);
+        rbadtag[0] ^= 0xFF;
+        err = wc_AsconAEAD128_SetKey(&asconAEAD, rkey);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_SetNonce(&asconAEAD, rnonce);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_SetAD(&asconAEAD, rad, radSz);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_DecryptUpdate(&asconAEAD, rbuf, rbuf, 0);
+        if (err != 0)
+            return WC_TEST_RET_ENC_EC(err);
+        err = wc_AsconAEAD128_DecryptFinal(&asconAEAD, rbadtag);
+        if (err != WC_NO_ERR_TRACE(ASCON_AUTH_E))
+            return WC_TEST_RET_ENC_EC(err);
+    }
+
+    /* Final pass proves the context recovered from the last rejected tag */
+    err = wc_AsconAEAD128_SetKey(&asconAEAD, rkey);
+    if (err != 0)
+        return WC_TEST_RET_ENC_EC(err);
+    err = wc_AsconAEAD128_SetNonce(&asconAEAD, rnonce);
+    if (err != 0)
+        return WC_TEST_RET_ENC_EC(err);
+    err = wc_AsconAEAD128_SetAD(&asconAEAD, rad, radSz);
+    if (err != 0)
+        return WC_TEST_RET_ENC_EC(err);
+    err = wc_AsconAEAD128_EncryptUpdate(&asconAEAD, rbuf, rbuf, 0);
+    if (err != 0)
+        return WC_TEST_RET_ENC_EC(err);
+    err = wc_AsconAEAD128_EncryptFinal(&asconAEAD, rtag);
+    if (err != 0)
+        return WC_TEST_RET_ENC_EC(err);
+    if (XMEMCMP(rtag, rct, ASCON_AEAD128_TAG_SZ) != 0)
+        return WC_TEST_RET_ENC_NC;
+    wc_AsconAEAD128_Clear(&asconAEAD);
 
     /* Negative test: corrupted tag must be rejected with ASCON_AUTH_E. */
     {


### PR DESCRIPTION
### Problem
Both Ascon `Final` functions ended with `_Clear()`, which `ForceZero`s the whole context — wiping the algorithm IV that `_Init()` installs along with the AEAD's `keySet`/`nonceSet`/`adSet`/`op` bits. Nothing then distinguishes a post-`Final` context from an initialized one, so continued use returns `0` while producing output that is not Ascon:

- **Hash** — a second `Update`/`Final` absorbs into an all-zero state instead of the `ASCON_HASH256_IV`-permuted state.
- **AEAD** — `SetKey` → `SetNonce` → `SetAD` → `EncryptUpdate` → `EncryptFinal` all succeed with `state.s64[0] == 0` instead of `ASCON_AEAD128_IV`, giving wrong, non-interoperable ciphertext and tag.

This was live in-tree: `bench_ascon_hash` calls `_Init` once *outside* its streaming loop, so every iteration after the first benchmarked a non-Ascon computation and reported success.

Closes f-7073.

### Fix (`wolfcrypt/src/ascon.c`)
All three `Final` functions keep the `ForceZero` and then re-initialize, matching the established wolfCrypt idiom (`wc_Md2Final`, `wc_ShaFinal`, `wc_Sha256Final`, `wc_Sha3Final`, …):

```c
    /* Clear state as soon as possible, then reset for reuse */
    wc_AsconHash256_Clear(a);
    return wc_AsconHash256_Init(a);
```

`wc_AsconAEAD128_DecryptFinal` routes the `Init` result through `initRet` so `ASCON_AUTH_E` is never masked.

`wolfssl/wolfcrypt/ascon.h` is untouched — no struct change, no ABI impact. No FIPS impact: `ascon.c` sits outside every `BUILD_FIPS*` conditional in `src/include.am`, and `HAVE_ASCON` requires `WOLFSSL_EXPERIMENTAL_SETTINGS`.

Docs: the EN and JA `\brief` for the three `Final` blocks now note the reset, using the same wording as `sha256.h`/`md5.h`.

### Tests
- **`tests/api/test_ascon.c`** — new `test_ascon_reuse_after_final`: hash reused twice against the KAT digest; AEAD encrypt reused with an absolute KAT tag anchor on the twice-reused context; decrypt reuse, including that an `ASCON_AUTH_E` failure still leaves the context usable.
- **`wolfcrypt/test/test.c`** — reuse loops added to `ascon_hash256_test`/`ascon_aead128_test` so embedded smoke builds cover it.
- Also drops an unused `dummy` declaration in `test_ascon.c` that broke `-Werror`.

### Verification
- Build clean under `--enable-ascon --enable-all --enable-experimental`, no warnings.
- `testwolfcrypt` passes; `unit.test --api` 1890 passed / 0 failed; `--group ascon` 5/5.
- Negative control, run twice: reverting the whole fix fails both new tests; reverting only the AEAD half leaves the hash passing and fails the AEAD tests.
- Default build with ASCON off: clean, ascon groups skipped.
