### PR TITLE
ECH: Take the AAD from the parsed ClientHello offset

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -7940,7 +7940,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (echX == NULL)
             ERROR_OUT(WOLFSSL_FATAL_ERROR, exit_dch);
 
-        ((WOLFSSL_ECH*)echX->data)->aad = input + HANDSHAKE_HEADER_SZ;
+        ((WOLFSSL_ECH*)echX->data)->aad = input + args->begin;
         ((WOLFSSL_ECH*)echX->data)->aadLen = helloSz;
     }
 #endif
@@ -15157,6 +15157,11 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 *inOutIdx = echInOutIdx;
                 /* call again with the inner hello */
                 if (ret == 0) {
+                    echInOutIdx = HANDSHAKE_HEADER_SZ;
+#ifdef WOLFSSL_DTLS13
+                    if (ssl->options.dtls)
+                        echInOutIdx = DTLS13_HANDSHAKE_HEADER_SZ;
+#endif
                     ssl->options.echProcessingInner = 1;
                     ret = DoTls13ClientHello(ssl,
                         ((WOLFSSL_ECH*)echX->data)->innerClientHello,

--- a/tests/api.c
+++ b/tests/api.c
@@ -17478,6 +17478,51 @@ static int test_wolfSSL_Tls13_ECH_sni_parse(void)
 }
 
 #undef ECH_KEPT
+
+#ifdef WOLFSSL_TLS_READ_AHEAD
+/* Server ssl_ready callback: set SNI and read the whole record in one go */
+static int test_ech_server_ssl_ready_read_ahead(WOLFSSL* ssl)
+{
+    if (wolfSSL_set_read_ahead(ssl, 1) != WOLFSSL_SUCCESS)
+        return TEST_FAIL;
+
+    return test_ech_server_ssl_ready(ssl);
+}
+#endif
+
+/* ECH must be accepted when the whole ClientHello record is already buffered
+ * when the handshake header is read, so that the ClientHello body sits behind
+ * the record header rather than at the start of the parsed buffer. */
+static int test_wolfSSL_Tls13_ECH_read_ahead(void)
+{
+    EXPECT_DECLS;
+#ifdef WOLFSSL_TLS_READ_AHEAD
+    struct test_ssl_memio_ctx test_ctx;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+
+    echCbTestKemID = 0;
+    echCbTestKdfID = 0;
+    echCbTestAeadID = 0;
+
+    test_ctx.s_cb.method = wolfTLSv1_3_server_method;
+    test_ctx.c_cb.method = wolfTLSv1_3_client_method;
+
+    test_ctx.s_cb.ctx_ready = test_ech_server_ctx_ready;
+    test_ctx.s_cb.ssl_ready = test_ech_server_ssl_ready_read_ahead;
+    test_ctx.c_cb.ssl_ready = test_ech_client_ssl_ready;
+
+    ExpectIntEQ(test_ssl_memio_setup(&test_ctx), TEST_SUCCESS);
+    ExpectIntEQ(test_ssl_memio_do_handshake(&test_ctx, 10, NULL), TEST_SUCCESS);
+    ExpectIntEQ(wolfSSL_GetEchStatus(test_ctx.c_ssl),
+        WOLFSSL_ECH_STATUS_ACCEPTED);
+    ExpectIntEQ(wolfSSL_GetEchStatus(test_ctx.s_ssl),
+        WOLFSSL_ECH_STATUS_ACCEPTED);
+
+    test_ssl_memio_cleanup(&test_ctx);
+#endif
+    return EXPECT_RESULT();
+}
 #endif /* HAVE_SSL_MEMIO_TESTS_DEPENDENCIES */
 
 /* verify that ECH can be enabled/disabled without issue */
@@ -40601,6 +40646,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_Tls13_ECH_rejected_cert_valid),
     TEST_DECL(test_wolfSSL_Tls13_ECH_rejected_empty_client_cert),
     TEST_DECL(test_wolfSSL_Tls13_ECH_sni_parse),
+    TEST_DECL(test_wolfSSL_Tls13_ECH_read_ahead),
 #endif
 #if defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TEST_ECH) && \
     !defined(WOLFSSL_NO_TLS12)


### PR DESCRIPTION
# Description

Sets the ECH AAD base to input + args->begin and the inner ClientHello re-entry index to that hello's reserved handshake-header size (in the case of DTLS, we set DTLS13_HANDSHAKE_HEADER_SZ), and adds an ECH handshake test that runs with read-ahead enabled on the server.


# Testing

Added associated regression test `test_wolfSSL_Tls13_ECH_read_ahead`.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
