### PR TITLE
fix overflow in wc_ecc_sign_hash_hw

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6879,7 +6879,7 @@ static int wc_ecc_sign_hash_hw(const byte* in, word32 inlen,
         mp_reverse(&out[keysize], keysize);
 
 error_out:
-        ForceZero(K, MAX_ECC_BYTES);
+        ForceZero(K, keysize);
         WC_FREE_VAR_EX(incopy, key->heap, DYNAMIC_TYPE_HASH_TMP);
         WC_FREE_VAR_EX(K, key->heap, DYNAMIC_TYPE_PRIVATE_KEY);
         if (err) {


### PR DESCRIPTION
## Summary

In `wc_ecc_sign_hash_hw()` (`wolfcrypt/src/ecc.c`), when built with both `WOLFSSL_XILINX_CRYPT_VERSAL` and `WOLFSSL_SMALL_STACK`, the nonce buffer `K` is heap-allocated with the curve's actual byte size:

```c
K = (byte*)XMALLOC(keysize, key->heap, DYNAMIC_TYPE_PRIVATE_KEY);
```

but the shared `error_out` cleanup path (hit on every exit from this section, success or error) wiped it using the maximum possible curve size instead of the allocated size:

```c
error_out:
    ForceZero(K, MAX_ECC_BYTES);
```

In any build supporting multiple curve sizes up to P-521, `MAX_ECC_BYTES` (66) exceeds `keysize` for every smaller curve (e.g. 48 bytes for P-384, 32 bytes for P-256). As a result, `ForceZero()` wrote up to 18 bytes past the end of the heap allocation on every call through this code path, not just on error paths.

This is a heap buffer overflow, not merely an unwiped-secret issue: the non-`WOLFSSL_SMALL_STACK` path is unaffected, since there `K` is a fixed-size stack array (`byte K[MAX_ECC_BYTES]`), so wiping `MAX_ECC_BYTES` bytes is in-bounds.

## Fix

Wipe only the bytes that were actually allocated/populated:

```c
error_out:
    ForceZero(K, keysize);
```

This is safe in both configurations:
- **`WOLFSSL_SMALL_STACK` (heap):** fixes the out-of-bounds write, since only `keysize` bytes were ever allocated or written into `K`.
- **Stack array:** `keysize <= MAX_ECC_BYTES` always holds, and the RNG / deterministic-K generation path only ever populates the first `keysize` bytes of `K`, so reducing the wipe length does not leave any previously written nonce bytes unwiped.

## Impact

- Affected configuration: `WOLFSSL_XILINX_CRYPT_VERSAL` + `WOLFSSL_SMALL_STACK`, with a curve size smaller than the build's maximum supported curve (i.e. any curve except the largest configured, typically P-521).
- Every call to ECC sign through the Xilinx Versal hardware-accelerated path in this configuration triggered a small out-of-bounds heap write (up to `MAX_ECC_BYTES - keysize`, i.e. up to 18 bytes) as part of the nonce zeroization.

## Testing

- Code inspection confirms `K`'s allocation size (`keysize`) and the `error_out` wipe size now match.
- No behavior change for the non-`WOLFSSL_SMALL_STACK` stack-array case.


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
