### PR TITLE
define ecc_get_k_raw when skipped by FIPS enable

### DIFF
--- a/src/pk_ec.c
+++ b/src/pk_ec.c
@@ -42,6 +42,11 @@
     #define ecc_blind_k_rng(key, rng) 0
     #define WOLFSSL_HAVE_ECC_KEY_GET_PRIV
 #endif
+#ifndef ecc_get_k_raw
+    /* FIPS replacement of ecc.h predates ecc_get_k_raw but is new enough to
+     * define WOLFSSL_HAVE_ECC_KEY_GET_PRIV, so the block above was skipped. */
+    #define ecc_get_k_raw(key)        (key)->k
+#endif
 
 #if !defined(WOLFSSL_PK_EC_INCLUDED)
     #ifndef WOLFSSL_IGNORE_FILE_WARN


### PR DESCRIPTION
# Description

Building with FIPS v6 with `--enable-jni` reported "error: implicit declaration of function 'ecc_get_k_raw'" caused by `ecc.h` being overwritten. Added additional definition of `ecc_get_k_raw` to compensate.


# Testing

```
./fips-check.sh v6.0.0 keep noautogen
cd XXX-fips-test/
./autogen.sh
./configure --enable-fips=v6 --enable-jni
make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
