### PR TITLE
PKCS11: Allow a generated EC key to both derive and sign via `WC_ECC_FLAG_DERIVE`

### DIFF
--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -3374,8 +3374,22 @@ static int Pkcs11EcKeyGen(Pkcs11Session* session, wc_CryptoInfo* info)
         { 0,           NULL,    0              },
         { 0,           NULL,    0              },
     };
+    /* As above but the key may derive as well. PKCS#11 leaves the defaults for
+     * CKA_SIGN and CKA_DERIVE up to the token, so a token that grants only what
+     * was asked for will refuse whichever operation was not requested. A TLS
+     * key generally needs both. Empty entries for optional label/ID. */
+    CK_ATTRIBUTE      privKeyTmplEncSignDerive[] = {
+        { CKA_SIGN,    &ckTrue, sizeof(ckTrue) },
+        { CKA_DECRYPT, &ckTrue, sizeof(ckTrue) },
+        { CKA_DERIVE,  &ckTrue, sizeof(ckTrue) },
+        { 0,           NULL,    0              },
+        { 0,           NULL,    0              },
+    };
     CK_ATTRIBUTE*     privKeyTmpl = privKeyTmplDerive;
-    /* Mandatory entries + 2 optional. */
+    /* Number of mandatory entries in whichever template is selected below:
+     * 1 for derive-only, 2 for sign+decrypt, 3 when derive is added to those.
+     * Every template also carries 2 trailing slots for the optional label
+     * and ID, which are filled in later if the key has them. */
     int               privTmplCnt = 1;
 
     ret = Pkcs11MechAvail(session, CKM_EC_KEY_PAIR_GEN, NULL);
@@ -3387,8 +3401,14 @@ static int Pkcs11EcKeyGen(Pkcs11Session* session, wc_CryptoInfo* info)
     if (ret == 0) {
         /* Default is to use for derivation. */
         if ((key->flags & WC_ECC_FLAG_DEC_SIGN) == WC_ECC_FLAG_DEC_SIGN) {
-            privKeyTmpl = privKeyTmplEncSign;
-            privTmplCnt = 2;
+            if ((key->flags & WC_ECC_FLAG_DERIVE) == WC_ECC_FLAG_DERIVE) {
+                privKeyTmpl = privKeyTmplEncSignDerive;
+                privTmplCnt = 3;
+            }
+            else {
+                privKeyTmpl = privKeyTmplEncSign;
+                privTmplCnt = 2;
+            }
             pubTmplCnt = 2;
         }
         if (key->labelLen != 0) {

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -489,7 +489,22 @@ struct ecc_point {
 enum {
     WC_ECC_FLAG_NONE     = 0x00,
     WC_ECC_FLAG_COFACTOR = 0x01,
-    WC_ECC_FLAG_DEC_SIGN = 0x02
+    WC_ECC_FLAG_DEC_SIGN = 0x02,
+    /* Add key derivation to a PKCS#11 token-generated key, so the same key can
+     * do both ECDH and ECDSA on a token that grants only what was explicitly
+     * requested.
+     *
+     * Consumed ONLY by PKCS#11-backed key generation; it has no effect on any
+     * software or other hardware ECC path.
+     *
+     * IGNORED unless WC_ECC_FLAG_DEC_SIGN is also set. Setting it on its own
+     * changes nothing, because a generated key is already derive-only by
+     * default - so the meaningful use is:
+     *
+     *     wc_ecc_make_key_ex2(rng, keysize, key, curve_id,
+     *                         WC_ECC_FLAG_DEC_SIGN | WC_ECC_FLAG_DERIVE);
+     */
+    WC_ECC_FLAG_DERIVE   = 0x04
 };
 
 /* ECC non-blocking */


### PR DESCRIPTION
## Problem

When generating an EC key in a PKCS#11 token, wolfSSL requests either `CKA_DERIVE` or `CKA_SIGN`, never both. The two templates in `Pkcs11EcKeyGen()` are mutually exclusive:

```c
CK_ATTRIBUTE privKeyTmplDerive[]  = { { CKA_DERIVE, ... } };
CK_ATTRIBUTE privKeyTmplEncSign[] = { { CKA_SIGN, ... }, { CKA_DECRYPT, ... } };
```

`WC_ECC_FLAG_DEC_SIGN` selects sign and decrypt; its absence selects derive.

PKCS#11 leaves the defaults for these attributes up to the token. A permissive token (SoftHSM) grants both regardless of what was asked for, so this has gone unnoticed. A token that grants only what was requested refuses the other operation with `CKR_KEY_FUNCTION_NOT_PERMITTED` (0x68), which surfaces as `WC_HW_E` (-248).

That makes a token-resident EC key usable for ECDH **or** ECDSA, but not both - and a TLS key generally needs both.

Measured on an NXP i.MX95 against OP-TEE's PKCS#11 trusted application:

| key generated with | ECDH derive | ECDSA sign |
|---|---|---|
| `wc_ecc_make_key_ex` (derive template) | OK | `CKR_KEY_FUNCTION_NOT_PERMITTED` |
| `wc_ecc_make_key_ex2(..., WC_ECC_FLAG_DEC_SIGN)` | `WC_HW_E` | OK |

## Change

Adds `WC_ECC_FLAG_DERIVE` (0x04) and a third template that asks for `CKA_SIGN`, `CKA_DECRYPT` and `CKA_DERIVE` together, selected when it is combined with `WC_ECC_FLAG_DEC_SIGN`:

```c
wc_ecc_make_key_ex2(&rng, 32, &key, ECC_SECP256R1,
                    WC_ECC_FLAG_DEC_SIGN | WC_ECC_FLAG_DERIVE);
```

## Opt-in, deliberately

The new flag is purely additive. Without it, the attribute templates sent to the token are byte-identical to today, so no existing deployment changes what it asks a token for. This was verified rather than assumed: the unmodified `pkcs11_test` built against the patched library still fails at exactly the same point on a strict token, while the same test passes once the flag is requested.

## Testing

- `testwolfcrypt` passes on a native build with `--enable-pkcs11 --enable-cryptocb-rsa-pad`, and on a plain default build.
- On hardware - NXP i.MX95 (Toradex SMARC iMX95), Torizon OS 7.7.0, OP-TEE 4.4, wolfSSL cross-built for aarch64 - the upstream `pkcs11_test` example now passes end to end against the OP-TEE token, including the ECDH-then-ECDSA sequence on generated keys (plain, LABEL and ID variants) that previously failed.
- Opt-in confirmed: same test without the flag fails identically to before the change.

The matching examples update is in wolfssl-examples branch `optee_pkcs11`.