### PR TITLE
Route ready pull requests through PRB trigger

### DIFF
--- a/.github/workflows/prb-preflight.yml
+++ b/.github/workflows/prb-preflight.yml
@@ -1,0 +1,17 @@
+name: PRB preflight
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, converted_to_draft, ready_for_review]
+    branches: [master, main]
+
+permissions: {}
+
+jobs:
+  preflight:
+    name: PRB-master-job/preflight
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark PR ready for Jenkins
+        run: echo "PR is ready for Jenkins PRB"

--- a/.github/workflows/retrigger-prb-on-ready.yml
+++ b/.github/workflows/retrigger-prb-on-ready.yml
@@ -1,9 +1,9 @@
-name: Trigger PRB for ready pull requests
+name: Retrigger PRB on ready for review
 
-# Jenkins is configured to build only after its trigger phrase appears. This
-# workflow posts that fixed phrase for every event that creates a new ready PR
-# head. Draft events still create the separate skipped preflight check, but do
-# not start Jenkins or allocate a runner here.
+# When a draft PR is marked ready_for_review, GitHub fires a
+# 'ready_for_review' pull_request event but no 'synchronize' event, so
+# the Jenkins GHPRB plugin does not re-trigger the PRB-master-job. Post
+# the configured GHPRB trigger phrase as a PR comment to kick it off.
 #
 # pull_request_target (not pull_request) is required so GITHUB_TOKEN
 # gets write permissions on PRs from forks - this workflow only posts
@@ -12,15 +12,14 @@ name: Trigger PRB for ready pull requests
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ready_for_review]
     branches: [master, main]
 
 permissions:
   pull-requests: write
 
 jobs:
-  trigger:
-    if: github.event.pull_request.draft == false
+  retrigger:
     runs-on: ubuntu-latest
     steps:
       - name: Post GHPRB trigger comment

--- a/.github/workflows/retrigger-prb-on-ready.yml
+++ b/.github/workflows/retrigger-prb-on-ready.yml
@@ -1,9 +1,9 @@
-name: Retrigger PRB on ready for review
+name: Trigger PRB for ready pull requests
 
-# When a draft PR is marked ready_for_review, GitHub fires a
-# 'ready_for_review' pull_request event but no 'synchronize' event, so
-# the Jenkins GHPRB plugin does not re-trigger the PRB-master-job. Post
-# the configured GHPRB trigger phrase as a PR comment to kick it off.
+# Jenkins is configured to build only after its trigger phrase appears. This
+# workflow posts that fixed phrase for every event that creates a new ready PR
+# head. Draft events still create the separate skipped preflight check, but do
+# not start Jenkins or allocate a runner here.
 #
 # pull_request_target (not pull_request) is required so GITHUB_TOKEN
 # gets write permissions on PRs from forks - this workflow only posts
@@ -12,14 +12,15 @@ name: Retrigger PRB on ready for review
 
 on:
   pull_request_target:
-    types: [ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [master, main]
 
 permissions:
   pull-requests: write
 
 jobs:
-  retrigger:
+  trigger:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Post GHPRB trigger comment


### PR DESCRIPTION
## Summary

- Add PRB-master-job/preflight as a GitHub check that is SKIPPED for drafts and SUCCESS for ready pull requests.
- Keep the existing ready-for-review workflow unchanged: it posts the normal retest this please comment only when a draft becomes ready.
- Keep normal Jenkins GHPRB triggering for opened, reopened, and synchronized pull requests.

## Jenkins configuration

PRB-master-job keeps Only use trigger phrase unchecked. The trigger phrase and skip-build phrase remain the same as the existing production master job. Disable the legacy GHPRB commit-status updater because it cannot represent skipped; the GitHub workflow owns the draft/ready preflight check, while the Jenkins pipeline owns real run results.

The temporary PRB-master-job-retry-canary mirrors those triggers, is hard-limited to PR #11322, skips every child except PRB-retry-canary, and sets PRB_SKIP_SMOKE_GATE=1.

## Tests

- Both workflows pass actionlint.
- Draft run 33417420979 completed PRB-master-job/preflight as SKIPPED with no runner.
- Ready run 33417547957 completed PRB-master-job/preflight as SUCCESS on the same SHA.
- Ready-trigger run 33417548184 posted the normal retest this please comment.
- Full Jenkins draft to ready lifecycle validation is being repeated with canary commit 5f30df31.