### PR TITLE
Fix ASN guards for RSA key DER export

### DIFF
--- a/.github/workflows/disable-pk-algs.yml
+++ b/.github/workflows/disable-pk-algs.yml
@@ -76,7 +76,8 @@ jobs:
            "configs": [
           {"name": "rsa-dh", "minutes": 1.2,
            "configure": ["--enable-rsa", "--enable-dh"]},
-          {"name": "rsa-key-to-der-original-asn", "minutes": 1.2,
+          {"name": "rsa-key-to-der-original-asn", "minutes": 0.3,
+           "check": false,
            "configure": ["--enable-rsa", "--enable-asn=original",
              "--disable-dsa", "CPPFLAGS=-DWOLFSSL_KEY_TO_DER"]},
           {"name": "ecc", "minutes": 1.2,

--- a/.github/workflows/disable-pk-algs.yml
+++ b/.github/workflows/disable-pk-algs.yml
@@ -76,6 +76,9 @@ jobs:
            "configs": [
           {"name": "rsa-dh", "minutes": 1.2,
            "configure": ["--enable-rsa", "--enable-dh"]},
+          {"name": "rsa-key-to-der-original-asn", "minutes": 1.2,
+           "configure": ["--enable-rsa", "--enable-asn=original",
+             "--disable-dsa", "CPPFLAGS=-DWOLFSSL_KEY_TO_DER"]},
           {"name": "ecc", "minutes": 1.2,
            "configure": ["--enable-ecc"]},
           {"name": "rsa-curve25519", "minutes": 1.2,

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3534,8 +3534,10 @@ WOLFSSL_LOCAL int SetASNInt(int len, byte firstByte, byte* output)
 #endif
 
 #ifndef WOLFSSL_ASN_TEMPLATE
-#if !defined(NO_DSA) || defined(HAVE_ECC) || (defined(WOLFSSL_CERT_GEN) && \
-    !defined(NO_RSA)) || ((defined(WOLFSSL_KEY_GEN) || \
+#if !defined(NO_DSA) || defined(HAVE_ECC) || \
+    (!defined(NO_RSA) && defined(WOLFSSL_KEY_TO_DER)) || \
+    (defined(WOLFSSL_CERT_GEN) && !defined(NO_RSA)) || \
+    ((defined(WOLFSSL_KEY_GEN) || \
     (!defined(NO_DH) && defined(WOLFSSL_DH_EXTRA)) || \
     defined(OPENSSL_EXTRA)) && !defined(NO_RSA))
 /* Set the DER/BER encoding of the ASN.1 INTEGER element with an mp_int.
@@ -4048,11 +4050,12 @@ int CheckBitString(const byte* input, word32* inOutIdx, int* len,
 #endif
 }
 
-/* RSA (with CertGen or KeyGen) OR ECC OR ED25519 OR ED448 (with CertGen or
- * KeyGen) OR CRL */
+/* RSA (with CertGen, KeyGen or KeyToDer) OR ECC OR ED25519 OR ED448 (with
+ * CertGen or KeyGen) OR CRL */
 #if (!defined(NO_RSA) && \
      (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN) || \
-      defined(OPENSSL_EXTRA))) || \
+      defined(OPENSSL_EXTRA) || \
+      (defined(WOLFSSL_KEY_TO_DER) && !defined(NO_CERTS)))) || \
     (defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT)) || \
     ((defined(HAVE_ED25519) || defined(HAVE_ED448)) && \
      (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN) || \


### PR DESCRIPTION
WOLFSSL_SE050 enables WOLFSSL_KEY_TO_DER, but the original ASN implementation only compiled SetASNIntMP and SetBitString when unrelated features such as ECC or key generation were enabled. An ECC-free SE050 build therefore compiled the RSA DER callers without these helpers and failed at link time.

Include WOLFSSL_KEY_TO_DER in both helper guards, while retaining the NO_CERTS constraint for the public-key BIT STRING encoder. This allows SE050 RSA builds to disable HAVE_ECC without unresolved ASN symbols.

ZD 22321