### PR TITLE
sniffer: place polled async events at the running offset

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -7440,6 +7440,10 @@ int ssl_PollSniffer(WOLF_EVENT** events, int maxEvents, WOLF_EVENT_FLAG flags,
     int i;
     SnifferServer* srv;
 
+    if (events == NULL || pEventCount == NULL || maxEvents <= 0) {
+        return BAD_FUNC_ARG;
+    }
+
     LOCK_SERVER_LIST();
 
     /* Iterate the open sniffer sessions calling wolfSSL_CTX_AsyncPoll */
@@ -7449,7 +7453,7 @@ int ssl_PollSniffer(WOLF_EVENT** events, int maxEvents, WOLF_EVENT_FLAG flags,
         if (nMax <= 0) {
             break; /* out of room in events list */
         }
-        ret = wolfSSL_CTX_AsyncPoll(srv->ctx, events + nReady, nMax, flags,
+        ret = wolfSSL_CTX_AsyncPoll(srv->ctx, events + eventCount, nMax, flags,
                                     &nReady);
         if (ret == 0) {
             eventCount += nReady;


### PR DESCRIPTION
### Problem

`ssl_PollSniffer()` used the per-server ready count as the destination offset into the caller's `events` array:

```c
int nMax = maxEvents - eventCount, nReady = 0;
ret = wolfSSL_CTX_AsyncPoll(srv->ctx, events + nReady, nMax, flags, &nReady);
```

`nReady` is declared and zeroed inside the loop body, so it is always `0` at the call. `wolfSSL_CTX_AsyncPoll()` fills `events[0 .. count-1]` of whatever base it is given, so every `SnifferServer` on `ServerList` wrote starting at `events[0]` while `eventCount` kept accumulating.

With two or more sniffer servers returning ready events — normal whenever `ssl_SetPrivateKey()` registers more than one server address — a later server's events overwrite the earlier ones, and the trailing slots `events[n .. eventCount-1]` are never written. The marking loop then dereferences them via `events[i]->context`. The only in-tree caller (`snifftest.c`) passes an uninitialized stack array, making those wild-pointer reads. Earlier servers' completed events are also silently dropped: removed from the event queue but never marked `wasPolled`, stalling those sessions.

Requires `WOLFSSL_ASYNC_CRYPT`. Closes f-12568.

### Fix (`src/sniffer.c`)

- **`events + eventCount`** is passed to `wolfSSL_CTX_AsyncPoll()`, so each server appends after the events already collected. `nMax = maxEvents - eventCount` already bounded the write correctly.
- **`BAD_FUNC_ARG`** is returned when `events` or `pEventCount` is `NULL`, or `maxEvents` is not positive — this is a public `SSL_SNIFFER_API` that dereferenced `pEventCount` unconditionally.

No API, ABI, or header change.

### Verification

- Build clean under `--enable-asynccrypt --enable-asynccrypt-sw --enable-sniffer --enable-debug` (the function is behind `WOLFSSL_ASYNC_CRYPT`, so a default build never compiles it).
- `scripts/sniffer-testsuite.test`: **Success**, with `async_crypt` in the reported feature list.
- Two-server harness (not committed): `eventCount=2` with two distinct pointers matching the queued events; all three `BAD_FUNC_ARG` cases reject. Negative control with only the offset reverted faults at the marking loop — `SEGV ... in ssl_PollSniffer`, plus a UBSan null-member-access report.
- ASan + UBSan clean.

### Not in this PR

The `else` branch still discards `nReady` when the poll returns an error. That path is currently unreachable: `wolfAsync_EventQueuePoll()` overwrites a hardware-poll error with the return of `wolfEventQueue_Remove()` whenever any event completes in the same pass. That masking behavior is a separate issue in `wolfcrypt/src/async.c`.