### PR TITLE
Reject curve448 public key export from an unset key

### DIFF
--- a/doc/dox_comments/header_files-ja/curve448.h
+++ b/doc/dox_comments/header_files-ja/curve448.h
@@ -509,7 +509,8 @@ int wc_curve448_check_public(const byte* pub, word32 pubSz, int endian);
     \brief この関数は、与えられた鍵構造体から公開鍵をエクスポートし、結果をoutバッファに格納します。ビッグエンディアンのみ。
 
     \return 0 curve448_key構造体から公開鍵のエクスポートに成功した場合に返されます。
-    \return ECC_BAD_ARG_E outLenがCURVE448_PUB_KEY_SIZEより小さい場合に返されます。
+    \return ECC_BAD_ARG_E outLenがCURVE448_PUB_KEY_SIZEより小さい場合、
+    または公開鍵と秘密鍵のどちらも設定されていない場合に返されます。
     \return BAD_FUNC_ARG 入力パラメータのいずれかがNULLの場合に返されます。
 
     \param [in] key 鍵をエクスポートするcurve448_key構造体へのポインタ。
@@ -546,7 +547,8 @@ int wc_curve448_export_public(curve448_key* key, byte* out, word32* outLen);
     \brief この関数は、与えられた鍵構造体から公開鍵をエクスポートし、結果をoutバッファに格納します。ビッグエンディアンとリトルエンディアンの両方をサポートします。
 
     \return 0 curve448_key構造体から公開鍵のエクスポートに成功した場合に返されます。
-    \return ECC_BAD_ARG_E outLenがCURVE448_PUB_KEY_SIZEより小さい場合に返されます。
+    \return ECC_BAD_ARG_E outLenがCURVE448_PUB_KEY_SIZEより小さい場合、
+    または公開鍵と秘密鍵のどちらも設定されていない場合に返されます。
     \return BAD_FUNC_ARG 入力パラメータのいずれかがNULLの場合に返されます。
 
     \param [in] key 鍵をエクスポートするcurve448_key構造体へのポインタ。

--- a/doc/dox_comments/header_files/curve448.h
+++ b/doc/dox_comments/header_files/curve448.h
@@ -565,7 +565,8 @@ int wc_curve448_check_public(const byte* pub, word32 pubSz, int endian);
 
     \return 0 Returned on successfully exporting the public key from the
     curve448_key structure.
-    \return ECC_BAD_ARG_E Returned if outLen is less than CURVE448_PUB_KEY_SIZE.
+    \return ECC_BAD_ARG_E Returned if outLen is less than CURVE448_PUB_KEY_SIZE,
+    or if neither the public nor the private key has been set.
     \return BAD_FUNC_ARG Returned if any of the input parameters are NULL.
 
     \param [in] key Pointer to the curve448_key structure in from which to
@@ -605,7 +606,8 @@ int wc_curve448_export_public(curve448_key* key, byte* out, word32* outLen);
 
     \return 0 Returned on successfully exporting the public key from the
     curve448_key structure.
-    \return ECC_BAD_ARG_E Returned if outLen is less than CURVE448_PUB_KEY_SIZE.
+    \return ECC_BAD_ARG_E Returned if outLen is less than CURVE448_PUB_KEY_SIZE,
+    or if neither the public nor the private key has been set.
     \return BAD_FUNC_ARG Returned if any of the input parameters are NULL.
 
     \param [in] key Pointer to the curve448_key structure in from which to

--- a/tests/api/test_curve448.c
+++ b/tests/api/test_curve448.c
@@ -167,18 +167,30 @@ int test_wc_curve448_export_public_ex(void)
 #if defined(HAVE_CURVE448)
     WC_RNG        rng;
     curve448_key  key;
+    curve448_key  unset;
+    curve448_key  pubOnly;
     byte          out[CURVE448_KEY_SIZE];
+    byte          pubOut[CURVE448_KEY_SIZE];
     word32        outLen = sizeof(out);
+    word32        pubOutLen = sizeof(pubOut);
     int           endian = EC448_BIG_ENDIAN;
 
     XMEMSET(&rng, 0, sizeof(WC_RNG));
 
     ExpectIntEQ(wc_curve448_init(&key), 0);
+    ExpectIntEQ(wc_curve448_init(&unset), 0);
+    ExpectIntEQ(wc_curve448_init(&pubOnly), 0);
     ExpectIntEQ(wc_InitRng(&rng), 0);
     ExpectIntEQ(wc_curve448_make_key(&rng, CURVE448_KEY_SIZE, &key), 0);
 
     ExpectIntEQ(wc_curve448_export_public(&key, out, &outLen), 0);
     ExpectIntEQ(wc_curve448_export_public_ex(&key, out, &outLen, endian), 0);
+    /* a key holding only a public component exports it unchanged */
+    ExpectIntEQ(wc_curve448_import_public(out, outLen, &pubOnly), 0);
+    ExpectIntEQ(wc_curve448_export_public_ex(&pubOnly, pubOut, &pubOutLen,
+        endian), 0);
+    ExpectIntEQ(pubOutLen, CURVE448_PUB_KEY_SIZE);
+    ExpectIntEQ(XMEMCMP(out, pubOut, CURVE448_PUB_KEY_SIZE), 0);
     /* test bad cases */
     ExpectIntEQ(wc_curve448_export_public_ex(NULL, NULL, NULL, endian),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
@@ -188,12 +200,19 @@ int test_wc_curve448_export_public_ex(void)
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_curve448_export_public_ex(&key, out, NULL, endian),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    /* no private or public key set to export */
+    ExpectIntEQ(wc_curve448_export_public(&unset, out, &outLen),
+        WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
+    ExpectIntEQ(wc_curve448_export_public_ex(&unset, out, &outLen, endian),
+        WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
     outLen = outLen - 2;
     ExpectIntEQ(wc_curve448_export_public_ex(&key, out, &outLen, endian),
         WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
 
     DoExpectIntEQ(wc_FreeRng(&rng), 0);
     wc_curve448_free(&key);
+    wc_curve448_free(&unset);
+    wc_curve448_free(&pubOnly);
 #endif
     return EXPECT_RESULT();
 } /* END test_wc_curve448_export_public_ex */

--- a/wolfcrypt/src/curve448.c
+++ b/wolfcrypt/src/curve448.c
@@ -232,7 +232,8 @@ int wc_curve448_shared_secret_ex(curve448_key* private_key,
  * outLen  [in/out]  On in, the number of bytes in array.
  *                   On out, the number bytes put into array.
  * returns BAD_FUNC_ARG when a parameter is NULL,
- *         ECC_BAD_ARG_E when outLen is less than CURVE448_PUB_KEY_SIZE,
+ *         ECC_BAD_ARG_E when outLen is less than CURVE448_PUB_KEY_SIZE or
+ *         neither the public nor the private key has been set,
  *         0 otherwise.
  */
 int wc_curve448_export_public(curve448_key* key, byte* out, word32* outLen)
@@ -248,7 +249,8 @@ int wc_curve448_export_public(curve448_key* key, byte* out, word32* outLen)
  *                   On out, the number bytes put into array.
  * endian  [in]      Endianness to use when encoding number in array.
  * returns BAD_FUNC_ARG when a parameter is NULL,
- *         ECC_BAD_ARG_E when outLen is less than CURVE448_PUB_KEY_SIZE,
+ *         ECC_BAD_ARG_E when outLen is less than CURVE448_PUB_KEY_SIZE or
+ *         neither the public nor the private key has been set,
  *         0 otherwise.
  */
 int wc_curve448_export_public_ex(curve448_key* key, byte* out, word32* outLen,
@@ -263,6 +265,11 @@ int wc_curve448_export_public_ex(curve448_key* key, byte* out, word32* outLen,
     /* check and set outgoing key size */
     if ((ret == 0) && (*outLen < CURVE448_PUB_KEY_SIZE)) {
         *outLen = CURVE448_PUB_KEY_SIZE;
+        ret = ECC_BAD_ARG_E;
+    }
+
+    /* no public key to export and no private key to derive it from */
+    if ((ret == 0) && (!key->pubSet) && (!key->privSet)) {
         ret = ECC_BAD_ARG_E;
     }
     if (ret == 0) {


### PR DESCRIPTION
### Problem

`wc_curve448_export_public_ex()` lazily derives the public key whenever `key->pubSet` is clear, but never checks `key->privSet`. `wc_curve448_init()` zeroes the whole key and `wc_curve448_make_pub()` does no clamping of its own, so this sequence succeeds and returns a public key for a key pair that does not exist:

```c
curve448_key k;
wc_curve448_init(&k);
wc_curve448_export_public(&k, buf, &len);   /* returns 0 */
```

The ladder runs over the all-zero scalar, `pubSet` is set to 1, `CURVE448_PUB_KEY_SIZE` bytes are written and 0 is returned, with nothing to distinguish the result from a real export. Callers that treat a 0 return as "this key is usable" get a degenerate public value.

This is inconsistent with the rest of the file: `wc_curve448_export_private_raw_ex()` rejects `!privSet`, and `wc_curve448_shared_secret_ex()` rejects `!privSet || !pubSet`. Only the public exporter was missing the state check. Closes f-7076.

### Fix (`wolfcrypt/src/curve448.c`)

Return `ECC_BAD_ARG_E` when neither component is set, before the lazy derivation:

```c
    /* no public key to export and no private key to derive it from */
    if ((ret == 0) && (!key->pubSet) && (!key->privSet)) {
        ret = ECC_BAD_ARG_E;
    }
```

Keys holding only a private scalar, as produced by `wc_curve448_import_private_ex()`, still derive the public key on export as before. Doc comments on both the `_ex` function and the `wc_curve448_export_public()` wrapper are updated, along with the doxygen headers (English and Japanese).

### Tests

`test_wc_curve448_export_public_ex()` gains an unset-key case: a second freshly `wc_curve448_init()`ed key, asserting `ECC_BAD_ARG_E` from both `wc_curve448_export_public()` and `wc_curve448_export_public_ex()`.

### Verification

- Build clean under `--enable-curve25519 --enable-curve448 --enable-all-crypto`, no warnings.
- `./tests/unit.test`: 943 passed, 0 failed. `testwolfcrypt` exit 0.
- Negative control: without the guard the new assertions return `0` instead of `ECC_BAD_ARG_E`.
- `test_wc_curve448_export_import_endian` still passes, covering the `privSet`-only lazy-derivation path.