### PR TITLE
Rust mlkem Fenrir fixes 2026-08-27

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -81707,6 +81707,7 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
         }
     #endif /* HAVE_FALCON && !WOLF_CRYPTO_CB_ONLY_FALCON */
     #ifdef WOLFSSL_HAVE_MLKEM
+    #ifndef WOLFSSL_MLKEM_NO_MAKE_KEY
         if (info->pk.type == WC_PK_TYPE_PQC_KEM_KEYGEN) {
             if ((info->pk.pqc_kem_kg.type == WC_PQC_KEM_TYPE_MLKEM) &&
                 (info->pk.pqc_kem_kg.key != NULL)) {
@@ -81727,7 +81728,9 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
                 key->prf.devId = prfDevId;
             }
         }
-        else if (info->pk.type == WC_PK_TYPE_PQC_KEM_ENCAPS) {
+    #endif
+    #ifndef WOLFSSL_MLKEM_NO_ENCAPSULATE
+        if (info->pk.type == WC_PK_TYPE_PQC_KEM_ENCAPS) {
             if ((info->pk.pqc_encaps.type == WC_PQC_KEM_TYPE_MLKEM) &&
                 (info->pk.pqc_encaps.key != NULL)) {
                 MlKemKey* key = (MlKemKey*)info->pk.pqc_encaps.key;
@@ -81750,7 +81753,9 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
                 key->prf.devId = prfDevId;
             }
         }
-        else if (info->pk.type == WC_PK_TYPE_PQC_KEM_DECAPS) {
+    #endif
+    #ifndef WOLFSSL_MLKEM_NO_DECAPSULATE
+        if (info->pk.type == WC_PK_TYPE_PQC_KEM_DECAPS) {
             if ((info->pk.pqc_decaps.type == WC_PQC_KEM_TYPE_MLKEM) &&
                 (info->pk.pqc_decaps.key != NULL)) {
                 MlKemKey* key = (MlKemKey*)info->pk.pqc_decaps.key;
@@ -81773,6 +81778,7 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
                 key->prf.devId = prfDevId;
             }
         }
+    #endif
     #endif /* WOLFSSL_HAVE_MLKEM */
     #ifdef WOLFSSL_HAVE_FRODOKEM
         if (info->pk.type == WC_PK_TYPE_PQC_KEM_KEYGEN) {

--- a/wolfssl/wolfcrypt/wc_mlkem.h
+++ b/wolfssl/wolfcrypt/wc_mlkem.h
@@ -440,19 +440,26 @@ WOLFSSL_API int wc_MlKemKey_Init_Label(MlKemKey* key, int type,
     const char* label, void* heap, int devId);
 #endif
 
+#ifndef WOLFSSL_MLKEM_NO_MAKE_KEY
 WOLFSSL_API int wc_MlKemKey_MakeKey(MlKemKey* key, WC_RNG* rng);
 WOLFSSL_API int wc_MlKemKey_MakeKeyWithRandom(MlKemKey* key,
     const unsigned char* rand, int len);
+#endif
 
 WOLFSSL_API int wc_MlKemKey_CipherTextSize(MlKemKey* key, word32* len);
 WOLFSSL_API int wc_MlKemKey_SharedSecretSize(MlKemKey* key, word32* len);
 
+#ifndef WOLFSSL_MLKEM_NO_ENCAPSULATE
 WOLFSSL_API int wc_MlKemKey_Encapsulate(MlKemKey* key, unsigned char* ct,
     unsigned char* ss, WC_RNG* rng);
 WOLFSSL_API int wc_MlKemKey_EncapsulateWithRandom(MlKemKey* key,
     unsigned char* ct, unsigned char* ss, const unsigned char* rand, int len);
+#endif
+
+#ifndef WOLFSSL_MLKEM_NO_DECAPSULATE
 WOLFSSL_API int wc_MlKemKey_Decapsulate(MlKemKey* key, unsigned char* ss,
     const unsigned char* ct, word32 len);
+#endif
 
 WOLFSSL_API int wc_MlKemKey_DecodePrivateKey(MlKemKey* key,
     const unsigned char* in, word32 len);

--- a/wrapper/rust/wolfssl-wolfcrypt/build.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/build.rs
@@ -506,7 +506,7 @@ fn scan_cfg() -> Result<()> {
     check_cfg(&binding, "WC_MLDSA_87_KEY_SIZE", "mldsa_level5");
 
     /* mlkem / ML-KEM */
-    check_cfg(&binding, "wc_MlKemKey_Init", "mlkem");
+    check_cfg(&binding, "wc_MlKemKey_New", "mlkem");
     check_cfg(&binding, "wc_MlKemKey_MakeKey", "mlkem_make_key");
     check_cfg(&binding, "wc_MlKemKey_Encapsulate", "mlkem_encapsulate");
     check_cfg(&binding, "wc_MlKemKey_Decapsulate", "mlkem_decapsulate");

--- a/wrapper/rust/wolfssl-wolfcrypt/build.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/build.rs
@@ -507,6 +507,12 @@ fn scan_cfg() -> Result<()> {
 
     /* mlkem / ML-KEM */
     check_cfg(&binding, "wc_MlKemKey_Init", "mlkem");
+    check_cfg(&binding, "wc_MlKemKey_MakeKey", "mlkem_make_key");
+    check_cfg(&binding, "wc_MlKemKey_Encapsulate", "mlkem_encapsulate");
+    check_cfg(&binding, "wc_MlKemKey_Decapsulate", "mlkem_decapsulate");
+    check_cfg(&binding, "WC_ML_KEM_512_K", "mlkem_512");
+    check_cfg(&binding, "WC_ML_KEM_768_K", "mlkem_768");
+    check_cfg(&binding, "WC_ML_KEM_1024_K", "mlkem_1024");
 
     /* lms / HSS */
     check_cfg(&binding, "wc_LmsKey_Init", "lms");

--- a/wrapper/rust/wolfssl-wolfcrypt/src/mlkem.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/mlkem.rs
@@ -38,7 +38,7 @@ construction time:
 # Examples
 
 ```rust
-#[cfg(all(mlkem, random))]
+#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 {
 use wolfssl_wolfcrypt::random::RNG;
 use wolfssl_wolfcrypt::mlkem::MlKem;
@@ -113,7 +113,7 @@ impl MlKem {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(mlkem, random))]
+    /// #[cfg(all(mlkem_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::mlkem::MlKem;
@@ -122,7 +122,7 @@ impl MlKem {
     ///     .expect("Error with generate()");
     /// }
     /// ```
-    #[cfg(random)]
+    #[cfg(all(random, mlkem_make_key))]
     pub fn generate(key_type: i32, rng: &RNG) -> Result<Self, i32> {
         Self::generate_ex(key_type, rng, None, None)
     }
@@ -145,7 +145,7 @@ impl MlKem {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(mlkem, random))]
+    /// #[cfg(all(mlkem_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::mlkem::MlKem;
@@ -154,7 +154,7 @@ impl MlKem {
     ///     .expect("Error with generate_ex()");
     /// }
     /// ```
-    #[cfg(random)]
+    #[cfg(all(random, mlkem_make_key))]
     pub fn generate_ex(
         key_type: i32,
         rng: &RNG,
@@ -189,7 +189,7 @@ impl MlKem {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(mlkem)]
+    /// #[cfg(mlkem_make_key)]
     /// {
     /// use wolfssl_wolfcrypt::mlkem::MlKem;
     /// let rand = [0x42u8; 64];
@@ -197,6 +197,7 @@ impl MlKem {
     ///     .expect("Error with generate_with_random()");
     /// }
     /// ```
+    #[cfg(mlkem_make_key)]
     pub fn generate_with_random(key_type: i32, rand: &[u8]) -> Result<Self, i32> {
         Self::generate_with_random_ex(key_type, rand, None, None)
     }
@@ -220,7 +221,7 @@ impl MlKem {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(mlkem)]
+    /// #[cfg(mlkem_make_key)]
     /// {
     /// use wolfssl_wolfcrypt::mlkem::MlKem;
     /// let rand = [0x42u8; 64];
@@ -228,6 +229,7 @@ impl MlKem {
     ///     .expect("Error with generate_with_random_ex()");
     /// }
     /// ```
+    #[cfg(mlkem_make_key)]
     pub fn generate_with_random_ex(
         key_type: i32,
         rand: &[u8],
@@ -452,7 +454,7 @@ impl MlKem {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(mlkem, random))]
+    /// #[cfg(all(mlkem_make_key, mlkem_encapsulate, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::mlkem::MlKem;
@@ -467,7 +469,7 @@ impl MlKem {
     ///     .expect("Error with encapsulate()");
     /// }
     /// ```
-    #[cfg(random)]
+    #[cfg(all(mlkem_encapsulate, random))]
     pub fn encapsulate(
         &mut self,
         ct: &mut [u8],
@@ -518,7 +520,7 @@ impl MlKem {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(mlkem)]
+    /// #[cfg(all(mlkem_make_key, mlkem_encapsulate))]
     /// {
     /// use wolfssl_wolfcrypt::mlkem::MlKem;
     /// let key_rand = [0x42u8; 64];
@@ -533,6 +535,7 @@ impl MlKem {
     ///     .expect("Error with encapsulate_with_random()");
     /// }
     /// ```
+    #[cfg(mlkem_encapsulate)]
     pub fn encapsulate_with_random(
         &mut self,
         ct: &mut [u8],
@@ -577,8 +580,8 @@ impl MlKem {
     /// # Parameters
     ///
     /// * `ss`: Output buffer for the shared secret.
-    /// * `ct`: Cipher text produced by [`MlKem::encapsulate()`] or
-    ///   [`MlKem::encapsulate_with_random()`].
+    /// * `ct`: Cipher text produced by `MlKem::encapsulate()` or
+    ///   `MlKem::encapsulate_with_random()`.
     ///
     /// # Returns
     ///
@@ -588,7 +591,7 @@ impl MlKem {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(mlkem, random))]
+    /// #[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::mlkem::MlKem;
@@ -607,6 +610,7 @@ impl MlKem {
     /// assert_eq!(ss_enc, ss_dec);
     /// }
     /// ```
+    #[cfg(mlkem_decapsulate)]
     pub fn decapsulate(&mut self, ss: &mut [u8], ct: &[u8]) -> Result<(), i32> {
         // Verify the shared secret length is as expected.
         if ss.len() != Self::SHARED_SECRET_SIZE {
@@ -643,7 +647,7 @@ impl MlKem {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(mlkem, random))]
+    /// #[cfg(all(mlkem_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::mlkem::MlKem;
@@ -682,7 +686,7 @@ impl MlKem {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(mlkem, random))]
+    /// #[cfg(all(mlkem_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::mlkem::MlKem;
@@ -719,7 +723,7 @@ impl MlKem {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(mlkem, random))]
+    /// #[cfg(all(mlkem_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::mlkem::MlKem;
@@ -758,7 +762,7 @@ impl MlKem {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(mlkem, random))]
+    /// #[cfg(all(mlkem_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::mlkem::MlKem;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/mlkem.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/mlkem.rs
@@ -38,7 +38,7 @@ construction time:
 # Examples
 
 ```rust
-#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
+#[cfg(all(mlkem_768, mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 {
 use wolfssl_wolfcrypt::random::RNG;
 use wolfssl_wolfcrypt::mlkem::MlKem;

--- a/wrapper/rust/wolfssl-wolfcrypt/src/mlkem_kem.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/mlkem_kem.rs
@@ -43,7 +43,7 @@ required random bytes from the RNG.
 # Examples
 
 ```rust
-#[cfg(all(mlkem, random, feature = "kem", feature = "rand_core"))]
+#[cfg(all(mlkem_encapsulate, mlkem_decapsulate, mlkem_make_key, mlkem_768, random, feature = "kem", feature = "rand_core"))]
 {
 use kem::{Kem, Encapsulate, Decapsulate};
 use kem::Generate;
@@ -60,7 +60,7 @@ assert_eq!(k_send, k_recv);
 ```
 */
 
-#![cfg(all(feature = "kem", mlkem))]
+#![cfg(all(feature = "kem", mlkem_encapsulate, mlkem_decapsulate, mlkem_make_key))]
 
 use kem::common::array::Array;
 use kem::common::typenum::{U32, U768, U800};
@@ -211,6 +211,7 @@ macro_rules! impl_mlkem_kem {
     };
 }
 
+#[cfg(mlkem_512)]
 impl_mlkem_kem! {
     kem = MlKem512,
     ek = MlKem512EncapsulationKey,
@@ -224,6 +225,7 @@ impl_mlkem_kem! {
     key_type = crate::mlkem::MlKem::TYPE_512,
 }
 
+#[cfg(mlkem_768)]
 impl_mlkem_kem! {
     kem = MlKem768,
     ek = MlKem768EncapsulationKey,
@@ -237,6 +239,7 @@ impl_mlkem_kem! {
     key_type = crate::mlkem::MlKem::TYPE_768,
 }
 
+#[cfg(mlkem_1024)]
 impl_mlkem_kem! {
     kem = MlKem1024,
     ek = MlKem1024EncapsulationKey,

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_mlkem.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_mlkem.rs
@@ -23,7 +23,7 @@
 mod common;
 
 use wolfssl_wolfcrypt::mlkem::MlKem;
-#[cfg(random)]
+#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 use wolfssl_wolfcrypt::random::RNG;
 
 /// Verify the type constants have the correct numeric values required by
@@ -85,7 +85,7 @@ fn test_size_queries() {
 /// Encapsulate and decapsulate with ML-KEM-512, verifying that both sides
 /// arrive at the same shared secret.
 #[test]
-#[cfg(random)]
+#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 fn test_encap_decap_type512() {
     common::setup();
     let mut rng = RNG::new().expect("Error creating RNG");
@@ -111,7 +111,7 @@ fn test_encap_decap_type512() {
 /// arrive at the same shared secret. Also verifies that a tampered cipher text
 /// produces a different (implicit rejection) shared secret.
 #[test]
-#[cfg(random)]
+#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 fn test_encap_decap_type768() {
     common::setup();
     let mut rng = RNG::new().expect("Error creating RNG");
@@ -145,7 +145,7 @@ fn test_encap_decap_type768() {
 /// Encapsulate and decapsulate with ML-KEM-1024, verifying that both sides
 /// arrive at the same shared secret.
 #[test]
-#[cfg(random)]
+#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 fn test_encap_decap_type1024() {
     common::setup();
     let mut rng = RNG::new().expect("Error creating RNG");
@@ -170,6 +170,7 @@ fn test_encap_decap_type1024() {
 /// Verify that `generate_with_random()` is deterministic: the same random
 /// bytes produce the same key pair on repeated calls.
 #[test]
+#[cfg(mlkem_make_key)]
 fn test_generate_with_random_determinism() {
     common::setup();
     // MAKEKEY_RAND_SIZE = 64 bytes
@@ -198,6 +199,7 @@ fn test_generate_with_random_determinism() {
 /// Verify that `encapsulate_with_random()` is deterministic: the same public
 /// key and random bytes produce the same cipher text and shared secret.
 #[test]
+#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate))]
 fn test_encapsulate_with_random_determinism() {
     common::setup();
     let key_rand = [0x11u8; 64];
@@ -232,7 +234,7 @@ fn test_encapsulate_with_random_determinism() {
 /// Encode and decode the public key for ML-KEM-768, verifying the round-trip
 /// preserves the key bytes and that encapsulation works with the re-imported key.
 #[test]
-#[cfg(random)]
+#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 fn test_encode_decode_public_key() {
     common::setup();
     let mut rng = RNG::new().expect("Error creating RNG");
@@ -266,7 +268,7 @@ fn test_encode_decode_public_key() {
 /// Encode and decode the private key for ML-KEM-768, verifying that
 /// decapsulation works with the re-imported key.
 #[test]
-#[cfg(random)]
+#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 fn test_encode_decode_private_key() {
     common::setup();
     let mut rng = RNG::new().expect("Error creating RNG");
@@ -300,7 +302,7 @@ fn test_encode_decode_private_key() {
 /// Verify that encapsulate/decapsulate round-trips work across all three
 /// security levels.
 #[test]
-#[cfg(random)]
+#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 fn test_encap_decap_all_types() {
     common::setup();
     let mut rng = RNG::new().expect("Error creating RNG");

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_mlkem.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_mlkem.rs
@@ -85,7 +85,7 @@ fn test_size_queries() {
 /// Encapsulate and decapsulate with ML-KEM-512, verifying that both sides
 /// arrive at the same shared secret.
 #[test]
-#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
+#[cfg(all(mlkem_512, mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 fn test_encap_decap_type512() {
     common::setup();
     let mut rng = RNG::new().expect("Error creating RNG");
@@ -111,7 +111,7 @@ fn test_encap_decap_type512() {
 /// arrive at the same shared secret. Also verifies that a tampered cipher text
 /// produces a different (implicit rejection) shared secret.
 #[test]
-#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
+#[cfg(all(mlkem_768, mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 fn test_encap_decap_type768() {
     common::setup();
     let mut rng = RNG::new().expect("Error creating RNG");
@@ -145,7 +145,7 @@ fn test_encap_decap_type768() {
 /// Encapsulate and decapsulate with ML-KEM-1024, verifying that both sides
 /// arrive at the same shared secret.
 #[test]
-#[cfg(all(mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
+#[cfg(all(mlkem_1024, mlkem_make_key, mlkem_encapsulate, mlkem_decapsulate, random))]
 fn test_encap_decap_type1024() {
     common::setup();
     let mut rng = RNG::new().expect("Error creating RNG");

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_mlkem_kem.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_mlkem_kem.rs
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#![cfg(all(mlkem, random, feature = "kem", feature = "rand_core"))]
+#![cfg(all(mlkem_encapsulate, mlkem_decapsulate, mlkem_make_key, random, feature = "kem", feature = "rand_core"))]
 
 mod common;
 
@@ -52,6 +52,7 @@ fn test_sizes_match_runtime() {
 
 /// Generate, encapsulate, and decapsulate with ML-KEM-512 via the kem traits.
 #[test]
+#[cfg(mlkem_512)]
 fn test_kem_512_round_trip() {
     common::setup();
     let mut rng = RNG::new().expect("RNG creation failed");
@@ -64,6 +65,7 @@ fn test_kem_512_round_trip() {
 
 /// Generate, encapsulate, and decapsulate with ML-KEM-768 via the kem traits.
 #[test]
+#[cfg(mlkem_768)]
 fn test_kem_768_round_trip() {
     common::setup();
     let mut rng = RNG::new().expect("RNG creation failed");
@@ -76,6 +78,7 @@ fn test_kem_768_round_trip() {
 
 /// Generate, encapsulate, and decapsulate with ML-KEM-1024 via the kem traits.
 #[test]
+#[cfg(mlkem_1024)]
 fn test_kem_1024_round_trip() {
     common::setup();
     let mut rng = RNG::new().expect("RNG creation failed");
@@ -89,6 +92,7 @@ fn test_kem_1024_round_trip() {
 /// Verify that `Generate::generate_from_rng` produces a usable decapsulation
 /// key and that the associated encapsulation key is consistent.
 #[test]
+#[cfg(mlkem_768)]
 fn test_generate_from_rng() {
     common::setup();
     let mut rng = RNG::new().expect("RNG creation failed");
@@ -104,6 +108,7 @@ fn test_generate_from_rng() {
 /// Verify that a tampered ciphertext produces a different shared secret
 /// (ML-KEM implicit rejection).
 #[test]
+#[cfg(mlkem_768)]
 fn test_implicit_rejection() {
     common::setup();
     let mut rng = RNG::new().expect("RNG creation failed");
@@ -121,6 +126,7 @@ fn test_implicit_rejection() {
 
 /// Verify that `TryKeyInit` and `KeyExport` round-trip the encapsulation key.
 #[test]
+#[cfg(mlkem_768)]
 fn test_ek_export_import() {
     common::setup();
     let mut rng = RNG::new().expect("RNG creation failed");
@@ -154,6 +160,7 @@ fn test_ek_try_new_zeroed_key() {
 /// Verify the `Decapsulator::encapsulation_key` method returns a key that
 /// can be used for encapsulation.
 #[test]
+#[cfg(mlkem_512)]
 fn test_decapsulator_encapsulation_key() {
     common::setup();
     let mut rng = RNG::new().expect("RNG creation failed");

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_mlkem_kem.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_mlkem_kem.rs
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#![cfg(all(mlkem_encapsulate, mlkem_decapsulate, mlkem_make_key, random, feature = "kem", feature = "rand_core"))]
+#![cfg(all(mlkem, mlkem_encapsulate, mlkem_decapsulate, mlkem_make_key, random, feature = "kem", feature = "rand_core"))]
 
 mod common;
 
@@ -147,6 +147,7 @@ fn test_ek_export_import() {
 
 /// Verify that `TryKeyInit` doesn't panic on a zeroed key.
 #[test]
+#[cfg(mlkem_768)]
 fn test_ek_try_new_zeroed_key() {
     common::setup();
 


### PR DESCRIPTION
# Description

```
commit 7e25ece857826b092b69fe11bf088ef51298d026
Author: Josh Holtrop <josh@wolfssl.com>
Date:   Thu Aug 27 09:20:13 2026 -0400

    Rust wrapper: only enable mlkem cfg when !WC_NO_CONSTRUCTORS
    
    Fixes F-11270

commit e67c45922859b76f19af89252324dee7f6f95857
Author: Josh Holtrop <josh@wolfssl.com>
Date:   Thu Aug 27 08:56:35 2026 -0400

    Rust wrapper: mlkem: generate operation-specific cfgs for mlkem features
    
    Fixes F-8298
```

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
