### PR TITLE
Fix peer key masking

### DIFF
--- a/doc/dox_comments/header_files-ja/ascon.h
+++ b/doc/dox_comments/header_files-ja/ascon.h
@@ -233,7 +233,8 @@ int wc_AsconAEAD128_SetNonce(wc_AsconAEAD128* a, const byte* nonce);
     \brief この関数は、Ascon AEADコンテキストの関連データを設定します。
 
     \return 0 成功時。
-    \return BAD_FUNC_ARG コンテキストまたは関連データポインタがNULLの場合。
+    \return BAD_FUNC_ARG コンテキストがNULLの場合、または関連データサイズが0より
+            大きいのに関連データポインタがNULLの場合。
     \return BAD_STATE_E 鍵またはnonceが設定されていない場合。
 
     \param a 初期化されたAscon AEADコンテキストへのポインタ。

--- a/doc/dox_comments/header_files/ascon.h
+++ b/doc/dox_comments/header_files/ascon.h
@@ -236,7 +236,8 @@ int wc_AsconAEAD128_SetNonce(wc_AsconAEAD128* a, const byte* nonce);
     \brief This function sets the associated data for the Ascon AEAD context.
 
     \return 0 on success.
-    \return BAD_FUNC_ARG if the context or associated data pointer is NULL.
+    \return BAD_FUNC_ARG if the context is NULL, or if the associated data
+            pointer is NULL while the associated data size is greater than 0.
     \return BAD_STATE_E if the key or nonce has not been set.
 
     \param a pointer to the initialized Ascon AEAD context.

--- a/src/internal.c
+++ b/src/internal.c
@@ -35495,24 +35495,6 @@ exit_gdpk:
 }
 #endif
 
-#if defined(HAVE_CURVE25519) && !defined(WOLFSSL_X25519_NO_MASK_PEER)
-/* RFC 7748 Section 5 requires X25519 receivers to clear the reserved high bit
- * of the final u-coordinate byte rather than reject a peer key that sets it.
- * Returns the pointer the caller should hand to the check and import calls: a
- * masked copy in maskBuf for a full-length key, otherwise pub unchanged. */
-const byte* MaskCurve25519PeerKey(const byte* pub, word32 pubSz,
-                                  byte maskBuf[CURVE25519_KEYSIZE])
-{
-    if (pubSz != CURVE25519_KEYSIZE) {
-        return pub;
-    }
-
-    XMEMCPY(maskBuf, pub, CURVE25519_KEYSIZE);
-    maskBuf[CURVE25519_KEYSIZE - 1] &= 0x7f;
-    return maskBuf;
-}
-#endif /* HAVE_CURVE25519 && !WOLFSSL_X25519_NO_MASK_PEER */
-
 #if defined(HAVE_ECC) || defined(HAVE_CURVE25519) || defined(HAVE_CURVE448)
 static int GetEcDiffieHellmanKea(WOLFSSL *ssl,
                                  const byte *input, word32 size, DskeArgs *args)
@@ -38208,6 +38190,27 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 #endif /* !NO_WOLFSSL_CLIENT && !NO_TLS */
 /* end client only parts */
+
+
+#if defined(HAVE_CURVE25519) && !defined(WOLFSSL_X25519_NO_MASK_PEER)
+/* RFC 7748 Section 5 requires X25519 receivers to clear the reserved high bit
+ * of the final u-coordinate byte rather than reject a peer key that sets it.
+ * Returns the pointer the caller should hand to the check and import calls: a
+ * masked copy in maskBuf for a full-length key, otherwise pub unchanged.
+ * Shared by the TLS 1.2 (client and server) and TLS 1.3 key exchange paths,
+ * so it must sit outside the client-only and !WOLFSSL_NO_TLS12 guards. */
+const byte* MaskCurve25519PeerKey(const byte* pub, word32 pubSz,
+                                  byte maskBuf[CURVE25519_KEYSIZE])
+{
+    if (pubSz != CURVE25519_KEYSIZE) {
+        return pub;
+    }
+
+    XMEMCPY(maskBuf, pub, CURVE25519_KEYSIZE);
+    maskBuf[CURVE25519_KEYSIZE - 1] &= 0x7f;
+    return maskBuf;
+}
+#endif /* HAVE_CURVE25519 && !WOLFSSL_X25519_NO_MASK_PEER */
 
 
 #ifndef NO_CERTS

--- a/src/internal.c
+++ b/src/internal.c
@@ -35505,6 +35505,12 @@ static int GetEcDiffieHellmanKea(WOLFSSL *ssl,
 #endif
     int curveOid;
     word16 length;
+#ifdef HAVE_CURVE25519
+    const byte* peerPub;
+#ifndef WOLFSSL_X25519_NO_MASK_PEER
+    byte maskedPub[CURVE25519_KEYSIZE];
+#endif
+#endif
 
     if ((args->idx - args->begin) + ENUM_LEN + OPAQUE16_LEN +
         OPAQUE8_LEN > size) {
@@ -35547,7 +35553,18 @@ static int GetEcDiffieHellmanKea(WOLFSSL *ssl,
             }
         }
 
-        if ((ret = wc_curve25519_check_public(input + args->idx, length,
+        peerPub = input + args->idx;
+#ifndef WOLFSSL_X25519_NO_MASK_PEER
+        if (length == CURVE25519_KEYSIZE) {
+            XMEMCPY(maskedPub, peerPub, CURVE25519_KEYSIZE);
+            /* RFC 7748 Section 5: X25519 receivers MUST mask (clear) the
+             * reserved high bit of the final wire byte before use. */
+            maskedPub[CURVE25519_KEYSIZE - 1] &= 0x7f;
+            peerPub = maskedPub;
+        }
+#endif
+
+        if ((ret = wc_curve25519_check_public(peerPub, length,
                                               EC25519_LITTLE_ENDIAN)) != 0) {
 #ifdef WOLFSSL_EXTRA_ALERTS
             if (ret == WC_NO_ERR_TRACE(BUFFER_E))
@@ -35563,7 +35580,7 @@ static int GetEcDiffieHellmanKea(WOLFSSL *ssl,
             return ECC_PEERKEY_ERROR;
         }
 
-        if (wc_curve25519_import_public_ex(input + args->idx,
+        if (wc_curve25519_import_public_ex(peerPub,
                                            length, ssl->peerX25519Key,
                                            EC25519_LITTLE_ENDIAN) != 0) {
             return ECC_PEERKEY_ERROR;
@@ -44364,6 +44381,12 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
     {
         int ret;
         int kea = ssl->specs.kea;
+    #ifdef HAVE_CURVE25519
+        const byte* peerPub;
+    #ifndef WOLFSSL_X25519_NO_MASK_PEER
+        byte maskedPub[CURVE25519_KEYSIZE];
+    #endif
+    #endif
 
         *haveCb = 0;
         if ((args->idx - args->begin) + OPAQUE8_LEN > size)
@@ -44408,7 +44431,19 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                 }
             }
 
-            if ((ret = wc_curve25519_check_public(input + args->idx,
+            peerPub = input + args->idx;
+        #ifndef WOLFSSL_X25519_NO_MASK_PEER
+            if (args->length == CURVE25519_KEYSIZE) {
+                XMEMCPY(maskedPub, peerPub, CURVE25519_KEYSIZE);
+                /* RFC 7748 Section 5: X25519 receivers MUST mask (clear)
+                 * the reserved high bit of the final wire byte before
+                 * use. */
+                maskedPub[CURVE25519_KEYSIZE - 1] &= 0x7f;
+                peerPub = maskedPub;
+            }
+        #endif
+
+            if ((ret = wc_curve25519_check_public(peerPub,
                                    args->length, EC25519_LITTLE_ENDIAN)) != 0) {
             #ifdef WOLFSSL_EXTRA_ALERTS
                 if (ret == WC_NO_ERR_TRACE(BUFFER_E))
@@ -44424,7 +44459,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                 return ECC_PEERKEY_ERROR;
             }
 
-            if (wc_curve25519_import_public_ex(input + args->idx, args->length,
+            if (wc_curve25519_import_public_ex(peerPub, args->length,
                                ssl->peerX25519Key, EC25519_LITTLE_ENDIAN)) {
              #ifdef WOLFSSL_EXTRA_ALERTS
                 SendAlert(ssl, alert_fatal, illegal_parameter);

--- a/src/internal.c
+++ b/src/internal.c
@@ -35494,6 +35494,25 @@ exit_gdpk:
     return ret;
 }
 #endif
+
+#if defined(HAVE_CURVE25519) && !defined(WOLFSSL_X25519_NO_MASK_PEER)
+/* RFC 7748 Section 5 requires X25519 receivers to clear the reserved high bit
+ * of the final u-coordinate byte rather than reject a peer key that sets it.
+ * Returns the pointer the caller should hand to the check and import calls: a
+ * masked copy in maskBuf for a full-length key, otherwise pub unchanged. */
+const byte* MaskCurve25519PeerKey(const byte* pub, word32 pubSz,
+                                  byte maskBuf[CURVE25519_KEYSIZE])
+{
+    if (pubSz != CURVE25519_KEYSIZE) {
+        return pub;
+    }
+
+    XMEMCPY(maskBuf, pub, CURVE25519_KEYSIZE);
+    maskBuf[CURVE25519_KEYSIZE - 1] &= 0x7f;
+    return maskBuf;
+}
+#endif /* HAVE_CURVE25519 && !WOLFSSL_X25519_NO_MASK_PEER */
+
 #if defined(HAVE_ECC) || defined(HAVE_CURVE25519) || defined(HAVE_CURVE448)
 static int GetEcDiffieHellmanKea(WOLFSSL *ssl,
                                  const byte *input, word32 size, DskeArgs *args)
@@ -35555,13 +35574,7 @@ static int GetEcDiffieHellmanKea(WOLFSSL *ssl,
 
         peerPub = input + args->idx;
 #ifndef WOLFSSL_X25519_NO_MASK_PEER
-        if (length == CURVE25519_KEYSIZE) {
-            XMEMCPY(maskedPub, peerPub, CURVE25519_KEYSIZE);
-            /* RFC 7748 Section 5: X25519 receivers MUST mask (clear) the
-             * reserved high bit of the final wire byte before use. */
-            maskedPub[CURVE25519_KEYSIZE - 1] &= 0x7f;
-            peerPub = maskedPub;
-        }
+        peerPub = MaskCurve25519PeerKey(peerPub, length, maskedPub);
 #endif
 
         if ((ret = wc_curve25519_check_public(peerPub, length,
@@ -44433,14 +44446,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 
             peerPub = input + args->idx;
         #ifndef WOLFSSL_X25519_NO_MASK_PEER
-            if (args->length == CURVE25519_KEYSIZE) {
-                XMEMCPY(maskedPub, peerPub, CURVE25519_KEYSIZE);
-                /* RFC 7748 Section 5: X25519 receivers MUST mask (clear)
-                 * the reserved high bit of the final wire byte before
-                 * use. */
-                maskedPub[CURVE25519_KEYSIZE - 1] &= 0x7f;
-                peerPub = maskedPub;
-            }
+            peerPub = MaskCurve25519PeerKey(peerPub, args->length, maskedPub);
         #endif
 
             if ((ret = wc_curve25519_check_public(peerPub,

--- a/src/tls.c
+++ b/src/tls.c
@@ -9777,13 +9777,7 @@ static int TLSX_KeyShare_ProcessX25519_ex(WOLFSSL* ssl,
     #endif
 
     #ifndef WOLFSSL_X25519_NO_MASK_PEER
-        if (peerPubLen == CURVE25519_KEYSIZE) {
-            XMEMCPY(maskedPub, peerPub, CURVE25519_KEYSIZE);
-            /* RFC 7748 Section 5: X25519 receivers MUST mask (clear) the
-             * reserved high bit of the final wire byte before use. */
-            maskedPub[CURVE25519_KEYSIZE - 1] &= 0x7f;
-            peerPub = maskedPub;
-        }
+        peerPub = MaskCurve25519PeerKey(peerPub, peerPubLen, maskedPub);
     #endif
 
         if (wc_curve25519_check_public(peerPub, peerPubLen,

--- a/src/tls.c
+++ b/src/tls.c
@@ -9741,6 +9741,11 @@ static int TLSX_KeyShare_ProcessX25519_ex(WOLFSSL* ssl,
 
 #ifdef HAVE_CURVE25519
     curve25519_key* key = (curve25519_key*)keyShareEntry->key;
+    const byte* peerPub = keyShareEntry->ke;
+    word32 peerPubLen = keyShareEntry->keLen;
+#ifndef WOLFSSL_X25519_NO_MASK_PEER
+    byte maskedPub[CURVE25519_KEYSIZE];
+#endif
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     if (keyShareEntry->lastRet == 0) /* don't enter here if WC_PENDING_E */
@@ -9771,15 +9776,24 @@ static int TLSX_KeyShare_ProcessX25519_ex(WOLFSSL* ssl,
         WOLFSSL_BUFFER(keyShareEntry->ke, keyShareEntry->keLen);
     #endif
 
-        if (wc_curve25519_check_public(keyShareEntry->ke, keyShareEntry->keLen,
+    #ifndef WOLFSSL_X25519_NO_MASK_PEER
+        if (peerPubLen == CURVE25519_KEYSIZE) {
+            XMEMCPY(maskedPub, peerPub, CURVE25519_KEYSIZE);
+            /* RFC 7748 Section 5: X25519 receivers MUST mask (clear) the
+             * reserved high bit of the final wire byte before use. */
+            maskedPub[CURVE25519_KEYSIZE - 1] &= 0x7f;
+            peerPub = maskedPub;
+        }
+    #endif
+
+        if (wc_curve25519_check_public(peerPub, peerPubLen,
                                                   EC25519_LITTLE_ENDIAN) != 0) {
             ret = ECC_PEERKEY_ERROR;
             WOLFSSL_ERROR_VERBOSE(ret);
         }
 
         if (ret == 0) {
-            if (wc_curve25519_import_public_ex(keyShareEntry->ke,
-                                        keyShareEntry->keLen,
+            if (wc_curve25519_import_public_ex(peerPub, peerPubLen,
                                         ssl->peerX25519Key,
                                         EC25519_LITTLE_ENDIAN) != 0) {
                 ret = ECC_PEERKEY_ERROR;

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -10025,3 +10025,112 @@ int test_tls13_pha_status_request(void)
 #endif
     return EXPECT_RESULT();
 }
+
+/* RFC 7748 Section 5: a receiver of a 32-byte X25519 u-coordinate MUST mask
+ * (clear) the reserved high bit of the final byte rather than reject it.
+ * Craft a ClientHello whose key_share entry has that bit set and confirm
+ * the server masks it and proceeds, instead of aborting the handshake with
+ * ECC_PEERKEY_ERROR the way wc_curve25519_check_public() alone would.
+ */
+int test_tls13_x25519_keyshare_masks_reserved_bit(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && defined(HAVE_CURVE25519) && \
+    defined(HAVE_SUPPORTED_CURVES) && \
+    defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_CERTS) && !defined(NO_FILESYSTEM) && \
+    (defined(HAVE_ECC) || !defined(NO_RSA))
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL_CTX *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL;
+    WOLFSSL *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+    byte ch_buf[4096];
+    const char* ch_bytes = NULL;
+    int ch_sz = 0;
+    int i;
+    int keShareOff = -1;
+    int ret;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_3_client_method, wolfTLSv1_3_server_method), 0);
+
+#if defined(HAVE_ECC)
+    ExpectTrue(wolfSSL_use_certificate_file(ssl_s, eccCertFile,
+        CERT_FILETYPE) == WOLFSSL_SUCCESS);
+    ExpectTrue(wolfSSL_use_PrivateKey_file(ssl_s, eccKeyFile,
+        CERT_FILETYPE) == WOLFSSL_SUCCESS);
+#else
+    ExpectTrue(wolfSSL_use_certificate_file(ssl_s, svrCertFile,
+        CERT_FILETYPE) == WOLFSSL_SUCCESS);
+    ExpectTrue(wolfSSL_use_PrivateKey_file(ssl_s, svrKeyFile,
+        CERT_FILETYPE) == WOLFSSL_SUCCESS);
+#endif
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, NULL);
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, NULL);
+
+    /* Force an X25519 key share so the ClientHello carries a key_share
+     * entry we can find by its fixed group id (0x001D) and length
+     * (0x0020) markers, without parsing the full extension list. */
+    do {
+        ret = wolfSSL_UseKeyShare(ssl_c, WOLFSSL_ECC_X25519);
+#ifdef WOLFSSL_ASYNC_CRYPT
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
+            wolfSSL_AsyncPoll(ssl_c, WOLF_POLL_FLAG_CHECK_HW);
+#endif
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+    ExpectIntEQ(ret, WOLFSSL_SUCCESS);
+
+    ExpectIntNE(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+
+    /* Pull the ClientHello out of the buffer the server will read from
+     * (client=0), tamper with the X25519 public value in place, then feed
+     * the modified message back in. */
+    ExpectIntEQ(test_memio_get_message(&test_ctx, 0, &ch_bytes, &ch_sz, 0),
+        0);
+    ExpectTrue(ch_sz > 0 && ch_sz <= (int)sizeof(ch_buf));
+    if (ch_sz > 0 && ch_sz <= (int)sizeof(ch_buf)) {
+        XMEMCPY(ch_buf, ch_bytes, (size_t)ch_sz);
+
+        for (i = 0; i + 4 + CURVE25519_KEYSIZE <= ch_sz; i++) {
+            if (ch_buf[i] == 0x00 && ch_buf[i + 1] == 0x1D &&
+                    ch_buf[i + 2] == 0x00 &&
+                    ch_buf[i + 3] == CURVE25519_KEYSIZE) {
+                keShareOff = i;
+                break;
+            }
+        }
+        ExpectIntGE(keShareOff, 0);
+        if (keShareOff >= 0) {
+            /* Set the reserved high bit of the final wire byte of the
+             * public value -- the bit RFC 7748 requires masking. */
+            ch_buf[keShareOff + 4 + CURVE25519_KEYSIZE - 1] |= 0x80;
+        }
+    }
+
+    test_memio_clear_buffer(&test_ctx, 0);
+    if (keShareOff >= 0) {
+        ExpectIntEQ(test_memio_inject_message(&test_ctx, 0,
+            (const char*)ch_buf, ch_sz), 0);
+    }
+
+    /* Before the fix: wc_curve25519_check_public() sees the reserved bit
+     * and returns ECC_OUT_OF_RANGE_E, which DoTls13ClientHello turns into
+     * ECC_PEERKEY_ERROR and a fatal alert -- the handshake dies here.
+     * After the fix: the bit is masked before the check, so the server
+     * accepts the share and moves on to building its response flight. */
+    ExpectIntNE(wolfSSL_accept(ssl_s), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WOLFSSL_ERROR_WANT_READ);
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -10118,14 +10118,19 @@ int test_tls13_x25519_keyshare_masks_reserved_bit(void)
             (const char*)ch_buf, ch_sz), 0);
     }
 
-    /* Before the fix: wc_curve25519_check_public() sees the reserved bit
-     * and returns ECC_OUT_OF_RANGE_E, which DoTls13ClientHello turns into
-     * ECC_PEERKEY_ERROR and a fatal alert -- the handshake dies here.
-     * After the fix: the bit is masked before the check, so the server
-     * accepts the share and moves on to building its response flight. */
     ExpectIntNE(wolfSSL_accept(ssl_s), WOLFSSL_SUCCESS);
+#ifdef WOLFSSL_X25519_NO_MASK_PEER
+    /* Masking is compiled out: wc_curve25519_check_public() still sees
+     * the reserved bit and rejects the key, so the server must abort the
+     * handshake with ECC_PEERKEY_ERROR instead of masking it. */
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
+        WC_NO_ERR_TRACE(ECC_PEERKEY_ERROR));
+#else
+    /* The bit is masked before the check, so the server accepts the
+     * share and moves on to building its response flight. */
     ExpectIntEQ(wolfSSL_get_error(ssl_s, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)),
         WOLFSSL_ERROR_WANT_READ);
+#endif
 
     wolfSSL_free(ssl_c);
     wolfSSL_free(ssl_s);

--- a/tests/api/test_tls13.h
+++ b/tests/api/test_tls13.h
@@ -119,6 +119,7 @@ int test_tls13_AEAD_limit_KU_aes128_ccm_8_sha256(void);
 int test_tls13_KeyUpdate_sender_limit(void);
 int test_tls13_pqc_hybrid_async_server(void);
 int test_tls13_pha_status_request(void);
+int test_tls13_x25519_keyshare_masks_reserved_bit(void);
 
 #define TEST_TLS13_DECLS                                        \
     TEST_DECL_GROUP("tls13", test_tls13_apis),                  \
@@ -215,6 +216,7 @@ int test_tls13_pha_status_request(void);
     TEST_DECL_GROUP("tls13", test_tls13_AEAD_limit_KU_aes128_ccm_8_sha256), \
     TEST_DECL_GROUP("tls13", test_tls13_KeyUpdate_sender_limit), \
     TEST_DECL_GROUP("tls13", test_tls13_pqc_hybrid_async_server), \
-    TEST_DECL_GROUP("tls13", test_tls13_pha_status_request)
+    TEST_DECL_GROUP("tls13", test_tls13_pha_status_request), \
+    TEST_DECL_GROUP("tls13", test_tls13_x25519_keyshare_masks_reserved_bit)
 
 #endif /* WOLFCRYPT_TEST_TLS13_H */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2258,6 +2258,11 @@ WOLFSSL_LOCAL int InitSSL_Suites(WOLFSSL* ssl);
 WOLFSSL_LOCAL int InitSSL_Side(WOLFSSL* ssl, word16 side);
 
 
+#if defined(HAVE_CURVE25519) && !defined(WOLFSSL_X25519_NO_MASK_PEER)
+WOLFSSL_LOCAL const byte* MaskCurve25519PeerKey(const byte* pub, word32 pubSz,
+                                               byte maskBuf[CURVE25519_KEYSIZE]);
+#endif
+
 WOLFSSL_LOCAL int DoHandShakeMsgType(WOLFSSL* ssl, byte* input,
         word32* inOutIdx, byte type, word32 size, word32 totalSz);
 /* for sniffer */


### PR DESCRIPTION
## Summary(F9972)

RFC 7748 Section 5 requires that a receiver of a 32-byte X25519 u-coordinate **mask** (clear) the reserved high bit of the final byte rather than reject it. wolfSSL's TLS 1.2/1.3 handshake code instead rejected any peer X25519 public value with that bit set, aborting the handshake with `ECC_PEERKEY_ERROR` before the key was ever imported.

This affected all three places a peer's X25519 public value is parsed off the wire:

- `TLSX_KeyShare_ProcessX25519_ex` (`src/tls.c`) — TLS 1.3 KeyShare
- `GetEcDiffieHellmanKea` (`src/internal.c`) — TLS 1.2 ServerKeyExchange
- `ImportPeerECCKey` (`src/internal.c`) — TLS 1.2 ClientKeyExchange

## Fix

Each site now copies the received 32-byte value into a local buffer, clears bit 7 of the last byte (`&= 0x7f`), and passes the masked copy to both `wc_curve25519_check_public()` and the import call. Behavior is unchanged when `WOLFSSL_X25519_NO_MASK_PEER` is defined (existing opt-in strict rejection is preserved).

`wc_curve25519_check_public()` itself is untouched — masking is a TLS-layer concern per RFC 7748; the primitive's existing reject-on-high-bit behavior and its unit tests (`tests/api/test_curve25519.c`) remain correct as-is.

## Testing

Added `test_tls13_x25519_keyshare_masks_reserved_bit` (`tests/api/test_tls13.c`): drives a real TLS 1.3 memio handshake, tampers the client's ClientHello key_share entry to set the reserved bit, and confirms the server now masks it and proceeds (`WOLFSSL_ERROR_WANT_READ`) instead of aborting with `ECC_PEERKEY_ERROR`.

Verified the test fails with the expected `-352 (ECC_PEERKEY_ERROR)` when run against the code without this fix, confirming it catches the regression.

TLS 1.2 paths (`GetEcDiffieHellmanKea`, `ImportPeerECCKey`) share the same masking logic but are not yet covered by a dedicated test.



# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
