### PR TITLE
ssl.c: clear SSL-owned credentials when switching CTX

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7711,6 +7711,7 @@ static int SetSSL_CTX_CertsAndKeys(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
         if (ret != 0) {
             return ret;
         }
+        ssl->buffers.weOwnAltKey = 1;
         /* Blind the private key for the SSL with new random mask. */
         wolfssl_priv_der_blind_toggle(ssl->buffers.altKey,
             ctx->altPrivateKeyMask);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8409,6 +8409,13 @@ void wolfSSL_certs_clear(WOLFSSL* ssl)
     /* ctx still owns certificate, certChain, key, dh, and cm */
     if (ssl->buffers.weOwnCert) {
         FreeDer(&ssl->buffers.certificate);
+    #ifdef KEEP_OUR_CERT
+        /* ourCert is only made when this SSL owns the certificate. */
+        if (ssl->ourCert != NULL) {
+            wolfSSL_X509_free(ssl->ourCert);
+            ssl->ourCert = NULL;
+        }
+    #endif
         ssl->buffers.weOwnCert = 0;
     }
     ssl->buffers.certificate = NULL;
@@ -8417,8 +8424,12 @@ void wolfSSL_certs_clear(WOLFSSL* ssl)
         ssl->buffers.weOwnCertChain = 0;
     }
     ssl->buffers.certChain = NULL;
-#ifdef WOLFSSL_TLS13
     ssl->buffers.certChainCnt = 0;
+#ifdef KEEP_OUR_CERT
+    if (ssl->ourCertChain != NULL) {
+        wolfSSL_sk_X509_pop_free(ssl->ourCertChain, NULL);
+        ssl->ourCertChain = NULL;
+    }
 #endif
     if (ssl->buffers.weOwnKey) {
         FreeDer(&ssl->buffers.key);
@@ -8828,33 +8839,26 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
     ssl->ctx = ctx;
 
 #ifndef NO_CERTS
+    /* Release the certificate, chain and keys this SSL owns so that a ctx
+     * without them leaves none of the old ones behind. */
+    wolfSSL_certs_clear(ssl);
 #ifdef WOLFSSL_COPY_CERT
     /* If WOLFSSL_COPY_CERT defined, always make new copy of cert from ctx */
     if (ctx->certificate != NULL) {
-        if (ssl->buffers.certificate != NULL) {
-            FreeDer(&ssl->buffers.certificate);
-            ssl->buffers.certificate = NULL;
-        }
         ret = AllocCopyDer(&ssl->buffers.certificate, ctx->certificate->buffer,
             ctx->certificate->length, ctx->certificate->type,
             ctx->certificate->heap);
         if (ret != 0) {
-            ssl->buffers.weOwnCert = 0;
             return NULL;
         }
 
         ssl->buffers.weOwnCert = 1;
     }
     if (ctx->certChain != NULL) {
-        if (ssl->buffers.certChain != NULL) {
-            FreeDer(&ssl->buffers.certChain);
-            ssl->buffers.certChain = NULL;
-        }
         ret = AllocCopyDer(&ssl->buffers.certChain, ctx->certChain->buffer,
             ctx->certChain->length, ctx->certChain->type,
             ctx->certChain->heap);
         if (ret != 0) {
-            ssl->buffers.weOwnCertChain = 0;
             return NULL;
         }
 
@@ -8865,20 +8869,14 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
     ssl->buffers.certificate = ctx->certificate;
     ssl->buffers.certChain = ctx->certChain;
 #endif
-#ifdef WOLFSSL_TLS13
     ssl->buffers.certChainCnt = ctx->certChainCnt;
-#endif
 #ifndef WOLFSSL_BLIND_PRIVATE_KEY
 #ifdef WOLFSSL_COPY_KEY
-    if (ssl->buffers.key != NULL && ssl->buffers.weOwnKey) {
-        FreeDer(&ssl->buffers.key);
-    }
     if (ctx->privateKey != NULL) {
         ret = AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
             ctx->privateKey->length, ctx->privateKey->type,
             ctx->privateKey->heap);
         if (ret != 0) {
-            ssl->buffers.weOwnKey = 0;
             return NULL;
         }
         ssl->buffers.weOwnKey = 1;
@@ -8891,15 +8889,13 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
 #endif
 #else
     if (ctx->privateKey != NULL) {
-        if (ssl->buffers.key != NULL && ssl->buffers.weOwnKey) {
-            FreeDer(&ssl->buffers.key);
-        }
         ret = AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
             ctx->privateKey->length, ctx->privateKey->type,
             ctx->privateKey->heap);
         if (ret != 0) {
             return NULL;
         }
+        ssl->buffers.weOwnKey = 1;
         /* Blind the private key for the SSL with new random mask. */
         wolfssl_priv_der_blind_toggle(ssl->buffers.key, ctx->privateKeyMask);
         ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.key,
@@ -8934,6 +8930,7 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
         if (ret != 0) {
             return NULL;
         }
+        ssl->buffers.weOwnAltKey = 1;
         /* Blind the private key for the SSL with new random mask. */
         wolfssl_priv_der_blind_toggle(ssl->buffers.altKey,
                                       ctx->altPrivateKeyMask);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10822,6 +10822,8 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                     /* Swap keys */
                     ssl->buffers.key     = ssl->buffers.altKey;
                     ssl->buffers.weOwnKey = ssl->buffers.weOwnAltKey;
+                    /* buffers.key is the only owner of the alt key now. */
+                    ssl->buffers.weOwnAltKey = 0;
 
                 #ifdef WOLFSSL_BLIND_PRIVATE_KEY
                     ssl->buffers.keyMask = ssl->buffers.altKeyMask;

--- a/tests/api.c
+++ b/tests/api.c
@@ -1289,7 +1289,7 @@ static int do_dual_alg_server_certgen(byte **out, char *caKeyFile,
 static int do_dual_alg_tls13_connection(byte *caCert, word32 caCertSz,
                                         byte *serverCert, word32 serverCertSz,
                                         byte *serverKey, word32 serverKeySz,
-                                        int negative_test)
+                                        int negative_test, int altSigSpec)
 {
     EXPECT_DECLS;
     WOLFSSL_CTX *ctx_c = NULL;
@@ -1297,12 +1297,27 @@ static int do_dual_alg_tls13_connection(byte *caCert, word32 caCertSz,
     WOLFSSL *ssl_c = NULL;
     WOLFSSL *ssl_s = NULL;
     struct test_memio_ctx test_ctx;
+    /* wolfSSL_UseCKS() keeps the specifier by reference, so it has to live
+     * until the handshake is done. */
+    byte cks = WOLFSSL_CKS_SIGSPEC_ALTERNATIVE;
+    byte *altKey = NULL;
+    size_t altKeySz = 0;
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
     ExpectIntEQ(test_memio_setup_ex(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
                 wolfTLSv1_3_client_method, wolfTLSv1_3_server_method,
                 caCert, caCertSz, serverCert, serverCertSz,
                 serverKey, serverKeySz), 0);
+    if (altSigSpec) {
+        /* The server ignores the CKS list unless buffers.altKey is set, and
+         * a client list of only ALTERNATIVE makes it sign with the
+         * alternative key in place of the native one. */
+        ExpectIntEQ(load_file("./certs/ecc-key.der", &altKey, &altKeySz), 0);
+        ExpectIntEQ(wolfSSL_use_AltPrivateKey_buffer(ssl_s, altKey,
+            (long)altKeySz, WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+        XFREE(altKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        ExpectIntEQ(wolfSSL_UseCKS(ssl_c, &cks, 1), WOLFSSL_SUCCESS);
+    }
     if (negative_test) {
         ExpectTrue(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL) != 0);
     }
@@ -1742,7 +1757,12 @@ static int test_dual_alg_support(void)
     ExpectNotNull(server);
     ExpectIntGT(serverSz, 0);
     ExpectIntEQ(do_dual_alg_tls13_connection(root, rootSz,
-                server, serverSz, serverKey, (word32)serverKeySz, 0),
+                server, serverSz, serverKey, (word32)serverKeySz, 0, 0),
+                TEST_SUCCESS);
+    /* Same certificates, but the server signs with the alternative key only.
+     * The key then moves into buffers.key and must be freed once. */
+    ExpectIntEQ(do_dual_alg_tls13_connection(root, rootSz,
+                server, serverSz, serverKey, (word32)serverKeySz, 0, 1),
                 TEST_SUCCESS);
     XFREE(root, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     root = NULL;
@@ -1769,11 +1789,11 @@ static int test_dual_alg_support(void)
     ExpectIntGT(serverSz, 0);
 #ifdef WOLFSSL_TRUST_PEER_CERT
     ExpectIntEQ(do_dual_alg_tls13_connection(root, rootSz,
-                server, serverSz, serverKey, (word32)serverKeySz, 0),
+                server, serverSz, serverKey, (word32)serverKeySz, 0, 0),
                 TEST_SUCCESS);
 #else
     ExpectIntEQ(do_dual_alg_tls13_connection(root, rootSz,
-                server, serverSz, serverKey, (word32)serverKeySz, 1),
+                server, serverSz, serverKey, (word32)serverKeySz, 1, 0),
                 TEST_SUCCESS);
 #endif
 
@@ -1796,6 +1816,61 @@ static int test_dual_alg_crit_ext_support(void)
 }
 
 #endif /* WOLFSSL_DUAL_ALG_CERTS && !NO_FILESYSTEM */
+
+/* The alternative private key of a ctx is copied into every ssl made from it,
+ * and the ssl has to free its copy. */
+static int test_dual_alg_ctx_alt_key(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_DUAL_ALG_CERTS) && defined(WOLFSSL_TLS13) && \
+    !defined(NO_WOLFSSL_SERVER) && !defined(NO_FILESYSTEM)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL_CTX* ctx2 = NULL;
+    WOLFSSL* ssl = NULL;
+    byte* altKey = NULL;
+    size_t altKeySz = 0;
+
+    ExpectIntEQ(load_file("./certs/ecc-key.der", &altKey, &altKeySz), 0);
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+        WOLFSSL_FILETYPE_PEM));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+        WOLFSSL_FILETYPE_PEM));
+    ExpectIntEQ(wolfSSL_CTX_use_AltPrivateKey_buffer(ctx, altKey,
+        (long)altKeySz, WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+#if defined(WOLFSSL_INT_H) && defined(WOLFSSL_BLIND_PRIVATE_KEY)
+    if (ssl != NULL && ctx != NULL) {
+        ExpectFalse(ssl->buffers.altKey == ctx->altPrivateKey);
+        ExpectIntEQ(ssl->buffers.weOwnAltKey, 1);
+    }
+#endif
+
+    /* Switching the ctx makes the ssl copy the alternative key again. */
+    ExpectNotNull(ctx2 = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx2, svrCertFile,
+        WOLFSSL_FILETYPE_PEM));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx2, svrKeyFile,
+        WOLFSSL_FILETYPE_PEM));
+    ExpectIntEQ(wolfSSL_CTX_use_AltPrivateKey_buffer(ctx2, altKey,
+        (long)altKeySz, WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+    ExpectNotNull(wolfSSL_set_SSL_CTX(ssl, ctx2));
+#if defined(WOLFSSL_INT_H) && defined(WOLFSSL_BLIND_PRIVATE_KEY)
+    if (ssl != NULL && ctx2 != NULL) {
+        ExpectFalse(ssl->buffers.altKey == ctx2->altPrivateKey);
+        ExpectIntEQ(ssl->buffers.weOwnAltKey, 1);
+    }
+#endif
+
+    XFREE(altKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+    wolfSSL_CTX_free(ctx2);
+#endif
+    return EXPECT_RESULT();
+}
 
 /**
  * Test dual-alg ECDSA + ML-DSA:
@@ -30786,13 +30861,17 @@ static int test_wolfSSL_set_SSL_CTX(void)
     !defined(NO_RSA)  && !defined(NO_WOLFSSL_SERVER)
     WOLFSSL_CTX *ctx1 = NULL;
     WOLFSSL_CTX *ctx2 = NULL;
+    WOLFSSL_CTX *ctx3 = NULL;
     WOLFSSL *ssl = NULL;
+#ifdef KEEP_OUR_CERT
+    WOLFSSL_X509 *x509 = NULL;
+#endif
     const byte *session_id1 = (const byte *)"CTX1";
     const byte *session_id2 = (const byte *)"CTX2";
 
     ExpectNotNull(ctx1 = wolfSSL_CTX_new(wolfTLS_server_method()));
-    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx1, svrCertFile,
-        WOLFSSL_FILETYPE_PEM));
+    /* A chain file so that ctx1 has a certChain and a certChainCnt. */
+    ExpectTrue(wolfSSL_CTX_use_certificate_chain_file(ctx1, svrCertFile));
     ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx1, svrKeyFile,
         WOLFSSL_FILETYPE_PEM));
     ExpectIntEQ(wolfSSL_CTX_set_min_proto_version(ctx1, TLS1_2_VERSION),
@@ -30867,14 +30946,99 @@ static int test_wolfSSL_set_SSL_CTX(void)
     ExpectTrue(ssl->buffers.certificate == ctx1->certificate);
     ExpectTrue(ssl->buffers.certChain == ctx1->certChain);
 #endif
+    if (ctx1 != NULL) {
+        ExpectIntGT(ctx1->certChainCnt, 0);
+        ExpectIntEQ(ssl->buffers.certChainCnt, ctx1->certChainCnt);
+    }
+#if defined(WOLFSSL_COPY_KEY) || defined(WOLFSSL_BLIND_PRIVATE_KEY)
+    if (ctx1 != NULL && ctx1->privateKey != NULL) {
+        ExpectFalse(ssl->buffers.key == ctx1->privateKey);
+        ExpectIntEQ(ssl->buffers.weOwnKey, 1);
+    }
+#else
+    ExpectTrue(ssl->buffers.key == ctx1->privateKey);
+    ExpectIntEQ(ssl->buffers.weOwnKey, 0);
+#endif
 #ifdef WOLFSSL_SESSION_ID_CTX
     ExpectIntEQ(XMEMCMP(ssl->sessionCtx, session_id1, 4), 0);
 #endif
 #endif
 
+    /* ctx2 holds a certificate but no chain: the chain of ctx1 must not be
+     * left behind. */
+    ExpectNotNull(wolfSSL_set_SSL_CTX(ssl, ctx2));
+#ifdef WOLFSSL_INT_H
+    if (ssl != NULL) {
+        ExpectNull(ssl->buffers.certChain);
+        ExpectIntEQ(ssl->buffers.certChainCnt, 0);
+    }
+#endif
+
+    /* Set a ctx that has no certificate and no key */
+    ExpectNotNull(ctx3 = wolfSSL_CTX_new(wolfTLS_server_method()));
+    ExpectNotNull(wolfSSL_set_SSL_CTX(ssl, ctx3));
+
+    /* MUST not keep the certificate, chain and key of ctx1 */
+#ifdef WOLFSSL_INT_H
+    if (ssl != NULL) {
+        ExpectNull(ssl->buffers.certificate);
+        ExpectNull(ssl->buffers.certChain);
+        ExpectIntEQ(ssl->buffers.certChainCnt, 0);
+        ExpectNull(ssl->buffers.key);
+        ExpectIntEQ(ssl->buffers.weOwnCert, 0);
+        ExpectIntEQ(ssl->buffers.weOwnCertChain, 0);
+        ExpectIntEQ(ssl->buffers.weOwnKey, 0);
+    }
+#endif
+#ifdef KEEP_OUR_CERT
+    ExpectNull(wolfSSL_get_certificate(ssl));
+#endif
+
     wolfSSL_free(ssl);
+    ssl = NULL;
+
+    /* An ssl holding a certificate of its own must not end up owning the one
+     * of ctx1: ctx1 is used again after the ssl is freed. */
+    ExpectNotNull(ssl = wolfSSL_new(ctx2));
+    ExpectTrue(wolfSSL_use_certificate_file(ssl, cliCertFile,
+        WOLFSSL_FILETYPE_PEM));
+#ifdef KEEP_OUR_CERT
+    /* Create the X509 of the certificate of the ssl and add one to its
+     * chain: the ctx switch has to drop both. */
+    ExpectNotNull(wolfSSL_get_certificate(ssl));
+    ExpectNotNull(x509 = wolfSSL_X509_load_certificate_file(caCertFile,
+        WOLFSSL_FILETYPE_PEM));
+    ExpectIntEQ(wolfSSL_add1_chain_cert(ssl, x509), 1);
+#endif
+    ExpectNotNull(wolfSSL_set_SSL_CTX(ssl, ctx1));
+#ifdef WOLFSSL_INT_H
+    if (ssl != NULL && ctx1 != NULL) {
+    #ifdef WOLFSSL_COPY_CERT
+        ExpectFalse(ssl->buffers.certificate == ctx1->certificate);
+        ExpectIntEQ(ssl->buffers.weOwnCert, 1);
+    #else
+        ExpectTrue(ssl->buffers.certificate == ctx1->certificate);
+        ExpectIntEQ(ssl->buffers.weOwnCert, 0);
+    #endif
+    #ifdef KEEP_OUR_CERT
+        ExpectNull(ssl->ourCertChain);
+    #endif
+    }
+#endif
+#ifdef KEEP_OUR_CERT
+    /* The certificate of ctx1 is reported, not the one dropped above. */
+    ExpectNotNull(wolfSSL_get_certificate(ssl));
+#endif
+    wolfSSL_free(ssl);
+    ssl = NULL;
+#ifdef KEEP_OUR_CERT
+    wolfSSL_X509_free(x509);
+    x509 = NULL;
+#endif
+
     wolfSSL_CTX_free(ctx1);
     wolfSSL_CTX_free(ctx2);
+    wolfSSL_CTX_free(ctx3);
 #endif /* defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) */
     return EXPECT_RESULT();
 }
@@ -30882,6 +31046,66 @@ static int test_wolfSSL_set_SSL_CTX(void)
     (defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
     defined(HAVE_LIGHTY) || defined(WOLFSSL_HAPROXY) || \
     defined(WOLFSSL_OPENSSH) || defined(HAVE_SBLIM_SFCB))) */
+
+static int test_wolfSSL_certs_clear(void)
+{
+    EXPECT_DECLS;
+#if defined(OPENSSL_EXTRA) && !defined(NO_RSA) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_WOLFSSL_SERVER)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+#ifdef KEEP_OUR_CERT
+    WOLFSSL_X509* x509 = NULL;
+#endif
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLS_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+        WOLFSSL_FILETYPE_PEM));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+        WOLFSSL_FILETYPE_PEM));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+
+    /* Give the ssl a certificate, a chain and an X509 of its own. */
+    ExpectTrue(wolfSSL_use_certificate_chain_file(ssl, svrCertFile));
+#ifdef KEEP_OUR_CERT
+    ExpectNotNull(wolfSSL_get_certificate(ssl));
+    ExpectNotNull(x509 = wolfSSL_X509_load_certificate_file(caCertFile,
+        WOLFSSL_FILETYPE_PEM));
+    ExpectIntEQ(wolfSSL_add1_chain_cert(ssl, x509), 1);
+#endif
+#ifdef WOLFSSL_INT_H
+    if (ssl != NULL) {
+        ExpectIntGT(ssl->buffers.certChainCnt, 0);
+    #ifdef KEEP_OUR_CERT
+        ExpectNotNull(ssl->ourCert);
+        ExpectNotNull(ssl->ourCertChain);
+    #endif
+    }
+#endif
+
+    wolfSSL_certs_clear(ssl);
+#ifdef WOLFSSL_INT_H
+    if (ssl != NULL) {
+        ExpectNull(ssl->buffers.certificate);
+        ExpectIntEQ(ssl->buffers.weOwnCert, 0);
+        ExpectNull(ssl->buffers.certChain);
+        ExpectIntEQ(ssl->buffers.weOwnCertChain, 0);
+        ExpectIntEQ(ssl->buffers.certChainCnt, 0);
+    #ifdef KEEP_OUR_CERT
+        ExpectNull(ssl->ourCert);
+        ExpectNull(ssl->ourCertChain);
+    #endif
+    }
+#endif
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#ifdef KEEP_OUR_CERT
+    wolfSSL_X509_free(x509);
+#endif
+#endif
+    return EXPECT_RESULT();
+}
 
 static int test_wolfSSL_security_level(void)
 {
@@ -40091,6 +40315,7 @@ TEST_CASE testCases[] = {
 
     TEST_DECL(test_dual_alg_support),
     TEST_DECL(test_dual_alg_crit_ext_support),
+    TEST_DECL(test_dual_alg_ctx_alt_key),
 
     TEST_DECL(test_dual_alg_ecdsa_mldsa),
 
@@ -40410,6 +40635,7 @@ TEST_CASE testCases[] = {
     defined(WOLFSSL_OPENSSH) || defined(HAVE_SBLIM_SFCB)))
     TEST_DECL(test_wolfSSL_set_SSL_CTX),
 #endif
+    TEST_DECL(test_wolfSSL_certs_clear),
     TEST_DECL(test_wolfSSL_CTX_get_min_proto_version),
     TEST_DECL(test_wolfSSL_security_level),
     TEST_DECL(test_wolfSSL_crypto_policy),


### PR DESCRIPTION
### Problem
`wolfSSL_set_SSL_CTX()` only wrote an `ssl->buffers` slot when the replacement CTX supplied a value, so switching to a CTX without credentials left the previous ones in place. This is the API an SNI/ClientHello callback uses to pick a per-host identity, so what stays behind is what goes on the wire.

- **With `WOLFSSL_COPY_CERT`** (implied by `OPENSSL_ALL`): a CTX with a leaf but no chain kept the previous CTX's chain, and TLS 1.2 sent it alongside the new leaf. Under `WOLFSSL_BLIND_PRIVATE_KEY` the old private key survived too, so the handshake completed under the previous identity. (f-12567)
- **Without it** (`--enable-opensslextra`): `ssl->buffers.certificate = ctx->certificate` ran without clearing `weOwnCert`, so an SSL holding its own certificate freed the CTX's `DerBuffer` at `wolfSSL_free()` — double free at `wolfSSL_CTX_free()`.

### Fix (`src/ssl.c`)
- **`wolfSSL_certs_clear()`** releases `ssl->ourCert` and `ssl->ourCertChain` with the buffers they mirror, and zeroes `certChainCnt` in every build. This also fixes a leak through the public `SSL_certs_clear()`, which cleared `weOwnCert` — the flag teardown uses to decide whether to free `ourCert`.
- **`wolfSSL_set_SSL_CTX()`** calls it before copying from the new CTX, so each buffer is released exactly once and a credential-less CTX leaves nothing behind.
- **Alt-key ownership**: `weOwnAltKey` is set after the copy in `wolfSSL_set_SSL_CTX()` and `SetSSL_CTX_CertsAndKeys()` (`src/internal.c`), and `SendTls13CertificateVerify()` (`src/tls13.c`) clears it when it moves the alt key into `buffers.key`. Without that transfer both fields own one buffer and teardown frees it twice.

Gives the same semantics as OpenSSL, which replaces the whole `CERT` with a dup of the new context's. Closes f-12567.

### Tests (`tests/api.c`)

| Test | Covers |
|---|---|
| `test_wolfSSL_set_SSL_CTX` | Switches to a CTX with no chain and to one with no credentials; buffers, `weOwn*` flags, `certChainCnt`, `wolfSSL_get_certificate()`; an SSL owning its certificate freed before the CTX |
| `test_wolfSSL_certs_clear` | Same state after `SSL_certs_clear()`, including `ourCert` and `ourCertChain` |
| `test_dual_alg_support`, `test_dual_alg_ctx_alt_key` | ALTERNATIVE-signature connection; alt key copied and owned via both `wolfSSL_new()` and a CTX switch |

### Verification
- `--enable-opensslall`: full `./tests/unit.test` passes. `--enable-opensslextra` and `--disable-tls13` builds pass.
- Dual-alg + `WOLFSSL_BLIND_PRIVATE_KEY` under ASan + UBSan: clean.
- Negative controls per fix: without the clear, the stale-chain assertions fail and ASan reports heap-use-after-free in `FreeDer()`; without the `tls13.c` line, ASan reports use-after-free in `wolfSSL_UnloadCertsKeys()`.
- Note: no CI job enables `--enable-dual-alg-certs` with the unit tests, so the alt-key coverage above was verified locally.