### PR TITLE
ssl_bn: skip truncation shift for byte-aligned BN_rand requests

### DIFF
--- a/src/ssl_bn.c
+++ b/src/ssl_bn.c
@@ -2167,8 +2167,8 @@ int wolfSSL_BN_rand(WOLFSSL_BIGNUM* bn, int bits, int top, int bottom)
         /* Dispose of buffer - no longer needed. */
         XFREE(buff, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
-        if (ret == 1) {
-            /* Truncate to requested bit length. */
+        /* Truncate to requested bit length when not a whole number of bytes. */
+        if ((ret == 1) && ((bits % 8) != 0)) {
             mp_rshb((mp_int*)bn->internal, 8 - (bits % 8));
         }
 

--- a/tests/api/test_ossl_bn.c
+++ b/tests/api/test_ossl_bn.c
@@ -921,6 +921,8 @@ int test_wolfSSL_BN_rand(void)
     BIGNUM* bn = NULL;
     BIGNUM* range = NULL;
     BIGNUM emptyBN;
+    int i;
+    int seen;
 
     XMEMSET(&emptyBN, 0, sizeof(emptyBN));
     ExpectNotNull(bn = BN_new());
@@ -1044,6 +1046,42 @@ int test_wolfSSL_BN_rand(void)
     ExpectIntEQ(BN_rand(bn, 13, WOLFSSL_BN_RAND_TOP_ONE,
         WOLFSSL_BN_RAND_BOTTOM_ANY), 1);
     ExpectIntEQ(BN_num_bits(bn), 13);
+
+    /* A request for a multiple of 8 bits keeps every generated bit. Shifting
+     * out a whole byte would make the 8-bit values zero, hold the 16-bit
+     * values in the low byte, and fix the 8-bit top bit results at 0x80. */
+    seen = 0;
+    for (i = 0; (i < 64) && EXPECT_SUCCESS(); i++) {
+        ExpectIntEQ(BN_rand(bn, 8, WOLFSSL_BN_RAND_TOP_ANY,
+            WOLFSSL_BN_RAND_BOTTOM_ANY), 1);
+        if (EXPECT_SUCCESS() && (BN_is_zero(bn) == 0)) {
+            seen = 1;
+            break;
+        }
+    }
+    ExpectIntEQ(seen, 1);
+
+    seen = 0;
+    for (i = 0; (i < 64) && EXPECT_SUCCESS(); i++) {
+        ExpectIntEQ(BN_rand(bn, 16, WOLFSSL_BN_RAND_TOP_ANY,
+            WOLFSSL_BN_RAND_BOTTOM_ANY), 1);
+        if (EXPECT_SUCCESS() && (BN_num_bits(bn) > 8)) {
+            seen = 1;
+            break;
+        }
+    }
+    ExpectIntEQ(seen, 1);
+
+    seen = 0;
+    for (i = 0; (i < 64) && EXPECT_SUCCESS(); i++) {
+        ExpectIntEQ(BN_pseudo_rand(bn, 8, WOLFSSL_BN_RAND_TOP_ONE,
+            WOLFSSL_BN_RAND_BOTTOM_ANY), 1);
+        if (EXPECT_SUCCESS() && (BN_get_word(bn) != 0x80)) {
+            seen = 1;
+            break;
+        }
+    }
+    ExpectIntEQ(seen, 1);
 
     ExpectIntEQ(BN_rand(range, 64, WOLFSSL_BN_RAND_TOP_ONE,
         WOLFSSL_BN_RAND_BOTTOM_ANY), 1);


### PR DESCRIPTION
### Problem
`wolfSSL_BN_rand()` generates `(bits + 7) / 8` random bytes and then truncates
the result with an unconditional right shift:

```c
mp_rshb((mp_int*)bn->internal, 8 - (bits % 8));
```

When `bits` is a multiple of 8, `bits % 8` is `0`, so the shift is `8` instead
of `0` and the top byte of entropy is discarded. `BN_rand(bn, 8, TOP_ANY,
BOTTOM_ANY)` always returns `0`; `BN_rand(bn, N*8, TOP_ANY, …)` always returns
a value below `2^(N*8-8)`.

The effect is not confined to direct `BN_rand()`/`BN_pseudo_rand()` callers.
`wolfSSL_BN_rand_range()` requests `BN_num_bits(range)` bits, and byte-aligned
ranges are the common case (256-bit EC group orders, 2048-bit moduli), so it
returns values confined to the bottom 1/256 of the requested range — a severe
bias in a routine applications use for nonces and blinding values.

Closes `f-12559`.

### Fix (`src/ssl_bn.c`)
The shift now runs only when the request is not a whole number of bytes. The
non-byte-aligned path is unchanged (13 bits still generates 2 bytes and shifts
by 3).

### Tests (`tests/api/test_ossl_bn.c`)
The existing byte-aligned assertions only exercised `TOP_ONE`/`TOP_TWO` and
checked `BN_num_bits()` or specific top bits — all of which the forced
`0x80`/`0xC0` results satisfied, so nothing caught this. Three sampling loops
were added to `test_wolfSSL_BN_rand()`:

| Request | Assertion |
|---|---|
| 8-bit `TOP_ANY` | at least one non-zero result |
| 16-bit `TOP_ANY` | at least one result above the low byte |
| 8-bit `TOP_ONE` | at least one result other than `0x80` |

Each loops up to 64 times, so false-failure probability is negligible.

### Verification
- Negative control: without the `ssl_bn.c` change, `test_wolfSSL_BN_rand` fails
  on the first new assertion.
- `--enable-opensslall --enable-debug`: `./tests/unit.test` 1152 passed,
  0 failed; `testwolfcrypt` clean.
- `--enable-opensslall --enable-fastmath` (routes `mp_rshb` through `fp_rshb`
  rather than SP math): 1147 passed, 0 failed.