### PR TITLE
Guard wolfSSL_CTX_set_alpn_protos with HAVE_ALPN

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9041,6 +9041,13 @@ then
     ENABLED_ALPN=yes
 fi
 
+# Mosquitto calls SSL_CTX_set_alpn_protos() unconditionally for its
+# bridge_alpn option, so the OpenSSL-compat ALPN surface has to be present.
+if test "x$ENABLED_MOSQUITTO" = "xyes"
+then
+    ENABLED_ALPN=yes
+fi
+
 if test "x$ENABLED_ALPN" = "xyes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_ALPN"

--- a/src/ssl_api_ext.c
+++ b/src/ssl_api_ext.c
@@ -2659,6 +2659,9 @@ int wolfSSL_set1_curves_list(WOLFSSL* ssl, const char* names)
 
 #ifdef OPENSSL_EXTRA
 
+#ifdef HAVE_ALPN
+#ifndef NO_BIO
+
 /* Set the ALPN protocol list, in wire format, on the context.
  *
  * @param [in] ctx    SSL/TLS context object.
@@ -2712,8 +2715,6 @@ int wolfSSL_CTX_set_alpn_protos(WOLFSSL_CTX *ctx, const unsigned char *p,
 }
 
 
-#ifdef HAVE_ALPN
-#ifndef NO_BIO
 /* Convert a wire-format ALPN protocol list into a comma-separated string.
  *
  * The wire format is a sequence of entries, each a length byte followed by

--- a/tests/api.c
+++ b/tests/api.c
@@ -18078,12 +18078,14 @@ static int test_wolfSSL_set_options(void)
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     char appData[] = "extra msg";
 #endif
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ALPN) && !defined(NO_BIO)
     unsigned char protos[] = {
         7, 't', 'l', 's', '/', '1', '.', '2',
         8, 'h', 't', 't', 'p', '/', '1', '.', '1'
     };
     unsigned int len = sizeof(protos);
+#endif
+#ifdef OPENSSL_EXTRA
     void *arg = (void *)TEST_ARG;
 #endif
 
@@ -18168,10 +18170,12 @@ static int test_wolfSSL_set_options(void)
 #ifdef OPENSSL_EXTRA
     ExpectTrue(wolfSSL_set_msg_callback(ssl, msg_cb) == WOLFSSL_SUCCESS);
     wolfSSL_set_msg_callback_arg(ssl, arg);
+#if defined(HAVE_ALPN) && !defined(NO_BIO)
 #ifdef WOLFSSL_ERROR_CODE_OPENSSL
     ExpectTrue(wolfSSL_CTX_set_alpn_protos(ctx, protos, len) == 0);
 #else
     ExpectTrue(wolfSSL_CTX_set_alpn_protos(ctx, protos, len) == WOLFSSL_SUCCESS);
+#endif
 #endif
 #endif
 

--- a/tests/api/test_ssl_ext.c
+++ b/tests/api/test_ssl_ext.c
@@ -947,7 +947,8 @@ int test_wolfSSL_CTX_set_servername_arg_inval_ext(void)
 int test_wolfSSL_CTX_set_alpn_protos_inval_ext(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_EXTRA) && !defined(NO_WOLFSSL_CLIENT) && !defined(NO_TLS)
+#if defined(OPENSSL_EXTRA) && !defined(NO_WOLFSSL_CLIENT) && !defined(NO_TLS) \
+    && defined(HAVE_ALPN) && !defined(NO_BIO)
     WOLFSSL_CTX* ctx = NULL;
     const unsigned char protos[] = { 2, 'h', '2' };
 #if defined(WOLFSSL_ERROR_CODE_OPENSSL)

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -6008,10 +6008,12 @@ WOLFSSL_API int wolfSSL_CTX_set_msg_callback_arg(WOLFSSL_CTX *ctx, void* arg);
 WOLFSSL_API int wolfSSL_set_msg_callback_arg(WOLFSSL *ssl, void* arg);
 WOLFSSL_API unsigned long wolfSSL_ERR_peek_error_line_data(const char **file,
     int *line, const char **data, int *flags);
+#if defined(HAVE_ALPN) && !defined(NO_BIO)
 WOLFSSL_API int wolfSSL_CTX_set_alpn_protos(WOLFSSL_CTX *ctx,
     const unsigned char *protos, unsigned int protos_len);
 WOLFSSL_API int wolfSSL_set_alpn_protos(WOLFSSL* ssl,
         const unsigned char* protos, unsigned int protos_len);
+#endif /* HAVE_ALPN && !NO_BIO */
 WOLFSSL_API void *wolfSSL_OPENSSL_memdup(const void *data,
     size_t siz, const char* file, int line);
 WOLFSSL_API void wolfSSL_OPENSSL_cleanse(void *ptr, size_t len);


### PR DESCRIPTION
# Description

This was found while investigating F-10717.

This does not change the default build options which is the main thing that F-10717 is identifying. Rather, a secondary finding related was that the `wolfSSL_CTX_set_alpn_protos` function was not guarded by `HAVE_ALPN`. I moved the guard in `ssl_api_ext.c` up so that `wolfSSL_CTX_set_alpn_protos` is guarded the same as `wolfSSL_set_alpn_protos` below it.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
