### PR TITLE
SE05x fixes

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4845,17 +4845,16 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
    err = silabs_ecc_shared_secret(private_key, public_key, out, outlen);
 #elif defined(WOLFSSL_KCAPI_ECC)
    err = KcapiEcc_SharedSecret(private_key, public_key, out, outlen);
-#elif defined(WOLFSSL_SE050) && !defined(WOLFSSL_SE050_NO_ECDHE) && \
-      defined(WOLFSSL_SE050_ONLY_KEY_ID)
+#elif defined(WOLFSSL_SE050) && !defined(WOLFSSL_SE050_NO_ECDHE)
    /* SE050-resident private key uses hardware ECDH; a software private key
-    * (keyIdSet == 0) uses the wolfCrypt software implementation. */
+    * (keyIdSet == 0, e.g. decoded from DER as in PKCS#7 KARI) has no key in
+    * the SE050 to derive with, so it uses the wolfCrypt software
+    * implementation. */
    if (private_key->keyIdSet)
        err = se050_ecc_shared_secret(private_key, public_key, out, outlen);
    else
        err = wc_ecc_shared_secret_ex(private_key, &public_key->pubkey, out,
                                      outlen);
-#elif defined(WOLFSSL_SE050) && !defined(WOLFSSL_SE050_NO_ECDHE)
-   err = se050_ecc_shared_secret(private_key, public_key, out, outlen);
 #else
    err = wc_ecc_shared_secret_ex(private_key, &public_key->pubkey, out, outlen);
 #endif /* WOLFSSL_ATECC508A */

--- a/wolfcrypt/src/port/nxp/se050_port.c
+++ b/wolfcrypt/src/port/nxp/se050_port.c
@@ -1427,6 +1427,7 @@ int se050_rsa_verify(const byte* in, word32 inLen, byte* out, word32 outLen,
     smStatus_t       smStatus = SM_NOT_OK;
     byte* pad    = NULL;
     byte* derBuf = NULL;
+    byte* decBuf = NULL;
     int derSz = 0;
 
 #ifdef SE050_DEBUG
@@ -1529,22 +1530,42 @@ int se050_rsa_verify(const byte* in, word32 inLen, byte* out, word32 outLen,
         status = sss_asymmetric_context_init(&ctx_asymm, cfg_se050_i2c_pi,
                                     &newKey, algorithm, kMode_SSS_Verify);
         if (status == kStatus_SSS_Success) {
+            /* The raw RSA public operation always produces keySz bytes, but
+             * callers such as PKCS#7 signature verify pass an out buffer
+             * sized for the unpadded payload only. Decrypt into a
+             * keySz-sized scratch buffer, then unpad and copy the payload
+             * to out. */
+            decBuf = (byte*)XMALLOC((size_t)keySz, key->heap,
+                                    DYNAMIC_TYPE_TMP_BUFFER);
+            if (decBuf == NULL) {
+                status = kStatus_SSS_Fail;
+                ret = MEMORY_E;
+            }
+        }
+        if (status == kStatus_SSS_Success) {
             /* Use lower Se05x API instead of sss_asymmetric_verify_digest()
              * since we need to return decoded data not just verify result */
-            decLen = outLen;
+            decLen = (size_t)keySz;
             se050_ctx_asymm = (sss_se05x_asymmetric_t*)&ctx_asymm;
             smStatus = Se05x_API_RSAEncrypt(&se050_ctx_asymm->session->s_ctx,
                                             se050_ctx_asymm->keyObject->keyId,
                                             kSE05x_RSAEncryptionAlgo_NO_PAD,
-                                            in, inLen, out, &decLen);
+                                            in, inLen, decBuf, &decLen);
             if (smStatus == SM_OK) {
                 /* find end of padding, pad points to start of actual data */
-                ret = wc_RsaUnPad_ex(out, decLen, &pad, pad_value,
+                ret = wc_RsaUnPad_ex(decBuf, decLen, &pad, pad_value,
                         pad_type, hash, mgf,
                         label, labelSz, RSA_PSS_SALT_LEN_DEFAULT, (keySz * 8),
                         key->heap);
                 if (ret >= 0) {
-                    XMEMCPY(out, pad, ret);
+                    if ((word32)ret > outLen) {
+                        WOLFSSL_MSG("Output buffer too small for RSA verify");
+                        ret = RSA_BUFFER_E;
+                        status = kStatus_SSS_Fail;
+                    }
+                    else {
+                        XMEMCPY(out, pad, ret);
+                    }
                 }
                 else {
                     WOLFSSL_MSG("Error in wc_RsaUnPad_ex for RSA verify");
@@ -1556,6 +1577,7 @@ int se050_rsa_verify(const byte* in, word32 inLen, byte* out, word32 outLen,
                 status = kStatus_SSS_Fail;
             }
         }
+        XFREE(decBuf, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
 
         sss_asymmetric_context_free(&ctx_asymm);
     }


### PR DESCRIPTION
# Description

se050_rsa_verify passed the caller's output buffer straight to
Se05x_API_RSAEncrypt, which performs the raw (NO_PAD) public key
operation and always produces a full modulus-size result. Callers that
size the output buffer for the unpadded payload - notably
wc_PKCS7_VerifySignedData, which passes a MAX_PKCS7_DIGEST_SZ (96 byte)
buffer - failed with WC_HW_E before any padding check ran, surfacing as
SIG_VERIFY_E from PKCS#7 verify on every SE050 build with PKCS7 enabled.

Decrypt into a keySz-sized scratch buffer instead, unpad there, and copy
only the payload to the caller's buffer, returning RSA_BUFFER_E if the
payload does not fit. This matches the software wc_RsaSSL_Verify
contract.

se050_ecc_shared_secret requires the private key to live in the SE050
(keyIdSet set) and returns BAD_FUNC_ARG for a software key, but the
default build dispatched every wc_ecc_shared_secret call to it. Any
ECDH with a software private key - for example one decoded from DER,
as wc_PKCS7_DecodeEnvelopedData does for a KARI recipient - failed
with BAD_FUNC_ARG, so PKCS#7 enveloped data could not be decoded on
any SE050 build.

The WOLFSSL_SE050_ONLY_KEY_ID dispatch already routes software private
keys to the wolfCrypt software implementation, which handles SE050
builds correctly. Make the default build do the same and collapse the
two branches.

# Testing

Tested against SE051 and simulators repo (patches coming for more CI tests in that repo).