### PR TITLE
Reject TLS 1.3 ClientHello when no shared supported group exists

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -38432,6 +38432,7 @@ const byte* MaskCurve25519PeerKey(const byte* pub, word32 pubSz,
             case WC_NO_ERR_TRACE(INCOMPLETE_DATA):
                 return missing_extension;
             case WC_NO_ERR_TRACE(MATCH_SUITE_ERROR):
+            case WC_NO_ERR_TRACE(KEY_SHARE_ERROR):
             case WC_NO_ERR_TRACE(MISSING_HANDSHAKE_DATA):
             case WC_NO_ERR_TRACE(PSK_MISSING_ERROR):
                 return handshake_failure;

--- a/src/tls.c
+++ b/src/tls.c
@@ -11817,27 +11817,13 @@ int TLSX_KeyShare_SetSupported(const WOLFSSL* ssl, TLSX** extensions)
     curve = preferredCurve;
 
     if (curve == NULL) {
-        byte i;
-        /* Fallback to user selected group */
-        preferredRank = WOLFSSL_MAX_GROUP_COUNT;
-        for (i = 0; i < ssl->numGroups; i++) {
-            rank = TLSX_KeyShare_GroupRank(ssl, ssl->group[i]);
-            if (rank == -1)
-                continue;
-            if (rank < preferredRank) {
-                name = ssl->group[i];
-                preferredRank = rank;
-            }
-        }
-        if (name == WOLFSSL_NAMED_GROUP_INVALID) {
-            /* No group selected or specified by the server */
-            WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
-            return BAD_KEY_SHARE_DATA;
-        }
+        /* No mutual group exists. An HRR may request only a group the
+         * client advertised in supported_groups, so it cannot recover.
+         * RFC 8446 4.2.1. */
+        WOLFSSL_ERROR_VERBOSE(KEY_SHARE_ERROR);
+        return KEY_SHARE_ERROR;
     }
-    else {
-        name = curve->name;
-    }
+    name = curve->name;
 
     #ifdef WOLFSSL_ASYNC_CRYPT
     /* Check the old key share data list. */
@@ -12224,9 +12210,12 @@ int TLSX_KeyShare_Establish(WOLFSSL *ssl, int* doHelloRetry)
 
     /* No supported group found - send HelloRetryRequest. */
     if (clientKSE == NULL) {
-        /* Set KEY_SHARE_ERROR to indicate HelloRetryRequest required. */
-        *doHelloRetry = 1;
-        return TLSX_KeyShare_SetSupported(ssl, &ssl->extensions);
+        /* HRR is only valid if it requests a group the client advertised.
+         * SetSupported fails when no mutual group exists. */
+        ret = TLSX_KeyShare_SetSupported(ssl, &ssl->extensions);
+        if (ret == 0)
+            *doHelloRetry = 1;
+        return ret;
     }
 
     return TLSX_KeyShare_Setup(ssl, clientKSE);

--- a/src/tls.c
+++ b/src/tls.c
@@ -11780,8 +11780,8 @@ static int TLSX_KeyShare_GroupRank(const WOLFSSL* ssl, int group)
 /* Set a key share that is supported by the client into extensions.
  *
  * ssl  The SSL/TLS object.
- * returns BAD_KEY_SHARE_DATA if no supported group has a key share,
- * 0 if a supported group has a key share and other values indicate an error.
+ * returns 0 if a mutual group was found, KEY_SHARE_ERROR if no mutual
+ * group exists and other values indicate an error.
  */
 int TLSX_KeyShare_SetSupported(const WOLFSSL* ssl, TLSX** extensions)
 {

--- a/tests/api.c
+++ b/tests/api.c
@@ -18895,9 +18895,11 @@ static int test_wolfSSL_curves_mismatch(void)
     } test_params[] = {
 #ifdef WOLFSSL_TLS13
         {wolfTLSv1_3_client_method, wolfTLSv1_3_server_method, "TLS 1.3",
-                /* Client gets error because server will attempt HRR */
-                WC_NO_ERR_TRACE(BAD_KEY_SHARE_DATA),
-                WC_NO_ERR_TRACE(FATAL_ERROR)
+                /* No shared group: server rejects the ClientHello with a
+                 * fatal handshake_failure alert (RFC 8446 4.2.1) instead of
+                 * a HelloRetryRequest. */
+                WC_NO_ERR_TRACE(FATAL_ERROR),
+                WC_NO_ERR_TRACE(KEY_SHARE_ERROR)
         },
 #endif
 #ifndef WOLFSSL_NO_TLS12

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -6422,6 +6422,7 @@ int test_key_share_mismatch(void)
     WOLFSSL_ALERT_HISTORY h;
     int client_group[] = {WOLFSSL_ECC_SECP521R1};
     int server_group[] = {WOLFSSL_ECC_SECP384R1, WOLFSSL_ECC_SECP256R1};
+    int ret;
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
     ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
@@ -6434,8 +6435,10 @@ int test_key_share_mismatch(void)
     /* No mutual group: server sends a fatal handshake_failure alert instead
      * of an HRR for a group the client never advertised (RFC 8446 4.2.1).
      * The client reads the alert on the next connect. */
-    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WC_NO_ERR_TRACE(FATAL_ERROR));
+    ret = wolfSSL_connect(ssl_c);
+    ExpectIntNE(ret, WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, ret), WC_NO_ERR_TRACE(FATAL_ERROR));
+    XMEMSET(&h, 0, sizeof(h));
     ExpectIntEQ(wolfSSL_get_alert_history(ssl_c, &h), WOLFSSL_SUCCESS);
     ExpectIntEQ(h.last_rx.code, handshake_failure);
     ExpectIntEQ(h.last_rx.level, alert_fatal);
@@ -6480,6 +6483,7 @@ int test_key_share_mismatch_psk_dhe(void)
     WOLFSSL_ALERT_HISTORY h;
     int client_group[] = {WOLFSSL_ECC_SECP521R1};
     int server_group[] = {WOLFSSL_ECC_SECP384R1, WOLFSSL_ECC_SECP256R1};
+    int ret;
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
     ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
@@ -6494,8 +6498,10 @@ int test_key_share_mismatch_psk_dhe(void)
     /* PSK-DHE needs a key share, and no group overlaps, so the server sends
      * a fatal handshake_failure alert (RFC 8446 4.2.1). The client reads the
      * alert on the next connect. */
-    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
-    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WC_NO_ERR_TRACE(FATAL_ERROR));
+    ret = wolfSSL_connect(ssl_c);
+    ExpectIntNE(ret, WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, ret), WC_NO_ERR_TRACE(FATAL_ERROR));
+    XMEMSET(&h, 0, sizeof(h));
     ExpectIntEQ(wolfSSL_get_alert_history(ssl_c, &h), WOLFSSL_SUCCESS);
     ExpectIntEQ(h.last_rx.code, handshake_failure);
     ExpectIntEQ(h.last_rx.level, alert_fatal);

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -6419,6 +6419,7 @@ int test_key_share_mismatch(void)
     WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
     WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
     struct test_memio_ctx test_ctx;
+    WOLFSSL_ALERT_HISTORY h;
     int client_group[] = {WOLFSSL_ECC_SECP521R1};
     int server_group[] = {WOLFSSL_ECC_SECP384R1, WOLFSSL_ECC_SECP256R1};
 
@@ -6430,7 +6431,14 @@ int test_key_share_mismatch(void)
     ExpectIntEQ(wolfSSL_set_groups(ssl_s,
             server_group, XELEM_CNT(server_group)), WOLFSSL_SUCCESS);
     ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), -1);
-    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), BAD_KEY_SHARE_DATA);
+    /* No mutual group: server sends a fatal handshake_failure alert instead
+     * of an HRR for a group the client never advertised (RFC 8446 4.2.1).
+     * The client reads the alert on the next connect. */
+    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WC_NO_ERR_TRACE(FATAL_ERROR));
+    ExpectIntEQ(wolfSSL_get_alert_history(ssl_c, &h), WOLFSSL_SUCCESS);
+    ExpectIntEQ(h.last_rx.code, handshake_failure);
+    ExpectIntEQ(h.last_rx.level, alert_fatal);
 
     wolfSSL_free(ssl_s);
     ssl_s = NULL;

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -6476,7 +6476,9 @@ int test_key_share_mismatch_psk_dhe(void)
 #if defined(WOLFSSL_TLS13) && !defined(NO_PSK) && \
     defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
     defined(HAVE_SUPPORTED_CURVES) && defined(HAVE_ECC) && \
-    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    (!defined(WOLFSSL_SP_MATH) || (defined(WOLFSSL_SP_521) && \
+     !defined(WOLFSSL_SP_NO_256) && defined(WOLFSSL_SP_384)))
     WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
     WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
     struct test_memio_ctx test_ctx;

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -6464,6 +6464,50 @@ int test_key_share_mismatch(void)
     return EXPECT_RESULT();
 }
 
+/* PSK-DHE variant of test_key_share_mismatch: the certificate handshake above
+ * fails in MatchSuite before reaching TLSX_KeyShare_Establish, which only the
+ * PSK-DHE path (usingPSK == 2) drives. */
+int test_key_share_mismatch_psk_dhe(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && !defined(NO_PSK) && \
+    defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(HAVE_SUPPORTED_CURVES) && defined(HAVE_ECC) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+    WOLFSSL_ALERT_HISTORY h;
+    int client_group[] = {WOLFSSL_ECC_SECP521R1};
+    int server_group[] = {WOLFSSL_ECC_SECP384R1, WOLFSSL_ECC_SECP256R1};
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+                    wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+    wolfSSL_set_psk_client_callback(ssl_c, test_tls13_fnp_client_cb);
+    wolfSSL_set_psk_server_callback(ssl_s, test_tls13_fnp_server_cb);
+    ExpectIntEQ(wolfSSL_set_groups(ssl_c,
+                    client_group, XELEM_CNT(client_group)), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_set_groups(ssl_s,
+                    server_group, XELEM_CNT(server_group)), WOLFSSL_SUCCESS);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), -1);
+    /* PSK-DHE needs a key share, and no group overlaps, so the server sends
+     * a fatal handshake_failure alert (RFC 8446 4.2.1). The client reads the
+     * alert on the next connect. */
+    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WC_NO_ERR_TRACE(FATAL_ERROR));
+    ExpectIntEQ(wolfSSL_get_alert_history(ssl_c, &h), WOLFSSL_SUCCESS);
+    ExpectIntEQ(h.last_rx.code, handshake_failure);
+    ExpectIntEQ(h.last_rx.level, alert_fatal);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, -1), WC_NO_ERR_TRACE(KEY_SHARE_ERROR));
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}
 
 #if defined(WOLFSSL_TLS13) && !defined(NO_RSA) && defined(HAVE_ECC) && \
     defined(HAVE_AESGCM) && !defined(NO_WOLFSSL_SERVER) && \

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -45,6 +45,7 @@ int test_tls13_ks_missing(void);
 int test_tls13_duplicate_extension(void);
 int test_tls13_duplicate_ech_extension(void);
 int test_key_share_mismatch(void);
+int test_key_share_mismatch_psk_dhe(void);
 int test_tls13_middlebox_compat_empty_session_id(void);
 int test_tls13_middlebox_compat_session_id(void);
 int test_tls13_plaintext_alert(void);
@@ -143,6 +144,7 @@ int test_tls13_x25519_keyshare_masks_reserved_bit(void);
     TEST_DECL_GROUP("tls13", test_tls13_duplicate_extension),   \
     TEST_DECL_GROUP("tls13", test_tls13_duplicate_ech_extension), \
     TEST_DECL_GROUP("tls13", test_key_share_mismatch),          \
+    TEST_DECL_GROUP("tls13", test_key_share_mismatch_psk_dhe),  \
     TEST_DECL_GROUP("tls13", test_tls13_middlebox_compat_empty_session_id), \
     TEST_DECL_GROUP("tls13", test_tls13_middlebox_compat_session_id), \
     TEST_DECL_GROUP("tls13", test_tls13_plaintext_alert),       \

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -2019,10 +2019,14 @@ static int test_quic_key_share(int verbose) {
 
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_fail(&conv);
+    /* No shared group: the server rejects the ClientHello with a fatal
+     * handshake_failure alert instead of a HelloRetryRequest (RFC 8446
+     * 4.2.1). The alert is only recorded by the QUIC transport here, so
+     * the client is still waiting. */
     ExpectIntEQ(wolfSSL_get_error(tserver.ssl, 0),
-                WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ));
+                WC_NO_ERR_TRACE(KEY_SHARE_ERROR));
     ExpectIntEQ(wolfSSL_get_error(tclient.ssl, 0),
-                WC_NO_ERR_TRACE(BAD_KEY_SHARE_DATA));
+                WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ));
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
     printf("    test_quic_key_share: no match ok\n");


### PR DESCRIPTION
Previously, when a client's `supported_groups` had no overlap with the
server's groups, the server would fall back to a server-only group,
causing the handshake to hang until timeout since an HRR may only
request a group the client advertised (RFC 8446 4.2.1).

- `TLSX_KeyShare_SetSupported` now returns `KEY_SHARE_ERROR` instead of
  picking a server-only group when there is no mutual group.
- `TLSX_KeyShare_Establish` only requests HelloRetry when
  `SetSupported` succeeds.
- `TranslateErrorToAlert` maps `KEY_SHARE_ERROR` to `handshake_failure`.
- `test_key_share_mismatch` updated to expect the fatal
  `handshake_failure` alert.