### PR TITLE
Return MISSING_KEY from wc_SlhDsaKey_Export* when key not present

### DIFF
--- a/doc/dox_comments/header_files-ja/wc_slhdsa.h
+++ b/doc/dox_comments/header_files-ja/wc_slhdsa.h
@@ -689,6 +689,7 @@ int wc_SlhDsaKey_CheckKey(SlhDsaKey* key);
 
     \return 0 成功した場合に返されます。
     \return BAD_FUNC_ARG key、out、outLenのいずれかがNULLの場合に返されます。
+    \return MISSING_KEY 秘密鍵が設定されていない場合に返されます。
     \return BUFFER_E 出力バッファが小さすぎる場合に返されます。
 
     \param [in] key 秘密鍵を保持するSlhDsaKeyへのポインタ。
@@ -718,6 +719,7 @@ int wc_SlhDsaKey_ExportPrivate(SlhDsaKey* key, byte* out,
 
     \return 0 成功した場合に返されます。
     \return BAD_FUNC_ARG key、out、outLenのいずれかがNULLの場合に返されます。
+    \return MISSING_KEY 公開鍵が設定されていない場合に返されます。
     \return BUFFER_E 出力バッファが小さすぎる場合に返されます。
 
     \param [in] key 公開鍵を保持するSlhDsaKeyへのポインタ。

--- a/doc/dox_comments/header_files/wc_slhdsa.h
+++ b/doc/dox_comments/header_files/wc_slhdsa.h
@@ -793,6 +793,7 @@ int wc_SlhDsaKey_CheckKey(SlhDsaKey* key);
 
     \return 0 on success.
     \return BAD_FUNC_ARG if key, out, or outLen is NULL.
+    \return MISSING_KEY if the key object holds no private key.
     \return BUFFER_E if the output buffer is too small.
 
     \param [in] key Pointer to the SlhDsaKey containing a private key.
@@ -824,6 +825,7 @@ int wc_SlhDsaKey_ExportPrivate(SlhDsaKey* key, byte* out,
 
     \return 0 on success.
     \return BAD_FUNC_ARG if key, out, or outLen is NULL.
+    \return MISSING_KEY if the key object holds no public key.
     \return BUFFER_E if the output buffer is too small.
 
     \param [in] key Pointer to the SlhDsaKey containing a public key.

--- a/tests/api/test_slhdsa.c
+++ b/tests/api/test_slhdsa.c
@@ -2834,7 +2834,8 @@ int test_wc_slhdsa_decoder_disabled_oid(void)
  *   - wc_SlhDsaKey_ImportPublic / _ExportPublic (and the private variants):
  *     each operand of the "(key==NULL)||(key->params==NULL)||(ptr==NULL)[||
  *     (lenPtr==NULL)]" OR is driven true alone (a zeroed key gives
- *     key!=NULL with key->params==NULL), plus the length else-if arm.
+ *     key!=NULL with key->params==NULL), plus the no-key MISSING_KEY arm
+ *     and the length else-if arm.
  *   - size getters: key==NULL vs params==NULL independence.
  *   - wc_SlhDsaKey_CheckKey: NULL / params==NULL / MISSING_KEY (no private).
  *   - wc_SlhDsaKey_Init_id / _Init_label compound guards (WOLF_PRIVATE_KEY_ID).
@@ -2877,7 +2878,7 @@ int test_wc_SlhdsaDecisionCoverage(void)
     ExpectIntEQ(wc_SlhDsaKey_ImportPublic(&key, pub, (word32)sizeof(pub) + 1),
         WC_NO_ERR_TRACE(BAD_LENGTH_E));                    /* wrong len   */
 
-    /* wc_SlhDsaKey_ExportPublic: 4-operand OR + length else-if. */
+    /* wc_SlhDsaKey_ExportPublic: 4-operand OR + no-key + length else-if. */
     pubLen = (word32)sizeof(pub);
     ExpectIntEQ(wc_SlhDsaKey_ExportPublic(NULL, pub, &pubLen),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));                    /* key==NULL     */
@@ -2887,6 +2888,10 @@ int test_wc_SlhdsaDecisionCoverage(void)
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));                    /* pub==NULL     */
     ExpectIntEQ(wc_SlhDsaKey_ExportPublic(&key, pub, NULL),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));                    /* pubLen==NULL  */
+    ExpectIntEQ(wc_SlhDsaKey_ExportPublic(&key, pub, &pubLen),
+        WC_NO_ERR_TRACE(MISSING_KEY));                     /* no public key */
+    /* Import (cheap - no key generation) so the length arm is reachable. */
+    ExpectIntEQ(wc_SlhDsaKey_ImportPublic(&key, pub, (word32)sizeof(pub)), 0);
     pubLen = 1;                                            /* too small     */
     ExpectIntEQ(wc_SlhDsaKey_ExportPublic(&key, pub, &pubLen),
         WC_NO_ERR_TRACE(BAD_LENGTH_E));
@@ -2911,7 +2916,13 @@ int test_wc_SlhdsaDecisionCoverage(void)
     ExpectIntEQ(wc_SlhDsaKey_ImportPrivate(&key, priv, (word32)sizeof(priv) + 1),
         WC_NO_ERR_TRACE(BAD_LENGTH_E));
 
-    /* wc_SlhDsaKey_ExportPrivate: 4-operand OR + length else-if. */
+    /* wc_SlhDsaKey_CheckKey: NULL / params==NULL / no-private MISSING_KEY.
+     * Done before importing a private key below. */
+    ExpectIntEQ(wc_SlhDsaKey_CheckKey(NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_SlhDsaKey_CheckKey(&zkey), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_SlhDsaKey_CheckKey(&key), WC_NO_ERR_TRACE(MISSING_KEY));
+
+    /* wc_SlhDsaKey_ExportPrivate: 4-operand OR + no-key + length else-if. */
     privLen = (word32)sizeof(priv);
     ExpectIntEQ(wc_SlhDsaKey_ExportPrivate(NULL, priv, &privLen),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
@@ -2921,14 +2932,14 @@ int test_wc_SlhdsaDecisionCoverage(void)
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_SlhDsaKey_ExportPrivate(&key, priv, NULL),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(wc_SlhDsaKey_ExportPrivate(&key, priv, &privLen),
+        WC_NO_ERR_TRACE(MISSING_KEY));                     /* no private key */
+    /* Import (cheap - no key generation) so the length arm is reachable. */
+    ExpectIntEQ(wc_SlhDsaKey_ImportPrivate(&key, priv, (word32)sizeof(priv)),
+        0);
     privLen = 1;
     ExpectIntEQ(wc_SlhDsaKey_ExportPrivate(&key, priv, &privLen),
         WC_NO_ERR_TRACE(BAD_LENGTH_E));
-
-    /* wc_SlhDsaKey_CheckKey: NULL / params==NULL / no-private MISSING_KEY. */
-    ExpectIntEQ(wc_SlhDsaKey_CheckKey(NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-    ExpectIntEQ(wc_SlhDsaKey_CheckKey(&zkey), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-    ExpectIntEQ(wc_SlhDsaKey_CheckKey(&key), WC_NO_ERR_TRACE(MISSING_KEY));
 
     /* MakeKey / MakeKeyWithRandom / Sign-family: key->params==NULL
      * independence (key==NULL and the other pointer/length operands are

--- a/wolfcrypt/src/wc_slhdsa.c
+++ b/wolfcrypt/src/wc_slhdsa.c
@@ -8804,6 +8804,7 @@ int wc_SlhDsaKey_CheckKey(SlhDsaKey* key)
  *                            On out, length of private key.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when key, key's parameters, priv or privLen is NULL.
+ * @return  MISSING_KEY when no private key is available.
  * @return  BAD_LENGTH_E when privLen is too small for private key.
  */
 int wc_SlhDsaKey_ExportPrivate(SlhDsaKey* key, byte* priv, word32* privLen)
@@ -8814,6 +8815,10 @@ int wc_SlhDsaKey_ExportPrivate(SlhDsaKey* key, byte* priv, word32* privLen)
     if ((key == NULL) || (key->params == NULL) || (priv == NULL) ||
             (privLen == NULL)) {
         ret = BAD_FUNC_ARG;
+    }
+    /* Check we have a private key to export. */
+    else if ((key->flags & WC_SLHDSA_FLAG_PRIVATE) == 0) {
+        ret = MISSING_KEY;
     }
     /* Check private key buffer length. */
     else if (*privLen < key->params->n * 4) {
@@ -8839,6 +8844,7 @@ int wc_SlhDsaKey_ExportPrivate(SlhDsaKey* key, byte* priv, word32* privLen)
  *                           On out, length of public key.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when key, key's parameters, pub or pubLen is NULL.
+ * @return  MISSING_KEY when no public key is available.
  * @return  BAD_LENGTH_E when pubLen is too small for public key.
  */
 int wc_SlhDsaKey_ExportPublic(SlhDsaKey* key, byte* pub, word32* pubLen)
@@ -8849,6 +8855,10 @@ int wc_SlhDsaKey_ExportPublic(SlhDsaKey* key, byte* pub, word32* pubLen)
     if ((key == NULL) || (key->params == NULL) || (pub == NULL) ||
             (pubLen == NULL)) {
         ret = BAD_FUNC_ARG;
+    }
+    /* Check we have a public key to export. */
+    else if ((key->flags & WC_SLHDSA_FLAG_PUBLIC) == 0) {
+        ret = MISSING_KEY;
     }
     /* Check public key buffer length. */
     else if (*pubLen < key->params->n * 2) {
@@ -9505,6 +9515,7 @@ int wc_SlhDsaKey_PublicKeyDecode(const byte* input, word32* inOutIdx,
  *          whose parameter set isn't compiled in. In practice unreachable
  *          because SlhDsaParams[] is itself gated on the build, but the
  *          contract matches wc_SlhDsaOidToParam for forward compatibility.
+ * @return  MISSING_KEY when public key not set.
  */
 int wc_SlhDsaKey_PublicKeyToDer(SlhDsaKey* key, byte* output, word32 inLen,
     int withAlg)


### PR DESCRIPTION
# Description

Return MISSING_KEY from wc_SlhDsaKey_Export* when key not present

Fixes F-8148

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
