### PR TITLE
Free every OCSP chain request in TLSX_CSR_Free

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -3464,7 +3464,15 @@ static void TLSX_CSR_Free(CertificateStatusRequest* csr, void* heap)
 
     switch (csr->status_type) {
         case WOLFSSL_CSR_OCSP:
-            for (i = 0; i < csr->requests; i++) {
+            /* Requests are stored at the certificate's position in the chain,
+             * not packed: ProcessChainOCSPRequest() writes
+             * csr->request.ocsp[i] with i counting from 1 for the first
+             * intermediate, while csr->requests is a count. Bounding the free
+             * by that count leaves the tail entries allocated and unreachable
+             * whenever it is lower than the highest index written. Walk the
+             * whole array instead; FreeOcspRequest() is a no-op on a request
+             * that was never populated. */
+            for (i = 0; i < MAX_CERT_EXTENSIONS; i++) {
                 FreeOcspRequest(&csr->request.ocsp[i]);
             }
         break;


### PR DESCRIPTION
# Description

`ProcessChainOCSPRequest()` stores one `OcspRequest` per certificate at that
certificate's **position in the chain**:

    request = &csr->request.ocsp[i];   /* i starts at 1, index 0 is the leaf */

`csr->requests`, however, is a **count** of calls that completed successfully,
maintained independently of `i`.

`TLSX_CSR_Free()` bounded the release by that count:

    for (i = 0; i < csr->requests; i++)
        FreeOcspRequest(&csr->request.ocsp[i]);

The two only coincide when index 0 was populated first. Whenever the highest
index written is at or above `csr->requests`, the tail entries are never
released, and the serial and URL buffers `InitOcspRequest()` allocated for them
become unreachable.

Valgrind reports them as definitely lost:

    InitOcspRequest (asn.c)
      <- CreateOcspRequest (internal.c)
        <- ProcessChainOCSPRequest (tls.c)

This affects OCSP multi-stapling for certificate chains
(`--enable-ocspstapling`). Functional behaviour is unaffected — every test
passes either way — so it only surfaces under a leak checker.

Fix: walk the whole array rather than a count. `FreeOcspRequest()` is a no-op
on a request that was never populated, and the array is sized
`MAX_CERT_EXTENSIONS`, so unpopulated slots cost nothing.

# Testing

Discovered through #11222 

* Reproducer that populates a request at chain position 1 with `csr->requests`
  still 0, then frees the `WOLFSSL` object, run under
  `valgrind --leak-check=full`:

  * before: `definitely lost: 43 bytes in 2 blocks`, `ERROR SUMMARY: 2 errors`
  * after:  no leaks, `ERROR SUMMARY: 0 errors`

  The 20-byte and 23-byte blocks correspond to the serial and URL allocations
  in `InitOcspRequest()`.

* `./tests/unit.test --group ocsp` — 0 failures.
* `./wolfcrypt/test/testwolfcrypt` — exit 0.
* Configuration used:
  `--enable-ocsp --enable-ocspstapling --enable-ocspstapling2 --enable-tls13`



