### PR TITLE
ntp CI: build wolfSSL with OPENSSL_EXTRA_BSD and MD4

### DIFF
--- a/.github/workflows/ntp.yml
+++ b/.github/workflows/ntp.yml
@@ -32,7 +32,9 @@ jobs:
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           path: wolfssl
-          configure: --enable-all
+          # NTP 4.2.8p18 needs OPENSSL_EXTRA_BSD (MD5Init/MD5Update/MD5Final)
+          # and MD4 (tests), neither of which --enable-all provides
+          configure: --enable-all --enable-md4 CFLAGS="-DOPENSSL_EXTRA_BSD"
           install: true
           check: false
 


### PR DESCRIPTION
The ntp 4.2.8p18 patch (wolfSSL/osp) requires wolfSSL to be built with `OPENSSL_EXTRA_BSD`, which provides `MD5Init`/`MD5Update`/`MD5Final`, and with MD4 for the new test suite. Neither is provided by `--enable-all`, so without these flags the 4.2.8p18 job fails at configure with a clear error.