### PR TITLE
tests: free PKCS7 cert stack when encode_certs fails

### DIFF
--- a/tests/api/test_ossl_p7p12.c
+++ b/tests/api/test_ossl_p7p12.c
@@ -154,10 +154,14 @@ int test_wolfSSL_PKCS7_certs(void)
         bio = NULL;
         ExpectNotNull(bio = BIO_new(BIO_s_mem()));
         ExpectIntEQ(wolfSSL_PKCS7_encode_certs(p7, sk, bio), 1);
-        if ((sk != NULL) && ((p7 == NULL) || (bio == NULL))) {
-            sk_X509_pop_free(sk, X509_free);
+        /* encode_certs takes sk only on success. */
+        if (EXPECT_SUCCESS()) {
+            sk = NULL;
         }
-        sk = NULL;
+        else if (sk != NULL) {
+            sk_X509_pop_free(sk, X509_free);
+            sk = NULL;
+        }
         ExpectIntGT((buflen = BIO_get_mem_data(bio, &p)), 0);
 
         if (i == 0) {
@@ -721,14 +725,10 @@ int test_wolfSSL_PKCS7_verify_degenerate(void)
     #endif
     }
     ExpectNotNull(derBio = BIO_new(BIO_s_mem()));
-    /* wolfSSL_PKCS7_encode_certs() takes ownership of sk (sets p7->certs, freed
-     * by PKCS7_free(encodeP7) below) whenever it is called with a valid PKCS7
-     * and BIO - success or failure. It only declines ownership when encodeP7 or
-     * derBio is NULL, in which case the test still owns sk and frees it in
-     * cleanup. */
+    /* encode_certs takes sk only on success; cleanup frees it otherwise. */
     ExpectIntEQ(wolfSSL_PKCS7_encode_certs(encodeP7, sk, derBio), 1);
-    if (encodeP7 != NULL && derBio != NULL)
-        sk = NULL; /* now owned by encodeP7 */
+    if (EXPECT_SUCCESS())
+        sk = NULL;
     ExpectIntGT((derSz = BIO_get_mem_data(derBio, &der)), 0);
 
     /* ---- Re-parse it; a degenerate bundle parses successfully. ---- */


### PR DESCRIPTION
## Description

`wolfSSL_PKCS7_encode_certs` takes the cert stack only when encode succeeds (`p7->certs = certHead` on success; caller still owns `certs` on every failure path).

`test_wolfSSL_PKCS7_certs` and `test_wolfSSL_PKCS7_verify_degenerate` dropped `sk` whenever `p7` and the BIO were non-NULL. Under `MEM_FAIL_CNT`, encode fails, the stack is leaked, and the nightly reports a Free/Alloc mismatch:

- `test_wolfSSL_PKCS7_certs` — 251/419
- `test_wolfSSL_PKCS7_verify_degenerate` — 126/210

The tests now free `sk` when encode fails, and only drop ownership when encode succeeds.

Library code is unchanged.

## Testing

Happy path:

```
./tests/unit.test -test_wolfSSL_PKCS7_certs
./tests/unit.test -test_wolfSSL_PKCS7_verify_degenerate
```

Both: `Failed/Skipped/Passed/All: 0/0/1/1`

Mem-fail (same check as Jenkins `mem_fail.sh`), after a build with `C_EXTRA_FLAGS=-DWOLFSSL_MEM_FAIL_COUNT`:

```
bash testing/Jenkins/wolfSSL/nightly-mem-fail-test/mem_fail.sh \
    test_wolfSSL_PKCS7_certs test_wolfSSL_PKCS7_verify_degenerate
```

Local result: no Free/Alloc mismatch across the full inject loops (1622 and 1051 allocations on this config).
