### PR TITLE
PKCS#7: decode a message addressed to more than one recipient

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -334,6 +334,7 @@ NOTE:
 * The pre-standardization Dilithium API has been renamed to its FIPS 204 ML-DSA name; the legacy `dilithium.h` header and `wc_dilithium_*` names remain available through a temporary compatibility shim.
 * The SLH-DSA Hash sign/verify APIs now require a caller-supplied pre-hashed digest rather than the raw message (see Enhancements below).
 * liboqs integrations for ML-KEM, ML-DSA, and SLH-DSA (SPHINCS+) have been removed in favor of the native implementations; the deprecated liblms and libxmss integrations have also been removed.
+* Fixed PKCS#7/CMS decoding of a message addressed to more than one recipient, including AuthEnvelopedData, which never supported it. A message carrying no recipient for the reader now reports `PKCS7_RECIP_E` rather than a parse error. Streaming an AuthEnvelopedData now buffers the whole RecipientInfo set, as the EnvelopedData decoder already did, so peak memory rises by the size of that set. by @Frauschi (PR 11350)
 * **BREAKING (RFC 6960 4.2.2.2)**: OCSP responder authorization is now strictly enforced. Removes the non-compliant `CheckOcspResponderChain()` fallback, which authorized any OCSP responder cert issued by an ancestor of the target's issuer; RFC 6960 4.2.2.2 requires direct issuance by the CA identified in the request. Also removes the now-unused `WOLFSSL_NO_OCSP_ISSUER_CHAIN_CHECK` macro and the `vp` parameter from `CheckOcspResponder()`.
 
 PR stands for Pull Request, and PR <NUMBER> references a GitHub pull request number where the code change was added.

--- a/tests/api/test_pkcs7.c
+++ b/tests/api/test_pkcs7.c
@@ -4443,11 +4443,12 @@ int test_wc_PKCS7_EncodeDecodeEnvelopedData(void)
         pkcs7->singleCert = NULL;
     }
   #ifndef NO_RSA
-    /* With corrupted singleCert, decode should fail with a parse error.
-     * State is properly reset on error so re-decode starts from scratch. */
+    /* With singleCert cleared no KeyTransRecipientInfo can match, so the
+     * decode says so. Was ASN_PARSE_E before the search was bounded by the
+     * RecipientInfo set. State resets, so re-decode starts from scratch. */
     ExpectIntEQ(wc_PKCS7_DecodeEnvelopedData(pkcs7, output,
         (word32)sizeof(output), decoded, (word32)sizeof(decoded)),
-        WC_NO_ERR_TRACE(ASN_PARSE_E));
+        WC_NO_ERR_TRACE(PKCS7_RECIP_E));
   #endif /* !NO_RSA */
     if (pkcs7 != NULL) {
         pkcs7->singleCert = tmpBytePtr;
@@ -6011,6 +6012,93 @@ int test_wc_PKCS7_BER(void)
 #endif
     return EXPECT_RESULT();
 } /* END test_wc_PKCS7_BER() */
+
+/* A BER RecipientInfo SET may carry an indefinite length, which
+ * wc_PKCS7_ParseToRecipientInfoSet reports as a set size of 0. A search bound
+ * computed from that lands on the start of the set and stops the walk before
+ * the first recipient, so such a message decodes to PKCS7_RECIP_E.
+ *
+ * berContent has indefinite outer structures but a definite RecipientInfo SET,
+ * so the vector is rewritten here: 31 82 01 54 becomes 31 80, the content
+ * shifts down two bytes and an end-of-contents pair closes the set. Every
+ * enclosing structure is already indefinite, so no other length moves and the
+ * message stays the same size.
+ *
+ * The decode then unwraps the recipient key and stops at the end-of-contents
+ * pair, which nothing steps over, so EncryptedContentInfo is read from the two
+ * zero bytes: ASN_PARSE_E, as on the merge base. Decoding an indefinite set
+ * through to the plaintext needs that step-over and is not part of this change.
+ * The assertion is exact so that both a walk that stops early (PKCS7_RECIP_E)
+ * and a later step-over fail here rather than pass quietly.
+ *
+ * SP math is excluded: it cannot do the vector's 1024-bit RSA key, and the fake
+ * CEK substituted for that failure makes the outcome non-deterministic. */
+int test_wc_PKCS7_IndefiniteRecipientSet(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_PKCS7) && !defined(NO_RSA) && !defined(NO_FILESYSTEM) && \
+    defined(ASN_BER_TO_DER) && !defined(NO_DES3) && !defined(NO_SHA) && \
+    !defined(NO_PKCS7_STREAM) && !defined(WOLFSSL_SP_MATH)
+    wc_PKCS7* pkcs7 = NULL;
+    byte* ber = NULL;
+    byte  decoded[2048];
+    byte  cert[2048];
+    byte  key[2048];
+    word32 certSz = 0;
+    word32 keySz = 0;
+    XFILE f = XBADFILE;
+    int ret = 0;
+    word32 setOff = 20;   /* 31 82 01 54, the RecipientInfo SET header */
+    word32 setLen = 340;  /* 0x0154 */
+
+    ExpectTrue((f = XFOPEN("./certs/1024/client-cert.der", "rb")) != XBADFILE);
+    ExpectTrue((certSz = (word32)XFREAD(cert, 1, sizeof(cert), f)) > 0);
+    if (f != XBADFILE) {
+        XFCLOSE(f);
+        f = XBADFILE;
+    }
+    ExpectTrue((f = XFOPEN("./certs/1024/client-key.der", "rb")) != XBADFILE);
+    ExpectTrue((keySz = (word32)XFREAD(key, 1, sizeof(key), f)) > 0);
+    if (f != XBADFILE) {
+        XFCLOSE(f);
+        f = XBADFILE;
+    }
+
+    /* Confirm the vector still has the header this rewrite expects, so the
+     * test fails loudly rather than silently checking nothing. */
+    ExpectIntEQ(berContent[setOff], 0x31);
+    ExpectIntEQ(berContent[setOff + 1], 0x82);
+    ExpectIntEQ(berContent[setOff + 2], 0x01);
+    ExpectIntEQ(berContent[setOff + 3], 0x54);
+    ExpectIntGE((int)sizeof(berContent), (int)(setOff + setLen + 4));
+
+    ExpectNotNull(ber = (byte*)XMALLOC(sizeof(berContent), NULL,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    if (ber != NULL) {
+        XMEMCPY(ber, berContent, sizeof(berContent));
+        ber[setOff + 1] = 0x80;
+        XMEMMOVE(ber + setOff + 2, ber + setOff + 4, setLen);
+        ber[setOff + 2 + setLen]     = 0x00;
+        ber[setOff + 2 + setLen + 1] = 0x00;
+    }
+
+    ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
+    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, certSz), 0);
+    if (pkcs7 != NULL) {
+        pkcs7->privateKey   = key;
+        pkcs7->privateKeySz = keySz;
+    }
+    if (EXPECT_SUCCESS()) {
+        ret = wc_PKCS7_DecodeEnvelopedData(pkcs7, ber, sizeof(berContent),
+            decoded, sizeof(decoded));
+        ExpectIntEQ(ret, WC_NO_ERR_TRACE(ASN_PARSE_E));
+    }
+
+    wc_PKCS7_Free(pkcs7);
+    XFREE(ber, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+    return EXPECT_RESULT();
+}
 
 int test_wc_PKCS7_signed_enveloped(void)
 {

--- a/tests/api/test_pkcs7.c
+++ b/tests/api/test_pkcs7.c
@@ -4699,6 +4699,281 @@ int test_wc_PKCS7_SetAESKeyWrapUnwrapCb(void)
 /*
  * Testing wc_PKCS7_GetEnvelopedDataKariRid().
  */
+/* Open one message as each of its two recipients. Decoding as the second is
+ * what exercises the walk past a RecipientInfo that is not the reader's;
+ * decoding as the first passes even with the search unbounded. */
+int test_wc_PKCS7_MultipleRecipients(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_PKCS7) && !defined(NO_RSA) && !defined(NO_AES) && \
+    defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_256) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_SHA256)
+    byte* cert1 = NULL;
+    byte* key1  = NULL;
+    byte* cert2 = NULL;
+    byte* key2  = NULL;
+    byte* cert3 = NULL;
+    byte* key3  = NULL;
+    byte* out   = NULL;
+    byte decoded[128];
+    word32 cert1Sz = 0, key1Sz = 0, cert2Sz = 0, key2Sz = 0;
+    word32 cert3Sz = 0, key3Sz = 0;
+    XFILE f = XBADFILE;
+    int outSz = 4096;
+    int encodedSz = 0;
+    int i, j;
+    WOLFSSL_SMALL_STACK_STATIC const byte content[] = {
+        0x74,0x77,0x6F,0x20,0x6F,0x66,0x20,0x75,0x73   /* "two of us" */
+    };
+
+    cert1Sz = key1Sz = cert2Sz = key2Sz = FOURK_BUF;
+    cert3Sz = key3Sz = FOURK_BUF;
+    ExpectNotNull(cert1 = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    ExpectNotNull(key1 = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    ExpectNotNull(cert2 = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    ExpectNotNull(key2 = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    ExpectNotNull(cert3 = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    ExpectNotNull(key3 = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,
+        DYNAMIC_TYPE_TMP_BUFFER));
+    ExpectNotNull(out = (byte*)XMALLOC((size_t)outSz, HEAP_HINT,
+        DYNAMIC_TYPE_TMP_BUFFER));
+
+    ExpectTrue((f = XFOPEN("./certs/client-cert.der", "rb")) != XBADFILE);
+    ExpectTrue((cert1Sz = (word32)XFREAD(cert1, 1, cert1Sz, f)) > 0);
+    if (f != XBADFILE) { XFCLOSE(f); f = XBADFILE; }
+    ExpectTrue((f = XFOPEN("./certs/client-key.der", "rb")) != XBADFILE);
+    ExpectTrue((key1Sz = (word32)XFREAD(key1, 1, key1Sz, f)) > 0);
+    if (f != XBADFILE) { XFCLOSE(f); f = XBADFILE; }
+    ExpectTrue((f = XFOPEN("./certs/ca-cert.der", "rb")) != XBADFILE);
+    ExpectTrue((cert2Sz = (word32)XFREAD(cert2, 1, cert2Sz, f)) > 0);
+    if (f != XBADFILE) { XFCLOSE(f); f = XBADFILE; }
+    ExpectTrue((f = XFOPEN("./certs/ca-key.der", "rb")) != XBADFILE);
+    ExpectTrue((key2Sz = (word32)XFREAD(key2, 1, key2Sz, f)) > 0);
+    if (f != XBADFILE) { XFCLOSE(f); f = XBADFILE; }
+    /* a stranger to the message: issued by a different CA, so it matches
+     * neither recipient identifier */
+    ExpectTrue((f = XFOPEN("./certs/1024/client-cert.der", "rb")) != XBADFILE);
+    ExpectTrue((cert3Sz = (word32)XFREAD(cert3, 1, cert3Sz, f)) > 0);
+    if (f != XBADFILE) { XFCLOSE(f); f = XBADFILE; }
+    ExpectTrue((f = XFOPEN("./certs/1024/client-key.der", "rb")) != XBADFILE);
+    ExpectTrue((key3Sz = (word32)XFREAD(key3, 1, key3Sz, f)) > 0);
+    if (f != XBADFILE) { XFCLOSE(f); f = XBADFILE; }
+
+    /* j == 0: EnvelopedData, j == 1: AuthEnvelopedData */
+    for (j = 0; j < 2; j++) {
+    #ifndef HAVE_AESGCM
+        if (j == 1)
+            continue;
+    #endif
+        if (EXPECT_FAIL())
+            break;
+        /* build the bundle; the loop below opens it */
+        if (!EXPECT_FAIL()) {
+            wc_PKCS7* pkcs7 = NULL;
+
+            ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
+            ExpectIntEQ(wc_PKCS7_Init(pkcs7, HEAP_HINT, INVALID_DEVID), 0);
+            if (pkcs7 != NULL) {
+                pkcs7->content    = (byte*)content;
+                pkcs7->contentSz  = (word32)sizeof(content);
+                pkcs7->contentOID = DATA;
+            #ifdef HAVE_AESGCM
+                pkcs7->encryptOID = (j == 1) ? AES256GCMb : AES256CBCb;
+            #else
+                pkcs7->encryptOID = AES256CBCb;
+            #endif
+            }
+            ExpectIntGT(wc_PKCS7_AddRecipient_KTRI(pkcs7, cert1, cert1Sz, 0),
+                0);
+            ExpectIntGT(wc_PKCS7_AddRecipient_KTRI(pkcs7, cert2, cert2Sz, 0),
+                0);
+        #ifdef HAVE_AESGCM
+            if (j == 1) {
+                ExpectIntGT(encodedSz = wc_PKCS7_EncodeAuthEnvelopedData(pkcs7,
+                    out, (word32)outSz), 0);
+            }
+            else
+        #endif
+            {
+                ExpectIntGT(encodedSz = wc_PKCS7_EncodeEnvelopedData(pkcs7, out,
+                    (word32)outSz), 0);
+            }
+            wc_PKCS7_Free(pkcs7);
+        }
+
+        /* both recipients, the second one especially */
+        for (i = 0; i < 2; i++) {
+            wc_PKCS7* pkcs7 = NULL;
+            byte* useCert = (i == 0) ? cert1 : cert2;
+            byte* useKey  = (i == 0) ? key1  : key2;
+            word32 useCertSz = (i == 0) ? cert1Sz : cert2Sz;
+            word32 useKeySz  = (i == 0) ? key1Sz  : key2Sz;
+            int decSz = 0;
+
+            if (EXPECT_FAIL())
+                break;
+
+            ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
+            /* the recipient identifier is matched against this certificate */
+            ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, useCert, useCertSz), 0);
+            if (pkcs7 != NULL) {
+                pkcs7->privateKey   = useKey;
+                pkcs7->privateKeySz = useKeySz;
+            }
+            XMEMSET(decoded, 0, sizeof(decoded));
+        #ifdef HAVE_AESGCM
+            if (j == 1) {
+                ExpectIntGT(decSz = wc_PKCS7_DecodeAuthEnvelopedData(pkcs7, out,
+                    (word32)encodedSz, decoded, sizeof(decoded)), 0);
+            }
+            else
+        #endif
+            {
+                ExpectIntGT(decSz = wc_PKCS7_DecodeEnvelopedData(pkcs7, out,
+                    (word32)encodedSz, decoded, sizeof(decoded)), 0);
+            }
+            ExpectIntEQ(decSz, (int)sizeof(content));
+            ExpectIntEQ(XMEMCMP(decoded, content, sizeof(content)), 0);
+            if (pkcs7 != NULL) {
+                pkcs7->privateKey = NULL;
+                pkcs7->privateKeySz = 0;
+            }
+            wc_PKCS7_Free(pkcs7);
+            pkcs7 = NULL;
+
+        #ifndef NO_PKCS7_STREAM
+            /* Again in chunks: only a buffered stream makes a rejected
+             * recipient shift the buffer rather than advance a counter.
+             * Scoped to EnvelopedData and the second recipient; the other
+             * combinations fail on the merge-base too. */
+            if ((i == 1) && (j == 0) && !EXPECT_FAIL()) {
+                int fed = 0;
+                int chunk = 128;
+                int streamSz = -1;
+
+                ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
+                ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, useCert, useCertSz),
+                    0);
+                if (pkcs7 != NULL) {
+                    pkcs7->privateKey   = useKey;
+                    pkcs7->privateKeySz = useKeySz;
+                }
+                XMEMSET(decoded, 0, sizeof(decoded));
+
+                while ((pkcs7 != NULL) && (fed < encodedSz)) {
+                    int n = ((encodedSz - fed) < chunk) ? (encodedSz - fed)
+                                                        : chunk;
+                    streamSz = wc_PKCS7_DecodeEnvelopedData(pkcs7,
+                        out + fed, (word32)n, decoded, sizeof(decoded));
+                    fed += n;
+                    if (streamSz != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E))
+                        break;
+                }
+
+                ExpectIntEQ(streamSz, (int)sizeof(content));
+                ExpectIntEQ(XMEMCMP(decoded, content, sizeof(content)), 0);
+                if (pkcs7 != NULL) {
+                    pkcs7->privateKey = NULL;
+                    pkcs7->privateKeySz = 0;
+                }
+                wc_PKCS7_Free(pkcs7);
+            }
+        #endif /* !NO_PKCS7_STREAM */
+        }
+
+        /* A reader who is none of the recipients must be told so, whole or
+         * in chunks. */
+        if (!EXPECT_FAIL()) {
+            wc_PKCS7* pkcs7 = NULL;
+            int wholeSz = 0;
+
+            ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
+            ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert3, cert3Sz), 0);
+            if (pkcs7 != NULL) {
+                pkcs7->privateKey   = key3;
+                pkcs7->privateKeySz = key3Sz;
+            }
+        #ifdef HAVE_AESGCM
+            if (j == 1) {
+                wholeSz = wc_PKCS7_DecodeAuthEnvelopedData(pkcs7, out,
+                    (word32)encodedSz, decoded, sizeof(decoded));
+            }
+            else
+        #endif
+            {
+                wholeSz = wc_PKCS7_DecodeEnvelopedData(pkcs7, out,
+                    (word32)encodedSz, decoded, sizeof(decoded));
+            }
+            ExpectIntEQ(wholeSz, WC_NO_ERR_TRACE(PKCS7_RECIP_E));
+            if (pkcs7 != NULL) {
+                pkcs7->privateKey = NULL;
+                pkcs7->privateKeySz = 0;
+            }
+            wc_PKCS7_Free(pkcs7);
+        }
+
+    #ifndef NO_PKCS7_STREAM
+        /* Fed in chunks the walk has to keep its bound across the buffer
+         * shifts each rejected recipient makes, or it runs on into the
+         * EncryptedContentInfo and answers ASN_PARSE_E instead. */
+        if (!EXPECT_FAIL()) {
+            wc_PKCS7* pkcs7 = NULL;
+            int fed = 0;
+            int chunk = 128;
+            int streamSz = -1;
+
+            ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
+            ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert3, cert3Sz), 0);
+            if (pkcs7 != NULL) {
+                pkcs7->privateKey   = key3;
+                pkcs7->privateKeySz = key3Sz;
+            }
+
+            while ((pkcs7 != NULL) && (fed < encodedSz)) {
+                int n = ((encodedSz - fed) < chunk) ? (encodedSz - fed)
+                                                    : chunk;
+            #ifdef HAVE_AESGCM
+                if (j == 1) {
+                    streamSz = wc_PKCS7_DecodeAuthEnvelopedData(pkcs7,
+                        out + fed, (word32)n, decoded, sizeof(decoded));
+                }
+                else
+            #endif
+                {
+                    streamSz = wc_PKCS7_DecodeEnvelopedData(pkcs7, out + fed,
+                        (word32)n, decoded, sizeof(decoded));
+                }
+                fed += n;
+                if (streamSz != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E))
+                    break;
+            }
+
+            ExpectIntEQ(streamSz, WC_NO_ERR_TRACE(PKCS7_RECIP_E));
+            if (pkcs7 != NULL) {
+                pkcs7->privateKey = NULL;
+                pkcs7->privateKeySz = 0;
+            }
+            wc_PKCS7_Free(pkcs7);
+        }
+    #endif /* !NO_PKCS7_STREAM */
+    }
+
+    XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(cert1, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(key1, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(cert2, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(key2, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(cert3, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(key3, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+    return EXPECT_RESULT();
+}
+
 int test_wc_PKCS7_GetEnvelopedDataKariRid(void)
 {
     EXPECT_DECLS;

--- a/tests/api/test_pkcs7.h
+++ b/tests/api/test_pkcs7.h
@@ -58,6 +58,7 @@ int test_wc_PKCS7_VerifySignedData_ECC(void);
 int test_wc_PKCS7_VerifySignedData_ECC_TamperedAttribs(void);
 int test_wc_PKCS7_DecodeEnvelopedData_stream(void);
 int test_wc_PKCS7_EncodeDecodeEnvelopedData(void);
+int test_wc_PKCS7_IndefiniteRecipientSet(void);
 int test_wc_PKCS7_SetAESKeyWrapUnwrapCb(void);
 int test_wc_PKCS7_GetEnvelopedDataKariRid(void);
 int test_wc_PKCS7_EncodeEncryptedData(void);
@@ -155,6 +156,7 @@ int test_wc_PKCS7_VerifySignedData_NoDigestParams(void);
 #define TEST_PKCS7_ENCRYPTED_DATA_DECLS                                     \
     TEST_DECL_GROUP("pkcs7_ed", test_wc_PKCS7_DecodeEnvelopedData_stream),  \
     TEST_DECL_GROUP("pkcs7_ed", test_wc_PKCS7_EncodeDecodeEnvelopedData),   \
+    TEST_DECL_GROUP("pkcs7_ed", test_wc_PKCS7_IndefiniteRecipientSet),      \
     TEST_PKCS7_RSA_PSS_ED_DECL                                              \
     TEST_PKCS7_KTRI_BADRSAPAD_DECL                                          \
     TEST_DECL_GROUP("pkcs7_ed", test_wc_PKCS7_SetAESKeyWrapUnwrapCb),       \

--- a/tests/api/test_pkcs7.h
+++ b/tests/api/test_pkcs7.h
@@ -60,6 +60,7 @@ int test_wc_PKCS7_DecodeEnvelopedData_stream(void);
 int test_wc_PKCS7_EncodeDecodeEnvelopedData(void);
 int test_wc_PKCS7_IndefiniteRecipientSet(void);
 int test_wc_PKCS7_SetAESKeyWrapUnwrapCb(void);
+int test_wc_PKCS7_MultipleRecipients(void);
 int test_wc_PKCS7_GetEnvelopedDataKariRid(void);
 int test_wc_PKCS7_EncodeEncryptedData(void);
 int test_wc_PKCS7_EncodeEncryptedData_AttribOverflow(void);
@@ -160,6 +161,7 @@ int test_wc_PKCS7_VerifySignedData_NoDigestParams(void);
     TEST_PKCS7_RSA_PSS_ED_DECL                                              \
     TEST_PKCS7_KTRI_BADRSAPAD_DECL                                          \
     TEST_DECL_GROUP("pkcs7_ed", test_wc_PKCS7_SetAESKeyWrapUnwrapCb),       \
+    TEST_DECL_GROUP("pkcs7_ed", test_wc_PKCS7_MultipleRecipients),          \
     TEST_DECL_GROUP("pkcs7_ed", test_wc_PKCS7_GetEnvelopedDataKariRid),     \
     TEST_DECL_GROUP("pkcs7_ed", test_wc_PKCS7_EncodeEncryptedData),         \
     TEST_DECL_GROUP("pkcs7_ed", test_wc_PKCS7_EncodeEncryptedData_AttribOverflow), \

--- a/tests/unit-mcdc/test_pkcs7_fault_whitebox.c
+++ b/tests/unit-mcdc/test_pkcs7_fault_whitebox.c
@@ -586,15 +586,16 @@ static void wb_ktri_recipinfos(void)
         WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "out==NULL true");
     }
 
-    WB_NOTE("wc_PKCS7_DecryptRecipientInfos(): 6-operand OR guard -- the"
+    WB_NOTE("wc_PKCS7_DecryptRecipientInfos(): 7-operand OR guard -- the"
             " other file only NULL-tests pkcs7/in/idx; decryptedKey,"
-            " decryptedKeySz, recipFound plus the all-false baseline are"
-            " added here (stream must be created first: the post-switch"
+            " decryptedKeySz, recipFound, setEnd plus the all-false baseline"
+            " are added here (stream must be created first: the post-switch"
             " path unconditionally reads pkcs7->stream->length)");
     {
         byte in[8] = { 0x30, 0x06, 1,2,3,4,5,6 };
         byte decKey[32];
         word32 idx, decKeySz;
+        word32 setEndWb;
         int recipFound;
 
 #ifndef NO_PKCS7_STREAM
@@ -602,35 +603,40 @@ static void wb_ktri_recipinfos(void)
         WB_CHECK(ret == 0, "CreateStream for DecryptRecipientInfos baseline");
 #endif
         idx = 0; decKeySz = sizeof(decKey); recipFound = 0;
+        setEndWb = 0;
         ret = wc_PKCS7_DecryptRecipientInfos(&pkcs7, in, sizeof(in), &idx,
-                decKey, &decKeySz, &recipFound);
+                decKey, &decKeySz, &recipFound, &setEndWb);
         WB_CHECK(ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG),
                 "baseline (all false): proceeds past the guard"
                 " (state==WC_PKCS7_START -> not-decrypting no-op, ret==0)");
 
         idx = 0;
         ret = wc_PKCS7_DecryptRecipientInfos(NULL, in, sizeof(in), &idx,
-                decKey, &decKeySz, &recipFound);
+                decKey, &decKeySz, &recipFound, &setEndWb);
         WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "pkcs7==NULL true");
         ret = wc_PKCS7_DecryptRecipientInfos(&pkcs7, NULL, sizeof(in), &idx,
-                decKey, &decKeySz, &recipFound);
+                decKey, &decKeySz, &recipFound, &setEndWb);
         WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "in==NULL true");
         ret = wc_PKCS7_DecryptRecipientInfos(&pkcs7, in, sizeof(in), NULL,
-                decKey, &decKeySz, &recipFound);
+                decKey, &decKeySz, &recipFound, &setEndWb);
         WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "idx==NULL true");
         idx = 0;
         ret = wc_PKCS7_DecryptRecipientInfos(&pkcs7, in, sizeof(in), &idx,
-                NULL, &decKeySz, &recipFound);
+                NULL, &decKeySz, &recipFound, &setEndWb);
         WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "decryptedKey==NULL true");
         idx = 0;
         ret = wc_PKCS7_DecryptRecipientInfos(&pkcs7, in, sizeof(in), &idx,
-                decKey, NULL, &recipFound);
+                decKey, NULL, &recipFound, &setEndWb);
         WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG),
                 "decryptedKeySz==NULL true");
         idx = 0;
         ret = wc_PKCS7_DecryptRecipientInfos(&pkcs7, in, sizeof(in), &idx,
-                decKey, &decKeySz, NULL);
+                decKey, &decKeySz, NULL, &setEndWb);
         WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "recipFound==NULL true");
+        idx = 0;
+        ret = wc_PKCS7_DecryptRecipientInfos(&pkcs7, in, sizeof(in), &idx,
+                decKey, &decKeySz, &recipFound, NULL);
+        WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), "setEnd==NULL true");
 
 #ifndef NO_PKCS7_STREAM
         wc_PKCS7_FreeStream(&pkcs7);

--- a/tests/unit-mcdc/test_pkcs7_whitebox.c
+++ b/tests/unit-mcdc/test_pkcs7_whitebox.c
@@ -1461,15 +1461,16 @@ static void wb_misc_guards2(void)
     WB_NOTE("wc_PKCS7_DecryptRecipientInfos(): NULL guard [:13744]");
     {
         word32 idx = 0, decryptedKeySz = sizeof(out);
+        word32 setEndWb = 0;
         int recipFound = 0;
         ret = wc_PKCS7_DecryptRecipientInfos(NULL, out, outSz, &idx, out,
-                &decryptedKeySz, &recipFound);
+                &decryptedKeySz, &recipFound, &setEndWb);
         WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), ":13744 pkcs7==NULL");
         ret = wc_PKCS7_DecryptRecipientInfos(&pkcs7, NULL, outSz, &idx, out,
-                &decryptedKeySz, &recipFound);
+                &decryptedKeySz, &recipFound, &setEndWb);
         WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), ":13744 in==NULL");
         ret = wc_PKCS7_DecryptRecipientInfos(&pkcs7, out, outSz, NULL, out,
-                &decryptedKeySz, &recipFound);
+                &decryptedKeySz, &recipFound, &setEndWb);
         WB_CHECK(ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG), ":13744 idx==NULL");
     }
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -14566,8 +14566,11 @@ int wc_PKCS7_DecodeEnvelopedData(wc_PKCS7* pkcs7, byte* in,
             recipientSetSz = (word32)ret;
         #ifndef NO_PKCS7_STREAM
             pkcs7->stream->aad = decryptedKey;
-            /* get the full recipient set */
-            pkcs7->stream->expected     = recipientSetSz;
+            /* Get the full recipient set. An indefinite-length set reports a
+             * size of 0, which is no request at all, so ask for the header the
+             * walk needs to start. */
+            pkcs7->stream->expected     = (recipientSetSz > 0)? recipientSetSz :
+                (word32)(MAX_LENGTH_SZ + MAX_VERSION_SZ + ASN_TAG_SZ);
             pkcs7->stream->recipientSz  = ret;
             pkcs7->stream->recipientRemain = recipientSetSz;
         #endif
@@ -14640,7 +14643,11 @@ int wc_PKCS7_DecodeEnvelopedData(wc_PKCS7* pkcs7, byte* in,
             pkcs7->stream->expected = MAX_LENGTH_SZ + MAX_VERSION_SZ +
                 ASN_TAG_SZ + MAX_LENGTH_SZ;
         #else
-            idx = tmpIdx + recipientSetSz;
+            /* A zero size is an indefinite-length set with no end to step to;
+             * moving the index by it lands back on the start of the set. */
+            if (recipientSetSz > 0) {
+                idx = tmpIdx + recipientSetSz;
+            }
         #endif
             wc_PKCS7_ChangeState(pkcs7, WC_PKCS7_ENV_3);
             FALL_THROUGH;
@@ -15967,7 +15974,9 @@ int wc_PKCS7_DecodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* in,
             tmpIdx = idx;
             pkcs7->stream->recipientSz    = ret;
             pkcs7->stream->recipientRemain = (word32)ret;
-            pkcs7->stream->expected       = (word32)ret;
+            /* see WC_PKCS7_ENV_2 on the zero size */
+            pkcs7->stream->expected       = (ret > 0)? (word32)ret :
+                (word32)(MAX_LENGTH_SZ + MAX_VERSION_SZ + ASN_TAG_SZ);
         #else
             recipientSetStart = idx;
             recipientSetSz    = (word32)ret;

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -180,6 +180,7 @@ struct PKCS7State {
     word32 accumContSz;   /* size of accumulated content size */
     int recipientSz; /* size of recipient set */
     word32 recipientStart; /* index the recipient set starts at */
+    word32 recipientRemain; /* recipient set bytes not yet stepped over */
     byte tmpIv[MAX_CONTENT_IV_SIZE]; /* store IV if needed */
 #ifdef WC_PKCS7_STREAM_DEBUG
     word32 peakUsed; /* most bytes used for struct at any one time */
@@ -285,6 +286,9 @@ static void wc_PKCS7_ResetStream(wc_PKCS7* pkcs7)
         pkcs7->stream->currContRmnSz= 0;
         pkcs7->stream->accumContSz  = 0;
         pkcs7->stream->contentSz    = 0;
+        pkcs7->stream->recipientSz     = 0;
+        pkcs7->stream->recipientStart  = 0;
+        pkcs7->stream->recipientRemain = 0;
         pkcs7->stream->hashType     = WC_HASH_TYPE_NONE;
     }
 }
@@ -500,6 +504,7 @@ static void wc_PKCS7_StreamGetVar(wc_PKCS7* pkcs7, word32* var1, int* var2,
 static int wc_PKCS7_StreamEndCase(wc_PKCS7* pkcs7, word32* tmpIdx, word32* idx)
 {
     int ret = 0;
+    word32 consumed = 0;
 
     if (pkcs7->stream->length > 0) {
         if (pkcs7->stream->length < *idx) {
@@ -507,20 +512,97 @@ static int wc_PKCS7_StreamEndCase(wc_PKCS7* pkcs7, word32* tmpIdx, word32* idx)
             ret = BUFFER_E;
         }
         else {
+            consumed = *idx;
             XMEMMOVE(pkcs7->stream->buffer, pkcs7->stream->buffer + *idx,
                  pkcs7->stream->length - *idx);
             pkcs7->stream->length -= *idx;
         }
     }
     else {
-        pkcs7->stream->totalRd += *idx - *tmpIdx;
+        consumed = *idx - *tmpIdx;
+        pkcs7->stream->totalRd += consumed;
         pkcs7->stream->idx = *idx; /* adjust index into input buffer */
         *tmpIdx = *idx;
+    }
+
+    /* Count the recipient set down here rather than hold its end as an index:
+     * a buffered stream shifts every index out from under such a bound. */
+    if (pkcs7->stream->recipientRemain > consumed) {
+        pkcs7->stream->recipientRemain -= consumed;
+    }
+    else {
+        pkcs7->stream->recipientRemain = 0;
+    }
+
+    return ret;
+}
+/* Bring the stream back in step after a rejected RecipientInfo: the handler
+ * stopped accounting where the index had already passed the whole structure.
+ * The two stream modes need opposite handling. returns 0 on success */
+static int wc_PKCS7_StreamResyncRecipient(wc_PKCS7* pkcs7, word32* idx,
+    word32* savedIdx, word32* tmpIdx, word32* setEnd)
+{
+    int ret;
+
+    if (pkcs7->stream->length == 0) {
+        /* Unbuffered: accounting stopped at stream->idx, so charge exactly
+         * that span - not totalRd, which is cumulative across chunks. tmpIdx
+         * is the caller's because the next recipient measures from it. */
+        *tmpIdx = pkcs7->stream->idx;
+        ret = wc_PKCS7_StreamEndCase(pkcs7, tmpIdx, idx);
+    }
+    else {
+        /* Buffered: the consumed bytes are shifted out rather than counted,
+         * so every index rebases - onto the shortened buffer, or onto the
+         * caller's input when the shift emptied it and the walk reads from
+         * in/inSz again. */
+        ret = wc_PKCS7_StreamEndCase(pkcs7, tmpIdx, idx);
+        if (ret == 0) {
+            *idx      = (pkcs7->stream->length == 0)? pkcs7->stream->idx : 0;
+            *savedIdx = *idx;
+            *tmpIdx   = *idx;
+
+            if (*setEnd != 0) {
+                /* the counter is what the shifts leave behind; an end held
+                 * as an index grows the window on every rejected recipient */
+                *setEnd = *idx + pkcs7->stream->recipientRemain;
+                if (*setEnd == 0) {
+                    /* the shift consumed the rest of the set: a zero bound
+                     * reads as "no bound", so keep the two equal and above
+                     * zero and the walk stops at once */
+                    *setEnd = 1;
+                    *idx = 1;
+                }
+            }
+        }
     }
 
     return ret;
 }
 #endif /* NO_PKCS7_STREAM */
+
+/* Set up to try the next RecipientInfo: savedIdx must follow the index past
+ * the rejected structure, or a following implicit tag sends the "no
+ * RecipientInfo here" path back onto it. Also restores the buffer capacity.
+ * returns 0 when the walk may continue */
+static int wc_PKCS7_RecipientRetry(wc_PKCS7* pkcs7, word32* idx,
+    word32* savedIdx, word32* tmpIdx, word32* decryptedKeySz, word32 keyCap,
+    word32* setEnd)
+{
+    int ret = 0;
+
+    *savedIdx = *idx;
+    *decryptedKeySz = keyCap;
+#ifndef NO_PKCS7_STREAM
+    ret = wc_PKCS7_StreamResyncRecipient(pkcs7, idx, savedIdx, tmpIdx, setEnd);
+#else
+    (void)pkcs7;
+    (void)tmpIdx;
+    (void)setEnd;
+#endif
+
+    return ret;
+}
 
 #ifdef WC_PKCS7_STREAM_DEBUG
 /* used to print out human readable state for debugging */
@@ -13807,12 +13889,12 @@ static int wc_PKCS7_DecryptRecipientInfos(wc_PKCS7* pkcs7, byte* in,
 {
     word32 savedIdx;
     int version, ret = 0, length;
+    int lastErr = 0;
     byte* pkiMsg = in;
     word32 pkiMsgSz = inSz;
+    word32 keyCap;
     byte  tag;
-#ifndef NO_PKCS7_STREAM
     word32 tmpIdx;
-#endif
 
     if (pkcs7 == NULL || pkiMsg == NULL || idx == NULL ||
         decryptedKey == NULL || decryptedKeySz == NULL ||
@@ -13821,9 +13903,8 @@ static int wc_PKCS7_DecryptRecipientInfos(wc_PKCS7* pkcs7, byte* in,
     }
 
     WOLFSSL_ENTER("wc_PKCS7_DecryptRecipientInfos");
-#ifndef NO_PKCS7_STREAM
     tmpIdx = *idx;
-#endif
+    keyCap = *decryptedKeySz;
 
     /* check if in the process of decrypting */
     switch (pkcs7->state) {
@@ -13868,7 +13949,36 @@ static int wc_PKCS7_DecryptRecipientInfos(wc_PKCS7* pkcs7, byte* in,
     }
 
     if (ret < 0) {
-        return ret;
+        /* A resumed decode re-enters here rather than through the walk, so
+         * each type must keep the same policy its arm in the walk uses. */
+        int retry = 0;
+
+        if ((*recipFound == 0) &&
+                (ret != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E)) &&
+                (ret != WC_NO_ERR_TRACE(MEMORY_E)) &&
+                (ret != WC_NO_ERR_TRACE(BUFFER_E))) {
+            switch (pkcs7->state) {
+                case WC_PKCS7_DECRYPT_KTRI:
+                case WC_PKCS7_DECRYPT_KTRI_2:
+                case WC_PKCS7_DECRYPT_KTRI_3:
+                    retry = 1;
+                    break;
+                default:
+                    /* kari, kekri and pwri do not walk on in either path */
+                    break;
+            }
+        }
+
+        if (!retry) {
+            return ret;
+        }
+
+        lastErr = ret;
+        ret = wc_PKCS7_RecipientRetry(pkcs7, idx, &savedIdx, &tmpIdx,
+                                      decryptedKeySz, keyCap, setEnd);
+        if (ret != 0) {
+            return ret;
+        }
     }
 
     savedIdx = *idx;
@@ -13895,6 +14005,8 @@ static int wc_PKCS7_DecryptRecipientInfos(wc_PKCS7* pkcs7, byte* in,
         }
     #endif
 
+        keyCap = *decryptedKeySz;
+
         /* remove RecipientInfo, if we don't have a SEQUENCE, back up idx to
          * last good saved one */
         if (GetSequence_ex(pkiMsg, idx, &length, pkiMsgSz, NO_USER_CHECK) > 0) {
@@ -13915,6 +14027,12 @@ static int wc_PKCS7_DecryptRecipientInfos(wc_PKCS7* pkcs7, byte* in,
                         ret != WC_NO_ERR_TRACE(MEMORY_E) &&
                         ret != WC_NO_ERR_TRACE(BUFFER_E) &&
                         *recipFound == 0) {
+                    lastErr = ret;
+                    ret = wc_PKCS7_RecipientRetry(pkcs7, idx, &savedIdx,
+                            &tmpIdx, decryptedKeySz, keyCap, setEnd);
+                    if (ret != 0) {
+                        return ret;
+                    }
                     continue; /* try next recipient */
                 }
                 else {
@@ -14051,6 +14169,13 @@ static int wc_PKCS7_DecryptRecipientInfos(wc_PKCS7* pkcs7, byte* in,
 
         /* update good idx */
         savedIdx = *idx;
+    }
+
+    /* Walking on discards the handler's error; with nothing found it is the
+     * answer, and PKCS7_RECIP_E from a recipient that was not the reader's is
+     * the same one the caller substitutes. */
+    if (ret == 0 && *recipFound == 0 && lastErr != 0) {
+        ret = lastErr;
     }
 
     return ret;
@@ -14444,6 +14569,7 @@ int wc_PKCS7_DecodeEnvelopedData(wc_PKCS7* pkcs7, byte* in,
             /* get the full recipient set */
             pkcs7->stream->expected     = recipientSetSz;
             pkcs7->stream->recipientSz  = ret;
+            pkcs7->stream->recipientRemain = recipientSetSz;
         #endif
             FALL_THROUGH;
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -179,6 +179,7 @@ struct PKCS7State {
     word32 currContRmnSz; /* remaining size of current content */
     word32 accumContSz;   /* size of accumulated content size */
     int recipientSz; /* size of recipient set */
+    word32 recipientStart; /* index the recipient set starts at */
     byte tmpIv[MAX_CONTENT_IV_SIZE]; /* store IV if needed */
 #ifdef WC_PKCS7_STREAM_DEBUG
     word32 peakUsed; /* most bytes used for struct at any one time */
@@ -13796,9 +13797,13 @@ static int wc_PKCS7_DecryptKari(wc_PKCS7* pkcs7, byte* in, word32 inSz,
 
 
 /* decode ASN.1 RecipientInfos SET, return 0 on success, < 0 on error */
+/* setEnd is in/out, non-NULL: index just past the last RecipientInfo, or 0
+ * when unknown. Without it a KeyTransRecipientInfo cannot be told from the
+ * EncryptedContentInfo that follows, both being a bare SEQUENCE. */
 static int wc_PKCS7_DecryptRecipientInfos(wc_PKCS7* pkcs7, byte* in,
                             word32  inSz, word32* idx, byte* decryptedKey,
-                            word32* decryptedKeySz, int* recipFound)
+                            word32* decryptedKeySz, int* recipFound,
+                            word32* setEnd)
 {
     word32 savedIdx;
     int version, ret = 0, length;
@@ -13811,7 +13816,7 @@ static int wc_PKCS7_DecryptRecipientInfos(wc_PKCS7* pkcs7, byte* in,
 
     if (pkcs7 == NULL || pkiMsg == NULL || idx == NULL ||
         decryptedKey == NULL || decryptedKeySz == NULL ||
-        recipFound == NULL) {
+        recipFound == NULL || setEnd == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -13867,15 +13872,28 @@ static int wc_PKCS7_DecryptRecipientInfos(wc_PKCS7* pkcs7, byte* in,
     }
 
     savedIdx = *idx;
-#ifndef NO_PKCS7_STREAM
-    pkiMsgSz = (pkcs7->stream->length > 0)? pkcs7->stream->length: inSz;
-    if (pkcs7->stream->length > 0)
-        pkiMsg = pkcs7->stream->buffer;
-#endif
 
     /* when looking for next recipient, use first sequence and version to
      * indicate there is another, if not, move on */
     while (*recipFound == 0) {
+
+        /* stop at the end of the set, not at the EncryptedContentInfo */
+        if ((*setEnd != 0) && (*idx >= *setEnd)) {
+            break;
+        }
+
+    #ifndef NO_PKCS7_STREAM
+        /* a handler may have moved the stream buffer; re-read pointer and
+         * bound */
+        if (pkcs7->stream->length > 0) {
+            pkiMsg   = pkcs7->stream->buffer;
+            pkiMsgSz = pkcs7->stream->length;
+        }
+        else {
+            pkiMsg   = in;
+            pkiMsgSz = inSz;
+        }
+    #endif
 
         /* remove RecipientInfo, if we don't have a SEQUENCE, back up idx to
          * last good saved one */
@@ -13894,6 +13912,8 @@ static int wc_PKCS7_DecryptRecipientInfos(wc_PKCS7* pkcs7, byte* in,
                                       recipFound);
             if (ret != 0) {
                 if (ret != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E) &&
+                        ret != WC_NO_ERR_TRACE(MEMORY_E) &&
+                        ret != WC_NO_ERR_TRACE(BUFFER_E) &&
                         *recipFound == 0) {
                     continue; /* try next recipient */
                 }
@@ -14348,6 +14368,7 @@ int wc_PKCS7_DecodeEnvelopedData(wc_PKCS7* pkcs7, byte* in,
     word32 idx = 0;
     word32 tmpIdx = 0;
     word32 recipientSetSz = 0;
+    word32 setEnd = 0;
     word32 contentType = 0, encOID = 0;
     word32 decryptedKeySz = MAX_ENCRYPTED_KEY_SZ;
 
@@ -14433,6 +14454,9 @@ int wc_PKCS7_DecodeEnvelopedData(wc_PKCS7* pkcs7, byte* in,
                     pkcs7->stream->expected, &pkiMsg, &idx)) != 0) {
                 return ret;
             }
+            /* Record the start only now: wc_PKCS7_AddDataToStream picks the
+             * buffer, so an earlier index is in the wrong coordinate space. */
+            pkcs7->stream->recipientStart = idx;
         #endif
             FALL_THROUGH;
 
@@ -14447,10 +14471,21 @@ int wc_PKCS7_DecodeEnvelopedData(wc_PKCS7* pkcs7, byte* in,
             decryptedKey   = pkcs7->stream->aad;
             decryptedKeySz = MAX_ENCRYPTED_KEY_SZ;
             tmpIdx = idx;
+            /* A zero size is an indefinite-length BER set, whose end is not
+             * known here; leave the bound off rather than place it at the
+             * start of the set. */
+            if (pkcs7->stream->recipientSz > 0) {
+                setEnd = pkcs7->stream->recipientStart +
+                         (word32)pkcs7->stream->recipientSz;
+            }
+        #else
+            if (recipientSetSz > 0) {
+                setEnd = tmpIdx + recipientSetSz;
+            }
         #endif
             ret = wc_PKCS7_DecryptRecipientInfos(pkcs7, in, inSz, &idx,
                                         decryptedKey, &decryptedKeySz,
-                                        &recipFound);
+                                        &recipFound, &setEnd);
             if (ret == 0 && recipFound == 0) {
                 WOLFSSL_MSG(
                       "No recipient found in envelopedData that matches input");
@@ -14461,7 +14496,9 @@ int wc_PKCS7_DecodeEnvelopedData(wc_PKCS7* pkcs7, byte* in,
                 break;
         #ifndef NO_PKCS7_STREAM
             /* advance idx past recipient info set if not all recipients
-             * parsed */
+             * parsed. NOTE: only right while the whole set is read in one
+             * piece; three or more recipients fed in small chunks still fail
+             * for a recipient that is not the first. */
             if (pkcs7->stream->totalRd < ((word32)pkcs7->stream->recipientSz +
                     tmpIdx)) {
                 idx = tmpIdx + (word32)pkcs7->stream->recipientSz;
@@ -15745,6 +15782,7 @@ int wc_PKCS7_DecodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* in,
 #ifndef NO_PKCS7_STREAM
     word32 tmpIdx = 0;
 #endif
+    word32 setEnd = 0;
     word32 contentType = 0, encOID = 0;
     word32 decryptedKeySz = 0;
     byte* pkiMsg = in;
@@ -15840,7 +15878,7 @@ int wc_PKCS7_DecodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* in,
 
             ret = wc_PKCS7_DecryptRecipientInfos(pkcs7, in, inSz, &idx,
                                                 decryptedKey, &decryptedKeySz,
-                                                &recipFound);
+                                                &recipFound, &setEnd);
             if (ret != 0) {
                 break;
             }

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -15907,6 +15907,9 @@ int wc_PKCS7_DecodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* in,
     word32 idx = 0;
 #ifndef NO_PKCS7_STREAM
     word32 tmpIdx = 0;
+#else
+    word32 recipientSetStart = 0;
+    word32 recipientSetSz = 0;
 #endif
     word32 setEnd = 0;
     word32 contentType = 0, encOID = 0;
@@ -15957,18 +15960,29 @@ int wc_PKCS7_DecodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* in,
             if (ret < 0)
                 break;
 
+            /* Decryption stops at the matching RecipientInfo, so remember
+             * the set's start and length to bound the search and step over
+             * the rest. Buffer all of it, as WC_PKCS7_ENV_2 does. */
         #ifndef NO_PKCS7_STREAM
             tmpIdx = idx;
+            pkcs7->stream->recipientSz    = ret;
+            pkcs7->stream->recipientRemain = (word32)ret;
+            pkcs7->stream->expected       = (word32)ret;
+        #else
+            recipientSetStart = idx;
+            recipientSetSz    = (word32)ret;
         #endif
             wc_PKCS7_ChangeState(pkcs7, WC_PKCS7_AUTHENV_2);
             FALL_THROUGH;
 
         case WC_PKCS7_AUTHENV_2:
         #ifndef NO_PKCS7_STREAM
-            if ((ret = wc_PKCS7_AddDataToStream(pkcs7, in, inSz, MAX_LENGTH_SZ +
-                            MAX_VERSION_SZ + ASN_TAG_SZ, &pkiMsg, &idx)) != 0) {
+            if ((ret = wc_PKCS7_AddDataToStream(pkcs7, in, inSz,
+                            pkcs7->stream->expected, &pkiMsg, &idx)) != 0) {
                 break;
             }
+            /* start of the set, in the space AddDataToStream established */
+            pkcs7->stream->recipientStart = idx;
         #endif
             decryptedKey = (byte*)XMALLOC(MAX_ENCRYPTED_KEY_SZ, pkcs7->heap,
                                                             DYNAMIC_TYPE_PKCS7);
@@ -16002,6 +16016,18 @@ int wc_PKCS7_DecodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* in,
             decryptedKey = pkcs7->stream->key;
         #endif
 
+        #ifndef NO_PKCS7_STREAM
+            /* Zero size means an indefinite-length BER set; see the
+             * EnvelopedData decoder. */
+            if (pkcs7->stream->recipientSz > 0) {
+                setEnd = pkcs7->stream->recipientStart +
+                         (word32)pkcs7->stream->recipientSz;
+            }
+        #else
+            if (recipientSetSz > 0) {
+                setEnd = recipientSetStart + recipientSetSz;
+            }
+        #endif
             ret = wc_PKCS7_DecryptRecipientInfos(pkcs7, in, inSz, &idx,
                                                 decryptedKey, &decryptedKeySz,
                                                 &recipFound, &setEnd);
@@ -16016,9 +16042,29 @@ int wc_PKCS7_DecodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* in,
                 break;
             }
 
+            /* Step over the recipients left unread after the match, or the
+             * EncryptedContentInfo below is parsed from the wrong offset.
+             * Only while the stream has not already passed the end of the
+             * set. Same chunked-decode caveat as WC_PKCS7_ENV_2. */
         #ifndef NO_PKCS7_STREAM
+            if (pkcs7->stream->totalRd < (pkcs7->stream->recipientStart +
+                    (word32)pkcs7->stream->recipientSz)) {
+                tmpIdx = idx;
+                idx = pkcs7->stream->recipientStart +
+                        (word32)pkcs7->stream->recipientSz;
+
+                if ((ret = wc_PKCS7_StreamEndCase(pkcs7, &tmpIdx, &idx)) != 0) {
+                    break;
+                }
+            }
+
             tmpIdx = idx;
             pkcs7->stream->expected = MAX_SEQ_SZ;
+        #else
+            /* Zero size is an indefinite-length set; see WC_PKCS7_ENV_2. */
+            if (recipientSetSz > 0) {
+                idx = recipientSetStart + recipientSetSz;
+            }
         #endif
             wc_PKCS7_ChangeState(pkcs7, WC_PKCS7_AUTHENV_3);
             FALL_THROUGH;


### PR DESCRIPTION
## Description

Four related defects in the PKCS#7 RecipientInfo walk. None involve post-quantum algorithms - the reproduction throughout is two plain RSA recipients. The commit messages carry the detailed rationale.

**AuthEnvelopedData with more than one recipient has never worked.** The decoder stops at the RecipientInfo that matches and, unlike the EnvelopedData decoder, never steps over the ones after it, so the `EncryptedContentInfo` that follows the set is parsed from the wrong offset. `wc_PKCS7_DecodeAuthEnvelopedData()` has behaved this way since `bc94cdc11`, first released in v3.15.5-stable. The equivalent fix landed for EnvelopedData alone in `6987304f4` (v5.8.4-stable), which introduced `PKCS7State.recipientSz` and the step-over; AuthEnvelopedData was not covered by it.

**The recipient search was not bounded by the RecipientInfo set.** After exhausting the recipients the walk read the `EncryptedContentInfo` that follows as though it were another RecipientInfo, so a message carrying no recipient for the reader came back as a parse error rather than as "no recipient found". `wc_PKCS7_ParseToRecipientInfoSet()` already returns the size of the set, so it is passed down as a new `setEnd` argument and the walk stops at the end of the set.

**An indefinite-length RecipientInfo set rewound the index.** `wc_PKCS7_ParseToRecipientInfoSet()` reports a BER set carrying an indefinite length as a size of zero, so stepping the index over the set by that size moves it back to the start of the set instead of past the matched recipient, and the `EncryptedContentInfo` that follows is parsed from the wrong offset. The assignment in the EnvelopedData decoder has been unguarded since `6987304f4`, so that one predates this change and is fixed in its own commit; the AuthEnvelopedData step-over added here carries the same guard from the start.

**The stream accounting was left inconsistent after a rejected RecipientInfo.** A rejected handler stops counting the moment it decides the recipient is not the reader's, but the index has already stepped over the whole structure, so the next handler's bookkeeping compounded the difference and the decode asked for input it had already consumed. The two stream modes need opposite handling, hence the new `wc_PKCS7_StreamResyncRecipient()` helper.

## Behaviour change

`wc_PKCS7_DecodeEnvelopedData()` returns **`PKCS7_RECIP_E` instead of `ASN_PARSE_E`** when no recipient in the set is the reader's. The old value was a symptom of the unbounded search rather than an answer; the one expectation in `tests/api/test_pkcs7.c` that asserted it is updated in the commit that makes it wrong.

`wc_PKCS7_DecryptRecipientInfos()` no longer discards the error a rejected RecipientInfo handler returned. Walking on to the next recipient overwrote it, so a resumed streaming decode - where the caller's `recipFound` starts at zero again while `WC_PKCS7_DECRYPT_KTRI_3` resumes past the issuer compare - could report `PKCS7_RECIP_E` in place of the real failure. The last error is kept and returned when the walk ends with no recipient found. This does not undo the value above: `wc_PKCS7_DecryptKtri()` returns `PKCS7_RECIP_E` for a recipient that is not the reader's, so a set in which none match still answers with it.

`wc_PKCS7_DecryptRecipientInfos()` takes an eighth argument. It is `static` to `pkcs7.c`, so no public or internal API changes; the only other callers are the MC/DC white-box programs under `tests/unit-mcdc/`, which `#include` the source directly and are updated here.

## Testing

New `test_wc_PKCS7_MultipleRecipients` encodes one message to two `KeyTransRecipientInfo` recipients and opens it as each of them in turn, for EnvelopedData and AuthEnvelopedData, whole and fed in 128-byte chunks. The second recipient is the interesting one - decoding as the first passes even with the search unbounded.

`test_wc_PKCS7_IndefiniteRecipientSet` rewrites the RecipientInfo set header of the existing `berContent` vector to an indefinite length and checks that the walk still reaches the recipient. Dropping the guard on the search bound makes it fail with `PKCS7_RECIP_E`.

## Out of scope

The chunked leg is scoped to EnvelopedData and the second recipient. Two gaps in the partial-input path predate this change and are untouched: matching on the *first* recipient in chunks fails with `ASN_PARSE_E` on the merge-base and still does, and AuthEnvelopedData fed in chunks has never opened for a recipient other than the first. A `NOTE` on the EnvelopedData step-over marks the arithmetic that is only right while the whole set is read in one piece; the AuthEnvelopedData step-over refers back to it.

An indefinite-length RecipientInfo set still cannot be decoded through to the plaintext. Nothing consumes the end-of-contents pair that closes it, so `EncryptedContentInfo` is parsed from those two zero bytes and the decode ends at `ASN_PARSE_E` - the behaviour on the merge-base as well. Doing better means walking the remaining RecipientInfos to find the end of the set, which is a change of its own; `test_wc_PKCS7_IndefiniteRecipientSet` asserts the current value exactly, so it fails loudly if that is ever added.
