### PR TITLE
Warn about non-conformance when using old TLS versions.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6096,7 +6096,7 @@ AC_ARG_ENABLE([errorqueue],
 
 # SSLv3
 AC_ARG_ENABLE([sslv3],
-    [AS_HELP_STRING([--enable-sslv3],[Enable SSL version 3.0 (default: disabled)])],
+    [AS_HELP_STRING([--enable-sslv3],[Enable SSL version 3.0 (default: disabled). WARNING: SSL 3.0 is deprecated by RFC 7568 and its use violates RFC 9846 and RFC 8996; such a build is not conformant with RFC 9846, RFC 8996 or RFC 9325])],
     [ ENABLED_SSLV3=$enableval ],
     [ ENABLED_SSLV3=no]
     )
@@ -6113,11 +6113,12 @@ fi
 if test "$ENABLED_SSLV3" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALLOW_SSLV3"
+    AC_MSG_WARN([SSL 3.0 (WOLFSSL_ALLOW_SSLV3) is enabled. SSL 3.0 is deprecated by RFC 7568 and RFC 8996, and RFC 9846 states it MUST NOT be negotiated for any reason. This build is NOT conformant with RFC 9846, RFC 8996 or RFC 9325.])
 fi
 
 # TLSv1.0
 AC_ARG_ENABLE([tlsv10],
-    [AS_HELP_STRING([--enable-tlsv10],[Enable old TLS versions 1.0 (default: disabled)])],
+    [AS_HELP_STRING([--enable-tlsv10],[Enable old TLS version 1.0 (default: disabled). WARNING: TLS 1.0 is deprecated by RFC 8996 and its use violates RFC 9846; such a build is not conformant with RFC 9846, RFC 8996 or RFC 9325])],
     [ ENABLED_TLSV10=$enableval ],
     [ ENABLED_TLSV10=no ]
     )
@@ -6125,12 +6126,13 @@ AC_ARG_ENABLE([tlsv10],
 if test "$ENABLED_TLSV10" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALLOW_TLSV10"
+    AC_MSG_WARN([TLS 1.0 (WOLFSSL_ALLOW_TLSV10) is enabled. TLS 1.0 is deprecated by RFC 8996, and RFC 9846 states it MUST NOT be negotiated for any reason. This build is NOT conformant with RFC 9846, RFC 8996 or RFC 9325.])
 fi
 
 
 # OLD TLS
 AC_ARG_ENABLE([oldtls],
-    [AS_HELP_STRING([--enable-oldtls],[Enable old TLS versions < 1.2, which RFC 8996 and RFC 9846 forbid negotiating (default: disabled)])],
+    [AS_HELP_STRING([--enable-oldtls],[Enable old TLS versions < 1.2 (default: disabled). WARNING: TLS 1.1 and earlier are deprecated by RFC 8996, and RFC 9846 states that SSL 2.0, SSL 3.0, TLS 1.0 and TLS 1.1 MUST NOT be negotiated for any reason; such a build is not conformant with RFC 9846, RFC 8996 or RFC 9325])],
     [ ENABLED_OLD_TLS=$enableval ],
     [ ENABLED_OLD_TLS=no ]
     )
@@ -14298,4 +14300,14 @@ echo "---"
 echo "Note: Make sure your application includes \"wolfssl/options.h\" before any other wolfSSL headers."
 echo "      You can define \"WOLFSSL_USE_OPTIONS_H\" in your application to include this automatically."
 
+fi
+
+if test "$ENABLED_OLD_TLS" = "yes"
+then
+echo ""
+echo "WARNING: This build enables old TLS versions (< 1.2). TLS 1.1 and earlier"
+echo "         are deprecated by RFC 8996, and RFC 9846 states that"
+echo "         SSL 2.0, SSL 3.0, TLS 1.0 and TLS 1.1 MUST NOT be negotiated for"
+echo "         any reason. This build is NOT conformant with RFC 9846, RFC 8996"
+echo "         or RFC 9325."
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -6096,7 +6096,7 @@ AC_ARG_ENABLE([errorqueue],
 
 # SSLv3
 AC_ARG_ENABLE([sslv3],
-    [AS_HELP_STRING([--enable-sslv3],[Enable SSL version 3.0 (default: disabled). WARNING: SSL 3.0 is deprecated by RFC 7568 and its use violates RFC 9846 and RFC 8996; such a build is not conformant with RFC 9846, RFC 8996 or RFC 9325])],
+    [AS_HELP_STRING([--enable-sslv3],[Enable SSL version 3.0 (default: disabled). NOTE: SSL 3.0 is deprecated by RFC 7568 and its use violates RFC 9846 and RFC 8996; such a build is not conformant with RFC 9846, RFC 8996 or RFC 9325])],
     [ ENABLED_SSLV3=$enableval ],
     [ ENABLED_SSLV3=no]
     )
@@ -6113,12 +6113,12 @@ fi
 if test "$ENABLED_SSLV3" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALLOW_SSLV3"
-    AC_MSG_WARN([SSL 3.0 (WOLFSSL_ALLOW_SSLV3) is enabled. SSL 3.0 is deprecated by RFC 7568 and RFC 8996, and RFC 9846 states it MUST NOT be negotiated for any reason. This build is NOT conformant with RFC 9846, RFC 8996 or RFC 9325.])
+    AC_MSG_NOTICE([SSL 3.0 (WOLFSSL_ALLOW_SSLV3) is enabled. SSL 3.0 is deprecated by RFC 7568 and RFC 8996, and RFC 9846 states it MUST NOT be negotiated for any reason. This build is not conformant with RFC 9846, RFC 8996 or RFC 9325.])
 fi
 
 # TLSv1.0
 AC_ARG_ENABLE([tlsv10],
-    [AS_HELP_STRING([--enable-tlsv10],[Enable old TLS version 1.0 (default: disabled). WARNING: TLS 1.0 is deprecated by RFC 8996 and its use violates RFC 9846; such a build is not conformant with RFC 9846, RFC 8996 or RFC 9325])],
+    [AS_HELP_STRING([--enable-tlsv10],[Enable old TLS version 1.0 (default: disabled). NOTE: TLS 1.0 is deprecated by RFC 8996 and its use violates RFC 9846; such a build is not conformant with RFC 9846, RFC 8996 or RFC 9325])],
     [ ENABLED_TLSV10=$enableval ],
     [ ENABLED_TLSV10=no ]
     )
@@ -6126,13 +6126,13 @@ AC_ARG_ENABLE([tlsv10],
 if test "$ENABLED_TLSV10" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALLOW_TLSV10"
-    AC_MSG_WARN([TLS 1.0 (WOLFSSL_ALLOW_TLSV10) is enabled. TLS 1.0 is deprecated by RFC 8996, and RFC 9846 states it MUST NOT be negotiated for any reason. This build is NOT conformant with RFC 9846, RFC 8996 or RFC 9325.])
+    AC_MSG_NOTICE([TLS 1.0 (WOLFSSL_ALLOW_TLSV10) is enabled. TLS 1.0 is deprecated by RFC 8996, and RFC 9846 states it MUST NOT be negotiated for any reason. This build is not conformant with RFC 9846, RFC 8996 or RFC 9325.])
 fi
 
 
 # OLD TLS
 AC_ARG_ENABLE([oldtls],
-    [AS_HELP_STRING([--enable-oldtls],[Enable old TLS versions < 1.2 (default: disabled). WARNING: TLS 1.1 and earlier are deprecated by RFC 8996, and RFC 9846 states that SSL 2.0, SSL 3.0, TLS 1.0 and TLS 1.1 MUST NOT be negotiated for any reason; such a build is not conformant with RFC 9846, RFC 8996 or RFC 9325])],
+    [AS_HELP_STRING([--enable-oldtls],[Enable old TLS versions < 1.2 (default: disabled). NOTE: TLS 1.1 and earlier are deprecated by RFC 8996, and RFC 9846 states that SSL 2.0, SSL 3.0, TLS 1.0 and TLS 1.1 MUST NOT be negotiated for any reason; such a build is not conformant with RFC 9846, RFC 8996 or RFC 9325])],
     [ ENABLED_OLD_TLS=$enableval ],
     [ ENABLED_OLD_TLS=no ]
     )
@@ -14305,9 +14305,9 @@ fi
 if test "$ENABLED_OLD_TLS" = "yes"
 then
 echo ""
-echo "WARNING: This build enables old TLS versions (< 1.2). TLS 1.1 and earlier"
-echo "         are deprecated by RFC 8996, and RFC 9846 states that"
-echo "         SSL 2.0, SSL 3.0, TLS 1.0 and TLS 1.1 MUST NOT be negotiated for"
-echo "         any reason. This build is NOT conformant with RFC 9846, RFC 8996"
-echo "         or RFC 9325."
+echo "NOTE: This build enables old TLS versions (< 1.2). TLS 1.1 and earlier"
+echo "      are deprecated by RFC 8996, and RFC 9846 states that SSL 2.0,"
+echo "      SSL 3.0, TLS 1.0 and TLS 1.1 MUST NOT be negotiated for any"
+echo "      reason. This build is not conformant with RFC 9846, RFC 8996 or"
+echo "      RFC 9325."
 fi


### PR DESCRIPTION
Fixes https://github.com/wolfSSL/wolfssl/issues/11133