### PR TITLE
Fix AES-GCM nonce reuse in the async encrypt path

### DIFF
--- a/doc/dox_comments/header_files/aes.h
+++ b/doc/dox_comments/header_files/aes.h
@@ -2751,11 +2751,13 @@ int wc_AesGcmSetIV(Aes* aes, word32 ivSz, const byte* ivFixed,
     parameters, including IV output. This is a one-shot encryption
     function that outputs the generated IV.
 
-    The IV is taken from an internal counter that is advanced on every call,
-    so no two calls under one key produce the same IV. ivOut must not overlap
-    out, in, authTag or authIn: the buffer is the working copy of the IV that
-    was consumed, and overwriting it corrupts the counter for the next call.
-    ivOut may be written even when the function returns an error.
+    The IV is taken from an internal counter that is advanced whenever an IV
+    is consumed - on success, and on submission to an asynchronous device - so
+    no two encryptions under one key use the same IV. A call that fails before
+    the cipher consumes the IV leaves the counter where it was. ivOut must not
+    overlap out, in, authTag or authIn: the buffer is the working copy of the
+    IV that was consumed, and overwriting it corrupts the counter for the next
+    call. ivOut may be written even when the function returns an error.
 
     When the Aes carries an asynchronous device, a return of WC_PENDING_E
     means the operation was submitted, not that it finished. ivOut - like out,
@@ -2929,12 +2931,14 @@ int wc_AesCcmSetNonce(Aes* aes, const byte* nonce, word32 nonceSz);
     parameters, including nonce output. This is useful when part of the
     nonce is generated internally.
 
-    The nonce is taken from an internal counter that is advanced on every
-    call, so no two calls under one key produce the same nonce. ivOut must not
-    overlap out, in, authTag or authIn: the buffer is the working copy of the
-    nonce that was consumed, and overwriting it corrupts the counter for the
-    next call. ivOut may be written even when the function returns an error -
-    earlier releases left it untouched on failure.
+    The nonce is taken from an internal counter that is advanced whenever a
+    nonce is consumed - on success, and on submission to an asynchronous
+    device - so no two encryptions under one key use the same nonce. A call
+    that fails before the cipher consumes the nonce leaves the counter where
+    it was. ivOut must not overlap out, in, authTag or authIn: the buffer is
+    the working copy of the nonce that was consumed, and overwriting it
+    corrupts the counter for the next call. ivOut may be written even when the
+    function returns an error - earlier releases left it untouched on failure.
 
     \return 0 On success.
     \return BAD_FUNC_ARG If parameters are invalid.

--- a/doc/dox_comments/header_files/aes.h
+++ b/doc/dox_comments/header_files/aes.h
@@ -2751,8 +2751,22 @@ int wc_AesGcmSetIV(Aes* aes, word32 ivSz, const byte* ivFixed,
     parameters, including IV output. This is a one-shot encryption
     function that outputs the generated IV.
 
+    The IV is taken from an internal counter that is advanced on every call,
+    so no two calls under one key produce the same IV. ivOut must not overlap
+    out, in, authTag or authIn: the buffer is the working copy of the IV that
+    was consumed, and overwriting it corrupts the counter for the next call.
+    ivOut may be written even when the function returns an error.
+
+    When the Aes carries an asynchronous device, a return of WC_PENDING_E
+    means the operation was submitted, not that it finished. ivOut - like out,
+    in, authTag and authIn - must stay allocated and unmodified until the
+    operation completes, because the backend reads the IV from it at
+    completion time.
+
     \return 0 On success.
     \return BAD_FUNC_ARG If parameters are invalid.
+    \return WC_PENDING_E If submitted to an asynchronous device and still
+    in progress.
     \return Other negative values on error.
 
     \param aes pointer to the AES structure
@@ -2914,6 +2928,13 @@ int wc_AesCcmSetNonce(Aes* aes, const byte* nonce, word32 nonceSz);
     \brief This function performs AES CCM encryption with extended
     parameters, including nonce output. This is useful when part of the
     nonce is generated internally.
+
+    The nonce is taken from an internal counter that is advanced on every
+    call, so no two calls under one key produce the same nonce. ivOut must not
+    overlap out, in, authTag or authIn: the buffer is the working copy of the
+    nonce that was consumed, and overwriting it corrupts the counter for the
+    next call. ivOut may be written even when the function returns an error -
+    earlier releases left it untouched on failure.
 
     \return 0 On success.
     \return BAD_FUNC_ARG If parameters are invalid.

--- a/tests/api/test_aes.c
+++ b/tests/api/test_aes.c
@@ -3976,6 +3976,211 @@ int test_wc_AesGcmSivEncryptDecrypt(void)
     return EXPECT_RESULT();
 }
 
+/* The self-test module does not build wc_AesGcmSetExtIV(), wc_AesCcmSetNonce()
+ * or the _ex() encrypts these tests drive, and GCM_NONCE_MID_SZ /
+ * CCM_NONCE_MIN_SZ are undeclared in the older FIPS module (aes.h gates them
+ * on HAVE_FIPS_VERSION >= 2). */
+#if !defined(NO_AES) && defined(WOLFSSL_AES_128) && !defined(WC_NO_RNG) && \
+    !defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_FIPS) || \
+     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))) && \
+    (defined(HAVE_AESGCM) || defined(HAVE_AESCCM))
+
+/* Number of records encrypted while checking nonce uniqueness. */
+#define TEST_AES_NONCE_RECS 4
+/* Payload size - above WC_ASYNC_THRESH_AES_GCM for every async backend so the
+ * asynchronous submission path is taken when one is built in. */
+#define TEST_AES_NONCE_SZ   256
+
+/* Big-endian increment of a nonce, mirroring IncCtr() in aes.c. */
+static void test_aes_nonce_inc(byte* nonce, int nonceSz)
+{
+    int i;
+
+    for (i = nonceSz - 1; i >= 0; i--) {
+        if (++nonce[i] != 0)
+            break;
+    }
+}
+
+#endif /* !NO_AES && WOLFSSL_AES_128 && !WC_NO_RNG && !HAVE_SELFTEST &&
+        * modern FIPS && (HAVE_AESGCM || HAVE_AESCCM) */
+
+/*
+ * wc_AesGcmEncrypt_ex() owns the record nonce counter for TLS 1.2 and
+ * DTLS 1.2 AES-GCM suites: it reports the nonce it consumed through ivOut and
+ * must advance aes->reg so that no two records are ever encrypted under the
+ * same key/nonce pair (NIST SP 800-38D section 8.3, RFC 5288 section 3).
+ * Reusing a nonce leaks the GHASH subkey H and allows arbitrary record
+ * forgery.
+ *
+ * The counter used to advance only when wc_AesGcmEncrypt() returned a literal
+ * 0. An asynchronous backend reports a *successful submission* with
+ * WC_PENDING_E, so the counter was never advanced and every record encrypted
+ * through the async path reused one nonce. The TLS state machine compounds
+ * this by advancing to CIPHER_STATE_END before returning the pending status,
+ * so wc_AesGcmEncrypt_ex() is not re-entered on completion.
+ *
+ * Checks, for both the synchronous and the asynchronous path:
+ *  1. Every reported nonce is distinct from all earlier ones.
+ *  2. Each nonce is the previous one incremented by one.
+ *  3. The reported nonce is the nonce actually used, proven by decrypting
+ *     with it on a separate Aes.
+ *  4. The counter carries correctly across an all-0xFF low-order boundary.
+ */
+int test_wc_AesGcmEncrypt_ex_NonceUnique(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AES_128) && \
+    !defined(WC_NO_RNG) && !defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_FIPS) || \
+     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)))
+    WC_RNG rng;
+    byte   key[AES_128_KEY_SIZE];
+    byte   tag[WC_AES_BLOCK_SIZE];
+    byte   ivOut[TEST_AES_NONCE_RECS][GCM_NONCE_MID_SZ];
+    byte   carryIv[2][GCM_NONCE_MID_SZ];
+    byte   expected[GCM_NONCE_MID_SZ];
+    byte   extIv[GCM_NONCE_MID_SZ];
+    int    devId = INVALID_DEVID;
+    int    ret;
+    int    i;
+    int    j;
+    WC_DECLARE_VAR(aes, Aes, 1, NULL);
+    WC_DECLARE_VAR(plain, byte, TEST_AES_NONCE_SZ, NULL);
+    WC_DECLARE_VAR(cipher, byte, TEST_AES_NONCE_SZ, NULL);
+#ifdef HAVE_AES_DECRYPT
+    WC_DECLARE_VAR(dec, Aes, 1, NULL);
+    WC_DECLARE_VAR(plainOut, byte, TEST_AES_NONCE_SZ, NULL);
+#endif
+
+    WC_ALLOC_VAR(aes, Aes, 1, NULL);
+    WC_ALLOC_VAR(plain, byte, TEST_AES_NONCE_SZ, NULL);
+    WC_ALLOC_VAR(cipher, byte, TEST_AES_NONCE_SZ, NULL);
+#ifdef HAVE_AES_DECRYPT
+    WC_ALLOC_VAR(dec, Aes, 1, NULL);
+    WC_ALLOC_VAR(plainOut, byte, TEST_AES_NONCE_SZ, NULL);
+#endif
+
+#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+    ExpectNotNull(aes);
+    ExpectNotNull(plain);
+    ExpectNotNull(cipher);
+#ifdef HAVE_AES_DECRYPT
+    ExpectNotNull(dec);
+    ExpectNotNull(plainOut);
+#endif
+    if (!EXPECT_SUCCESS())
+        goto out;
+#endif
+
+    XMEMSET(aes, 0, sizeof(Aes));
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(ivOut, 0, sizeof(ivOut));
+    XMEMSET(key, 0x2b, sizeof(key));
+    XMEMSET(plain, 0x41, TEST_AES_NONCE_SZ);
+#ifdef HAVE_AES_DECRYPT
+    XMEMSET(dec, 0, sizeof(Aes));
+#endif
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    /* Take the asynchronous submission path, which reports success with
+     * WC_PENDING_E rather than 0. A hardware device returns its devId here,
+     * so any non-negative value is a successful open. */
+    ExpectIntGE(wolfAsync_DevOpen(&devId), 0);
+#endif
+
+    ExpectIntEQ(wc_InitRng(&rng), 0);
+    ExpectIntEQ(wc_AesInit(aes, NULL, devId), 0);
+    ExpectIntEQ(wc_AesGcmSetKey(aes, key, sizeof(key)), 0);
+    ExpectIntEQ(wc_AesGcmSetIV(aes, GCM_NONCE_MID_SZ, NULL, 0, &rng), 0);
+
+#ifdef HAVE_AES_DECRYPT
+    /* Decrypt on its own Aes - some backends use aes->reg as scratch space,
+     * so sharing one Aes would perturb the counter under test. */
+    ExpectIntEQ(wc_AesInit(dec, NULL, INVALID_DEVID), 0);
+    ExpectIntEQ(wc_AesGcmSetKey(dec, key, sizeof(key)), 0);
+#endif
+
+    for (i = 0; i < TEST_AES_NONCE_RECS; i++) {
+        ret = wc_AesGcmEncrypt_ex(aes, cipher, plain, TEST_AES_NONCE_SZ,
+            ivOut[i], GCM_NONCE_MID_SZ, tag, sizeof(tag), NULL, 0);
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        ret = wc_AsyncWait(ret, &aes->asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
+        ExpectIntEQ(ret, 0);
+
+        /* The reported nonce must differ from every earlier one. */
+        for (j = 0; j < i; j++) {
+            ExpectIntNE(XMEMCMP(ivOut[i], ivOut[j], GCM_NONCE_MID_SZ), 0);
+        }
+
+        /* ...and must be exactly one past the previous nonce. */
+        if (i > 0) {
+            XMEMCPY(expected, ivOut[i - 1], GCM_NONCE_MID_SZ);
+            test_aes_nonce_inc(expected, GCM_NONCE_MID_SZ);
+            ExpectIntEQ(XMEMCMP(ivOut[i], expected, GCM_NONCE_MID_SZ), 0);
+        }
+
+    #ifdef HAVE_AES_DECRYPT
+        /* The reported nonce is the one the ciphertext was produced with. */
+        XMEMSET(plainOut, 0, TEST_AES_NONCE_SZ);
+        ExpectIntEQ(wc_AesGcmDecrypt(dec, plainOut, cipher,
+            TEST_AES_NONCE_SZ, ivOut[i], GCM_NONCE_MID_SZ, tag,
+            sizeof(tag), NULL, 0), 0);
+        ExpectIntEQ(XMEMCMP(plainOut, plain, TEST_AES_NONCE_SZ), 0);
+    #endif
+    }
+
+    /* Carry across the low-order boundary: 0x...FFFF must roll into the next
+     * higher byte rather than wrapping back onto a used nonce. */
+    XMEMSET(extIv, 0x00, sizeof(extIv));
+    extIv[GCM_NONCE_MID_SZ - 2] = 0xFF;
+    extIv[GCM_NONCE_MID_SZ - 1] = 0xFF;
+    ExpectIntEQ(wc_AesGcmSetExtIV(aes, extIv, sizeof(extIv)), 0);
+
+    ret = wc_AesGcmEncrypt_ex(aes, cipher, plain, TEST_AES_NONCE_SZ,
+        carryIv[0], GCM_NONCE_MID_SZ, tag, sizeof(tag), NULL, 0);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    ret = wc_AsyncWait(ret, &aes->asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    ExpectIntEQ(ret, 0);
+    ExpectIntEQ(XMEMCMP(carryIv[0], extIv, GCM_NONCE_MID_SZ), 0);
+
+    ret = wc_AesGcmEncrypt_ex(aes, cipher, plain, TEST_AES_NONCE_SZ,
+        carryIv[1], GCM_NONCE_MID_SZ, tag, sizeof(tag), NULL, 0);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    ret = wc_AsyncWait(ret, &aes->asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    ExpectIntEQ(ret, 0);
+    XMEMCPY(expected, extIv, GCM_NONCE_MID_SZ);
+    test_aes_nonce_inc(expected, GCM_NONCE_MID_SZ);
+    ExpectIntEQ(XMEMCMP(carryIv[1], expected, GCM_NONCE_MID_SZ), 0);
+    ExpectIntNE(XMEMCMP(carryIv[1], carryIv[0], GCM_NONCE_MID_SZ), 0);
+
+#ifdef HAVE_AES_DECRYPT
+    wc_AesFree(dec);
+#endif
+    wc_AesFree(aes);
+    DoExpectIntEQ(wc_FreeRng(&rng), 0);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    wolfAsync_DevClose(&devId);
+#endif
+
+#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+out:
+#endif
+    WC_FREE_VAR(plain, NULL);
+    WC_FREE_VAR(cipher, NULL);
+    WC_FREE_VAR(aes, NULL);
+#ifdef HAVE_AES_DECRYPT
+    WC_FREE_VAR(plainOut, NULL);
+    WC_FREE_VAR(dec, NULL);
+#endif
+#endif /* !NO_AES && HAVE_AESGCM && WOLFSSL_AES_128 && !WC_NO_RNG */
+    return EXPECT_RESULT();
+}
+
 /*
  * Non-standard (non-96-bit) nonce tests for AES-GCM.
  *
@@ -5338,6 +5543,92 @@ int test_wc_AesCcmAeadEdgeCases(void)
 #endif /* HAVE_AESCCM && WOLFSSL_AES_128 */
     return EXPECT_RESULT();
 } /* END test_wc_AesCcmAeadEdgeCases */
+
+/*
+ * wc_AesCcmEncrypt_ex() carries the same nonce-counter contract as
+ * wc_AesGcmEncrypt_ex(): the nonce reported through ivOut must be the one the
+ * ciphertext was produced with, and the counter must advance so no two records
+ * share a nonce. No CCM backend defers work today, but the counter is advanced
+ * on a deferred submission as well so that adding one cannot silently
+ * reintroduce nonce reuse.
+ */
+int test_wc_AesCcmEncrypt_ex_NonceUnique(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_AES) && defined(HAVE_AESCCM) && defined(WOLFSSL_AES_128) && \
+    !defined(WC_NO_RNG) && !defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_FIPS) || \
+     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)))
+    Aes    aes;
+    byte   key[AES_128_KEY_SIZE];
+    byte   nonce[CCM_NONCE_MIN_SZ];
+    byte   plain[32];
+    byte   cipher[32];
+    byte   tag[WC_AES_BLOCK_SIZE];
+    byte   ivOut[TEST_AES_NONCE_RECS][CCM_NONCE_MIN_SZ];
+    byte   expected[CCM_NONCE_MIN_SZ];
+    int    i;
+    int    j;
+#ifdef HAVE_AES_DECRYPT
+    Aes    dec;
+    byte   plainOut[32];
+
+    XMEMSET(&dec, 0, sizeof(dec));
+#endif
+
+    XMEMSET(&aes, 0, sizeof(aes));
+    XMEMSET(ivOut, 0, sizeof(ivOut));
+    XMEMSET(key, 0x2b, sizeof(key));
+    XMEMSET(plain, 0x41, sizeof(plain));
+    /* Start two below a low-order boundary so the loop crosses a carry. */
+    XMEMSET(nonce, 0x00, sizeof(nonce));
+    nonce[sizeof(nonce) - 2] = 0xFF;
+    nonce[sizeof(nonce) - 1] = 0xFE;
+
+    ExpectIntEQ(wc_AesInit(&aes, NULL, INVALID_DEVID), 0);
+    ExpectIntEQ(wc_AesCcmSetKey(&aes, key, sizeof(key)), 0);
+    ExpectIntEQ(wc_AesCcmSetNonce(&aes, nonce, sizeof(nonce)), 0);
+
+#ifdef HAVE_AES_DECRYPT
+    ExpectIntEQ(wc_AesInit(&dec, NULL, INVALID_DEVID), 0);
+    ExpectIntEQ(wc_AesCcmSetKey(&dec, key, sizeof(key)), 0);
+#endif
+
+    for (i = 0; i < TEST_AES_NONCE_RECS; i++) {
+        ExpectIntEQ(wc_AesCcmEncrypt_ex(&aes, cipher, plain,
+            (word32)sizeof(plain), ivOut[i], sizeof(nonce), tag, sizeof(tag),
+            NULL, 0), 0);
+
+        for (j = 0; j < i; j++) {
+            ExpectIntNE(XMEMCMP(ivOut[i], ivOut[j], sizeof(nonce)), 0);
+        }
+
+        if (i == 0) {
+            ExpectIntEQ(XMEMCMP(ivOut[i], nonce, sizeof(nonce)), 0);
+        }
+        else {
+            XMEMCPY(expected, ivOut[i - 1], sizeof(nonce));
+            test_aes_nonce_inc(expected, (int)sizeof(nonce));
+            ExpectIntEQ(XMEMCMP(ivOut[i], expected, sizeof(nonce)), 0);
+        }
+
+    #ifdef HAVE_AES_DECRYPT
+        XMEMSET(plainOut, 0, sizeof(plainOut));
+        ExpectIntEQ(wc_AesCcmDecrypt(&dec, plainOut, cipher,
+            (word32)sizeof(cipher), ivOut[i], sizeof(nonce), tag, sizeof(tag),
+            NULL, 0), 0);
+        ExpectIntEQ(XMEMCMP(plainOut, plain, sizeof(plain)), 0);
+    #endif
+    }
+
+#ifdef HAVE_AES_DECRYPT
+    wc_AesFree(&dec);
+#endif
+    wc_AesFree(&aes);
+#endif /* !NO_AES && HAVE_AESCCM && WOLFSSL_AES_128 && !WC_NO_RNG &&
+        * !HAVE_SELFTEST && modern FIPS */
+    return EXPECT_RESULT();
+} /* END test_wc_AesCcmEncrypt_ex_NonceUnique */
 
 /*******************************************************************************
  * AES-XTS

--- a/tests/api/test_aes.h
+++ b/tests/api/test_aes.h
@@ -51,6 +51,8 @@ int test_wc_AesGcmEncryptDecrypt_UnalignedBuffers(void);
 int test_wc_AesGcm_CrossCipher(void);
 int test_wc_AesGcmMixedEncDecLongIV(void);
 int test_wc_AesGcmNonStdNonce(void);
+int test_wc_AesGcmEncrypt_ex_NonceUnique(void);
+int test_wc_AesCcmEncrypt_ex_NonceUnique(void);
 int test_wc_AesGcmSivEncryptDecrypt(void);
 int test_wc_AesGcmStream(void);
 int test_wc_AesGcmStream_MidStreamState(void);
@@ -210,6 +212,8 @@ int test_wc_CryptoCb_AesKeyWrapEcbCompose(void);
     TEST_DECL_GROUP("aes", test_wc_AesGcm_CrossCipher),                    \
     TEST_DECL_GROUP("aes", test_wc_AesGcmMixedEncDecLongIV),                \
     TEST_DECL_GROUP("aes", test_wc_AesGcmNonStdNonce),          \
+    TEST_DECL_GROUP("aes", test_wc_AesGcmEncrypt_ex_NonceUnique), \
+    TEST_DECL_GROUP("aes", test_wc_AesCcmEncrypt_ex_NonceUnique), \
     TEST_DECL_GROUP("aes", test_wc_AesGcmSivEncryptDecrypt),    \
     TEST_DECL_GROUP("aes", test_wc_AesGcmStream),               \
     TEST_DECL_GROUP("aes", test_wc_AesGcmStream_MidStreamState),  \

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -3384,6 +3384,14 @@ int test_record_size_cache_invalidated_on_renegotiation(void)
 /* Payload size - above WC_ASYNC_THRESH_AES_GCM for every async backend so an
  * async build actually offloads the record encryption. */
 #define TEST_TLS12_NONCE_PAYLOAD 256
+/* Drive the record cipher through the software async simulator where the build
+ * has one. Non-blocking math livelocks the async re-drive - see
+ * test_tls13_pqc_hybrid_async_server() - so those builds run the test on the
+ * synchronous path, where it pins the same invariant. */
+#if defined(WOLFSSL_ASYNC_CRYPT) && !defined(WC_ECC_NONBLOCK) && \
+    !defined(WOLFSSL_SP_NONBLOCK)
+    #define TEST_TLS12_NONCE_ASYNC
+#endif
 
 /*
  * A TLS 1.2 AES-GCM sender must never reuse a nonce under one traffic key
@@ -3431,7 +3439,7 @@ int test_tls12_aesgcm_record_nonce_unique(void)
     XMEMSET(payload, 0x5a, sizeof(payload));
     test_ctx.c_ciphers = test_ctx.s_ciphers = "ECDHE-RSA-AES128-GCM-SHA256";
 
-#ifdef WOLFSSL_ASYNC_CRYPT
+#ifdef TEST_TLS12_NONCE_ASYNC
     /* Offload the record cipher so the WC_PENDING_E path is taken. A hardware
      * device returns its devId, so any non-negative value is a good open. */
     ExpectIntGE(wolfAsync_DevOpen(&devId), 0);
@@ -3439,7 +3447,7 @@ int test_tls12_aesgcm_record_nonce_unique(void)
 
     ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
                     wolfTLSv1_2_client_method, wolfTLSv1_2_server_method), 0);
-#ifdef WOLFSSL_ASYNC_CRYPT
+#ifdef TEST_TLS12_NONCE_ASYNC
     ExpectIntEQ(wolfSSL_SetDevId(ssl_c, devId), WOLFSSL_SUCCESS);
     ExpectIntEQ(wolfSSL_SetDevId(ssl_s, devId), WOLFSSL_SUCCESS);
 #endif
@@ -3516,7 +3524,7 @@ int test_tls12_aesgcm_record_nonce_unique(void)
     wolfSSL_free(ssl_s);
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_CTX_free(ctx_s);
-#ifdef WOLFSSL_ASYNC_CRYPT
+#ifdef TEST_TLS12_NONCE_ASYNC
     wolfAsync_DevClose(&devId);
 #endif
     (void)devId;

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -3378,3 +3378,148 @@ int test_record_size_cache_invalidated_on_renegotiation(void)
 #endif
     return EXPECT_RESULT();
 }
+
+/* Number of application records written while checking nonce uniqueness. */
+#define TEST_TLS12_NONCE_RECS 4
+/* Payload size - above WC_ASYNC_THRESH_AES_GCM for every async backend so an
+ * async build actually offloads the record encryption. */
+#define TEST_TLS12_NONCE_PAYLOAD 256
+
+/*
+ * A TLS 1.2 AES-GCM sender must never reuse a nonce under one traffic key
+ * (RFC 5288 section 3, NIST SP 800-38D section 8.3). The 8-byte explicit part
+ * of the nonce is carried in the clear at the front of each record, so a
+ * repeat is directly observable on the wire - and a repeat hands an on-path
+ * attacker the GHASH subkey H and with it the ability to forge records.
+ *
+ * The explicit nonce comes from ssl->encrypt.nonce, which wc_AesGcmEncrypt_ex()
+ * fills from its internal counter. That counter used to advance only when the
+ * cipher returned a literal 0, so an asynchronous backend - which reports a
+ * successful submission with WC_PENDING_E - left it parked and every record
+ * went out under the same nonce.
+ *
+ * Writes several records, then reads the explicit nonces straight out of the
+ * memio wire buffer and requires them to be pairwise distinct. Runs in
+ * synchronous builds too, where it pins the same invariant end to end.
+ */
+int test_tls12_aesgcm_record_nonce_unique(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(WOLFSSL_NO_TLS12) && defined(BUILD_AESGCM) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    defined(HAVE_ECC) && !defined(NO_RSA) && defined(WOLFSSL_AES_128) && \
+    !defined(NO_PUBLIC_GCM_SET_IV) && \
+    ((!defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)) || \
+     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)))
+    struct test_memio_ctx test_ctx;
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    byte payload[TEST_TLS12_NONCE_PAYLOAD];
+    byte readBuf[TEST_TLS12_NONCE_PAYLOAD];
+    byte nonces[TEST_TLS12_NONCE_RECS][AESGCM_EXP_IV_SZ];
+    int devId = INVALID_DEVID;
+    int off = 0;
+    int recLen = 0;
+    int ret = 0;
+    int err = 0;
+    int i;
+    int j;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    XMEMSET(nonces, 0, sizeof(nonces));
+    XMEMSET(payload, 0x5a, sizeof(payload));
+    test_ctx.c_ciphers = test_ctx.s_ciphers = "ECDHE-RSA-AES128-GCM-SHA256";
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    /* Offload the record cipher so the WC_PENDING_E path is taken. A hardware
+     * device returns its devId, so any non-negative value is a good open. */
+    ExpectIntGE(wolfAsync_DevOpen(&devId), 0);
+#endif
+
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+                    wolfTLSv1_2_client_method, wolfTLSv1_2_server_method), 0);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    ExpectIntEQ(wolfSSL_SetDevId(ssl_c, devId), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_SetDevId(ssl_s, devId), WOLFSSL_SUCCESS);
+#endif
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    ExpectStrEQ(wolfSSL_get_cipher_name(ssl_c), "ECDHE-RSA-AES128-GCM-SHA256");
+
+    /* Drop the handshake traffic so the buffer holds only application data.
+     * The client writes into s_buff - the buffer the server reads from. */
+    if (EXPECT_SUCCESS()) {
+        test_memio_clear_buffer(&test_ctx, 0);
+    }
+
+    for (i = 0; i < TEST_TLS12_NONCE_RECS && EXPECT_SUCCESS(); i++) {
+        do {
+        #ifdef WOLFSSL_ASYNC_CRYPT
+            if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
+                ret = wolfSSL_AsyncPoll(ssl_c, WOLF_POLL_FLAG_CHECK_HW);
+                if (ret < 0)
+                    break;
+            }
+        #endif
+            ret = wolfSSL_write(ssl_c, payload, (int)sizeof(payload));
+            err = (ret > 0) ? 0 : wolfSSL_get_error(ssl_c, ret);
+        } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+        ExpectIntEQ(ret, (int)sizeof(payload));
+    }
+
+    /* Walk the wire buffer record by record and lift the explicit nonce out
+     * of each one: [type][version][length][8-byte explicit nonce][...]. */
+    for (i = 0; i < TEST_TLS12_NONCE_RECS && EXPECT_SUCCESS(); i++) {
+        ExpectIntGE(test_ctx.s_len - off,
+            RECORD_HEADER_SZ + AESGCM_EXP_IV_SZ);
+        if (EXPECT_SUCCESS()) {
+            ExpectIntEQ(test_ctx.s_buff[off], application_data);
+            recLen = (test_ctx.s_buff[off + 3] << 8) |
+                      test_ctx.s_buff[off + 4];
+            ExpectIntGE(recLen, AESGCM_EXP_IV_SZ);
+        }
+        if (EXPECT_SUCCESS()) {
+            XMEMCPY(nonces[i], test_ctx.s_buff + off + RECORD_HEADER_SZ,
+                AESGCM_EXP_IV_SZ);
+            off += RECORD_HEADER_SZ + recLen;
+        }
+    }
+    ExpectIntEQ(off, test_ctx.s_len);
+
+    /* No explicit nonce may repeat under this traffic key. */
+    for (i = 1; i < TEST_TLS12_NONCE_RECS; i++) {
+        for (j = 0; j < i; j++) {
+            ExpectIntNE(XMEMCMP(nonces[i], nonces[j], AESGCM_EXP_IV_SZ), 0);
+        }
+    }
+
+    /* The records are still valid: the peer authenticates and decrypts each. */
+    for (i = 0; i < TEST_TLS12_NONCE_RECS && EXPECT_SUCCESS(); i++) {
+        err = 0;
+        do {
+        #ifdef WOLFSSL_ASYNC_CRYPT
+            if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
+                ret = wolfSSL_AsyncPoll(ssl_s, WOLF_POLL_FLAG_CHECK_HW);
+                if (ret < 0)
+                    break;
+            }
+        #endif
+            XMEMSET(readBuf, 0, sizeof(readBuf));
+            ret = wolfSSL_read(ssl_s, readBuf, (int)sizeof(readBuf));
+            err = (ret > 0) ? 0 : wolfSSL_get_error(ssl_s, ret);
+        } while (err == WC_NO_ERR_TRACE(WC_PENDING_E));
+        ExpectIntEQ(ret, (int)sizeof(payload));
+        ExpectIntEQ(XMEMCMP(readBuf, payload, sizeof(payload)), 0);
+    }
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    wolfAsync_DevClose(&devId);
+#endif
+    (void)devId;
+#endif
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_tls.c
+++ b/tests/api/test_tls.c
@@ -3503,7 +3503,11 @@ int test_tls12_aesgcm_record_nonce_unique(void)
 
     /* The records are still valid: the peer authenticates and decrypts each. */
     for (i = 0; i < TEST_TLS12_NONCE_RECS && EXPECT_SUCCESS(); i++) {
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        /* Clear any pending state left by the previous record so the first
+         * pass reads rather than polls. */
         err = 0;
+    #endif
         do {
         #ifdef WOLFSSL_ASYNC_CRYPT
             if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {

--- a/tests/api/test_tls.h
+++ b/tests/api/test_tls.h
@@ -66,6 +66,7 @@ int test_record_size_matches_build_message(void);
 int test_record_size_preserves_build_msg_state(void);
 int test_record_size_cache_invalidated_on_renegotiation(void);
 int test_wolfSSL_get_shared_ciphers(void);
+int test_tls12_aesgcm_record_nonce_unique(void);
 
 #define TEST_TLS_DECLS                                                         \
         TEST_DECL_GROUP("tls", test_utils_memio_move_message),                 \
@@ -114,6 +115,7 @@ int test_wolfSSL_get_shared_ciphers(void);
             test_record_size_preserves_build_msg_state),                       \
         TEST_DECL_GROUP("tls",                                                 \
             test_record_size_cache_invalidated_on_renegotiation),              \
-        TEST_DECL_GROUP("tls", test_wolfSSL_get_shared_ciphers)
+        TEST_DECL_GROUP("tls", test_wolfSSL_get_shared_ciphers),               \
+        TEST_DECL_GROUP("tls", test_tls12_aesgcm_record_nonce_unique)
 
 #endif /* TESTS_API_TEST_TLS_H */

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -14917,12 +14917,23 @@ int wc_AesGcmEncrypt_ex(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if (ret == 0) {
+        /* Hand the encrypt the nonce out of ivOut rather than aes->reg. Some
+         * backends use aes->reg as scratch space, and an asynchronous backend
+         * keeps the pointer until the operation completes, so aes->reg is not
+         * a stable place to hold the nonce being consumed. */
         XMEMCPY(ivOut, aes->reg, ivOutSz);
         ret = wc_AesGcmEncrypt(aes, out, in, sz,
-                               (byte*)aes->reg, ivOutSz,
+                               ivOut, ivOutSz,
                                authTag, authTagSz,
                                authIn, authInSz);
-        if (ret == 0)
+        /* Put the nonce back unconditionally - a backend may have left scratch
+         * data in aes->reg - so a failed encrypt leaves the counter on the
+         * nonce it did not consume rather than on backend leftovers. */
+        XMEMCPY(aes->reg, ivOut, ivOutSz);
+        /* A nonce handed to an asynchronous backend has been consumed even
+         * though the operation has not finished yet - the counter must still
+         * advance or the next record would reuse this nonce. */
+        if (ret == 0 || ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             IncCtr((byte*)aes->reg, ivOutSz);
     }
 
@@ -15749,14 +15760,19 @@ int wc_AesCcmEncrypt_ex(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if (ret == 0) {
+        /* Keep the nonce being consumed in ivOut rather than aes->reg - see
+         * wc_AesGcmEncrypt_ex() for why aes->reg is not a stable holder. */
+        XMEMCPY(ivOut, aes->reg, aes->nonceSz);
         ret = wc_AesCcmEncrypt(aes, out, in, sz,
-                               (byte*)aes->reg, aes->nonceSz,
+                               ivOut, aes->nonceSz,
                                authTag, authTagSz,
                                authIn, authInSz);
-        if (ret == 0) {
-            XMEMCPY(ivOut, aes->reg, aes->nonceSz);
+        /* Put the nonce back unconditionally - see wc_AesGcmEncrypt_ex(). */
+        XMEMCPY(aes->reg, ivOut, aes->nonceSz);
+        /* Advance past a nonce handed to a backend that defers the work - it
+         * has been consumed even though the operation has not finished. */
+        if (ret == 0 || ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             IncCtr((byte*)aes->reg, aes->nonceSz);
-        }
     }
 
     return ret;

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -14917,7 +14917,7 @@ int wc_AesGcmEncrypt_ex(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if (ret == 0) {
-        /* Hand the encrypt the nonce out of ivOut rather than aes->reg. Some
+        /* Pass the encrypt its nonce out of ivOut rather than aes->reg. Some
          * backends use aes->reg as scratch space, and an asynchronous backend
          * keeps the pointer until the operation completes, so aes->reg is not
          * a stable place to hold the nonce being consumed. */

--- a/wolfcrypt/src/port/ti/ti-aes.c
+++ b/wolfcrypt/src/port/ti/ti-aes.c
@@ -804,11 +804,17 @@ int wc_AesGcmEncrypt_ex(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if (ret == 0) {
+        /* Hand the encrypt the nonce out of ivOut rather than aes->reg -
+         * AesAuthSetIv() leaves the GHASH result in aes->reg for a nonce that
+         * is not 96 bits, so aes->reg does not survive the call. */
         XMEMCPY(ivOut, aes->reg, ivOutSz);
         ret = wc_AesGcmEncrypt(aes, out, in, sz,
-                               (byte*)aes->reg, ivOutSz,
+                               ivOut, ivOutSz,
                                authTag, authTagSz,
                                authIn, authInSz);
+        /* Put the nonce back over any scratch data the driver left behind,
+         * then advance so the next record cannot reuse this nonce. */
+        XMEMCPY(aes->reg, ivOut, ivOutSz);
         if (ret == 0)
             IncCtr((byte*)aes->reg, ivOutSz);
     }
@@ -975,14 +981,16 @@ int wc_AesCcmEncrypt_ex(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if (ret == 0) {
+        /* Keep the nonce being consumed in ivOut - see wc_AesGcmEncrypt_ex()
+         * for why aes->reg does not survive the call. */
+        XMEMCPY(ivOut, aes->reg, aes->nonceSz);
         ret = wc_AesCcmEncrypt(aes, out, in, sz,
-                               (byte*)aes->reg, aes->nonceSz,
+                               ivOut, aes->nonceSz,
                                authTag, authTagSz,
                                authIn, authInSz);
-        if (ret == 0) {
-            XMEMCPY(ivOut, aes->reg, aes->nonceSz);
+        XMEMCPY(aes->reg, ivOut, aes->nonceSz);
+        if (ret == 0)
             IncCtr((byte*)aes->reg, aes->nonceSz);
-        }
     }
 
     return ret;

--- a/wolfcrypt/src/port/ti/ti-aes.c
+++ b/wolfcrypt/src/port/ti/ti-aes.c
@@ -804,7 +804,7 @@ int wc_AesGcmEncrypt_ex(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if (ret == 0) {
-        /* Hand the encrypt the nonce out of ivOut rather than aes->reg -
+        /* Pass the encrypt its nonce out of ivOut rather than aes->reg -
          * AesAuthSetIv() leaves the GHASH result in aes->reg for a nonce that
          * is not 96 bits, so aes->reg does not survive the call. */
         XMEMCPY(ivOut, aes->reg, ivOutSz);


### PR DESCRIPTION
# Description

`wc_AesGcmEncrypt_ex()` reports the nonce it consumed via `ivOut` and advances an internal counter so no two records share a nonce under one key. The counter only advanced when `wc_AesGcmEncrypt()` returned 0; but an async backend reports a successful submission with `WC_PENDING_E`.

Fixes zd22291

# Testing

`test_wc_AesGcmEncrypt_ex_NonceUnique`
`test_wc_AesCcmEncrypt_ex_NonceUnique`
`test_tls12_aesgcm_record_nonce_unique`

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
