### PR TITLE
Reject repeated wc_AsconAEAD128_SetAD calls

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -274,6 +274,16 @@
   manager with the store the context owns.  Only affects applications calling
   `wolfSSL_CTX_set_cert_store()`.
 
+* **Fix (`wc_AsconAEAD128_SetAD` called more than once)**: the function
+  absorbs the key, nonce and associated data into the sponge state and then
+  applies domain separation, but unlike `wc_AsconAEAD128_SetKey()` and
+  `wc_AsconAEAD128_SetNonce()` it did not reject a repeat call.  A caller that
+  passed associated data in more than one call re-ran the absorption on the
+  already-advanced state, and every call still returned 0, so the resulting
+  tag did not authenticate under any conforming Ascon implementation with no
+  error raised.  `wc_AsconAEAD128_SetAD()` now returns `BAD_STATE_E` when the
+  associated data has already been set; it must be supplied in a single call.
+
 * **Fix (`wolfSSL_set_accept_state` with `WOLFSSL_BLIND_PRIVATE_KEY`)**: the
   static-ECC check decoded `ssl->buffers.key` directly.  Under
   `WOLFSSL_BLIND_PRIVATE_KEY` that buffer is masked, so the decode always

--- a/doc/dox_comments/header_files/ascon.h
+++ b/doc/dox_comments/header_files/ascon.h
@@ -237,7 +237,8 @@ int wc_AsconAEAD128_SetNonce(wc_AsconAEAD128* a, const byte* nonce);
 
     \return 0 on success.
     \return BAD_FUNC_ARG if the context is NULL, or if the associated data
-            pointer is NULL while the associated data size is greater than 0.
+            pointer is NULL while adSz is greater than 0. A NULL associated
+            data pointer is permitted when adSz is 0.
     \return BAD_STATE_E if the key or nonce has not been set, or if the
             associated data has already been set. The associated data must be
             provided in a single call.

--- a/doc/dox_comments/header_files/ascon.h
+++ b/doc/dox_comments/header_files/ascon.h
@@ -238,7 +238,9 @@ int wc_AsconAEAD128_SetNonce(wc_AsconAEAD128* a, const byte* nonce);
     \return 0 on success.
     \return BAD_FUNC_ARG if the context is NULL, or if the associated data
             pointer is NULL while the associated data size is greater than 0.
-    \return BAD_STATE_E if the key or nonce has not been set.
+    \return BAD_STATE_E if the key or nonce has not been set, or if the
+            associated data has already been set. The associated data must be
+            provided in a single call.
 
     \param a pointer to the initialized Ascon AEAD context.
     \param ad pointer to the associated data buffer.

--- a/tests/api/test_ascon.c
+++ b/tests/api/test_ascon.c
@@ -387,6 +387,7 @@ int test_ascon_aead128_edge_cases(void)
  *   - wc_AsconAEAD128_SetNonce:     a == NULL || nonce == NULL
  *   - wc_AsconAEAD128_SetAD:        a == NULL || (ad == NULL && adSz > 0)
  *                                   !keySet || !nonceSet
+ *                                   adSet (AD must be set in a single call)
  *   - wc_AsconAEAD128_EncryptUpdate: a == NULL || (in == NULL && inSz > 0)
  *                                   !keySet || !nonceSet || !adSet
  *   - wc_AsconAEAD128_EncryptFinal:  a == NULL || tag == NULL
@@ -476,8 +477,12 @@ int test_ascon_decision_coverage(void)
     ExpectIntEQ(wc_AsconAEAD128_SetAD(asconAEAD, NULL, sizeof(ad)),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     /* a != NULL, ad == NULL, adSz == 0 -> inner && false, proceeds past
-     * arg check to the state check (both keySet/nonceSet true here) */
+     * arg check to the state check (both keySet/nonceSet true here); key
+     * and nonce are set above so this succeeds and marks adSet. */
     ExpectIntEQ(wc_AsconAEAD128_SetAD(asconAEAD, NULL, 0), 0);
+    /* adSet now true -> a repeat call is rejected: AD is one-shot */
+    ExpectIntEQ(wc_AsconAEAD128_SetAD(asconAEAD, ad, sizeof(ad)),
+        WC_NO_ERR_TRACE(BAD_STATE_E));
 
     /* State guard on SetAD: !keySet || !nonceSet, using freshly Init'd
      * contexts to isolate each operand. */
@@ -502,12 +507,15 @@ int test_ascon_decision_coverage(void)
         ExpectIntEQ(wc_AsconAEAD128_SetKey(&stateCtx, key), 0);
         ExpectIntEQ(wc_AsconAEAD128_SetNonce(&stateCtx, nonce), 0);
         ExpectIntEQ(wc_AsconAEAD128_SetAD(&stateCtx, ad, sizeof(ad)), 0);
+        /* adSet now true -> a repeat call is rejected: AD is one-shot */
+        ExpectIntEQ(wc_AsconAEAD128_SetAD(&stateCtx, ad, sizeof(ad)),
+            WC_NO_ERR_TRACE(BAD_STATE_E));
         wc_AsconAEAD128_Clear(&stateCtx);
     }
 
-    /* Finish setting up asconAEAD (key+nonce already set above) with AD
-     * so it is fully configured for the Encrypt/Decrypt tests below. */
-    ExpectIntEQ(wc_AsconAEAD128_SetAD(asconAEAD, ad, sizeof(ad)), 0);
+    /* asconAEAD is already fully configured for the Encrypt/Decrypt tests
+     * below: key and nonce set above, and adSet marked by the
+     * SetAD(asconAEAD, NULL, 0) call above. */
 
     /* ---------------------------------------------------------------- */
     /* wc_AsconAEAD128_EncryptUpdate:                                    */

--- a/wolfcrypt/src/ascon.c
+++ b/wolfcrypt/src/ascon.c
@@ -347,6 +347,8 @@ int wc_AsconAEAD128_SetAD(wc_AsconAEAD128* a, const byte* ad,
         return BAD_FUNC_ARG;
     if (!a->keySet || !a->nonceSet) /* key and nonce must be set before */
         return BAD_STATE_E;
+    if (a->adSet) /* associated data is processed in a single call */
+        return BAD_STATE_E;
 
     permutation(&a->state, ASCON_AEAD128_ROUNDS_PA);
     a->state.s64[3] ^= a->key[0];


### PR DESCRIPTION
## Summary(f7399)

`wc_AsconAEAD128_SetKey()` and `wc_AsconAEAD128_SetNonce()` reject a second call with `BAD_STATE_E`, but `wc_AsconAEAD128_SetAD()` did not. `SetAD` is not a plain field setter: it runs the key/nonce absorption permutation, XORs the key into the state, absorbs the AD blocks, and applies domain separation. Calling it twice re-runs that sequence on the already-advanced state, and both calls return `0`. A caller that split associated data across two buffers would get a tag that authenticates under no conforming Ascon implementation, with no error reported anywhere.

Associated data must be supplied in a single call. This adds the missing `if (a->adSet) return BAD_STATE_E;` guard, matching the two sibling functions.

## Changes

- `wolfcrypt/src/ascon.c`: return `BAD_STATE_E` from `wc_AsconAEAD128_SetAD()` when the associated data has already been set.
- `doc/dox_comments/header_files/ascon.h`: document the new return case.
- `tests/api/test_ascon.c`: assert the repeat call is rejected.
- `ChangeLog.md`: add entry under Fixes.

## Testing

- `./configure --enable-ascon --enable-experimental && make`
- `./wolfcrypt/test/testwolfcrypt` — ASCON AEAD test passes
- `./tests/unit.test` ascon group (tests 377-381) — all pass



# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
