### PR TITLE
nxp hashcrypt: validate AES ECB/CBC args and zero-length

### DIFF
--- a/wolfcrypt/src/port/nxp/README.md
+++ b/wolfcrypt/src/port/nxp/README.md
@@ -22,8 +22,6 @@ wolfSSL supports the following hardware acceleration on the LPC55S69:
 The following caveats should be noted about the LPC55S69 hardware acceleration:
 - AES-CTR mode fails when the counter wraps from all FF's to 0.  User should
 ensure this never happens, by properly managing the iv/counter in use.
-- AES-CFB and AES-OFB only support full 16-byte blocks and multiples thereof.
-Encrypt/Decrypt requests of other sizes will fail.
 - RSA acceleration is only supported for public keys.  Private key operations
 will use a fully software implementation.
 - When the HashCrypt engine is in use for SHA-1 or SHA-256, it must not be

--- a/wolfcrypt/src/port/nxp/hashcrypt_port.c
+++ b/wolfcrypt/src/port/nxp/hashcrypt_port.c
@@ -211,8 +211,15 @@ static int _hashcrypt_set_key(Aes* aes)
 #ifdef HAVE_AES_ECB
 int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-    int ret = _hashcrypt_set_key(aes);
+    int ret;
 
+    if (aes == NULL || out == NULL || in == NULL)
+        return BAD_FUNC_ARG;
+
+    if (sz == 0)
+        return 0;
+
+    ret = _hashcrypt_set_key(aes);
     if (ret)
         return ret;
 
@@ -226,8 +233,15 @@ int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 #ifdef HAVE_AES_DECRYPT
 int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-    int ret = _hashcrypt_set_key(aes);
+    int ret;
 
+    if (aes == NULL || out == NULL || in == NULL)
+        return BAD_FUNC_ARG;
+
+    if (sz == 0)
+        return 0;
+
+    ret = _hashcrypt_set_key(aes);
     if (ret)
         return ret;
 
@@ -243,8 +257,15 @@ int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 #ifdef HAVE_AES_CBC
 int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-    int ret = _hashcrypt_set_key(aes);
+    int ret;
 
+    if (aes == NULL || out == NULL || in == NULL)
+        return BAD_FUNC_ARG;
+
+    if (sz == 0)
+        return 0;
+
+    ret = _hashcrypt_set_key(aes);
     if (ret)
         return ret;
 
@@ -263,6 +284,12 @@ int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     int ret;
     byte tmp_iv[16];
+
+    if (aes == NULL || out == NULL || in == NULL)
+        return BAD_FUNC_ARG;
+
+    if (sz == 0)
+        return 0;
 
     ret = _hashcrypt_set_key(aes);
     if (ret)


### PR DESCRIPTION
Reject NULL aes/in/out with BAD_FUNC_ARG and return early on zero length before key setup and the sz-16 IV copy, matching wc_AesCtrEncrypt.