### PR TITLE
[NXP DCP port] Fix four fenrir claims

### DIFF
--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -198,10 +198,12 @@ int wc_dcp_init(void)
     return 0;
 }
 
-/* Release a channel without taking the DCP lock. For the dcp_lock()
- * failure branches only: a contended lock blocks rather than fails, so
- * a failure there means no other thread can be inside the critical
- * section and the clear cannot race a live access. */
+/* Release a channel without taking the DCP lock. Safe whenever
+ * dcp_lock() is known to be unavailable: a contended lock blocks
+ * rather than fails, so a failure means no other thread can be
+ * inside the critical section (or the caller already holds the
+ * mutex), and the owner check prevents releasing a channel held by
+ * another context. */
 static void dcp_free_unlocked(void* owner, int ch)
 {
 #ifndef SINGLE_THREADED
@@ -220,12 +222,17 @@ static void dcp_free_unlocked(void* owner, int ch)
 #endif
 }
 
+/* Total: always releases, so callers may drop their handle record
+ * unconditionally. A lock failure falls back to the unlocked release
+ * (safe per dcp_free_unlocked) instead of orphaning the reservation. */
 static void dcp_free(void* owner, int ch)
 {
-    if (dcp_lock() != 0)
-        return;
+    int locked;
+
+    locked = (dcp_lock() == 0);
     dcp_free_unlocked(owner, ch);
-    dcp_unlock();
+    if (locked)
+        dcp_unlock();
 }
 
 /*

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -205,6 +205,34 @@ static void dcp_free(int ch)
 #endif
 }
 
+/*
+ * The DCP SDK's opaque hash context embeds a pointer to the
+ * dcp_handle_t passed to DCP_HASH_Init; all engine scheduling goes
+ * through that pointer, so a copied context must be rebound to its own
+ * handle. The internal layout is not exported by fsl_dcp.h, so locate
+ * the pointer word by binding a scratch context to a probe handle and
+ * scanning for the word holding the probe address. DCP_HASH_Init is a
+ * pure software state setup and touches neither the DCP peripheral nor
+ * shared port state. Returns DCP_HASH_CTX_SIZE if the layout no longer
+ * matches, so the copy fails instead of binding a wrong word.
+ */
+#if !defined(NO_SHA256) || !defined(NO_SHA)
+static word32 dcp_hash_handle_word(void)
+{
+    dcp_hash_ctx_t bound;
+    dcp_handle_t probe;
+    word32 i;
+
+    XMEMSET(&bound, 0, sizeof(bound));
+    (void)DCP_HASH_Init(DCP, &probe, &bound, kDCP_Sha256);
+    for (i = 0; i < DCP_HASH_CTX_SIZE; i++) {
+        if (bound.x[i] == (word32)&probe)
+            return i;
+    }
+    return DCP_HASH_CTX_SIZE;
+}
+#endif
+
 
 #ifndef NO_AES
 int DCPAesInit(Aes *aes)
@@ -449,11 +477,33 @@ int wc_Sha256GetFlags(wc_Sha256* sha256, word32* flags)
 
 int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
 {
+    int ch;
+    int keyslot;
+    word32 handleWord;
+
     if (src == NULL || dst == NULL)
         return BAD_FUNC_ARG;
-    if (dcp_lock() != 0)
+    if (src == dst)
+        return 0;
+    handleWord = dcp_hash_handle_word();
+    if (handleWord >= DCP_HASH_CTX_SIZE)
         return WC_HW_E;
+    ch = dcp_get_channel();
+    if (ch == 0)
+        return WC_PENDING_E;
+    keyslot = dcp_key_slot(ch);
+    if (dcp_lock() != 0) {
+        dcp_free(ch);
+        return WC_HW_E;
+    }
+    dst->handle.channel    = (dcp_channel_t)ch;
+    dst->handle.keySlot    = (dcp_key_slot_t)keyslot;
+    dst->handle.swapConfig = kDCP_NoSwap;
     XMEMCPY(&dst->ctx, &src->ctx, sizeof(dcp_hash_ctx_t));
+    /* Rebind the copied context to its own handle: the SDK stages the
+     * running hash per channel, so a copy sharing the source channel
+     * would corrupt both digests. */
+    dst->ctx.x[handleWord] = (word32)&dst->handle;
     dcp_unlock();
     return 0;
 }
@@ -572,11 +622,33 @@ int wc_ShaGetFlags(wc_Sha* sha, word32* flags)
 
 int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
 {
+    int ch;
+    int keyslot;
+    word32 handleWord;
+
     if (src == NULL || dst == NULL)
         return BAD_FUNC_ARG;
-    if (dcp_lock() != 0)
+    if (src == dst)
+        return 0;
+    handleWord = dcp_hash_handle_word();
+    if (handleWord >= DCP_HASH_CTX_SIZE)
         return WC_HW_E;
+    ch = dcp_get_channel();
+    if (ch == 0)
+        return WC_PENDING_E;
+    keyslot = dcp_key_slot(ch);
+    if (dcp_lock() != 0) {
+        dcp_free(ch);
+        return WC_HW_E;
+    }
+    dst->handle.channel    = (dcp_channel_t)ch;
+    dst->handle.keySlot    = (dcp_key_slot_t)keyslot;
+    dst->handle.swapConfig = kDCP_NoSwap;
     XMEMCPY(&dst->ctx, &src->ctx, sizeof(dcp_hash_ctx_t));
+    /* Rebind the copied context to its own handle: the SDK stages the
+     * running hash per channel, so a copy sharing the source channel
+     * would corrupt both digests. */
+    dst->ctx.x[handleWord] = (word32)&dst->handle;
     dcp_unlock();
     return 0;
 }

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -116,11 +116,17 @@ static const int dcp_channels[4] = {
 
 #ifndef SINGLE_THREADED
 static int dcp_status[4] = {0, 0, 0, 0};
+/* Context that reserved each channel: a release only takes effect from
+ * the recorded owner, so a stale or uninitialized handle.channel value
+ * (a struct never zeroed before init, a freed struct reused) cannot
+ * free a channel another live context holds. */
+static void* dcp_owner[4] = {NULL, NULL, NULL, NULL};
 #endif
 
-static int dcp_get_channel(void)
+static int dcp_get_channel(void* owner)
 {
 #ifdef SINGLE_THREADED
+    (void)owner;
     return dcp_channels[0];
 #else
     int i;
@@ -132,6 +138,7 @@ static int dcp_get_channel(void)
     for (i = 0; i < 4; i++) {
         if (dcp_status[i] == 0) {
             dcp_status[i]++;
+            dcp_owner[i] = owner;
             ret = dcp_channels[i];
             break;
         }
@@ -189,7 +196,7 @@ int wc_dcp_init(void)
     return 0;
 }
 
-static void dcp_free(int ch)
+static void dcp_free(void* owner, int ch)
 {
 #ifndef SINGLE_THREADED
     int i;
@@ -197,8 +204,9 @@ static void dcp_free(int ch)
     if (dcp_lock() != 0)
         return;
     for (i = 0; i < 4; i++) {
-        if (ch == dcp_channels[i]) {
+        if (ch == dcp_channels[i] && dcp_owner[i] == owner) {
             dcp_status[i] = 0;
+            dcp_owner[i] = NULL;
             break;
         }
     }
@@ -243,7 +251,7 @@ int DCPAesInit(Aes *aes)
     int ch;
     if (!aes)
         return BAD_FUNC_ARG;
-    ch = dcp_get_channel();
+    ch = dcp_get_channel(aes);
     if (ch == 0)
         return WC_PENDING_E;
     XMEMSET(&aes->handle, 0, sizeof(aes->handle));
@@ -264,7 +272,7 @@ void DCPAesFree(Aes *aes)
         ForceZero(aes_key_aligned, sizeof(aes_key_aligned));
         dcp_unlock();
     }
-    dcp_free(aes->handle.channel);
+    dcp_free(aes, aes->handle.channel);
     aes->handle.channel = 0;
 }
 
@@ -377,15 +385,16 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
     if (sha256 == NULL)
         return BAD_FUNC_ARG;
     /* A context owns at most one DCP channel; drop whatever this struct
-     * recorded before (no-op when it holds none) so re-initializing a
-     * live context cannot leak its channel. */
-    dcp_free(sha256->handle.channel);
-    ch = dcp_get_channel();
+     * recorded before so re-initializing a live context cannot leak its
+     * channel. dcp_free only acts on a channel this struct owns, so a
+     * struct never zeroed before init is harmless. */
+    dcp_free(sha256, sha256->handle.channel);
+    ch = dcp_get_channel(sha256);
     if (ch == 0)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
-        dcp_free(ch);
+        dcp_free(sha256, ch);
         return WC_HW_E;
     }
     (void)devId;
@@ -402,7 +411,7 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
          * failure (after dropping the lock: dcp_free takes it itself)
          * so repeated failures cannot exhaust the channels, and leave
          * the context explicitly uninitialized. */
-        dcp_free(ch);
+        dcp_free(sha256, ch);
         sha256->handle.channel = 0;
     }
     return ret;
@@ -411,7 +420,7 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
 void DCPSha256Free(wc_Sha256* sha256)
 {
     if (sha256)
-        dcp_free(sha256->handle.channel);
+        dcp_free(sha256, sha256->handle.channel);
 }
 
 int wc_Sha256Update(wc_Sha256* sha256, const byte* data, word32 len)
@@ -498,14 +507,14 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
     if (handleWord >= DCP_HASH_CTX_SIZE)
         return WC_HW_E;
     /* The copy replaces dst (software contract: free dst resources,
-     * then clone); drop any channel dst recorded. */
-    dcp_free(dst->handle.channel);
-    ch = dcp_get_channel();
+     * then clone); drop any channel dst owns. */
+    dcp_free(dst, dst->handle.channel);
+    ch = dcp_get_channel(dst);
     if (ch == 0)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
-        dcp_free(ch);
+        dcp_free(dst, ch);
         return WC_HW_E;
     }
     dst->handle.channel    = (dcp_channel_t)ch;
@@ -537,15 +546,16 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     if (sha == NULL)
         return BAD_FUNC_ARG;
     /* A context owns at most one DCP channel; drop whatever this struct
-     * recorded before (no-op when it holds none) so re-initializing a
-     * live context cannot leak its channel. */
-    dcp_free(sha->handle.channel);
-    ch = dcp_get_channel();
+     * recorded before so re-initializing a live context cannot leak its
+     * channel. dcp_free only acts on a channel this struct owns, so a
+     * struct never zeroed before init is harmless. */
+    dcp_free(sha, sha->handle.channel);
+    ch = dcp_get_channel(sha);
     if (ch == 0)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
-        dcp_free(ch);
+        dcp_free(sha, ch);
         return WC_HW_E;
     }
     (void)devId;
@@ -562,7 +572,7 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
          * failure (after dropping the lock: dcp_free takes it itself)
          * so repeated failures cannot exhaust the channels, and leave
          * the context explicitly uninitialized. */
-        dcp_free(ch);
+        dcp_free(sha, ch);
         sha->handle.channel = 0;
     }
     return ret;
@@ -571,7 +581,7 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
 void DCPShaFree(wc_Sha* sha)
 {
     if (sha)
-        dcp_free(sha->handle.channel);
+        dcp_free(sha, sha->handle.channel);
 }
 
 int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
@@ -659,14 +669,14 @@ int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
     if (handleWord >= DCP_HASH_CTX_SIZE)
         return WC_HW_E;
     /* The copy replaces dst (software contract: free dst resources,
-     * then clone); drop any channel dst recorded. */
-    dcp_free(dst->handle.channel);
-    ch = dcp_get_channel();
+     * then clone); drop any channel dst owns. */
+    dcp_free(dst, dst->handle.channel);
+    ch = dcp_get_channel(dst);
     if (ch == 0)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
-        dcp_free(ch);
+        dcp_free(dst, ch);
         return WC_HW_E;
     }
     dst->handle.channel    = (dcp_channel_t)ch;

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -54,10 +54,11 @@
 #define dcp_unlock() wolfSSL_CryptHwMutexUnLock()
 #else
 /* Single-threaded: no mutex, the lock calls evaluate to success (0) so
- * the "if (dcp_lock() != 0)" checks compile out as constants. */
+ * the "if (dcp_lock() != 0)" checks compile out as constants. unlock is
+ * statement-only, hence (void)0 to keep -Wunused-value quiet. */
 #define dcp_lock_init() 0
 #define dcp_lock()      0
-#define dcp_unlock()    0
+#define dcp_unlock()    ((void)0)
 #endif
 
 #if DCP_USE_OTP_KEY

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -270,14 +270,22 @@ static word32 dcp_hash_handle_word(void)
 int DCPAesInit(Aes *aes)
 {
     int ch;
+    int keyslot;
     if (!aes)
         return BAD_FUNC_ARG;
     ch = dcp_get_channel(aes);
     if (ch == 0)
         return WC_HW_WAIT_E;
+    /* dcp_key_slot() fails with -1 if its lock acquisition fails;
+     * never keep a channel with an invalid key slot. */
+    keyslot = dcp_key_slot(ch);
+    if (keyslot < 0) {
+        dcp_free(aes, ch);
+        return WC_HW_E;
+    }
     XMEMSET(&aes->handle, 0, sizeof(aes->handle));
     aes->handle.channel = (dcp_channel_t)ch;
-    aes->handle.keySlot = (dcp_key_slot_t)dcp_key_slot(aes->handle.channel);
+    aes->handle.keySlot = (dcp_key_slot_t)keyslot;
     aes->handle.swapConfig = kDCP_NoSwap;
     return 0;
 }
@@ -413,7 +421,13 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
     ch = dcp_get_channel(sha256);
     if (ch == 0)
         return WC_HW_WAIT_E;
+    /* dcp_key_slot() fails with -1 if its lock acquisition fails;
+     * never keep a channel with an invalid key slot. */
     keyslot = dcp_key_slot(ch);
+    if (keyslot < 0) {
+        dcp_free(sha256, ch);
+        return WC_HW_E;
+    }
     if (dcp_lock() != 0) {
         dcp_free_unlocked(sha256, ch);
         return WC_HW_E;
@@ -537,7 +551,13 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
     ch = dcp_get_channel(dst);
     if (ch == 0)
         return WC_HW_WAIT_E;
+    /* dcp_key_slot() fails with -1 if its lock acquisition fails;
+     * never keep a channel with an invalid key slot. */
     keyslot = dcp_key_slot(ch);
+    if (keyslot < 0) {
+        dcp_free(dst, ch);
+        return WC_HW_E;
+    }
     if (dcp_lock() != 0) {
         dcp_free_unlocked(dst, ch);
         return WC_HW_E;
@@ -578,7 +598,13 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     ch = dcp_get_channel(sha);
     if (ch == 0)
         return WC_HW_WAIT_E;
+    /* dcp_key_slot() fails with -1 if its lock acquisition fails;
+     * never keep a channel with an invalid key slot. */
     keyslot = dcp_key_slot(ch);
+    if (keyslot < 0) {
+        dcp_free(sha, ch);
+        return WC_HW_E;
+    }
     if (dcp_lock() != 0) {
         dcp_free_unlocked(sha, ch);
         return WC_HW_E;
@@ -703,7 +729,13 @@ int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
     ch = dcp_get_channel(dst);
     if (ch == 0)
         return WC_HW_WAIT_E;
+    /* dcp_key_slot() fails with -1 if its lock acquisition fails;
+     * never keep a channel with an invalid key slot. */
     keyslot = dcp_key_slot(ch);
+    if (keyslot < 0) {
+        dcp_free(dst, ch);
+        return WC_HW_E;
+    }
     if (dcp_lock() != 0) {
         dcp_free_unlocked(dst, ch);
         return WC_HW_E;

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -378,25 +378,27 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
     if (ch == 0)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
-
-    if (dcp_lock() != 0)
+    if (dcp_lock() != 0) {
+        dcp_free(ch);
         return WC_HW_E;
+    }
     (void)devId;
     XMEMSET(sha256, 0, sizeof(wc_Sha256));
     sha256->handle.channel    = (dcp_channel_t)ch;
     sha256->handle.keySlot    = (dcp_key_slot_t)keyslot;
     sha256->handle.swapConfig = kDCP_NoSwap;
     ret = DCP_HASH_Init(DCP, &sha256->handle, &sha256->ctx, kDCP_Sha256);
-    if (ret != kStatus_Success) {
+    if (ret != kStatus_Success)
+        ret = WC_HW_E;
+    dcp_unlock();
+    if (ret == WC_HW_E) {
         /* The channel is reserved before the SDK init; release it on
-         * failure so repeated failures cannot exhaust the channels, and
-         * leave the context explicitly uninitialized. */
+         * failure (after dropping the lock: dcp_free takes it itself)
+         * so repeated failures cannot exhaust the channels, and leave
+         * the context explicitly uninitialized. */
         dcp_free(ch);
         sha256->handle.channel = 0;
-        ret = WC_HW_E;
     }
-    dcp_unlock();
-
     return ret;
 }
 
@@ -524,23 +526,27 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     if (ch == 0)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
-    if (dcp_lock() != 0)
+    if (dcp_lock() != 0) {
+        dcp_free(ch);
         return WC_HW_E;
+    }
     (void)devId;
     XMEMSET(sha, 0, sizeof(wc_Sha));
     sha->handle.channel    = (dcp_channel_t)ch;
     sha->handle.keySlot    = (dcp_key_slot_t)keyslot;
     sha->handle.swapConfig = kDCP_NoSwap;
     ret = DCP_HASH_Init(DCP, &sha->handle, &sha->ctx, kDCP_Sha1);
-    if (ret != kStatus_Success) {
+    if (ret != kStatus_Success)
+        ret = WC_HW_E;
+    dcp_unlock();
+    if (ret == WC_HW_E) {
         /* The channel is reserved before the SDK init; release it on
-         * failure so repeated failures cannot exhaust the channels, and
-         * leave the context explicitly uninitialized. */
+         * failure (after dropping the lock: dcp_free takes it itself)
+         * so repeated failures cannot exhaust the channels, and leave
+         * the context explicitly uninitialized. */
         dcp_free(ch);
         sha->handle.channel = 0;
-        ret = WC_HW_E;
     }
-    dcp_unlock();
     return ret;
 }
 

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -225,7 +225,9 @@ static word32 dcp_hash_handle_word(void)
     word32 i;
 
     XMEMSET(&bound, 0, sizeof(bound));
-    (void)DCP_HASH_Init(DCP, &probe, &bound, kDCP_Sha256);
+    XMEMSET(&probe, 0, sizeof(probe));
+    if (DCP_HASH_Init(DCP, &probe, &bound, kDCP_Sha256) != kStatus_Success)
+        return DCP_HASH_CTX_SIZE;
     for (i = 0; i < DCP_HASH_CTX_SIZE; i++) {
         if (bound.x[i] == (word32)&probe)
             return i;

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -132,7 +132,9 @@ static int dcp_get_channel(void* owner)
     int i;
     int ret = 0;
 
-    /* 0 = no channel available; callers map it to WC_PENDING_E. */
+    /* 0 = no channel available; callers map it to WC_HW_WAIT_E
+     * ("Hardware waiting on resource"), the same code the CAAM and
+     * Atmel ports return when a hardware slot pool is exhausted. */
     if (dcp_lock() != 0)
         return 0;
     for (i = 0; i < 4; i++) {
@@ -265,7 +267,7 @@ int DCPAesInit(Aes *aes)
         return BAD_FUNC_ARG;
     ch = dcp_get_channel(aes);
     if (ch == 0)
-        return WC_PENDING_E;
+        return WC_HW_WAIT_E;
     XMEMSET(&aes->handle, 0, sizeof(aes->handle));
     aes->handle.channel = (dcp_channel_t)ch;
     aes->handle.keySlot = (dcp_key_slot_t)dcp_key_slot(aes->handle.channel);
@@ -403,7 +405,7 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
     dcp_free(sha256, sha256->handle.channel);
     ch = dcp_get_channel(sha256);
     if (ch == 0)
-        return WC_PENDING_E;
+        return WC_HW_WAIT_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
         dcp_free_unlocked(sha256, ch);
@@ -527,7 +529,7 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
     dcp_free(dst, dst->handle.channel);
     ch = dcp_get_channel(dst);
     if (ch == 0)
-        return WC_PENDING_E;
+        return WC_HW_WAIT_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
         dcp_free_unlocked(dst, ch);
@@ -568,7 +570,7 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     dcp_free(sha, sha->handle.channel);
     ch = dcp_get_channel(sha);
     if (ch == 0)
-        return WC_PENDING_E;
+        return WC_HW_WAIT_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
         dcp_free_unlocked(sha, ch);
@@ -693,7 +695,7 @@ int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
     dcp_free(dst, dst->handle.channel);
     ch = dcp_get_channel(dst);
     if (ch == 0)
-        return WC_PENDING_E;
+        return WC_HW_WAIT_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
         dcp_free_unlocked(dst, ch);

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -53,9 +53,11 @@
 #define dcp_lock() wolfSSL_CryptHwMutexLock()
 #define dcp_unlock() wolfSSL_CryptHwMutexUnLock()
 #else
-#define dcp_lock_init() WC_DO_NOTHING
-#define dcp_lock()      WC_DO_NOTHING
-#define dcp_unlock()    WC_DO_NOTHING
+/* Single-threaded: no mutex, the lock calls evaluate to success (0) so
+ * the "if (dcp_lock() != 0)" checks compile out as constants. */
+#define dcp_lock_init() 0
+#define dcp_lock()      0
+#define dcp_unlock()    0
 #endif
 
 #if DCP_USE_OTP_KEY
@@ -122,7 +124,10 @@ static int dcp_get_channel(void)
 #else
     int i;
     int ret = 0;
-    dcp_lock();
+
+    /* 0 = no channel available; callers map it to WC_PENDING_E. */
+    if (dcp_lock() != 0)
+        return 0;
     for (i = 0; i < 4; i++) {
         if (dcp_status[i] == 0) {
             dcp_status[i]++;
@@ -147,7 +152,8 @@ static int dcp_key_slot(int ch)
     int i;
     int ret = -1;
 
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return ret;
     for (i = 0; i < 4; i++) {
         if (ch == dcp_channels[i]) {
             ret = i;
@@ -163,8 +169,11 @@ static int dcp_key_slot(int ch)
 int wc_dcp_init(void)
 {
     dcp_config_t dcpConfig;
-    dcp_lock_init();
-    dcp_lock();
+
+    if (dcp_lock_init() != 0)
+        return WC_HW_E;
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     DCP_GetDefaultConfig(&dcpConfig);
 
     /* Reset and initialize DCP */
@@ -183,7 +192,9 @@ static void dcp_free(int ch)
 {
 #ifndef SINGLE_THREADED
     int i;
-    dcp_lock();
+
+    if (dcp_lock() != 0)
+        return;
     for (i = 0; i < 4; i++) {
         if (ch == dcp_channels[i]) {
             dcp_status[i] = 0;
@@ -215,9 +226,13 @@ static unsigned char  aes_key_aligned[16] __attribute__((aligned(0x10)));
 
 void DCPAesFree(Aes *aes)
 {
-    dcp_lock();
-    ForceZero(aes_key_aligned, sizeof(aes_key_aligned));
-    dcp_unlock();
+    /* The shared key scratch buffer is zeroed under the DCP lock; if
+     * the lock is unavailable, skip the zeroing rather than race
+     * another thread on the buffer. */
+    if (dcp_lock() == 0) {
+        ForceZero(aes_key_aligned, sizeof(aes_key_aligned));
+        dcp_unlock();
+    }
     dcp_free(aes->handle.channel);
     aes->handle.channel = 0;
 }
@@ -240,7 +255,8 @@ int  DCPAesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv,
         if (DCPAesInit(aes) != 0)
             return WC_HW_E;
     }
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     XMEMCPY(aes_key_aligned, key, 16);
     status = DCP_AES_SetKey(DCP, &aes->handle, aes_key_aligned, 16);
     ForceZero(aes_key_aligned, sizeof(aes_key_aligned));
@@ -261,7 +277,8 @@ int  DCPAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     int ret;
     if (sz % 16)
         return BAD_FUNC_ARG;
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     ret = DCP_AES_EncryptCbc(DCP, &aes->handle, in, out, sz, (const byte *)aes->reg);
     if (ret)
         ret = WC_HW_E;
@@ -279,7 +296,8 @@ int  DCPAesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     /* Snapshot last ciphertext block before decrypt; in-place decryption
      * (in == out) overwrites the input with plaintext. */
     XMEMCPY(aes->tmp, in + sz - WC_AES_BLOCK_SIZE, WC_AES_BLOCK_SIZE);
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     ret = DCP_AES_DecryptCbc(DCP, &aes->handle, in, out, sz, (const byte *)aes->reg);
     if (ret)
         ret = WC_HW_E;
@@ -294,7 +312,8 @@ int  DCPAesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     int ret;
     if (sz % 16)
         return BAD_FUNC_ARG;
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     ret = DCP_AES_EncryptEcb(DCP, &aes->handle, in, out, sz);
     if (ret)
         ret = WC_HW_E;
@@ -307,7 +326,8 @@ int  DCPAesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     int ret;
     if (sz % 16)
         return BAD_FUNC_ARG;
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     ret = DCP_AES_DecryptEcb(DCP, &aes->handle, in, out, sz);
     if (ret)
         ret = WC_HW_E;
@@ -330,7 +350,8 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
 
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     (void)devId;
     XMEMSET(sha256, 0, sizeof(wc_Sha256));
     sha256->handle.channel    = (dcp_channel_t)ch;
@@ -356,7 +377,8 @@ int wc_Sha256Update(wc_Sha256* sha256, const byte* data, word32 len)
     if (sha256 == NULL || (data == NULL && len != 0)) {
         return BAD_FUNC_ARG;
     }
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     ret = DCP_HASH_Update(DCP, &sha256->ctx, data, len);
     if (ret != kStatus_Success)
         ret = WC_HW_E;
@@ -371,7 +393,8 @@ int wc_Sha256GetHash(wc_Sha256* sha256, byte* hash)
     dcp_hash_ctx_t saved_ctx;
     if (sha256 == NULL || hash == NULL)
         return BAD_FUNC_ARG;
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     XMEMCPY(&saved_ctx, &sha256->ctx, sizeof(dcp_hash_ctx_t));
     XMEMSET(hash, 0, WC_SHA256_DIGEST_SIZE);
     ret = DCP_HASH_Finish(DCP, &sha256->ctx, hash, &outlen);
@@ -387,7 +410,8 @@ int wc_Sha256Final(wc_Sha256* sha256, byte* hash)
 {
     int ret;
     size_t outlen = WC_SHA256_DIGEST_SIZE;
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     ret = DCP_HASH_Finish(DCP, &sha256->ctx, hash, &outlen);
     if ((ret != kStatus_Success) || (outlen != SHA256_DIGEST_SIZE))
         ret = WC_HW_E;
@@ -421,7 +445,8 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
 {
     if (src == NULL || dst == NULL)
         return BAD_FUNC_ARG;
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     XMEMCPY(&dst->ctx, &src->ctx, sizeof(dcp_hash_ctx_t));
     dcp_unlock();
     return 0;
@@ -442,7 +467,8 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     if (ch == 0)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     (void)devId;
     XMEMSET(sha, 0, sizeof(wc_Sha));
     sha->handle.channel    = (dcp_channel_t)ch;
@@ -467,7 +493,8 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
     if (sha == NULL || (data == NULL && len != 0)) {
         return BAD_FUNC_ARG;
     }
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     ret = DCP_HASH_Update(DCP, &sha->ctx, data, len);
     if (ret != kStatus_Success)
         ret = WC_HW_E;
@@ -483,7 +510,8 @@ int wc_ShaGetHash(wc_Sha* sha, byte* hash)
     dcp_hash_ctx_t saved_ctx;
     if (sha == NULL || hash == NULL)
         return BAD_FUNC_ARG;
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     XMEMCPY(&saved_ctx, &sha->ctx, sizeof(dcp_hash_ctx_t));
     XMEMSET(hash, 0, WC_SHA_DIGEST_SIZE);
     ret = DCP_HASH_Finish(DCP, &sha->ctx, hash, &outlen);
@@ -499,7 +527,8 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
 {
     int ret;
     size_t outlen = WC_SHA_DIGEST_SIZE;
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     ret = DCP_HASH_Finish(DCP, &sha->ctx, hash, &outlen);
     if ((ret != kStatus_Success) || (outlen != SHA_DIGEST_SIZE)) {
         ret = WC_HW_E;
@@ -533,7 +562,8 @@ int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
 {
     if (src == NULL || dst == NULL)
         return BAD_FUNC_ARG;
-    dcp_lock();
+    if (dcp_lock() != 0)
+        return WC_HW_E;
     XMEMCPY(&dst->ctx, &src->ctx, sizeof(dcp_hash_ctx_t));
     dcp_unlock();
     return 0;

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -419,8 +419,12 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
 
 void DCPSha256Free(wc_Sha256* sha256)
 {
-    if (sha256)
+    if (sha256) {
         dcp_free(sha256, sha256->handle.channel);
+        /* Drop the channel record: the context no longer owns a
+         * channel, and the value must not outlive the reservation. */
+        sha256->handle.channel = 0;
+    }
 }
 
 int wc_Sha256Update(wc_Sha256* sha256, const byte* data, word32 len)
@@ -580,8 +584,12 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
 
 void DCPShaFree(wc_Sha* sha)
 {
-    if (sha)
+    if (sha) {
         dcp_free(sha, sha->handle.channel);
+        /* Drop the channel record: the context no longer owns a
+         * channel, and the value must not outlive the reservation. */
+        sha->handle.channel = 0;
+    }
 }
 
 int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -376,6 +376,10 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
     int keyslot;
     if (sha256 == NULL)
         return BAD_FUNC_ARG;
+    /* A context owns at most one DCP channel; drop whatever this struct
+     * recorded before (no-op when it holds none) so re-initializing a
+     * live context cannot leak its channel. */
+    dcp_free(sha256->handle.channel);
     ch = dcp_get_channel();
     if (ch == 0)
         return WC_PENDING_E;
@@ -493,6 +497,9 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
     handleWord = dcp_hash_handle_word();
     if (handleWord >= DCP_HASH_CTX_SIZE)
         return WC_HW_E;
+    /* The copy replaces dst (software contract: free dst resources,
+     * then clone); drop any channel dst recorded. */
+    dcp_free(dst->handle.channel);
     ch = dcp_get_channel();
     if (ch == 0)
         return WC_PENDING_E;
@@ -509,6 +516,11 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
      * running hash per channel, so a copy sharing the source channel
      * would corrupt both digests. */
     dst->ctx.x[handleWord] = (word32)&dst->handle;
+    dst->heap = src->heap;
+#ifdef WOLFSSL_HASH_FLAGS
+    dst->flags = src->flags;
+    dst->flags |= WC_HASH_FLAG_ISCOPY;
+#endif
     dcp_unlock();
     return 0;
 }
@@ -524,6 +536,10 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     int keyslot;
     if (sha == NULL)
         return BAD_FUNC_ARG;
+    /* A context owns at most one DCP channel; drop whatever this struct
+     * recorded before (no-op when it holds none) so re-initializing a
+     * live context cannot leak its channel. */
+    dcp_free(sha->handle.channel);
     ch = dcp_get_channel();
     if (ch == 0)
         return WC_PENDING_E;
@@ -642,6 +658,9 @@ int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
     handleWord = dcp_hash_handle_word();
     if (handleWord >= DCP_HASH_CTX_SIZE)
         return WC_HW_E;
+    /* The copy replaces dst (software contract: free dst resources,
+     * then clone); drop any channel dst recorded. */
+    dcp_free(dst->handle.channel);
     ch = dcp_get_channel();
     if (ch == 0)
         return WC_PENDING_E;
@@ -658,6 +677,11 @@ int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
      * running hash per channel, so a copy sharing the source channel
      * would corrupt both digests. */
     dst->ctx.x[handleWord] = (word32)&dst->handle;
+    dst->heap = src->heap;
+#ifdef WOLFSSL_HASH_FLAGS
+    dst->flags = src->flags;
+    dst->flags |= WC_HASH_FLAG_ISCOPY;
+#endif
     dcp_unlock();
     return 0;
 }

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -119,10 +119,19 @@ static int dcp_status[4] = {0, 0, 0, 0};
 /* Context that reserved each channel: a release only takes effect from
  * the recorded owner, so a stale or uninitialized handle.channel value
  * (a struct never zeroed before init, a freed struct reused) cannot
- * free a channel another live context holds. */
+ * free a channel another live context holds. This table is also what
+ * lets the port answer "does this context already hold a channel?"
+ * without reading the caller's struct, which init is allowed to
+ * receive uninitialized. */
 static void* dcp_owner[4] = {NULL, NULL, NULL, NULL};
 #endif
 
+/* Reserve a channel for owner.
+ * Returns the channel on success, 0 if the pool is exhausted (callers
+ * map it to WC_HW_WAIT_E, "Hardware waiting on resource", the same code
+ * the CAAM and Atmel ports return for an exhausted slot pool), or -1 if
+ * the lock is unusable, which is a hard WC_HW_E rather than a transient
+ * shortage. */
 static int dcp_get_channel(void* owner)
 {
 #ifdef SINGLE_THREADED
@@ -132,17 +141,28 @@ static int dcp_get_channel(void* owner)
     int i;
     int ret = 0;
 
-    /* 0 = no channel available; callers map it to WC_HW_WAIT_E
-     * ("Hardware waiting on resource"), the same code the CAAM and
-     * Atmel ports return when a hardware slot pool is exhausted. */
     if (dcp_lock() != 0)
-        return 0;
+        return -1;
+    /* A context owns at most one channel. If this one already holds a
+     * reservation - a live context being re-initialized, or the
+     * destination of a copy - hand back the same channel instead of
+     * taking a second. Looking the owner up here, in the port's own
+     * table, is what lets the callers avoid reading a handle.channel
+     * that may never have been initialized. */
     for (i = 0; i < 4; i++) {
-        if (dcp_status[i] == 0) {
-            dcp_status[i]++;
-            dcp_owner[i] = owner;
+        if (dcp_status[i] != 0 && dcp_owner[i] == owner) {
             ret = dcp_channels[i];
             break;
+        }
+    }
+    if (ret == 0) {
+        for (i = 0; i < 4; i++) {
+            if (dcp_status[i] == 0) {
+                dcp_status[i]++;
+                dcp_owner[i] = owner;
+                ret = dcp_channels[i];
+                break;
+            }
         }
     }
     dcp_unlock();
@@ -274,6 +294,8 @@ int DCPAesInit(Aes *aes)
     if (!aes)
         return BAD_FUNC_ARG;
     ch = dcp_get_channel(aes);
+    if (ch < 0)
+        return WC_HW_E;
     if (ch == 0)
         return WC_HW_WAIT_E;
     /* dcp_key_slot() fails with -1 if its lock acquisition fails;
@@ -413,12 +435,14 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
     int keyslot;
     if (sha256 == NULL)
         return BAD_FUNC_ARG;
-    /* A context owns at most one DCP channel; drop whatever this struct
-     * recorded before so re-initializing a live context cannot leak its
-     * channel. dcp_free only acts on a channel this struct owns, so a
-     * struct never zeroed before init is harmless. */
-    dcp_free(sha256, sha256->handle.channel);
+    /* Nothing in the supplied struct is read here: init accepts raw
+     * stack or XMALLOC storage, so handle.channel is indeterminate
+     * until the XMEMSET below. dcp_get_channel() hands back the
+     * reservation this pointer already holds, if any, so
+     * re-initializing a live context still cannot leak its channel. */
     ch = dcp_get_channel(sha256);
+    if (ch < 0)
+        return WC_HW_E;
     if (ch == 0)
         return WC_HW_WAIT_E;
     /* dcp_key_slot() fails with -1 if its lock acquisition fails;
@@ -545,10 +569,17 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
     handleWord = dcp_hash_handle_word();
     if (handleWord >= DCP_HASH_CTX_SIZE)
         return WC_HW_E;
-    /* The copy replaces dst (software contract: free dst resources,
-     * then clone); drop any channel dst owns. */
-    dcp_free(dst, dst->handle.channel);
+    /* The copy overwrites dst's hash state, not its channel
+     * reservation: dcp_get_channel() returns the channel dst already
+     * owns, and only reserves a new one when dst holds none. Releasing
+     * first and re-reserving would let another context take the
+     * channel in between, so a copy into a perfectly live dst - what
+     * wc_HmacUpdate() does on every call under WOLFSSL_HMAC_COPY_HASH -
+     * could fail for want of a channel it already had. It also avoids
+     * reading dst->handle, which need not be initialized here. */
     ch = dcp_get_channel(dst);
+    if (ch < 0)
+        return WC_HW_E;
     if (ch == 0)
         return WC_HW_WAIT_E;
     /* dcp_key_slot() fails with -1 if its lock acquisition fails;
@@ -590,12 +621,14 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     int keyslot;
     if (sha == NULL)
         return BAD_FUNC_ARG;
-    /* A context owns at most one DCP channel; drop whatever this struct
-     * recorded before so re-initializing a live context cannot leak its
-     * channel. dcp_free only acts on a channel this struct owns, so a
-     * struct never zeroed before init is harmless. */
-    dcp_free(sha, sha->handle.channel);
+    /* Nothing in the supplied struct is read here: init accepts raw
+     * stack or XMALLOC storage, so handle.channel is indeterminate
+     * until the XMEMSET below. dcp_get_channel() hands back the
+     * reservation this pointer already holds, if any, so
+     * re-initializing a live context still cannot leak its channel. */
     ch = dcp_get_channel(sha);
+    if (ch < 0)
+        return WC_HW_E;
     if (ch == 0)
         return WC_HW_WAIT_E;
     /* dcp_key_slot() fails with -1 if its lock acquisition fails;
@@ -723,10 +756,17 @@ int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
     handleWord = dcp_hash_handle_word();
     if (handleWord >= DCP_HASH_CTX_SIZE)
         return WC_HW_E;
-    /* The copy replaces dst (software contract: free dst resources,
-     * then clone); drop any channel dst owns. */
-    dcp_free(dst, dst->handle.channel);
+    /* The copy overwrites dst's hash state, not its channel
+     * reservation: dcp_get_channel() returns the channel dst already
+     * owns, and only reserves a new one when dst holds none. Releasing
+     * first and re-reserving would let another context take the
+     * channel in between, so a copy into a perfectly live dst - what
+     * wc_HmacUpdate() does on every call under WOLFSSL_HMAC_COPY_HASH -
+     * could fail for want of a channel it already had. It also avoids
+     * reading dst->handle, which need not be initialized here. */
     ch = dcp_get_channel(dst);
+    if (ch < 0)
+        return WC_HW_E;
     if (ch == 0)
         return WC_HW_WAIT_E;
     /* dcp_key_slot() fails with -1 if its lock acquisition fails;

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -137,14 +137,16 @@ static int dcp_get_channel(void)
 
 static int dcp_key_slot(int ch)
 {
+#if DCP_USE_OTP_KEY
+    (void)ch;
+    return kDCP_OtpKey;
+#elif defined(SINGLE_THREADED)
+    (void)ch;
+    return 0;
+#else
+    int i;
     int ret = -1;
 
-#if DCP_USE_OTP_KEY
-    return kDCP_OtpKey;
-#endif
-
-#ifndef SINGLE_THREADED
-    int i;
     dcp_lock();
     for (i = 0; i < 4; i++) {
         if (ch == dcp_channels[i]) {
@@ -153,10 +155,8 @@ static int dcp_key_slot(int ch)
         }
     }
     dcp_unlock();
-#else
-    ret = 0;
-#endif
     return ret;
+#endif
 }
 
 

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -196,13 +196,15 @@ int wc_dcp_init(void)
     return 0;
 }
 
-static void dcp_free(void* owner, int ch)
+/* Release a channel without taking the DCP lock. For the dcp_lock()
+ * failure branches only: a contended lock blocks rather than fails, so
+ * a failure there means no other thread can be inside the critical
+ * section and the clear cannot race a live access. */
+static void dcp_free_unlocked(void* owner, int ch)
 {
 #ifndef SINGLE_THREADED
     int i;
 
-    if (dcp_lock() != 0)
-        return;
     for (i = 0; i < 4; i++) {
         if (ch == dcp_channels[i] && dcp_owner[i] == owner) {
             dcp_status[i] = 0;
@@ -210,8 +212,18 @@ static void dcp_free(void* owner, int ch)
             break;
         }
     }
-    dcp_unlock();
+#else
+    (void)owner;
+    (void)ch;
 #endif
+}
+
+static void dcp_free(void* owner, int ch)
+{
+    if (dcp_lock() != 0)
+        return;
+    dcp_free_unlocked(owner, ch);
+    dcp_unlock();
 }
 
 /*
@@ -394,7 +406,7 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
-        dcp_free(sha256, ch);
+        dcp_free_unlocked(sha256, ch);
         return WC_HW_E;
     }
     (void)devId;
@@ -518,7 +530,7 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
-        dcp_free(dst, ch);
+        dcp_free_unlocked(dst, ch);
         return WC_HW_E;
     }
     dst->handle.channel    = (dcp_channel_t)ch;
@@ -559,7 +571,7 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
-        dcp_free(sha, ch);
+        dcp_free_unlocked(sha, ch);
         return WC_HW_E;
     }
     (void)devId;
@@ -684,7 +696,7 @@ int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
         return WC_PENDING_E;
     keyslot = dcp_key_slot(ch);
     if (dcp_lock() != 0) {
-        dcp_free(dst, ch);
+        dcp_free_unlocked(dst, ch);
         return WC_HW_E;
     }
     dst->handle.channel    = (dcp_channel_t)ch;

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -358,8 +358,14 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
     sha256->handle.keySlot    = (dcp_key_slot_t)keyslot;
     sha256->handle.swapConfig = kDCP_NoSwap;
     ret = DCP_HASH_Init(DCP, &sha256->handle, &sha256->ctx, kDCP_Sha256);
-    if (ret != kStatus_Success)
+    if (ret != kStatus_Success) {
+        /* The channel is reserved before the SDK init; release it on
+         * failure so repeated failures cannot exhaust the channels, and
+         * leave the context explicitly uninitialized. */
+        dcp_free(ch);
+        sha256->handle.channel = 0;
         ret = WC_HW_E;
+    }
     dcp_unlock();
 
     return ret;
@@ -475,8 +481,14 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     sha->handle.keySlot    = (dcp_key_slot_t)keyslot;
     sha->handle.swapConfig = kDCP_NoSwap;
     ret = DCP_HASH_Init(DCP, &sha->handle, &sha->ctx, kDCP_Sha1);
-    if (ret != kStatus_Success)
+    if (ret != kStatus_Success) {
+        /* The channel is reserved before the SDK init; release it on
+         * failure so repeated failures cannot exhaust the channels, and
+         * leave the context explicitly uninitialized. */
+        dcp_free(ch);
+        sha->handle.channel = 0;
         ret = WC_HW_E;
+    }
     dcp_unlock();
     return ret;
 }

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -115,7 +115,13 @@ static const int dcp_channels[4] = {
 };
 
 #ifndef SINGLE_THREADED
-static int dcp_status[4] = {0, 0, 0, 0};
+/* Channel table. dcp_status[i] is the publication flag for entry i: it
+ * is the LAST field written when reserving and when releasing, so an
+ * entry is only ever visible as claimable once dcp_owner[i] already
+ * agrees. dcp_free_unlocked() relies on that ordering to release
+ * without the lock, so both arrays are volatile to stop the compiler
+ * reordering or caching the paired accesses. */
+static volatile int dcp_status[4] = {0, 0, 0, 0};
 /* Context that reserved each channel: a release only takes effect from
  * the recorded owner, so a stale or uninitialized handle.channel value
  * (a struct never zeroed before init, a freed struct reused) cannot
@@ -123,7 +129,7 @@ static int dcp_status[4] = {0, 0, 0, 0};
  * lets the port answer "does this context already hold a channel?"
  * without reading the caller's struct, which init is allowed to
  * receive uninitialized. */
-static void* dcp_owner[4] = {NULL, NULL, NULL, NULL};
+static void* volatile dcp_owner[4] = {NULL, NULL, NULL, NULL};
 #endif
 
 /* Reserve a channel for owner.
@@ -158,8 +164,11 @@ static int dcp_get_channel(void* owner)
     if (ret == 0) {
         for (i = 0; i < 4; i++) {
             if (dcp_status[i] == 0) {
-                dcp_status[i]++;
+                /* Owner first, status last: dcp_status[i] publishes the
+                 * entry, so it must never be set while dcp_owner[i]
+                 * still names somebody else. */
                 dcp_owner[i] = owner;
+                dcp_status[i] = 1;
                 ret = dcp_channels[i];
                 break;
             }
@@ -218,12 +227,26 @@ int wc_dcp_init(void)
     return 0;
 }
 
-/* Release a channel without taking the DCP lock. Safe whenever
- * dcp_lock() is known to be unavailable: a contended lock blocks
- * rather than fails, so a failure means no other thread can be
- * inside the critical section (or the caller already holds the
- * mutex), and the owner check prevents releasing a channel held by
- * another context. */
+/* Release a channel without taking the DCP lock.
+ *
+ * A failed dcp_lock() does not prove the critical section is empty:
+ * wolfSSL_CryptHwMutexLock() can fail before it ever reaches
+ * wc_LockMutex(), because on every port without a static mutex
+ * initializer it first runs the lazy wolfSSL_CryptHwMutexInit(). One
+ * thread can lose that init race, or hit an allocation failure in it,
+ * and be told the lock is unavailable while another thread is inside
+ * the critical section. So this must be correct against a concurrent
+ * locked allocator, not merely against nobody.
+ *
+ * It is, because it only ever publishes a consistent entry: the owner
+ * is cleared while dcp_status[i] still marks the entry busy, so no
+ * allocator can claim it yet, and the single store that frees the
+ * entry is the last thing that happens. An allocator that claims the
+ * entry afterwards owns both fields outright and nothing here writes
+ * to them again. The reverse order would let an allocator claim the
+ * channel between the two stores and then have its fresh owner
+ * overwritten with NULL, leaving the channel busy but ownerless -
+ * unreleasable, and lost for the lifetime of the process. */
 static void dcp_free_unlocked(void* owner, int ch)
 {
 #ifndef SINGLE_THREADED
@@ -231,8 +254,8 @@ static void dcp_free_unlocked(void* owner, int ch)
 
     for (i = 0; i < 4; i++) {
         if (ch == dcp_channels[i] && dcp_owner[i] == owner) {
-            dcp_status[i] = 0;
             dcp_owner[i] = NULL;
+            dcp_status[i] = 0;
             break;
         }
     }
@@ -243,8 +266,11 @@ static void dcp_free_unlocked(void* owner, int ch)
 }
 
 /* Total: always releases, so callers may drop their handle record
- * unconditionally. A lock failure falls back to the unlocked release
- * (safe per dcp_free_unlocked) instead of orphaning the reservation. */
+ * unconditionally. A lock failure falls back to the unlocked release,
+ * which is ordered to be safe against a concurrent locked allocator
+ * (see dcp_free_unlocked), instead of orphaning the reservation - with
+ * only four channels, refusing to release on a lock failure would leak
+ * one permanently. */
 static void dcp_free(void* owner, int ch)
 {
     int locked;


### PR DESCRIPTION
f52198314 F-11239: give copied DCP hash contexts their own channel
d67eb0d5f F-11244: release the reserved DCP channel when hash init fails
5a8127d2a F-8261: check DCP lock results before touching shared state
f4ad17ce8 F-7127: restructure dcp_key_slot as mutually exclusive branches