### PR TITLE
Add OpenSSH 10.5p1 to CI matrix

### DIFF
--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -88,6 +88,11 @@ jobs:
             SKIP_LTESTS: >-
               exit-status rekey multiplex forward-control channel-timeout
               connection-timeout
+          - git_ref: 'V_10_5_P1'
+            osp_ver: '10.5p1'
+            SKIP_LTESTS: >-
+              exit-status rekey multiplex forward-control channel-timeout
+              connection-timeout
     name: ${{ matrix.osp_ver }}
     if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Extends the CI test matrix to include OpenSSH 10.5p1.

Depends on https://github.com/wolfSSL/osp/pull/359