### PR TITLE
Return error code from atmel_get_random_number for unknown targets

### DIFF
--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -301,6 +301,9 @@ int atmel_get_random_number(uint32_t count, uint8_t* rand_out)
 #endif
 #else
     /* TODO: Use on-board TRNG */
+    (void)count;
+    (void)rand_out;
+    ret = NOT_COMPILED_IN;
 #endif
     return ret;
 }


### PR DESCRIPTION
# Description

Return error code from atmel_get_random_number for unknown targets

Fixes F-11237

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
