### PR TITLE
wolfio: validate ISO-TP frames before copying payload

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -4228,6 +4228,10 @@ static int isotp_receive_single_frame(struct isotp_wolfssl_ctx *ctx)
     /* 1 nibble for data size which will be 1 - 7 in a regular 8 byte CAN
      * packet */
     data_size = (byte)ctx->frame.data[0] & 0xf;
+    if (data_size > ISOTP_SINGLE_FRAME_DATA_SIZE) {
+        WOLFSSL_MSG("Data size is too large for ISO-TP single frame");
+        return WOLFSSL_CBIO_ERR_GENERAL;
+    }
     if (ctx->receive_buffer_size < (int)data_size) {
         WOLFSSL_MSG("ISO-TP buffer is too small to receive data");
         return BUFFER_E;
@@ -4250,7 +4254,11 @@ static int isotp_receive_multi_frame(struct isotp_wolfssl_ctx *ctx)
      * Full data size is lower nibble of first byte for the most significant
      * followed by the second byte for the rest. Last 6 bytes are data */
     data_size = ((ctx->frame.data[0] & 0xf) << 8) + ctx->frame.data[1];
-    XMEMCPY(ctx->receive_buffer, &ctx->frame.data[2], ISOTP_FIRST_FRAME_DATA_SIZE);
+    if ((ctx->frame.length != ISOTP_CAN_BUS_PAYLOAD_SIZE) ||
+            (data_size <= ISOTP_SINGLE_FRAME_DATA_SIZE)) {
+        WOLFSSL_MSG("ISO-TP first frame is malformed");
+        return WOLFSSL_CBIO_ERR_GENERAL;
+    }
     /* Need to send a flow control packet to either cancel or continue
      * transmission of data */
     if (ctx->receive_buffer_size < data_size) {
@@ -4258,6 +4266,7 @@ static int isotp_receive_multi_frame(struct isotp_wolfssl_ctx *ctx)
         WOLFSSL_MSG("ISO-TP buffer is too small to receive data");
         return BUFFER_E;
     }
+    XMEMCPY(ctx->receive_buffer, &ctx->frame.data[2], ISOTP_FIRST_FRAME_DATA_SIZE);
     isotp_send_flow_control(ctx, FALSE);
 
     ctx->buf_length = ISOTP_FIRST_FRAME_DATA_SIZE;
@@ -4273,6 +4282,9 @@ static int isotp_receive_multi_frame(struct isotp_wolfssl_ctx *ctx)
                 (delay / 1000));
         if (ret == 0) {
             return WOLFSSL_CBIO_ERR_TIMEOUT;
+        } else if (ret < 0) {
+            WOLFSSL_MSG("ISO-TP error receiving consecutive frame");
+            return WOLFSSL_CBIO_ERR_GENERAL;
         }
         type = ctx->frame.data[0] >> 4;
         /* Consecutive frames have sequence number as lower nibble */
@@ -4285,8 +4297,19 @@ static int isotp_receive_multi_frame(struct isotp_wolfssl_ctx *ctx)
             WOLFSSL_MSG("ISO-TP frames out of sequence");
             return WOLFSSL_CBIO_ERR_GENERAL;
         }
-        /* Last 7 bytes or whatever we got after the first byte is data */
+        /* A consecutive frame carries the sequence byte and at least one byte
+         * of data */
+        if ((ctx->frame.length < 2) ||
+                (ctx->frame.length > ISOTP_CAN_BUS_PAYLOAD_SIZE)) {
+            WOLFSSL_MSG("ISO-TP consecutive frame is malformed");
+            return WOLFSSL_CBIO_ERR_GENERAL;
+        }
+        /* Last 7 bytes or whatever we got after the first byte is data, the
+         * final frame can be padded beyond the data we are still owed */
         frame_len = ctx->frame.length - 1;
+        if (frame_len > data_size) {
+            frame_len = (byte)data_size;
+        }
         XMEMCPY(ctx->buf_ptr, &ctx->frame.data[1], frame_len);
         ctx->buf_ptr += frame_len;
         ctx->buf_length += frame_len;


### PR DESCRIPTION
### Problem

`isotp_receive_multi_frame()` in `src/wolfio.c` copies six bytes of first-frame payload into the caller's `receive_buffer` before checking that the buffer can hold the declared message, so a buffer smaller than six bytes is overwritten before `BUFFER_E` is returned (`12564`).

Two worse defects sit in the same six lines, both reachable from the CAN peer since every byte here comes off the bus:

```c
data_size -= ISOTP_FIRST_FRAME_DATA_SIZE;   /* wraps when the FF declares < 6 */
frame_len = ctx->frame.length - 1;          /* not capped to what is still owed */
```

- A first frame declaring 0-5 bytes wraps the `word16` to ~65530, and the consecutive-frame loop then writes 7 bytes per frame indefinitely past `receive_buffer`.
- A padded or oversized final consecutive frame writes past the declared end and underflows `data_size` into the same unbounded loop (`f-12565`).
- A consecutive frame with a CAN DLC of 0 wraps `frame_len` to 255, giving a 255-byte read out of the 8-byte `frame.data` and a 255-byte write; a DLC of 1 makes no progress and loops forever.

Reachable only in `WOLFSSL_ISOTP` builds.

### Fix (`src/wolfio.c`)

- **`isotp_receive_single_frame()`** rejects a length nibble above `ISOTP_SINGLE_FRAME_DATA_SIZE`, which previously read up to 8 bytes past `frame.data[8]` into the TLS input buffer.
- **`isotp_receive_multi_frame()`** requires a first frame to be a full `ISOTP_CAN_BUS_PAYLOAD_SIZE` frame declaring more than `ISOTP_SINGLE_FRAME_DATA_SIZE` bytes, and copies its payload **after** the `receive_buffer_size` check.
- **The consecutive-frame loop** rejects a negative `recv_fn()` result and a frame length below 2 or above `ISOTP_CAN_BUS_PAYLOAD_SIZE`, and caps `frame_len` at the `data_size` still owed.

Closes `f-12564` and `f-12565`.

### Verification

Built with `-DWOLFSSL_ISOTP` under ASan + UBSan and driven through a local harness with mock `can_recv_fn`/`can_send_fn` callbacks and an exactly-sized heap receive buffer:

| Case | Before | After |
|---|---|---|
| FF declaring 8 + CF with 7 data bytes | heap-buffer-overflow | 8 bytes, contents correct |
| FF declaring 5 | heap-buffer-overflow | `WOLFSSL_CBIO_ERR_GENERAL` |
| CF with DLC 0 | heap-buffer-overflow | `WOLFSSL_CBIO_ERR_GENERAL` |
| CF with DLC 1 | no progress | `WOLFSSL_CBIO_ERR_GENERAL` |
| FF declaring 100, 4-byte buffer | heap-buffer-overflow | `BUFFER_E`, abort flow control, no write |
| Single frame, nibble 15 | 15 bytes, 8 read past the frame | `WOLFSSL_CBIO_ERR_GENERAL` |
| 100-byte multi-frame; 7-byte single frame | correct | correct, byte-for-byte |

Clean under `-Wall -Wextra -Werror -Wdeclaration-after-statement` with and without `WOLFSSL_ISOTP`.

### Test coverage limitation

No unit test accompanies this change. `WOLFSSL_ISOTP` has no configure option and makes `wolfSSL_CTX_new()` install `ISOTP_Receive`/`ISOTP_Send` as the IO callbacks for **every** `WOLFSSL_CTX` (`src/internal.c`), so the api suite cannot be built with it — a test added there would compile out in every CI job, and the one configuration that would compile it turns the rest of the suite red. The harness above covers the cases a unit test would; landing it in-tree needs a standalone `WOLFSSL_ISOTP` test binary, which is left for a follow-up.