### PR TITLE
Rust wrapper Fenrir fixes 2026-08-17

### DIFF
--- a/wrapper/rust/wolfssl-wolfcrypt/src/ed25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ed25519.rs
@@ -26,6 +26,7 @@ This module provides a Rust wrapper for the wolfCrypt library's EdDSA Curve
 #![cfg(ed25519)]
 
 use crate::sys;
+#[cfg(random)]
 use crate::random::RNG;
 use core::mem::MaybeUninit;
 
@@ -67,11 +68,15 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed25519::generate(&mut rng).expect("Error with generate()");
+    /// }
     /// ```
+    #[cfg(random)]
     pub fn generate(rng: &RNG) -> Result<Self, i32> {
         Self::generate_ex(rng, None, None)
     }
@@ -92,11 +97,15 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed25519::generate_ex(&mut rng, None, None).expect("Error with generate_ex()");
+    /// }
     /// ```
+    #[cfg(random)]
     pub fn generate_ex(rng: &RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut ws_key: MaybeUninit<sys::ed25519_key> = MaybeUninit::uninit();
         let heap = match heap {
@@ -198,11 +207,14 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let mut ed = Ed25519::generate(&mut rng).expect("Error with generate()");
     /// ed.check_key().expect("Error with check_key()");
+    /// }
     /// ```
     pub fn check_key(&mut self) -> Result<(), i32> {
         let rc = unsafe { sys::wc_ed25519_check_key(&mut self.ws_key) };
@@ -229,7 +241,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_export)]
+    /// #[cfg(all(ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -271,7 +283,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_export)]
+    /// #[cfg(all(ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -310,7 +322,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_export)]
+    /// #[cfg(all(ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -349,7 +361,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_export)]
+    /// #[cfg(all(ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -390,7 +402,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_import)]
+    /// #[cfg(all(ed25519_import, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -434,7 +446,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_import)]
+    /// #[cfg(all(ed25519_import, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -474,7 +486,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_import)]
+    /// #[cfg(all(ed25519_import, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -518,7 +530,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_import)]
+    /// #[cfg(all(ed25519_import, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -569,7 +581,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_import)]
+    /// #[cfg(all(ed25519_import, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -618,6 +630,8 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(all(ed25519_export, ed25519_import, random))]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
     /// let mut rng = RNG::new().expect("Error creating RNG");
@@ -628,6 +642,7 @@ impl Ed25519 {
     /// ed.import_private_only(&private).expect("Error with import_private_only()");
     /// let mut public = [0u8; Ed25519::KEY_SIZE];
     /// ed.make_public(&mut public).expect("Error with make_public()");
+    /// }
     /// ```
     pub fn make_public(&mut self, pubkey: &mut [u8]) -> Result<(), i32> {
         let pubkey_size = crate::buffer_len_to_u32(pubkey.len())?;
@@ -657,7 +672,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_sign)]
+    /// #[cfg(all(ed25519_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -701,7 +716,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_sign)]
+    /// #[cfg(all(ed25519_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -752,7 +767,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_sign)]
+    /// #[cfg(all(ed25519_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -817,7 +832,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_sign)]
+    /// #[cfg(all(ed25519_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -873,7 +888,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_sign)]
+    /// #[cfg(all(ed25519_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -924,7 +939,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_verify)]
+    /// #[cfg(all(ed25519_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -975,7 +990,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_verify)]
+    /// #[cfg(all(ed25519_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1034,7 +1049,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_verify)]
+    /// #[cfg(all(ed25519_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1106,7 +1121,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_verify)]
+    /// #[cfg(all(ed25519_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1169,7 +1184,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_verify)]
+    /// #[cfg(all(ed25519_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1229,7 +1244,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_streaming_verify)]
+    /// #[cfg(all(ed25519_streaming_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1281,7 +1296,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_streaming_verify)]
+    /// #[cfg(all(ed25519_streaming_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1324,7 +1339,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed25519_streaming_verify)]
+    /// #[cfg(all(ed25519_streaming_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1369,12 +1384,15 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed25519::generate(&mut rng).expect("Error with generate()");
     /// let key_size = ed.size().expect("Error with size()");
     /// assert_eq!(key_size, Ed25519::KEY_SIZE);
+    /// }
     /// ```
     pub fn size(&self) -> Result<usize, i32> {
         let rc = unsafe { sys::wc_ed25519_size(&self.ws_key) };
@@ -1394,12 +1412,15 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed25519::generate(&mut rng).expect("Error with generate()");
     /// let priv_size = ed.priv_size().expect("Error with priv_size()");
     /// assert_eq!(priv_size, Ed25519::PRV_KEY_SIZE);
+    /// }
     /// ```
     pub fn priv_size(&self) -> Result<usize, i32> {
         let rc = unsafe { sys::wc_ed25519_priv_size(&self.ws_key) };
@@ -1419,12 +1440,15 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed25519::generate(&mut rng).expect("Error with generate()");
     /// let pub_size = ed.pub_size().expect("Error with pub_size()");
     /// assert_eq!(pub_size, Ed25519::PUB_KEY_SIZE);
+    /// }
     /// ```
     pub fn pub_size(&self) -> Result<usize, i32> {
         let rc = unsafe { sys::wc_ed25519_pub_size(&self.ws_key) };
@@ -1444,12 +1468,15 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed25519::generate(&mut rng).expect("Error with generate()");
     /// let sig_size = ed.sig_size().expect("Error with sig_size()");
     /// assert_eq!(sig_size, Ed25519::SIG_SIZE);
+    /// }
     /// ```
     pub fn sig_size(&self) -> Result<usize, i32> {
         let rc = unsafe { sys::wc_ed25519_sig_size(&self.ws_key) };

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ed448.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ed448.rs
@@ -26,6 +26,7 @@ This module provides a Rust wrapper for the wolfCrypt library's EdDSA Curve
 #![cfg(ed448)]
 
 use crate::sys;
+#[cfg(random)]
 use crate::random::RNG;
 use core::mem::MaybeUninit;
 
@@ -66,11 +67,15 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed448::generate(&mut rng).expect("Error with generate()");
+    /// }
     /// ```
+    #[cfg(random)]
     pub fn generate(rng: &RNG) -> Result<Self, i32> {
         Self::generate_ex(rng, None, None)
     }
@@ -91,11 +96,15 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed448::generate_ex(&mut rng, None, None).expect("Error with generate_ex()");
+    /// }
     /// ```
+    #[cfg(random)]
     pub fn generate_ex(rng: &RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut ws_key: MaybeUninit<sys::ed448_key> = MaybeUninit::uninit();
         let heap = match heap {
@@ -197,11 +206,14 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let mut ed = Ed448::generate(&mut rng).expect("Error with generate()");
     /// ed.check_key().expect("Error with check_key()");
+    /// }
     /// ```
     pub fn check_key(&mut self) -> Result<(), i32> {
         let rc = unsafe { sys::wc_ed448_check_key(&mut self.ws_key) };
@@ -228,7 +240,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_export)]
+    /// #[cfg(all(ed448_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -269,7 +281,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_export)]
+    /// #[cfg(all(ed448_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -307,7 +319,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_export)]
+    /// #[cfg(all(ed448_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -345,7 +357,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_export)]
+    /// #[cfg(all(ed448_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -386,7 +398,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_import)]
+    /// #[cfg(all(ed448_import, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -430,7 +442,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_import)]
+    /// #[cfg(all(ed448_import, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -470,7 +482,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_import)]
+    /// #[cfg(all(ed448_import, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -514,7 +526,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_import)]
+    /// #[cfg(all(ed448_import, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -565,7 +577,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_import)]
+    /// #[cfg(all(ed448_import, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -614,6 +626,8 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(all(ed448_export, ed448_import, random))]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
     /// let mut rng = RNG::new().expect("Error creating RNG");
@@ -624,6 +638,7 @@ impl Ed448 {
     /// ed.import_private_only(&private).expect("Error with import_private_only()");
     /// let mut public = [0u8; Ed448::KEY_SIZE];
     /// ed.make_public(&mut public).expect("Error with make_public()");
+    /// }
     /// ```
     pub fn make_public(&mut self, pubkey: &mut [u8]) -> Result<(), i32> {
         let pubkey_size = crate::buffer_len_to_u32(pubkey.len())?;
@@ -656,7 +671,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_sign)]
+    /// #[cfg(all(ed448_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -712,7 +727,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_sign)]
+    /// #[cfg(all(ed448_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -777,7 +792,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_sign)]
+    /// #[cfg(all(ed448_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -833,7 +848,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_sign)]
+    /// #[cfg(all(ed448_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -887,7 +902,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_verify)]
+    /// #[cfg(all(ed448_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -951,7 +966,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_verify)]
+    /// #[cfg(all(ed448_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -1023,7 +1038,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_verify)]
+    /// #[cfg(all(ed448_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -1086,7 +1101,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_verify)]
+    /// #[cfg(all(ed448_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -1146,7 +1161,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_streaming_verify)]
+    /// #[cfg(all(ed448_streaming_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -1199,7 +1214,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_streaming_verify)]
+    /// #[cfg(all(ed448_streaming_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -1243,7 +1258,7 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(ed448_streaming_verify)]
+    /// #[cfg(all(ed448_streaming_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
@@ -1289,12 +1304,15 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed448::generate(&mut rng).expect("Error with generate()");
     /// let key_size = ed.size().expect("Error with size()");
     /// assert_eq!(key_size, Ed448::KEY_SIZE);
+    /// }
     /// ```
     pub fn size(&self) -> Result<usize, i32> {
         let rc = unsafe { sys::wc_ed448_size(&self.ws_key) };
@@ -1314,12 +1332,15 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed448::generate(&mut rng).expect("Error with generate()");
     /// let priv_size = ed.priv_size().expect("Error with priv_size()");
     /// assert_eq!(priv_size, Ed448::PRV_KEY_SIZE);
+    /// }
     /// ```
     pub fn priv_size(&self) -> Result<usize, i32> {
         let rc = unsafe { sys::wc_ed448_priv_size(&self.ws_key) };
@@ -1339,12 +1360,15 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed448::generate(&mut rng).expect("Error with generate()");
     /// let pub_size = ed.pub_size().expect("Error with pub_size()");
     /// assert_eq!(pub_size, Ed448::PUB_KEY_SIZE);
+    /// }
     /// ```
     pub fn pub_size(&self) -> Result<usize, i32> {
         let rc = unsafe { sys::wc_ed448_pub_size(&self.ws_key) };
@@ -1364,12 +1388,15 @@ impl Ed448 {
     /// # Example
     ///
     /// ```rust
+    /// #[cfg(random)]
+    /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed448::Ed448;
     /// let mut rng = RNG::new().expect("Error creating RNG");
     /// let ed = Ed448::generate(&mut rng).expect("Error with generate()");
     /// let sig_size = ed.sig_size().expect("Error with sig_size()");
     /// assert_eq!(sig_size, Ed448::SIG_SIZE);
+    /// }
     /// ```
     pub fn sig_size(&self) -> Result<usize, i32> {
         let rc = unsafe { sys::wc_ed448_sig_size(&self.ws_key) };

--- a/wrapper/rust/wolfssl-wolfcrypt/src/lms.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/lms.rs
@@ -765,6 +765,7 @@ impl Lms {
     ///
     /// Returns either Ok(usize) containing the key ID length on success,
     /// or Err(e) containing the wolfSSL library error code value.
+    #[cfg(lms_make_key)]
     pub fn get_kid(&mut self, kid: &mut [u8]) -> Result<usize, i32> {
         let mut kid_ptr: *const u8 = core::ptr::null();
         let mut kid_sz: u32 = 0;

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_ed25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_ed25519.rs
@@ -2,11 +2,12 @@
 
 mod common;
 
+#[cfg(random)]
 use wolfssl_wolfcrypt::random::RNG;
 use wolfssl_wolfcrypt::ed25519::*;
 
 #[test]
-#[cfg(all(ed25519_import, ed25519_export))]
+#[cfg(all(ed25519_import, ed25519_export, random))]
 fn test_make_public() {
     common::setup();
 
@@ -21,6 +22,7 @@ fn test_make_public() {
 }
 
 #[test]
+#[cfg(random)]
 fn test_check_key() {
     let mut rng = RNG::new().expect("Error creating RNG");
     let mut ed = Ed25519::generate(&mut rng).expect("Error with generate()");
@@ -224,7 +226,7 @@ fn test_ph_sign_verify() {
 // invalid signature is reported as Ok(false) rather than an error.
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_verify))]
+#[cfg(all(ed25519_sign, ed25519_verify, random))]
 fn test_verify_msg_bad_sig() {
     common::setup();
 
@@ -240,7 +242,7 @@ fn test_verify_msg_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_verify))]
+#[cfg(all(ed25519_sign, ed25519_verify, random))]
 fn test_verify_msg_ex_bad_sig() {
     common::setup();
 
@@ -256,7 +258,7 @@ fn test_verify_msg_ex_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_verify))]
+#[cfg(all(ed25519_sign, ed25519_verify, random))]
 fn test_verify_msg_ctx_bad_sig() {
     common::setup();
 
@@ -273,7 +275,7 @@ fn test_verify_msg_ctx_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_verify))]
+#[cfg(all(ed25519_sign, ed25519_verify, random))]
 fn test_verify_msg_ph_bad_sig() {
     common::setup();
 
@@ -290,7 +292,7 @@ fn test_verify_msg_ph_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_verify))]
+#[cfg(all(ed25519_sign, ed25519_verify, random))]
 fn test_verify_hash_ph_bad_sig() {
     common::setup();
 
@@ -307,7 +309,7 @@ fn test_verify_hash_ph_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_streaming_verify))]
+#[cfg(all(ed25519_sign, ed25519_streaming_verify, random))]
 fn test_verify_msg_final_bad_sig() {
     common::setup();
 
@@ -327,7 +329,7 @@ fn test_verify_msg_final_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_import, ed25519_export))]
+#[cfg(all(ed25519_import, ed25519_export, random))]
 fn test_import_export() {
     common::setup();
 
@@ -359,7 +361,7 @@ fn test_import_export() {
 }
 
 #[test]
-#[cfg(all(feature = "signature", ed25519_import, ed25519_export, ed25519_sign, ed25519_verify))]
+#[cfg(all(feature = "signature", ed25519_import, ed25519_export, ed25519_sign, ed25519_verify, random))]
 fn test_signature_traits() {
     use signature::{Keypair, SignerMut, Verifier};
 
@@ -396,6 +398,7 @@ fn test_signature_traits() {
 }
 
 #[test]
+#[cfg(random)]
 fn test_sizes() {
     let mut rng = RNG::new().expect("Error creating RNG");
     let ed = Ed25519::generate(&mut rng).expect("Error with generate()");

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_ed448.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_ed448.rs
@@ -2,11 +2,12 @@
 
 mod common;
 
+#[cfg(random)]
 use wolfssl_wolfcrypt::random::RNG;
 use wolfssl_wolfcrypt::ed448::*;
 
 #[test]
-#[cfg(all(ed448_import, ed448_export))]
+#[cfg(all(ed448_import, ed448_export, random))]
 fn test_make_public() {
     common::setup();
 
@@ -21,6 +22,7 @@ fn test_make_public() {
 }
 
 #[test]
+#[cfg(random)]
 fn test_check_key() {
     let mut rng = RNG::new().expect("Error creating RNG");
     let mut ed = Ed448::generate(&mut rng).expect("Error with generate()");
@@ -228,7 +230,7 @@ fn test_ph_sign_verify() {
 // invalid signature is reported as Ok(false) rather than an error.
 
 #[test]
-#[cfg(all(ed448_sign, ed448_verify))]
+#[cfg(all(ed448_sign, ed448_verify, random))]
 fn test_verify_msg_bad_sig() {
     common::setup();
 
@@ -244,7 +246,7 @@ fn test_verify_msg_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed448_sign, ed448_verify))]
+#[cfg(all(ed448_sign, ed448_verify, random))]
 fn test_verify_msg_ex_bad_sig() {
     common::setup();
 
@@ -260,7 +262,7 @@ fn test_verify_msg_ex_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed448_sign, ed448_verify))]
+#[cfg(all(ed448_sign, ed448_verify, random))]
 fn test_verify_msg_ph_bad_sig() {
     common::setup();
 
@@ -277,7 +279,7 @@ fn test_verify_msg_ph_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed448_sign, ed448_verify))]
+#[cfg(all(ed448_sign, ed448_verify, random))]
 fn test_verify_hash_ph_bad_sig() {
     common::setup();
 
@@ -294,7 +296,7 @@ fn test_verify_hash_ph_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed448_sign, ed448_streaming_verify))]
+#[cfg(all(ed448_sign, ed448_streaming_verify, random))]
 fn test_verify_msg_final_bad_sig() {
     common::setup();
 
@@ -313,7 +315,7 @@ fn test_verify_msg_final_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed448_import, ed448_export))]
+#[cfg(all(ed448_import, ed448_export, random))]
 fn test_import_export() {
     common::setup();
 
@@ -345,7 +347,7 @@ fn test_import_export() {
 }
 
 #[test]
-#[cfg(all(feature = "signature", ed448_import, ed448_export, ed448_sign, ed448_verify))]
+#[cfg(all(feature = "signature", ed448_import, ed448_export, ed448_sign, ed448_verify, random))]
 fn test_signature_traits() {
     use signature::{Keypair, SignerMut, Verifier};
 
@@ -382,6 +384,7 @@ fn test_signature_traits() {
 }
 
 #[test]
+#[cfg(random)]
 fn test_sizes() {
     let mut rng = RNG::new().expect("Error creating RNG");
     let ed = Ed448::generate(&mut rng).expect("Error with generate()");


### PR DESCRIPTION
# Description

```
commit 0ec162341e4a265087350e4044b5f6e5bb125705
Author: Josh Holtrop <josh@wolfssl.com>
Date:   Mon Aug 17 16:52:50 2026 -0400

    Rust wrapper: ed448: gate RNG references with random cfg
    
    Fixes F-8304.

commit 44d4905b3ca1b99c8ddf3d75259f122ba06ca491
Author: Josh Holtrop <josh@wolfssl.com>
Date:   Mon Aug 17 16:41:35 2026 -0400

    Rust wrapper: ed25519: gate RNG references with random cfg
    
    Fixes F-8302.

commit 2a1993645b86ba65fddbc1b06048ac9e38f55a35
Author: Josh Holtrop <josh@wolfssl.com>
Date:   Mon Aug 17 14:54:14 2026 -0400

    Rust wrapper: gate Lms::get_kid() with lms_make_key cfg
    
    Fixes F-8301.
```

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
