### PR TITLE
Reject out-of-range SHE counter, flags and key IDs

### DIFF
--- a/doc/dox_comments/header_files-ja/wc_she.h
+++ b/doc/dox_comments/header_files-ja/wc_she.h
@@ -265,15 +265,15 @@ int wc_SHE_ImportM1M2M3(wc_SHE* she,
     \brief SHEの鍵更新メッセージM1、M2、M3を生成し、呼び出し側が用意したバッファへ書き込みます。認可鍵からK1とK2を導出するためにMiyaguchi-Preneel AES-128 KDFを、新しい鍵の暗号化(M2)にAES-CBCを、認証(M3)にAES-CMACを使用します。
 
     \return 0 成功した場合に返されます
-    \return BAD_FUNC_ARG 必要なポインタのいずれかがNULLの場合、またはサイズが正しくない場合に返されます
+    \return BAD_FUNC_ARG 必要なポインタのいずれかがNULLの場合、サイズが正しくない場合、またはcounter、flags、authKeyId、targetKeyIdがパックされるフィールドの幅を超える場合に返されます
 
     \param she 初期化済みのSHEコンテキスト
     \param uid 15バイトのSHE UID(120ビットのECU/モジュール識別子)
     \param uidSz WC_SHE_UID_SZ(15)でなければなりません
-    \param authKeyId 認可鍵のスロットID(0〜14)
+    \param authKeyId 認可鍵の4ビットのスロットID
     \param authKey 認可鍵の16バイトの値
     \param authKeySz WC_SHE_KEY_SZ(16)でなければなりません
-    \param targetKeyId ロード対象の鍵のスロットID(1〜14)
+    \param targetKeyId ロード対象の鍵の4ビットのスロットID
     \param newKey ロードする新しい鍵の16バイトの値
     \param newKeySz WC_SHE_KEY_SZ(16)でなければなりません
     \param counter 28ビットの単調増加カウンタ値(対象スロットに格納されているカウンタより大きい値でなければなりません。同じ値は使用できません)
@@ -317,13 +317,13 @@ int wc_SHE_GenerateM1M2M3(wc_SHE* she,
     \brief SHEの検証メッセージM4とM5を生成し、呼び出し側が用意したバッファへ書き込みます。新しい鍵からK3とK4を導出するためにMiyaguchi-Preneel AES-128 KDFを、M4のカウンタブロックにAES-ECBを、M5にAES-CMACを使用します。M1/M2/M3とは独立しており、別のコンテキストで呼び出すこともできます。
 
     \return 0 成功した場合に返されます
-    \return BAD_FUNC_ARG 必要なポインタのいずれかがNULLの場合、またはサイズが正しくない場合に返されます
+    \return BAD_FUNC_ARG 必要なポインタのいずれかがNULLの場合、サイズが正しくない場合、またはcounter、authKeyId、targetKeyIdがパックされるフィールドの幅を超える場合に返されます
 
     \param she 初期化済みのSHEコンテキスト
     \param uid 15バイトのSHE UID(M1で使用したものと同じUID)
     \param uidSz WC_SHE_UID_SZ(15)でなければなりません
-    \param authKeyId 認可鍵のスロットID(M1と同じ)
-    \param targetKeyId ロード対象の鍵のスロットID(M1と同じ)
+    \param authKeyId 認可鍵の4ビットのスロットID(M1と同じ)
+    \param targetKeyId ロード対象の鍵の4ビットのスロットID(M1と同じ)
     \param newKey 新しい鍵の16バイトの値
     \param newKeySz WC_SHE_KEY_SZ(16)でなければなりません
     \param counter 28ビットの単調増加カウンタ(M2と同じ値)

--- a/doc/dox_comments/header_files/wc_she.h
+++ b/doc/dox_comments/header_files/wc_she.h
@@ -294,16 +294,17 @@ int wc_SHE_ImportM1M2M3(wc_SHE* she,
     new key (M2), and AES-CMAC for authentication (M3).
 
     \return 0 on success
-    \return BAD_FUNC_ARG if any required pointer is NULL or sizes are
-    incorrect
+    \return BAD_FUNC_ARG if any required pointer is NULL, sizes are
+    incorrect, or counter, flags, authKeyId or targetKeyId is wider than
+    its packed field
 
     \param she initialized SHE context
     \param uid 15-byte SHE UID (120-bit ECU/module identifier)
     \param uidSz must be WC_SHE_UID_SZ (15)
-    \param authKeyId slot ID of the authorizing key (0-14)
+    \param authKeyId 4-bit slot ID of the authorizing key
     \param authKey 16-byte value of the authorizing key
     \param authKeySz must be WC_SHE_KEY_SZ (16)
-    \param targetKeyId slot ID of the key being loaded (1-14)
+    \param targetKeyId 4-bit slot ID of the key being loaded
     \param newKey 16-byte value of the new key to load
     \param newKeySz must be WC_SHE_KEY_SZ (16)
     \param counter 28-bit monotonic counter value (must be strictly greater
@@ -352,14 +353,15 @@ int wc_SHE_GenerateM1M2M3(wc_SHE* she,
     separate context.
 
     \return 0 on success
-    \return BAD_FUNC_ARG if any required pointer is NULL or sizes are
-    incorrect
+    \return BAD_FUNC_ARG if any required pointer is NULL, sizes are
+    incorrect, or counter, authKeyId or targetKeyId is wider than its
+    packed field
 
     \param she initialized SHE context
     \param uid 15-byte SHE UID (same UID used for M1)
     \param uidSz must be WC_SHE_UID_SZ (15)
-    \param authKeyId slot ID of the authorizing key (same as in M1)
-    \param targetKeyId slot ID of the key being loaded (same as in M1)
+    \param authKeyId 4-bit slot ID of the authorizing key (same as in M1)
+    \param targetKeyId 4-bit slot ID of the key being loaded (same as in M1)
     \param newKey 16-byte value of the new key
     \param newKeySz must be WC_SHE_KEY_SZ (16)
     \param counter 28-bit monotonic counter (same value as in M2)

--- a/tests/api/test_she.c
+++ b/tests/api/test_she.c
@@ -227,6 +227,15 @@ int test_wc_SHE_GenerateM1M2M3(void)
                     m1, WC_SHE_M1_SZ, m2, WC_SHE_M2_SZ, m3, WC_SHE_M3_SZ), 0);
     ExpectIntEQ(XMEMCMP(m1, sheTestExpM1, WC_SHE_M1_SZ), 0);
 
+    /* Largest encodable counter, flags and key IDs are still accepted */
+    ExpectIntEQ(wc_SHE_GenerateM1M2M3(&she,
+                    sheTestUid, sizeof(sheTestUid),
+                    WC_SHE_KEY_ID_MAX, sheTestAuthKey, sizeof(sheTestAuthKey),
+                    WC_SHE_KEY_ID_MAX, sheTestNewKey, sizeof(sheTestNewKey),
+                    WC_SHE_COUNTER_MAX, WC_SHE_FLAGS_MAX,
+                    m1, WC_SHE_M1_SZ, m2, WC_SHE_M2_SZ, m3, WC_SHE_M3_SZ), 0);
+    ExpectIntEQ(m1[WC_SHE_M1_KID_OFFSET], 0xFF);
+
     /* Bad args */
     ExpectIntEQ(wc_SHE_GenerateM1M2M3(NULL,
                     sheTestUid, sizeof(sheTestUid),
@@ -259,6 +268,14 @@ int test_wc_SHE_GenerateM4M5(void)
                     m4, WC_SHE_M4_SZ, m5, WC_SHE_M5_SZ), 0);
     ExpectIntEQ(XMEMCMP(m4, sheTestExpM4, WC_SHE_M4_SZ), 0);
     ExpectIntEQ(XMEMCMP(m5, sheTestExpM5, WC_SHE_M5_SZ), 0);
+
+    /* Largest encodable counter and key IDs are still accepted */
+    ExpectIntEQ(wc_SHE_GenerateM4M5(&she,
+                    sheTestUid, sizeof(sheTestUid),
+                    WC_SHE_KEY_ID_MAX, WC_SHE_KEY_ID_MAX,
+                    sheTestNewKey, sizeof(sheTestNewKey), WC_SHE_COUNTER_MAX,
+                    m4, WC_SHE_M4_SZ, m5, WC_SHE_M5_SZ), 0);
+    ExpectIntEQ(m4[WC_SHE_M4_KID_OFFSET], 0xFF);
 
     /* Bad args */
     ExpectIntEQ(wc_SHE_GenerateM4M5(NULL,
@@ -837,6 +854,25 @@ int test_wc_SHE_DecisionCoverage(void)
             WC_SHE_KEY_SZ, 2, key, WC_SHE_KEY_SZ, 1, 0, m1, sizeof(m1), m2,
             sizeof(m2), m3, WC_SHE_M3_SZ - 1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
+        /* wc_SHE_GenerateM1M2M3: packed field widths, one invalid per call.
+         * Each of these silently wrapped or bled into a neighbouring field. */
+        ExpectIntEQ(wc_SHE_GenerateM1M2M3(&she, uid, WC_SHE_UID_SZ, 1, key,
+            WC_SHE_KEY_SZ, 2, key, WC_SHE_KEY_SZ, WC_SHE_COUNTER_MAX + 1, 0,
+            m1, sizeof(m1), m2, sizeof(m2), m3, sizeof(m3)),
+            WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(wc_SHE_GenerateM1M2M3(&she, uid, WC_SHE_UID_SZ, 1, key,
+            WC_SHE_KEY_SZ, 2, key, WC_SHE_KEY_SZ, 1, WC_SHE_FLAGS_MAX + 1,
+            m1, sizeof(m1), m2, sizeof(m2), m3, sizeof(m3)),
+            WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(wc_SHE_GenerateM1M2M3(&she, uid, WC_SHE_UID_SZ,
+            WC_SHE_KEY_ID_MAX + 1, key,
+            WC_SHE_KEY_SZ, 2, key, WC_SHE_KEY_SZ, 1, 0, m1, sizeof(m1), m2,
+            sizeof(m2), m3, sizeof(m3)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(wc_SHE_GenerateM1M2M3(&she, uid, WC_SHE_UID_SZ, 1, key,
+            WC_SHE_KEY_SZ, WC_SHE_KEY_ID_MAX + 1, key,
+            WC_SHE_KEY_SZ, 1, 0, m1, sizeof(m1), m2,
+            sizeof(m2), m3, sizeof(m3)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
         /* wc_SHE_GenerateM4M5: 8 operands, one invalid per call. */
         ExpectIntEQ(wc_SHE_GenerateM4M5(&she, NULL, WC_SHE_UID_SZ, 1, 2, key,
             WC_SHE_KEY_SZ, 1, m4, sizeof(m4), m5, sizeof(m5)),
@@ -861,6 +897,19 @@ int test_wc_SHE_DecisionCoverage(void)
             WC_NO_ERR_TRACE(BAD_FUNC_ARG));
         ExpectIntEQ(wc_SHE_GenerateM4M5(&she, uid, WC_SHE_UID_SZ, 1, 2, key,
             WC_SHE_KEY_SZ, 1, m4, sizeof(m4), m5, WC_SHE_M5_SZ - 1),
+            WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+
+        /* wc_SHE_GenerateM4M5: packed field widths, one invalid per call. */
+        ExpectIntEQ(wc_SHE_GenerateM4M5(&she, uid, WC_SHE_UID_SZ, 1, 2, key,
+            WC_SHE_KEY_SZ, WC_SHE_COUNTER_MAX + 1, m4, sizeof(m4), m5,
+            sizeof(m5)), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(wc_SHE_GenerateM4M5(&she, uid, WC_SHE_UID_SZ,
+            WC_SHE_KEY_ID_MAX + 1, 2, key,
+            WC_SHE_KEY_SZ, 1, m4, sizeof(m4), m5, sizeof(m5)),
+            WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(wc_SHE_GenerateM4M5(&she, uid, WC_SHE_UID_SZ, 1,
+            WC_SHE_KEY_ID_MAX + 1, key,
+            WC_SHE_KEY_SZ, 1, m4, sizeof(m4), m5, sizeof(m5)),
             WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     }
 

--- a/wolfcrypt/src/wc_she.c
+++ b/wolfcrypt/src/wc_she.c
@@ -501,6 +501,12 @@ int wc_SHE_GenerateM1M2M3(wc_SHE* she,
         return BAD_FUNC_ARG;
     }
 
+    /* Reject values wider than their packed field */
+    if (counter > WC_SHE_COUNTER_MAX || flags > WC_SHE_FLAGS_MAX ||
+        authKeyId > WC_SHE_KEY_ID_MAX || targetKeyId > WC_SHE_KEY_ID_MAX) {
+        return BAD_FUNC_ARG;
+    }
+
 #ifdef WOLF_CRYPTO_CB
     /* Try callback first -- callback handles its own parameter validation.
      * This allows callers to pass NULL authKey/newKey when a secure element
@@ -673,6 +679,12 @@ int wc_SHE_GenerateM4M5(wc_SHE* she,
 
     /* Validate SHE context first */
     if (she == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* Reject values wider than their packed field */
+    if (counter > WC_SHE_COUNTER_MAX ||
+        authKeyId > WC_SHE_KEY_ID_MAX || targetKeyId > WC_SHE_KEY_ID_MAX) {
         return BAD_FUNC_ARG;
     }
 

--- a/wolfssl/wolfcrypt/wc_she.h
+++ b/wolfssl/wolfcrypt/wc_she.h
@@ -73,6 +73,11 @@ enum wc_SheType {
 #define WC_SHE_M4_COUNT_SHIFT   4
 #define WC_SHE_M4_COUNT_PAD     0x8
 
+/* largest value each packed field can hold */
+#define WC_SHE_COUNTER_MAX  0x0FFFFFFFU
+#define WC_SHE_FLAGS_MAX    0x0F
+#define WC_SHE_KEY_ID_MAX   0x0F
+
 /* SHE KDF constants (Miyaguchi-Preneel input) */
 #define WC_SHE_KEY_UPDATE_ENC_C { \
     0x01, 0x01, 0x53, 0x48, \
@@ -240,12 +245,12 @@ WOLFSSL_API int wc_SHE_ImportM1M2M3(wc_SHE* she,
  *   she        - initialized SHE context
  *   uid        - 15-byte SHE UID (120-bit ECU/module identifier)
  *   uidSz      - must be WC_SHE_UID_SZ (15)
- *   authKeyId  - slot ID of the authorizing key (0-14, e.g.
+ *   authKeyId  - 4-bit slot ID of the authorizing key (e.g.
  *                MASTER_ECU_KEY=1, KEY_1..KEY_10=4..13)
  *   authKey    - 16-byte value of the authorizing key. Used to derive
  *                K1 (encryption) and K2 (MAC).
  *   authKeySz  - must be WC_SHE_KEY_SZ (16)
- *   targetKeyId - slot ID of the key being loaded (1-14)
+ *   targetKeyId - 4-bit slot ID of the key being loaded
  *   newKey     - 16-byte value of the new key to load. Placed in M2
  *                cleartext and used to derive K3/K4 for M4/M5.
  *   newKeySz   - must be WC_SHE_KEY_SZ (16)


### PR DESCRIPTION
### Problem
The SHE key-update builders expose packed protocol fields as full-width C
integers and validate only pointers and buffer lengths, never value ranges.
Out-of-range values were silently truncated or bled into the adjacent field,
and the call still returned 0:

| Parameter | C type | Field width | Effect when exceeded |
|---|---|---|---|
| `counter` | `word32` | 28 bits | wraps to a smaller value |
| `flags` | `byte` | 4 bits | overwrites the counter's low nibble |
| `authKeyId` | `byte` | 4 bits | bleeds into the target-key-ID nibble |
| `targetKeyId` | `byte` | 4 bits | truncated |

The counter is SHE's anti-rollback field, and `wc_SHE_GetCounter()` hands the
caller a `word32` that is fed straight back in, so the wrap is reachable on a
normal round trip. A key ID above `0x0F` is worse: the generated M1 or M4 names
a different HSM key slot than the caller asked for, with no error returned.
Medium severity.

### Fix (`wolfcrypt/src/wc_she.c`)
`wc_SHE_GenerateM1M2M3()` and `wc_SHE_GenerateM4M5()` now reject these with
`BAD_FUNC_ARG`:

```c
    /* Reject values wider than their packed field */
    if (counter > WC_SHE_COUNTER_MAX || flags > WC_SHE_FLAGS_MAX ||
        authKeyId > WC_SHE_KEY_ID_MAX || targetKeyId > WC_SHE_KEY_ID_MAX) {
        return BAD_FUNC_ARG;
    }
```

- **Placement is at function entry, ahead of the crypto-callback dispatch**,
  unlike the existing pointer/size checks. The widths come from the SHE
  protocol, so an HSM backend handed a 2^28 counter would build an equally
  wrong message. There is no "the secure element supplies it instead" case for
  a value range the way there is for `authKey`/`newKey` being `NULL`.
- **Rejecting, not masking.** Masking would still change the caller's intent
  without saying so.
- **`WC_SHE_COUNTER_MAX`, `WC_SHE_FLAGS_MAX`, `WC_SHE_KEY_ID_MAX`** added to
  `wc_she.h` beside the existing shift constants.
- Checks the encodable 4-bit width, not the narrower slot policy the header
  prose mentions (auth 0-14, target 1-14), since slot numbering is
  HSM-specific.

In-tree callers are unaffected: `wc_SHE_LoadKey_Internal()` passes zeros and
the KATs pass small values.

Closes f-7077.

### Tests (`tests/api/test_she.c`)
Seven negative cases in `test_wc_SHE_DecisionCoverage()`, one out-of-range
operand per call, plus a boundary-accept case in
`test_wc_SHE_GenerateM1M2M3()` proving the largest encodable values still
succeed and the comparison is `>` and not `>=`.

### Verification
- Negative control: before the fix, `test_wc_SHE_DecisionCoverage` failed with
  `result: 0 != -173`. After, the `she` group is 14/14 passed, 0 failed.
- Full `./tests/unit.test` and `./wolfcrypt/test/testwolfcrypt` pass.
- Builds clean with no new warnings under both `--enable-she=standard` (no
  `WOLF_CRYPTO_CB`) and `--enable-she=extended --enable-cryptocb`.
