### PR TITLE
Rework post-handshake checks for resumed connections.

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -16686,6 +16686,9 @@ int wolfSSL_request_certificate(WOLFSSL* ssl)
     ssl->msgsReceived.got_certificate = 0;
     ssl->msgsReceived.got_certificate_verify = 0;
     ssl->msgsReceived.got_finished = 0;
+    /* Each round must prove possession again; these are only ever set to 1. */
+    ssl->options.havePeerCert = 0;
+    ssl->options.havePeerVerify = 0;
 
     ret = SendTls13CertificateRequest(ssl, &certReqCtx->ctx, certReqCtx->len);
     if (ret == WC_NO_ERR_TRACE(WANT_WRITE))

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -13064,13 +13064,12 @@ exit_dcv:
 #endif /* !NO_CERTS */
 
 #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
-/* The message being processed belongs to a post-handshake exchange rather than
- * to the enclosing handshake. Whatever resumption, PSK or deferred
- * (post-handshake) verification excused during that handshake, a later
- * post-handshake exchange has to stand on its own. */
-#define TLS13_POST_HANDSHAKE(ssl)   ((ssl)->options.handShakeDone)
+/* Message is being processed after the enclosing handshake completed. Whatever
+ * resumption, PSK or deferred (post-handshake) verification excused during that
+ * handshake, a later post-handshake exchange has to stand on its own. */
+#define TLS13_AFTER_HANDSHAKE(ssl)  ((ssl)->options.handShakeDone)
 #else
-#define TLS13_POST_HANDSHAKE(ssl)   0
+#define TLS13_AFTER_HANDSHAKE(ssl)  0
 #endif
 
 /* Parse and handle a TLS v1.3 Finished message.
@@ -13098,10 +13097,10 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CLIENT_AUTH)
     /* verify the client sent certificate if required */
     if (ssl->options.side == WOLFSSL_SERVER_END &&
-            (!ssl->options.resuming || TLS13_POST_HANDSHAKE(ssl)) &&
+            (!ssl->options.resuming || TLS13_AFTER_HANDSHAKE(ssl)) &&
             (ssl->options.mutualAuth || ssl->options.failNoCert)) {
 #ifdef OPENSSL_COMPATIBLE_DEFAULTS
-        if (ssl->options.isPSK && !TLS13_POST_HANDSHAKE(ssl)) {
+        if (ssl->options.isPSK && !TLS13_AFTER_HANDSHAKE(ssl)) {
             WOLFSSL_MSG("TLS v1.3 client used PSK but cert required. Allowing "
                         "for OpenSSL compatibility");
         }
@@ -13112,7 +13111,7 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             /* Exempt only the enclosing handshake; a post-handshake exchange
              * still requires a peer certificate and a valid
              * CertificateVerify. */
-            (!ssl->options.verifyPostHandshake || TLS13_POST_HANDSHAKE(ssl)) &&
+            (!ssl->options.verifyPostHandshake || TLS13_AFTER_HANDSHAKE(ssl)) &&
         #endif
             (!ssl->options.havePeerCert || !ssl->options.havePeerVerify)) {
             ret = NO_PEER_CERT; /* NO_PEER_VERIFY */
@@ -14681,7 +14680,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
         #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
             /* RFC 8446 4.3.2: a server authenticating with a PSK must not send
              * this in the main handshake, but may send it post-handshake. */
-            if (ssl->options.pskNegotiated && !TLS13_POST_HANDSHAKE(ssl)
+            if (ssl->options.pskNegotiated && !TLS13_AFTER_HANDSHAKE(ssl)
 #ifdef WOLFSSL_CERT_WITH_EXTERN_PSK
                 && !ssl->options.certWithExternPsk
 #endif
@@ -14843,7 +14842,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
         #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
             if (!ssl->options.pskNegotiated ||
                 (ssl->options.side == WOLFSSL_SERVER_END &&
-                 TLS13_POST_HANDSHAKE(ssl))
+                 TLS13_AFTER_HANDSHAKE(ssl))
 #ifdef WOLFSSL_CERT_WITH_EXTERN_PSK
                 || ssl->options.certWithExternPsk
 #endif
@@ -14863,7 +14862,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                      * verify mode (FAIL_IF_NO_PEER_CERT), exactly as for
                      * first-handshake client authentication. */
                     (!ssl->options.verifyPostHandshake ||
-                     TLS13_POST_HANDSHAKE(ssl)) &&
+                     TLS13_AFTER_HANDSHAKE(ssl)) &&
                 #endif
                                            !ssl->msgsReceived.got_certificate) {
                     WOLFSSL_MSG("Finished received out of order - "
@@ -15951,7 +15950,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
                 return WOLFSSL_FATAL_ERROR;
             }
         #ifndef NO_CERTS
-            if ((!ssl->options.resuming || TLS13_POST_HANDSHAKE(ssl)) &&
+            if ((!ssl->options.resuming || TLS13_AFTER_HANDSHAKE(ssl)) &&
                     ssl->options.sendVerify) {
                 ssl->error = SendTls13Certificate(ssl);
                 if (ssl->error != 0) {
@@ -15973,7 +15972,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
              defined(HAVE_FALCON) || defined(WOLFSSL_HAVE_MLDSA) || \
              defined(WOLFSSL_HAVE_SLHDSA))) && \
              (!defined(NO_WOLFSSL_SERVER) || !defined(WOLFSSL_NO_CLIENT_AUTH))
-            if ((!ssl->options.resuming || TLS13_POST_HANDSHAKE(ssl)) &&
+            if ((!ssl->options.resuming || TLS13_AFTER_HANDSHAKE(ssl)) &&
                     ssl->options.sendVerify) {
                 ssl->error = SendTls13CertificateVerify(ssl);
                 if (ssl->error != 0) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -13063,6 +13063,16 @@ exit_dcv:
         * HAVE_FALCON || WOLFSSL_HAVE_MLDSA || WOLFSSL_HAVE_SLHDSA */
 #endif /* !NO_CERTS */
 
+#ifdef WOLFSSL_POST_HANDSHAKE_AUTH
+/* The message being processed belongs to a post-handshake exchange rather than
+ * to the enclosing handshake. Whatever resumption, PSK or deferred
+ * (post-handshake) verification excused during that handshake, a later
+ * post-handshake exchange has to stand on its own. */
+#define TLS13_POST_HANDSHAKE(ssl)   ((ssl)->options.handShakeDone)
+#else
+#define TLS13_POST_HANDSHAKE(ssl)   0
+#endif
+
 /* Parse and handle a TLS v1.3 Finished message.
  *
  * ssl       The SSL/TLS object.
@@ -13087,10 +13097,11 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CLIENT_AUTH)
     /* verify the client sent certificate if required */
-    if (ssl->options.side == WOLFSSL_SERVER_END && !ssl->options.resuming &&
+    if (ssl->options.side == WOLFSSL_SERVER_END &&
+            (!ssl->options.resuming || TLS13_POST_HANDSHAKE(ssl)) &&
             (ssl->options.mutualAuth || ssl->options.failNoCert)) {
 #ifdef OPENSSL_COMPATIBLE_DEFAULTS
-        if (ssl->options.isPSK) {
+        if (ssl->options.isPSK && !TLS13_POST_HANDSHAKE(ssl)) {
             WOLFSSL_MSG("TLS v1.3 client used PSK but cert required. Allowing "
                         "for OpenSSL compatibility");
         }
@@ -13098,10 +13109,10 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #endif
         if (
         #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
-            /* Exempt only the initial handshake; a pending post-handshake
-             * CertificateRequest (certReqCtx != NULL) still requires a peer
-             * certificate and a valid CertificateVerify. */
-            (!ssl->options.verifyPostHandshake || ssl->certReqCtx != NULL) &&
+            /* Exempt only the enclosing handshake; a post-handshake exchange
+             * still requires a peer certificate and a valid
+             * CertificateVerify. */
+            (!ssl->options.verifyPostHandshake || TLS13_POST_HANDSHAKE(ssl)) &&
         #endif
             (!ssl->options.havePeerCert || !ssl->options.havePeerVerify)) {
             ret = NO_PEER_CERT; /* NO_PEER_VERIFY */
@@ -14668,8 +14679,9 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             }
         #endif
         #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-            /* Server's authenticating with PSK must not send this. */
-            if (ssl->options.pskNegotiated
+            /* RFC 8446 4.3.2: a server authenticating with a PSK must not send
+             * this in the main handshake, but may send it post-handshake. */
+            if (ssl->options.pskNegotiated && !TLS13_POST_HANDSHAKE(ssl)
 #ifdef WOLFSSL_CERT_WITH_EXTERN_PSK
                 && !ssl->options.certWithExternPsk
 #endif
@@ -14829,7 +14841,9 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             }
         #endif
         #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-            if (!ssl->options.pskNegotiated
+            if (!ssl->options.pskNegotiated ||
+                (ssl->options.side == WOLFSSL_SERVER_END &&
+                 TLS13_POST_HANDSHAKE(ssl))
 #ifdef WOLFSSL_CERT_WITH_EXTERN_PSK
                 || ssl->options.certWithExternPsk
 #endif
@@ -14843,18 +14857,13 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 if (ssl->options.verifyPeer &&
                 #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
                     /* The post-handshake-auth exemption is only valid during
-                     * the initial handshake. On the server, once a
-                     * post-handshake CertificateRequest is outstanding
-                     * (certReqCtx != NULL), a Certificate is required again.
-                     * Scoped to the server: certReqCtx means something
-                     * different on the client (a received request) and the
-                     * client does not process an inbound Finished in that
-                     * state. Whether an empty Certificate is then accepted
-                     * follows the verify mode (FAIL_IF_NO_PEER_CERT), exactly
-                     * as for first-handshake client authentication. */
+                     * the enclosing handshake. Once the server has requested a
+                     * certificate post-handshake, one is required again.
+                     * Whether an empty Certificate is then accepted follows the
+                     * verify mode (FAIL_IF_NO_PEER_CERT), exactly as for
+                     * first-handshake client authentication. */
                     (!ssl->options.verifyPostHandshake ||
-                     (ssl->options.side == WOLFSSL_SERVER_END &&
-                      ssl->certReqCtx != NULL)) &&
+                     TLS13_POST_HANDSHAKE(ssl)) &&
                 #endif
                                            !ssl->msgsReceived.got_certificate) {
                     WOLFSSL_MSG("Finished received out of order - "
@@ -15942,7 +15951,8 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
                 return WOLFSSL_FATAL_ERROR;
             }
         #ifndef NO_CERTS
-            if (!ssl->options.resuming && ssl->options.sendVerify) {
+            if ((!ssl->options.resuming || TLS13_POST_HANDSHAKE(ssl)) &&
+                    ssl->options.sendVerify) {
                 ssl->error = SendTls13Certificate(ssl);
                 if (ssl->error != 0) {
                     wolfssl_local_MaybeCheckAlertOnErr(ssl, ssl->error);
@@ -15963,7 +15973,8 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
              defined(HAVE_FALCON) || defined(WOLFSSL_HAVE_MLDSA) || \
              defined(WOLFSSL_HAVE_SLHDSA))) && \
              (!defined(NO_WOLFSSL_SERVER) || !defined(WOLFSSL_NO_CLIENT_AUTH))
-            if (!ssl->options.resuming && ssl->options.sendVerify) {
+            if ((!ssl->options.resuming || TLS13_POST_HANDSHAKE(ssl)) &&
+                    ssl->options.sendVerify) {
                 ssl->error = SendTls13CertificateVerify(ssl);
                 if (ssl->error != 0) {
                     wolfssl_local_MaybeCheckAlertOnErr(ssl, ssl->error);

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -4142,6 +4142,91 @@ int test_tls13_ctx_dh_rotation(void)
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
+    #endif
+    return EXPECT_RESULT();
+}
+
+/* Post-handshake auth over a resumed (ticket-PSK) connection. Client
+ * credentials go on the CTX: FreeHandshakeResources() unloads SSL-owned
+ * certificates, leaving nothing to answer a later request with. */
+int test_tls13_pha_resumption(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13) && \
+    defined(WOLFSSL_POST_HANDSHAKE_AUTH) && defined(HAVE_SESSION_TICKET) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_RSA) && !defined(NO_CERTS)
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    WOLFSSL_SESSION* sess = NULL;
+    struct test_memio_ctx test_ctx;
+    char msg[] = "hello wolfssl!";
+    char buf[sizeof(msg)];
+    int i;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, NULL, NULL,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx_c, cliCertFile,
+        WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_file(ctx_c, cliKeyFile,
+        WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    /* PHA has to be offered in the ClientHello. */
+    ExpectIntEQ(wolfSSL_CTX_allow_post_handshake_auth(ctx_c), 0);
+    ExpectIntEQ(wolfSSL_CTX_load_verify_locations(ctx_s, cliCertFile, NULL),
+        WOLFSSL_SUCCESS);
+    /* No client certificate wanted for the handshake itself. */
+    wolfSSL_CTX_set_verify(ctx_s, WOLFSSL_VERIFY_NONE, NULL);
+
+    for (i = 0; i < 2 && EXPECT_SUCCESS(); i++) {
+        test_ctx.c_len = test_ctx.s_len = 0;
+        ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+            wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+
+        if (i == 1)
+            ExpectIntEQ(wolfSSL_set_session(ssl_c, sess), WOLFSSL_SUCCESS);
+
+        ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+        ExpectIntEQ(wolfSSL_session_reused(ssl_c), i);
+
+        if (i == 0) {
+            /* Drain the NewSessionTicket so the ticket gets cached. */
+            ExpectIntEQ(wolfSSL_read(ssl_c, buf, sizeof(buf)), -1);
+            ExpectIntEQ(wolfSSL_get_error(ssl_c, -1),
+                WOLFSSL_ERROR_WANT_READ);
+            ExpectNotNull(sess = wolfSSL_get1_session(ssl_c));
+        }
+
+        if (EXPECT_SUCCESS()) {
+            wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_PEER |
+                WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+            ExpectIntEQ(wolfSSL_request_certificate(ssl_s), WOLFSSL_SUCCESS);
+        }
+
+        /* The server's write carries the CertificateRequest. */
+        ExpectIntEQ(wolfSSL_write(ssl_s, msg, (int)sizeof(msg) - 1),
+            (int)sizeof(msg) - 1);
+        ExpectIntEQ(wolfSSL_read(ssl_c, buf, sizeof(buf) - 1),
+            (int)sizeof(msg) - 1);
+        ExpectIntEQ(wolfSSL_write(ssl_c, msg, (int)sizeof(msg) - 1),
+            (int)sizeof(msg) - 1);
+        ExpectIntEQ(wolfSSL_read(ssl_s, buf, sizeof(buf) - 1),
+            (int)sizeof(msg) - 1);
+
+        ExpectIntEQ(ssl_s->options.havePeerCert, 1);
+        ExpectIntEQ(ssl_s->options.havePeerVerify, 1);
+
+        wolfSSL_free(ssl_c);
+        ssl_c = NULL;
+        wolfSSL_free(ssl_s);
+        ssl_s = NULL;
+    }
+
+    wolfSSL_SESSION_free(sess);
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
 #endif
     return EXPECT_RESULT();
 }
@@ -4202,10 +4287,113 @@ int test_tls13_accept_state_dh_copy(void)
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
-#endif
+    #endif
     return EXPECT_RESULT();
 }
 
+/* Server must reject a post-handshake Finished that omits the Certificate
+ * flight on a resumed connection. A client answers the request from inside
+ * wolfSSL_read(), so handShakeState is parked for that read and the response is
+ * driven by hand with sendVerify cleared. handShakeDone stays set, so
+ * SendTls13Finished() still produces a valid MAC. */
+int test_tls13_pha_resumption_bare_finished(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13) && \
+    defined(WOLFSSL_POST_HANDSHAKE_AUTH) && defined(HAVE_SESSION_TICKET) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_RSA) && !defined(NO_CERTS)
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    WOLFSSL_SESSION* sess = NULL;
+    struct test_memio_ctx test_ctx;
+    char msg[] = "hello wolfssl!";
+    char buf[sizeof(msg)];
+    int i;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, NULL, NULL,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx_c, cliCertFile,
+        WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_file(ctx_c, cliKeyFile,
+        WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_allow_post_handshake_auth(ctx_c), 0);
+    ExpectIntEQ(wolfSSL_CTX_load_verify_locations(ctx_s, cliCertFile, NULL),
+        WOLFSSL_SUCCESS);
+    wolfSSL_CTX_set_verify(ctx_s, WOLFSSL_VERIFY_NONE, NULL);
+
+    /* First connection only exists to obtain a ticket. */
+    for (i = 0; i < 2 && EXPECT_SUCCESS(); i++) {
+        test_ctx.c_len = test_ctx.s_len = 0;
+        ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+            wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+
+        if (i == 1)
+            ExpectIntEQ(wolfSSL_set_session(ssl_c, sess), WOLFSSL_SUCCESS);
+
+        ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+        ExpectIntEQ(wolfSSL_session_reused(ssl_c), i);
+
+        if (i == 0) {
+            ExpectIntEQ(wolfSSL_read(ssl_c, buf, sizeof(buf)), -1);
+            ExpectIntEQ(wolfSSL_get_error(ssl_c, -1),
+                WOLFSSL_ERROR_WANT_READ);
+            ExpectNotNull(sess = wolfSSL_get1_session(ssl_c));
+        }
+        else {
+            if (EXPECT_SUCCESS()) {
+                wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_PEER |
+                    WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+                ExpectIntEQ(wolfSSL_request_certificate(ssl_s),
+                    WOLFSSL_SUCCESS);
+            }
+            ExpectIntEQ(wolfSSL_write(ssl_s, msg, (int)sizeof(msg) - 1),
+                (int)sizeof(msg) - 1);
+
+            /* Consume the CertificateRequest without answering it. */
+            if (EXPECT_SUCCESS()) {
+                ssl_c->options.handShakeState = CLIENT_FINISHED_COMPLETE;
+            }
+            ExpectIntEQ(wolfSSL_read(ssl_c, buf, sizeof(buf) - 1),
+                (int)sizeof(msg) - 1);
+            ExpectIntEQ(ssl_c->options.sendVerify, SEND_CERT);
+
+            /* Answer with a bare Finished over that same transcript. */
+            if (EXPECT_SUCCESS()) {
+                ssl_c->options.sendVerify = 0;
+                ssl_c->options.clientState = CLIENT_HELLO_COMPLETE;
+                ssl_c->options.connectState = FIRST_REPLY_DONE;
+                ssl_c->options.handShakeState = CLIENT_HELLO_COMPLETE;
+                ssl_c->options.processReply = 0;
+                ExpectIntEQ(wolfSSL_connect_TLSv13(ssl_c), WOLFSSL_SUCCESS);
+            }
+
+            /* Data behind the Finished: a server that wrongly accepted it
+             * returns this instead of an error. */
+            ExpectIntEQ(wolfSSL_write(ssl_c, msg, (int)sizeof(msg) - 1),
+                (int)sizeof(msg) - 1);
+
+            ExpectIntEQ(wolfSSL_read(ssl_s, buf, sizeof(buf) - 1), -1);
+            ExpectIntEQ(wolfSSL_get_error(ssl_s, -1), OUT_OF_ORDER_E);
+            ExpectIntEQ(ssl_s->options.havePeerCert, 0);
+            ExpectIntEQ(ssl_s->options.havePeerVerify, 0);
+        }
+
+        wolfSSL_free(ssl_c);
+        ssl_c = NULL;
+        wolfSSL_free(ssl_s);
+        ssl_s = NULL;
+    }
+
+    wolfSSL_SESSION_free(sess);
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
 
 #if defined(HAVE_RPK) && defined(WOLFSSL_TLS13) && \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -4164,6 +4164,8 @@ int test_tls13_pha_resumption(void)
     char buf[sizeof(msg)];
     int i;
 
+    /* Setup only creates a CTX when the pointer is NULL, so the call in the
+     * loop reuses these and creates just the SSL objects. */
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
     ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, NULL, NULL,
         wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
@@ -4311,6 +4313,8 @@ int test_tls13_pha_resumption_bare_finished(void)
     char buf[sizeof(msg)];
     int i;
 
+    /* Setup only creates a CTX when the pointer is NULL, so the call in the
+     * loop reuses these and creates just the SSL objects. */
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
     ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, NULL, NULL,
         wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -4024,27 +4024,11 @@ int test_tls13_rpk_handshake_no_negotiation(void)
     return EXPECT_RESULT();
 }
 
-/* Post-handshake authentication (PHA) positive guard. A server configured with
- * WOLFSSL_VERIFY_POST_HANDSHAKE must complete the initial handshake WITHOUT a
- * client certificate (verification is deferred) and then be able to request one
- * post-handshake. This guards the property the auth-bypass fix must preserve:
- * the missing-certificate exemption stays in force while no post-handshake
- * request is outstanding (certReqCtx == NULL). If the fix wrongly treated the
- * initial handshake as a pending PHA request, the handshake below would fail.
- *
- * Scope: this is a positive guard only.
- *  - The bypass itself is NOT reproduced here: the
- *    SanityCheckTls13MsgReceived / DoTls13Finished branches the fix re-enables
- *    only fire when a client sends a Finished with NO Certificate message at all
- *    (got_certificate == 0). A conformant wolfSSL client always sends at least
- *    an empty Certificate, so reproducing the bypass needs a non-conformant
- *    client; the report used a state-machine model. The negative direction
- *    rests on code review.
- *  - Driving the full post-handshake certificate exchange to completion is
- *    intentionally not asserted: whether the peer chain ends up populated
- *    depends on build options unrelated to this fix (it differs between
- *    --enable-all and the user_settings_all header build), so it is not a
- *    portable assertion. */
+/* A server using WOLFSSL_VERIFY_POST_HANDSHAKE must complete the initial
+ * handshake without a client certificate and still be able to request one
+ * afterwards: the deferred-verification exemption holds while handShakeDone is
+ * 0. Driving the exchange to completion is not asserted here - whether the peer
+ * chain ends up populated depends on unrelated build options. */
 int test_tls13_pha(void)
 {
     EXPECT_DECLS;
@@ -4075,8 +4059,8 @@ int test_tls13_pha(void)
         WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
     ExpectIntEQ(wolfSSL_allow_post_handshake_auth(ssl_c), 0);
 
-    /* Initial handshake must complete even though no client cert was sent -
-     * the verifyPostHandshake exemption (certReqCtx == NULL) is intact. */
+    /* Initial handshake completes with no client cert: still in-handshake, so
+     * the exemption applies. */
     ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
     ExpectNotNull(chain = wolfSSL_get_peer_chain(ssl_s));
     ExpectIntEQ(wolfSSL_get_chain_count(chain), 0);
@@ -4347,8 +4331,11 @@ int test_tls13_pha_resumption_bare_finished(void)
         }
         else {
             if (EXPECT_SUCCESS()) {
+                /* POST_HANDSHAKE so the deferred-verification exemption is
+                 * evaluated rather than short-circuited. */
                 wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_PEER |
-                    WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+                    WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT |
+                    WOLFSSL_VERIFY_POST_HANDSHAKE, NULL);
                 ExpectIntEQ(wolfSSL_request_certificate(ssl_s),
                     WOLFSSL_SUCCESS);
             }
@@ -4382,6 +4369,89 @@ int test_tls13_pha_resumption_bare_finished(void)
             ExpectIntEQ(wolfSSL_get_error(ssl_s, -1), OUT_OF_ORDER_E);
             ExpectIntEQ(ssl_s->options.havePeerCert, 0);
             ExpectIntEQ(ssl_s->options.havePeerVerify, 0);
+        }
+
+        wolfSSL_free(ssl_c);
+        ssl_c = NULL;
+        wolfSSL_free(ssl_s);
+        ssl_s = NULL;
+    }
+
+    wolfSSL_SESSION_free(sess);
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* A client with no certificate answers the post-handshake request with an empty
+ * Certificate; a server requiring one must reject it. Pins behaviour on the
+ * resumed path that nothing else covers - the rejection is in ProcessPeerCerts()
+ * and does not depend on the resumption state. */
+int test_tls13_pha_resumption_blank_cert(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13) && \
+    defined(WOLFSSL_POST_HANDSHAKE_AUTH) && defined(HAVE_SESSION_TICKET) && \
+    !defined(WOLFSSL_NO_CLIENT_CERT_ERROR) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_RSA) && !defined(NO_CERTS)
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    WOLFSSL_SESSION* sess = NULL;
+    struct test_memio_ctx test_ctx;
+    char msg[] = "hello wolfssl!";
+    char buf[sizeof(msg)];
+    int i;
+
+    /* Setup only creates a CTX when the pointer is NULL, so the call in the
+     * loop reuses these and creates just the SSL objects. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, NULL, NULL,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    /* No client cert/key: the client can only answer with a blank Certificate. */
+    ExpectIntEQ(wolfSSL_CTX_allow_post_handshake_auth(ctx_c), 0);
+    ExpectIntEQ(wolfSSL_CTX_load_verify_locations(ctx_s, cliCertFile, NULL),
+        WOLFSSL_SUCCESS);
+    wolfSSL_CTX_set_verify(ctx_s, WOLFSSL_VERIFY_NONE, NULL);
+
+    for (i = 0; i < 2 && EXPECT_SUCCESS(); i++) {
+        test_ctx.c_len = test_ctx.s_len = 0;
+        ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+            wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+
+        if (i == 1)
+            ExpectIntEQ(wolfSSL_set_session(ssl_c, sess), WOLFSSL_SUCCESS);
+
+        ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+        ExpectIntEQ(wolfSSL_session_reused(ssl_c), i);
+
+        if (i == 0) {
+            ExpectIntEQ(wolfSSL_read(ssl_c, buf, sizeof(buf)), -1);
+            ExpectIntEQ(wolfSSL_get_error(ssl_c, -1),
+                WOLFSSL_ERROR_WANT_READ);
+            ExpectNotNull(sess = wolfSSL_get1_session(ssl_c));
+        }
+        else {
+            if (EXPECT_SUCCESS()) {
+                wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_PEER |
+                    WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+                ExpectIntEQ(wolfSSL_request_certificate(ssl_s),
+                    WOLFSSL_SUCCESS);
+            }
+            ExpectIntEQ(wolfSSL_write(ssl_s, msg, (int)sizeof(msg) - 1),
+                (int)sizeof(msg) - 1);
+            ExpectIntEQ(wolfSSL_read(ssl_c, buf, sizeof(buf) - 1),
+                (int)sizeof(msg) - 1);
+            ExpectIntEQ(ssl_c->options.sendVerify, SEND_BLANK_CERT);
+
+            ExpectIntEQ(wolfSSL_write(ssl_c, msg, (int)sizeof(msg) - 1),
+                (int)sizeof(msg) - 1);
+            ExpectIntEQ(wolfSSL_read(ssl_s, buf, sizeof(buf) - 1), -1);
+            ExpectIntEQ(wolfSSL_get_error(ssl_s, -1), NO_PEER_CERT);
+            ExpectIntEQ(ssl_s->options.havePeerCert, 0);
         }
 
         wolfSSL_free(ssl_c);

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -4126,7 +4126,7 @@ int test_tls13_ctx_dh_rotation(void)
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
-    #endif
+#endif
     return EXPECT_RESULT();
 }
 
@@ -4138,6 +4138,7 @@ int test_tls13_pha_resumption(void)
     EXPECT_DECLS;
 #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13) && \
     defined(WOLFSSL_POST_HANDSHAKE_AUTH) && defined(HAVE_SESSION_TICKET) && \
+    !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
     !defined(NO_RSA) && !defined(NO_CERTS)
     WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
@@ -4165,7 +4166,8 @@ int test_tls13_pha_resumption(void)
     wolfSSL_CTX_set_verify(ctx_s, WOLFSSL_VERIFY_NONE, NULL);
 
     for (i = 0; i < 2 && EXPECT_SUCCESS(); i++) {
-        test_ctx.c_len = test_ctx.s_len = 0;
+        test_memio_clear_buffer(&test_ctx, 0);
+        test_memio_clear_buffer(&test_ctx, 1);
         ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
             wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
 
@@ -4273,7 +4275,7 @@ int test_tls13_accept_state_dh_copy(void)
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
-    #endif
+#endif
     return EXPECT_RESULT();
 }
 
@@ -4287,6 +4289,7 @@ int test_tls13_pha_resumption_bare_finished(void)
     EXPECT_DECLS;
 #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13) && \
     defined(WOLFSSL_POST_HANDSHAKE_AUTH) && defined(HAVE_SESSION_TICKET) && \
+    !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
     !defined(NO_RSA) && !defined(NO_CERTS)
     WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
@@ -4313,7 +4316,8 @@ int test_tls13_pha_resumption_bare_finished(void)
 
     /* First connection only exists to obtain a ticket. */
     for (i = 0; i < 2 && EXPECT_SUCCESS(); i++) {
-        test_ctx.c_len = test_ctx.s_len = 0;
+        test_memio_clear_buffer(&test_ctx, 0);
+        test_memio_clear_buffer(&test_ctx, 1);
         ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
             wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
 
@@ -4386,6 +4390,175 @@ int test_tls13_pha_resumption_bare_finished(void)
     return EXPECT_RESULT();
 }
 
+/* A second post-handshake round must prove possession again: peer-auth state
+ * from the previous round is cleared when the next request goes out, so the
+ * message-order checks cannot be satisfied by it. */
+int test_tls13_pha_resumption_second_round(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13) && \
+    defined(WOLFSSL_POST_HANDSHAKE_AUTH) && defined(HAVE_SESSION_TICKET) && \
+    !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_RSA) && !defined(NO_CERTS)
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    WOLFSSL_SESSION* sess = NULL;
+    struct test_memio_ctx test_ctx;
+    char msg[] = "hello wolfssl!";
+    char buf[sizeof(msg)];
+    int i, round;
+
+    /* Setup only creates a CTX when the pointer is NULL, so the call in the
+     * loop reuses these and creates just the SSL objects. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, NULL, NULL,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    ExpectIntEQ(wolfSSL_CTX_use_certificate_file(ctx_c, cliCertFile,
+        WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_file(ctx_c, cliKeyFile,
+        WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_CTX_allow_post_handshake_auth(ctx_c), 0);
+    ExpectIntEQ(wolfSSL_CTX_load_verify_locations(ctx_s, cliCertFile, NULL),
+        WOLFSSL_SUCCESS);
+    wolfSSL_CTX_set_verify(ctx_s, WOLFSSL_VERIFY_NONE, NULL);
+
+    for (i = 0; i < 2 && EXPECT_SUCCESS(); i++) {
+        test_memio_clear_buffer(&test_ctx, 0);
+        test_memio_clear_buffer(&test_ctx, 1);
+        ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+            wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+
+        if (i == 1)
+            ExpectIntEQ(wolfSSL_set_session(ssl_c, sess), WOLFSSL_SUCCESS);
+
+        ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+        ExpectIntEQ(wolfSSL_session_reused(ssl_c), i);
+
+        if (i == 0) {
+            ExpectIntEQ(wolfSSL_read(ssl_c, buf, sizeof(buf)), -1);
+            ExpectIntEQ(wolfSSL_get_error(ssl_c, -1),
+                WOLFSSL_ERROR_WANT_READ);
+            ExpectNotNull(sess = wolfSSL_get1_session(ssl_c));
+        }
+
+        for (round = 0; i == 1 && round < 2 && EXPECT_SUCCESS(); round++) {
+            if (EXPECT_SUCCESS()) {
+                wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_PEER |
+                    WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+                ExpectIntEQ(wolfSSL_request_certificate(ssl_s),
+                    WOLFSSL_SUCCESS);
+            }
+            /* Whatever the previous round established is not carried over. */
+            ExpectIntEQ(ssl_s->options.havePeerCert, 0);
+            ExpectIntEQ(ssl_s->options.havePeerVerify, 0);
+
+            ExpectIntEQ(wolfSSL_write(ssl_s, msg, (int)sizeof(msg) - 1),
+                (int)sizeof(msg) - 1);
+            ExpectIntEQ(wolfSSL_read(ssl_c, buf, sizeof(buf) - 1),
+                (int)sizeof(msg) - 1);
+            ExpectIntEQ(wolfSSL_write(ssl_c, msg, (int)sizeof(msg) - 1),
+                (int)sizeof(msg) - 1);
+            ExpectIntEQ(wolfSSL_read(ssl_s, buf, sizeof(buf) - 1),
+                (int)sizeof(msg) - 1);
+
+            /* And the round that just ran established them again. */
+            ExpectIntEQ(ssl_s->options.havePeerCert, 1);
+            ExpectIntEQ(ssl_s->options.havePeerVerify, 1);
+        }
+
+        wolfSSL_free(ssl_c);
+        ssl_c = NULL;
+        wolfSSL_free(ssl_s);
+        ssl_s = NULL;
+    }
+
+    wolfSSL_SESSION_free(sess);
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
+
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13) && \
+    defined(WOLFSSL_CERT_WITH_EXTERN_PSK) && !defined(NO_PSK) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_RSA) && !defined(NO_CERTS)
+static const char test_tls13_pha_psk_id[] = "pha_psk";
+static const byte test_tls13_pha_psk_key[] = {
+    0x35, 0x1F, 0x2A, 0x0C, 0x7D, 0x64, 0x4B, 0x18,
+    0x9E, 0xC2, 0x50, 0x77, 0x36, 0xA1, 0xE9, 0x83
+};
+
+static unsigned int test_tls13_pha_psk_client_cb(WOLFSSL* ssl, const char* hint,
+    char* identity, unsigned int id_max_len, unsigned char* key,
+    unsigned int key_max_len)
+{
+    (void)ssl;
+    (void)hint;
+    if (id_max_len < sizeof(test_tls13_pha_psk_id) ||
+            key_max_len < sizeof(test_tls13_pha_psk_key))
+        return 0;
+    XSTRNCPY(identity, test_tls13_pha_psk_id, id_max_len);
+    XMEMCPY(key, test_tls13_pha_psk_key, sizeof(test_tls13_pha_psk_key));
+    return (unsigned int)sizeof(test_tls13_pha_psk_key);
+}
+
+static unsigned int test_tls13_pha_psk_server_cb(WOLFSSL* ssl, const char* id,
+    unsigned char* key, unsigned int key_max_len)
+{
+    (void)ssl;
+    if (id == NULL || key_max_len < sizeof(test_tls13_pha_psk_key) ||
+            XSTRCMP(id, test_tls13_pha_psk_id) != 0)
+        return 0;
+    XMEMCPY(key, test_tls13_pha_psk_key, sizeof(test_tls13_pha_psk_key));
+    return (unsigned int)sizeof(test_tls13_pha_psk_key);
+}
+#endif
+
+/* Bounds the other side of the RFC 8446 4.3.2 relaxation: a CertificateRequest
+ * during the main handshake under a PSK must still be rejected. The client is
+ * untouched here - it has not sent its Finished, so handShakeDone is 0 on its
+ * own. A wolfSSL server normally clears verifyPeer once a PSK is chosen and so
+ * never sends one; cert_with_extern_psk on the server alone suppresses that
+ * clearing, which makes it emit the request the client must refuse. */
+int test_tls13_psk_cert_request_in_handshake(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13) && \
+    defined(WOLFSSL_CERT_WITH_EXTERN_PSK) && !defined(NO_PSK) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_RSA) && !defined(NO_CERTS)
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_psk_client_callback(ssl_c, test_tls13_pha_psk_client_cb);
+    wolfSSL_set_psk_server_callback(ssl_s, test_tls13_pha_psk_server_cb);
+    /* Server side only: the client neither offers the extension nor takes the
+     * matching exemption, so it must reject on message order alone. */
+    ExpectIntEQ(wolfSSL_set_cert_with_extern_psk(ssl_s, 1), WOLFSSL_SUCCESS);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_PEER, NULL);
+
+    ExpectIntNE(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), SANITY_MSG_E);
+    ExpectIntEQ(ssl_c->options.pskNegotiated, 1);
+    ExpectIntEQ(ssl_c->options.certWithExternPsk, 0);
+    ExpectIntEQ(ssl_c->options.handShakeDone, 0);
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
+
 /* A client with no certificate answers the post-handshake request with an empty
  * Certificate; a server requiring one must reject it. Pins behaviour on the
  * resumed path that nothing else covers - the rejection is in ProcessPeerCerts()
@@ -4395,6 +4568,7 @@ int test_tls13_pha_resumption_blank_cert(void)
     EXPECT_DECLS;
 #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13) && \
     defined(WOLFSSL_POST_HANDSHAKE_AUTH) && defined(HAVE_SESSION_TICKET) && \
+    !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
     !defined(WOLFSSL_NO_CLIENT_CERT_ERROR) && \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
     !defined(NO_RSA) && !defined(NO_CERTS)
@@ -4418,7 +4592,8 @@ int test_tls13_pha_resumption_blank_cert(void)
     wolfSSL_CTX_set_verify(ctx_s, WOLFSSL_VERIFY_NONE, NULL);
 
     for (i = 0; i < 2 && EXPECT_SUCCESS(); i++) {
-        test_ctx.c_len = test_ctx.s_len = 0;
+        test_memio_clear_buffer(&test_ctx, 0);
+        test_memio_clear_buffer(&test_ctx, 1);
         ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
             wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
 

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -35,6 +35,7 @@ int test_tls13_ctx_dh_rotation(void);
 int test_tls13_accept_state_dh_copy(void);
 int test_tls13_pha_resumption(void);
 int test_tls13_pha_resumption_bare_finished(void);
+int test_tls13_pha_resumption_blank_cert(void);
 int test_tls13_rpk_untrusted(void);
 int test_tls13_rpk_trust(void);
 int test_tls13_rpk_unoffered_cert_type(void);
@@ -146,6 +147,7 @@ int test_tls13_x25519_keyshare_masks_reserved_bit(void);
     TEST_DECL_GROUP("tls13", test_tls13_accept_state_dh_copy),  \
     TEST_DECL_GROUP("tls13", test_tls13_pha_resumption),        \
     TEST_DECL_GROUP("tls13", test_tls13_pha_resumption_bare_finished), \
+    TEST_DECL_GROUP("tls13", test_tls13_pha_resumption_blank_cert), \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_untrusted),         \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_trust),             \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_unoffered_cert_type), \

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -33,6 +33,8 @@ int test_tls13_rpk_handshake_no_negotiation(void);
 int test_tls13_pha(void);
 int test_tls13_ctx_dh_rotation(void);
 int test_tls13_accept_state_dh_copy(void);
+int test_tls13_pha_resumption(void);
+int test_tls13_pha_resumption_bare_finished(void);
 int test_tls13_rpk_untrusted(void);
 int test_tls13_rpk_trust(void);
 int test_tls13_rpk_unoffered_cert_type(void);
@@ -142,6 +144,8 @@ int test_tls13_x25519_keyshare_masks_reserved_bit(void);
     TEST_DECL_GROUP("tls13", test_tls13_pha),                   \
     TEST_DECL_GROUP("tls13", test_tls13_ctx_dh_rotation),       \
     TEST_DECL_GROUP("tls13", test_tls13_accept_state_dh_copy),  \
+    TEST_DECL_GROUP("tls13", test_tls13_pha_resumption),        \
+    TEST_DECL_GROUP("tls13", test_tls13_pha_resumption_bare_finished), \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_untrusted),         \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_trust),             \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_unoffered_cert_type), \

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -36,6 +36,8 @@ int test_tls13_accept_state_dh_copy(void);
 int test_tls13_pha_resumption(void);
 int test_tls13_pha_resumption_bare_finished(void);
 int test_tls13_pha_resumption_blank_cert(void);
+int test_tls13_psk_cert_request_in_handshake(void);
+int test_tls13_pha_resumption_second_round(void);
 int test_tls13_rpk_untrusted(void);
 int test_tls13_rpk_trust(void);
 int test_tls13_rpk_unoffered_cert_type(void);
@@ -148,6 +150,8 @@ int test_tls13_x25519_keyshare_masks_reserved_bit(void);
     TEST_DECL_GROUP("tls13", test_tls13_pha_resumption),        \
     TEST_DECL_GROUP("tls13", test_tls13_pha_resumption_bare_finished), \
     TEST_DECL_GROUP("tls13", test_tls13_pha_resumption_blank_cert), \
+    TEST_DECL_GROUP("tls13", test_tls13_psk_cert_request_in_handshake), \
+    TEST_DECL_GROUP("tls13", test_tls13_pha_resumption_second_round), \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_untrusted),         \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_trust),             \
     TEST_DECL_GROUP("tls13", test_tls13_rpk_unoffered_cert_type), \


### PR DESCRIPTION
# Description

Fixes zd#22349

# Testing

Built in tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
