### PR TITLE
Rust wrapper: curve25519: fix possible dangling WC_RNG pointer

### DIFF
--- a/wrapper/rust/wolfssl-wolfcrypt/CHANGELOG.md
+++ b/wrapper/rust/wolfssl-wolfcrypt/CHANGELOG.md
@@ -1,5 +1,17 @@
 # wolfssl-wolfcrypt Change Log
 
+## v3.0.0
+
+Breaking changes:
+
+- Curve25519Key::generate() now takes ownership of the RNG instead of borrowing
+  it; the key holds the RNG for its lifetime
+
+New features:
+
+- Add Curve25519Key::generate_shared_rng() to generate a key from an RNG shared
+  between keys via Rc (requires the alloc feature)
+
 ## v2.2.0
 
 New features:

--- a/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
@@ -32,7 +32,8 @@ use core::mem::MaybeUninit;
 
 pub struct Curve25519Key {
     wc_key: sys::curve25519_key,
-    /// RNG bound via `set_rng`, kept alive while the C struct holds its pointer.
+    /// RNG associated with the Curve25519Key, kept alive while the C struct
+    /// holds its pointer.
     #[cfg(random)]
     rng: Option<RngHandle>,
 }
@@ -69,14 +70,16 @@ impl Curve25519Key {
     ///
     /// # Parameters
     ///
-    /// * `rng`: Random number generator struct to use for blinding operation.
+    /// * `rng`: Random number generator struct to use for key generation and
+    ///   blinding operation. Ownership of the `RNG` instance is transferred to
+    ///   the `Curve25519Key` instance constructed here.
     ///
     /// # Returns
     ///
     /// Returns either Ok(curve25519key) on success or Err(e) containing the
     /// wolfSSL library error code value.
     #[cfg(random)]
-    pub fn generate(rng: &RNG) -> Result<Self, i32> {
+    pub fn generate(rng: RNG) -> Result<Self, i32> {
         let mut wc_key: MaybeUninit<sys::curve25519_key> = MaybeUninit::uninit();
         let rc = unsafe {
             sys::wc_curve25519_init(wc_key.as_mut_ptr())
@@ -85,13 +88,50 @@ impl Curve25519Key {
             return Err(rc);
         }
         let wc_key = unsafe { wc_key.assume_init() };
+        let wc_rng = rng.wc_rng;
         let mut curve25519key = Curve25519Key {
             wc_key,
-            #[cfg(random)]
-            rng: None,
+            rng: Some(RngHandle::Owned(rng)),
         };
         let rc = unsafe {
-            sys::wc_curve25519_make_key(rng.wc_rng, Self::KEYSIZE as i32,
+            sys::wc_curve25519_make_key(wc_rng, Self::KEYSIZE as i32,
+                &mut curve25519key.wc_key)
+        };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(curve25519key)
+    }
+
+    /// Generate a new private key with a shared RNG.
+    ///
+    /// # Parameters
+    ///
+    /// * `rng`: Random number generator struct to use for key generation and
+    ///   blinding operation. The `Curve25519Key` instance created here shares
+    ///   the same `RNG` instance via `Rc`.
+    ///
+    /// # Returns
+    ///
+    /// Returns either Ok(curve25519key) on success or Err(e) containing the
+    /// wolfSSL library error code value.
+    #[cfg(all(random, feature = "alloc"))]
+    pub fn generate_shared_rng(rng: alloc::rc::Rc<RNG>) -> Result<Self, i32> {
+        let mut wc_key: MaybeUninit<sys::curve25519_key> = MaybeUninit::uninit();
+        let rc = unsafe {
+            sys::wc_curve25519_init(wc_key.as_mut_ptr())
+        };
+        if rc != 0 {
+            return Err(rc);
+        }
+        let wc_key = unsafe { wc_key.assume_init() };
+        let wc_rng = rng.wc_rng;
+        let mut curve25519key = Curve25519Key {
+            wc_key,
+            rng: Some(RngHandle::Shared(rng)),
+        };
+        let rc = unsafe {
+            sys::wc_curve25519_make_key(wc_rng, Self::KEYSIZE as i32,
                 &mut curve25519key.wc_key)
         };
         if rc != 0 {
@@ -485,6 +525,11 @@ impl Curve25519Key {
     /// This is necessary when generating a shared secret if wolfSSL is built
     /// with the `WOLFSSL_CURVE25519_BLINDING` build option enabled.
     ///
+    /// Note that if the `Curve25519Key` instance was created with either
+    /// `generate()` or `generate_shared_rng()`, the `RNG` instance was already
+    /// registered, so calling this function is not necessary unless it is
+    /// desired to change the associated `RNG` instance.
+    ///
     /// The key takes ownership of the RNG, so the underlying `WC_RNG` is
     /// guaranteed to outlive this key.
     ///
@@ -510,8 +555,25 @@ impl Curve25519Key {
         Ok(())
     }
 
-    /// Bind a shared `RNG` to this key. Available when the `alloc` feature
-    /// is enabled.
+    /// Associates a shared `RNG` instance with this `Curve25519Key` instance.
+    ///
+    /// This is necessary when generating a shared secret if wolfSSL is built
+    /// with the `WOLFSSL_CURVE25519_BLINDING` build option enabled.
+    ///
+    /// Note that if the `Curve25519Key` instance was created with either
+    /// `generate()` or `generate_shared_rng()`, the `RNG` instance was already
+    /// registered, so calling this function is not necessary unless it is
+    /// desired to change the associated `RNG` instance.
+    ///
+    /// # Parameters
+    ///
+    /// * `rng`: The `RNG` struct instance to associate with this
+    ///   `Curve25519Key` instance.
+    ///
+    /// # Returns
+    ///
+    /// Returns Ok(()) on success or Err(e) containing the wolfSSL library
+    /// error code value.
     #[cfg(all(curve25519_blinding, random, feature = "alloc"))]
     pub fn set_shared_rng(&mut self, rng: alloc::rc::Rc<RNG>) -> Result<(), i32> {
         let wc_rng = rng.wc_rng;
@@ -525,7 +587,8 @@ impl Curve25519Key {
         Ok(())
     }
 
-    /// Borrow the RNG previously bound via `set_rng` or `set_shared_rng`.
+    /// Borrow the RNG previously bound via `generate`, `generate_shared_rng`,
+    /// `set_rng` or `set_shared_rng`.
     #[cfg(random)]
     pub fn rng(&self) -> Option<&RNG> {
         match &self.rng {

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_curve25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_curve25519.rs
@@ -1,15 +1,15 @@
 #![cfg(all(curve25519, random))]
 
-#[cfg(curve25519_blinding)]
+#[cfg(feature = "alloc")]
 use std::rc::Rc;
 use wolfssl_wolfcrypt::curve25519::*;
 use wolfssl_wolfcrypt::random::RNG;
 
 #[test]
 fn test_check_pub() {
-    let mut rng = RNG::new().expect("Error with new()");
+    let rng = RNG::new().expect("Error with new()");
     let mut private_buffer = [0u8; Curve25519Key::KEYSIZE];
-    Curve25519Key::generate_priv(&mut rng, &mut private_buffer).expect("Error with generate_priv()");
+    Curve25519Key::generate_priv(&rng, &mut private_buffer).expect("Error with generate_priv()");
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     Curve25519Key::make_pub(&private_buffer, &mut public_buffer).expect("Error with make_pub()");
     Curve25519Key::check_public(&public_buffer, false).expect("Error with check_public()");
@@ -17,15 +17,58 @@ fn test_check_pub() {
 
 #[test]
 fn test_generate_priv() {
-    let mut rng = RNG::new().expect("Error with new()");
+    let rng = RNG::new().expect("Error with new()");
     let mut private_buffer = [0u8; Curve25519Key::KEYSIZE];
-    Curve25519Key::generate_priv(&mut rng, &mut private_buffer).expect("Error with generate_priv()");
+    Curve25519Key::generate_priv(&rng, &mut private_buffer).expect("Error with generate_priv()");
+}
+
+#[test]
+fn test_generate() {
+    let rng = RNG::new().expect("Error with new()");
+    let key = Curve25519Key::generate(rng).expect("Error with generate()");
+    /* The key takes ownership of the RNG and keeps it alive. */
+    assert!(key.rng().is_some());
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn test_generate_shared_rng() {
+    let rng = Rc::new(RNG::new().expect("Error with new()"));
+    let mut key1 = Curve25519Key::generate_shared_rng(Rc::clone(&rng)).expect("Error with generate_shared_rng()");
+    let mut key2 = Curve25519Key::generate_shared_rng(Rc::clone(&rng)).expect("Error with generate_shared_rng()");
+    /* Both keys hold a reference to the same shared RNG. */
+    assert_eq!(Rc::strong_count(&rng), 3);
+    assert!(key1.rng().is_some());
+    assert!(key2.rng().is_some());
+
+    /* The keys are still independently generated. */
+    let mut public1 = [0u8; Curve25519Key::KEYSIZE];
+    let mut public2 = [0u8; Curve25519Key::KEYSIZE];
+    key1.export_public(&mut public1).expect("Error with export_public()");
+    key2.export_public(&mut public2).expect("Error with export_public()");
+    assert_ne!(public1, public2);
+
+    /* Dropping the keys releases their references to the shared RNG. */
+    drop(key1);
+    drop(key2);
+    assert_eq!(Rc::strong_count(&rng), 1);
+}
+
+#[test]
+fn test_import_no_rng() {
+    let rng = RNG::new().expect("Error with new()");
+    let mut key = Curve25519Key::generate(rng).expect("Error with generate()");
+    let mut private_buffer = [0u8; Curve25519Key::KEYSIZE];
+    key.export_private_raw(&mut private_buffer).expect("Error with export_private_raw()");
+    /* An imported key has no RNG bound to it until set_rng() is called. */
+    let imported = Curve25519Key::import_private(&private_buffer).expect("Error with import_private()");
+    assert!(imported.rng().is_none());
 }
 
 #[test]
 fn test_import_export_private() {
-    let mut rng = RNG::new().expect("Error with new()");
-    let mut curve25519key = Curve25519Key::generate(&mut rng).expect("Error with generate()");
+    let rng = RNG::new().expect("Error with new()");
+    let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
     let mut private_buffer = [0u8; Curve25519Key::KEYSIZE];
     curve25519key.export_private_raw(&mut private_buffer).expect("Error with export_private_raw()");
     Curve25519Key::import_private(&private_buffer).expect("Error with import_private()");
@@ -33,8 +76,8 @@ fn test_import_export_private() {
 
 #[test]
 fn test_import_export_private_ex() {
-    let mut rng = RNG::new().expect("Error with new()");
-    let mut curve25519key = Curve25519Key::generate(&mut rng).expect("Error with generate()");
+    let rng = RNG::new().expect("Error with new()");
+    let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
     let mut private_buffer = [0u8; Curve25519Key::KEYSIZE];
     curve25519key.export_private_raw_ex(&mut private_buffer, false).expect("Error with export_private_raw_ex()");
     Curve25519Key::import_private_ex(&private_buffer, false).expect("Error with import_private_ex()");
@@ -42,8 +85,8 @@ fn test_import_export_private_ex() {
 
 #[test]
 fn test_import_export_raw() {
-    let mut rng = RNG::new().expect("Error with new()");
-    let mut curve25519key = Curve25519Key::generate(&mut rng).expect("Error with generate()");
+    let rng = RNG::new().expect("Error with new()");
+    let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
     let mut private_buffer = [0u8; Curve25519Key::KEYSIZE];
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     curve25519key.export_key_raw(&mut private_buffer, &mut public_buffer).expect("Error with export_key_raw()");
@@ -52,8 +95,8 @@ fn test_import_export_raw() {
 
 #[test]
 fn test_import_export_raw_ex() {
-    let mut rng = RNG::new().expect("Error with new()");
-    let mut curve25519key = Curve25519Key::generate(&mut rng).expect("Error with generate()");
+    let rng = RNG::new().expect("Error with new()");
+    let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
     let mut private_buffer = [0u8; Curve25519Key::KEYSIZE];
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     curve25519key.export_key_raw_ex(&mut private_buffer, &mut public_buffer, false).expect("Error with export_key_raw_ex()");
@@ -62,8 +105,8 @@ fn test_import_export_raw_ex() {
 
 #[test]
 fn test_import_export_public() {
-    let mut rng = RNG::new().expect("Error with new()");
-    let mut curve25519key = Curve25519Key::generate(&mut rng).expect("Error with generate()");
+    let rng = RNG::new().expect("Error with new()");
+    let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     curve25519key.export_public(&mut public_buffer).expect("Error with export_public()");
     Curve25519Key::import_public(&public_buffer).expect("Error with import_public()");
@@ -71,8 +114,8 @@ fn test_import_export_public() {
 
 #[test]
 fn test_import_export_public_ex() {
-    let mut rng = RNG::new().expect("Error with new()");
-    let mut curve25519key = Curve25519Key::generate(&mut rng).expect("Error with generate()");
+    let rng = RNG::new().expect("Error with new()");
+    let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     curve25519key.export_public_ex(&mut public_buffer, false).expect("Error with export_public_ex()");
     Curve25519Key::import_public_ex(&public_buffer, false).expect("Error with import_public_ex()");
@@ -80,9 +123,9 @@ fn test_import_export_public_ex() {
 
 #[test]
 fn test_make_pub() {
-    let mut rng = RNG::new().expect("Error with new()");
+    let rng = RNG::new().expect("Error with new()");
     let mut private_buffer = [0u8; Curve25519Key::KEYSIZE];
-    Curve25519Key::generate_priv(&mut rng, &mut private_buffer).expect("Error with generate_priv()");
+    Curve25519Key::generate_priv(&rng, &mut private_buffer).expect("Error with generate_priv()");
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     Curve25519Key::make_pub(&private_buffer, &mut public_buffer).expect("Error with make_pub()");
 }
@@ -90,26 +133,27 @@ fn test_make_pub() {
 #[test]
 #[cfg(curve25519_blinding)]
 fn test_make_pub_blind() {
-    let mut rng = RNG::new().expect("Error with new()");
+    let rng = RNG::new().expect("Error with new()");
     let mut private_buffer = [0u8; Curve25519Key::KEYSIZE];
-    Curve25519Key::generate_priv(&mut rng, &mut private_buffer).expect("Error with generate_priv()");
+    Curve25519Key::generate_priv(&rng, &mut private_buffer).expect("Error with generate_priv()");
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
-    Curve25519Key::make_pub_blind(&private_buffer, &mut public_buffer, &mut rng).expect("Error with make_pub_blind()");
+    Curve25519Key::make_pub_blind(&private_buffer, &mut public_buffer, &rng).expect("Error with make_pub_blind()");
 }
 
 #[test]
 fn test_shared_secret() {
-    #[cfg(curve25519_blinding)]
+    /* With the alloc feature the two keys can share a single RNG. */
+    #[cfg(feature = "alloc")]
     let rng = Rc::new(RNG::new().expect("Error with new()"));
-    #[cfg(not(curve25519_blinding))]
-    let rng = RNG::new().expect("Error with new()");
-    let mut key1 = Curve25519Key::generate(&rng).expect("Error with generate()");
-    let mut key2 = Curve25519Key::generate(&rng).expect("Error with generate()");
-
-    #[cfg(curve25519_blinding)]
-    key1.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
-    #[cfg(curve25519_blinding)]
-    key2.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
+    #[cfg(feature = "alloc")]
+    let mut key1 = Curve25519Key::generate_shared_rng(Rc::clone(&rng)).expect("Error with generate_shared_rng()");
+    #[cfg(feature = "alloc")]
+    let mut key2 = Curve25519Key::generate_shared_rng(Rc::clone(&rng)).expect("Error with generate_shared_rng()");
+    /* Without it, each key owns its own RNG. */
+    #[cfg(not(feature = "alloc"))]
+    let mut key1 = Curve25519Key::generate(RNG::new().expect("Error with new()")).expect("Error with generate()");
+    #[cfg(not(feature = "alloc"))]
+    let mut key2 = Curve25519Key::generate(RNG::new().expect("Error with new()")).expect("Error with generate()");
 
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     key1.export_public(&mut public_buffer).expect("Error with export_public()");
@@ -127,17 +171,27 @@ fn test_shared_secret() {
 
 #[test]
 fn test_shared_secret_ex() {
-    #[cfg(curve25519_blinding)]
+    /* With the alloc feature the two keys can share a single RNG. */
+    #[cfg(feature = "alloc")]
     let rng = Rc::new(RNG::new().expect("Error with new()"));
-    #[cfg(not(curve25519_blinding))]
-    let rng = RNG::new().expect("Error with new()");
-    let mut key1 = Curve25519Key::generate(&rng).expect("Error with generate()");
-    let mut key2 = Curve25519Key::generate(&rng).expect("Error with generate()");
+    #[cfg(feature = "alloc")]
+    let mut key1 = Curve25519Key::generate_shared_rng(Rc::clone(&rng)).expect("Error with generate_shared_rng()");
+    #[cfg(feature = "alloc")]
+    let mut key2 = Curve25519Key::generate_shared_rng(Rc::clone(&rng)).expect("Error with generate_shared_rng()");
+    /* Without it, each key owns its own RNG. */
+    #[cfg(not(feature = "alloc"))]
+    let mut key1 = Curve25519Key::generate(RNG::new().expect("Error with new()")).expect("Error with generate()");
+    #[cfg(not(feature = "alloc"))]
+    let mut key2 = Curve25519Key::generate(RNG::new().expect("Error with new()")).expect("Error with generate()");
 
-    #[cfg(curve25519_blinding)]
+    #[cfg(all(curve25519_blinding, feature = "alloc"))]
     key1.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
-    #[cfg(curve25519_blinding)]
+    #[cfg(all(curve25519_blinding, feature = "alloc"))]
     key2.set_shared_rng(Rc::clone(&rng)).expect("Error with set_shared_rng()");
+    #[cfg(all(curve25519_blinding, not(feature = "alloc")))]
+    key1.set_rng(RNG::new().expect("Error with new()")).expect("Error with set_rng()");
+    #[cfg(all(curve25519_blinding, not(feature = "alloc")))]
+    key2.set_rng(RNG::new().expect("Error with new()")).expect("Error with set_rng()");
 
     let mut public_buffer = [0u8; Curve25519Key::KEYSIZE];
     key1.export_public(&mut public_buffer).expect("Error with export_public()");


### PR DESCRIPTION
# Description

Rust wrapper: curve25519: fix possible dangling WC_RNG pointer

Fixes F-11269

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
