### PR TITLE
certificatePolicies fixes

### DIFF
--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -1577,6 +1577,91 @@ int test_DecodeCertExtensions_dup_certpol(void)
     return EXPECT_RESULT();
 }
 
+/* RFC 5280 4.2.1.4 defines certificatePolicies as SEQUENCE SIZE (1..MAX) OF
+ * PolicyInformation, so an empty SEQUENCE must be rejected instead of being
+ * accepted as zero policies. */
+int test_DecodeCertExtensions_empty_certpol(void)
+{
+    EXPECT_DECLS;
+#if (defined(WOLFSSL_SEP) || defined(WOLFSSL_CERT_EXT)) && \
+    !defined(NO_CERTS) && !defined(NO_ASN)
+    /* certificatePolicies extnValue carrying no PolicyInformation. */
+    static const byte emptyPolicy[] = {
+        0x30, 0x00                          /* certificatePolicies SEQUENCE */
+    };
+    DecodedCert cert;
+    int isUnknown = 0;
+
+    wc_InitDecodedCert(&cert, emptyPolicy, (word32)sizeof(emptyPolicy), NULL);
+
+    ExpectIntEQ(DecodeExtensionType(emptyPolicy, (word32)sizeof(emptyPolicy),
+        CERT_POLICY_OID, 0, &cert, &isUnknown),
+        WC_NO_ERR_TRACE(ASN_PARSE_E));
+
+    wc_FreeDecodedCert(&cert);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* Trailing bytes after the last PolicyInformation must be rejected rather than
+ * skipped. */
+int test_DecodeCertExtensions_certpol_trailing_junk(void)
+{
+    EXPECT_DECLS;
+#if (defined(WOLFSSL_SEP) || defined(WOLFSSL_CERT_EXT)) && \
+    !defined(NO_CERTS) && !defined(NO_ASN)
+    /* One valid PolicyInformation followed by two bytes that are not one. */
+    static const byte trailingJunk[] = {
+        0x30, 0x09,                          /* certificatePolicies SEQUENCE */
+            0x30, 0x05,                      /* PolicyInformation SEQUENCE */
+                0x06, 0x03, 0x2A, 0x03, 0x04,/* policyIdentifier OID 1.2.3.4 */
+            0x00, 0x00                       /* trailing junk */
+    };
+    DecodedCert cert;
+    int isUnknown = 0;
+
+    wc_InitDecodedCert(&cert, trailingJunk, (word32)sizeof(trailingJunk), NULL);
+
+    ExpectIntEQ(DecodeExtensionType(trailingJunk, (word32)sizeof(trailingJunk),
+        CERT_POLICY_OID, 0, &cert, &isUnknown),
+        WC_NO_ERR_TRACE(ASN_PARSE_E));
+
+    wc_FreeDecodedCert(&cert);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* An empty certificatePolicies SEQUENCE followed by extra bytes: the
+ * non-template decoder reads a PolicyInformation before testing the loop
+ * condition, so it parses those bytes past the SEQUENCE end and returns 0. */
+int test_DecodeCertExtensions_empty_certpol_trailing(void)
+{
+    EXPECT_DECLS;
+#if (defined(WOLFSSL_SEP) || defined(WOLFSSL_CERT_EXT)) && \
+    !defined(NO_CERTS) && !defined(NO_ASN)
+    static const byte emptyThenPolicy[] = {
+        0x30, 0x00,                          /* certificatePolicies SEQUENCE */
+        0x30, 0x05,                          /* bytes after the SEQUENCE */
+            0x06, 0x03, 0x2A, 0x03, 0x04     /* OID 1.2.3.4 */
+    };
+    DecodedCert cert;
+    int isUnknown = 0;
+
+    wc_InitDecodedCert(&cert, emptyThenPolicy, (word32)sizeof(emptyThenPolicy),
+        NULL);
+
+    ExpectIntEQ(DecodeExtensionType(emptyThenPolicy,
+        (word32)sizeof(emptyThenPolicy), CERT_POLICY_OID, 0, &cert, &isUnknown),
+        WC_NO_ERR_TRACE(ASN_PARSE_E));
+#ifdef WOLFSSL_CERT_EXT
+    ExpectIntEQ(cert.extCertPoliciesNb, 0);
+#endif
+
+    wc_FreeDecodedCert(&cert);
+#endif
+    return EXPECT_RESULT();
+}
+
 int test_ParseCert_SM3wSM2_short_pubkey(void)
 {
     EXPECT_DECLS;

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -36,6 +36,9 @@ int test_wc_DecodeRsaPssParams(void);
 int test_SerialNumber0_RootCA(void);
 int test_DecodeAltNames_length_underflow(void);
 int test_DecodeCertExtensions_dup_certpol(void);
+int test_DecodeCertExtensions_empty_certpol(void);
+int test_DecodeCertExtensions_certpol_trailing_junk(void);
+int test_DecodeCertExtensions_empty_certpol_trailing(void);
 int test_ParseCert_SM3wSM2_short_pubkey(void);
 int test_ParseCert_dnBufferBoundary(void);
 int test_wc_DecodeObjectId(void);
@@ -61,6 +64,9 @@ int test_wc_AsnFeatureCoverage(void);
     TEST_DECL_GROUP("asn", test_SerialNumber0_RootCA),              \
     TEST_DECL_GROUP("asn", test_DecodeAltNames_length_underflow),   \
     TEST_DECL_GROUP("asn", test_DecodeCertExtensions_dup_certpol),  \
+    TEST_DECL_GROUP("asn", test_DecodeCertExtensions_empty_certpol), \
+    TEST_DECL_GROUP("asn", test_DecodeCertExtensions_certpol_trailing_junk), \
+    TEST_DECL_GROUP("asn", test_DecodeCertExtensions_empty_certpol_trailing), \
     TEST_DECL_GROUP("asn", test_ParseCert_SM3wSM2_short_pubkey),    \
     TEST_DECL_GROUP("asn", test_ParseCert_dnBufferBoundary),        \
     TEST_DECL_GROUP("asn", test_wc_DecodeObjectId),                 \

--- a/tests/unit-mcdc/test_asn_ext_whitebox.c
+++ b/tests/unit-mcdc/test_asn_ext_whitebox.c
@@ -1288,7 +1288,8 @@ static void wb_decode_policy_oid(void)
 /* ------------------------------------------------------------------------- *
  * Section 17: DecodeCertPolicy() (static, called directly).
  * Gated on WOLFSSL_SEP || WOLFSSL_CERT_EXT, same as the source.
- *   :21346  while ((ret==0) && (idx<total_length) && (extCertPoliciesNb<MAX_CERTPOL_NB))
+ *   :21346  while ((ret==0) && (idx<seqEnd) && (extCertPoliciesNb<MAX_CERTPOL_NB))
+ *           total_length==0 empty-SEQUENCE check, reached before that loop
  *   :21369  ret==0 && cert->deviceType==NULL          (WOLFSSL_SEP)
  *   :21401  duplicate-OID scan loop (WOLFSSL_CERT_EXT, !WOLFSSL_DUP_CERTPOL)
  * MAX_CERTPOL_NB is 2, so three policies exercise the count limit.
@@ -1338,10 +1339,11 @@ static void wb_decode_cert_policy(void)
     /* Zero policies. */
     static const byte noPolicies[] = { 0x30, 0x00 };
 
-    WB_NOTE("DecodeCertPolicy(): zero policies (loop false via idx<total_length) [:21346]");
+    WB_NOTE("DecodeCertPolicy(): empty SEQUENCE rejected before the loop (total_length==0)");
     XMEMSET(&cert, 0, sizeof(cert));
     ret = DecodeCertPolicy(noPolicies, sizeof(noPolicies), &cert);
-    WB_CHECK(ret == 0, "no policies present");
+    WB_CHECK(ret == WC_NO_ERR_TRACE(ASN_PARSE_E),
+            "empty SEQUENCE rejected: RFC 5280 4.2.1.4 requires SIZE (1..MAX)");
 
     WB_NOTE("DecodeCertPolicy(): one policy (loop true then false) [:21346,:21369]");
     XMEMSET(&cert, 0, sizeof(cert));

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -21458,6 +21458,7 @@ exit:
 static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
 {
     word32 idx = 0;
+    word32 seqEnd = 0;
     int ret = 0;
     int total_length = 0;
 #if defined(WOLFSSL_CERT_EXT) && !defined(WOLFSSL_DUP_CERTPOL)
@@ -21481,10 +21482,17 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
         {
             ret = ASN_PARSE_E;
         }
+        /* RFC 5280 4.2.1.4: certificatePolicies is SEQUENCE SIZE (1..MAX). */
+        else if (total_length == 0) {
+            ret = ASN_PARSE_E;
+        }
+        else {
+            seqEnd = idx + (word32)total_length;
+        }
     }
 
-    /* Unwrap certificatePolicies */
-    while ((ret == 0) && ((int)idx < total_length)
+    /* Unwrap certificatePolicies, stopping at the end of the SEQUENCE. */
+    while ((ret == 0) && (idx < seqEnd)
     #if defined(WOLFSSL_CERT_EXT)
         && (cert->extCertPoliciesNb < MAX_CERTPOL_NB)
     #endif

--- a/wolfcrypt/src/asn_orig.c
+++ b/wolfcrypt/src/asn_orig.c
@@ -4161,6 +4161,7 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
 {
     word32 idx = 0;
     word32 oldIdx;
+    word32 seqEnd;
     int policy_length = 0;
     int ret;
     int total_length = 0;
@@ -4184,10 +4185,16 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
     }
 
     /* Validate total length */
-    if (total_length > (int)(sz - idx)) {
+    if (total_length != (int)(sz - idx)) {
         WOLFSSL_MSG("\tCertPolicy length mismatch");
         return ASN_PARSE_E;
     }
+
+    if (total_length == 0) {
+        WOLFSSL_MSG("\tCertPolicy empty sequence");
+        return ASN_PARSE_E;
+    }
+    seqEnd = idx + (word32)total_length;
 
     /* Unwrap certificatePolicies */
     do {
@@ -4254,7 +4261,8 @@ static int DecodeCertPolicy(const byte* input, word32 sz, DecodedCert* cert)
     #endif
         }
         idx += (word32)policy_length;
-    } while((int)idx < total_length
+    /* Stop at the end of the certificatePolicies SEQUENCE. */
+    } while(idx < seqEnd
     #ifdef WOLFSSL_CERT_EXT
         && cert->extCertPoliciesNb < MAX_CERTPOL_NB
     #endif


### PR DESCRIPTION
# Description

Two simple and small fixes on how certificatePolicies are handled:
1. reject empty certificatePolicies (since they are outside the boundary of 1 to MAX as defined from the RFC);
2. reject trailing bytes after the last PolicyInformation in certificatePolicies rather than skipped;

And a minor edit updating the whitebox notes to match with these changes.

# Testing

Added two regression tests, one for each test.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation