### PR TITLE
ASN.1 portability and a KeyUsage encoding fix

### DIFF
--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -2621,6 +2621,96 @@ static int test_wc_SignCert_makeBodyEcc(Cert* cert, ecc_key* key, WC_RNG* rng,
  * bit string header, so capacities in a narrow band just below the exact
  * encoding size get accepted and overrun.
  */
+#if !defined(NO_ASN) && !defined(NO_RSA) && !defined(NO_CERTS) && \
+    defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT) && \
+    !defined(NO_SHA256) && defined(USE_CERT_BUFFERS_2048) && \
+    !defined(NO_ASN_TIME) && !defined(WC_NO_RNG) && !defined(NO_ASN_CRYPT)
+    #define TEST_KEYUSAGE_DECIPHER_ONLY
+#endif
+
+/*
+ * decipherOnly is bit 8, the only KeyUsage value landing in the second byte
+ * of the BIT STRING - so the only one needing a second content byte to encode
+ * and the high-byte shift to decode. Round-trip it alone and combined with a
+ * first-byte bit to cover both halves.
+ */
+int test_wc_DecodeKeyUsage_decipherOnly(void)
+{
+    EXPECT_DECLS;
+#ifdef TEST_KEYUSAGE_DECIPHER_ONLY
+    static const struct {
+        const char* str;
+        word16      expected;
+    } kuCases[] = {
+        { "decipherOnly",                  KEYUSE_DECIPHER_ONLY },
+        { "digitalSignature,decipherOnly", (word16)(KEYUSE_DIGITAL_SIG |
+                                                    KEYUSE_DECIPHER_ONLY) },
+        { "encipherOnly,decipherOnly",     (word16)(KEYUSE_ENCIPHER_ONLY |
+                                                    KEYUSE_DECIPHER_ONLY) },
+        /* A first-byte-only value must keep encoding in a single byte. */
+        { "digitalSignature",              KEYUSE_DIGITAL_SIG },
+    };
+    WC_RNG      rng;
+    RsaKey      key;
+    byte*       der = NULL;
+    word32      idx = 0;
+    int         rngInit = 0;
+    int         keyInit = 0;
+    size_t      c;
+
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
+
+    ExpectIntEQ(wc_InitRng(&rng), 0);
+    if (EXPECT_SUCCESS()) rngInit = 1;
+
+    ExpectNotNull(der = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,
+        DYNAMIC_TYPE_TMP_BUFFER));
+
+    ExpectIntEQ(wc_InitRsaKey_ex(&key, HEAP_HINT, testDevId), 0);
+    if (EXPECT_SUCCESS()) keyInit = 1;
+    ExpectIntEQ(wc_RsaPrivateKeyDecode(server_key_der_2048, &idx, &key,
+        sizeof_server_key_der_2048), 0);
+
+    for (c = 0; c < XELEM_CNT(kuCases); c++) {
+        Cert        cert;
+        DecodedCert dCert;
+        int         dCertInit = 0;
+        int         derSz = 0;
+
+        if (!EXPECT_SUCCESS()) break;
+
+        XMEMSET(&cert, 0, sizeof(cert));
+        ExpectIntEQ(wc_InitCert(&cert), 0);
+        if (EXPECT_SUCCESS()) {
+            cert.sigType = CTC_SHA256wRSA;
+            cert.isCA = 0;
+            XSTRNCPY(cert.subject.country, "US", CTC_NAME_SIZE);
+            XSTRNCPY(cert.subject.org, "wolfSSL", CTC_NAME_SIZE);
+            XSTRNCPY(cert.subject.commonName, "keyUsage", CTC_NAME_SIZE);
+        }
+        ExpectIntEQ(wc_SetKeyUsage(&cert, kuCases[c].str), 0);
+        ExpectIntGT(derSz = wc_MakeSelfCert(&cert, der, FOURK_BUF, &key, &rng),
+            0);
+
+        if (EXPECT_SUCCESS() && (der != NULL)) {
+            wc_InitDecodedCert(&dCert, der, (word32)derSz, HEAP_HINT);
+            dCertInit = 1;
+            ExpectIntEQ(wc_ParseCert(&dCert, CERT_TYPE, NO_VERIFY, NULL), 0);
+            /* Every requested bit must survive and nothing else be set - a
+             * byte-order slip silently yields a first-byte usage. */
+            ExpectIntEQ(dCert.extKeyUsage, kuCases[c].expected);
+        }
+        if (dCertInit) wc_FreeDecodedCert(&dCert);
+    }
+
+    if (keyInit) wc_FreeRsaKey(&key);
+    if (rngInit) wc_FreeRng(&rng);
+    XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+#endif /* TEST_KEYUSAGE_DECIPHER_ONLY */
+    return EXPECT_RESULT();
+}
+
 int test_wc_SignCert_buffer_bounds(void)
 {
     EXPECT_DECLS;

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -44,6 +44,7 @@ int test_ToTraditional_ex_roundtrip(void);
 int test_ToTraditional_ex_negative(void);
 int test_ToTraditional_ex_mldsa_bad_params(void);
 int test_wc_SignCert_buffer_bounds(void);
+int test_wc_DecodeKeyUsage_decipherOnly(void);
 int test_wc_AsnDecisionCoverage(void);
 int test_wc_AsnFeatureCoverage(void);
 
@@ -68,6 +69,7 @@ int test_wc_AsnFeatureCoverage(void);
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_negative),         \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_mldsa_bad_params), \
     TEST_DECL_GROUP("asn", test_wc_SignCert_buffer_bounds),         \
+    TEST_DECL_GROUP("asn", test_wc_DecodeKeyUsage_decipherOnly),    \
     TEST_DECL_GROUP("asn", test_wc_AsnDecisionCoverage),           \
     TEST_DECL_GROUP("asn", test_wc_AsnFeatureCoverage)
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -20735,7 +20735,9 @@ int DecodeKeyUsage(const byte* input, word32 sz, word16 *extKeyUsage)
         /* Decode the bit string number as LE */
         *extKeyUsage = (word16)(keyUsage[0]);
         if (keyUsageSz == 2)
-            *extKeyUsage |= (word16)(keyUsage[1] << 8);
+            /* Cast first: a 0x80 byte overflows the shift where int is
+             * 16-bit. */
+            *extKeyUsage |= (word16)((word32)keyUsage[1] << 8);
     }
     return ret;
 }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -814,6 +814,23 @@ static word32 SizeASN_Num(word32 n, int bits, byte tag)
     return len;
 }
 
+/* Size of a DER BIT STRING holding a 16-bit word.
+ *
+ * KeyUsage layout: bit 0 is the top bit of the LOW byte, so the low byte is
+ * the first content byte and a set bit 8 needs a second. Opposite word
+ * layout to SizeASN_BitString32().
+ *
+ * @param [in] n  16-bit word to be encoded.
+ * @return  Number of bytes of the ASN.1 item.
+ */
+static word32 SizeASN_BitString16(word16 n)
+{
+    word32 len = ((n >> 8) != 0) ? 2 : 1;
+
+    /* Tag, length, unused bits byte and data. */
+    return 1 + 1 + 1 + len;
+}
+
 #ifdef WOLFSSL_ASN_TEMPLATE_NEED_SET_INT32
 /* Calculate the size of a DER encoded BIT STRING of a 32-bit word.
  *
@@ -916,7 +933,13 @@ int SizeASN_Items(const ASNItem* asn, ASNSetData *data, int count,
                 len = SizeASN_Num(data[i].data.u8, 8, asn[i].tag);
                 break;
             case ASN_DATA_TYPE_WORD16:
-                len = SizeASN_Num(data[i].data.u16, 16, asn[i].tag);
+                /* BIT_STRING is a named bit string in a 16-bit word. */
+                if (asn[i].tag == ASN_BIT_STRING) {
+                    len = SizeASN_BitString16(data[i].data.u16);
+                }
+                else {
+                    len = SizeASN_Num(data[i].data.u16, 16, asn[i].tag);
+                }
                 break;
         #ifdef WOLFSSL_ASN_TEMPLATE_NEED_SET_INT32
             case ASN_DATA_TYPE_WORD32:
@@ -1094,6 +1117,45 @@ static void SetASN_Num(word32 n, int bits, byte* out, byte tag)
         out[idx++] = (byte)(n >> j);
 }
 
+/* DER encode a BIT STRING from a 16-bit word.
+ *
+ * KeyUsage layout: the low byte goes out first, the high byte only when it
+ * carries a set bit, and the unused-bit count belongs to the last byte
+ * written. Mirrors SetBitString16Bit() on the non-template path.
+ *
+ * Assumes that the out buffer is large enough for encoding.
+ *
+ * @param [in]  n    16-bit word to be encoded.
+ * @param [out] out  Buffer holding the item. The caller has already written
+ *                   the tag at out[0]; the length, unused-bit count and data
+ *                   are written from out[1] on.
+ */
+static void SetASN_BitString16(word16 n, byte* out)
+{
+    byte len = 1;
+    byte lastByte = (byte)n;
+    byte unusedBits = 0;
+    word32 idx = 3;
+
+    if ((n >> 8) != 0) {
+        len = 2;
+        lastByte = (byte)(n >> 8);
+    }
+
+    if (lastByte != 0) {
+        /* Count trailing zero bits of the last byte written. */
+        while (((lastByte >> unusedBits) & 0x01) == 0x00)
+            unusedBits++;
+    }
+
+    /* Length includes unused bits byte. */
+    out[1] = (byte)(1 + len);
+    out[2] = unusedBits;
+    out[idx++] = (byte)n;
+    if (len > 1)
+        out[idx] = (byte)(n >> 8);
+}
+
 #ifdef WOLFSSL_ASN_TEMPLATE_NEED_SET_INT32
 /* Create the DER encoding of a BIT STRING from a 32-bit word.
  *
@@ -1190,7 +1252,13 @@ int SetASN_Items(const ASNItem* asn, ASNSetData *data, int count, byte* output)
                 SetASN_Num(data[i].data.u8, 8, out, asn[i].tag);
                 break;
             case ASN_DATA_TYPE_WORD16:
-                SetASN_Num(data[i].data.u16, 16, out, asn[i].tag);
+                /* BIT_STRING is a named bit string in a 16-bit word. */
+                if (asn[i].tag == ASN_BIT_STRING) {
+                    SetASN_BitString16(data[i].data.u16, out);
+                }
+                else {
+                    SetASN_Num(data[i].data.u16, 16, out, asn[i].tag);
+                }
                 break;
         #ifdef WOLFSSL_ASN_TEMPLATE_NEED_SET_INT32
             case ASN_DATA_TYPE_WORD32:

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -14775,7 +14775,7 @@ static int GenerateDNSEntryRIDString(DNS_entry* entry, void* heap)
 #if !defined(WOLFCRYPT_ONLY) && defined(OPENSSL_EXTRA)
     int nid         = 0;
 #endif
-    int tmpSize     = MAX_OID_SZ;
+    word32 tmpSize  = MAX_OID_SZ;
     word32 oid      = 0;
     word32 idx      = 0;
     word16 tmpName[MAX_OID_SZ];
@@ -14805,17 +14805,17 @@ static int GenerateDNSEntryRIDString(DNS_entry* entry, void* heap)
         {
             /* Decode OBJECT_ID into dotted form array. */
             ret = DecodeObjectId((const byte*)(entry->name),(word32)entry->len,
-                    tmpName, (word32*)&tmpSize);
+                    tmpName, &tmpSize);
 
             if (ret == 0) {
                 j = 0;
                 /* Append each number of dotted form. */
-                for (i = 0; i < tmpSize; i++) {
+                for (i = 0; (word32)i < tmpSize; i++) {
                     if (j >= MAX_OID_SZ) {
                         return BUFFER_E;
                     }
 
-                    if (i < tmpSize - 1) {
+                    if ((word32)i < tmpSize - 1) {
                         ret = XSNPRINTF(oidName + j, (word32)(MAX_OID_SZ - j),
                             "%d.", tmpName[i]);
                     }
@@ -23918,6 +23918,7 @@ int wc_GetSubjectPubKeyInfoDerFromCert(const byte* certDer,
     word32      startIdx;
     word32      idx;
     word32      length;
+    int         seqLen;
     int         badDate;
 
     if (certDer == NULL || certDerSz == 0 || pubKeyDerSz == NULL) {
@@ -23928,6 +23929,7 @@ int wc_GetSubjectPubKeyInfoDerFromCert(const byte* certDer,
         return MEMORY_E);
 
     length = 0;
+    seqLen = 0;
     badDate = 0;
 
     wc_InitDecodedCert(cert, certDer, certDerSz, NULL);
@@ -23940,8 +23942,9 @@ int wc_GetSubjectPubKeyInfoDerFromCert(const byte* certDer,
 
         /* Get the length of the SubjectPublicKeyInfo sequence */
         idx = startIdx;
-        ret = GetSequence(certDer, &idx, (int*)&length, certDerSz);
+        ret = GetSequence(certDer, &idx, &seqLen, certDerSz);
         if (ret >= 0) {
+            length = (word32)seqLen;
             /* Calculate total length including sequence header */
             length += (idx - startIdx);
 
@@ -24132,7 +24135,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
 #endif
 #endif
 #if defined(WOLFSSL_RENESAS_TSIP_TLS) || defined(WOLFSSL_RENESAS_FSPSM_TLS)
-    int    idx = 0;
+    word32 idx = 0;
 #endif
     byte*  sce_tsip_encRsaKeyIdx;
 #ifndef IGNORE_NAME_CONSTRAINTS
@@ -24659,7 +24662,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm,
     /* prepare for TSIP TLS cert verification API use */
     if (cert->keyOID == RSAk) {
         /* to call TSIP API, it needs keys position info in bytes */
-        if ((ret = RsaPublicKeyDecodeRawIndex(cert->publicKey, (word32*)&idx,
+        if ((ret = RsaPublicKeyDecodeRawIndex(cert->publicKey, &idx,
                                    cert->pubKeySize,
                                    &cert->sigCtx.CertAtt.pubkey_n_start,
                                    &cert->sigCtx.CertAtt.pubkey_n_len,
@@ -25962,6 +25965,7 @@ int wc_DerToPemEx(const byte* der, word32 derSz, byte* output, word32 outSz,
     int i;
     int err;
     int outLen;   /* return length or error */
+    word32 outLenSz;  /* Base64_Encode in/out length */
 
     (void)cipher_info;
 
@@ -26010,12 +26014,13 @@ int wc_DerToPemEx(const byte* der, word32 derSz, byte* output, word32 outSz,
     if (!output && outSz == 0) {
         WC_FREE_VAR_EX(header, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         WC_FREE_VAR_EX(footer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        outLen = 0;
-        if ((err = Base64_Encode(der, derSz, NULL, (word32*)&outLen))
+        outLenSz = 0;
+        if ((err = Base64_Encode(der, derSz, NULL, &outLenSz))
                 != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             WOLFSSL_ERROR_VERBOSE(err);
             return err;
         }
+        outLen = (int)outLenSz;
         return (int)headerLen + (int)footerLen + outLen;
     }
 
@@ -26038,13 +26043,16 @@ int wc_DerToPemEx(const byte* der, word32 derSz, byte* output, word32 outSz,
 
     WC_FREE_VAR_EX(header, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
-    /* body */
-    outLen = (int)outSz - (int)(headerLen + footerLen);  /* input to Base64_Encode */
-    if ( (err = Base64_Encode(der, derSz, output + i, (word32*)&outLen)) < 0) {
+    /* body - capacity for Base64_Encode. Kept in word32: the size guard above
+     * already established outSz >= headerLen + footerLen + derSz, and going
+     * via int would truncate where int is 16-bit. */
+    outLenSz = outSz - ((word32)headerLen + (word32)footerLen);
+    if ( (err = Base64_Encode(der, derSz, output + i, &outLenSz)) < 0) {
         WC_FREE_VAR_EX(footer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         WOLFSSL_ERROR_VERBOSE(err);
         return err;
     }
+    outLen = (int)outLenSz;
     i += outLen;
 
     /* footer */

--- a/wolfcrypt/src/asn_orig.c
+++ b/wolfcrypt/src/asn_orig.c
@@ -3897,7 +3897,9 @@ int DecodeKeyUsage(const byte* input, word32 sz, word16 *extKeyUsage)
 
     *extKeyUsage = (word16)(input[idx]);
     if (length == 2)
-        *extKeyUsage |= (word16)(input[idx+1] << 8);
+        /* Cast first: a 0x80 byte overflows the shift where int is
+         * 16-bit. */
+        *extKeyUsage |= (word16)((word32)input[idx+1] << 8);
 
     return 0;
 }

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -9894,6 +9894,7 @@ int wolfSSL_EVP_PKEY_assign(WOLFSSL_EVP_PKEY *pkey, int type, void *key)
 static int ECC_populate_EVP_PKEY(WOLFSSL_EVP_PKEY* pkey, WOLFSSL_EC_KEY *key)
 {
     int derSz = 0;
+    word32 derSzOut = 0;
     byte* derBuf = NULL;
     ecc_key* ecc;
 
@@ -9905,11 +9906,14 @@ static int ECC_populate_EVP_PKEY(WOLFSSL_EVP_PKEY* pkey, WOLFSSL_EC_KEY *key)
 #ifdef HAVE_PKCS8
         if (key->pkcs8HeaderSz) {
             /* when key has pkcs8 header the pkey should too */
-            if (wc_EccKeyToPKCS8(ecc, NULL, (word32*)&derSz) == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
+            if (wc_EccKeyToPKCS8(ecc, NULL, &derSzOut) ==
+                    WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
+                derSz = (int)derSzOut;
                 derBuf = (byte*)XMALLOC((size_t)derSz, pkey->heap,
                     DYNAMIC_TYPE_OPENSSL);
                 if (derBuf) {
-                    if (wc_EccKeyToPKCS8(ecc, derBuf, (word32*)&derSz) >= 0) {
+                    if (wc_EccKeyToPKCS8(ecc, derBuf, &derSzOut) >= 0) {
+                        derSz = (int)derSzOut;
                         if (pkey->pkey.ptr) {
                             /* The outgoing buffer can hold a private key
                              * encoding, so wipe it before it is returned to


### PR DESCRIPTION
# ASN.1 portability and a KeyUsage encoding fix

Part 2 of 4 from an internal automated source review. Independent of the other three; no shared files.

| Report | Summary |
|---|---|
| F-1541 | int / word32 pointer type punning in ASN.1 and EVP helpers |
| F-1973 | int / word32 pointer type punning in a certificate helper |
| F-2650 | Key usage high byte promotion on 16-bit int targets |
| F-2651 | Key usage high byte promotion on 16-bit int targets (non-template) |

## Behaviour change

While writing the regression test for the key usage decode, a functional bug turned up in the encoder.

**`wc_SetKeyUsage(cert, "decipherOnly")` produced a certificate whose KeyUsage extension parsed back as `digitalSignature`.** decipherOnly is bit 8, the only KeyUsage value needing a second BIT STRING content byte, and the ASN template encoder wrote the two bytes in the wrong order. The non-template encoder was already correct, and the fix adds the missing 16-bit sibling of the existing `SetASN_BitString32()` rather than changing shared code - the TSP `failInfo` BIT STRING deliberately uses the opposite word layout and would otherwise have broken.

**Certificates generated with `decipherOnly` by an affected build carry the wrong usage and should be reissued.**

## Testing

`make check` passes on `--enable-all` and `--enable-all --enable-lms`.

New test: KeyUsage round trip covering all nine bits and several combinations (`tests/api/test_asn.c`).
