### PR TITLE
SE050 CI: update pinned simulator for PKCS7 coverage

### DIFF
--- a/.github/workflows/se050-sim.yml
+++ b/.github/workflows/se050-sim.yml
@@ -31,7 +31,7 @@ permissions:
 # We patch it to COPY the PR checkout instead so CI reflects the PR's source.
 
 env:
-  SIMULATORS_REF: 895ff41b2447efe952e902c467c5ef479f3eda37
+  SIMULATORS_REF: bbb959a1ef79c553a3e25393ce989942bd858b2d
 
 jobs:
   se050_sim:


### PR DESCRIPTION
Pin bump to the simulators commit that adds --enable-pkcs7 to the wolfcrypt CI build, so the suite's pkcs7signed_test and pkcs7enveloped_test regression-guard the SE050 RSA verify buffer fix and the ECDH software-key fallback. The pinned commit is fetchable by CI once the corresponding simulators change merges.