### PR TITLE
Rust wrapper: ed25519: guard generate with ed25519_make_key cfg

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -5309,7 +5309,8 @@ int wolfSSL_EC25519_shared_key(unsigned char *shared, unsigned int *sharedSz,
 int wolfSSL_ED25519_generate_key(unsigned char *priv, unsigned int *privSz,
     unsigned char *pub, unsigned int *pubSz)
 {
-#if defined(WOLFSSL_KEY_GEN) && defined(HAVE_ED25519_KEY_EXPORT)
+#if defined(WOLFSSL_KEY_GEN) && defined(HAVE_ED25519_KEY_EXPORT) && \
+    defined(HAVE_ED25519_MAKE_KEY)
     int res = 1;
     int initTmpRng = 0;
     WC_RNG *rng = NULL;
@@ -5366,7 +5367,9 @@ int wolfSSL_ED25519_generate_key(unsigned char *priv, unsigned int *privSz,
 
     return res;
 #else
-#ifndef WOLFSSL_KEY_GEN
+#ifndef HAVE_ED25519_MAKE_KEY
+    WOLFSSL_MSG("No ED25519 make key built in");
+#elif !defined(WOLFSSL_KEY_GEN)
     WOLFSSL_MSG("No Key Gen built in");
 #else
     WOLFSSL_MSG("No ED25519 key export built in");
@@ -5378,7 +5381,7 @@ int wolfSSL_ED25519_generate_key(unsigned char *priv, unsigned int *privSz,
     (void)pubSz;
 
     return 0;
-#endif /* WOLFSSL_KEY_GEN && HAVE_ED25519_KEY_EXPORT */
+#endif /* WOLFSSL_KEY_GEN && HAVE_ED25519_KEY_EXPORT && HAVE_ED25519_MAKE_KEY */
 }
 
 /* Sign a message with Ed25519 using the private key.

--- a/tests/api.c
+++ b/tests/api.c
@@ -12172,7 +12172,8 @@ static int test_wc_SetSubjectKeyIdFromPublicKey_ex(void)
     ecc_key     eccKey;
     int         ret;
 #endif
-#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT) && \
+    defined(HAVE_ED25519_MAKE_KEY)
     ed25519_key ed25519Key;
 #endif
 #if defined(HAVE_ED448) && defined(HAVE_ED448_KEY_EXPORT)
@@ -12211,7 +12212,8 @@ static int test_wc_SetSubjectKeyIdFromPublicKey_ex(void)
     DoExpectIntEQ(wc_ecc_free(&eccKey), 0);
 #endif
 
-#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT) && \
+    defined(HAVE_ED25519_MAKE_KEY)
     /* ED25519 */
     XMEMSET(&ed25519Key, 0, sizeof(ed25519_key));
     ExpectIntEQ(wc_ed25519_init(&ed25519Key), 0);
@@ -12254,7 +12256,8 @@ static int test_wc_SetAuthKeyIdFromPublicKey_ex(void)
     ecc_key     eccKey;
     int         ret;
 #endif
-#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT) && \
+    defined(HAVE_ED25519_MAKE_KEY)
     ed25519_key ed25519Key;
 #endif
 #if defined(HAVE_ED448) && defined(HAVE_ED448_KEY_EXPORT)
@@ -12291,7 +12294,8 @@ static int test_wc_SetAuthKeyIdFromPublicKey_ex(void)
     DoExpectIntEQ(wc_ecc_free(&eccKey), 0);
 #endif
 
-#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT)
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT) && \
+    defined(HAVE_ED25519_MAKE_KEY)
     /* ED25519 */
     XMEMSET(&ed25519Key, 0, sizeof(ed25519_key));
     ExpectIntEQ(wc_ed25519_init(&ed25519Key), 0);
@@ -32602,7 +32606,8 @@ static int test_CryptoCb_Func(int thisDevId, wc_CryptoInfo* info, void* ctx)
             }
         }
     #endif /* HAVE_ECC */
-    #ifdef HAVE_ED25519
+    #if defined(HAVE_ED25519) && defined(HAVE_ED25519_MAKE_KEY) && \
+        defined(HAVE_ED25519_SIGN) && defined(HAVE_ED25519_KEY_IMPORT)
         if (info->pk.type == WC_PK_TYPE_ED25519_SIGN) {
             ed25519_key key;
 
@@ -32649,7 +32654,8 @@ static int test_CryptoCb_Func(int thisDevId, wc_CryptoInfo* info, void* ctx)
                 ret, *info->pk.ed25519sign.outLen);
         #endif
         }
-    #endif /* HAVE_ED25519 */
+    #endif /* HAVE_ED25519 && HAVE_ED25519_MAKE_KEY && HAVE_ED25519_SIGN &&
+              HAVE_ED25519_KEY_IMPORT */
     }
 #ifdef WOLF_CRYPTO_CB_COPY
     else if (info->algo_type == WC_ALGO_TYPE_COPY) {

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -440,7 +440,8 @@ int test_DecodeAsymKey_lenient_versions(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT) && \
-    defined(HAVE_ED25519_KEY_IMPORT) && defined(WOLFSSL_KEY_GEN)
+    defined(HAVE_ED25519_KEY_IMPORT) && defined(WOLFSSL_KEY_GEN) && \
+    defined(HAVE_ED25519_MAKE_KEY)
     ed25519_key key;
     ed25519_key parsed;
     WC_RNG rng;
@@ -519,7 +520,8 @@ int test_DecodeAsymKey_negative(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT) && \
-    defined(HAVE_ED25519_KEY_IMPORT) && defined(WOLFSSL_KEY_GEN)
+    defined(HAVE_ED25519_KEY_IMPORT) && defined(WOLFSSL_KEY_GEN) && \
+    defined(HAVE_ED25519_MAKE_KEY)
     ed25519_key key;
     ed25519_key parsed;
     WC_RNG rng;
@@ -2818,7 +2820,7 @@ int test_ToTraditional_ex_roundtrip(void)
      defined(OPENSSL_EXTRA_X509_SMALL) || defined(WOLFSSL_PUBLIC_ASN))
 
 #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT) && \
-    defined(WOLFSSL_KEY_GEN)
+    defined(WOLFSSL_KEY_GEN) && defined(HAVE_ED25519_MAKE_KEY)
     {
         ed25519_key key;
         WC_RNG rng;
@@ -2845,7 +2847,8 @@ int test_ToTraditional_ex_roundtrip(void)
         wc_ed25519_free(&key);
         wc_FreeRng(&rng);
     }
-#endif /* HAVE_ED25519 */
+#endif /* HAVE_ED25519 && HAVE_ED25519_KEY_EXPORT && WOLFSSL_KEY_GEN &&
+          HAVE_ED25519_MAKE_KEY */
 
 #if defined(HAVE_ED448) && defined(HAVE_ED448_KEY_EXPORT) && \
     defined(WOLFSSL_KEY_GEN)
@@ -2948,8 +2951,8 @@ int test_ToTraditional_ex_negative(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_PKCS8) && defined(HAVE_ED25519) && \
-    defined(HAVE_ED25519_KEY_EXPORT) && defined(WOLFSSL_KEY_GEN) && \
-    defined(WOLFSSL_ASN_TEMPLATE) && \
+    defined(HAVE_ED25519_KEY_EXPORT) && defined(HAVE_ED25519_MAKE_KEY) && \
+    defined(WOLFSSL_KEY_GEN) && defined(WOLFSSL_ASN_TEMPLATE) && \
     (defined(WOLFSSL_TEST_CERT) || defined(OPENSSL_EXTRA) || \
      defined(OPENSSL_EXTRA_X509_SMALL) || defined(WOLFSSL_PUBLIC_ASN))
     ed25519_key key;

--- a/tests/api/test_ossl_ecx.c
+++ b/tests/api/test_ossl_ecx.c
@@ -132,7 +132,7 @@ int test_ED25519(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_EXPORT) && \
-    defined(WOLFSSL_KEY_GEN)
+    defined(HAVE_ED25519_MAKE_KEY) && defined(WOLFSSL_KEY_GEN)
     byte         priv[ED25519_PRV_KEY_SIZE];
     unsigned int privSz = (unsigned int)sizeof(priv);
     byte         pub[ED25519_PUB_KEY_SIZE];
@@ -240,7 +240,8 @@ int test_ED25519(void)
         sigSz), 0);
 #endif /* HAVE_ED25519_VERIFY */
 #endif /* HAVE_ED25519_SIGN && HAVE_ED25519_KEY_IMPORT */
-#endif /* HAVE_ED25519 && HAVE_ED25519_KEY_EXPORT && WOLFSSL_KEY_GEN */
+#endif /* HAVE_ED25519 && HAVE_ED25519_KEY_EXPORT && HAVE_ED25519_MAKE_KEY &&
+          WOLFSSL_KEY_GEN */
     return EXPECT_RESULT();
 }
 

--- a/wolfssl/wolfcrypt/ed25519.h
+++ b/wolfssl/wolfcrypt/ed25519.h
@@ -115,12 +115,14 @@ struct ed25519_key {
     #define WC_ED25519KEY_TYPE_DEFINED
 #endif
 
-
+#ifdef HAVE_ED25519_MAKE_KEY
 WOLFSSL_API
 int wc_ed25519_make_public(ed25519_key* key, unsigned char* pubKey,
                            word32 pubKeySz);
 WOLFSSL_API
 int wc_ed25519_make_key(WC_RNG* rng, int keysize, ed25519_key* key);
+#endif /* HAVE_ED25519_MAKE_KEY */
+
 #ifdef HAVE_ED25519_SIGN
 WOLFSSL_API
 int wc_ed25519_sign_msg(const byte* in, word32 inLen, byte* out,

--- a/wrapper/rust/wolfssl-wolfcrypt/build.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/build.rs
@@ -420,6 +420,7 @@ fn scan_cfg() -> Result<()> {
 
     /* ed25519 */
     check_cfg(&binding, "wc_ed25519_init", "ed25519");
+    check_cfg(&binding, "wc_ed25519_make_key", "ed25519_make_key");
     check_cfg(&binding, "wc_ed25519_import_public", "ed25519_import");
     check_cfg(&binding, "wc_ed25519_export_public", "ed25519_export");
     check_cfg(&binding, "wc_ed25519_sign_msg", "ed25519_sign");

--- a/wrapper/rust/wolfssl-wolfcrypt/src/ed25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ed25519.rs
@@ -26,7 +26,7 @@ This module provides a Rust wrapper for the wolfCrypt library's EdDSA Curve
 #![cfg(ed25519)]
 
 use crate::sys;
-#[cfg(random)]
+#[cfg(all(ed25519_make_key, random))]
 use crate::random::RNG;
 use core::mem::MaybeUninit;
 
@@ -68,7 +68,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(random)]
+    /// #[cfg(all(ed25519_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -76,7 +76,7 @@ impl Ed25519 {
     /// let ed = Ed25519::generate(&mut rng).expect("Error with generate()");
     /// }
     /// ```
-    #[cfg(random)]
+    #[cfg(all(ed25519_make_key, random))]
     pub fn generate(rng: &RNG) -> Result<Self, i32> {
         Self::generate_ex(rng, None, None)
     }
@@ -97,7 +97,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(random)]
+    /// #[cfg(all(ed25519_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -105,7 +105,7 @@ impl Ed25519 {
     /// let ed = Ed25519::generate_ex(&mut rng, None, None).expect("Error with generate_ex()");
     /// }
     /// ```
-    #[cfg(random)]
+    #[cfg(all(ed25519_make_key, random))]
     pub fn generate_ex(rng: &RNG, heap: Option<*mut core::ffi::c_void>, dev_id: Option<i32>) -> Result<Self, i32> {
         let mut ws_key: MaybeUninit<sys::ed25519_key> = MaybeUninit::uninit();
         let heap = match heap {
@@ -207,7 +207,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(random)]
+    /// #[cfg(all(ed25519_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -241,7 +241,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_export, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -283,7 +283,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_export, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -322,7 +322,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_export, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -361,7 +361,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_export, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -402,7 +402,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_import, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_import, ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -446,7 +446,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_import, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_import, ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -486,7 +486,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_import, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_import, ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -530,7 +530,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_import, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_import, ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -581,7 +581,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_import, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_import, ed25519_export, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -630,7 +630,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_export, ed25519_import, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_export, ed25519_import, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -644,6 +644,7 @@ impl Ed25519 {
     /// ed.make_public(&mut public).expect("Error with make_public()");
     /// }
     /// ```
+    #[cfg(ed25519_make_key)]
     pub fn make_public(&mut self, pubkey: &mut [u8]) -> Result<(), i32> {
         let pubkey_size = crate::buffer_len_to_u32(pubkey.len())?;
         let rc = unsafe {
@@ -672,7 +673,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_sign, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -716,7 +717,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_sign, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -767,7 +768,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_sign, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -832,7 +833,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_sign, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -888,7 +889,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_sign, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -939,7 +940,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_verify, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, ed25519_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -990,7 +991,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_verify, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, ed25519_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1049,7 +1050,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_verify, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, ed25519_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1121,7 +1122,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_verify, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, ed25519_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1184,7 +1185,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_verify, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, ed25519_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1244,7 +1245,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_streaming_verify, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, ed25519_streaming_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1296,7 +1297,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_streaming_verify, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, ed25519_streaming_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1339,7 +1340,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(all(ed25519_streaming_verify, random))]
+    /// #[cfg(all(ed25519_make_key, ed25519_sign, ed25519_streaming_verify, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1384,7 +1385,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(random)]
+    /// #[cfg(all(ed25519_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1412,7 +1413,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(random)]
+    /// #[cfg(all(ed25519_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1440,7 +1441,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(random)]
+    /// #[cfg(all(ed25519_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;
@@ -1468,7 +1469,7 @@ impl Ed25519 {
     /// # Example
     ///
     /// ```rust
-    /// #[cfg(random)]
+    /// #[cfg(all(ed25519_make_key, random))]
     /// {
     /// use wolfssl_wolfcrypt::random::RNG;
     /// use wolfssl_wolfcrypt::ed25519::Ed25519;

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_ed25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_ed25519.rs
@@ -2,12 +2,12 @@
 
 mod common;
 
-#[cfg(random)]
+#[cfg(all(ed25519_make_key, random))]
 use wolfssl_wolfcrypt::random::RNG;
 use wolfssl_wolfcrypt::ed25519::*;
 
 #[test]
-#[cfg(all(ed25519_import, ed25519_export, random))]
+#[cfg(all(ed25519_make_key, ed25519_import, ed25519_export, random))]
 fn test_make_public() {
     common::setup();
 
@@ -22,7 +22,7 @@ fn test_make_public() {
 }
 
 #[test]
-#[cfg(random)]
+#[cfg(all(ed25519_make_key, random))]
 fn test_check_key() {
     let mut rng = RNG::new().expect("Error creating RNG");
     let mut ed = Ed25519::generate(&mut rng).expect("Error with generate()");
@@ -226,7 +226,7 @@ fn test_ph_sign_verify() {
 // invalid signature is reported as Ok(false) rather than an error.
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_verify, random))]
+#[cfg(all(ed25519_make_key, ed25519_sign, ed25519_verify, random))]
 fn test_verify_msg_bad_sig() {
     common::setup();
 
@@ -242,7 +242,7 @@ fn test_verify_msg_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_verify, random))]
+#[cfg(all(ed25519_make_key, ed25519_sign, ed25519_verify, random))]
 fn test_verify_msg_ex_bad_sig() {
     common::setup();
 
@@ -258,7 +258,7 @@ fn test_verify_msg_ex_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_verify, random))]
+#[cfg(all(ed25519_make_key, ed25519_sign, ed25519_verify, random))]
 fn test_verify_msg_ctx_bad_sig() {
     common::setup();
 
@@ -275,7 +275,7 @@ fn test_verify_msg_ctx_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_verify, random))]
+#[cfg(all(ed25519_make_key, ed25519_sign, ed25519_verify, random))]
 fn test_verify_msg_ph_bad_sig() {
     common::setup();
 
@@ -292,7 +292,7 @@ fn test_verify_msg_ph_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_verify, random))]
+#[cfg(all(ed25519_make_key, ed25519_sign, ed25519_verify, random))]
 fn test_verify_hash_ph_bad_sig() {
     common::setup();
 
@@ -309,7 +309,7 @@ fn test_verify_hash_ph_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_sign, ed25519_streaming_verify, random))]
+#[cfg(all(ed25519_make_key, ed25519_sign, ed25519_streaming_verify, random))]
 fn test_verify_msg_final_bad_sig() {
     common::setup();
 
@@ -329,7 +329,7 @@ fn test_verify_msg_final_bad_sig() {
 }
 
 #[test]
-#[cfg(all(ed25519_import, ed25519_export, random))]
+#[cfg(all(ed25519_make_key, ed25519_import, ed25519_export, random))]
 fn test_import_export() {
     common::setup();
 
@@ -361,7 +361,7 @@ fn test_import_export() {
 }
 
 #[test]
-#[cfg(all(feature = "signature", ed25519_import, ed25519_export, ed25519_sign, ed25519_verify, random))]
+#[cfg(all(feature = "signature", ed25519_make_key, ed25519_import, ed25519_export, ed25519_sign, ed25519_verify, random))]
 fn test_signature_traits() {
     use signature::{Keypair, SignerMut, Verifier};
 
@@ -398,7 +398,7 @@ fn test_signature_traits() {
 }
 
 #[test]
-#[cfg(random)]
+#[cfg(all(ed25519_make_key, random))]
 fn test_sizes() {
     let mut rng = RNG::new().expect("Error creating RNG");
     let ed = Ed25519::generate(&mut rng).expect("Error with generate()");


### PR DESCRIPTION
# Description

Detect based on wc_ed25519_make_key prototype presence and guard prototype presence with HAVE_ED25519_MAKE_KEY.

Fixes F-8303

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
