### PR TITLE
Ensure the casper and hashcrypt accelerator functions are using mutexes

### DIFF
--- a/wolfcrypt/src/port/nxp/README.md
+++ b/wolfcrypt/src/port/nxp/README.md
@@ -28,7 +28,15 @@ Encrypt/Decrypt requests of other sizes will fail.
 will use a fully software implementation.
 - When the HashCrypt engine is in use for SHA-1 or SHA-256, it must not be
 interrupted with another hash request or an AES request.  The hash must be
-completed before another operation is requested.
+completed before another operation is requested.  Only one SHA stream exists
+at a time, so `NO_WOLFSSL_SHA256_INTERLEAVE` is set and a `wc_Sha256Update()`
+after a `wc_Sha256GetHash()` restarts the stream.
+- SHA-224 is unavailable when HashCrypt SHA is enabled.
+- Hardware access is serialized with the wolfCrypt crypto HW mutex, enabled
+automatically.  A threaded build setting `WOLFSSL_CRYPT_HW_MUTEX` to 0 is
+rejected at compile time; use `SINGLE_THREADED` instead.  Being a software
+mutex it does not arbitrate between the two cores -- do not drive either
+accelerator from both.
 
 ### wolfSSL LPC55S69 Hardware Acceleration Enable
 

--- a/wolfcrypt/src/port/nxp/casper_port.c
+++ b/wolfcrypt/src/port/nxp/casper_port.c
@@ -23,16 +23,21 @@
 
 #ifdef WOLFSSL_NXP_CASPER
 
-#if defined(WOLFSSL_CRYPT_HW_MUTEX) && WOLFSSL_CRYPT_HW_MUTEX > 0
-    #error WOLFSSL_CRYPT_HW_MUTEX=1 not supported yet
-#endif
-
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/port/nxp/casper_port.h>
 #include "fsl_casper.h"
 
 int wc_casper_init(void)
 {
+    int ret;
+
+    /* Required, not just defensive: wolfCrypt_Init() initializes only the
+     * global crypt HW mutex and never the per-algorithm ones, so under
+     * WOLFSSL_ALGO_HW_MUTEX this is the only place the PK mutex is set up
+     * ahead of first use.  No-op when WOLFSSL_CRYPT_HW_MUTEX is off. */
+    if ((ret = wolfSSL_HwPkMutexInit()) != 0)
+        return ret;
+
     CASPER_Init(CASPER);
 
     return 0;
@@ -63,19 +68,22 @@ int casper_rsa_public_exptmod(
     if (exp_sz <= 0 || exp_sz > (int)sizeof(exp_buf))
         return BAD_FUNC_ARG;
 
+    if ((res = wolfSSL_HwPkMutexLock()) != 0)
+        return res;
+
     /* casper requires little endian format for inputs/outputs */
     XMEMCPY(sig_buf, in, sig_sz);
     mp_reverse(sig_buf, sig_sz);
 
     if ((res = mp_to_unsigned_bin(&key->n, key_buf)) != MP_OKAY)
-        return res;
+        goto unlock;
     mp_reverse(key_buf, key_sz);
 
     XMEMSET(exp_buf, 0, sizeof(exp_buf));
     if ((res = mp_to_unsigned_bin(&key->e,
                                   exp_buf + sizeof(exp_buf) - exp_sz))
         != MP_OKAY)
-        return res;
+        goto unlock;
     exp = ((uint32_t)exp_buf[0] << 24) | ((uint32_t)exp_buf[1] << 16) |
           ((uint32_t)exp_buf[2] <<  8) | ((uint32_t)exp_buf[3]);
 
@@ -86,8 +94,12 @@ int casper_rsa_public_exptmod(
     XMEMCPY(out, out_buf, sig_sz);
 
     *outLen = inLen;
+    res = 0;
 
-    return 0;
+unlock:
+    wolfSSL_HwPkMutexUnLock();
+
+    return res;
 }
 #endif /* !NO_RSA && WOLFSSL_NXP_CASPER_RSA_PUB_EXPTMOD */
 
@@ -105,64 +117,86 @@ int casper_ecc_mulmod(
     uint32_t X[CASPER_MAX_ECC_SIZE_BYTES / sizeof(uint32_t)] = { 0 };
     uint32_t Y[CASPER_MAX_ECC_SIZE_BYTES / sizeof(uint32_t)] = { 0 };
     int size;
+    int ret;
 
     if (!m || !P || !R)
         return BAD_FUNC_ARG;
 
+    /* Resolve the curve before taking the lock.  An unsupported curve_id is an
+     * argument error, and should not have to wait out an in-flight CASPER
+     * operation just to be rejected. */
     if (curve_id == ECC_SECP256R1)
-    {
         size = 32;
-        CASPER_ecc_init(kCASPER_ECC_P256);
-    }
     else if (curve_id == ECC_SECP384R1)
-    {
         size = 48;
-        CASPER_ecc_init(kCASPER_ECC_P384);
-    }
     else if (curve_id == ECC_SECP521R1)
-    {
         size = 66;
-        CASPER_ecc_init(kCASPER_ECC_P521);
-    }
     else
         return BAD_FUNC_ARG;
 
+    /* CASPER is a single shared peripheral; serialize against the RSA path
+     * and against other ECC callers for the whole hardware sequence. */
+    if ((ret = wolfSSL_HwPkMutexLock()) != 0)
+        return ret;
+
     /* scalar */
     if (mp_to_unsigned_bin(m, (unsigned char *)&M[0]) != MP_OKAY)
-        return MP_TO_E;
+    {
+        ret = MP_TO_E;
+        goto unlock;
+    }
     mp_reverse((unsigned char *)&M[0], size);
 
     /* point */
     if (mp_to_unsigned_bin(P->x, (unsigned char *)&X[0]) != MP_OKAY)
-        return MP_TO_E;
+    {
+        ret = MP_TO_E;
+        goto unlock;
+    }
     mp_reverse((unsigned char *)&X[0], size);
     if (mp_to_unsigned_bin(P->y, (unsigned char *)&Y[0]) != MP_OKAY)
-        return MP_TO_E;
+    {
+        ret = MP_TO_E;
+        goto unlock;
+    }
     mp_reverse((unsigned char *)&Y[0], size);
 
     if (curve_id == ECC_SECP256R1)
     {
+        CASPER_ecc_init(kCASPER_ECC_P256);
         CASPER_ECC_SECP256R1_Mul(CASPER, X, Y, X, Y, (void *)M);
     }
     else if (curve_id == ECC_SECP384R1)
     {
+        CASPER_ecc_init(kCASPER_ECC_P384);
         CASPER_ECC_SECP384R1_Mul(CASPER, X, Y, X, Y, (void *)M);
     }
     else if (curve_id == ECC_SECP521R1)
     {
+        CASPER_ecc_init(kCASPER_ECC_P521);
         CASPER_ECC_SECP521R1_Mul(CASPER, X, Y, X, Y, (void *)M);
     }
 
     /* result */
     mp_reverse((unsigned char *)&X[0], size);
     if (mp_read_unsigned_bin(R->x, (unsigned char *)&X[0], size) != MP_OKAY)
-        return MP_READ_E;
+    {
+        ret = MP_READ_E;
+        goto unlock;
+    }
     mp_reverse((unsigned char *)&Y[0], size);
     if (mp_read_unsigned_bin(R->y, (unsigned char *)&Y[0], size) != MP_OKAY)
-        return MP_READ_E;
+    {
+        ret = MP_READ_E;
+        goto unlock;
+    }
     mp_set(R->z, 1);
+    ret = 0;
 
-    return 0;
+unlock:
+    wolfSSL_HwPkMutexUnLock();
+
+    return ret;
 }
 #endif /* HAVE_ECC && WOLFSSL_NXP_CASPER_ECC_MULMOD */
 
@@ -180,66 +214,87 @@ int casper_ecc_mul2add(
     uint32_t X2[CASPER_MAX_ECC_SIZE_BYTES / sizeof(uint32_t)] = { 0 };
     uint32_t Y2[CASPER_MAX_ECC_SIZE_BYTES / sizeof(uint32_t)] = { 0 };
     int size;
+    int ret;
 
     if (!m || !P || !n || !Q || !R)
         return BAD_FUNC_ARG;
 
+    /* Resolve the curve before taking the lock.  An unsupported curve_id is an
+     * argument error, and should not have to wait out an in-flight CASPER
+     * operation just to be rejected. */
     if (curve_id == ECC_SECP256R1)
-    {
         size = 32;
-        CASPER_ecc_init(kCASPER_ECC_P256);
-    }
     else if (curve_id == ECC_SECP384R1)
-    {
         size = 48;
-        CASPER_ecc_init(kCASPER_ECC_P384);
-    }
     else if (curve_id == ECC_SECP521R1)
-    {
         size = 66;
-        CASPER_ecc_init(kCASPER_ECC_P521);
-    }
     else
         return BAD_FUNC_ARG;
 
+    /* CASPER is a single shared peripheral; serialize against the RSA path
+     * and against other ECC callers for the whole hardware sequence. */
+    if ((ret = wolfSSL_HwPkMutexLock()) != 0)
+        return ret;
+
     /* first scalar */
     if (mp_to_unsigned_bin(m, (unsigned char *)&M[0]) != MP_OKAY)
-        return MP_TO_E;
+    {
+        ret = MP_TO_E;
+        goto unlock;
+    }
     mp_reverse((unsigned char *)&M[0], size);
 
     /* first point */
     if (mp_to_unsigned_bin(P->x, (unsigned char *)&X1[0]) != MP_OKAY)
-        return MP_TO_E;
+    {
+        ret = MP_TO_E;
+        goto unlock;
+    }
     mp_reverse((unsigned char *)&X1[0], size);
     if (mp_to_unsigned_bin(P->y, (unsigned char *)&Y1[0]) != MP_OKAY)
-        return MP_TO_E;
+    {
+        ret = MP_TO_E;
+        goto unlock;
+    }
     mp_reverse((unsigned char *)&Y1[0], size);
 
     /* second scalar */
     if (mp_to_unsigned_bin(n, (unsigned char *)&N[0]) != MP_OKAY)
-        return MP_TO_E;
+    {
+        ret = MP_TO_E;
+        goto unlock;
+    }
     mp_reverse((unsigned char *)&N[0], size);
 
     /* second point */
     if (mp_to_unsigned_bin(Q->x, (unsigned char *)&X2[0]) != MP_OKAY)
-        return MP_TO_E;
+    {
+        ret = MP_TO_E;
+        goto unlock;
+    }
     mp_reverse((unsigned char *)&X2[0], size);
     if (mp_to_unsigned_bin(Q->y, (unsigned char *)&Y2[0]) != MP_OKAY)
-        return MP_TO_E;
+    {
+        ret = MP_TO_E;
+        goto unlock;
+    }
     mp_reverse((unsigned char *)&Y2[0], size);
 
     if (curve_id == ECC_SECP256R1)
     {
+        CASPER_ecc_init(kCASPER_ECC_P256);
         CASPER_ECC_SECP256R1_MulAdd(CASPER, &X1[0], &Y1[0], &X1[0], &Y1[0],
             (void *)M, &X2[0], &Y2[0], (void *)N);
     }
     else if (curve_id == ECC_SECP384R1)
     {
+        CASPER_ecc_init(kCASPER_ECC_P384);
         CASPER_ECC_SECP384R1_MulAdd(CASPER, &X1[0], &Y1[0], &X1[0], &Y1[0],
             (void *)M, &X2[0], &Y2[0], (void *)N);
     }
     else if (curve_id == ECC_SECP521R1)
     {
+        CASPER_ecc_init(kCASPER_ECC_P521);
         CASPER_ECC_SECP521R1_MulAdd(CASPER, &X1[0], &Y1[0], &X1[0], &Y1[0],
             (void *)M, &X2[0], &Y2[0], (void *)N);
     }
@@ -247,13 +302,23 @@ int casper_ecc_mul2add(
     /* result */
     mp_reverse((unsigned char *)&X1[0], size);
     if (mp_read_unsigned_bin(R->x, (unsigned char *)&X1[0], size) != MP_OKAY)
-        return MP_READ_E;
+    {
+        ret = MP_READ_E;
+        goto unlock;
+    }
     mp_reverse((unsigned char *)&Y1[0], size);
     if (mp_read_unsigned_bin(R->y, (unsigned char *)&Y1[0], size) != MP_OKAY)
-        return MP_READ_E;
+    {
+        ret = MP_READ_E;
+        goto unlock;
+    }
     mp_set(R->z, 1);
+    ret = 0;
 
-    return 0;
+unlock:
+    wolfSSL_HwPkMutexUnLock();
+
+    return ret;
 }
 #endif /* HAVE_ECC && WOLFSSL_NXP_CASPER_ECC_MUL2ADD */
 

--- a/wolfcrypt/src/port/nxp/hashcrypt_port.c
+++ b/wolfcrypt/src/port/nxp/hashcrypt_port.c
@@ -23,9 +23,11 @@
 
 #ifdef WOLFSSL_NXP_HASHCRYPT
 
-#if defined(WOLFSSL_CRYPT_HW_MUTEX) && WOLFSSL_CRYPT_HW_MUTEX > 0
-    #error WOLFSSL_CRYPT_HW_MUTEX=1 not supported yet
-#endif
+/* AES and SHA are two views of the SAME HashCrypt engine, so both have to be
+ * serialized by the same lock.  That is why this port takes the global crypto
+ * hardware mutex rather than the per-algorithm aes_mutex/hash_mutex pair of
+ * WOLFSSL_ALGO_HW_MUTEX, which would hand them two independent locks and leave
+ * an AES request free to interrupt a hash. */
 
 #include <wolfssl/wolfcrypt/aes.h>
 #include <wolfssl/wolfcrypt/sha.h>
@@ -35,6 +37,10 @@
 
 #if (!defined(NO_SHA) || !defined(NO_SHA256)) && \
     defined(WOLFSSL_NXP_HASHCRYPT_SHA)
+/* The HashCrypt engine keeps the running digest itself, so one context is all
+ * it can carry -- hence NO_WOLFSSL_SHA256_INTERLEAVE for this part.  Moving
+ * this into wc_Sha256/wc_Sha buys nothing and breaks wc_Sha256GetHash(), whose
+ * generic implementation finalizes a struct copy. */
 static hashcrypt_hash_ctx_t hash_ctx;
 static int finish_called;
 #endif
@@ -48,6 +54,15 @@ int wc_hashcrypt_init(void)
 #if ((!defined(NO_SHA) || !defined(NO_SHA256)) && \
         defined(WOLFSSL_NXP_HASHCRYPT_SHA)) || \
     (!defined(NO_AES) && defined(WOLFSSL_NXP_HASHCRYPT_AES))
+    int ret;
+
+    /* Redundant on the normal path -- wolfCrypt_Init() initializes the global
+     * crypt HW mutex before it reaches here -- but it keeps a standalone
+     * wc_hashcrypt_init() caller from having to rely on the lazy init inside
+     * wolfSSL_CryptHwMutexLock().  No-op when WOLFSSL_CRYPT_HW_MUTEX is off. */
+    if ((ret = wolfSSL_CryptHwMutexInit()) != 0)
+        return ret;
+
     HASHCRYPT_Init(HASHCRYPT);
 #endif
     return 0;
@@ -56,6 +71,8 @@ int wc_hashcrypt_init(void)
 #if !defined(NO_SHA256) && defined(WOLFSSL_NXP_HASHCRYPT_SHA)
 int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
 {
+    int ret;
+
     (void)heap;
     (void)devId;
 
@@ -63,19 +80,30 @@ int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
         return BAD_FUNC_ARG;
 
     XMEMSET(sha256, 0, sizeof(wc_Sha256));
+
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
+        return ret;
+
     if (HASHCRYPT_SHA_Init(HASHCRYPT, &hash_ctx, kHASHCRYPT_Sha256)
             != kStatus_Success)
-        return WC_HW_E;
+        ret = WC_HW_E;
+    else
+        finish_called = 0;
 
-    finish_called = 0;
+    wolfSSL_CryptHwMutexUnLock();
 
-    return 0;
+    return ret;
 }
 
 int wc_Sha256Update(wc_Sha256* sha256, const byte* data, word32 len)
 {
+    int ret;
+
     if (sha256 == NULL || (data == NULL && len != 0))
         return BAD_FUNC_ARG;
+
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
+        return ret;
 
     if (finish_called)
     {
@@ -84,23 +112,32 @@ int wc_Sha256Update(wc_Sha256* sha256, const byte* data, word32 len)
     }
     if (HASHCRYPT_SHA_Update(HASHCRYPT, &hash_ctx, data, len)
             != kStatus_Success)
-        return WC_HW_E;
+        ret = WC_HW_E;
 
-    return 0;
+    wolfSSL_CryptHwMutexUnLock();
+
+    return ret;
 }
 
 int wc_Sha256Final(wc_Sha256* sha256, byte* hash)
 {
     size_t outlen = WC_SHA256_DIGEST_SIZE;
     static byte previous_sha256_hash[WC_SHA256_DIGEST_SIZE];
+    int ret;
 
     if (sha256 == NULL || hash == NULL)
         return BAD_FUNC_ARG;
 
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
+        return ret;
+
+    /* wc_Sha256GetHash() finalizes a copy of the object, which on this engine
+     * consumes the one running digest.  Replaying the cached result keeps a
+     * later Final() consistent with the value GetHash() already returned. */
     if (finish_called)
     {
         memcpy(hash, previous_sha256_hash, WC_SHA256_DIGEST_SIZE);
-        return 0;
+        goto unlock;
     }
 
     if (
@@ -109,12 +146,16 @@ int wc_Sha256Final(wc_Sha256* sha256, byte* hash)
                 || outlen != WC_SHA256_DIGEST_SIZE
     )
     {
-        return WC_HW_E;
+        ret = WC_HW_E;
+        goto unlock;
     }
     memcpy(previous_sha256_hash, hash, WC_SHA256_DIGEST_SIZE);
     finish_called = 1;
 
-    return 0;
+unlock:
+    wolfSSL_CryptHwMutexUnLock();
+
+    return ret;
 }
 #endif /* !defined(NO_SHA256) && defined(WOLFSSL_NXP_HASHCRYPT_SHA) */
 
@@ -122,6 +163,8 @@ int wc_Sha256Final(wc_Sha256* sha256, byte* hash)
 #if !defined(NO_SHA) && defined(WOLFSSL_NXP_HASHCRYPT_SHA)
 int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
 {
+    int ret;
+
     (void)heap;
     (void)devId;
 
@@ -129,19 +172,30 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
         return BAD_FUNC_ARG;
 
     XMEMSET(sha, 0, sizeof(wc_Sha));
+
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
+        return ret;
+
     if (HASHCRYPT_SHA_Init(HASHCRYPT, &hash_ctx, kHASHCRYPT_Sha1)
             != kStatus_Success)
-        return WC_HW_E;
+        ret = WC_HW_E;
+    else
+        finish_called = 0;
 
-    finish_called = 0;
+    wolfSSL_CryptHwMutexUnLock();
 
-    return 0;
+    return ret;
 }
 
 int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
 {
+    int ret;
+
     if (sha == NULL || (data == NULL && len != 0))
         return BAD_FUNC_ARG;
+
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
+        return ret;
 
     if (finish_called)
     {
@@ -150,23 +204,32 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
     }
     if (HASHCRYPT_SHA_Update(HASHCRYPT, &hash_ctx, data, len)
             != kStatus_Success)
-        return WC_HW_E;
+        ret = WC_HW_E;
 
-    return 0;
+    wolfSSL_CryptHwMutexUnLock();
+
+    return ret;
 }
 
 int wc_ShaFinal(wc_Sha* sha, byte* hash)
 {
     size_t outlen = WC_SHA_DIGEST_SIZE;
     static byte previous_sha_hash[WC_SHA_DIGEST_SIZE];
+    int ret;
 
     if (sha == NULL || hash == NULL)
         return BAD_FUNC_ARG;
 
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
+        return ret;
+
+    /* wc_Sha256GetHash() finalizes a copy of the object, which on this engine
+     * consumes the one running digest.  Replaying the cached result keeps a
+     * later Final() consistent with the value GetHash() already returned. */
     if (finish_called)
     {
         memcpy(hash, previous_sha_hash, WC_SHA_DIGEST_SIZE);
-        return 0;
+        goto unlock;
     }
 
     if (
@@ -175,12 +238,16 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
                 || outlen != WC_SHA_DIGEST_SIZE
     )
     {
-        return WC_HW_E;
+        ret = WC_HW_E;
+        goto unlock;
     }
     memcpy(previous_sha_hash, hash, WC_SHA_DIGEST_SIZE);
     finish_called = 1;
 
-    return 0;
+unlock:
+    wolfSSL_CryptHwMutexUnLock();
+
+    return ret;
 }
 #endif /* !defined(NO_SHA) && defined(WOLFSSL_NXP_HASHCRYPT_SHA) */
 
@@ -211,31 +278,39 @@ static int _hashcrypt_set_key(Aes* aes)
 #ifdef HAVE_AES_ECB
 int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-    int ret = _hashcrypt_set_key(aes);
+    int ret;
 
-    if (ret)
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
         return ret;
 
-    if (HASHCRYPT_AES_EncryptEcb(HASHCRYPT, &aes_handle, in, out, sz)
+    ret = _hashcrypt_set_key(aes);
+    if (ret == 0 &&
+        HASHCRYPT_AES_EncryptEcb(HASHCRYPT, &aes_handle, in, out, sz)
              != kStatus_Success)
-         return WC_HW_E;
+        ret = WC_HW_E;
 
-    return 0;
+    wolfSSL_CryptHwMutexUnLock();
+
+    return ret;
 }
 
 #ifdef HAVE_AES_DECRYPT
 int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-    int ret = _hashcrypt_set_key(aes);
+    int ret;
 
-    if (ret)
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
         return ret;
 
-    if (HASHCRYPT_AES_DecryptEcb(HASHCRYPT, &aes_handle, in, out, sz)
+    ret = _hashcrypt_set_key(aes);
+    if (ret == 0 &&
+        HASHCRYPT_AES_DecryptEcb(HASHCRYPT, &aes_handle, in, out, sz)
              != kStatus_Success)
-         return WC_HW_E;
+        ret = WC_HW_E;
 
-    return 0;
+    wolfSSL_CryptHwMutexUnLock();
+
+    return ret;
 }
 #endif
 #endif /* HAVE_AES_ECB */
@@ -243,19 +318,24 @@ int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 #ifdef HAVE_AES_CBC
 int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-    int ret = _hashcrypt_set_key(aes);
+    int ret;
 
-    if (ret)
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
         return ret;
 
-    if (HASHCRYPT_AES_EncryptCbc(
-            HASHCRYPT, &aes_handle, in, out, sz, (const uint8_t *)aes->reg)
-                != kStatus_Success)
-         return WC_HW_E;
+    ret = _hashcrypt_set_key(aes);
+    if (ret == 0) {
+        if (HASHCRYPT_AES_EncryptCbc(
+                HASHCRYPT, &aes_handle, in, out, sz, (const uint8_t *)aes->reg)
+                    != kStatus_Success)
+            ret = WC_HW_E;
+        else
+            XMEMCPY(aes->reg, out + sz - 16, 16);
+    }
 
-    XMEMCPY(aes->reg, out + sz - 16, 16);
+    wolfSSL_CryptHwMutexUnLock();
 
-    return 0;
+    return ret;
 }
 
 #ifdef HAVE_AES_DECRYPT
@@ -264,20 +344,24 @@ int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     int ret;
     byte tmp_iv[16];
 
-    ret = _hashcrypt_set_key(aes);
-    if (ret)
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
         return ret;
 
-    XMEMCPY(tmp_iv, in + sz - 16, 16);
+    ret = _hashcrypt_set_key(aes);
+    if (ret == 0) {
+        XMEMCPY(tmp_iv, in + sz - 16, 16);
 
-    if (HASHCRYPT_AES_DecryptCbc(
-            HASHCRYPT, &aes_handle, in, out, sz, (const uint8_t *)aes->reg)
-                != kStatus_Success)
-         return WC_HW_E;
+        if (HASHCRYPT_AES_DecryptCbc(
+                HASHCRYPT, &aes_handle, in, out, sz, (const uint8_t *)aes->reg)
+                    != kStatus_Success)
+            ret = WC_HW_E;
+        else
+            XMEMCPY(aes->reg, tmp_iv, 16);
+    }
 
-    XMEMCPY(aes->reg, tmp_iv, 16);
+    wolfSSL_CryptHwMutexUnLock();
 
-    return 0;
+    return ret;
 }
 #endif
 #endif /* HAVE_AES_CBC */
@@ -287,16 +371,19 @@ int wc_AesOfbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     int ret;
 
-    ret = _hashcrypt_set_key(aes);
-    if (ret)
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
         return ret;
 
-    if (HASHCRYPT_AES_CryptOfb(
+    ret = _hashcrypt_set_key(aes);
+    if (ret == 0 &&
+        HASHCRYPT_AES_CryptOfb(
             HASHCRYPT, &aes_handle, in, out, sz, (const uint8_t *)aes->reg)
                 != kStatus_Success)
-         return WC_HW_E;
+        ret = WC_HW_E;
 
-    return 0;
+    wolfSSL_CryptHwMutexUnLock();
+
+    return ret;
 }
 
 #ifdef HAVE_AES_DECRYPT
@@ -304,16 +391,19 @@ int wc_AesOfbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     int ret;
 
-    ret = _hashcrypt_set_key(aes);
-    if (ret)
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
         return ret;
 
-    if (HASHCRYPT_AES_CryptOfb(
+    ret = _hashcrypt_set_key(aes);
+    if (ret == 0 &&
+        HASHCRYPT_AES_CryptOfb(
             HASHCRYPT, &aes_handle, in, out, sz, (const uint8_t *)aes->reg)
                 != kStatus_Success)
-         return WC_HW_E;
+        ret = WC_HW_E;
 
-    return 0;
+    wolfSSL_CryptHwMutexUnLock();
+
+    return ret;
 }
 #endif
 #endif /* WOLFSSL_AES_OFB */
@@ -323,16 +413,19 @@ int wc_AesCfbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     int ret;
 
-    ret = _hashcrypt_set_key(aes);
-    if (ret)
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
         return ret;
 
-    if (HASHCRYPT_AES_EncryptCfb(
+    ret = _hashcrypt_set_key(aes);
+    if (ret == 0 &&
+        HASHCRYPT_AES_EncryptCfb(
             HASHCRYPT, &aes_handle, in, out, sz, (const uint8_t *)aes->reg)
                 != kStatus_Success)
-         return WC_HW_E;
+        ret = WC_HW_E;
 
-    return 0;
+    wolfSSL_CryptHwMutexUnLock();
+
+    return ret;
 }
 
 #ifdef HAVE_AES_DECRYPT
@@ -340,16 +433,19 @@ int wc_AesCfbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     int ret;
 
-    ret = _hashcrypt_set_key(aes);
-    if (ret)
+    if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
         return ret;
 
-    if (HASHCRYPT_AES_DecryptCfb(
+    ret = _hashcrypt_set_key(aes);
+    if (ret == 0 &&
+        HASHCRYPT_AES_DecryptCfb(
             HASHCRYPT, &aes_handle, in, out, sz, (const uint8_t *)aes->reg)
                 != kStatus_Success)
-         return WC_HW_E;
+        ret = WC_HW_E;
 
-    return 0;
+    wolfSSL_CryptHwMutexUnLock();
+
+    return ret;
 }
 #endif
 #endif /* WOLFSSL_AES_CFB */
@@ -357,7 +453,7 @@ int wc_AesCfbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 #ifdef WOLFSSL_AES_COUNTER
 int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-    int ret;
+    int ret = 0;   /* sz may reach 0 in the drain below, skipping the lock */
     byte* tmp;
 
     if (aes == NULL || out == NULL || in == NULL) {
@@ -373,18 +469,21 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 
     if (sz) {
-        ret = _hashcrypt_set_key(aes);
-        if (ret)
+        if ((ret = wolfSSL_CryptHwMutexLock()) != 0)
             return ret;
 
-        if (HASHCRYPT_AES_CryptCtr(
+        ret = _hashcrypt_set_key(aes);
+        if (ret == 0 &&
+            HASHCRYPT_AES_CryptCtr(
                 HASHCRYPT, &aes_handle, in, out, sz, (byte *)aes->reg,
                 (byte *)aes->tmp, (word32 *)&aes->left)
                     != kStatus_Success)
-         return WC_HW_E;
+            ret = WC_HW_E;
+
+        wolfSSL_CryptHwMutexUnLock();
     }
 
-    return 0;
+    return ret;
 }
 #endif /* WOLFSSL_AES_COUNTER */
 

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -918,12 +918,13 @@ WOLFSSL_LOCAL void wolfSSL_RefWithMutexDec_IfEquals(wolfSSL_RefWithMutex* ref,
 #endif
 
 
-/* Enable crypt HW mutex for Freescale MMCAU, PIC32MZ, STM32, MAX3266X or
- * RTL8735B */
+/* Enable crypt HW mutex for Freescale MMCAU, PIC32MZ, STM32, MAX3266X,
+ * RTL8735B, NXP CASPER or NXP HashCrypt */
 #if defined(FREESCALE_MMCAU) || defined(WOLFSSL_MICROCHIP_PIC32MZ) || \
     defined(STM32_CRYPTO) || defined(STM32_HASH) || defined(STM32_RNG) || \
     defined(WOLFSSL_MAX3266X) || defined(WOLFSSL_MAX3266X_OLD) || \
-    defined(WOLFSSL_RTL8735B_HUK)
+    defined(WOLFSSL_RTL8735B_HUK) || defined(WOLFSSL_NXP_CASPER) || \
+    defined(WOLFSSL_NXP_HASHCRYPT)
     #ifndef WOLFSSL_CRYPT_HW_MUTEX
         #define WOLFSSL_CRYPT_HW_MUTEX  1
     #endif
@@ -931,6 +932,17 @@ WOLFSSL_LOCAL void wolfSSL_RefWithMutexDec_IfEquals(wolfSSL_RefWithMutex* ref,
 
 #ifndef WOLFSSL_CRYPT_HW_MUTEX
     #define WOLFSSL_CRYPT_HW_MUTEX  0
+#endif
+
+/* The NXP CASPER and HashCrypt ports depend on the crypt HW mutex to serialize
+ * their single shared peripherals and the file-scope state that goes with them
+ * (CASPER's conversion scratch, HashCrypt's AES handle and SHA context).  The
+ * auto-enable above is #ifndef-guarded, so an explicit WOLFSSL_CRYPT_HW_MUTEX
+ * of 0 wins and turns every lock in those ports into a no-op.  Fail loudly
+ * rather than ship a build whose documented serialization is not there. */
+#if (defined(WOLFSSL_NXP_CASPER) || defined(WOLFSSL_NXP_HASHCRYPT)) && \
+    !defined(SINGLE_THREADED) && (WOLFSSL_CRYPT_HW_MUTEX == 0)
+    #error "NXP CASPER/HashCrypt require WOLFSSL_CRYPT_HW_MUTEX unless SINGLE_THREADED"
 #endif
 
 #if WOLFSSL_CRYPT_HW_MUTEX


### PR DESCRIPTION
## Serialize NXP CASPER and HashCrypt accelerator access

  The LPC55S69 CASPER and HashCrypt ports did no locking. They also refused to build with `WOLFSSL_CRYPT_HW_MUTEX=1`, which FreeRTOS builds turn on automatically.

  ### Changes
  - **CASPER:** RSA public exptmod and ECC mulmod/mul2add now hold the PK HW mutex for the whole hardware sequence. `wc_casper_init()` initializes that mutex.
  - **HashCrypt:** all SHA-1/SHA-256 and AES (ECB, CBC, OFB, CFB, CTR) operations now hold the global crypt HW mutex. AES and SHA run on the same engine, so they share one
  lock.
  - **wc_port.h:** `WOLFSSL_CRYPT_HW_MUTEX` is enabled automatically for CASPER and HashCrypt. A threaded build that sets it to 0 now fails to compile.
  - **README:** documents the locking and the existing single SHA stream and no SHA-224 limitations.