### PR TITLE
Fix: TLS 1.3 receiver must ignore legacy_record_version

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -13308,13 +13308,9 @@ static int GetDtlsRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
 static int GetRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
                            RecordLayerHeader* rh, word16 *size)
 {
-    byte tls12minor = 0;
-
 #ifdef OPENSSL_ALL
     word32 start = *inOutIdx;
 #endif
-
-    (void)tls12minor;
 
     if (!ssl->options.dtls) {
 #ifdef HAVE_FUZZER
@@ -13358,23 +13354,13 @@ static int GetRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
     }
 #endif
 
-#if defined(WOLFSSL_DTLS13) || defined(WOLFSSL_TLS13)
-    tls12minor = TLSv1_2_MINOR;
-#endif
-#ifdef WOLFSSL_DTLS13
-    if (ssl->options.dtls)
-        tls12minor = DTLSv1_2_MINOR;
-#endif /* WOLFSSL_DTLS13 */
-    /* catch version mismatch */
-#ifndef WOLFSSL_TLS13
-    if (rh->pvMajor != ssl->version.major || rh->pvMinor != ssl->version.minor)
-#else
-    if (rh->pvMajor != ssl->version.major ||
-        (rh->pvMinor != ssl->version.minor &&
-         (!IsAtLeastTLSv1_3(ssl->version) || rh->pvMinor != tls12minor)
-        ))
-#endif
-    {
+    /* Catch version mismatch.
+     * The record layer version is deprecated in (D)TLS 1.3: RFC 8446
+     * Section 5.1 and RFC 9147 Section 4 both state that
+     * legacy_record_version "MUST be ignored for all purposes". */
+    if (!IsAtLeastTLSv1_3(ssl->version) &&
+        (rh->pvMajor != ssl->version.major ||
+         rh->pvMinor != ssl->version.minor)) {
         if (ssl->options.side == WOLFSSL_SERVER_END &&
             ssl->options.acceptState < ACCEPT_FIRST_REPLY_DONE)
 
@@ -13386,15 +13372,17 @@ static int GetRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
         else if (ssl->options.dtls && rh->type == handshake)
             /* Check the DTLS handshake message RH version later. */
             WOLFSSL_MSG("DTLS handshake, skip RH version number check");
-#ifdef WOLFSSL_DTLS13
-        else if (ssl->options.dtls && !ssl->options.handShakeDone) {
-            /* we may have lost the ServerHello and this is a unified record
-               before version been negotiated */
-            if (Dtls13IsUnifiedHeader(*ssl->buffers.inputBuffer.buffer)) {
-                return SEQUENCE_ERROR;
-            }
-        }
-#endif /* WOLFSSL_DTLS13 */
+#ifdef WOLFSSL_DTLS
+        /* A DTLS peer that disagrees on the version stamps its alert record
+         * with its own version, so a mismatch here is expected. Accept it
+         * while the handshake is still in progress so that the alert gets
+         * processed and its reason reported to the application instead of
+         * being replaced by a version error. */
+        else if (ssl->options.dtls && rh->type == alert &&
+                 !ssl->options.handShakeDone &&
+                 rh->pvMajor == ssl->version.major)
+            WOLFSSL_MSG("DTLS alert during handshake, skip RH version check");
+#endif
         /* Don't care about protocol version being lower than expected on alerts
          * sent back before version negotiation. */
         else if (!(ssl->options.side == WOLFSSL_CLIENT_END &&
@@ -13505,10 +13493,12 @@ int GetDtlsHandShakeHeader(WOLFSSL* ssl, const byte* input,
     idx += DTLS_HANDSHAKE_FRAG_SZ;
     c24to32(input + idx, fragSz);
 
-    if ((ssl->curRL.pvMajor != ssl->version.major) ||
-        (!IsAtLeastTLSv1_3(ssl->version) && ssl->curRL.pvMinor != ssl->version.minor) ||
-        (IsAtLeastTLSv1_3(ssl->version) && ssl->curRL.pvMinor != DTLSv1_2_MINOR)
-        ) {
+    /* The record header version check deferred by GetRecordHeader(). As above,
+     * DTLS 1.3 requires legacy_record_version to be ignored for all purposes
+     * (RFC 9147 Section 4), so only DTLS 1.2 and earlier check it here. */
+    if (!IsAtLeastTLSv1_3(ssl->version) &&
+        ((ssl->curRL.pvMajor != ssl->version.major) ||
+         (ssl->curRL.pvMinor != ssl->version.minor))) {
         if (*type != client_hello && *type != hello_verify_request && *type != server_hello) {
             WOLFSSL_ERROR(VERSION_ERROR);
             return VERSION_ERROR;

--- a/tests/api/test_dtls.c
+++ b/tests/api/test_dtls.c
@@ -5274,8 +5274,10 @@ int test_WOLFSSL_dtls_version_alert(void)
     WOLFSSL_CTX *ctx_s = NULL;
     WOLFSSL *ssl_c = NULL;
     WOLFSSL *ssl_s = NULL;
+    WOLFSSL_ALERT_HISTORY h;
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    XMEMSET(&h, 0, sizeof(h));
 
     ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
         wolfDTLSv1_2_client_method, wolfDTLSv1_server_method), 0);
@@ -5295,9 +5297,15 @@ int test_WOLFSSL_dtls_version_alert(void)
     /* should fail */
     ExpectTrue((wolfSSL_connect(ssl_c) == WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)) &&
         (ssl_c->error == WC_NO_ERR_TRACE(VERSION_ERROR)));
-    /* shuould fail */
+    /* Should fail. The client sends a protocol_version alert in a record
+     * stamped with its own (DTLS 1.2) version. The server must still process
+     * that alert rather than reject the record on its version, so that the
+     * peer's alert reason reaches the application. */
     ExpectTrue((wolfSSL_accept(ssl_s) == WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)) &&
-        (ssl_s->error == WC_NO_ERR_TRACE(VERSION_ERROR) || ssl_s->error == WC_NO_ERR_TRACE(FATAL_ERROR)));
+        (ssl_s->error == WC_NO_ERR_TRACE(FATAL_ERROR)));
+    ExpectIntEQ(wolfSSL_get_alert_history(ssl_s, &h), WOLFSSL_SUCCESS);
+    ExpectIntEQ(h.last_rx.code, wolfssl_alert_protocol_version);
+    ExpectIntEQ(h.last_rx.level, alert_fatal);
 
     wolfSSL_free(ssl_c);
     wolfSSL_free(ssl_s);

--- a/tests/api/test_dtls13.c
+++ b/tests/api/test_dtls13.c
@@ -2486,3 +2486,105 @@ int test_dtls13_reset_clears_alert_history(void)
 #endif
     return EXPECT_RESULT();
 }
+
+/* RFC 9147 Section 4: a DTLS 1.3 receiver MUST ignore legacy_record_version
+ * "for all purposes".  Garble those two bytes in the first unencrypted record
+ * of the server's first flight (the HelloRetryRequest produced by the DTLS 1.3
+ * stateless cookie exchange; the record header is not covered by the transcript
+ * hash) and the handshake must still complete.  For DTLS 1.2 the record layer
+ * version is still meaningful, so the same tampering must be rejected. */
+int test_dtls13_ignore_legacy_record_version(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_DTLS13) && defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES)
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL;
+    WOLFSSL *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfDTLSv1_3_client_method, wolfDTLSv1_3_server_method), 0);
+
+    /* Run the ClientHello, then the server's first flight. */
+    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+    ExpectIntNE(wolfSSL_accept(ssl_s), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+
+    /* Bytes 1 and 2 of the record header are legacy_record_version. */
+    ExpectIntGT(test_ctx.c_len, DTLS_RECORD_HEADER_SZ);
+    if (EXPECT_SUCCESS()) {
+        test_ctx.c_buff[1] = 0xEE;
+        test_ctx.c_buff[2] = 0xEE;
+    }
+
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+
+    wolfSSL_free(ssl_c);
+    ssl_c = NULL;
+    wolfSSL_free(ssl_s);
+    ssl_s = NULL;
+    wolfSSL_CTX_free(ctx_c);
+    ctx_c = NULL;
+    wolfSSL_CTX_free(ctx_s);
+    ctx_s = NULL;
+
+#ifndef WOLFSSL_NO_TLS12
+    /* Same tampering under TLS 1.2 must still be caught. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfDTLSv1_2_client_method, wolfDTLSv1_2_server_method), 0);
+
+    /* The record layer version of ClientHello, HelloVerifyRequest and
+     * ServerHello is deliberately not checked: the version is not negotiated
+     * yet when they are exchanged. Run the cookie exchange first, then tamper
+     * with the record that follows the ServerHello. */
+    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS); /* ClientHello */
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+    ExpectIntNE(wolfSSL_accept(ssl_s), WOLFSSL_SUCCESS); /* HelloVerifyRequest */
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS); /* ClientHello+cookie */
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+    ExpectIntNE(wolfSSL_accept(ssl_s), WOLFSSL_SUCCESS); /* server flight */
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+
+    /* Skip over the ServerHello record and garble the next record's version. */
+    ExpectIntGT(test_ctx.c_len, DTLS_RECORD_HEADER_SZ);
+    ExpectIntEQ(test_ctx.c_buff[0], handshake);
+    ExpectIntEQ(test_ctx.c_buff[DTLS_RECORD_HEADER_SZ], server_hello);
+    if (EXPECT_SUCCESS()) {
+        int idx = DTLS_RECORD_HEADER_SZ +
+            ((int)test_ctx.c_buff[DTLS_RECORD_HEADER_SZ - 2] << 8) +
+            (int)test_ctx.c_buff[DTLS_RECORD_HEADER_SZ - 1];
+
+        ExpectIntGT(test_ctx.c_len, idx + DTLS_RECORD_HEADER_SZ);
+        ExpectIntEQ(test_ctx.c_buff[idx], handshake);
+        if (EXPECT_SUCCESS()) {
+            test_ctx.c_buff[idx + 1] = 0xEE;
+            test_ctx.c_buff[idx + 2] = 0xEE;
+        }
+    }
+
+    /* GetDtlsHandShakeHeader() detects the version mismatch (VERSION_ERROR),
+     * but DoDtlsHandShakeMsg() reports any header parsing failure to the
+     * caller as PARSE_ERROR. */
+    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WC_NO_ERR_TRACE(PARSE_ERROR));
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+#endif
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_dtls13.h
+++ b/tests/api/test_dtls13.h
@@ -61,6 +61,7 @@ int test_dtls13_epoch_slot_reuse_replay(void);
 int test_dtls13_epoch_slot_reuse_decrypt_epoch(void);
 int test_dtls13_plaintext_ack_after_handshake(void);
 int test_dtls13_reset_clears_alert_history(void);
+int test_dtls13_ignore_legacy_record_version(void);
 
 #define TEST_DTLS13_DECLS                                                      \
     TEST_DECL_GROUP("dtls13", test_dtls13_bad_epoch_ch),                       \
@@ -91,7 +92,8 @@ int test_dtls13_reset_clears_alert_history(void);
     TEST_DECL_GROUP("dtls13", test_dtls13_reuse_after_clear),                  \
     TEST_DECL_GROUP("dtls13", test_dtls13_epoch_slot_reuse_replay),            \
     TEST_DECL_GROUP("dtls13", test_dtls13_epoch_slot_reuse_decrypt_epoch),     \
-    TEST_DECL_GROUP("dtls13", test_dtls13_plaintext_ack_after_handshake), \
-    TEST_DECL_GROUP("dtls13", test_dtls13_reset_clears_alert_history)
+    TEST_DECL_GROUP("dtls13", test_dtls13_plaintext_ack_after_handshake),      \
+    TEST_DECL_GROUP("dtls13", test_dtls13_reset_clears_alert_history),         \
+    TEST_DECL_GROUP("dtls13", test_dtls13_ignore_legacy_record_version)        \
 
 #endif /* TESTS_API_DTLS13_H */

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -11036,3 +11036,81 @@ int test_tls13_x25519_keyshare_masks_reserved_bit(void)
 #endif
     return EXPECT_RESULT();
 }
+
+/* RFC 8446 Section 5.1: a TLS 1.3 receiver MUST ignore legacy_record_version
+ * "for all purposes".  Garble those two bytes in the server's first flight
+ * (the unencrypted ServerHello record, which is not covered by the transcript
+ * hash) and the handshake must still complete.  For TLS 1.2 the record layer
+ * version is still meaningful, so the same tampering must be rejected. */
+int test_tls13_ignore_legacy_record_version(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES)
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL;
+    WOLFSSL *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+
+    /* Run the ClientHello, then the server's first flight. */
+    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+    ExpectIntNE(wolfSSL_accept(ssl_s), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+
+    /* Bytes 1 and 2 of the record header are legacy_record_version. */
+    ExpectIntGT(test_ctx.c_len, RECORD_HEADER_SZ);
+    if (EXPECT_SUCCESS()) {
+        test_ctx.c_buff[1] = 0xEE;
+        test_ctx.c_buff[2] = 0xEE;
+    }
+
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+
+    wolfSSL_free(ssl_c);
+    ssl_c = NULL;
+    wolfSSL_free(ssl_s);
+    ssl_s = NULL;
+    wolfSSL_CTX_free(ctx_c);
+    ctx_c = NULL;
+    wolfSSL_CTX_free(ctx_s);
+    ctx_s = NULL;
+
+#ifndef WOLFSSL_NO_TLS12
+    /* Same tampering under TLS 1.2 must still be caught. */
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_2_client_method, wolfTLSv1_2_server_method), 0);
+
+    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+    ExpectIntNE(wolfSSL_accept(ssl_s), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+
+    /* Bytes 1 and 2 of the record header are legacy_record_version. */
+    ExpectIntGT(test_ctx.c_len, RECORD_HEADER_SZ);
+    if (EXPECT_SUCCESS()) {
+        test_ctx.c_buff[1] = 0xEE;
+        test_ctx.c_buff[2] = 0xEE;
+    }
+
+    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WC_NO_ERR_TRACE(VERSION_ERROR));
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif /* !WOLFSSL_NO_TLS12 */
+#endif /* WOLFSSL_TLS13 && HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES */
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -129,6 +129,7 @@ int test_tls12_fatal_alert_closes_and_evicts(void);
 int test_tls13_pqc_hybrid_async_server(void);
 int test_tls13_pha_status_request(void);
 int test_tls13_x25519_keyshare_masks_reserved_bit(void);
+int test_tls13_ignore_legacy_record_version(void);
 
 #define TEST_TLS13_DECLS                                        \
     TEST_DECL_GROUP("tls13", test_tls13_apis),                  \
@@ -235,6 +236,8 @@ int test_tls13_x25519_keyshare_masks_reserved_bit(void);
     TEST_DECL_GROUP("tls13", test_tls12_fatal_alert_closes_and_evicts), \
     TEST_DECL_GROUP("tls13", test_tls13_pqc_hybrid_async_server), \
     TEST_DECL_GROUP("tls13", test_tls13_pha_status_request), \
-    TEST_DECL_GROUP("tls13", test_tls13_x25519_keyshare_masks_reserved_bit)
+    TEST_DECL_GROUP("tls13", test_tls13_x25519_keyshare_masks_reserved_bit), \
+    TEST_DECL_GROUP("tls13", test_tls13_pha_status_request), \
+    TEST_DECL_GROUP("tls13", test_tls13_ignore_legacy_record_version) \
 
 #endif /* WOLFCRYPT_TEST_TLS13_H */


### PR DESCRIPTION
# Description

If the receiver is TLS 1.3 capable it should not have the ability to read the legacy record version. This PR changes the guard on the logic that reads the legacy record version to not fire if the receiver is D/TLS 1.3 capable.

Fenrir finding: [10723](https://fenrir.wolfssl.com/finding/10723)

# Testing

Asserted that a malformed legacy record version does not impact D/TLS 1.3 capable receivers and that is does impact D/TLS 1.2 and below receivers. 

# Checklist

 - [x] added tests
