### PR TITLE
Fil-C improvements

### DIFF
--- a/.github/workflows/fil-c.yml
+++ b/.github/workflows/fil-c.yml
@@ -1,7 +1,7 @@
 name: Fil-C Tests
 
 env:
-  FIL_C_VERSION: v0.674
+  FIL_C_VERSION: v0.684
 
 # START OF COMMON SECTION
 on:
@@ -24,28 +24,135 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [
-          # Add new configs here. Don't use CPPFLAGS.
-          '',
-          '--enable-all',
-        ]
+        # Add new configs here. Fil-C cannot link a .S file, so every config
+        # is built with --disable-asm (added to the configure line below, not
+        # here) unless it sets asm: 'yes'. cflags: is appended to EXTRA_CFLAGS
+        # for a leg that needs a define with no configure option of its own.
+        #
+        # --enable-intelasm and --enable-aesni cannot be added, and neither
+        # can the assembly builds of ML-KEM and ML-DSA. Fil-C gives every
+        # function a capability carrying entry point, which a .S file does not
+        # have, so the link fails on 227 symbols, 64% of them ML-KEM and
+        # ML-DSA. The aarch64 inline assembly build of ML-KEM does not help
+        # either: its constraints are register only, but it takes pointers and
+        # loads through them inside the assembly, which Fil-C also rejects.
+        # Those routines are outside what this job can cover, so a green run
+        # says nothing about them. The C implementations of the same
+        # algorithms are covered by the other legs.
+        #
+        # There is no aarch64 counterpart to the 'default, asm' leg either.
+        # Leaving assembly on for an aarch64 host makes configure define
+        # WOLFSSL_AARCH64_BUILD, so cpuid.h defines HAVE_CPUID_AARCH64 and
+        # cpuid.c includes <asm/hwcap.h>, a Linux kernel header that Fil-C's
+        # sysroot does not ship. That is a property of the sysroot, not of
+        # wolfSSL, and there is no way to keep the assembly while dropping the
+        # CPU id, so the aarch64 legs stay on --disable-asm.
+        include:
+          - name: 'default'
+            config: ''
+          # The default build with assembly left on. No .S file is compiled on
+          # x86_64 or aarch64 without --enable-intelasm/--enable-aesni/
+          # --enable-armasm, so what this adds over 'default' is the inline
+          # assembly in sp_int.c, which is what most users actually build.
+          - name: 'default, asm'
+            config: ''
+            asm: 'yes'
+          - name: 'all'
+            config: '--enable-all'
+          # Builds sp_c64.c, the fixed size SP code, which 'all' does not.
+          - name: 'single precision'
+            config: '--enable-sp'
+          # Same build as 'all', run against the assertion enabled Fil-C
+          # runtime, collecting continuously and scribbling over freed
+          # objects. Turns latent pointer races and stale pointer reads into
+          # deterministic panics for about 1.4x the run time. FUGC_VERIFY is
+          # deliberately left off: it checks the collector's own invariants
+          # and costs more than 14x.
+          - name: 'all, gc stress'
+            config: '--enable-all'
+            gc-stress: 'yes'
+          - name: 'post-quantum'
+            config: '--enable-all --enable-experimental --enable-mldsa --enable-lms --enable-xmss --enable-falcon'
+          - name: 'crypto only'
+            config: '--enable-cryptonly --enable-all-crypto'
+          - name: 'heap math'
+            config: '--enable-all-crypto --enable-heapmath'
+          - name: 'fast math'
+            config: '--enable-fastmath'
+          # _fp_exptmod_ct is covered by the leg above, but the
+          # WC_PROTECT_ENCRYPTED_MEM ladder next to it is a separate copy of
+          # the same code with its own fp_cond_copy calls, and nothing else
+          # here builds it. The fp_exptmod_nb ladder stays uncovered: it needs
+          # --enable-rsa=nonblock, which fails with fastmath on master with
+          # plain gcc too.
+          - name: 'fast math, protect encrypted mem'
+            config: '--enable-fastmath'
+            cflags: '-DWC_PROTECT_ENCRYPTED_MEM'
+          - name: 'small stack'
+            config: '--enable-all --enable-smallstack'
+          # Not combined with --enable-all: the static pool is too small for
+          # that feature set, with Fil-C and with gcc alike.
+          - name: 'static memory'
+            config: '--enable-staticmemory'
+          # Not combined with --enable-all: that pairing fails
+          # scripts/ocsp-stapling_tls13multi.test with gcc as well.
+          # --enable-sniffer on its own still turns on static RSA and static
+          # ephemeral, which is the code this leg is here for.
+          - name: 'sniffer'
+            config: '--enable-sniffer'
+          - name: 'low resource'
+            config: '--enable-lowresource'
+          - name: 'old tls'
+            config: '--enable-oldtls --disable-tls13'
+          - name: 'default, arm64'
+            config: ''
+            runner: 'ubuntu-24.04-arm'
+          - name: 'all, arm64'
+            config: '--enable-all'
+            runner: 'ubuntu-24.04-arm'
     # This should be a safe limit for the tests to run.
-    timeout-minutes: 30
+    timeout-minutes: 45
     if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
-    runs-on: ubuntu-24.04
-    name: ${{ matrix.config }}
+    runs-on: ${{ matrix.runner || 'ubuntu-24.04' }}
+    name: ${{ matrix.name }}
     steps:
     - name: Download fil-c release
-      run: gh release download ${{ env.FIL_C_VERSION }} --repo pizlonator/fil-c --pattern 'filc-*'
+      run: |
+        case "$(uname -m)" in
+          x86_64)  filc_arch=x86_64 ;;
+          aarch64) filc_arch=aarch64 ;;
+          *) echo "No Fil-C release for $(uname -m)"; exit 1 ;;
+        esac
+        gh release download ${{ env.FIL_C_VERSION }} --repo pizlonator/fil-c \
+            --pattern "filc-*-linux-$filc_arch.tar.xz"
       env:
         GH_TOKEN: ${{ github.token }}
 
     - name: Extract fil-c tarball
-      run: mkdir -p filc && tar -xf filc-*.tar* --strip-components=1 -C filc
+      run: mkdir -p filc && tar -xf filc-*.tar.xz --strip-components=1 -C filc
 
+    # EXTRA_CFLAGS=-g makes Fil-C report file and line for the frames of a
+    # panic instead of just symbol names.
+    #
+    # The environment is set on this step rather than on the job: pizfix/lib
+    # holds Fil-C's own libc, and the download and extract steps run ordinary
+    # glibc linked runner tooling that has no reason to see it.
     - name: Build and test wolfSSL
       uses: wolfSSL/actions-build-autotools-project@v1
+      env:
+        # Fil-C rejects an empty value for these, so use 0 rather than ''. The
+        # non stress legs point at pizfix/lib, which is where the binaries look
+        # anyway, rather than at an empty path.
+        LD_LIBRARY_PATH: ${{ matrix.gc-stress == 'yes' && format('{0}/filc/pizfix/lib_test', github.workspace) || format('{0}/filc/pizfix/lib', github.workspace) }}
+        FUGC_RAGE_MODE: ${{ matrix.gc-stress == 'yes' && '1' || '0' }}
+        FUGC_SCRIBBLE: ${{ matrix.gc-stress == 'yes' && '1' || '0' }}
+        # One collector thread per process on the stress leg. make check runs
+        # several test programs at once, and with rage mode each of them would
+        # otherwise start a collector thread per core and thrash the runner.
+        # 4 elsewhere is the standard runner's core count, which is what Fil-C
+        # would pick on its own; it is set only to keep the value explicit.
+        FUGC_CORES: ${{ matrix.gc-stress == 'yes' && '1' || '4' }}
       with:
         path: wolfssl
-        configure: ${{ matrix.config }} CC=$GITHUB_WORKSPACE/filc/build/bin/filcc --disable-asm CPPFLAGS=-DWC_NO_CACHE_RESISTANT
+        configure: ${{ matrix.config }} CC=$GITHUB_WORKSPACE/filc/build/bin/filcc ${{ matrix.asm == 'yes' && ' ' || '--disable-asm' }} EXTRA_CFLAGS='-g ${{ matrix.cflags }}'
         check: true

--- a/.wolfssl_known_macro_extras
+++ b/.wolfssl_known_macro_extras
@@ -1255,6 +1255,7 @@ __DCC__
 __DECC_VER
 __ELF__
 __EMSCRIPTEN__
+__FILC__
 __FPU_PRESENT
 __FreeBSD__
 __GLIBC__

--- a/src/internal.c
+++ b/src/internal.c
@@ -6080,7 +6080,7 @@ int RsaDec(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, word32* outSz,
     RsaKey* key, DerBuffer* keyBufInfo)
 {
     byte *outTmp;
-    byte mask;
+    volatile byte mask;
     int ret;
 #ifdef HAVE_PK_CALLBACKS
     const byte* keyBuf = NULL;
@@ -6132,7 +6132,13 @@ int RsaDec(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, word32* outSz,
     *outSz = (word32)(ret & (int)(sword8)mask);
     ret &= (int)(sword8)(~mask);
     /* Copy pointer */
+#ifdef WC_NO_PTR_INT_CAST
+    /* A byte wise copy drops the capability of a pointer, so select it
+     * instead. Neither path branches on the decryption result. */
+    *out = (byte*)ctMaskSelPtr(mask, *out, outTmp);
+#else
     ctMaskCopy(mask, (byte*)out, (byte*)&outTmp, sizeof(*out));
+#endif
 
     WOLFSSL_LEAVE("RsaDec", ret);
 
@@ -45232,8 +45238,16 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                         ssl->arrays->preMasterSecret[1] = ssl->chVersion.minor;
 
                         tmpRsa = input + args->idx - VERSION_SZ - SECRET_LEN;
+                    #ifdef WC_NO_PTR_INT_CAST
+                        /* A byte wise copy drops the capability of a pointer,
+                         * so select it instead. Neither path branches on the
+                         * decryption result. */
+                        args->output = (byte*)ctMaskSelPtr(mask, tmpRsa,
+                            args->output);
+                    #else
                         ctMaskCopy(~mask, (byte*)&args->output, (byte*)&tmpRsa,
                             sizeof(args->output));
+                    #endif
                         if (args->output != NULL) {
                             int i;
                             /* Use random secret on error */

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -960,6 +960,28 @@ WC_MISC_STATIC WC_INLINE void ctMaskCopy(byte mask, byte* dst, byte* src,
     }
 }
 
+#ifdef WC_NO_PTR_INT_CAST
+/* Constant time - return b when mask is set and a when it is clear.
+ *
+ * ctMaskCopy() cannot be used to select a pointer on a capability based
+ * target: it copies byte by byte, which drops the capability even when the
+ * bytes are unchanged. Index a two entry table instead. The table is aligned
+ * to 32 bytes - not 16 - so that both entries share one cache line even when
+ * a pointer is 16 bytes wide, as it is on CHERI purecap. XALIGNED is used
+ * rather than ALIGN16 because ALIGN16 expands to nothing unless
+ * WOLFSSL_USE_ALIGN is defined.
+ */
+WC_MISC_STATIC WC_INLINE void* ctMaskSelPtr(byte mask, void* a, void* b)
+{
+    XALIGNED(32) void* p[2];
+
+    p[0] = a;
+    p[1] = b;
+
+    return p[mask & 1];
+}
+#endif /* WC_NO_PTR_INT_CAST */
+
 #endif /* !WOLFSSL_NO_CT_OPS */
 
 #ifndef WOLFSSL_HAVE_MIN

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -261,8 +261,43 @@ sp_uint64 __muldi3(sp_uint64 a, sp_uint64 b)
 #endif
 
 #ifdef NEED_ADDR_MASK
+#ifdef WC_NO_PTR_INT_CAST
+/* Conditionally copy len bytes from a to r when copy is 1, in constant time.
+ * Used where a pointer cannot be rebuilt from integer arithmetic on two
+ * addresses, such as on capability based targets. Both candidates are always
+ * touched, so which one was selected is not observable. */
+WC_MAYBE_UNUSED static void sp_cond_memcpy(void* r, const void* a, int copy,
+    size_t len)
+{
+    byte* rb = (byte*)r;
+    const byte* ab = (const byte*)a;
+    byte mask = (byte)(0U - (unsigned int)(copy != 0));
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        rb[i] ^= (byte)((rb[i] ^ ab[i]) & mask);
+    }
+}
+
+/* Set r to a when sel is 0 and to b when sel is 1, in constant time.
+ * Writes r without reading it, so r may be an uninitialized scratch buffer. */
+WC_MAYBE_UNUSED static void sp_cond_select(void* r, const void* a,
+    const void* b, int sel, size_t len)
+{
+    byte* rb = (byte*)r;
+    const byte* ab = (const byte*)a;
+    const byte* bb = (const byte*)b;
+    byte mask = (byte)(0U - (unsigned int)(sel != 0));
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        rb[i] = (byte)((ab[i] & (byte)~mask) | (bb[i] & mask));
+    }
+}
+#else
 /* Mask for address to obfuscate which of the two address will be used. */
 static const size_t addr_mask[2] = { 0, (size_t)-1 };
+#endif
 #endif
 
 #if defined(WOLFSSL_SP_NONBLOCK) && (!defined(WOLFSSL_SP_NO_MALLOC) || \
@@ -2143,17 +2178,21 @@ static WC_INLINE sp_digit sp_2048_div_word_36(sp_digit d1, sp_digit d0,
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
     sp_uint32 lo = (sp_uint32)d;
     sp_digit hi = (sp_digit)(d >> 32);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -2395,13 +2434,22 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_36(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 36 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 36 * 2);
+            #endif
             sp_2048_mont_sqr_36(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 36 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 36 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 36 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_36(t[0], m, mp);
@@ -2471,13 +2519,22 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_36(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 36 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 36 * 2);
+            #endif
             sp_2048_mont_sqr_36(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 36 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 36 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 36 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_36(t[0], m, mp);
@@ -3178,17 +3235,21 @@ static WC_INLINE sp_digit sp_2048_div_word_72(sp_digit d1, sp_digit d0,
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
     sp_uint32 lo = (sp_uint32)d;
     sp_digit hi = (sp_digit)(d >> 32);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -3433,13 +3494,22 @@ static int sp_2048_mod_exp_72(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_72(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 72 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 72 * 2);
+            #endif
             sp_2048_mont_sqr_72(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 72 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 72 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 72 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_72(t[0], m, mp);
@@ -3509,13 +3579,22 @@ static int sp_2048_mod_exp_72(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_72(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 72 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 72 * 2);
+            #endif
             sp_2048_mont_sqr_72(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 72 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 72 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 72 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_72(t[0], m, mp);
@@ -3760,9 +3839,13 @@ static int sp_2048_mod_exp_72_nb(sp_2048_mod_exp_72_ctx* ctx,
         ctx->state = 7;
         break;
     case 7: /* COPY_OUT: constant-time copy &t[y] -> t[2] */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_select(ctx->t[2], ctx->t[0], ctx->t[1], (ctx->y), sizeof(sp_digit) * 72 * 2);
+        #else
         XMEMCPY(ctx->t[2], (void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                                    ((size_t)ctx->t[1] & addr_mask[ctx->y])),
                 sizeof(sp_digit) * 72 * 2);
+        #endif
         ctx->state = 8;
         break;
     case 8: /* SQR: t[2] = t[2]^2 in Montgomery form */
@@ -3770,9 +3853,14 @@ static int sp_2048_mod_exp_72_nb(sp_2048_mod_exp_72_ctx* ctx,
         ctx->state = 9;
         break;
     case 9: /* COPY_BACK: constant-time copy t[2] -> &t[y]; advance bit */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_memcpy(ctx->t[0], ctx->t[2], (ctx->y)^1, sizeof(sp_digit) * 72 * 2);
+        sp_cond_memcpy(ctx->t[1], ctx->t[2], (ctx->y), sizeof(sp_digit) * 72 * 2);
+        #else
         XMEMCPY((void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                         ((size_t)ctx->t[1] & addr_mask[ctx->y])), ctx->t[2],
                 sizeof(sp_digit) * 72 * 2);
+        #endif
         ctx->c--;
         ctx->state = 5;
         break;
@@ -6145,17 +6233,21 @@ static WC_INLINE sp_digit sp_3072_div_word_53(sp_digit d1, sp_digit d0,
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
     sp_uint32 lo = (sp_uint32)d;
     sp_digit hi = (sp_digit)(d >> 32);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -6397,13 +6489,22 @@ static int sp_3072_mod_exp_53(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_53(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 53 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 53 * 2);
+            #endif
             sp_3072_mont_sqr_53(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 53 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 53 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 53 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_53(t[0], m, mp);
@@ -6473,13 +6574,22 @@ static int sp_3072_mod_exp_53(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_53(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 53 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 53 * 2);
+            #endif
             sp_3072_mont_sqr_53(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 53 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 53 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 53 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_53(t[0], m, mp);
@@ -6956,17 +7066,21 @@ static WC_INLINE sp_digit sp_3072_div_word_106(sp_digit d1, sp_digit d0,
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
     sp_uint32 lo = (sp_uint32)d;
     sp_digit hi = (sp_digit)(d >> 32);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -7209,13 +7323,22 @@ static int sp_3072_mod_exp_106(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_106(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 106 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 106 * 2);
+            #endif
             sp_3072_mont_sqr_106(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 106 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 106 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 106 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_106(t[0], m, mp);
@@ -7285,13 +7408,22 @@ static int sp_3072_mod_exp_106(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_106(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 106 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 106 * 2);
+            #endif
             sp_3072_mont_sqr_106(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 106 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 106 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 106 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_106(t[0], m, mp);
@@ -7536,9 +7668,13 @@ static int sp_3072_mod_exp_106_nb(sp_3072_mod_exp_106_ctx* ctx,
         ctx->state = 7;
         break;
     case 7: /* COPY_OUT: constant-time copy &t[y] -> t[2] */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_select(ctx->t[2], ctx->t[0], ctx->t[1], (ctx->y), sizeof(sp_digit) * 106 * 2);
+        #else
         XMEMCPY(ctx->t[2], (void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                                    ((size_t)ctx->t[1] & addr_mask[ctx->y])),
                 sizeof(sp_digit) * 106 * 2);
+        #endif
         ctx->state = 8;
         break;
     case 8: /* SQR: t[2] = t[2]^2 in Montgomery form */
@@ -7546,9 +7682,14 @@ static int sp_3072_mod_exp_106_nb(sp_3072_mod_exp_106_ctx* ctx,
         ctx->state = 9;
         break;
     case 9: /* COPY_BACK: constant-time copy t[2] -> &t[y]; advance bit */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_memcpy(ctx->t[0], ctx->t[2], (ctx->y)^1, sizeof(sp_digit) * 106 * 2);
+        sp_cond_memcpy(ctx->t[1], ctx->t[2], (ctx->y), sizeof(sp_digit) * 106 * 2);
+        #else
         XMEMCPY((void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                         ((size_t)ctx->t[1] & addr_mask[ctx->y])), ctx->t[2],
                 sizeof(sp_digit) * 106 * 2);
+        #endif
         ctx->c--;
         ctx->state = 5;
         break;
@@ -10495,17 +10636,21 @@ static WC_INLINE sp_digit sp_3072_div_word_56(sp_digit d1, sp_digit d0,
     sp_int64 d = ((sp_int64)d1 << 28) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int64 d = ((sp_int64)d1 << 28) + d0;
     sp_uint32 lo = (sp_uint32)d;
     sp_digit hi = (sp_digit)(d >> 32);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -10747,13 +10892,22 @@ static int sp_3072_mod_exp_56(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_56(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 56 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 56 * 2);
+            #endif
             sp_3072_mont_sqr_56(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 56 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 56 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 56 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_56(t[0], m, mp);
@@ -10823,13 +10977,22 @@ static int sp_3072_mod_exp_56(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_56(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 56 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 56 * 2);
+            #endif
             sp_3072_mont_sqr_56(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 56 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 56 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 56 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_56(t[0], m, mp);
@@ -11385,17 +11548,21 @@ static WC_INLINE sp_digit sp_3072_div_word_112(sp_digit d1, sp_digit d0,
     sp_int64 d = ((sp_int64)d1 << 28) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int64 d = ((sp_int64)d1 << 28) + d0;
     sp_uint32 lo = (sp_uint32)d;
     sp_digit hi = (sp_digit)(d >> 32);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -11641,13 +11808,22 @@ static int sp_3072_mod_exp_112(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_112(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 112 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 112 * 2);
+            #endif
             sp_3072_mont_sqr_112(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 112 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 112 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 112 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_112(t[0], m, mp);
@@ -11717,13 +11893,22 @@ static int sp_3072_mod_exp_112(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_112(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 112 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 112 * 2);
+            #endif
             sp_3072_mont_sqr_112(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 112 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 112 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 112 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_112(t[0], m, mp);
@@ -11968,9 +12153,13 @@ static int sp_3072_mod_exp_112_nb(sp_3072_mod_exp_112_ctx* ctx,
         ctx->state = 7;
         break;
     case 7: /* COPY_OUT: constant-time copy &t[y] -> t[2] */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_select(ctx->t[2], ctx->t[0], ctx->t[1], (ctx->y), sizeof(sp_digit) * 112 * 2);
+        #else
         XMEMCPY(ctx->t[2], (void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                                    ((size_t)ctx->t[1] & addr_mask[ctx->y])),
                 sizeof(sp_digit) * 112 * 2);
+        #endif
         ctx->state = 8;
         break;
     case 8: /* SQR: t[2] = t[2]^2 in Montgomery form */
@@ -11978,9 +12167,14 @@ static int sp_3072_mod_exp_112_nb(sp_3072_mod_exp_112_ctx* ctx,
         ctx->state = 9;
         break;
     case 9: /* COPY_BACK: constant-time copy t[2] -> &t[y]; advance bit */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_memcpy(ctx->t[0], ctx->t[2], (ctx->y)^1, sizeof(sp_digit) * 112 * 2);
+        sp_cond_memcpy(ctx->t[1], ctx->t[2], (ctx->y), sizeof(sp_digit) * 112 * 2);
+        #else
         XMEMCPY((void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                         ((size_t)ctx->t[1] & addr_mask[ctx->y])), ctx->t[2],
                 sizeof(sp_digit) * 112 * 2);
+        #endif
         ctx->c--;
         ctx->state = 5;
         break;
@@ -14025,17 +14219,21 @@ static WC_INLINE sp_digit sp_4096_div_word_71(sp_digit d1, sp_digit d0,
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
     sp_uint32 lo = (sp_uint32)d;
     sp_digit hi = (sp_digit)(d >> 32);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -14277,13 +14475,22 @@ static int sp_4096_mod_exp_71(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_71(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 71 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 71 * 2);
+            #endif
             sp_4096_mont_sqr_71(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 71 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 71 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 71 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_71(t[0], m, mp);
@@ -14353,13 +14560,22 @@ static int sp_4096_mod_exp_71(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_71(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 71 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 71 * 2);
+            #endif
             sp_4096_mont_sqr_71(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 71 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 71 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 71 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_71(t[0], m, mp);
@@ -14837,17 +15053,21 @@ static WC_INLINE sp_digit sp_4096_div_word_142(sp_digit d1, sp_digit d0,
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int64 d = ((sp_int64)d1 << 29) + d0;
     sp_uint32 lo = (sp_uint32)d;
     sp_digit hi = (sp_digit)(d >> 32);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -15090,13 +15310,22 @@ static int sp_4096_mod_exp_142(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_142(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 142 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 142 * 2);
+            #endif
             sp_4096_mont_sqr_142(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 142 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 142 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 142 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_142(t[0], m, mp);
@@ -15166,13 +15395,22 @@ static int sp_4096_mod_exp_142(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_142(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 142 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 142 * 2);
+            #endif
             sp_4096_mont_sqr_142(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 142 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 142 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 142 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_142(t[0], m, mp);
@@ -15417,9 +15655,13 @@ static int sp_4096_mod_exp_142_nb(sp_4096_mod_exp_142_ctx* ctx,
         ctx->state = 7;
         break;
     case 7: /* COPY_OUT: constant-time copy &t[y] -> t[2] */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_select(ctx->t[2], ctx->t[0], ctx->t[1], (ctx->y), sizeof(sp_digit) * 142 * 2);
+        #else
         XMEMCPY(ctx->t[2], (void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                                    ((size_t)ctx->t[1] & addr_mask[ctx->y])),
                 sizeof(sp_digit) * 142 * 2);
+        #endif
         ctx->state = 8;
         break;
     case 8: /* SQR: t[2] = t[2]^2 in Montgomery form */
@@ -15427,9 +15669,14 @@ static int sp_4096_mod_exp_142_nb(sp_4096_mod_exp_142_ctx* ctx,
         ctx->state = 9;
         break;
     case 9: /* COPY_BACK: constant-time copy t[2] -> &t[y]; advance bit */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_memcpy(ctx->t[0], ctx->t[2], (ctx->y)^1, sizeof(sp_digit) * 142 * 2);
+        sp_cond_memcpy(ctx->t[1], ctx->t[2], (ctx->y), sizeof(sp_digit) * 142 * 2);
+        #else
         XMEMCPY((void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                         ((size_t)ctx->t[1] & addr_mask[ctx->y])), ctx->t[2],
                 sizeof(sp_digit) * 142 * 2);
+        #endif
         ctx->c--;
         ctx->state = 5;
         break;
@@ -18294,17 +18541,21 @@ static WC_INLINE sp_digit sp_4096_div_word_81(sp_digit d1, sp_digit d0,
     sp_int64 d = ((sp_int64)d1 << 26) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int64 d = ((sp_int64)d1 << 26) + d0;
     sp_uint32 lo = (sp_uint32)d;
     sp_digit hi = (sp_digit)(d >> 32);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -18547,13 +18798,22 @@ static int sp_4096_mod_exp_81(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_81(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 81 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 81 * 2);
+            #endif
             sp_4096_mont_sqr_81(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 81 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 81 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 81 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_81(t[0], m, mp);
@@ -18623,13 +18883,22 @@ static int sp_4096_mod_exp_81(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_81(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 81 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 81 * 2);
+            #endif
             sp_4096_mont_sqr_81(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 81 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 81 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 81 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_81(t[0], m, mp);
@@ -19170,17 +19439,21 @@ static WC_INLINE sp_digit sp_4096_div_word_162(sp_digit d1, sp_digit d0,
     sp_int64 d = ((sp_int64)d1 << 26) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int64 d = ((sp_int64)d1 << 26) + d0;
     sp_uint32 lo = (sp_uint32)d;
     sp_digit hi = (sp_digit)(d >> 32);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -19428,13 +19701,22 @@ static int sp_4096_mod_exp_162(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_162(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 162 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 162 * 2);
+            #endif
             sp_4096_mont_sqr_162(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 162 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 162 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 162 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_162(t[0], m, mp);
@@ -19504,13 +19786,22 @@ static int sp_4096_mod_exp_162(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_162(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 162 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 162 * 2);
+            #endif
             sp_4096_mont_sqr_162(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 162 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 162 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 162 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_162(t[0], m, mp);
@@ -19755,9 +20046,13 @@ static int sp_4096_mod_exp_162_nb(sp_4096_mod_exp_162_ctx* ctx,
         ctx->state = 7;
         break;
     case 7: /* COPY_OUT: constant-time copy &t[y] -> t[2] */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_select(ctx->t[2], ctx->t[0], ctx->t[1], (ctx->y), sizeof(sp_digit) * 162 * 2);
+        #else
         XMEMCPY(ctx->t[2], (void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                                    ((size_t)ctx->t[1] & addr_mask[ctx->y])),
                 sizeof(sp_digit) * 162 * 2);
+        #endif
         ctx->state = 8;
         break;
     case 8: /* SQR: t[2] = t[2]^2 in Montgomery form */
@@ -19765,9 +20060,14 @@ static int sp_4096_mod_exp_162_nb(sp_4096_mod_exp_162_ctx* ctx,
         ctx->state = 9;
         break;
     case 9: /* COPY_BACK: constant-time copy t[2] -> &t[y]; advance bit */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_memcpy(ctx->t[0], ctx->t[2], (ctx->y)^1, sizeof(sp_digit) * 162 * 2);
+        sp_cond_memcpy(ctx->t[1], ctx->t[2], (ctx->y), sizeof(sp_digit) * 162 * 2);
+        #else
         XMEMCPY((void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                         ((size_t)ctx->t[1] & addr_mask[ctx->y])), ctx->t[2],
                 sizeof(sp_digit) * 162 * 2);
+        #endif
         ctx->c--;
         ctx->state = 5;
         break;
@@ -23013,13 +23313,22 @@ static int sp_256_ecc_mulmod_9(sp_point_256* r, const sp_point_256* g,
 
             sp_256_proj_point_add_9(&t[y^1], &t[0], &t[1], tmp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&t[2], &t[0], &t[1], (y), sizeof(sp_point_256));
+            #else
             XMEMCPY(&t[2], (void*)(((size_t)&t[0] & addr_mask[y^1]) +
                                    ((size_t)&t[1] & addr_mask[y])),
                     sizeof(sp_point_256));
+            #endif
             sp_256_proj_point_dbl_9(&t[2], &t[2], tmp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&t[0], &t[2], (y)^1, sizeof(sp_point_256));
+            sp_cond_memcpy(&t[1], &t[2], (y), sizeof(sp_point_256));
+            #else
             XMEMCPY((void*)(((size_t)&t[0] & addr_mask[y^1]) +
                             ((size_t)&t[1] & addr_mask[y])), &t[2],
                     sizeof(sp_point_256));
+            #endif
         }
 
         if (map != 0) {
@@ -23124,9 +23433,13 @@ static int sp_256_ecc_mulmod_9_nb(sp_ecc_ctx_t* sp_ctx, sp_point_256* r,
         err = sp_256_proj_point_add_9_nb((sp_ecc_ctx_t*)&ctx->add_ctx,
             &ctx->t[ctx->y^1], &ctx->t[0], &ctx->t[1], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&ctx->t[2], &ctx->t[0], &ctx->t[1], (ctx->y), sizeof(sp_point_256));
+            #else
             XMEMCPY(&ctx->t[2], (void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                                         ((size_t)&ctx->t[1] & addr_mask[ctx->y])),
                     sizeof(sp_point_256));
+            #endif
             XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
             ctx->state = 6;
         }
@@ -23135,9 +23448,14 @@ static int sp_256_ecc_mulmod_9_nb(sp_ecc_ctx_t* sp_ctx, sp_point_256* r,
         err = sp_256_proj_point_dbl_9_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->t[2],
             &ctx->t[2], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&ctx->t[0], &ctx->t[2], (ctx->y)^1, sizeof(sp_point_256));
+            sp_cond_memcpy(&ctx->t[1], &ctx->t[2], (ctx->y), sizeof(sp_point_256));
+            #else
             XMEMCPY((void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                             ((size_t)&ctx->t[1] & addr_mask[ctx->y])), &ctx->t[2],
                     sizeof(sp_point_256));
+            #endif
             ctx->state = 4;
             ctx->c--;
         }
@@ -30341,13 +30659,22 @@ static int sp_384_ecc_mulmod_15(sp_point_384* r, const sp_point_384* g,
 
             sp_384_proj_point_add_15(&t[y^1], &t[0], &t[1], tmp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&t[2], &t[0], &t[1], (y), sizeof(sp_point_384));
+            #else
             XMEMCPY(&t[2], (void*)(((size_t)&t[0] & addr_mask[y^1]) +
                                    ((size_t)&t[1] & addr_mask[y])),
                     sizeof(sp_point_384));
+            #endif
             sp_384_proj_point_dbl_15(&t[2], &t[2], tmp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&t[0], &t[2], (y)^1, sizeof(sp_point_384));
+            sp_cond_memcpy(&t[1], &t[2], (y), sizeof(sp_point_384));
+            #else
             XMEMCPY((void*)(((size_t)&t[0] & addr_mask[y^1]) +
                             ((size_t)&t[1] & addr_mask[y])), &t[2],
                     sizeof(sp_point_384));
+            #endif
         }
 
         if (map != 0) {
@@ -30452,9 +30779,13 @@ static int sp_384_ecc_mulmod_15_nb(sp_ecc_ctx_t* sp_ctx, sp_point_384* r,
         err = sp_384_proj_point_add_15_nb((sp_ecc_ctx_t*)&ctx->add_ctx,
             &ctx->t[ctx->y^1], &ctx->t[0], &ctx->t[1], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&ctx->t[2], &ctx->t[0], &ctx->t[1], (ctx->y), sizeof(sp_point_384));
+            #else
             XMEMCPY(&ctx->t[2], (void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                                         ((size_t)&ctx->t[1] & addr_mask[ctx->y])),
                     sizeof(sp_point_384));
+            #endif
             XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
             ctx->state = 6;
         }
@@ -30463,9 +30794,14 @@ static int sp_384_ecc_mulmod_15_nb(sp_ecc_ctx_t* sp_ctx, sp_point_384* r,
         err = sp_384_proj_point_dbl_15_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->t[2],
             &ctx->t[2], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&ctx->t[0], &ctx->t[2], (ctx->y)^1, sizeof(sp_point_384));
+            sp_cond_memcpy(&ctx->t[1], &ctx->t[2], (ctx->y), sizeof(sp_point_384));
+            #else
             XMEMCPY((void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                             ((size_t)&ctx->t[1] & addr_mask[ctx->y])), &ctx->t[2],
                     sizeof(sp_point_384));
+            #endif
             ctx->state = 4;
             ctx->c--;
         }
@@ -37734,13 +38070,22 @@ static int sp_521_ecc_mulmod_21(sp_point_521* r, const sp_point_521* g,
 
             sp_521_proj_point_add_21(&t[y^1], &t[0], &t[1], tmp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&t[2], &t[0], &t[1], (y), sizeof(sp_point_521));
+            #else
             XMEMCPY(&t[2], (void*)(((size_t)&t[0] & addr_mask[y^1]) +
                                    ((size_t)&t[1] & addr_mask[y])),
                     sizeof(sp_point_521));
+            #endif
             sp_521_proj_point_dbl_21(&t[2], &t[2], tmp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&t[0], &t[2], (y)^1, sizeof(sp_point_521));
+            sp_cond_memcpy(&t[1], &t[2], (y), sizeof(sp_point_521));
+            #else
             XMEMCPY((void*)(((size_t)&t[0] & addr_mask[y^1]) +
                             ((size_t)&t[1] & addr_mask[y])), &t[2],
                     sizeof(sp_point_521));
+            #endif
         }
 
         if (map != 0) {
@@ -37845,9 +38190,13 @@ static int sp_521_ecc_mulmod_21_nb(sp_ecc_ctx_t* sp_ctx, sp_point_521* r,
         err = sp_521_proj_point_add_21_nb((sp_ecc_ctx_t*)&ctx->add_ctx,
             &ctx->t[ctx->y^1], &ctx->t[0], &ctx->t[1], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&ctx->t[2], &ctx->t[0], &ctx->t[1], (ctx->y), sizeof(sp_point_521));
+            #else
             XMEMCPY(&ctx->t[2], (void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                                         ((size_t)&ctx->t[1] & addr_mask[ctx->y])),
                     sizeof(sp_point_521));
+            #endif
             XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
             ctx->state = 6;
         }
@@ -37856,9 +38205,14 @@ static int sp_521_ecc_mulmod_21_nb(sp_ecc_ctx_t* sp_ctx, sp_point_521* r,
         err = sp_521_proj_point_dbl_21_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->t[2],
             &ctx->t[2], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&ctx->t[0], &ctx->t[2], (ctx->y)^1, sizeof(sp_point_521));
+            sp_cond_memcpy(&ctx->t[1], &ctx->t[2], (ctx->y), sizeof(sp_point_521));
+            #else
             XMEMCPY((void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                             ((size_t)&ctx->t[1] & addr_mask[ctx->y])), &ctx->t[2],
                     sizeof(sp_point_521));
+            #endif
             ctx->state = 4;
             ctx->c--;
         }
@@ -44784,17 +45138,21 @@ static WC_INLINE sp_digit sp_1024_div_word_42(sp_digit d1, sp_digit d0,
     sp_int64 d = ((sp_int64)d1 << 25) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int64 d = ((sp_int64)d1 << 25) + d0;
     sp_uint32 lo = (sp_uint32)d;
     sp_digit hi = (sp_digit)(d >> 32);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -46395,13 +46753,22 @@ static int sp_1024_ecc_mulmod_42(sp_point_1024* r, const sp_point_1024* g,
 
             sp_1024_proj_point_add_42(&t[y^1], &t[0], &t[1], tmp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&t[2], &t[0], &t[1], (y), sizeof(sp_point_1024));
+            #else
             XMEMCPY(&t[2], (void*)(((size_t)&t[0] & addr_mask[y^1]) +
                                    ((size_t)&t[1] & addr_mask[y])),
                     sizeof(sp_point_1024));
+            #endif
             sp_1024_proj_point_dbl_42(&t[2], &t[2], tmp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&t[0], &t[2], (y)^1, sizeof(sp_point_1024));
+            sp_cond_memcpy(&t[1], &t[2], (y), sizeof(sp_point_1024));
+            #else
             XMEMCPY((void*)(((size_t)&t[0] & addr_mask[y^1]) +
                             ((size_t)&t[1] & addr_mask[y])), &t[2],
                     sizeof(sp_point_1024));
+            #endif
         }
 
         if (map != 0) {
@@ -46506,9 +46873,13 @@ static int sp_1024_ecc_mulmod_42_nb(sp_ecc_ctx_t* sp_ctx, sp_point_1024* r,
         err = sp_1024_proj_point_add_42_nb((sp_ecc_ctx_t*)&ctx->add_ctx,
             &ctx->t[ctx->y^1], &ctx->t[0], &ctx->t[1], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&ctx->t[2], &ctx->t[0], &ctx->t[1], (ctx->y), sizeof(sp_point_1024));
+            #else
             XMEMCPY(&ctx->t[2], (void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                                         ((size_t)&ctx->t[1] & addr_mask[ctx->y])),
                     sizeof(sp_point_1024));
+            #endif
             XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
             ctx->state = 6;
         }
@@ -46517,9 +46888,14 @@ static int sp_1024_ecc_mulmod_42_nb(sp_ecc_ctx_t* sp_ctx, sp_point_1024* r,
         err = sp_1024_proj_point_dbl_42_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->t[2],
             &ctx->t[2], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&ctx->t[0], &ctx->t[2], (ctx->y)^1, sizeof(sp_point_1024));
+            sp_cond_memcpy(&ctx->t[1], &ctx->t[2], (ctx->y), sizeof(sp_point_1024));
+            #else
             XMEMCPY((void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                             ((size_t)&ctx->t[1] & addr_mask[ctx->y])), &ctx->t[2],
                     sizeof(sp_point_1024));
+            #endif
             ctx->state = 4;
             ctx->c--;
         }

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -187,8 +187,43 @@
 #endif
 
 #ifdef NEED_ADDR_MASK
+#ifdef WC_NO_PTR_INT_CAST
+/* Conditionally copy len bytes from a to r when copy is 1, in constant time.
+ * Used where a pointer cannot be rebuilt from integer arithmetic on two
+ * addresses, such as on capability based targets. Both candidates are always
+ * touched, so which one was selected is not observable. */
+WC_MAYBE_UNUSED static void sp_cond_memcpy(void* r, const void* a, int copy,
+    size_t len)
+{
+    byte* rb = (byte*)r;
+    const byte* ab = (const byte*)a;
+    byte mask = (byte)(0U - (unsigned int)(copy != 0));
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        rb[i] ^= (byte)((rb[i] ^ ab[i]) & mask);
+    }
+}
+
+/* Set r to a when sel is 0 and to b when sel is 1, in constant time.
+ * Writes r without reading it, so r may be an uninitialized scratch buffer. */
+WC_MAYBE_UNUSED static void sp_cond_select(void* r, const void* a,
+    const void* b, int sel, size_t len)
+{
+    byte* rb = (byte*)r;
+    const byte* ab = (const byte*)a;
+    const byte* bb = (const byte*)b;
+    byte mask = (byte)(0U - (unsigned int)(sel != 0));
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        rb[i] = (byte)((ab[i] & (byte)~mask) | (bb[i] & mask));
+    }
+}
+#else
 /* Mask for address to obfuscate which of the two address will be used. */
 static const size_t addr_mask[2] = { 0, (size_t)-1 };
+#endif
 #endif
 
 #if defined(WOLFSSL_SP_NONBLOCK) && (!defined(WOLFSSL_SP_NO_MALLOC) || \
@@ -980,17 +1015,21 @@ static WC_INLINE sp_digit sp_2048_div_word_17(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 61) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 61) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -1232,13 +1271,22 @@ static int sp_2048_mod_exp_17(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_17(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 17 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 17 * 2);
+            #endif
             sp_2048_mont_sqr_17(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 17 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 17 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 17 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_17(t[0], m, mp);
@@ -1308,13 +1356,22 @@ static int sp_2048_mod_exp_17(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_17(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 17 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 17 * 2);
+            #endif
             sp_2048_mont_sqr_17(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 17 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 17 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 17 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_17(t[0], m, mp);
@@ -1777,17 +1834,21 @@ static WC_INLINE sp_digit sp_2048_div_word_34(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 61) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 61) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -2030,13 +2091,22 @@ static int sp_2048_mod_exp_34(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_34(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 34 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 34 * 2);
+            #endif
             sp_2048_mont_sqr_34(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 34 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 34 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 34 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_34(t[0], m, mp);
@@ -2106,13 +2176,22 @@ static int sp_2048_mod_exp_34(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_34(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 34 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 34 * 2);
+            #endif
             sp_2048_mont_sqr_34(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 34 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 34 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 34 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_34(t[0], m, mp);
@@ -2357,9 +2436,13 @@ static int sp_2048_mod_exp_34_nb(sp_2048_mod_exp_34_ctx* ctx,
         ctx->state = 7;
         break;
     case 7: /* COPY_OUT: constant-time copy &t[y] -> t[2] */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_select(ctx->t[2], ctx->t[0], ctx->t[1], (ctx->y), sizeof(sp_digit) * 34 * 2);
+        #else
         XMEMCPY(ctx->t[2], (void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                                    ((size_t)ctx->t[1] & addr_mask[ctx->y])),
                 sizeof(sp_digit) * 34 * 2);
+        #endif
         ctx->state = 8;
         break;
     case 8: /* SQR: t[2] = t[2]^2 in Montgomery form */
@@ -2367,9 +2450,14 @@ static int sp_2048_mod_exp_34_nb(sp_2048_mod_exp_34_ctx* ctx,
         ctx->state = 9;
         break;
     case 9: /* COPY_BACK: constant-time copy t[2] -> &t[y]; advance bit */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_memcpy(ctx->t[0], ctx->t[2], (ctx->y)^1, sizeof(sp_digit) * 34 * 2);
+        sp_cond_memcpy(ctx->t[1], ctx->t[2], (ctx->y), sizeof(sp_digit) * 34 * 2);
+        #else
         XMEMCPY((void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                         ((size_t)ctx->t[1] & addr_mask[ctx->y])), ctx->t[2],
                 sizeof(sp_digit) * 34 * 2);
+        #endif
         ctx->c--;
         ctx->state = 5;
         break;
@@ -4831,17 +4919,21 @@ static WC_INLINE sp_digit sp_2048_div_word_18(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 57) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 57) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -5083,13 +5175,22 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_18(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 18 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 18 * 2);
+            #endif
             sp_2048_mont_sqr_18(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 18 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 18 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 18 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_18(t[0], m, mp);
@@ -5159,13 +5260,22 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_18(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 18 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 18 * 2);
+            #endif
             sp_2048_mont_sqr_18(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 18 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 18 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 18 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_18(t[0], m, mp);
@@ -5689,17 +5799,21 @@ static WC_INLINE sp_digit sp_2048_div_word_36(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 57) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 57) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -5944,13 +6058,22 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_36(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 36 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 36 * 2);
+            #endif
             sp_2048_mont_sqr_36(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 36 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 36 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 36 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_36(t[0], m, mp);
@@ -6020,13 +6143,22 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a,
 
             sp_2048_mont_mul_36(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 36 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 36 * 2);
+            #endif
             sp_2048_mont_sqr_36(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 36 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 36 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 36 * 2);
+            #endif
         }
 
         sp_2048_mont_reduce_36(t[0], m, mp);
@@ -6271,9 +6403,13 @@ static int sp_2048_mod_exp_36_nb(sp_2048_mod_exp_36_ctx* ctx,
         ctx->state = 7;
         break;
     case 7: /* COPY_OUT: constant-time copy &t[y] -> t[2] */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_select(ctx->t[2], ctx->t[0], ctx->t[1], (ctx->y), sizeof(sp_digit) * 36 * 2);
+        #else
         XMEMCPY(ctx->t[2], (void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                                    ((size_t)ctx->t[1] & addr_mask[ctx->y])),
                 sizeof(sp_digit) * 36 * 2);
+        #endif
         ctx->state = 8;
         break;
     case 8: /* SQR: t[2] = t[2]^2 in Montgomery form */
@@ -6281,9 +6417,14 @@ static int sp_2048_mod_exp_36_nb(sp_2048_mod_exp_36_ctx* ctx,
         ctx->state = 9;
         break;
     case 9: /* COPY_BACK: constant-time copy t[2] -> &t[y]; advance bit */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_memcpy(ctx->t[0], ctx->t[2], (ctx->y)^1, sizeof(sp_digit) * 36 * 2);
+        sp_cond_memcpy(ctx->t[1], ctx->t[2], (ctx->y), sizeof(sp_digit) * 36 * 2);
+        #else
         XMEMCPY((void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                         ((size_t)ctx->t[1] & addr_mask[ctx->y])), ctx->t[2],
                 sizeof(sp_digit) * 36 * 2);
+        #endif
         ctx->c--;
         ctx->state = 5;
         break;
@@ -8080,17 +8221,21 @@ static WC_INLINE sp_digit sp_3072_div_word_26(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 60) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 60) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -8332,13 +8477,22 @@ static int sp_3072_mod_exp_26(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_26(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 26 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 26 * 2);
+            #endif
             sp_3072_mont_sqr_26(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 26 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 26 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 26 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_26(t[0], m, mp);
@@ -8408,13 +8562,22 @@ static int sp_3072_mod_exp_26(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_26(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 26 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 26 * 2);
+            #endif
             sp_3072_mont_sqr_26(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 26 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 26 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 26 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_26(t[0], m, mp);
@@ -8883,17 +9046,21 @@ static WC_INLINE sp_digit sp_3072_div_word_52(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 60) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 60) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -9136,13 +9303,22 @@ static int sp_3072_mod_exp_52(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_52(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 52 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 52 * 2);
+            #endif
             sp_3072_mont_sqr_52(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 52 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 52 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 52 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_52(t[0], m, mp);
@@ -9212,13 +9388,22 @@ static int sp_3072_mod_exp_52(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_52(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 52 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 52 * 2);
+            #endif
             sp_3072_mont_sqr_52(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 52 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 52 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 52 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_52(t[0], m, mp);
@@ -9463,9 +9648,13 @@ static int sp_3072_mod_exp_52_nb(sp_3072_mod_exp_52_ctx* ctx,
         ctx->state = 7;
         break;
     case 7: /* COPY_OUT: constant-time copy &t[y] -> t[2] */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_select(ctx->t[2], ctx->t[0], ctx->t[1], (ctx->y), sizeof(sp_digit) * 52 * 2);
+        #else
         XMEMCPY(ctx->t[2], (void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                                    ((size_t)ctx->t[1] & addr_mask[ctx->y])),
                 sizeof(sp_digit) * 52 * 2);
+        #endif
         ctx->state = 8;
         break;
     case 8: /* SQR: t[2] = t[2]^2 in Montgomery form */
@@ -9473,9 +9662,14 @@ static int sp_3072_mod_exp_52_nb(sp_3072_mod_exp_52_ctx* ctx,
         ctx->state = 9;
         break;
     case 9: /* COPY_BACK: constant-time copy t[2] -> &t[y]; advance bit */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_memcpy(ctx->t[0], ctx->t[2], (ctx->y)^1, sizeof(sp_digit) * 52 * 2);
+        sp_cond_memcpy(ctx->t[1], ctx->t[2], (ctx->y), sizeof(sp_digit) * 52 * 2);
+        #else
         XMEMCPY((void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                         ((size_t)ctx->t[1] & addr_mask[ctx->y])), ctx->t[2],
                 sizeof(sp_digit) * 52 * 2);
+        #endif
         ctx->c--;
         ctx->state = 5;
         break;
@@ -12075,17 +12269,21 @@ static WC_INLINE sp_digit sp_3072_div_word_27(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 57) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 57) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -12327,13 +12525,22 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_27(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 27 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 27 * 2);
+            #endif
             sp_3072_mont_sqr_27(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 27 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 27 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 27 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_27(t[0], m, mp);
@@ -12403,13 +12610,22 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_27(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 27 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 27 * 2);
+            #endif
             sp_3072_mont_sqr_27(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 27 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 27 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 27 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_27(t[0], m, mp);
@@ -12944,17 +13160,21 @@ static WC_INLINE sp_digit sp_3072_div_word_54(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 57) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 57) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -13199,13 +13419,22 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_54(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 54 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 54 * 2);
+            #endif
             sp_3072_mont_sqr_54(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 54 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 54 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 54 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_54(t[0], m, mp);
@@ -13275,13 +13504,22 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a,
 
             sp_3072_mont_mul_54(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 54 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 54 * 2);
+            #endif
             sp_3072_mont_sqr_54(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 54 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 54 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 54 * 2);
+            #endif
         }
 
         sp_3072_mont_reduce_54(t[0], m, mp);
@@ -13526,9 +13764,13 @@ static int sp_3072_mod_exp_54_nb(sp_3072_mod_exp_54_ctx* ctx,
         ctx->state = 7;
         break;
     case 7: /* COPY_OUT: constant-time copy &t[y] -> t[2] */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_select(ctx->t[2], ctx->t[0], ctx->t[1], (ctx->y), sizeof(sp_digit) * 54 * 2);
+        #else
         XMEMCPY(ctx->t[2], (void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                                    ((size_t)ctx->t[1] & addr_mask[ctx->y])),
                 sizeof(sp_digit) * 54 * 2);
+        #endif
         ctx->state = 8;
         break;
     case 8: /* SQR: t[2] = t[2]^2 in Montgomery form */
@@ -13536,9 +13778,14 @@ static int sp_3072_mod_exp_54_nb(sp_3072_mod_exp_54_ctx* ctx,
         ctx->state = 9;
         break;
     case 9: /* COPY_BACK: constant-time copy t[2] -> &t[y]; advance bit */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_memcpy(ctx->t[0], ctx->t[2], (ctx->y)^1, sizeof(sp_digit) * 54 * 2);
+        sp_cond_memcpy(ctx->t[1], ctx->t[2], (ctx->y), sizeof(sp_digit) * 54 * 2);
+        #else
         XMEMCPY((void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                         ((size_t)ctx->t[1] & addr_mask[ctx->y])), ctx->t[2],
                 sizeof(sp_digit) * 54 * 2);
+        #endif
         ctx->c--;
         ctx->state = 5;
         break;
@@ -15377,17 +15624,21 @@ static WC_INLINE sp_digit sp_4096_div_word_35(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 59) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 59) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -15629,13 +15880,22 @@ static int sp_4096_mod_exp_35(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_35(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 35 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 35 * 2);
+            #endif
             sp_4096_mont_sqr_35(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 35 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 35 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 35 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_35(t[0], m, mp);
@@ -15705,13 +15965,22 @@ static int sp_4096_mod_exp_35(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_35(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 35 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 35 * 2);
+            #endif
             sp_4096_mont_sqr_35(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 35 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 35 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 35 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_35(t[0], m, mp);
@@ -16175,17 +16444,21 @@ static WC_INLINE sp_digit sp_4096_div_word_70(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 59) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 59) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -16428,13 +16701,22 @@ static int sp_4096_mod_exp_70(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_70(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 70 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 70 * 2);
+            #endif
             sp_4096_mont_sqr_70(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 70 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 70 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 70 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_70(t[0], m, mp);
@@ -16504,13 +16786,22 @@ static int sp_4096_mod_exp_70(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_70(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 70 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 70 * 2);
+            #endif
             sp_4096_mont_sqr_70(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 70 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 70 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 70 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_70(t[0], m, mp);
@@ -16755,9 +17046,13 @@ static int sp_4096_mod_exp_70_nb(sp_4096_mod_exp_70_ctx* ctx,
         ctx->state = 7;
         break;
     case 7: /* COPY_OUT: constant-time copy &t[y] -> t[2] */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_select(ctx->t[2], ctx->t[0], ctx->t[1], (ctx->y), sizeof(sp_digit) * 70 * 2);
+        #else
         XMEMCPY(ctx->t[2], (void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                                    ((size_t)ctx->t[1] & addr_mask[ctx->y])),
                 sizeof(sp_digit) * 70 * 2);
+        #endif
         ctx->state = 8;
         break;
     case 8: /* SQR: t[2] = t[2]^2 in Montgomery form */
@@ -16765,9 +17060,14 @@ static int sp_4096_mod_exp_70_nb(sp_4096_mod_exp_70_ctx* ctx,
         ctx->state = 9;
         break;
     case 9: /* COPY_BACK: constant-time copy t[2] -> &t[y]; advance bit */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_memcpy(ctx->t[0], ctx->t[2], (ctx->y)^1, sizeof(sp_digit) * 70 * 2);
+        sp_cond_memcpy(ctx->t[1], ctx->t[2], (ctx->y), sizeof(sp_digit) * 70 * 2);
+        #else
         XMEMCPY((void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                         ((size_t)ctx->t[1] & addr_mask[ctx->y])), ctx->t[2],
                 sizeof(sp_digit) * 70 * 2);
+        #endif
         ctx->c--;
         ctx->state = 5;
         break;
@@ -19465,17 +19765,21 @@ static WC_INLINE sp_digit sp_4096_div_word_39(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 53) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 53) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -19717,13 +20021,22 @@ static int sp_4096_mod_exp_39(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_39(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 39 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 39 * 2);
+            #endif
             sp_4096_mont_sqr_39(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 39 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 39 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 39 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_39(t[0], m, mp);
@@ -19793,13 +20106,22 @@ static int sp_4096_mod_exp_39(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_39(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 39 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 39 * 2);
+            #endif
             sp_4096_mont_sqr_39(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 39 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 39 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 39 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_39(t[0], m, mp);
@@ -20335,17 +20657,21 @@ static WC_INLINE sp_digit sp_4096_div_word_78(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 53) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 53) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -20590,13 +20916,22 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_78(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 78 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 78 * 2);
+            #endif
             sp_4096_mont_sqr_78(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 78 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 78 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 78 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_78(t[0], m, mp);
@@ -20666,13 +21001,22 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a,
 
             sp_4096_mont_mul_78(t[y^1], t[0], t[1], m, mp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(t[2], t[0], t[1], (y), sizeof(*t[2]) * 78 * 2);
+            #else
             XMEMCPY(t[2], (void*)(((size_t)t[0] & addr_mask[y^1]) +
                                   ((size_t)t[1] & addr_mask[y])),
                                   sizeof(*t[2]) * 78 * 2);
+            #endif
             sp_4096_mont_sqr_78(t[2], t[2], m, mp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(t[0], t[2], (y)^1, sizeof(*t[2]) * 78 * 2);
+            sp_cond_memcpy(t[1], t[2], (y), sizeof(*t[2]) * 78 * 2);
+            #else
             XMEMCPY((void*)(((size_t)t[0] & addr_mask[y^1]) +
                             ((size_t)t[1] & addr_mask[y])), t[2],
                             sizeof(*t[2]) * 78 * 2);
+            #endif
         }
 
         sp_4096_mont_reduce_78(t[0], m, mp);
@@ -20917,9 +21261,13 @@ static int sp_4096_mod_exp_78_nb(sp_4096_mod_exp_78_ctx* ctx,
         ctx->state = 7;
         break;
     case 7: /* COPY_OUT: constant-time copy &t[y] -> t[2] */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_select(ctx->t[2], ctx->t[0], ctx->t[1], (ctx->y), sizeof(sp_digit) * 78 * 2);
+        #else
         XMEMCPY(ctx->t[2], (void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                                    ((size_t)ctx->t[1] & addr_mask[ctx->y])),
                 sizeof(sp_digit) * 78 * 2);
+        #endif
         ctx->state = 8;
         break;
     case 8: /* SQR: t[2] = t[2]^2 in Montgomery form */
@@ -20927,9 +21275,14 @@ static int sp_4096_mod_exp_78_nb(sp_4096_mod_exp_78_ctx* ctx,
         ctx->state = 9;
         break;
     case 9: /* COPY_BACK: constant-time copy t[2] -> &t[y]; advance bit */
+        #ifdef WC_NO_PTR_INT_CAST
+        sp_cond_memcpy(ctx->t[0], ctx->t[2], (ctx->y)^1, sizeof(sp_digit) * 78 * 2);
+        sp_cond_memcpy(ctx->t[1], ctx->t[2], (ctx->y), sizeof(sp_digit) * 78 * 2);
+        #else
         XMEMCPY((void*)(((size_t)ctx->t[0] & addr_mask[ctx->y ^ 1]) +
                         ((size_t)ctx->t[1] & addr_mask[ctx->y])), ctx->t[2],
                 sizeof(sp_digit) * 78 * 2);
+        #endif
         ctx->c--;
         ctx->state = 5;
         break;
@@ -23803,13 +24156,22 @@ static int sp_256_ecc_mulmod_5(sp_point_256* r, const sp_point_256* g,
 
             sp_256_proj_point_add_5(&t[y^1], &t[0], &t[1], tmp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&t[2], &t[0], &t[1], (y), sizeof(sp_point_256));
+            #else
             XMEMCPY(&t[2], (void*)(((size_t)&t[0] & addr_mask[y^1]) +
                                    ((size_t)&t[1] & addr_mask[y])),
                     sizeof(sp_point_256));
+            #endif
             sp_256_proj_point_dbl_5(&t[2], &t[2], tmp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&t[0], &t[2], (y)^1, sizeof(sp_point_256));
+            sp_cond_memcpy(&t[1], &t[2], (y), sizeof(sp_point_256));
+            #else
             XMEMCPY((void*)(((size_t)&t[0] & addr_mask[y^1]) +
                             ((size_t)&t[1] & addr_mask[y])), &t[2],
                     sizeof(sp_point_256));
+            #endif
         }
 
         if (map != 0) {
@@ -23914,9 +24276,13 @@ static int sp_256_ecc_mulmod_5_nb(sp_ecc_ctx_t* sp_ctx, sp_point_256* r,
         err = sp_256_proj_point_add_5_nb((sp_ecc_ctx_t*)&ctx->add_ctx,
             &ctx->t[ctx->y^1], &ctx->t[0], &ctx->t[1], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&ctx->t[2], &ctx->t[0], &ctx->t[1], (ctx->y), sizeof(sp_point_256));
+            #else
             XMEMCPY(&ctx->t[2], (void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                                         ((size_t)&ctx->t[1] & addr_mask[ctx->y])),
                     sizeof(sp_point_256));
+            #endif
             XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
             ctx->state = 6;
         }
@@ -23925,9 +24291,14 @@ static int sp_256_ecc_mulmod_5_nb(sp_ecc_ctx_t* sp_ctx, sp_point_256* r,
         err = sp_256_proj_point_dbl_5_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->t[2],
             &ctx->t[2], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&ctx->t[0], &ctx->t[2], (ctx->y)^1, sizeof(sp_point_256));
+            sp_cond_memcpy(&ctx->t[1], &ctx->t[2], (ctx->y), sizeof(sp_point_256));
+            #else
             XMEMCPY((void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                             ((size_t)&ctx->t[1] & addr_mask[ctx->y])), &ctx->t[2],
                     sizeof(sp_point_256));
+            #endif
             ctx->state = 4;
             ctx->c--;
         }
@@ -30604,13 +30975,22 @@ static int sp_384_ecc_mulmod_7(sp_point_384* r, const sp_point_384* g,
 
             sp_384_proj_point_add_7(&t[y^1], &t[0], &t[1], tmp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&t[2], &t[0], &t[1], (y), sizeof(sp_point_384));
+            #else
             XMEMCPY(&t[2], (void*)(((size_t)&t[0] & addr_mask[y^1]) +
                                    ((size_t)&t[1] & addr_mask[y])),
                     sizeof(sp_point_384));
+            #endif
             sp_384_proj_point_dbl_7(&t[2], &t[2], tmp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&t[0], &t[2], (y)^1, sizeof(sp_point_384));
+            sp_cond_memcpy(&t[1], &t[2], (y), sizeof(sp_point_384));
+            #else
             XMEMCPY((void*)(((size_t)&t[0] & addr_mask[y^1]) +
                             ((size_t)&t[1] & addr_mask[y])), &t[2],
                     sizeof(sp_point_384));
+            #endif
         }
 
         if (map != 0) {
@@ -30715,9 +31095,13 @@ static int sp_384_ecc_mulmod_7_nb(sp_ecc_ctx_t* sp_ctx, sp_point_384* r,
         err = sp_384_proj_point_add_7_nb((sp_ecc_ctx_t*)&ctx->add_ctx,
             &ctx->t[ctx->y^1], &ctx->t[0], &ctx->t[1], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&ctx->t[2], &ctx->t[0], &ctx->t[1], (ctx->y), sizeof(sp_point_384));
+            #else
             XMEMCPY(&ctx->t[2], (void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                                         ((size_t)&ctx->t[1] & addr_mask[ctx->y])),
                     sizeof(sp_point_384));
+            #endif
             XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
             ctx->state = 6;
         }
@@ -30726,9 +31110,14 @@ static int sp_384_ecc_mulmod_7_nb(sp_ecc_ctx_t* sp_ctx, sp_point_384* r,
         err = sp_384_proj_point_dbl_7_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->t[2],
             &ctx->t[2], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&ctx->t[0], &ctx->t[2], (ctx->y)^1, sizeof(sp_point_384));
+            sp_cond_memcpy(&ctx->t[1], &ctx->t[2], (ctx->y), sizeof(sp_point_384));
+            #else
             XMEMCPY((void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                             ((size_t)&ctx->t[1] & addr_mask[ctx->y])), &ctx->t[2],
                     sizeof(sp_point_384));
+            #endif
             ctx->state = 4;
             ctx->c--;
         }
@@ -37883,13 +38272,22 @@ static int sp_521_ecc_mulmod_9(sp_point_521* r, const sp_point_521* g,
 
             sp_521_proj_point_add_9(&t[y^1], &t[0], &t[1], tmp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&t[2], &t[0], &t[1], (y), sizeof(sp_point_521));
+            #else
             XMEMCPY(&t[2], (void*)(((size_t)&t[0] & addr_mask[y^1]) +
                                    ((size_t)&t[1] & addr_mask[y])),
                     sizeof(sp_point_521));
+            #endif
             sp_521_proj_point_dbl_9(&t[2], &t[2], tmp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&t[0], &t[2], (y)^1, sizeof(sp_point_521));
+            sp_cond_memcpy(&t[1], &t[2], (y), sizeof(sp_point_521));
+            #else
             XMEMCPY((void*)(((size_t)&t[0] & addr_mask[y^1]) +
                             ((size_t)&t[1] & addr_mask[y])), &t[2],
                     sizeof(sp_point_521));
+            #endif
         }
 
         if (map != 0) {
@@ -37994,9 +38392,13 @@ static int sp_521_ecc_mulmod_9_nb(sp_ecc_ctx_t* sp_ctx, sp_point_521* r,
         err = sp_521_proj_point_add_9_nb((sp_ecc_ctx_t*)&ctx->add_ctx,
             &ctx->t[ctx->y^1], &ctx->t[0], &ctx->t[1], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&ctx->t[2], &ctx->t[0], &ctx->t[1], (ctx->y), sizeof(sp_point_521));
+            #else
             XMEMCPY(&ctx->t[2], (void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                                         ((size_t)&ctx->t[1] & addr_mask[ctx->y])),
                     sizeof(sp_point_521));
+            #endif
             XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
             ctx->state = 6;
         }
@@ -38005,9 +38407,14 @@ static int sp_521_ecc_mulmod_9_nb(sp_ecc_ctx_t* sp_ctx, sp_point_521* r,
         err = sp_521_proj_point_dbl_9_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->t[2],
             &ctx->t[2], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&ctx->t[0], &ctx->t[2], (ctx->y)^1, sizeof(sp_point_521));
+            sp_cond_memcpy(&ctx->t[1], &ctx->t[2], (ctx->y), sizeof(sp_point_521));
+            #else
             XMEMCPY((void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                             ((size_t)&ctx->t[1] & addr_mask[ctx->y])), &ctx->t[2],
                     sizeof(sp_point_521));
+            #endif
             ctx->state = 4;
             ctx->c--;
         }
@@ -44082,17 +44489,21 @@ static WC_INLINE sp_digit sp_1024_div_word_18(sp_digit d1, sp_digit d0,
     sp_int128 d = ((sp_int128)d1 << 57) + d0;
 
     return d / div;
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(WOLFSSL_NO_ASM)
     sp_int128 d = ((sp_int128)d1 << 57) + d0;
     sp_uint64 lo = (sp_uint64)d;
     sp_digit hi = (sp_digit)(d >> 64);
+    sp_digit rem;
 
+    /* idiv puts the remainder in dx, so dx must be an output and not just an
+     * input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "idiv %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (div)
+        : "+a" (lo), "=d" (rem)
+        : "r" (div), "1" (hi)
         : "cc"
     );
+    (void)rem;
 
     return (sp_digit)lo;
 #elif !defined(__aarch64__) &&  !defined(SP_DIV_WORD_USE_DIV)
@@ -45630,13 +46041,22 @@ static int sp_1024_ecc_mulmod_18(sp_point_1024* r, const sp_point_1024* g,
 
             sp_1024_proj_point_add_18(&t[y^1], &t[0], &t[1], tmp);
 
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&t[2], &t[0], &t[1], (y), sizeof(sp_point_1024));
+            #else
             XMEMCPY(&t[2], (void*)(((size_t)&t[0] & addr_mask[y^1]) +
                                    ((size_t)&t[1] & addr_mask[y])),
                     sizeof(sp_point_1024));
+            #endif
             sp_1024_proj_point_dbl_18(&t[2], &t[2], tmp);
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&t[0], &t[2], (y)^1, sizeof(sp_point_1024));
+            sp_cond_memcpy(&t[1], &t[2], (y), sizeof(sp_point_1024));
+            #else
             XMEMCPY((void*)(((size_t)&t[0] & addr_mask[y^1]) +
                             ((size_t)&t[1] & addr_mask[y])), &t[2],
                     sizeof(sp_point_1024));
+            #endif
         }
 
         if (map != 0) {
@@ -45741,9 +46161,13 @@ static int sp_1024_ecc_mulmod_18_nb(sp_ecc_ctx_t* sp_ctx, sp_point_1024* r,
         err = sp_1024_proj_point_add_18_nb((sp_ecc_ctx_t*)&ctx->add_ctx,
             &ctx->t[ctx->y^1], &ctx->t[0], &ctx->t[1], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_select(&ctx->t[2], &ctx->t[0], &ctx->t[1], (ctx->y), sizeof(sp_point_1024));
+            #else
             XMEMCPY(&ctx->t[2], (void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                                         ((size_t)&ctx->t[1] & addr_mask[ctx->y])),
                     sizeof(sp_point_1024));
+            #endif
             XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
             ctx->state = 6;
         }
@@ -45752,9 +46176,14 @@ static int sp_1024_ecc_mulmod_18_nb(sp_ecc_ctx_t* sp_ctx, sp_point_1024* r,
         err = sp_1024_proj_point_dbl_18_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->t[2],
             &ctx->t[2], ctx->tmp);
         if (err == MP_OKAY) {
+            #ifdef WC_NO_PTR_INT_CAST
+            sp_cond_memcpy(&ctx->t[0], &ctx->t[2], (ctx->y)^1, sizeof(sp_point_1024));
+            sp_cond_memcpy(&ctx->t[1], &ctx->t[2], (ctx->y), sizeof(sp_point_1024));
+            #else
             XMEMCPY((void*)(((size_t)&ctx->t[0] & addr_mask[ctx->y^1]) +
                             ((size_t)&ctx->t[1] & addr_mask[ctx->y])), &ctx->t[2],
                     sizeof(sp_point_1024));
+            #endif
             ctx->state = 4;
             ctx->c--;
         }

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -413,6 +413,24 @@ while (0)
  * CPU: x86_64
  */
 
+/* Fil-C only accepts inline assembly without memory operands, so the operand
+ * has to be forced into a register there. The compiler is already free to
+ * pick a register for SP_ASM_RM, so this changes no other target.
+ *
+ * Defined inside the WOLFSSL_SP_X86_64 block and deliberately not #undef'd at
+ * the end of it: the SP_ASM_* macro bodies below expand at their call sites,
+ * far past that point, so undefining them here breaks the build. The 32 bit
+ * x86 block that follows carries the same "rm"/"m" constraints and does not
+ * use these, because Fil-C has no 32 bit x86 target to build it.
+ */
+#ifdef __FILC__
+    #define SP_ASM_RM   "r"
+    #define SP_ASM_M    "r"
+#else
+    #define SP_ASM_RM   "rm"
+    #define SP_ASM_M    "m"
+#endif
+
 #ifndef _MSC_VER
 /* Multiply va by vb and store double size result in: vh | vl */
 #define SP_ASM_MUL(vl, vh, va, vb)                       \
@@ -422,7 +440,7 @@ while (0)
         "movq	%%rax, %[l]	\n\t"                    \
         "movq	%%rdx, %[h]	\n\t"                    \
         : [h] "+r" (vh), [l] "+r" (vl)                   \
-        : [a] "rm" (va), [b] "rm" (vb)                   \
+        : [a] SP_ASM_RM (va), [b] SP_ASM_RM (vb)         \
         : "%rax", "%rdx", "cc"                           \
     )
 /* Multiply va by vb and store double size result in: vo | vh | vl */
@@ -434,7 +452,7 @@ while (0)
         "movq	%%rax, %[l]	\n\t"                    \
         "movq	%%rdx, %[h]	\n\t"                    \
         : [l] "+r" (vl), [h] "+r" (vh), [o] "=r" (vo)    \
-        : [a] "m" (va), [b] "m" (vb)                     \
+        : [a] SP_ASM_M (va), [b] SP_ASM_M (vb)           \
         : "%rax", "%rdx", "cc"                           \
     )
 /* Multiply va by vb and add double size result into: vo | vh | vl */
@@ -446,7 +464,7 @@ while (0)
         "adcq	%%rdx, %[h]	\n\t"                    \
         "adcq	$0   , %[o]	\n\t"                    \
         : [l] "+r" (vl), [h] "+r" (vh), [o] "+r" (vo)    \
-        : [a] "rm" (va), [b] "rm" (vb)                   \
+        : [a] SP_ASM_RM (va), [b] SP_ASM_RM (vb)         \
         : "%rax", "%rdx", "cc"                           \
     )
 /* Multiply va by vb and add double size result into: vh | vl */
@@ -457,7 +475,7 @@ while (0)
         "addq	%%rax, %[l]	\n\t"                    \
         "adcq	%%rdx, %[h]	\n\t"                    \
         : [l] "+r" (vl), [h] "+r" (vh)                   \
-        : [a] "rm" (va), [b] "rm" (vb)                   \
+        : [a] SP_ASM_RM (va), [b] SP_ASM_RM (vb)         \
         : "%rax", "%rdx", "cc"                           \
     )
 /* Multiply va by vb and add double size result twice into: vo | vh | vl */
@@ -472,7 +490,7 @@ while (0)
         "adcq	%%rdx, %[h]	\n\t"                    \
         "adcq	$0   , %[o]	\n\t"                    \
         : [l] "+r" (vl), [h] "+r" (vh), [o] "+r" (vo)    \
-        : [a] "rm" (va), [b] "rm" (vb)                   \
+        : [a] SP_ASM_RM (va), [b] SP_ASM_RM (vb)         \
         : "%rax", "%rdx", "cc"                           \
     )
 /* Multiply va by vb and add double size result twice into: vo | vh | vl
@@ -488,7 +506,7 @@ while (0)
         "adcq	%%rdx, %[h]	\n\t"                    \
         "adcq	$0   , %[o]	\n\t"                    \
         : [l] "+r" (vl), [h] "+r" (vh), [o] "+r" (vo)    \
-        : [a] "rm" (va), [b] "rm" (vb)                   \
+        : [a] SP_ASM_RM (va), [b] SP_ASM_RM (vb)         \
         : "%rax", "%rdx", "cc"                           \
     )
 /* Square va and store double size result in: vh | vl */
@@ -499,7 +517,7 @@ while (0)
         "movq	%%rax, %[l]	\n\t"                    \
         "movq	%%rdx, %[h]	\n\t"                    \
         : [h] "+r" (vh), [l] "+r" (vl)                   \
-        : [a] "rm" (va)                                  \
+        : [a] SP_ASM_RM (va)                             \
         : "%rax", "%rdx", "cc"                           \
     )
 /* Square va and add double size result into: vo | vh | vl */
@@ -511,7 +529,7 @@ while (0)
         "adcq	%%rdx, %[h]	\n\t"                    \
         "adcq	$0   , %[o]	\n\t"                    \
         : [l] "+r" (vl), [h] "+r" (vh), [o] "+r" (vo)    \
-        : [a] "rm" (va)                                  \
+        : [a] SP_ASM_RM (va)                             \
         : "%rax", "%rdx", "cc"                           \
     )
 /* Square va and add double size result into: vh | vl */
@@ -522,7 +540,7 @@ while (0)
         "addq	%%rax, %[l]	\n\t"                    \
         "adcq	%%rdx, %[h]	\n\t"                    \
         : [l] "+r" (vl), [h] "+r" (vh)                   \
-        : [a] "rm" (va)                                  \
+        : [a] SP_ASM_RM (va)                             \
         : "%rax", "%rdx", "cc"                           \
     )
 /* Add va into: vh | vl */
@@ -531,7 +549,7 @@ while (0)
         "addq	%[a], %[l]	\n\t"                    \
         "adcq	$0  , %[h]	\n\t"                    \
         : [l] "+r" (vl), [h] "+r" (vh)                   \
-        : [a] "rm" (va)                                  \
+        : [a] SP_ASM_RM (va)                             \
         : "cc"                                           \
     )
 #define SP_ASM_ADDC_REG(vl, vh, va)                      \
@@ -548,7 +566,7 @@ while (0)
         "subq	%[a], %[l]	\n\t"                    \
         "sbbq	$0  , %[h]	\n\t"                    \
         : [l] "+r" (vl), [h] "+r" (vh)                   \
-        : [a] "rm" (va)                                  \
+        : [a] SP_ASM_RM (va)                             \
         : "cc"                                           \
     )
 /* Sub va from: vh | vl */

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -740,12 +740,17 @@ static WC_INLINE sp_int_digit sp_div_word(sp_int_digit hi, sp_int_digit lo,
                                           sp_int_digit d)
 {
 #ifndef _MSC_VER
+    sp_int_digit rem;
+
+    /* divq puts the remainder in rdx, so rdx must be an output and not just
+     * an input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "divq %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (d)
+        : "+a" (lo), "=d" (rem)
+        : "r" (d), "1" (hi)
         : "cc"
     );
+    (void)rem;
     return lo;
 #elif defined(_MSC_VER) && _MSC_VER >= 1920
     return _udiv128(hi, lo, d, NULL);
@@ -944,12 +949,17 @@ static WC_INLINE sp_int_digit sp_div_word(sp_int_digit hi, sp_int_digit lo,
 static WC_INLINE sp_int_digit sp_div_word(sp_int_digit hi, sp_int_digit lo,
                                           sp_int_digit d)
 {
+    sp_int_digit rem;
+
+    /* divl puts the remainder in edx, so edx must be an output and not just
+     * an input, or the compiler assumes it still holds hi afterwards. */
     __asm__ __volatile__ (
         "divl %2"
-        : "+a" (lo)
-        : "d" (hi), "r" (d)
+        : "+a" (lo), "=d" (rem)
+        : "r" (d), "1" (hi)
         : "cc"
     );
+    (void)rem;
     return lo;
 }
 #define SP_ASM_DIV_WORD

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -1669,6 +1669,33 @@ int fp_addmod_ct(fp_int *a, fp_int *b, fp_int *c, fp_int *d)
 
 #ifdef TFM_TIMING_RESISTANT
 
+/* The WC_PROTECT_ENCRYPTED_MEM ladder has no WC_NO_CACHE_RESISTANT variant, so
+ * it needs this helper even when cache resistance is off. */
+#if defined(WC_NO_PTR_INT_CAST) && (!defined(WC_NO_CACHE_RESISTANT) || \
+    defined(WC_PROTECT_ENCRYPTED_MEM))
+/* Copy a into r when copy is 1, in constant time.
+ * Used where the address of the operand cannot be derived from the secret
+ * bit, as on capability based targets.
+ *
+ * Not a drop in replacement for fp_copy(): it always writes FP_SIZE digits
+ * and does not consult r->size, so r must be a full fp_int and never an
+ * alt_fp_int, whose dp[] is only FP_SIZE_ECC digits under ALT_ECC_SIZE. Every
+ * caller below passes a local fp_int from the exptmod ladders, which is.
+ */
+static void fp_cond_copy(const fp_int* a, int copy, fp_int* r)
+{
+  fp_digit mask = (fp_digit)0 - (fp_digit)(copy != 0);
+  int      imask = 0 - (copy != 0);
+  int      i;
+
+  for (i = 0; i < FP_SIZE; i++) {
+    r->dp[i] ^= (r->dp[i] ^ a->dp[i]) & mask;
+  }
+  r->used ^= (r->used ^ a->used) & imask;
+  r->sign ^= (r->sign ^ a->sign) & imask;
+}
+#endif
+
 #ifdef WC_RSA_NONBLOCK
 
 #ifdef WC_RSA_NONBLOCK_TIME
@@ -1865,6 +1892,10 @@ int fp_exptmod_nb(exptModNb_t* nb, fp_int* G, fp_int* X, fp_int* P, fp_int* Y)
   case TFM_EXPTMOD_NB_SQR:
   #ifdef WC_NO_CACHE_RESISTANT
     err = fp_sqr(&nb->R[nb->y], &nb->R[nb->y]);
+  #elif defined(WC_NO_PTR_INT_CAST)
+    fp_cond_copy(&nb->R[0], nb->y^1, &nb->R[2]);
+    fp_cond_copy(&nb->R[1], nb->y,   &nb->R[2]);
+    err = fp_sqr(&nb->R[2], &nb->R[2]);
   #else
     fp_copy((fp_int*) ( ((wc_ptr_t)&nb->R[0] & wc_off_on_addr[nb->y^1]) +
                         ((wc_ptr_t)&nb->R[1] & wc_off_on_addr[nb->y]) ),
@@ -1882,6 +1913,10 @@ int fp_exptmod_nb(exptModNb_t* nb, fp_int* G, fp_int* X, fp_int* P, fp_int* Y)
   case TFM_EXPTMOD_NB_SQR_RED:
   #ifdef WC_NO_CACHE_RESISTANT
     err = fp_montgomery_reduce(&nb->R[nb->y], P, nb->mp);
+  #elif defined(WC_NO_PTR_INT_CAST)
+    err = fp_montgomery_reduce(&nb->R[2], P, nb->mp);
+    fp_cond_copy(&nb->R[2], nb->y^1, &nb->R[0]);
+    fp_cond_copy(&nb->R[2], nb->y,   &nb->R[1]);
   #else
     err = fp_montgomery_reduce(&nb->R[2], P, nb->mp);
     fp_copy(&nb->R[2],
@@ -2050,16 +2085,26 @@ static int _fp_exptmod_ct(fp_int * G, fp_int * X, int digits, fp_int * P,
     /* instead of using R[y^1] for mul, which leaks key bit to cache monitor,
      * use R[2] as temp, make sure address calc is constant, keep
      * &R[0] and &R[1] in cache */
+#ifdef WC_NO_PTR_INT_CAST
+    fp_cond_copy(&R[2], y,   &R[0]);
+    fp_cond_copy(&R[2], y^1, &R[1]);
+#else
     fp_copy(&R[2],
             (fp_int*) ( ((wc_ptr_t)&R[0] & wc_off_on_addr[y]) +
                         ((wc_ptr_t)&R[1] & wc_off_on_addr[y^1]) ) );
+#endif
 
     /* instead of using R[y] for sqr, which leaks key bit to cache monitor,
      * use R[2] as temp, make sure address calc is constant, keep
      * &R[0] and &R[1] in cache */
+#ifdef WC_NO_PTR_INT_CAST
+    fp_cond_copy(&R[0], y^1, &R[2]);
+    fp_cond_copy(&R[1], y,   &R[2]);
+#else
     fp_copy((fp_int*) ( ((wc_ptr_t)&R[0] & wc_off_on_addr[y^1]) +
                         ((wc_ptr_t)&R[1] & wc_off_on_addr[y]) ),
             &R[2]);
+#endif
     err = fp_sqr(&R[2], &R[2]);
     if (err != FP_OKAY) {
       WC_FREE_VAR_EX(R, NULL, DYNAMIC_TYPE_BIGINT);
@@ -2070,9 +2115,14 @@ static int _fp_exptmod_ct(fp_int * G, fp_int * X, int digits, fp_int * P,
       WC_FREE_VAR_EX(R, NULL, DYNAMIC_TYPE_BIGINT);
       return err;
     }
+#ifdef WC_NO_PTR_INT_CAST
+    fp_cond_copy(&R[2], y^1, &R[0]);
+    fp_cond_copy(&R[2], y,   &R[1]);
+#else
     fp_copy(&R[2],
             (fp_int*) ( ((wc_ptr_t)&R[0] & wc_off_on_addr[y^1]) +
                         ((wc_ptr_t)&R[1] & wc_off_on_addr[y]) ) );
+#endif
 #endif /* WC_NO_CACHE_RESISTANT */
   }
 
@@ -2204,9 +2254,14 @@ static int _fp_exptmod_ct(fp_int * G, fp_int * X, int digits, fp_int * P,
     /* instead of using R[y] for sqr, which leaks key bit to cache monitor,
      * use R[3] as temp, make sure address calc is constant, keep
      * &R[0] and &R[1] in cache */
+#ifdef WC_NO_PTR_INT_CAST
+    fp_cond_copy(&R[0], y^1, &R[3]);
+    fp_cond_copy(&R[1], y,   &R[3]);
+#else
     fp_copy((fp_int*) ( ((wc_ptr_t)&R[0] & wc_off_on_addr[y^1]) +
                         ((wc_ptr_t)&R[1] & wc_off_on_addr[y]) ),
             &R[3]);
+#endif
     err = fp_sqr(&R[3], &R[3]);
     if (err != FP_OKAY) {
       WC_FREE_VAR_EX(R, NULL, DYNAMIC_TYPE_BIGINT);

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -170,6 +170,9 @@ WOLFSSL_LOCAL int  ctMaskSelInt(byte m, int a, int b);
 WOLFSSL_LOCAL word32 ctMaskSelWord32(byte m, word32 a, word32 b);
 WOLFSSL_LOCAL byte ctSetLTE(int a, int b);
 WOLFSSL_LOCAL void ctMaskCopy(byte mask, byte* dst, byte* src, word16 size);
+#ifdef WC_NO_PTR_INT_CAST
+WOLFSSL_LOCAL void* ctMaskSelPtr(byte mask, void* a, void* b);
+#endif
 WOLFSSL_LOCAL word32 MakeWordFromHash(const byte* hashID);
 WOLFSSL_LOCAL word32 HashObject(const byte* o, word32 len, int* error);
 WOLFSSL_LOCAL char* CopyString(const char* src, int srcLen, void* heap,

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -5970,7 +5970,9 @@ blinding by defining WC_BLINDING_NO_RNG_ACKNOWLEDGE_WEAKNESS."
     #endif
 #endif
 
-#ifdef __CHERI_PURE_CAPABILITY__
+/* Capability based targets cannot rebuild a pointer out of integer arithmetic
+ * on two addresses, which the cache resistant code paths do. */
+#if defined(__CHERI_PURE_CAPABILITY__) || defined(__FILC__)
     #define WC_NO_PTR_INT_CAST
 #endif
 


### PR DESCRIPTION
### Summary

Three commits. The first is an independent correctness fix; the other two are the Fil-C CI rework and what it exposed.

**1. `sp_div_word` rdx clobber.** `divq` and `divl` write the remainder to `dx`, but `dx` was listed only as an input and was neither an output nor a clobber, so the compiler may assume it still holds `hi` after the asm block. This is a latent miscompile in every x86_64 and x86 build using SP math, which is the default. Fil-C's inline assembly validation refuses to run it, which is how it surfaced.

**2. Fixed size SP code on capability targets.** Regenerated `sp_c32.c` and `sp_c64.c`. Comes from https://github.com/wolfSSL/scripts/pull/667 and must merge with it, or the next regeneration reverts these files silently.

**3. Fil-C job.** The job pinned v0.674 and ran two configurations, and its release pattern matches both the x86_64 and the aarch64 tarball, so it would break on any release from v0.682 on. Moves to v0.684, picks the tarball by `uname -m`, and grows the matrix to eighteen legs.

It also passed `-DWC_NO_CACHE_RESISTANT`, which compiled out the cache resistant paths, so CI was not testing the code that ships. Those paths build a pointer by masking and adding two addresses, which a capability target cannot do. `WC_NO_PTR_INT_CAST` already exists for this and is defined for CHERI purecap, so it is now defined for Fil-C too and the flag is dropped.

That exposed three places the macro did not cover:

* `tfm.c` never honored it. New `fp_cond_copy` replaces the masked address selections in the timing resistant exptmod ladders.
* `RsaDec` and `DoClientKeyExchange` selected a pointer with `ctMaskCopy`, which copies byte by byte and so drops the capability. This fires on the success path, not only on error. New `ctMaskSelPtr` in `misc.c` indexes a two entry table aligned so both candidates share a cache line, and still does not branch on the decryption result.
* `sp_int.c`'s x86_64 assembly uses `"rm"` and `"m"` operands, which Fil-C does not allow. These now route through `SP_ASM_RM` and `SP_ASM_M`, which differ only under `__FILC__`. Verified byte identical object code on other targets.

### Testing

`make check` passes for `--enable-all`, and for `--enable-sp`, `--enable-sniffer` and `--enable-fastmath` built with `-DWC_NO_PTR_INT_CAST`. The sniffer configuration is the one that reaches both `ctMaskSelPtr` call sites, through static RSA.

The rdx fix was exercised on an x86_64 build with assembly enabled, confirming `divq` is still emitted and `testwolfcrypt` passes.

### Notes for review

`--disable-asm` stays on most legs because Fil-C cannot link a `.S` file at all: it gives every function a capability carrying entry point that a raw asm symbol lacks. `--enable-intelasm` fails on 227 symbols, most of them ML-KEM and ML-DSA. The `default, asm` and `default, asm, arm64` legs do build the inline assembly in `sp_int.c`, which is what most users compile.

The `fp_exptmod_nb` ladder is still uncovered. It needs `--enable-rsa=nonblock`, which fails together with `--enable-fastmath` on master with plain gcc as well.
