### PR TITLE
Map name/IP mismatches to X509_V_* codes in GetX509Error()

### DIFF
--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -309,6 +309,10 @@ int GetX509Error(int e)
              * accept ASN_NO_SIGNER_E / UNABLE_TO_GET_ISSUER_CERT_LOCALLY do not
              * accidentally accept an unauthenticated RPK. */
             return WOLFSSL_X509_V_ERR_RPK_UNTRUSTED;
+        case WC_NO_ERR_TRACE(DOMAIN_NAME_MISMATCH):
+            return WOLFSSL_X509_V_ERR_HOSTNAME_MISMATCH;
+        case WC_NO_ERR_TRACE(IPADDR_MISMATCH):
+            return WOLFSSL_X509_V_ERR_IP_ADDRESS_MISMATCH;
         case WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E):
             return WOLFSSL_X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT;
         case WC_NO_ERR_TRACE(ASN_PATHLEN_INV_E):


### PR DESCRIPTION
`SetupStoreCtxCallback()` runs the handshake store-ctx error through `GetX509Error()` under `OPENSSL_COMPATIBLE_DEFAULTS`, but that function passed `DOMAIN_NAME_MISMATCH` / `IPADDR_MISMATCH` through unmapped, so `X509_STORE_CTX_get_error()` reported the internal codes for peer name mismatches in that build.

- `src/x509_str.c`: add `DOMAIN_NAME_MISMATCH` / `IPADDR_MISMATCH` cases to `GetX509Error()`, mapping them to `WOLFSSL_X509_V_ERR_HOSTNAME_MISMATCH` / `WOLFSSL_X509_V_ERR_IP_ADDRESS_MISMATCH` to match OpenSSL.
- Default builds keep returning the internal codes, unchanged.