### PR TITLE
move wolfentropy outside the FIPS boundary and add example in dox for custom oe timer

### DIFF
--- a/doc/dox_comments/header_files/random.h
+++ b/doc/dox_comments/header_files/random.h
@@ -565,6 +565,39 @@ int wc_Entropy_GetRawEntropy(unsigned char* raw, int cnt);
     \endcode
 
     \sa wc_Entropy_GetRawEntropy
+
+    \par Supplying your own counter
+    The entropy source samples a high resolution counter for timing jitter.
+    CUSTOM_ENTROPY_TIMEHIRES overrides which counter it uses.  It is a build
+    time macro, not a runtime callback: define it to the name of a function
+    returning word64.  Requires HAVE_ENTROPY_MEMUSE (--enable-wolfEntropy).
+
+    Without it, wolfentropy.c picks a counter in this order: a per platform
+    hardware counter if it has one for the target, otherwise a counter thread
+    when ENTROPY_MEMUSE_THREAD is set, otherwise the build fails.  A custom
+    counter is checked before all of those and always wins, so on a platform
+    with no hardware counter it means the counter thread is not used at all,
+    and setting ENTROPY_MEMUSE_THREAD as well changes nothing.
+
+    The counter needs resolution, not accuracy.  It only has to advance
+    quickly, and need not be monotonic or related to wall clock time.
+
+    \code
+    // Replacing a hardware counter, on a platform that already has one.
+    // Build with -DCUSTOM_ENTROPY_TIMEHIRES=my_cycle_counter
+    word64 my_cycle_counter(void)
+    {
+        return (word64)board_read_cycle_count();
+    }
+
+    // Avoiding the counter thread, on a platform that has no hardware
+    // counter and would otherwise spin one up.
+    // Build with -DCUSTOM_ENTROPY_TIMEHIRES=my_tick
+    word64 my_tick(void)
+    {
+        return (word64)my_rtos_tick_count();
+    }
+    \endcode
 */
 int wc_Entropy_Get(int bits, unsigned char* entropy, word32 len);
 

--- a/src/include.am
+++ b/src/include.am
@@ -946,10 +946,6 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += \
                wolfcrypt/src/hmac.c \
                wolfcrypt/src/random.c
 
-if BUILD_MEMUSE
-src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfentropy.c
-endif
-
 if BUILD_RNG_BANK
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/rng_bank.c
 endif
@@ -1376,6 +1372,16 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fips.c \
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfcrypt_last.c
 
 endif !BUILD_FIPS_NO_POST
+
+# v7+ only.  Listed after wolfcrypt_last.c so its code sits past
+# wolfCrypt_FIPS_last() and the in-core integrity hash does not cover it.  The
+# module calls out to this entropy source, which is what IG 9.3.A asks for.
+# v5 and v6 keep it inside their boundary, as their certified module
+# definitions have it, and must not be reordered to match this.  Outside the
+# !BUILD_FIPS_NO_POST guard above so --enable-fips=dev-no-post builds it too.
+if BUILD_MEMUSE
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfentropy.c
+endif
 
 endif BUILD_FIPS_V7_PLUS
 

--- a/src/include.am
+++ b/src/include.am
@@ -197,10 +197,6 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += \
                wolfcrypt/src/hmac.c \
                wolfcrypt/src/random.c
 
-if BUILD_MEMUSE
-src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfentropy.c
-endif
-
 if BUILD_RNG_BANK
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/rng_bank.c
 endif
@@ -514,6 +510,15 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fips.c \
 
 # fips last file
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfcrypt_last.c
+
+# v7+ and v5 only.  Listed after wolfcrypt_last.c so its code sits past
+# wolfCrypt_FIPS_last() and the in-core integrity hash does not cover it.  The
+# module calls out to this entropy source, which is what IG 9.3.A asks for.
+# v6 keeps it inside boundary.
+if BUILD_MEMUSE
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfentropy.c
+endif
+
 endif BUILD_FIPS_V5
 
 if BUILD_FIPS_V6
@@ -1373,12 +1378,11 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfcrypt_last.c
 
 endif !BUILD_FIPS_NO_POST
 
-# v7+ only.  Listed after wolfcrypt_last.c so its code sits past
+# v7+ and v5 only.  Listed after wolfcrypt_last.c so its code sits past
 # wolfCrypt_FIPS_last() and the in-core integrity hash does not cover it.  The
 # module calls out to this entropy source, which is what IG 9.3.A asks for.
-# v5 and v6 keep it inside their boundary, as their certified module
-# definitions have it, and must not be reordered to match this.  Outside the
-# !BUILD_FIPS_NO_POST guard above so --enable-fips=dev-no-post builds it too.
+# v6 keeps it inside boundary. Outside the !BUILD_FIPS_NO_POST guard above so
+# --enable-fips=dev-no-post builds it too.
 if BUILD_MEMUSE
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfentropy.c
 endif

--- a/wolfcrypt/src/wolfentropy.c
+++ b/wolfcrypt/src/wolfentropy.c
@@ -38,6 +38,13 @@ data, use this implementation to seed and re-seed the DRBG.
 
 #include <wolfssl/wolfcrypt/wolfentropy.h>
 
+#ifdef HAVE_FIPS
+    /* for fips @wc_fips.  Named here rather than relied on through sha3.h:
+     * this file sits outside the module boundary from v7 on, and the fips.h
+     * redirect is what makes its SHA3 calls approved service calls. */
+    #include <wolfssl/wolfcrypt/fips.h>
+#endif
+
 #include <wolfssl/wolfcrypt/sha3.h>
 #if defined(__APPLE__) || defined(__MACH__)
     #include <mach/mach_time.h>


### PR DESCRIPTION
# Description

Keeps SP800-90B ESV source on the TOEPP but outside the well defined FIPS 140-3 boundary for porting purposes. We can validate multiple SHA3 conditioner functions from different module versions under the same ESV certificate. 

# Testing

Linux kernels, userspace on arm, intel, amd.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
