### PR TITLE
Set actual date length in CRL ASN1_TIME fields

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -148,6 +148,18 @@ static void SortCRL_CertList(RevokedCert* certs, int totalCerts)
 }
 #endif /* CRL_STATIC_REVOKED_LIST */
 
+#if defined(OPENSSL_EXTRA)
+/* Get length of date string. The parsed date is not guaranteed to be
+ * NUL-terminated, so stop at the end of the buffer. */
+static int GetDateLen(const byte* date)
+{
+    int len = 0;
+    while (len < MAX_DATE_SIZE && date[len] != 0)
+        len++;
+    return len;
+}
+#endif
+
 /* Initialize CRL Entry */
 static int InitCRL_Entry(CRL_Entry* crle, DecodedCRL* dcrl, const byte* buff,
                          int verified, void* heap)
@@ -164,12 +176,11 @@ static int InitCRL_Entry(CRL_Entry* crle, DecodedCRL* dcrl, const byte* buff,
     crle->version = dcrl->version;
 
 #if defined(OPENSSL_EXTRA)
-    /* Set the actual date length, not MAX_DATE_SIZE. The dates are
-     * NUL-terminated since DecodedCRL is zero-initialized. */
-    crle->lastDateAsn1.length = (int)XSTRLEN((const char*)crle->lastDate);
+    /* Set the actual date length, not MAX_DATE_SIZE. */
+    crle->lastDateAsn1.length = GetDateLen(crle->lastDate);
     XMEMCPY (crle->lastDateAsn1.data, crle->lastDate, MAX_DATE_SIZE);
     crle->lastDateAsn1.type = crle->lastDateFormat;
-    crle->nextDateAsn1.length = (int)XSTRLEN((const char*)crle->nextDate);
+    crle->nextDateAsn1.length = GetDateLen(crle->nextDate);
     XMEMCPY (crle->nextDateAsn1.data, crle->nextDate, MAX_DATE_SIZE);
     crle->nextDateAsn1.type = crle->nextDateFormat;
 

--- a/src/crl.c
+++ b/src/crl.c
@@ -164,13 +164,13 @@ static int InitCRL_Entry(CRL_Entry* crle, DecodedCRL* dcrl, const byte* buff,
     crle->version = dcrl->version;
 
 #if defined(OPENSSL_EXTRA)
-    crle->lastDateAsn1.length = MAX_DATE_SIZE;
-    XMEMCPY (crle->lastDateAsn1.data, crle->lastDate,
-             (size_t)crle->lastDateAsn1.length);
+    /* Set the actual date length, not MAX_DATE_SIZE. The dates are
+     * NUL-terminated since DecodedCRL is zero-initialized. */
+    crle->lastDateAsn1.length = (int)XSTRLEN((const char*)crle->lastDate);
+    XMEMCPY (crle->lastDateAsn1.data, crle->lastDate, MAX_DATE_SIZE);
     crle->lastDateAsn1.type = crle->lastDateFormat;
-    crle->nextDateAsn1.length = MAX_DATE_SIZE;
-    XMEMCPY (crle->nextDateAsn1.data, crle->nextDate,
-             (size_t)crle->nextDateAsn1.length);
+    crle->nextDateAsn1.length = (int)XSTRLEN((const char*)crle->nextDate);
+    XMEMCPY (crle->nextDateAsn1.data, crle->nextDate, MAX_DATE_SIZE);
     crle->nextDateAsn1.type = crle->nextDateFormat;
 
     crle->issuer = NULL;

--- a/tests/api.c
+++ b/tests/api.c
@@ -28186,6 +28186,11 @@ static int test_wolfSSL_X509_CRL(void)
             crl = NULL;
         }
         ExpectNotNull(crl);
+#ifndef NO_ASN_TIME
+        /* Dates must have their actual length set, not MAX_DATE_SIZE. */
+        ExpectIntEQ(ASN1_TIME_check(X509_CRL_get0_lastUpdate(crl)), 1);
+        ExpectIntEQ(ASN1_TIME_check(X509_CRL_get0_nextUpdate(crl)), 1);
+#endif
         X509_CRL_free(crl);
         crl = NULL;
         if (fp != XBADFILE) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -28167,6 +28167,9 @@ static int test_wolfSSL_X509_CRL(void)
 
     XFILE fp = XBADFILE;
     int i;
+#ifndef NO_ASN_TIME
+    ASN1_TIME* nextUpdate = NULL;
+#endif
 
     for (i = 0; pem[i][0] != '\0'; i++)
     {
@@ -28187,9 +28190,13 @@ static int test_wolfSSL_X509_CRL(void)
         }
         ExpectNotNull(crl);
 #ifndef NO_ASN_TIME
-        /* Dates must have their actual length set, not MAX_DATE_SIZE. */
+        /* Dates must have their actual length set, not MAX_DATE_SIZE.
+         * nextUpdate is optional so only check it when present. */
         ExpectIntEQ(ASN1_TIME_check(X509_CRL_get0_lastUpdate(crl)), 1);
-        ExpectIntEQ(ASN1_TIME_check(X509_CRL_get0_nextUpdate(crl)), 1);
+        nextUpdate = X509_CRL_get0_nextUpdate(crl);
+        if (nextUpdate != NULL) {
+            ExpectIntEQ(ASN1_TIME_check(nextUpdate), 1);
+        }
 #endif
         X509_CRL_free(crl);
         crl = NULL;


### PR DESCRIPTION
# Description

lastDateAsn1/nextDateAsn1 used MAX_DATE_SIZE as the ASN1_TIME length
instead of the real date string length, breaking ASN1_TIME_check()
and date printing/comparison on X509_CRL_get0_lastUpdate()/
get0_nextUpdate(). Set the length with XSTRLEN() and add
ASN1_TIME_check() coverage to test_wolfSSL_X509_CRL().

Fixes zd#22281

# Testing

Added length check on the time.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
