### PR TITLE
Fix C++ guards in SE050 header

### DIFF
--- a/wolfssl/wolfcrypt/port/nxp/se050_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/se050_port.h
@@ -57,6 +57,9 @@
 #pragma GCC diagnostic pop
 #endif
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 /* Default key ID's */
 #ifndef SE050_KEYSTOREID_AES
@@ -217,4 +220,9 @@ WOLFSSL_LOCAL int se050_curve25519_shared_secret(
     struct ECPoint* out);
 WOLFSSL_LOCAL void se050_curve25519_free_key(struct curve25519_key* key);
 #endif /* HAVE_CURVE25519 */
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+
 #endif /* _SE050_PORT_H_ */


### PR DESCRIPTION
# Description

se050_port.h does not wrap its declarations in an #ifdef __cplusplus / extern "C" linkage guard. When this header is included from a C++ translation unit, the declared functions receive C++ linkage and name mangling.

Fixes zd22377

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
