### PR TITLE
Fix ignored return codes in `wc_CryptKey()` DES/RC4 branches

### DIFF
--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -557,10 +557,12 @@ int wc_CryptKey(const char* password, int passwordSz, const byte* salt,
                 }
                 if (ret == 0) {
                     if (enc) {
-                        wc_Des_CbcEncrypt(&des, input, input, (word32)length);
+                        ret = wc_Des_CbcEncrypt(&des, input, input,
+                            (word32)length);
                     }
                     else {
-                        wc_Des_CbcDecrypt(&des, input, input, (word32)length);
+                        ret = wc_Des_CbcDecrypt(&des, input, input,
+                            (word32)length);
                     }
                 }
                 ForceZero(&des, sizeof(Des));
@@ -605,8 +607,10 @@ int wc_CryptKey(const char* password, int passwordSz, const byte* salt,
             {
                 Arc4    dec;
 
-                wc_Arc4SetKey(&dec, key, derivedLen);
-                wc_Arc4Process(&dec, input, input, (word32)length);
+                ret = wc_Arc4SetKey(&dec, key, derivedLen);
+                if (ret == 0) {
+                    ret = wc_Arc4Process(&dec, input, input, (word32)length);
+                }
                 ForceZero(&dec, sizeof(Arc4));
                 break;
             }


### PR DESCRIPTION
## Summary(f9945)

In `wc_CryptKey()` (`wolfcrypt/src/wc_encrypt.c`), the `PBE_MD5_DES` / `PBE_SHA1_DES` case called `wc_Des_CbcEncrypt()` / `wc_Des_CbcDecrypt()` as bare statements, and the `PBE_SHA1_RC4_128` case called `wc_Arc4SetKey()` / `wc_Arc4Process()` as bare statements. All four functions return `int`, but none of these calls captured the result. Every sibling branch in the same switch (`PBE_SHA1_DES3`, AES-CBC, RC2) does assign the return value to `ret`.

Because `ret` was never updated, `wc_CryptKey()` could return success (`0`) even when the underlying cipher operation failed — contradicting the function's own doc comment ("returns a negative value on fail case").

## Security impact

This is reachable through `DecryptContent()` (`wolfcrypt/src/asn.c`), which parses `keySz` straight out of an attacker-supplied ASN.1 `OCTET STRING` (the `encryptedData` field of a PKCS#8 `EncryptedPrivateKeyInfo`, or the PKCS#12 content-info encryption wrapper) with no validation that it is a multiple of `DES_BLOCK_SIZE` before calling `wc_CryptKey()`.

The generic software `wc_Des_CbcDecrypt()` checks the block-alignment *before* touching the buffer:

```c
if (sz % DES_BLOCK_SIZE != 0) {
    return BAD_LENGTH_E;
}
```

So when the length check fails, the "ciphertext" bytes are left completely untouched — i.e. exactly what the attacker supplied. Combined with the ignored return code, this is not just a masked error:

1. An attacker crafts a PBES1/SHA1-DES (or MD5-DES) `EncryptedPrivateKeyInfo` whose `encryptedData` length is **not** a multiple of 8, so `wc_Des_CbcDecrypt()` bails immediately with `BAD_LENGTH_E` and never runs.
2. The attacker sets the content of that field to their own **already valid** DER `SEQUENCE` bytes.
3. Pre-fix, `wc_CryptKey()` reports success (`ret == 0`) regardless of the discarded `BAD_LENGTH_E`, so `DecryptContent()` treats the untouched buffer as "decrypted" plaintext.
4. `wc_DecryptPKCS8Key()` re-parses that buffer as a DER `SEQUENCE` purely to strip PKCS#5 padding (`asn.c`, `GetSequence()` after `DecryptContent()` returns) — since the attacker's bytes are already a valid `SEQUENCE`, this check passes too.

Net effect: **`wc_DecryptPKCS8Key()` returns success and hands back the attacker's chosen bytes, without the password ever being checked.**

Verified with a proof of concept: calling `wc_DecryptPKCS8Key()` with a **wrong** password against such a crafted blob returned `55` (success) and the output buffer matched the attacker's planted payload byte-for-byte on the pre-fix code. After the fix, the same call returns `-279` (`BAD_LENGTH_E`).

`wc_PKCS12_parse()` (`wolfcrypt/src/pkcs12.c`) calls `DecryptContent()` directly and only checks `ret < 0` — it has no equivalent "re-parse-as-SEQUENCE" step at all, so a masked failure there is not even incidentally caught the way it is in the PKCS#8 path.

## Fix

Capture the return value of each call and propagate it through `ret`, matching the existing pattern used by the DES3/AES/RC2 branches:

```c
if (ret == 0) {
    if (enc) {
        ret = wc_Des_CbcEncrypt(&des, input, input, (word32)length);
    }
    else {
        ret = wc_Des_CbcDecrypt(&des, input, input, (word32)length);
    }
}
```

```c
ret = wc_Arc4SetKey(&dec, key, derivedLen);
if (ret == 0) {
    ret = wc_Arc4Process(&dec, input, input, (word32)length);
}
```

## Testing

- `./configure --enable-all && make` — clean build.
- `./wolfcrypt/test/testwolfcrypt` — full suite passes (includes `pkcs12_test`).
- `./tests/unit.test` — full suite passes, including the tests that round-trip DES/RC4 PBE encryption: `test_wc_EncryptPKCS8Key_pbes1BlockAligned` (PBES1/SHA1-DES), `test_wc_EncryptPKCS8Key_rc4NoPad` (PKCS#12/RC4), `test_wc_PKCS12_create` (round-trips `PBE_SHA1_DES` and `PBE_SHA1_RC4_128`).
- Regression check: toggled the fix on/off and rebuilt each way to confirm a truncated (non-block-aligned) DES ciphertext deterministically returns `BAD_LENGTH_E` post-fix vs. a masked/incidental `ASN_PARSE_E` pre-fix.
- Security PoC (see above): confirmed the password-bypass smuggling path is closed by the fix (`wc_DecryptPKCS8Key()` now returns `BAD_LENGTH_E` instead of accepting attacker-controlled bytes under a wrong password).


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
