### PR TITLE
Rust Fenrir fixes 2026-08-12

### DIFF
--- a/wrapper/rust/wolfssl-wolfcrypt/build.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/build.rs
@@ -355,7 +355,8 @@ fn scan_cfg() -> Result<()> {
     check_cfg(&binding, "wc_AesCfbEncrypt", "aes_cfb");
     check_cfg(&binding, "wc_AesCtrEncrypt", "aes_ctr");
     check_cfg(&binding, "wc_AesCtsEncrypt", "aes_cts");
-    check_cfg(&binding, "wc_AesCfbDecrypt", "aes_decrypt");
+    check_cfg(&binding, "wc_AesCfbDecrypt", "aes_cfb_decrypt");
+    check_cfg(&binding, "wc_AesOfbDecrypt", "aes_ofb_decrypt");
     check_cfg(&binding, "wc_AesEaxInit", "aes_eax");
     check_cfg(&binding, "wc_AesEcbEncrypt", "aes_ecb");
     check_cfg(&binding, "wc_AesGcmSetKey", "aes_gcm");

--- a/wrapper/rust/wolfssl-wolfcrypt/src/aes.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/aes.rs
@@ -697,7 +697,7 @@ impl AeadInPlace for Aes256Ccm {
 /// assert_eq!(outbuf, cipher);
 /// cfb.init(&key, &iv).expect("Error with init()");
 /// let mut plain: [u8; 48] = [0; 48];
-/// #[cfg(aes_decrypt)]
+/// #[cfg(aes_cfb_decrypt)]
 /// {
 /// cfb.decrypt(&outbuf, &mut plain).expect("Error with decrypt()");
 /// assert_eq!(plain, msg);
@@ -873,7 +873,7 @@ impl CFB {
     ///
     /// A Result which is Ok(()) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    #[cfg(aes_decrypt)]
+    #[cfg(aes_cfb_decrypt)]
     pub fn decrypt(&mut self, din: &[u8], dout: &mut [u8]) -> Result<(), i32> {
         let in_size = crate::buffer_len_to_u32(din.len())?;
         let out_size = crate::buffer_len_to_u32(dout.len())?;
@@ -905,7 +905,7 @@ impl CFB {
     ///
     /// A Result which is Ok(()) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    #[cfg(aes_decrypt)]
+    #[cfg(aes_cfb_decrypt)]
     pub fn decrypt1(&mut self, din: &[u8], dout: &mut [u8], size: usize) -> Result<(), i32> {
         if din.len() != dout.len() {
             return Err(sys::wolfCrypt_ErrorCodes_BAD_FUNC_ARG);
@@ -937,7 +937,7 @@ impl CFB {
     ///
     /// A Result which is Ok(()) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    #[cfg(aes_decrypt)]
+    #[cfg(aes_cfb_decrypt)]
     pub fn decrypt8(&mut self, din: &[u8], dout: &mut [u8]) -> Result<(), i32> {
         let in_size = crate::buffer_len_to_u32(din.len())?;
         let out_size = crate::buffer_len_to_u32(dout.len())?;
@@ -2200,7 +2200,7 @@ impl Drop for GCMStream {
 /// assert_eq!(cipher, expected_cipher);
 /// ofb.init(&key, &iv).expect("Error with init()");
 /// let mut plain_out: [u8; 48] = [0; 48];
-/// #[cfg(aes_decrypt)]
+/// #[cfg(aes_ofb_decrypt)]
 /// {
 /// ofb.decrypt(&cipher, &mut plain_out).expect("Error with decrypt()");
 /// assert_eq!(plain_out, plain);
@@ -2313,7 +2313,7 @@ impl OFB {
     ///
     /// A Result which is Ok(()) on success or an Err containing the wolfSSL
     /// library return code on failure.
-    #[cfg(aes_decrypt)]
+    #[cfg(aes_ofb_decrypt)]
     pub fn decrypt(&mut self, din: &[u8], dout: &mut [u8]) -> Result<(), i32> {
         let in_size = crate::buffer_len_to_u32(din.len())?;
         let out_size = crate::buffer_len_to_u32(dout.len())?;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -1343,7 +1343,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ecc_import, random))]
+    /// #[cfg(all(ecc_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
@@ -1358,7 +1358,7 @@ impl ECC {
     /// ecc.export(&mut qx, &mut qx_len, &mut qy, &mut qy_len, &mut d, &mut d_len).expect("Error with export()");
     /// }
     /// ```
-    #[cfg(ecc_import)]
+    #[cfg(ecc_export)]
     pub fn export(&mut self, qx: &mut [u8], qx_len: &mut u32,
             qy: &mut [u8], qy_len: &mut u32, d: &mut [u8], d_len: &mut u32) -> Result<(), i32> {
         *qx_len = crate::buffer_len_to_u32(qx.len())?;
@@ -1398,7 +1398,7 @@ impl ECC {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ecc_import, random))]
+    /// #[cfg(all(ecc_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ecc::ECC;
@@ -1413,7 +1413,7 @@ impl ECC {
     /// ecc.export_ex(&mut qx, &mut qx_len, &mut qy, &mut qy_len, &mut d, &mut d_len, false).expect("Error with export_ex()");
     /// }
     /// ```
-    #[cfg(ecc_import)]
+    #[cfg(ecc_export)]
     #[allow(clippy::too_many_arguments)]
     pub fn export_ex(&mut self, qx: &mut [u8], qx_len: &mut u32,
             qy: &mut [u8], qy_len: &mut u32, d: &mut [u8], d_len: &mut u32,

--- a/wrapper/rust/wolfssl-wolfcrypt/src/sys.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/sys.rs
@@ -18,7 +18,7 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 /* Include generated FIPS symbol aliases. */
 include!(concat!(env!("OUT_DIR"), "/fips_aliases.rs"));
 
-#[cfg(not(rsa_setrng))]
+#[cfg(all(rsa,not(rsa_setrng)))]
 unsafe extern "C" {
     pub fn wc_RsaSetRNG(key: *mut RsaKey, rng: *mut WC_RNG) -> core::ffi::c_int;
 }


### PR DESCRIPTION
# Description

```
commit a224123dcdc9bd97feda6bcdd939e369fdc2dcce
Author: Josh Holtrop <josh@wolfssl.com>
Date:   Wed Aug 12 12:20:34 2026 -0400

    Rust wrapper: fix ecc_export cfg gating for ECC export functions
    
    Fixes F-8299.

commit 4518e8b5ec189d50c0a0bba47f1c06152c5ea595
Author: Josh Holtrop <josh@wolfssl.com>
Date:   Wed Aug 12 10:22:34 2026 -0400

    Rust wrapper: detect AES-OFB decrypt support if AES-CFB is disabled
    
    Fixes F-8295.

commit cb0343dcef13af1eed6441c559287dcf65c81071
Author: Josh Holtrop <josh@wolfssl.com>
Date:   Wed Aug 12 10:06:35 2026 -0400

    Rust wrapper: guard wc_RsaSetRNG with rsa cfg
    
    Fixes F-8293.
```

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
