### PR TITLE
Gate SHA3-224/256/384/512 prototypes separately

### DIFF
--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -195,33 +195,41 @@ struct wc_Sha3 {
     #endif
 #endif
 
+#ifndef WOLFSSL_NOSHA3_224
 WOLFSSL_API int wc_InitSha3_224(wc_Sha3* sha3, void* heap, int devId);
 WOLFSSL_API int wc_Sha3_224_Update(wc_Sha3* sha3, const byte* data, word32 len);
 WOLFSSL_API int wc_Sha3_224_Final(wc_Sha3* sha3, byte* hash);
 WOLFSSL_API void wc_Sha3_224_Free(wc_Sha3* sha3);
 WOLFSSL_API int wc_Sha3_224_GetHash(wc_Sha3* sha3, byte* hash);
 WOLFSSL_API int wc_Sha3_224_Copy(wc_Sha3* src, wc_Sha3* dst);
+#endif
 
+#ifndef WOLFSSL_NOSHA3_256
 WOLFSSL_API int wc_InitSha3_256(wc_Sha3* sha3, void* heap, int devId);
 WOLFSSL_API int wc_Sha3_256_Update(wc_Sha3* sha3, const byte* data, word32 len);
 WOLFSSL_API int wc_Sha3_256_Final(wc_Sha3* sha3, byte* hash);
 WOLFSSL_API void wc_Sha3_256_Free(wc_Sha3* sha3);
 WOLFSSL_API int wc_Sha3_256_GetHash(wc_Sha3* sha3, byte* hash);
 WOLFSSL_API int wc_Sha3_256_Copy(wc_Sha3* src, wc_Sha3* dst);
+#endif
 
+#ifndef WOLFSSL_NOSHA3_384
 WOLFSSL_API int wc_InitSha3_384(wc_Sha3* sha3, void* heap, int devId);
 WOLFSSL_API int wc_Sha3_384_Update(wc_Sha3* sha3, const byte* data, word32 len);
 WOLFSSL_API int wc_Sha3_384_Final(wc_Sha3* sha3, byte* hash);
 WOLFSSL_API void wc_Sha3_384_Free(wc_Sha3* sha3);
 WOLFSSL_API int wc_Sha3_384_GetHash(wc_Sha3* sha3, byte* hash);
 WOLFSSL_API int wc_Sha3_384_Copy(wc_Sha3* src, wc_Sha3* dst);
+#endif
 
+#ifndef WOLFSSL_NOSHA3_512
 WOLFSSL_API int wc_InitSha3_512(wc_Sha3* sha3, void* heap, int devId);
 WOLFSSL_API int wc_Sha3_512_Update(wc_Sha3* sha3, const byte* data, word32 len);
 WOLFSSL_API int wc_Sha3_512_Final(wc_Sha3* sha3, byte* hash);
 WOLFSSL_API void wc_Sha3_512_Free(wc_Sha3* sha3);
 WOLFSSL_API int wc_Sha3_512_GetHash(wc_Sha3* sha3, byte* hash);
 WOLFSSL_API int wc_Sha3_512_Copy(wc_Sha3* src, wc_Sha3* dst);
+#endif
 
 #ifdef WOLFSSL_SHAKE128
 WOLFSSL_API int wc_InitShake128(wc_Shake* shake, void* heap, int devId);

--- a/wrapper/rust/wolfssl-wolfcrypt/build.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/build.rs
@@ -520,7 +520,10 @@ fn scan_cfg() -> Result<()> {
     check_cfg(&binding, "wc_InitSha512", "sha512");
     check_cfg(&binding, "wc_HashType_WC_HASH_TYPE_SHA512_224", "sha512_224");
     check_cfg(&binding, "wc_HashType_WC_HASH_TYPE_SHA512_256", "sha512_256");
-    check_cfg(&binding, "wc_InitSha3_224", "sha3");
+    check_cfg(&binding, "wc_InitSha3_224", "sha3_224");
+    check_cfg(&binding, "wc_InitSha3_256", "sha3_256");
+    check_cfg(&binding, "wc_InitSha3_384", "sha3_384");
+    check_cfg(&binding, "wc_InitSha3_512", "sha3_512");
     check_cfg(&binding, "wc_InitShake128", "shake128");
     check_cfg(&binding, "wc_InitShake256", "shake256");
 

--- a/wrapper/rust/wolfssl-wolfcrypt/src/hmac_mac.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/hmac_mac.rs
@@ -132,21 +132,21 @@ impl_hmac_mac! {
 }
 
 impl_hmac_mac! {
-    #[cfg(sha3)]
+    #[cfg(sha3_224)]
     HmacSha3_224, hmac_type = crate::hmac::HMAC::TYPE_SHA3_224, key = U144, out = U28
 }
 
 impl_hmac_mac! {
-    #[cfg(sha3)]
+    #[cfg(sha3_256)]
     HmacSha3_256, hmac_type = crate::hmac::HMAC::TYPE_SHA3_256, key = U136, out = U32
 }
 
 impl_hmac_mac! {
-    #[cfg(sha3)]
+    #[cfg(sha3_384)]
     HmacSha3_384, hmac_type = crate::hmac::HMAC::TYPE_SHA3_384, key = U104, out = U48
 }
 
 impl_hmac_mac! {
-    #[cfg(sha3)]
+    #[cfg(sha3_512)]
     HmacSha3_512, hmac_type = crate::hmac::HMAC::TYPE_SHA3_512, key = U72, out = U64
 }

--- a/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/rsa.rs
@@ -95,13 +95,13 @@ impl RSA {
     #[cfg(sha512)]
     pub const HASH_TYPE_SHA512     : u32 = sys::wc_HashType_WC_HASH_TYPE_SHA512;
     pub const HASH_TYPE_MD5_SHA    : u32 = sys::wc_HashType_WC_HASH_TYPE_MD5_SHA;
-    #[cfg(sha3)]
+    #[cfg(sha3_224)]
     pub const HASH_TYPE_SHA3_224   : u32 = sys::wc_HashType_WC_HASH_TYPE_SHA3_224;
-    #[cfg(sha3)]
+    #[cfg(sha3_256)]
     pub const HASH_TYPE_SHA3_256   : u32 = sys::wc_HashType_WC_HASH_TYPE_SHA3_256;
-    #[cfg(sha3)]
+    #[cfg(sha3_384)]
     pub const HASH_TYPE_SHA3_384   : u32 = sys::wc_HashType_WC_HASH_TYPE_SHA3_384;
-    #[cfg(sha3)]
+    #[cfg(sha3_512)]
     pub const HASH_TYPE_SHA3_512   : u32 = sys::wc_HashType_WC_HASH_TYPE_SHA3_512;
     pub const HASH_TYPE_BLAKE2B    : u32 = sys::wc_HashType_WC_HASH_TYPE_BLAKE2B;
     pub const HASH_TYPE_BLAKE2S    : u32 = sys::wc_HashType_WC_HASH_TYPE_BLAKE2S;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/sha.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/sha.rs
@@ -1082,12 +1082,12 @@ impl Drop for SHA512 {
 }
 
 /// Context for SHA3-224 computation.
-#[cfg(sha3)]
+#[cfg(sha3_224)]
 pub struct SHA3_224 {
     wc_sha3: sys::wc_Sha3,
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_224)]
 impl SHA3_224 {
     /// SHA3-224 digest size in bytes.
     pub const DIGEST_SIZE: usize = sys::WC_SHA3_224_DIGEST_SIZE as usize;
@@ -1270,14 +1270,14 @@ impl SHA3_224 {
     }
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_224)]
 impl SHA3_224 {
     fn zeroize(&mut self) {
         unsafe { crate::zeroize_raw(&mut self.wc_sha3); }
     }
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_224)]
 impl Drop for SHA3_224 {
     /// Safely free the underlying wolfSSL SHA3_224 context.
     ///
@@ -1293,12 +1293,12 @@ impl Drop for SHA3_224 {
 }
 
 /// Context for SHA3-256 computation.
-#[cfg(sha3)]
+#[cfg(sha3_256)]
 pub struct SHA3_256 {
     wc_sha3: sys::wc_Sha3,
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_256)]
 impl SHA3_256 {
     /// SHA3-256 digest size in bytes.
     pub const DIGEST_SIZE: usize = sys::WC_SHA3_256_DIGEST_SIZE as usize;
@@ -1481,14 +1481,14 @@ impl SHA3_256 {
     }
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_256)]
 impl SHA3_256 {
     fn zeroize(&mut self) {
         unsafe { crate::zeroize_raw(&mut self.wc_sha3); }
     }
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_256)]
 impl Drop for SHA3_256 {
     /// Safely free the underlying wolfSSL SHA3_256 context.
     ///
@@ -1504,12 +1504,12 @@ impl Drop for SHA3_256 {
 }
 
 /// Context for SHA3-384 computation.
-#[cfg(sha3)]
+#[cfg(sha3_384)]
 pub struct SHA3_384 {
     wc_sha3: sys::wc_Sha3,
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_384)]
 impl SHA3_384 {
     /// SHA3-384 digest size in bytes.
     pub const DIGEST_SIZE: usize = sys::WC_SHA3_384_DIGEST_SIZE as usize;
@@ -1692,14 +1692,14 @@ impl SHA3_384 {
     }
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_384)]
 impl SHA3_384 {
     fn zeroize(&mut self) {
         unsafe { crate::zeroize_raw(&mut self.wc_sha3); }
     }
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_384)]
 impl Drop for SHA3_384 {
     /// Safely free the underlying wolfSSL SHA3_384 context.
     ///
@@ -1715,12 +1715,12 @@ impl Drop for SHA3_384 {
 }
 
 /// Context for SHA3-512 computation.
-#[cfg(sha3)]
+#[cfg(sha3_512)]
 pub struct SHA3_512 {
     wc_sha3: sys::wc_Sha3,
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_512)]
 impl SHA3_512 {
     /// SHA3-512 digest size in bytes.
     pub const DIGEST_SIZE: usize = sys::WC_SHA3_512_DIGEST_SIZE as usize;
@@ -1903,14 +1903,14 @@ impl SHA3_512 {
     }
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_512)]
 impl SHA3_512 {
     fn zeroize(&mut self) {
         unsafe { crate::zeroize_raw(&mut self.wc_sha3); }
     }
 }
 
-#[cfg(sha3)]
+#[cfg(sha3_512)]
 impl Drop for SHA3_512 {
     /// Safely free the underlying wolfSSL SHA3_512 context.
     ///

--- a/wrapper/rust/wolfssl-wolfcrypt/src/sha_digest.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/sha_digest.rs
@@ -122,21 +122,21 @@ impl_digest_traits! {
 }
 
 impl_digest_traits! {
-    #[cfg(sha3)]
+    #[cfg(sha3_224)]
     crate::sha::SHA3_224, out = U28, block = U144
 }
 
 impl_digest_traits! {
-    #[cfg(sha3)]
+    #[cfg(sha3_256)]
     crate::sha::SHA3_256, out = U32, block = U136
 }
 
 impl_digest_traits! {
-    #[cfg(sha3)]
+    #[cfg(sha3_384)]
     crate::sha::SHA3_384, out = U48, block = U104
 }
 
 impl_digest_traits! {
-    #[cfg(sha3)]
+    #[cfg(sha3_512)]
     crate::sha::SHA3_512, out = U64, block = U72
 }

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_sha.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_sha.rs
@@ -119,7 +119,7 @@ fn test_sha512() {
 }
 
 #[test]
-#[cfg(sha3)]
+#[cfg(sha3_224)]
 fn test_sha3_224() {
     let mut sha = SHA3_224::new().expect("Error with new()");
     fn test1(sha: &mut SHA3_224, input: &[u8], expected_hash: &[u8]) {
@@ -142,7 +142,7 @@ fn test_sha3_224() {
 }
 
 #[test]
-#[cfg(sha3)]
+#[cfg(sha3_256)]
 fn test_sha3_256() {
     let mut sha = SHA3_256::new().expect("Error with new()");
     fn test1(sha: &mut SHA3_256, input: &[u8], expected_hash: &[u8]) {
@@ -165,7 +165,7 @@ fn test_sha3_256() {
 }
 
 #[test]
-#[cfg(sha3)]
+#[cfg(sha3_384)]
 fn test_sha3_384() {
     let mut sha = SHA3_384::new().expect("Error with new()");
     fn test1(sha: &mut SHA3_384, input: &[u8], expected_hash: &[u8]) {
@@ -192,7 +192,7 @@ fn test_sha3_384() {
 }
 
 #[test]
-#[cfg(sha3)]
+#[cfg(sha3_512)]
 fn test_sha3_512() {
     let mut sha = SHA3_512::new().expect("Error with new()");
     fn test1(sha: &mut SHA3_512, input: &[u8], expected_hash: &[u8]) {

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_sha_digest.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_sha_digest.rs
@@ -102,7 +102,7 @@ fn test_digest_sha512() {
 }
 
 #[test]
-#[cfg(sha3)]
+#[cfg(sha3_224)]
 fn test_digest_sha3_224() {
     use wolfssl_wolfcrypt::sha::SHA3_224;
     common::setup();
@@ -114,7 +114,7 @@ fn test_digest_sha3_224() {
 }
 
 #[test]
-#[cfg(sha3)]
+#[cfg(sha3_256)]
 fn test_digest_sha3_256() {
     use wolfssl_wolfcrypt::sha::SHA3_256;
     common::setup();
@@ -126,7 +126,7 @@ fn test_digest_sha3_256() {
 }
 
 #[test]
-#[cfg(sha3)]
+#[cfg(sha3_384)]
 fn test_digest_sha3_384() {
     use wolfssl_wolfcrypt::sha::SHA3_384;
     common::setup();
@@ -138,7 +138,7 @@ fn test_digest_sha3_384() {
 }
 
 #[test]
-#[cfg(sha3)]
+#[cfg(sha3_512)]
 fn test_digest_sha3_512() {
     use wolfssl_wolfcrypt::sha::SHA3_512;
     common::setup();


### PR DESCRIPTION
# Description

Gate SHA3-224/256/384/512 prototypes separately

Rust wrapper: detect SHA3-224/256/384/512 build options separately.

Fixes F-8297.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
