### PR TITLE
ChaCha20 ARM32/Thumb2 BE asm: remove start of support

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-32-chacha-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-32-chacha-asm.S
@@ -45,11 +45,6 @@ wc_chacha_setiv:
 	ldr	r12, [r1, #4]
 	ldr	lr, [r1, #8]
 	str	r2, [r0, #48]
-#ifdef BIG_ENDIAN_ORDER
-	rev	r4, r4
-	rev	r12, r12
-	rev	lr, lr
-#endif /* BIG_ENDIAN_ORDER */
 	stm	r3, {r4, r12, lr}
 	pop	{r4, pc}
 	.size	wc_chacha_setiv,.-wc_chacha_setiv
@@ -88,12 +83,6 @@ wc_chacha_setkey:
 	ldr	r5, [r1, #4]
 	ldr	r12, [r1, #8]
 	ldr	lr, [r1, #12]
-#ifdef BIG_ENDIAN_ORDER
-	rev	r4, r4
-	rev	r5, r5
-	rev	r12, r12
-	rev	lr, lr
-#endif /* BIG_ENDIAN_ORDER */
 	stm	r0!, {r4, r5, r12, lr}
 	# Next 16 bytes of key.
 	beq	L_chacha_arm32_setkey_same_key_bytes
@@ -1199,15 +1188,9 @@ wc_chacha_setkey:
 	# Start with constants
 	vldm	r3, {q0}
 	vld1.8	{q1}, [r1]!
-#ifdef BIG_ENDIAN_ORDER
-	vrev32.16	q1, q1
-#endif /* BIG_ENDIAN_ORDER */
 	vstm	r0!, {q0-q1}
 	beq	L_chacha_setkey_arm32_done
 	vld1.8	{q1}, [r1]
-#ifdef BIG_ENDIAN_ORDER
-	vrev32.16	q1, q1
-#endif /* BIG_ENDIAN_ORDER */
 L_chacha_setkey_arm32_done:
 	vstm	r0, {q1}
 	bx	lr

--- a/wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c
@@ -72,11 +72,6 @@ WC_OMIT_FRAME_POINTER void wc_chacha_setiv(word32* x, const byte* iv,
         "ldr	r12, [%[iv], #4]\n\t"
         "ldr	lr, [%[iv], #8]\n\t"
         "str	%[counter], [%[x], #48]\n\t"
-#ifdef BIG_ENDIAN_ORDER
-        "rev	r4, r4\n\t"
-        "rev	r12, r12\n\t"
-        "rev	lr, lr\n\t"
-#endif /* BIG_ENDIAN_ORDER */
         "stm	r3, {r4, r12, lr}\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [x] "+r" (x), [iv] "+r" (iv), [counter] "+r" (counter)
@@ -126,12 +121,6 @@ WC_OMIT_FRAME_POINTER void wc_chacha_setkey(word32* x, const byte* key,
         "ldr	r5, [%[key], #4]\n\t"
         "ldr	r12, [%[key], #8]\n\t"
         "ldr	lr, [%[key], #12]\n\t"
-#ifdef BIG_ENDIAN_ORDER
-        "rev	r4, r4\n\t"
-        "rev	r5, r5\n\t"
-        "rev	r12, r12\n\t"
-        "rev	lr, lr\n\t"
-#endif /* BIG_ENDIAN_ORDER */
         "stm	%[x]!, {r4, r5, r12, lr}\n\t"
         /* Next 16 bytes of key. */
         "beq	L_chacha_arm32_setkey_same_key_bytes_%=\n\t"
@@ -1336,15 +1325,9 @@ WC_OMIT_FRAME_POINTER void wc_chacha_setkey(word32* x, const byte* key,
         /* Start with constants */
         "vldm	r3, {q0}\n\t"
         "vld1.8	{q1}, [%[key]]!\n\t"
-#ifdef BIG_ENDIAN_ORDER
-        "vrev32.16	q1, q1\n\t"
-#endif /* BIG_ENDIAN_ORDER */
         "vstm	%[x]!, {q0-q1}\n\t"
         "beq	L_chacha_setkey_arm32_done_%=\n\t"
         "vld1.8	{q1}, [%[key]]\n\t"
-#ifdef BIG_ENDIAN_ORDER
-        "vrev32.16	q1, q1\n\t"
-#endif /* BIG_ENDIAN_ORDER */
         "\n"
     "L_chacha_setkey_arm32_done_%=:\n\t"
         "vstm	%[x], {q1}\n\t"

--- a/wolfcrypt/src/port/arm/thumb2-chacha-asm.S
+++ b/wolfcrypt/src/port/arm/thumb2-chacha-asm.S
@@ -47,14 +47,9 @@ wc_chacha_setiv:
 	LDR	r5, [r1, #4]
 	LDR	r6, [r1, #8]
 	STR	r2, [r0, #48]
-#ifdef BIG_ENDIAN_ORDER
-	REV	r4, r4
-	REV	r5, r5
-	REV	r6, r6
-#endif /* BIG_ENDIAN_ORDER */
 	STM	r3, {r4, r5, r6}
 	POP	{r4, r5, r6, pc}
-	/* Cycle Count = 26 */
+	/* Cycle Count = 23 */
 	.size	wc_chacha_setiv,.-wc_chacha_setiv
 #ifndef __APPLE__
 	.text
@@ -90,12 +85,6 @@ wc_chacha_setkey:
 	LDR	r4, [r1, #4]
 	LDR	r5, [r1, #8]
 	LDR	r6, [r1, #12]
-#ifdef BIG_ENDIAN_ORDER
-	REV	r3, r3
-	REV	r4, r4
-	REV	r5, r5
-	REV	r6, r6
-#endif /* BIG_ENDIAN_ORDER */
 	STM	r0!, {r3, r4, r5, r6}
 	/* Next 16 bytes of key. */
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
@@ -112,7 +101,7 @@ wc_chacha_setkey:
 L_chacha_thumb2_setkey_same_key_bytes:
 	STM	r0, {r3, r4, r5, r6}
 	POP	{r4, r5, r6, r7, pc}
-	/* Cycle Count = 60 */
+	/* Cycle Count = 56 */
 	.size	wc_chacha_setkey,.-wc_chacha_setkey
 	.text
 	.align	4

--- a/wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c
@@ -72,11 +72,6 @@ WC_OMIT_FRAME_POINTER void wc_chacha_setiv(word32* x, const byte* iv,
         "LDR	r5, [%[iv], #4]\n\t"
         "LDR	r6, [%[iv], #8]\n\t"
         "STR	%[counter], [%[x], #48]\n\t"
-#ifdef BIG_ENDIAN_ORDER
-        "REV	r4, r4\n\t"
-        "REV	r5, r5\n\t"
-        "REV	r6, r6\n\t"
-#endif /* BIG_ENDIAN_ORDER */
         "STM	r3, {r4, r5, r6}\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [x] "+r" (x), [iv] "+r" (iv), [counter] "+r" (counter)
@@ -125,12 +120,6 @@ WC_OMIT_FRAME_POINTER void wc_chacha_setkey(word32* x, const byte* key,
         "LDR	r4, [%[key], #4]\n\t"
         "LDR	r5, [%[key], #8]\n\t"
         "LDR	r6, [%[key], #12]\n\t"
-#ifdef BIG_ENDIAN_ORDER
-        "REV	r3, r3\n\t"
-        "REV	r4, r4\n\t"
-        "REV	r5, r5\n\t"
-        "REV	r6, r6\n\t"
-#endif /* BIG_ENDIAN_ORDER */
         "STM	%[x]!, {r3, r4, r5, r6}\n\t"
         /* Next 16 bytes of key. */
 #if defined(__GNUC__)


### PR DESCRIPTION
# Description

Support for big-endian was never done for ARM32/Thumb2.
Removing fragements that are incomplete

Fixes F-9717 .F-9718

# Testing

ARM32/Thumb2 ChaCha20 LE still works.
