### PR TITLE
Constant-time handling of the ECC point at infinity

### DIFF
--- a/tests/unit-mcdc/test_ecc_fault_whitebox.c
+++ b/tests/unit-mcdc/test_ecc_fault_whitebox.c
@@ -740,6 +740,15 @@ static void wb_fp_cache_suite(void)
 #if defined(HAVE_ECC) && !defined(WOLFSSL_SP_MATH) && \
     !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
     !defined(WOLFSSL_CRYPTOCELL)
+/* Coordinate-for-coordinate equality, for asserting a _safe wrapper copied
+ * an operand out verbatim. */
+static int wb_point_eq(ecc_point* p1, ecc_point* p2)
+{
+    return (mp_cmp(p1->x, p2->x) == MP_EQ) &&
+           (mp_cmp(p1->y, p2->y) == MP_EQ) &&
+           (mp_cmp(p1->z, p2->z) == MP_EQ);
+}
+
 static void wb_degenerate_points(void)
 {
     mp_int      a, zero, prime;
@@ -824,11 +833,19 @@ static void wb_degenerate_points(void)
     /* --- the _safe wrappers --- */
 
     /* A = -B: the wrapper's own set-to-infinity chain, with and without an
-     * infinity out-pointer, and with the chain faulted. */
+     * infinity out-pointer, and with the chain faulted. The result must be
+     * the (0, 0, 1) infinity representation with the flag raised. */
     (void)wc_ecc_copy_point(P, Q);
     (void)mp_sub(&prime, P->y, Q->y);
     inf = 0;
-    (void)ecc_projective_add_point_safe(P, Q, R, &a, &prime, mp, &inf);
+    if (ecc_projective_add_point_safe(P, Q, R, &a, &prime, mp, &inf)
+            != MP_OKAY ||
+        inf != 1 ||
+        mp_iszero(R->x) != MP_YES || mp_iszero(R->y) != MP_YES ||
+        mp_cmp_d(R->z, 1) != MP_EQ) {
+        WB_NOTE("FAIL: A = -B did not give infinity with the flag set");
+        wb_fail = 1;
+    }
     (void)ecc_projective_add_point_safe(P, Q, R, &a, &prime, mp, NULL);
     for (n = 1; n <= 6; n++) {
         mcdc_fm_arm(n);
@@ -864,7 +881,15 @@ static void wb_degenerate_points(void)
     (void)mp_mulmod(P->z, &zero, &prime, Q->z);
     (void)mp_set(&zero, 0);
     inf = 0;
-    (void)ecc_projective_add_point_safe(P, Q, R, &a, &prime, mp, &inf);
+    if (ecc_projective_add_point_safe(P, Q, R, &a, &prime, mp, &inf)
+            != MP_OKAY ||
+        inf != 1 ||
+        mp_iszero(R->x) != MP_YES || mp_iszero(R->y) != MP_YES ||
+        mp_cmp_d(R->z, 1) != MP_EQ) {
+        WB_NOTE("FAIL: negated representative did not give infinity with "
+                "the flag set");
+        wb_fail = 1;
+    }
     (void)ecc_projective_add_point_safe(P, Q, R, &a, &prime, mp, NULL);
     for (n = 1; n <= 40; n++) {
         mcdc_fm_arm(n);
@@ -904,13 +929,32 @@ static void wb_degenerate_points(void)
     (void)ecc_projective_add_point_safe(P, Q, R, &a, &prime, mp, &inf);
     (void)mp_set(&zero, 0);
 
-    /* A already at infinity (x == y == 0) on either side */
+    /* A already at infinity (x == y == 0) on either side: the result must
+     * be the finite operand, coordinate for coordinate, with the infinity
+     * flag left clear. Doubling infinity must give (0, 0, 1). */
     (void)mp_set(Q->x, 0);
     (void)mp_set(Q->y, 0);
     (void)mp_set(Q->z, 1);
-    (void)ecc_projective_add_point_safe(Q, P, R, &a, &prime, mp, &inf);
-    (void)ecc_projective_add_point_safe(P, Q, R, &a, &prime, mp, &inf);
-    (void)ecc_projective_dbl_point_safe(Q, R, &a, &prime, mp);
+    inf = 0;
+    if (ecc_projective_add_point_safe(Q, P, R, &a, &prime, mp, &inf)
+            != MP_OKAY ||
+        inf != 0 || wb_point_eq(R, P) == 0) {
+        WB_NOTE("FAIL: infinity + P did not give P with the flag clear");
+        wb_fail = 1;
+    }
+    inf = 0;
+    if (ecc_projective_add_point_safe(P, Q, R, &a, &prime, mp, &inf)
+            != MP_OKAY ||
+        inf != 0 || wb_point_eq(R, P) == 0) {
+        WB_NOTE("FAIL: P + infinity did not give P with the flag clear");
+        wb_fail = 1;
+    }
+    if (ecc_projective_dbl_point_safe(Q, R, &a, &prime, mp) != MP_OKAY ||
+        mp_iszero(R->x) != MP_YES || mp_iszero(R->y) != MP_YES ||
+        mp_cmp_d(R->z, 1) != MP_EQ) {
+        WB_NOTE("FAIL: doubling infinity did not give (0, 0, 1)");
+        wb_fail = 1;
+    }
 
     /* P->z == 0 -> doubling yields Z == 0, so the dbl wrapper's own
      * set-to-infinity chain runs (and is then faulted). */
@@ -921,6 +965,36 @@ static void wb_degenerate_points(void)
         mcdc_fm_arm(n);
         (void)ecc_projective_dbl_point_safe(Q, R, &a, &prime, mp);
         mcdc_fm_disarm();
+    }
+
+    /* Finite (0, y, 1) with y != 0 (off-curve is fine here) plus infinity,
+     * in both operand orders. Both x ordinates are zero, so the raw add
+     * formula's H is zero and it returns Z == 0 with a nonzero X - the
+     * shape that raises the wrapper's own infinity note. The operand
+     * selection must override that note: the result is the finite operand
+     * copied out verbatim and the flag stays clear. Regression for the add
+     * reporting infinity while returning a finite point. */
+    (void)mp_set(Q->x, 0);
+    (void)mp_set(Q->y, 5);
+    (void)mp_set(Q->z, 1);
+    (void)mp_set(P->x, 0);
+    (void)mp_set(P->y, 0);
+    (void)mp_set(P->z, 1);
+    inf = 0;
+    if (ecc_projective_add_point_safe(Q, P, R, &a, &prime, mp, &inf)
+            != MP_OKAY ||
+        inf != 0 || wb_point_eq(R, Q) == 0) {
+        WB_NOTE("FAIL: (0, y, 1) + infinity did not give the finite operand "
+                "with the flag clear");
+        wb_fail = 1;
+    }
+    inf = 0;
+    if (ecc_projective_add_point_safe(P, Q, R, &a, &prime, mp, &inf)
+            != MP_OKAY ||
+        inf != 0 || wb_point_eq(R, Q) == 0) {
+        WB_NOTE("FAIL: infinity + (0, y, 1) did not give the finite operand "
+                "with the flag clear");
+        wb_fail = 1;
     }
 
     WB_NOTE("degenerate point-operand vectors done");

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -8700,6 +8700,10 @@ static int ecc_cond_copy_point(ecc_point* S, int copy, ecc_point* D)
  *   A = B             -> Doubled by the add itself when the z values match;
  *                        all-zero result when they differ - doubled here.
  *   A + B = infinity  -> Add result has z == 0, x/y not 0; set to infinity.
+ *
+ * The infinity out-flag is set only for the last two cases - a finite pair
+ * whose sum is infinity - matching the original branching version, which
+ * never touched the flag when copying an operand out.
  */
 int ecc_projective_add_point_safe(ecc_point* A, ecc_point* B, ecc_point* R,
     mp_int* a, mp_int* modulus, mp_digit mp, int* infinity)
@@ -8708,6 +8712,7 @@ int ecc_projective_add_point_safe(ecc_point* A, ecc_point* B, ecc_point* R,
     int aInf;
     int bInf;
     int nInf;
+    int rInf = 0;
 #ifdef WOLFSSL_SMALL_STACK
     ecc_point* T = NULL;
 #else
@@ -8770,16 +8775,14 @@ int ecc_projective_add_point_safe(ecc_point* A, ecc_point* B, ecc_point* R,
         /* When only Z zero then result is infinity */
         else {
             err = ecc_set_point_infinity(T);
-            if ((err == MP_OKAY) && (infinity != NULL))
-                *infinity = 1;
+            rInf = 1;
         }
     }
 
     /* A = -B with matching z: replace the double the add produced. */
     if ((err == MP_OKAY) && nInf) {
         err = ecc_set_point_infinity(T);
-        if ((err == MP_OKAY) && (infinity != NULL))
-            *infinity = 1;
+        rInf = 1;
     }
 
     /* Select without branching on which operand was infinity: A infinity
@@ -8791,6 +8794,16 @@ int ecc_projective_add_point_safe(ecc_point* A, ecc_point* B, ecc_point* R,
         err = ecc_cond_copy_point(A, bInf, T);
     if (err == MP_OKAY)
         err = wc_ecc_copy_point(T, R);
+
+    /* An infinity operand feeds the raw formula a shape it cannot represent,
+     * so the add's infinity note may be spurious. The selection above then
+     * replaces the result with the other operand, and that selection
+     * overrides the note as well: the flag reports only a result the add
+     * itself produced. */
+    rInf &= (aInf == 0);
+    rInf &= (bInf == 0);
+    if ((err == MP_OKAY) && (infinity != NULL) && (rInf != 0))
+        *infinity = 1;
 
 #if defined(WOLFSSL_SMALL_STACK_CACHE) && !defined(WOLFSSL_ECC_NO_SMALL_STACK)
     T->key = NULL;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -8667,88 +8667,137 @@ int wc_ecc_free(ecc_key* key)
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SP_MATH) && \
     (!defined(WOLF_CRYPTO_CB_ONLY_ECC) || defined(WOLFSSL_QNX_CAAM) || \
       defined(WOLFSSL_IMXRT1170_CAAM))
-/* Handles add failure cases:
+/* Set a point to the representation of infinity, (0, 0, 1). */
+static int ecc_set_point_infinity(ecc_point* P)
+{
+    int err = mp_set(P->x, 0);
+    if (err == MP_OKAY)
+        err = mp_set(P->y, 0);
+    if (err == MP_OKAY)
+        err = mp_set(P->z, 1);
+    return err;
+}
+
+/* Copy S over D when copy is non-zero, without branching on copy. */
+static int ecc_cond_copy_point(ecc_point* S, int copy, ecc_point* D)
+{
+    int err = mp_cond_copy(S->x, copy, D->x);
+    if (err == MP_OKAY)
+        err = mp_cond_copy(S->y, copy, D->y);
+    if (err == MP_OKAY)
+        err = mp_cond_copy(S->z, copy, D->z);
+    return err;
+}
+
+/* Add A and B, handling the exceptional cases the projective add formula
+ * cannot represent. The exceptional inputs are noted with non-short-circuit
+ * tests, then the add always runs and the exceptional results are selected
+ * in over its output:
  *
- * Before add:
- *   Case 1: A is infinity
- *        -> Copy B into result.
- *   Case 2: B is infinity
- *        -> Copy A into result.
- *   Case 3: x and z are the same in A and B (same x value in affine)
- *     Case 3a: y values the same - same point
- *           -> Double instead of add.
- *     Case 3b: y values different - negative of the other when points on curve
- *           -> Need to set result to infinity.
- *
- * After add:
- *   Case 1: A and B are the same point (maybe different z)
- *           (Result was: x == y == z == 0)
- *        -> Need to double instead.
- *
- *   Case 2: A + B = <infinity> = 0.
- *           (Result was: z == 0, x and/or y not 0)
- *        -> Need to set result to infinity.
+ *   A is infinity     -> B copied over the result.
+ *   B is infinity     -> A copied over the result.
+ *   A = -B, same z    -> The add doubles instead; result set to infinity.
+ *   A = B             -> Doubled by the add itself when the z values match;
+ *                        all-zero result when they differ - doubled here.
+ *   A + B = infinity  -> Add result has z == 0, x/y not 0; set to infinity.
  */
 int ecc_projective_add_point_safe(ecc_point* A, ecc_point* B, ecc_point* R,
     mp_int* a, mp_int* modulus, mp_digit mp, int* infinity)
 {
     int err;
+    int aInf;
+    int bInf;
+    int nInf;
+#ifdef WOLFSSL_SMALL_STACK
+    ecc_point* T = NULL;
+#else
+    ecc_point  T_lcl[1];
+    ecc_point* T = T_lcl;
+#endif
 
-    if (mp_iszero(A->x) && mp_iszero(A->y)) {
-        /* A is infinity. */
-        err = wc_ecc_copy_point(B, R);
+    /* Note the exceptional inputs with non-short-circuit tests, then add
+     * regardless, so they cost the same as the ordinary case. The result
+     * goes to a temporary: callers pass the first operand as the
+     * destination, so writing R early would destroy A before the selection
+     * below. */
+    aInf  = (mp_iszero(A->x) == MP_YES);
+    aInf &= (mp_iszero(A->y) == MP_YES);
+    bInf  = (mp_iszero(B->x) == MP_YES);
+    bInf &= (mp_iszero(B->y) == MP_YES);
+
+    /* A = -B with matching z gives infinity, which the add turns into a
+     * double instead: note it now and write infinity over the result after
+     * the add. A = B needs no note - the add doubles it correctly. */
+    nInf  = (mp_cmp(A->x, B->x) == MP_EQ);
+    nInf &= (mp_cmp(A->z, B->z) == MP_EQ);
+    nInf &= (mp_cmp(A->y, B->y) != MP_EQ);
+    nInf &= (aInf == 0);
+    nInf &= (bInf == 0);
+
+    /* Off the stack unless the build asked for small stacks. Inherit the
+     * key's heap and small-stack cache from R so the temporary behaves like
+     * the caller's own points - this is the scalar multiplication inner
+     * loop. */
+#if defined(WOLFSSL_SMALL_STACK_CACHE) && !defined(WOLFSSL_ECC_NO_SMALL_STACK)
+    err = wc_ecc_new_point_ex(&T, (R->key != NULL) ? R->key->heap : NULL);
+#else
+    err = wc_ecc_new_point_ex(&T, NULL);
+#endif
+    if (err != MP_OKAY) {
+        return err;
     }
-    else if (mp_iszero(B->x) && mp_iszero(B->y)) {
-        /* B is infinity. */
-        err = wc_ecc_copy_point(A, R);
-    }
-    else if ((mp_cmp(A->x, B->x) == MP_EQ) && (mp_cmp(A->z, B->z) == MP_EQ)) {
-        /* x ordinattes the same. */
-        if (mp_cmp(A->y, B->y) == MP_EQ) {
-            /* A = B */
-            err = _ecc_projective_dbl_point(B, R, a, modulus, mp);
+#if defined(WOLFSSL_SMALL_STACK_CACHE) && !defined(WOLFSSL_ECC_NO_SMALL_STACK)
+    T->key = R->key;
+#endif
+
+    err = _ecc_projective_add_point(A, B, T, a, modulus, mp);
+    if ((err == MP_OKAY) && mp_iszero(T->z)) {
+        /* When all zero then should have done a double */
+        if (mp_iszero(T->x) && mp_iszero(T->y)) {
+            if (mp_iszero(B->z)) {
+                err = wc_ecc_copy_point(B, T);
+                if (err == MP_OKAY) {
+                    err = mp_montgomery_calc_normalization(T->z, modulus);
+                }
+                if (err == MP_OKAY) {
+                    err = _ecc_projective_dbl_point(T, T, a, modulus, mp);
+                }
+            }
+            else {
+                err = _ecc_projective_dbl_point(B, T, a, modulus, mp);
+            }
         }
+        /* When only Z zero then result is infinity */
         else {
-            /* A = -B */
-            err = mp_set(R->x, 0);
-            if (err == MP_OKAY)
-                err = mp_set(R->y, 0);
-            if (err == MP_OKAY)
-                err = mp_set(R->z, 1);
+            err = ecc_set_point_infinity(T);
             if ((err == MP_OKAY) && (infinity != NULL))
                 *infinity = 1;
         }
     }
-    else {
-        err = _ecc_projective_add_point(A, B, R, a, modulus, mp);
-        if ((err == MP_OKAY) && mp_iszero(R->z)) {
-            /* When all zero then should have done a double */
-            if (mp_iszero(R->x) && mp_iszero(R->y)) {
-                if (mp_iszero(B->z)) {
-                    err = wc_ecc_copy_point(B, R);
-                    if (err == MP_OKAY) {
-                        err = mp_montgomery_calc_normalization(R->z, modulus);
-                    }
-                    if (err == MP_OKAY) {
-                        err = _ecc_projective_dbl_point(R, R, a, modulus, mp);
-                    }
-                }
-                else {
-                    err = _ecc_projective_dbl_point(B, R, a, modulus, mp);
-                }
-            }
-            /* When only Z zero then result is infinity */
-            else {
-                err = mp_set(R->x, 0);
-                if (err == MP_OKAY)
-                    err = mp_set(R->y, 0);
-                if (err == MP_OKAY)
-                    err = mp_set(R->z, 1);
-                if ((err == MP_OKAY) && (infinity != NULL))
-                    *infinity = 1;
-            }
-        }
+
+    /* A = -B with matching z: replace the double the add produced. */
+    if ((err == MP_OKAY) && nInf) {
+        err = ecc_set_point_infinity(T);
+        if ((err == MP_OKAY) && (infinity != NULL))
+            *infinity = 1;
     }
+
+    /* Select without branching on which operand was infinity: A infinity
+     * gives B, B infinity gives A. Both infinity leaves A, itself infinity,
+     * so needs no separate case. */
+    if (err == MP_OKAY)
+        err = ecc_cond_copy_point(B, aInf, T);
+    if (err == MP_OKAY)
+        err = ecc_cond_copy_point(A, bInf, T);
+    if (err == MP_OKAY)
+        err = wc_ecc_copy_point(T, R);
+
+#if defined(WOLFSSL_SMALL_STACK_CACHE) && !defined(WOLFSSL_ECC_NO_SMALL_STACK)
+    T->key = NULL;
+    wc_ecc_del_point_ex(T, (R->key != NULL) ? R->key->heap : NULL);
+#else
+    wc_ecc_del_point_ex(T, NULL);
+#endif
 
     return err;
 }
@@ -8762,19 +8811,19 @@ int ecc_projective_dbl_point_safe(ecc_point *P, ecc_point *R, mp_int* a,
                                   mp_int* modulus, mp_digit mp)
 {
     int err;
+    int inf;
 
-    if (mp_iszero(P->x) && mp_iszero(P->y)) {
-        /* P is infinity. */
-        err = wc_ecc_copy_point(P, R);
-    }
-    else {
-        err = _ecc_projective_dbl_point(P, R, a, modulus, mp);
-        if ((err == MP_OKAY) && mp_iszero(R->z)) {
-           err = mp_set(R->x, 0);
-           if (err == MP_OKAY)
-               err = mp_set(R->y, 0);
-           if (err == MP_OKAY)
-               err = mp_set(R->z, 1);
+    /* Note infinity before doubling - callers alias source and destination -
+     * then double regardless so the exceptional case costs the same. Doubling
+     * infinity gives infinity, as does a zero Z; both are written (0, 0, 1). */
+    inf  = (mp_iszero(P->x) == MP_YES);
+    inf &= (mp_iszero(P->y) == MP_YES);
+
+    err = _ecc_projective_dbl_point(P, R, a, modulus, mp);
+    if (err == MP_OKAY) {
+        inf |= (mp_iszero(R->z) == MP_YES);
+        if (inf) {
+            err = ecc_set_point_infinity(R);
         }
     }
 


### PR DESCRIPTION
# Constant-time handling of the ECC point at infinity

Part 4 of 4 from an internal automated source review, and the last of the batch. Parts 1-3 (#11170, #11171, #11172) have merged; this branch is now rebased onto master and is a single commit touching one file. It was kept separate because it is the only change in the batch with a measurable performance cost.

| Report | Summary |
|---|---|
| F-2618 | ECC point add and double exceptional case handling |

`ecc_projective_add_point_safe()` and `ecc_projective_dbl_point_safe()` branched on whether an operand was the point at infinity, collapsing to a point copy instead of doing the arithmetic. Both now run the ordinary operation regardless and select the result with `mp_cond_copy()`, so an exceptional operand costs the same as an ordinary one.

The addition computes into a temporary rather than into `R`: every call site passes the first operand as the destination, so writing `R` early would destroy `A` before the selection. The temporary is on the stack unless the build asked otherwise, and inherits the key heap and the small-stack cache back-pointer from `R` so it behaves like the caller's own points.

The `A == B` equality branch is deliberately left in place. The Montgomery ladder cannot reach it, and covering it would mean computing a doubling as well as an addition on every call.

## Performance

Measured interleaved A/B with standalone binaries, four runs each, on a default `./configure` build:

| Operation | master | branch | Delta |
|---|---|---|---|
| ECDH agree | 5747.6 | 5228.0 | **-9.0%** |
| ECDSA sign | 5484.8 | 5043.8 | **-8.0%** |
| ECDSA verify | 8181.6 | 7746.1 | **-5.3%** |

This is the legacy point arithmetic only. Builds using `--enable-sp` - including `--enable-all` - route P-256/384/521 through the SP implementations and are unaffected.

Worth noting for the record: this code is **not** compiled out under SP math as the report claims. The guard is `!WOLFSSL_SP_MATH`, not `!WOLFSSL_SP_MATH_ALL`, and instrumentation confirms P-256 ECDH and ECDSA reach both functions in a default build.

A further caveat: `mp_cmp_ct()` and `mp_montgomery_reduce_ct()` are `#define`d to the non-constant-time versions on `integer.c` and `tfm.c`, so this change cannot deliver constant time on those backends regardless.

## Testing

`make check` passes on `--enable-all`, `--enable-all --enable-lms`, `--enable-fastmath`, `--enable-heapmath`, `--enable-smallstack --enable-smallstackcache` and `--enable-fpecc`. Re-verified after the rebase onto master: build, `testwolfcrypt` and the full unit suite all clean.

The source-text lint (`wolfssl-multi-test.sh check-source-text`) passes on the commit.
