### PR TITLE
CI: assert test-lib exit status in the wolfBoot host-smoke job

### DIFF
--- a/.github/workflows/wolfboot-integration.yml
+++ b/.github/workflows/wolfboot-integration.yml
@@ -168,13 +168,28 @@ jobs:
 
           make test-lib SIGN=ED25519 HASH=SHA256
 
-          # test-lib (hal/library.c) always returns 0; success vs failure is
-          # signalled by stdout: "Firmware Valid" on the golden path,
-          # "Failure %d: Hdr %d, Hash %d, Sig %d" when verification rejects
-          # the image. Assert on output, not on exit status.
+          # test-lib (hal/library.c) signals the verdict two ways: the golden
+          # path prints "Firmware Valid" and exits 0, a rejected image prints
+          # "Failure %d: Hdr %d, Hash %d, Sig %d" and exits non-zero (255,
+          # from the -1 the verify path returns). The exit code only became
+          # meaningful in wolfBoot 2e918de2; before that every run exited 0
+          # and this step asserted on output alone.
+          #
+          # Both runs disable errexit so the status can be captured and
+          # asserted. A bare $(...) under "set -e" aborts the step at the
+          # assignment, before the output is ever printed -- which is what
+          # made the tamper run look like a golden-path failure.
 
+          set +e
           success_output=$(./test-lib test_v1_signed.bin 2>&1)
+          success_status=$?
+          set -e
+
           printf '%s\n' "$success_output"
+          if [ "$success_status" -ne 0 ]; then
+            echo "Expected golden-path success, but test-lib exited $success_status"
+            exit 1
+          fi
           if ! printf '%s\n' "$success_output" | grep -qF "Firmware Valid"; then
             echo "Expected golden-path success, but test-lib did not print \"Firmware Valid\""
             exit 1
@@ -183,8 +198,16 @@ jobs:
           truncate -s -1 test_v1_signed.bin
           printf 'A' >> test_v1_signed.bin
 
+          set +e
           tamper_output=$(./test-lib test_v1_signed.bin 2>&1)
+          tamper_status=$?
+          set -e
+
           printf '%s\n' "$tamper_output"
+          if [ "$tamper_status" -eq 0 ]; then
+            echo "Expected tamper rejection, but test-lib exited 0"
+            exit 1
+          fi
           if printf '%s\n' "$tamper_output" | grep -qF "Firmware Valid"; then
             echo "Expected tamper rejection, but test-lib reported \"Firmware Valid\""
             exit 1


### PR DESCRIPTION
The `host-smoke` job has been failing on every branch since wolfBoot `2e918de2` ("propagate the verify result from wolfBoot_start to the exit code") landed on wolfBoot master: `test-lib` now exits 255 for a rejected image instead of always exiting 0, so the tamper run's `$(...)` capture trips `set -e` and aborts the step at the assignment, before the output is printed or any assertion runs -- which is why the log ends with the *golden* run's "Firmware Valid" followed by exit 255 and looks like a golden-path failure. This scopes `errexit` around the two deliberately-non-zero invocations using the same `set +e` / capture `$?` / `set -e` idiom wolfBoot adopted in its own `test-library.yml` in that same commit, and takes the opportunity to assert the exit status on both paths (golden must exit 0, tamper must exit non-zero) in addition to the existing output checks, so the two workflows stay in step. Verified locally by building wolfBoot master's `test-lib` and reproducing both cases exactly (golden "Firmware Valid" / exit 0, tamper "Failure -1: Hdr 1, Hash 0, Sig 0" / exit 255), confirming the current step body fails identically to CI against that binary, confirming the new body passes, and negative-testing all four assertions with stubs to prove they actually fail when they should.
