### PR TITLE
Bring in fips.h into pwdbased.h for FIPS v6+

### DIFF
--- a/wolfssl/wolfcrypt/pwdbased.h
+++ b/wolfssl/wolfcrypt/pwdbased.h
@@ -30,6 +30,9 @@
 
 #ifndef NO_PWDBASED
 
+#if FIPS_VERSION3_GE(7,0,0)
+    #include <wolfssl/wolfcrypt/fips.h>
+#endif
 
 #ifdef __cplusplus
     extern "C" {


### PR DESCRIPTION
# Description

Redirect PBKDF API's to _fips versions without requiring a manual fips.h include

# Testing

Make check

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
