### PR TITLE
Fix: Out of date comment

### DIFF
--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -6319,8 +6319,11 @@ WOLFSSL_API int wolfSSL_CTX_AllowEncryptThenMac(WOLFSSL_CTX* ctx, int set);
 WOLFSSL_API int wolfSSL_AllowEncryptThenMac(WOLFSSL *s, int set);
 #endif
 
-/* This feature is used to set a fixed ephemeral key and is for testing only */
-/* Currently allows ECDHE and DHE only */
+/* This feature is used to set a fixed ephemeral key and is for testing only.
+ * Reusing a key share across connections is incorrect behavior
+ * and is forbidden by RFC 9846 Section 1.2 so do not enable this in
+ * production. */
+/* Currently allows DHE, ECDHE, X25519 and X448 only */
 #ifdef WOLFSSL_STATIC_EPHEMERAL
 WOLFSSL_API int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo,
     const char* key, unsigned int keySz, int format);


### PR DESCRIPTION
Strengthen wording of 'test only' comment and cite relevant RFC along with correcting 'Currently allows' comment to represent current behavior.

Found while closing https://fenrir.wolfssl.com/finding/10723 as won't fix.