### PR TITLE
Documents a precondition in the signle-DES API

### DIFF
--- a/doc/dox_comments/header_files/des3.h
+++ b/doc/dox_comments/header_files/des3.h
@@ -7,6 +7,13 @@
     yet been initialized. Note: If no iv is provided (i.e. iv == NULL)
     the initialization vector defaults to an iv of 0.
 
+    \note This function must be called on a Des structure before it is
+    passed to wc_Des_CbcEncrypt(), wc_Des_CbcDecrypt(), or
+    wc_Des_EcbEncrypt(). Unlike the Des3 API, the Des structure has no
+    key-set state, so those functions do not verify that a key has been
+    set and will operate on undefined key material if this precondition
+    is not met.
+
     \return 0 On successfully setting the key and initialization vector for
     the Des structure
 
@@ -70,6 +77,10 @@ void wc_Des_SetIV(Des* des, const byte* iv);
     in the output buffer, out. It uses DES encryption with cipher block
     chaining (CBC) mode.
 
+    \note wc_Des_SetKey() must be called on des before calling this
+    function. This function does not check whether a key has been set
+    and will encrypt using undefined key material if it has not.
+
     \return 0 Returned upon successfully encrypting the given input message
 
     \param des pointer to the Des structure to use for encryption
@@ -102,6 +113,10 @@ int  wc_Des_CbcEncrypt(Des* des, byte* out,
     \brief This function decrypts the input ciphertext, in, and stores the
     resulting plaintext in the output buffer, out. It uses DES encryption
     with cipher block chaining (CBC) mode.
+
+    \note wc_Des_SetKey() must be called on des before calling this
+    function. This function does not check whether a key has been set
+    and will decrypt using undefined key material if it has not.
 
     \return 0 Returned upon successfully decrypting the given ciphertext
 
@@ -136,6 +151,10 @@ int  wc_Des_CbcDecrypt(Des* des, byte* out,
     in the output buffer, out. It uses Des encryption with Electronic
     Codebook (ECB) mode.
 
+    \note wc_Des_SetKey() must be called on des before calling this
+    function. This function does not check whether a key has been set
+    and will encrypt using undefined key material if it has not.
+
     \return 0: Returned upon successfully encrypting the given plaintext.
 
     \param des pointer to the Des structure to use for encryption
@@ -156,7 +175,7 @@ int  wc_Des_CbcDecrypt(Des* des, byte* out,
     }
     \endcode
 
-    \sa wc_Des_SetKe
+    \sa wc_Des_SetKey
 */
 int  wc_Des_EcbEncrypt(Des* des, byte* out,
                                    const byte* in, word32 sz);

--- a/doc/dox_comments/header_files/des3.h
+++ b/doc/dox_comments/header_files/des3.h
@@ -8,11 +8,11 @@
     the initialization vector defaults to an iv of 0.
 
     \note This function must be called on a Des structure before it is
-    passed to wc_Des_CbcEncrypt(), wc_Des_CbcDecrypt(), or
-    wc_Des_EcbEncrypt(). Unlike the Des3 API, the Des structure has no
-    key-set state, so those functions do not verify that a key has been
-    set and will operate on undefined key material if this precondition
-    is not met.
+    passed to wc_Des_CbcEncrypt(), wc_Des_CbcDecrypt(),
+    wc_Des_EcbEncrypt(), or wc_Des_EcbDecrypt(). Unlike the Des3 API,
+    the Des structure has no key-set state, so those functions do not
+    verify that a key has been set and will operate on undefined key
+    material if this precondition is not met.
 
     \return 0 On successfully setting the key and initialization vector for
     the Des structure
@@ -365,6 +365,10 @@ int  wc_Des3_CbcDecrypt(Des3* des, byte* out,
     with Electronic Codebook (ECB) mode. Warning: In nearly all use
     cases ECB mode is considered to be less secure. Please avoid using
     ECB APIs directly whenever possible.
+
+    \note wc_Des_SetKey() must be called on des before calling this
+    function. This function does not check whether a key has been set
+    and will decrypt using undefined key material if it has not.
 
     \return 0 On successfully decrypting the given ciphertext
 


### PR DESCRIPTION
## Summary

- Documents a precondition gap in the single-DES API: `Des` has no `keySet` state (unlike `Des3`), so `wc_Des_CbcEncrypt`, `wc_Des_CbcDecrypt`, and `wc_Des_EcbEncrypt` do not verify that `wc_Des_SetKey()` was called first, and will silently operate on undefined key material if it wasn't.
- Adds `\note` blocks to `wc_Des_SetKey`, `wc_Des_CbcEncrypt`, `wc_Des_CbcDecrypt`, and `wc_Des_EcbEncrypt` in `doc/dox_comments/header_files/des3.h` stating this precondition.
- Fixes a `\sa wc_Des_SetKe` typo (missing `y`) on `wc_Des_EcbEncrypt`.

## Why doc-only

A code fix would need a `keySet`-style guard added consistently across every `wc_Des_CbcEncrypt`/`Decrypt` and `wc_Des3_CbcEncrypt`/`Decrypt` implementation in `des3.c` (~6 backend variants: generic software, STM32 CubeMX, Freescale MMCAU, ColdFire SEC, etc.), several of which also lack the check for `Des3` today. It would also touch the file's FIPS-boundary code segment (`des3.c` is placed in `.fipsA$d`/`.fipsB$d` for `HAVE_FIPS_VERSION` 2/3). Given this is a low-severity, API-misuse-only issue (caller must skip `wc_Des_SetKey()` entirely to hit it) and is consistent with existing accepted-risk precedent for the same class of issue in Camellia and RC2, this PR only documents the precondition rather than reworking every backend.

## Scope

Single file: `doc/dox_comments/header_files/des3.h`. No functional/code changes.

## Testing

Documentation-only change; no build or test impact.



# Checklist

 - [ ] added tests
 - [x] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [x] Updated manual and documentation
