### PR TITLE
wolfio: drop the unreachable ISO-TP receive timeout branch

### DIFF
--- a/doc/dox_comments/header_files-ja/wolfio.h
+++ b/doc/dox_comments/header_files-ja/wolfio.h
@@ -529,7 +529,7 @@ void* wolfSSL_GetCookieCtx(WOLFSSL* ssl);
 
     \param ssl wolfSSLコンテキスト。
     \param ctx この関数が初期化するユーザー作成のISOTPコンテキスト。
-    \param recv_fn ユーザーのCANバス受信コールバック。
+    \param recv_fn ユーザーのCANバス受信コールバック。フレーム長、timeout (ms)内に届かなければ0、エラー時は負の値を返す。
     \param send_fn ユーザーのCANバス送信コールバック。
     \param delay_fn ユーザーのマイクロ秒粒度遅延関数。
     \param receive_delay 各CANバスパケットを遅延させる設定マイクロ秒数。

--- a/doc/dox_comments/header_files/wolfio.h
+++ b/doc/dox_comments/header_files/wolfio.h
@@ -584,7 +584,8 @@ void* wolfSSL_GetCookieCtx(WOLFSSL* ssl);
 
     \param ssl the wolfSSL context
     \param ctx a user created ISOTP context which this function initializes
-    \param recv_fn a user CAN bus receive callback
+    \param recv_fn a user CAN bus receive callback, returning the frame
+    length, 0 if none arrived within timeout (ms), or negative on error
     \param send_fn a user CAN bus send callback
     \param delay_fn a user microsecond granularity delay function
     \param receive_delay a set amount of microseconds to delay each CAN bus

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -4324,14 +4324,13 @@ int ISOTP_Receive(WOLFSSL* ssl, char* buf, int sz, void* ctx)
             return WOLFSSL_ERROR_WANT_READ;
         }
         isotp_ctx->state = ISOTP_CONN_STATE_RECEIVING;
+        /* Each poll waits ISOTP_DEFAULT_TIMEOUT ms, but nothing bounds
+         * the wait for a message to start, so keep polling. */
         do {
             ret = isotp_ctx->recv_fn(&isotp_ctx->frame, isotp_ctx->arg,
                     ISOTP_DEFAULT_TIMEOUT);
         } while (ret == 0);
-        if (ret == 0) {
-            isotp_ctx->state = ISOTP_CONN_STATE_IDLE;
-            return WOLFSSL_CBIO_ERR_TIMEOUT;
-        } else if (ret < 0) {
+        if (ret < 0) {
             isotp_ctx->state = ISOTP_CONN_STATE_IDLE;
             WOLFSSL_MSG("ISO-TP receive error");
             return WOLFSSL_CBIO_ERR_GENERAL;


### PR DESCRIPTION
### Problem
`ISOTP_Receive()` waits for the first frame of a new message in a loop that
exits only on a non-zero result, so the `if (ret == 0)` arm immediately after it
was unreachable and its `WOLFSSL_CBIO_ERR_TIMEOUT` return could never fire.
Both lines landed together in the original ISO-TP commit (shipped in 5.2.0), so
no release has ever executed that branch. Dead error handling only, no runtime
impact. Reported as f-12563.

### Fix (`src/wolfio.c`)
Removed the unreachable arm; `else if (ret < 0)` becomes `if (ret < 0)`.

The blocking wait itself is kept deliberately, and a comment now records why:

- **The three receive wait points are asymmetric on purpose.**
  `isotp_receive_flow_control()` and the consecutive-frame wait in
  `isotp_receive_multi_frame()` each call `recv_fn` once and fail on the first
  zero. Only the first-frame wait retries.
- **That matches ISO 15765-2** — the N_Bs/N_Cr timers constrain gaps *within* a
  segmented transfer, which is exactly what those two sites enforce. Nothing
  times out while waiting for a peer to begin a new message.
- **`ISOTP_DEFAULT_TIMEOUT` (100 ms) is a poll granularity, not a session
  timeout.** `ISOTP_Receive` is also what blocks between application records,
  and for non-DTLS `WOLFSSL_CBIO_ERR_TIMEOUT` is fatal in `Receive()`
  (`src/internal.c`), with no retry — so capping the wait would tear down any
  connection whose peer went quiet longer than the cap.

The `wolfSSL_SetIO_ISOTP()` doxygen block now states the `recv_fn` contract the
loop depends on (frame length / `0` if none arrived within `timeout` /
negative on error); a callback that returns `0` without waiting is what would
turn this into a busy loop.

Closes f-12563.

### Verification
- Builds clean with `CFLAGS="-DWOLFSSL_ISOTP"`; `src/wolfio.c` recompiled under
  `-Wall -Wextra -Werror -Wunreachable-code` with no warnings.
- Functional harness driving `ISOTP_Receive()` with a stub `recv_fn`: frame
  ready → 3 bytes in 1 poll; two empty polls then a frame → 3 bytes in 3 polls
  (the wait still resumes); `recv_fn` returning `-1` →
  `WOLFSSL_CBIO_ERR_GENERAL`. 3/3 pass, and a negative control (error arm
  returning `0`) fails case 3 as expected.