### PR TITLE
DTLS: honor configured MTU for SCTP application data

### DIFF
--- a/examples/sctp/sctp-client-dtls.c
+++ b/examples/sctp/sctp-client-dtls.c
@@ -113,7 +113,11 @@ int main(int argc, char **argv)
 
     for (i = 0; i < (int)sizeof(bigBuf); i++)
         bigBuf[i] = (unsigned char)(i & 0xFF);
-    wolfSSL_write(ssl, bigBuf, sizeof(bigBuf));
+    ret = wolfSSL_write(ssl, bigBuf, sizeof(bigBuf));
+    if (ret != (int)sizeof(bigBuf)) {
+        fprintf(stderr, "ssl write big message failed\n");
+        exit(EXIT_FAILURE);
+    }
     memset(bigBuf, 0, sizeof(bigBuf));
 
     wolfSSL_read(ssl, bigBuf, sizeof(bigBuf));

--- a/examples/sctp/sctp-server-dtls.c
+++ b/examples/sctp/sctp-server-dtls.c
@@ -122,7 +122,11 @@ int main(int argc, char **argv)
     unsigned char bigBuf[4096];
 
     wolfSSL_read(ssl, bigBuf, sizeof(bigBuf));
-    wolfSSL_write(ssl, bigBuf, sizeof(bigBuf));
+    ret = wolfSSL_write(ssl, bigBuf, sizeof(bigBuf));
+    if (ret != (int)sizeof(bigBuf)) {
+        fprintf(stderr, "ssl write big message failed\n");
+        exit(EXIT_FAILURE);
+    }
 
     wolfSSL_shutdown(ssl);
     wolfSSL_free(ssl);

--- a/src/internal.c
+++ b/src/internal.c
@@ -28963,7 +28963,7 @@ int SendData(WOLFSSL* ssl, const void* data, size_t sz)
         }
 #if defined(WOLFSSL_DTLS)
         if (ssl->options.dtls) {
-#if defined(WOLFSSL_DTLS_MTU)
+#if defined(WOLFSSL_SCTP) || defined(WOLFSSL_DTLS_MTU)
             int mtu = ssl->dtlsMtuSz;
 #else
             int mtu = MAX_MTU;


### PR DESCRIPTION
# Description

`WOLFSSL_SCTP` initializes `dtlsMtuSz` to `MAX_RECORD_SIZE`, and
the other DTLS size-checking paths use that value when either
`WOLFSSL_SCTP` or `WOLFSSL_DTLS_MTU` is enabled.

`SendData()` only used `dtlsMtuSz` with `WOLFSSL_DTLS_MTU`.
An SCTP-only build therefore fell back to `MAX_MTU` and rejected
larger application records with `DTLS_SIZE_ERROR`.

Use the configured SCTP MTU consistently. Also check the existing
4096-byte transfers in the SCTP client and server examples so this
failure is detected.

This was found while developing Mercurius, a zero-trust network-native
window system using DTLS 1.3 over SCTP:

https://mercurius.tebibyte.org/

Mercurius uses SCTP streams and large application records to carry window
content, which exposed the inconsistency between wolfSSL's configured SCTP
MTU and the application-data path.

# Testing

Built current master with DTLS, DTLS 1.3 and `WOLFSSL_SCTP`.

Before the fix, both bundled SCTP examples failed their existing
4096-byte application transfer.

After the fix:

- the bundled 4096-byte SCTP echo completed in both directions;
- a separate Mercurius DTLS 1.3 integration test completed over two
  simultaneous SCTP associations;
- ordered and unordered records retained their SCTP stream metadata;
- both endpoints derived matching exporter values for each association.

Autotools testing was not available because `autoreconf` is not
installed on the test host. The CMake build completed without warnings.

# Checklist

- [x] added tests
- [ ] updated/added doxygen
- [ ] updated appropriate READMEs
- [ ] Updated manual and documentation