### PR TITLE
Fix: Unchecked buffer overrun when adding Cert Directory

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -8640,6 +8640,11 @@ static int x509AddCertDir(WOLFSSL_BY_DIR *ctx, const char *argc, long argl)
             pathLen = 0;
             XMEMSET(buf, 0, MAX_FILENAME_SZ);
         }
+        if (pathLen >= MAX_FILENAME_SZ) {
+            WOLFSSL_MSG("Could not write full dir name not enough space");
+                WC_FREE_VAR_EX(buf, 0, DYNAMIC_TYPE_OPENSSL);
+            return 0;
+        }
         buf[pathLen++] = *c;
 
     } while(*c++ != '\0');

--- a/src/x509.c
+++ b/src/x509.c
@@ -8552,6 +8552,8 @@ WOLFSSL_X509_LOOKUP_METHOD* wolfSSL_X509_LOOKUP_file(void)
 /* @param argl   file type, either WOLFSSL_FILETYPE_PEM or                  */
 /*                                          WOLFSSL_FILETYPE_ASN1           */
 /* @return WOLFSSL_SUCCESS on successful, otherwise negative or zero        */
+/* Note: on failure, path elements parsed before the failing one have       */
+/*       already been added to ctx->dir_entry                               */
 static int x509AddCertDir(WOLFSSL_BY_DIR *ctx, const char *argc, long argl)
 {
 #if defined(OPENSSL_ALL) && !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR)
@@ -8625,7 +8627,7 @@ static int x509AddCertDir(WOLFSSL_BY_DIR *ctx, const char *argc, long argl)
                     return 0;
                 }
 
-                XSTRNCPY(entry->dir_name, buf, pathLen);
+                XMEMCPY(entry->dir_name, buf, pathLen);
                 entry->dir_name[pathLen] = '\0';
 
                 if (wolfSSL_sk_BY_DIR_entry_push(ctx->dir_entry, entry) <= 0) {
@@ -8641,8 +8643,8 @@ static int x509AddCertDir(WOLFSSL_BY_DIR *ctx, const char *argc, long argl)
             XMEMSET(buf, 0, MAX_FILENAME_SZ);
         }
         if (pathLen >= MAX_FILENAME_SZ) {
-            WOLFSSL_MSG("Could not write full dir name not enough space");
-                WC_FREE_VAR_EX(buf, 0, DYNAMIC_TYPE_OPENSSL);
+            WOLFSSL_MSG("dir name too long for internal buffer");
+            WC_FREE_VAR_EX(buf, 0, DYNAMIC_TYPE_OPENSSL);
             return 0;
         }
         buf[pathLen++] = *c;
@@ -8672,6 +8674,8 @@ static int x509AddCertDir(WOLFSSL_BY_DIR *ctx, const char *argc, long argl)
 /* note: WOLFSSL_X509_L_ADD_STORE and WOLFSSL_X509_L_LOAD_STORE have not*/
 /*       yet implemented. It returns WOLFSSL_NOT_IMPLEMENTED            */
 /*       when those control commands are passed.                        */
+/* Note: on failure, path elements parsed before the failing one have   */
+/*       already been added to ctx->dir_entry                           */
 int wolfSSL_X509_LOOKUP_ctrl(WOLFSSL_X509_LOOKUP *ctx, int cmd,
         const char *argc, long argl, char **ret)
 {

--- a/tests/api/test_ossl_x509_lu.c
+++ b/tests/api/test_ossl_x509_lu.c
@@ -294,6 +294,63 @@ int test_wolfSSL_X509_LOOKUP_ctrl_hash_dir(void)
     return EXPECT_RESULT();
 }
 
+/* Check that a path element longer than the internal MAX_FILENAME_SZ buffer is
+ * rejected instead of overflowing it. */
+int test_wolfSSL_X509_LOOKUP_ctrl_dir_len(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_ALL) && !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR)
+    X509_STORE* str = NULL;
+    X509_LOOKUP* lookup = NULL;
+    char* longPath = NULL;
+    char maxPath[MAX_FILENAME_SZ + 1];
+
+    /* one element that does not fit in the buffer - must fail */
+    ExpectNotNull(longPath = (char*)XMALLOC(MAX_FILENAME_SZ + 4, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    if (longPath != NULL) {
+        XMEMSET(longPath, 'a', MAX_FILENAME_SZ + 3);
+        longPath[MAX_FILENAME_SZ + 3] = '\0';
+    }
+
+    ExpectNotNull((str = wolfSSL_X509_STORE_new()));
+    ExpectNotNull(lookup = X509_STORE_add_lookup(str, X509_LOOKUP_file()));
+    ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR, longPath,
+        SSL_FILETYPE_PEM, NULL), 0);
+
+    X509_STORE_free(str);
+    str = NULL;
+
+    /* oversized element preceded by a valid one - still fails */
+    ExpectNotNull((str = wolfSSL_X509_STORE_new()));
+    ExpectNotNull(lookup = X509_STORE_add_lookup(str, X509_LOOKUP_file()));
+    if (longPath != NULL) {
+        longPath[0] = '.';
+        longPath[1] = SEPARATOR_CHAR;
+    }
+    ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR, longPath,
+        SSL_FILETYPE_PEM, NULL), 0);
+
+    X509_STORE_free(str);
+    str = NULL;
+
+    XFREE(longPath, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    longPath = NULL;
+
+    /* an element that exactly fills the buffer is still accepted */
+    XMEMSET(maxPath, 'a', MAX_FILENAME_SZ);
+    maxPath[MAX_FILENAME_SZ] = '\0';
+
+    ExpectNotNull((str = wolfSSL_X509_STORE_new()));
+    ExpectNotNull(lookup = X509_STORE_add_lookup(str, X509_LOOKUP_file()));
+    ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR, maxPath,
+        SSL_FILETYPE_PEM, NULL), 1);
+
+    X509_STORE_free(str);
+#endif
+    return EXPECT_RESULT();
+}
+
 int test_wolfSSL_X509_load_crl_file(void)
 {
     EXPECT_DECLS;

--- a/tests/api/test_ossl_x509_lu.c
+++ b/tests/api/test_ossl_x509_lu.c
@@ -303,7 +303,7 @@ int test_wolfSSL_X509_LOOKUP_ctrl_dir_len(void)
     X509_STORE* str = NULL;
     X509_LOOKUP* lookup = NULL;
     char* longPath = NULL;
-    const int longPathCap = MAX_FILENAME_SZ + 4;
+    const int longPathCap = MAX_FILENAME_SZ + 5;
 
     ExpectNotNull((longPath = (char*)XMALLOC(longPathCap, HEAP_HINT,
             DYNAMIC_TYPE_TMP_BUFFER)));
@@ -351,6 +351,7 @@ int test_wolfSSL_X509_LOOKUP_ctrl_dir_len(void)
         XMEMSET(longPath, 'a', longPathCap);
         XMEMSET(longPath, 'b', 2);
         longPath[2] = SEPARATOR_CHAR;
+        longPath[longPathCap-1] = '\0';
     }
 
     ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR,
@@ -368,7 +369,7 @@ int test_wolfSSL_X509_LOOKUP_ctrl_dir_len(void)
         XMEMSET(longPath, 'a', longPathCap);
         XMEMSET(longPath, 'b', 2);
         longPath[2] = SEPARATOR_CHAR;
-        longPath[longPathCap - 1] = '\0';
+        longPath[longPathCap - 2] = '\0';
     }
 
     ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR,

--- a/tests/api/test_ossl_x509_lu.c
+++ b/tests/api/test_ossl_x509_lu.c
@@ -303,50 +303,100 @@ int test_wolfSSL_X509_LOOKUP_ctrl_dir_len(void)
     X509_STORE* str = NULL;
     X509_LOOKUP* lookup = NULL;
     char* longPath = NULL;
-    char maxPath[MAX_FILENAME_SZ + 1];
+    const int longPathCap = MAX_FILENAME_SZ + 4;
 
-    /* one element that does not fit in the buffer - must fail */
-    ExpectNotNull(longPath = (char*)XMALLOC(MAX_FILENAME_SZ + 4, NULL,
-        DYNAMIC_TYPE_TMP_BUFFER));
-    if (longPath != NULL) {
-        XMEMSET(longPath, 'a', MAX_FILENAME_SZ + 3);
-        longPath[MAX_FILENAME_SZ + 3] = '\0';
+    ExpectNotNull((longPath = (char*)XMALLOC(longPathCap, HEAP_HINT,
+            DYNAMIC_TYPE_TMP_BUFFER)));
+
+    /* One Path One Over Max Size */
+    if (EXPECT_SUCCESS()) {
+        XMEMSET(longPath, 'a', MAX_FILENAME_SZ + 1);
+        XMEMSET(longPath + MAX_FILENAME_SZ + 1, '\0',
+                longPathCap - MAX_FILENAME_SZ - 1);
     }
 
-    ExpectNotNull((str = wolfSSL_X509_STORE_new()));
-    ExpectNotNull(lookup = X509_STORE_add_lookup(str, X509_LOOKUP_file()));
-    ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR, longPath,
-        SSL_FILETYPE_PEM, NULL), 0);
+    ExpectNotNull((str = X509_STORE_new()));
+    ExpectNotNull((lookup = X509_STORE_add_lookup(str,
+                    X509_LOOKUP_file())));
+
+    ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR,
+                longPath, SSL_FILETYPE_PEM, NULL), 0);
 
     X509_STORE_free(str);
     str = NULL;
 
-    /* oversized element preceded by a valid one - still fails */
-    ExpectNotNull((str = wolfSSL_X509_STORE_new()));
-    ExpectNotNull(lookup = X509_STORE_add_lookup(str, X509_LOOKUP_file()));
-    if (longPath != NULL) {
-        longPath[0] = '.';
-        longPath[1] = SEPARATOR_CHAR;
+    ExpectNotNull((str = X509_STORE_new()));
+    ExpectNotNull((lookup = X509_STORE_add_lookup(str,
+                    X509_LOOKUP_file())));
+
+    /* One Path Max Size */
+    if (EXPECT_SUCCESS()) {
+        XMEMSET(longPath, 'a', MAX_FILENAME_SZ);
+        XMEMSET(longPath + MAX_FILENAME_SZ, '\0',
+                longPathCap - MAX_FILENAME_SZ);
     }
-    ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR, longPath,
-        SSL_FILETYPE_PEM, NULL), 0);
+
+    ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR,
+                longPath, SSL_FILETYPE_PEM, NULL), WOLFSSL_SUCCESS);
 
     X509_STORE_free(str);
     str = NULL;
 
-    XFREE(longPath, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    longPath = NULL;
+    ExpectNotNull((str = X509_STORE_new()));
+    ExpectNotNull((lookup = X509_STORE_add_lookup(str,
+                    X509_LOOKUP_file())));
 
-    /* an element that exactly fills the buffer is still accepted */
-    XMEMSET(maxPath, 'a', MAX_FILENAME_SZ);
-    maxPath[MAX_FILENAME_SZ] = '\0';
+    /* Second path one too long */
+    if (EXPECT_SUCCESS()) {
+        XMEMSET(longPath, 'a', longPathCap);
+        XMEMSET(longPath, 'b', 2);
+        longPath[2] = SEPARATOR_CHAR;
+    }
 
-    ExpectNotNull((str = wolfSSL_X509_STORE_new()));
-    ExpectNotNull(lookup = X509_STORE_add_lookup(str, X509_LOOKUP_file()));
-    ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR, maxPath,
-        SSL_FILETYPE_PEM, NULL), 1);
+    ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR,
+                longPath, SSL_FILETYPE_PEM, NULL), 0);
 
     X509_STORE_free(str);
+    str = NULL;
+
+    ExpectNotNull((str = X509_STORE_new()));
+    ExpectNotNull((lookup = X509_STORE_add_lookup(str,
+                    X509_LOOKUP_file())));
+
+    /* Two Paths Correct Size */
+    if (EXPECT_SUCCESS()) {
+        XMEMSET(longPath, 'a', longPathCap);
+        XMEMSET(longPath, 'b', 2);
+        longPath[2] = SEPARATOR_CHAR;
+        longPath[longPathCap - 1] = '\0';
+    }
+
+    ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR,
+                longPath, SSL_FILETYPE_PEM, NULL), WOLFSSL_SUCCESS);
+
+    X509_STORE_free(str);
+    str = NULL;
+
+    ExpectNotNull((str = X509_STORE_new()));
+    ExpectNotNull((lookup = X509_STORE_add_lookup(str,
+                    X509_LOOKUP_file())));
+
+    /* path max size terminated by separator char */
+    if (EXPECT_SUCCESS()) {
+        XMEMSET(longPath, 'a', longPathCap);
+        longPath[MAX_FILENAME_SZ] = SEPARATOR_CHAR;
+        longPath[MAX_FILENAME_SZ + 1] = '\0';
+    }
+
+    ExpectIntEQ(X509_LOOKUP_ctrl(lookup, X509_L_ADD_DIR,
+                longPath, SSL_FILETYPE_PEM, NULL), WOLFSSL_SUCCESS);
+
+    X509_STORE_free(str);
+    str = NULL;
+
+    if (longPath != NULL) {
+        XFREE(longPath, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    }
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_ossl_x509_lu.h
+++ b/tests/api/test_ossl_x509_lu.h
@@ -27,6 +27,7 @@
 int test_wolfSSL_X509_LOOKUP_load_file(void);
 int test_wolfSSL_X509_LOOKUP_ctrl_file(void);
 int test_wolfSSL_X509_LOOKUP_ctrl_hash_dir(void);
+int test_wolfSSL_X509_LOOKUP_ctrl_dir_len(void);
 int test_wolfSSL_X509_load_crl_file(void);
 int test_X509_LOOKUP_add_dir(void);
 
@@ -34,6 +35,7 @@ int test_X509_LOOKUP_add_dir(void);
     TEST_DECL_GROUP("ossl_x509_lu", test_wolfSSL_X509_LOOKUP_load_file),       \
     TEST_DECL_GROUP("ossl_x509_lu", test_wolfSSL_X509_LOOKUP_ctrl_file),       \
     TEST_DECL_GROUP("ossl_x509_lu", test_wolfSSL_X509_LOOKUP_ctrl_hash_dir),   \
+    TEST_DECL_GROUP("ossl_x509_lu", test_wolfSSL_X509_LOOKUP_ctrl_dir_len),    \
     TEST_DECL_GROUP("ossl_x509_lu", test_wolfSSL_X509_load_crl_file),          \
     TEST_DECL_GROUP("ossl_x509_lu", test_X509_LOOKUP_add_dir)
 


### PR DESCRIPTION
# Description

Added a check to make sure buffer cannot be over run by an extra long directory path.

Fenrir fix: https://fenrir.wolfssl.com/finding/10736

# Testing

Made a test that loads string of correct size and one of correct size + 1.

# Checklist

 - [x] added tests
