### PR TITLE
Regression testing fixes: TLS1.3 and Aarch64 AES-GCM guards

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10759,7 +10759,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 args->sigLen = (word32)fSigSz;
             }
         #endif /* HAVE_FALCON */
-        #if defined(WOLFSSL_HAVE_MLDSA)
+        #if defined(WOLFSSL_HAVE_MLDSA) && !defined(WOLFSSL_MLDSA_NO_SIGN)
             if (ssl->hsType == DYNAMIC_TYPE_MLDSA) {
                 int mSigSz = wc_MlDsaKey_SigSize((wc_MlDsaKey*)ssl->hsKey);
                 if (mSigSz <= 0) {
@@ -10767,7 +10767,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 }
                 args->sigLen = (word32)mSigSz;
             }
-        #endif /* WOLFSSL_HAVE_MLDSA */
+        #endif /* WOLFSSL_HAVE_MLDSA && !WOLFSSL_MLDSA_NO_SIGN */
         #if defined(WOLFSSL_HAVE_SLHDSA)
             if (ssl->hsType == DYNAMIC_TYPE_SLHDSA) {
                 int slhSigSz = wc_SlhDsaKey_SigSize((SlhDsaKey*)ssl->hsKey);

--- a/wolfcrypt/src/port/arm/armv8-aes-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-aes-asm.S
@@ -10056,7 +10056,7 @@ L_aes_gcm_encrypt_arm64_crypto_done:
 #ifndef __APPLE__
 	.size	AES_GCM_encrypt_AARCH64,.-AES_GCM_encrypt_AARCH64
 #endif /* __APPLE__ */
-#ifdef HAVE_AES_DECRYPT
+#if defined(HAVE_AES_DECRYPT) || defined(HAVE_AESGCM_DECRYPT)
 #ifndef __APPLE__
 .text
 .globl	AES_GCM_decrypt_AARCH64
@@ -14908,7 +14908,7 @@ L_aes_gcm_decrypt_arm64_crypto_done:
 #ifndef __APPLE__
 	.size	AES_GCM_decrypt_AARCH64,.-AES_GCM_decrypt_AARCH64
 #endif /* __APPLE__ */
-#endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_DECRYPT || HAVE_AESGCM_DECRYPT */
 #ifdef WOLFSSL_ARMASM_CRYPTO_SHA3
 #ifndef __APPLE__
 .text
@@ -19603,7 +19603,7 @@ L_aes_gcm_encrypt_arm64_crypto_eor3_done:
 #ifndef __APPLE__
 	.size	AES_GCM_encrypt_AARCH64_EOR3,.-AES_GCM_encrypt_AARCH64_EOR3
 #endif /* __APPLE__ */
-#ifdef HAVE_AES_DECRYPT
+#if defined(HAVE_AES_DECRYPT) || defined(HAVE_AESGCM_DECRYPT)
 #ifndef __APPLE__
 .text
 .globl	AES_GCM_decrypt_AARCH64_EOR3
@@ -24346,7 +24346,7 @@ L_aes_gcm_decrypt_arm64_crypto_eor3_done:
 #ifndef __APPLE__
 	.size	AES_GCM_decrypt_AARCH64_EOR3,.-AES_GCM_decrypt_AARCH64_EOR3
 #endif /* __APPLE__ */
-#endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_DECRYPT || HAVE_AESGCM_DECRYPT */
 #endif /* !WOLFSSL_ARMASM_CRYPTO_SHA3 */
 #ifdef WOLFSSL_AESGCM_STREAM
 #ifndef __APPLE__
@@ -28888,6 +28888,7 @@ L_aes_gcm_encrypt_final_arm64_crypto_done:
 #ifndef __APPLE__
 	.size	AES_GCM_encrypt_final_AARCH64,.-AES_GCM_encrypt_final_AARCH64
 #endif /* __APPLE__ */
+#if defined(HAVE_AES_DECRYPT) || defined(HAVE_AESGCM_DECRYPT)
 #ifndef __APPLE__
 .text
 .globl	AES_GCM_decrypt_update_AARCH64
@@ -32803,6 +32804,7 @@ L_aes_gcm_decrypt_final_arm64_crypto_tag_loaded:
 #ifndef __APPLE__
 	.size	AES_GCM_decrypt_final_AARCH64,.-AES_GCM_decrypt_final_AARCH64
 #endif /* __APPLE__ */
+#endif /* HAVE_AES_DECRYPT || HAVE_AESGCM_DECRYPT */
 #ifdef WOLFSSL_ARMASM_CRYPTO_SHA3
 #ifndef __APPLE__
 .text
@@ -37236,6 +37238,7 @@ L_aes_gcm_encrypt_final_arm64_crypto_eor3_done:
 #ifndef __APPLE__
 	.size	AES_GCM_encrypt_final_AARCH64_EOR3,.-AES_GCM_encrypt_final_AARCH64_EOR3
 #endif /* __APPLE__ */
+#if defined(HAVE_AES_DECRYPT) || defined(HAVE_AESGCM_DECRYPT)
 #ifndef __APPLE__
 .text
 .globl	AES_GCM_decrypt_update_AARCH64_EOR3
@@ -41066,6 +41069,7 @@ L_aes_gcm_decrypt_final_arm64_crypto_eor3_tag_loaded:
 #ifndef __APPLE__
 	.size	AES_GCM_decrypt_final_AARCH64_EOR3,.-AES_GCM_decrypt_final_AARCH64_EOR3
 #endif /* __APPLE__ */
+#endif /* HAVE_AES_DECRYPT || HAVE_AESGCM_DECRYPT */
 #endif /* !WOLFSSL_ARMASM_CRYPTO_SHA3 */
 #endif /* WOLFSSL_AESGCM_STREAM */
 #endif /* HAVE_AESGCM */

--- a/wolfcrypt/src/port/arm/armv8-aes-asm.asm
+++ b/wolfcrypt/src/port/arm/armv8-aes-asm.asm
@@ -9926,7 +9926,7 @@ L_aes_gcm_encrypt_arm64_crypto_done
 	ldp	x29, x30, [sp], #0x90
 	ret
 	ENDP
-	IF :DEF:HAVE_AES_DECRYPT
+	IF :DEF:HAVE_AES_DECRYPT :LOR: :DEF:HAVE_AESGCM_DECRYPT
 	AREA	|.text|, CODE, READONLY
 	ALIGN	4
 	EXPORT	AES_GCM_decrypt_AARCH64
@@ -19449,7 +19449,7 @@ L_aes_gcm_encrypt_arm64_crypto_eor3_done
 	ldp	x29, x30, [sp], #0x90
 	ret
 	ENDP
-	IF :DEF:HAVE_AES_DECRYPT
+	IF :DEF:HAVE_AES_DECRYPT :LOR: :DEF:HAVE_AESGCM_DECRYPT
 	AREA	|.text|, CODE, READONLY
 	ALIGN	4
 	EXPORT	AES_GCM_decrypt_AARCH64_EOR3
@@ -28650,6 +28650,7 @@ L_aes_gcm_encrypt_final_arm64_crypto_tag_end_bytes
 L_aes_gcm_encrypt_final_arm64_crypto_done
 	ret
 	ENDP
+	IF :DEF:HAVE_AES_DECRYPT :LOR: :DEF:HAVE_AESGCM_DECRYPT
 	AREA	|.text|, CODE, READONLY
 	ALIGN	4
 	EXPORT	AES_GCM_decrypt_update_AARCH64
@@ -32541,6 +32542,7 @@ L_aes_gcm_decrypt_final_arm64_crypto_tag_loaded
 	str	w8, [x7]
 	ret
 	ENDP
+	ENDIF
 	IF :DEF:WOLFSSL_ARMASM_CRYPTO_SHA3
 	AREA	|.text|, CODE, READONLY
 	ALIGN	4
@@ -36902,6 +36904,7 @@ L_aes_gcm_encrypt_final_arm64_crypto_eor3_tag_end_bytes
 L_aes_gcm_encrypt_final_arm64_crypto_eor3_done
 	ret
 	ENDP
+	IF :DEF:HAVE_AES_DECRYPT :LOR: :DEF:HAVE_AESGCM_DECRYPT
 	AREA	|.text|, CODE, READONLY
 	ALIGN	4
 	EXPORT	AES_GCM_decrypt_update_AARCH64_EOR3
@@ -40708,6 +40711,7 @@ L_aes_gcm_decrypt_final_arm64_crypto_eor3_tag_loaded
 	str	w8, [x7]
 	ret
 	ENDP
+	ENDIF
 	ENDIF
 	ENDIF
 	ENDIF

--- a/wolfcrypt/src/port/arm/armv8-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-aes-asm_c.c
@@ -10133,7 +10133,7 @@ void AES_GCM_encrypt_AARCH64(const byte* in, byte* out, word32 sz,
     );
 }
 
-#ifdef HAVE_AES_DECRYPT
+#if defined(HAVE_AES_DECRYPT) || defined(HAVE_AESGCM_DECRYPT)
 int AES_GCM_decrypt_AARCH64(const byte* in, byte* out, word32 sz,
     const byte* nonce, word32 nonceSz, const byte* tag, word32 tagSz,
     const byte* aad, word32 aadSz, byte* key, byte* gcm_h, byte* tmp, byte* reg,
@@ -15061,7 +15061,7 @@ int AES_GCM_decrypt_AARCH64(const byte* in, byte* out, word32 sz,
     return (word32)(size_t)in;
 }
 
-#endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_DECRYPT || HAVE_AESGCM_DECRYPT */
 #ifdef WOLFSSL_ARMASM_CRYPTO_SHA3
 void AES_GCM_encrypt_AARCH64_EOR3(const byte* in, byte* out, word32 sz,
     const byte* nonce, word32 nonceSz, byte* tag, word32 tagSz, const byte* aad,
@@ -19830,7 +19830,7 @@ void AES_GCM_encrypt_AARCH64_EOR3(const byte* in, byte* out, word32 sz,
     );
 }
 
-#ifdef HAVE_AES_DECRYPT
+#if defined(HAVE_AES_DECRYPT) || defined(HAVE_AESGCM_DECRYPT)
 int AES_GCM_decrypt_AARCH64_EOR3(const byte* in, byte* out, word32 sz,
     const byte* nonce, word32 nonceSz, const byte* tag, word32 tagSz,
     const byte* aad, word32 aadSz, byte* key, byte* gcm_h, byte* tmp, byte* reg,
@@ -24649,7 +24649,7 @@ int AES_GCM_decrypt_AARCH64_EOR3(const byte* in, byte* out, word32 sz,
     return (word32)(size_t)in;
 }
 
-#endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_DECRYPT || HAVE_AESGCM_DECRYPT */
 #endif /* !WOLFSSL_ARMASM_CRYPTO_SHA3 */
 #ifdef WOLFSSL_AESGCM_STREAM
 void AES_GCM_init_AARCH64(byte* key, int nr, const byte* nonce, word32 nonceSz,
@@ -29175,6 +29175,7 @@ void AES_GCM_encrypt_final_AARCH64(byte* tag, byte* authTag, word32 tbytes,
     );
 }
 
+#if defined(HAVE_AES_DECRYPT) || defined(HAVE_AESGCM_DECRYPT)
 void AES_GCM_decrypt_update_AARCH64(const byte* key, int nr, byte* out,
     const byte* in, word32 nbytes, byte* tag, byte* h, byte* counter)
 {
@@ -33108,6 +33109,7 @@ void AES_GCM_decrypt_final_AARCH64(byte* tag, const byte* authTag,
     );
 }
 
+#endif /* HAVE_AES_DECRYPT || HAVE_AESGCM_DECRYPT */
 #ifdef WOLFSSL_ARMASM_CRYPTO_SHA3
 void AES_GCM_init_AARCH64_EOR3(byte* key, int nr, const byte* nonce,
     word32 nonceSz, byte* gcm_h, byte* counter, byte* initCtr)
@@ -37525,6 +37527,7 @@ void AES_GCM_encrypt_final_AARCH64_EOR3(byte* tag, byte* authTag, word32 tbytes,
     );
 }
 
+#if defined(HAVE_AES_DECRYPT) || defined(HAVE_AESGCM_DECRYPT)
 void AES_GCM_decrypt_update_AARCH64_EOR3(const byte* key, int nr, byte* out,
     const byte* in, word32 nbytes, byte* tag, byte* h, byte* counter)
 {
@@ -41374,6 +41377,7 @@ void AES_GCM_decrypt_final_AARCH64_EOR3(byte* tag, const byte* authTag,
     );
 }
 
+#endif /* HAVE_AES_DECRYPT || HAVE_AESGCM_DECRYPT */
 #endif /* !WOLFSSL_ARMASM_CRYPTO_SHA3 */
 #endif /* WOLFSSL_AESGCM_STREAM */
 #endif /* HAVE_AESGCM */


### PR DESCRIPTION
# Description

tls1.3: fix guard
SendTls13CertificateVerify: ML-DSA sig size, and signing, only available when compiled when WOLFSSL_MLDSA_NO_SIGN is not defined.

AArch64 AES-GCM: fix decrypt guards
Have decrypt guards for AES-GCM assembly code for AArch64.

# Testing

 ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm --enable-aescbc --enable-aesofb --enable-aescfb --enable-aesgcm --enable-aesgcm-stream --enable-aesccm --enable-aesctr --enable-aesxts --enable-aeseax
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm --enable-aescbc --enable-aesofb --enable-aescfb --enable-aesgcm --enable-aesgcm-stream --enable-aesccm --enable-aesctr --enable-aesxts --enable-aeseax CFLAGS=-DNO_AES_DECRYPT
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm=inline --enable-aescbc --enable-aesofb --enable-aescfb --enable-aesgcm --enable-aesgcm-stream --enable-aesccm --enable-aesctr --enable-aesxts --enable-aeseax
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm=inline --enable-aescbc --enable-aesofb --enable-aescfb --enable-aesgcm --enable-aesgcm-stream --enable-aesccm --enable-aesctr --enable-aesxts --enable-aeseax CFLAGS=-DNO_AES_DECRYPT
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm=sha3-crypto --enable-aescbc --enable-aesofb --enable-aescfb --enable-aesgcm --enable-aesgcm-stream --enable-aesccm --enable-aesctr --enable-aesxts --enable-aeseax
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm=sha3-crypto --enable-aescbc --enable-aesofb --enable-aescfb --enable-aesgcm --enable-aesgcm-stream --enable-aesccm --enable-aesctr --enable-aesxts --enable-aeseax CFLAGS=-DNO_AES_DECRYPT
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm=inline,sha3-crypto --enable-aescbc --enable-aesofb --enable-aescfb --enable-aesgcm --enable-aesgcm-stream --enable-aesccm --enable-aesctr --enable-aesxts --enable-aeseax
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm=inline,sha3-crypto --enable-aescbc --enable-aesofb --enable-aescfb --enable-aesgcm --enable-aesgcm-stream --enable-aesccm --enable-aesctr --enable-aesxts --enable-aeseax CFLAGS=-DNO_AES_DECRYPT

  One-shot guard in isolation, plus the GCM-off negative control:

  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm --enable-aesgcm
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm --enable-aesgcm CFLAGS=-DNO_AES_DECRYPT
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm --disable-aesgcm CFLAGS=-DNO_AES_DECRYPT
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm=inline --enable-aesgcm
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm=inline --enable-aesgcm CFLAGS=-DNO_AES_DECRYPT
  ./configure --disable-shared --enable-cryptonly --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm=inline --disable-aesgcm CFLAGS=-DNO_AES_DECRYPT

./configure --disable-shared --disable-asm --disable-sp-asm --enable-mldsa=make,44,65,87
  ./configure --disable-shared --disable-asm --disable-sp-asm --enable-mldsa=make,44
  ./configure --disable-shared --disable-asm --disable-sp-asm --enable-mldsa=make,44,65
  ./configure --disable-shared --disable-asm --disable-sp-asm --enable-mldsa=make,44,87
  ./configure --disable-shared --disable-asm --disable-sp-asm --enable-mldsa=make,65
  ./configure --disable-shared --disable-asm --disable-sp-asm --enable-mldsa=make,65,87
  ./configure --disable-shared --disable-asm --disable-sp-asm --enable-mldsa=make,87
  ./configure --disable-shared --disable-asm --disable-sp-asm --enable-mldsa