### PR TITLE
Cut the signature algorithms extensions down to what they actually need

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -9843,6 +9843,10 @@ void wolfSSL_ResourceFree(WOLFSSL* ssl)
     ForceZero(&ssl->clientSecret, sizeof(ssl->clientSecret));
     ForceZero(&ssl->serverSecret, sizeof(ssl->serverSecret));
 
+    XFREE(ssl->certHashSigAlgo, ssl->heap, DYNAMIC_TYPE_TLSX);
+    ssl->certHashSigAlgo = NULL;
+    ssl->certHashSigAlgoSz = 0;
+
 #if defined(HAVE_ECH)
     if (ssl->echConfigs != NULL) {
         FreeEchConfigs(ssl->echConfigs, ssl->heap);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5701,6 +5701,9 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         ssl->options.hrrSentCookie = 0;
     #endif
         ssl->options.hrrSentKeyShare = 0;
+        XFREE(ssl->certHashSigAlgo, ssl->heap, DYNAMIC_TYPE_TLSX);
+        ssl->certHashSigAlgo = NULL;
+        ssl->certHashSigAlgoSz = 0;
     #endif
     #ifdef WOLFSSL_DTLS
         ssl->options.dtlsStateful = 0;

--- a/src/tls.c
+++ b/src/tls.c
@@ -7952,18 +7952,14 @@ static int TLSX_CA_Names_Parse(WOLFSSL *ssl, const byte* input,
 
 /* Return the size of the SignatureAlgorithms extension's data.
  *
- * data  Unused
+ * data  The SSL/TLS object.
  * returns the length of data that will be in the extension.
  */
-
 static word16 TLSX_SignatureAlgorithms_GetSize(void* data)
 {
-    SignatureAlgorithms* sa = (SignatureAlgorithms*)data;
+    WOLFSSL* ssl = (WOLFSSL*)data;
 
-    if (sa->hashSigAlgoSz == 0)
-        return OPAQUE16_LEN + WOLFSSL_SUITES(sa->ssl)->hashSigAlgoSz;
-    else
-        return OPAQUE16_LEN + sa->hashSigAlgoSz;
+    return OPAQUE16_LEN + WOLFSSL_SUITES(ssl)->hashSigAlgoSz;
 }
 
 /* Creates a bit string of supported hash algorithms with RSA PSS.
@@ -8001,35 +7997,24 @@ static int TLSX_SignatureAlgorithms_MapPss(WOLFSSL *ssl, const byte* input,
 
 /* Writes the SignatureAlgorithms extension into the buffer.
  *
- * data    Unused
+ * data    The SSL/TLS object.
  * output  The buffer to write the extension into.
  * returns the length of data that was written.
  */
 static word16 TLSX_SignatureAlgorithms_Write(void* data, byte* output)
 {
-    SignatureAlgorithms* sa = (SignatureAlgorithms*)data;
-    const Suites* suites = WOLFSSL_SUITES(sa->ssl);
-    word16 hashSigAlgoSz;
+    WOLFSSL* ssl = (WOLFSSL*)data;
+    const Suites* suites = WOLFSSL_SUITES(ssl);
 
-    if (sa->hashSigAlgoSz == 0) {
-        c16toa(suites->hashSigAlgoSz, output);
-        XMEMCPY(output + OPAQUE16_LEN, suites->hashSigAlgo,
-                suites->hashSigAlgoSz);
-        hashSigAlgoSz = suites->hashSigAlgoSz;
-    }
-    else {
-        c16toa(sa->hashSigAlgoSz, output);
-        XMEMCPY(output + OPAQUE16_LEN, sa->hashSigAlgo,
-                sa->hashSigAlgoSz);
-        hashSigAlgoSz = sa->hashSigAlgoSz;
-    }
+    c16toa(suites->hashSigAlgoSz, output);
+    XMEMCPY(output + OPAQUE16_LEN, suites->hashSigAlgo, suites->hashSigAlgoSz);
 
 #ifndef NO_RSA
-    TLSX_SignatureAlgorithms_MapPss(sa->ssl, output + OPAQUE16_LEN,
-            hashSigAlgoSz);
+    TLSX_SignatureAlgorithms_MapPss(ssl, output + OPAQUE16_LEN,
+            suites->hashSigAlgoSz);
 #endif
 
-    return OPAQUE16_LEN + hashSigAlgoSz;
+    return OPAQUE16_LEN + suites->hashSigAlgoSz;
 }
 
 /* Parse the SignatureAlgorithms extension.
@@ -8075,16 +8060,14 @@ static int TLSX_SignatureAlgorithms_Parse(WOLFSSL *ssl, const byte* input,
 /* Sets a new SignatureAlgorithms extension into the extension list.
  *
  * extensions  The list of extensions.
- * data        The extensions specific data.
+ * ssl         The SSL/TLS object. Not const: the write callback maps the PSS
+ *             algorithms through it.
  * heap        The heap used for allocation.
  * returns 0 on success, otherwise failure.
  */
 static int TLSX_SetSignatureAlgorithms(TLSX** extensions, WOLFSSL* ssl,
                                        void* heap)
 {
-    SignatureAlgorithms* sa;
-    int ret;
-
     if (extensions == NULL)
         return BAD_FUNC_ARG;
 
@@ -8092,43 +8075,12 @@ static int TLSX_SetSignatureAlgorithms(TLSX** extensions, WOLFSSL* ssl,
     if (TLSX_Find(*extensions, TLSX_SIGNATURE_ALGORITHMS) != NULL)
         return 0;
 
-    sa = TLSX_SignatureAlgorithms_New(ssl, 0, heap);
-    if (sa == NULL)
-        return MEMORY_ERROR;
-
-    ret = TLSX_Push(extensions, TLSX_SIGNATURE_ALGORITHMS, sa, heap);
-    if (ret != 0)
-        TLSX_SignatureAlgorithms_FreeAll(sa, heap);
-    return ret;
-}
-
-SignatureAlgorithms* TLSX_SignatureAlgorithms_New(WOLFSSL* ssl,
-        word16 hashSigAlgoSz, void* heap)
-{
-    SignatureAlgorithms* sa;
-    (void)heap;
-
-    sa = (SignatureAlgorithms*)XMALLOC(sizeof(*sa) + hashSigAlgoSz, heap,
-                                       DYNAMIC_TYPE_TLSX);
-    if (sa != NULL) {
-        XMEMSET(sa, 0, sizeof(*sa) + hashSigAlgoSz);
-        sa->ssl = ssl;
-        sa->hashSigAlgoSz = hashSigAlgoSz;
-    }
-    return sa;
-}
-
-void TLSX_SignatureAlgorithms_FreeAll(SignatureAlgorithms* sa,
-                                             void* heap)
-{
-    XFREE(sa, heap, DYNAMIC_TYPE_TLSX);
-    (void)heap;
+    return TLSX_Push(extensions, TLSX_SIGNATURE_ALGORITHMS, ssl, heap);
 }
 
 #define SA_GET_SIZE  TLSX_SignatureAlgorithms_GetSize
 #define SA_WRITE     TLSX_SignatureAlgorithms_Write
 #define SA_PARSE     TLSX_SignatureAlgorithms_Parse
-#define SA_FREE_ALL  TLSX_SignatureAlgorithms_FreeAll
 #endif
 /******************************************************************************/
 /* Signature Algorithms Certificate                                           */
@@ -15416,8 +15368,7 @@ void TLSX_FreeAll(TLSX* list, void* heap)
                 break;
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
             case TLSX_SIGNATURE_ALGORITHMS:
-                WOLFSSL_MSG("Signature Algorithms extension to free");
-                SA_FREE_ALL((SignatureAlgorithms*)extension->data, heap);
+                WOLFSSL_MSG("Signature Algorithms extension free");
                 break;
 #endif
 #if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)

--- a/src/tls.c
+++ b/src/tls.c
@@ -8087,27 +8087,35 @@ static int TLSX_SetSignatureAlgorithms(TLSX** extensions, WOLFSSL* ssl,
 /******************************************************************************/
 
 #if defined(WOLFSSL_TLS13) && !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
-/* Return the size of the SignatureAlgorithms extension's data.
+/* Return the size of the SignatureAlgorithmsCert extension's data.
  *
- * data  Unused
+ * data  The SSL/TLS object.
  * returns the length of data that will be in the extension.
  */
 static word16 TLSX_SignatureAlgorithmsCert_GetSize(void* data)
 {
     WOLFSSL* ssl = (WOLFSSL*)data;
 
+    if (ssl->certHashSigAlgo == NULL)
+        return OPAQUE16_LEN;
+
     return OPAQUE16_LEN + ssl->certHashSigAlgoSz;
 }
 
 /* Writes the SignatureAlgorithmsCert extension into the buffer.
  *
- * data    Unused
+ * data    The SSL/TLS object.
  * output  The buffer to write the extension into.
  * returns the length of data that was written.
  */
 static word16 TLSX_SignatureAlgorithmsCert_Write(void* data, byte* output)
 {
     WOLFSSL* ssl = (WOLFSSL*)data;
+
+    if (ssl->certHashSigAlgo == NULL) {
+        c16toa(0, output);
+        return OPAQUE16_LEN;
+    }
 
     c16toa(ssl->certHashSigAlgoSz, output);
     XMEMCPY(output + OPAQUE16_LEN, ssl->certHashSigAlgo,
@@ -8143,12 +8151,19 @@ static int TLSX_SignatureAlgorithmsCert_Parse(WOLFSSL *ssl, const byte* input,
         return BUFFER_ERROR;
 
     /* truncate hashSigAlgo list if too long */
-    ssl->certHashSigAlgoSz = len;
-    if (ssl->certHashSigAlgoSz > WOLFSSL_MAX_SIGALGO) {
+    if (len > WOLFSSL_MAX_SIGALGO) {
         WOLFSSL_MSG("TLSX SigAlgo list exceeds max, truncating");
-        ssl->certHashSigAlgoSz = WOLFSSL_MAX_SIGALGO;
+        len = WOLFSSL_MAX_SIGALGO;
     }
-    XMEMCPY(ssl->certHashSigAlgo, input, ssl->certHashSigAlgoSz);
+
+    XFREE(ssl->certHashSigAlgo, ssl->heap, DYNAMIC_TYPE_TLSX);
+    ssl->certHashSigAlgoSz = 0;
+    ssl->certHashSigAlgo = (byte*)XMALLOC(len, ssl->heap, DYNAMIC_TYPE_TLSX);
+    if (ssl->certHashSigAlgo == NULL)
+        return MEMORY_E;
+
+    XMEMCPY(ssl->certHashSigAlgo, input, len);
+    ssl->certHashSigAlgoSz = len;
 
     return 0;
 }
@@ -8161,12 +8176,12 @@ static int TLSX_SignatureAlgorithmsCert_Parse(WOLFSSL *ssl, const byte* input,
  * returns 0 on success, otherwise failure.
  */
 static int TLSX_SetSignatureAlgorithmsCert(TLSX** extensions,
-        const WOLFSSL* data, void* heap)
+        const WOLFSSL* ssl, void* heap)
 {
     if (extensions == NULL)
         return BAD_FUNC_ARG;
 
-    return TLSX_Push(extensions, TLSX_SIGNATURE_ALGORITHMS_CERT, data, heap);
+    return TLSX_Push(extensions, TLSX_SIGNATURE_ALGORITHMS_CERT, ssl, heap);
 }
 
 #define SAC_GET_SIZE  TLSX_SignatureAlgorithmsCert_GetSize
@@ -17612,6 +17627,13 @@ int TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType, word32* pLength)
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
         if (WOLFSSL_SUITES(ssl)->hashSigAlgoSz == 0)
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_SIGNATURE_ALGORITHMS));
+    #ifdef WOLFSSL_TLS13
+        /* RFC 8446 4.2.3: the list may not be empty, so drop the extension. */
+        if ((ssl->certHashSigAlgo == NULL) || (ssl->certHashSigAlgoSz == 0)) {
+            TURN_ON(semaphore,
+                    TLSX_ToSemaphore(TLSX_SIGNATURE_ALGORITHMS_CERT));
+        }
+    #endif
 #endif
 #if defined(WOLFSSL_TLS13)
         if (!IsAtLeastTLSv1_2(ssl)) {
@@ -17849,6 +17871,13 @@ int TLSX_WriteRequest(WOLFSSL* ssl, byte* output, byte msgType, word32* pOffset)
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
         if (WOLFSSL_SUITES(ssl)->hashSigAlgoSz == 0)
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_SIGNATURE_ALGORITHMS));
+    #ifdef WOLFSSL_TLS13
+        /* RFC 8446 4.2.3: the list may not be empty, so drop the extension. */
+        if ((ssl->certHashSigAlgo == NULL) || (ssl->certHashSigAlgoSz == 0)) {
+            TURN_ON(semaphore,
+                    TLSX_ToSemaphore(TLSX_SIGNATURE_ALGORITHMS_CERT));
+        }
+    #endif
 #endif
 #ifdef WOLFSSL_TLS13
         if (!IsAtLeastTLSv1_2(ssl)) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8795,7 +8795,6 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
     int    sendSz;
     word32 i;
     word32 reqSz;
-    SignatureAlgorithms* sa;
 
     WOLFSSL_START(WC_FUNC_CERTIFICATE_REQUEST_SEND);
     WOLFSSL_ENTER("SendTls13CertificateRequest");
@@ -8805,16 +8804,11 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
     if (ssl->options.side != WOLFSSL_SERVER_END)
         return SIDE_ERROR;
 
-    /* Use ssl->suites->hashSigAlgo so wolfSSL_set1_sigalgs_list() is honored.
-     * hashSigAlgoSz=0 makes GetSize/Write fall back to WOLFSSL_SUITES(ssl). */
-    sa = TLSX_SignatureAlgorithms_New(ssl, 0, ssl->heap);
-    if (sa == NULL)
-        return MEMORY_ERROR;
-    ret = TLSX_Push(&ssl->extensions, TLSX_SIGNATURE_ALGORITHMS, sa, ssl->heap);
-    if (ret != 0) {
-        TLSX_SignatureAlgorithms_FreeAll(sa, ssl->heap);
+    /* The extension writes WOLFSSL_SUITES(ssl), honoring set1_sigalgs_list. */
+    ret = TLSX_Push(&ssl->extensions, TLSX_SIGNATURE_ALGORITHMS, ssl,
+                    ssl->heap);
+    if (ret != 0)
         return ret;
-    }
 
     i = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ;
 #ifdef WOLFSSL_DTLS13

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4080,7 +4080,7 @@ static int EchCalcAcceptance(WOLFSSL* ssl, byte* label, word16 labelSz,
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG) && \
     (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER))
 /* Record whether the peer's advertised algorithms permit SHA-1 signed
- * certificates.
+ * certificates, and release the peer's signature_algorithms_cert list.
  *
  * RFC 8446 Section 4.2.3 has signature_algorithms cover certificate signatures
  * when signature_algorithms_cert is absent.
@@ -4104,11 +4104,8 @@ static void SetPeerSha1CertOk(WOLFSSL* ssl, const Suites* peerSuites)
         list = peerSuites->hashSigAlgo;
         listSz = peerSuites->hashSigAlgoSz;
     }
-    else {
-        return;
-    }
 
-    for (i = 0; i + 2 <= listSz; i += 2) {
+    for (i = 0; (list != NULL) && (i + 2 <= listSz); i += 2) {
         /* Only rsa_pkcs1_sha1, dsa_sha1 and ecdsa_sha1 carry sha_mac as the
          * first byte of the signature scheme. */
         if (list[i] == sha_mac) {
@@ -4116,6 +4113,11 @@ static void SetPeerSha1CertOk(WOLFSSL* ssl, const Suites* peerSuites)
             break;
         }
     }
+
+    /* Post-handshake auth parses its own list. */
+    XFREE(ssl->certHashSigAlgo, ssl->heap, DYNAMIC_TYPE_TLSX);
+    ssl->certHashSigAlgo = NULL;
+    ssl->certHashSigAlgoSz = 0;
 }
 #endif /* !NO_CERTS && !WOLFSSL_NO_SIGALG && (client || server) */
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -6230,6 +6230,8 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
 #if !defined(WOLFSSL_NO_SIGALG)
     /* Post-handshake auth can deliver several requests; each one's cert
      * signature algorithms replace the last rather than adding to them. */
+    XFREE(ssl->certHashSigAlgo, ssl->heap, DYNAMIC_TYPE_TLSX);
+    ssl->certHashSigAlgo = NULL;
     ssl->certHashSigAlgoSz = 0;
 #endif
 
@@ -7900,6 +7902,8 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
     /* Discard any list kept from a previous ClientHello on this object; a
      * second hello that drops signature_algorithms_cert must not inherit it. */
+    XFREE(ssl->certHashSigAlgo, ssl->heap, DYNAMIC_TYPE_TLSX);
+    ssl->certHashSigAlgo = NULL;
     ssl->certHashSigAlgoSz = 0;
 #endif
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -41639,6 +41639,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_TLSX_QUIC_TP_non_quic),
     TEST_DECL(test_TLSX_ALPN_server_response_count),
     TEST_DECL(test_TLSX_SupportedCurve_empty_or_unsupported),
+    TEST_DECL(test_TLSX_SignatureAlgorithmsCert_parse),
     TEST_DECL(test_TLSX_PointFormat_uncompressed_required),
     TEST_DECL(test_wolfSSL_CTX_add_client_custom_ext),
     TEST_DECL(test_wolfSSL_custom_ext_handshake),

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -7595,7 +7595,9 @@ int test_tls13_sha1_cert_chain(void)
         ssl_c->certHashSigAlgoSz = 2;
     }
     ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
-    ExpectIntEQ(ssl_s->certHashSigAlgoSz, 2);
+    ExpectIntEQ(ssl_s->options.peerSha1CertOk, 1);
+    ExpectNull(ssl_s->certHashSigAlgo);
+    ExpectIntEQ(ssl_s->certHashSigAlgoSz, 0);
 
     wolfSSL_free(ssl_c);    ssl_c = NULL;
     wolfSSL_free(ssl_s);    ssl_s = NULL;

--- a/tests/api/test_tls13.c
+++ b/tests/api/test_tls13.c
@@ -7585,6 +7585,11 @@ int test_tls13_sha1_cert_chain(void)
     ExpectIntEQ(wolfSSL_use_certificate_chain_file(ssl_s, sha1CertFile),
         WOLFSSL_SUCCESS);
     if (EXPECT_SUCCESS()) {
+        ssl_c->certHashSigAlgo = (byte*)XMALLOC(2, ssl_c->heap,
+                                                DYNAMIC_TYPE_TLSX);
+    }
+    ExpectNotNull(ssl_c->certHashSigAlgo);
+    if (EXPECT_SUCCESS()) {
         ssl_c->certHashSigAlgo[0] = sha_mac;
         ssl_c->certHashSigAlgo[1] = rsa_sa_algo;
         ssl_c->certHashSigAlgoSz = 2;
@@ -7612,6 +7617,11 @@ int test_tls13_sha1_cert_chain(void)
         ssl_c->suites->hashSigAlgo[ssl_c->suites->hashSigAlgoSz++] = sha_mac;
         ssl_c->suites->hashSigAlgo[ssl_c->suites->hashSigAlgoSz++] =
             rsa_sa_algo;
+        ssl_c->certHashSigAlgo = (byte*)XMALLOC(2, ssl_c->heap,
+                                                DYNAMIC_TYPE_TLSX);
+    }
+    ExpectNotNull(ssl_c->certHashSigAlgo);
+    if (EXPECT_SUCCESS()) {
         ssl_c->certHashSigAlgo[0] = sha256_mac;
         ssl_c->certHashSigAlgo[1] = rsa_sa_algo;
         ssl_c->certHashSigAlgoSz = 2;

--- a/tests/api/test_tls_ext.c
+++ b/tests/api/test_tls_ext.c
@@ -2303,6 +2303,92 @@ int test_TLSX_SupportedCurve_empty_or_unsupported(void)
     return EXPECT_RESULT();
 }
 
+/* The signature_algorithms_cert list is allocated only when a peer sends the
+ * extension: first list, replacement, truncation, and release. */
+int test_TLSX_SignatureAlgorithmsCert_parse(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_CLIENT) && \
+    !defined(NO_TLS) && !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG) && \
+    defined(HAVE_TLS_EXTENSIONS)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    /* A local: WOLFSSL_SUITES() would resolve to the CTX suites all the
+     * WOLFSSL objects share. */
+    Suites suites;
+    word16 i;
+    /* Two more algorithms than the parser will keep. */
+    byte tooLong[OPAQUE16_LEN + OPAQUE16_LEN + OPAQUE16_LEN +
+                 WOLFSSL_MAX_SIGALGO + 2];
+    /* signature_algorithms_cert (0x0032): ext len 6, list len 4, 2 algos. */
+    const byte first[] = { 0x00, 0x32, 0x00, 0x06, 0x00, 0x04,
+                           0x04, 0x03, 0x08, 0x04 };
+    /* The same extension carrying three algorithms. */
+    const byte second[] = { 0x00, 0x32, 0x00, 0x08, 0x00, 0x06,
+                            0x08, 0x04, 0x04, 0x03, 0x02, 0x01 };
+
+    XMEMSET(&suites, 0, sizeof(suites));
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+    if (ssl != NULL) {
+        ExpectNull(ssl->certHashSigAlgo);
+        ExpectIntEQ(ssl->certHashSigAlgoSz, 0);
+    }
+
+    ExpectIntEQ(TLSX_Parse(ssl, first, (word16)sizeof(first), client_hello,
+                           &suites), 0);
+    if (ssl != NULL) {
+        ExpectNotNull(ssl->certHashSigAlgo);
+        ExpectIntEQ(ssl->certHashSigAlgoSz, 4);
+    }
+    if ((ssl != NULL) && (ssl->certHashSigAlgo != NULL)) {
+        ExpectIntEQ(XMEMCMP(ssl->certHashSigAlgo, first + 6, 4), 0);
+    }
+
+    ExpectIntEQ(TLSX_Parse(ssl, second, (word16)sizeof(second), client_hello,
+                           &suites), 0);
+    if (ssl != NULL) {
+        ExpectNotNull(ssl->certHashSigAlgo);
+        ExpectIntEQ(ssl->certHashSigAlgoSz, 6);
+    }
+    if ((ssl != NULL) && (ssl->certHashSigAlgo != NULL)) {
+        ExpectIntEQ(XMEMCMP(ssl->certHashSigAlgo, second + 6, 6), 0);
+    }
+
+    /* The clamp and the allocation size have to agree, or the copy runs off
+     * the block. */
+    tooLong[0] = 0x00;
+    tooLong[1] = 0x32;
+    c16toa((word16)(OPAQUE16_LEN + WOLFSSL_MAX_SIGALGO + 2), tooLong + 2);
+    c16toa((word16)(WOLFSSL_MAX_SIGALGO + 2), tooLong + 4);
+    for (i = 0; i < WOLFSSL_MAX_SIGALGO + 2; i++) {
+        tooLong[OPAQUE16_LEN + OPAQUE16_LEN + OPAQUE16_LEN + i] = (byte)i;
+    }
+    ExpectIntEQ(TLSX_Parse(ssl, tooLong, (word16)sizeof(tooLong), client_hello,
+                           &suites), 0);
+    if (ssl != NULL) {
+        ExpectNotNull(ssl->certHashSigAlgo);
+        ExpectIntEQ(ssl->certHashSigAlgoSz, WOLFSSL_MAX_SIGALGO);
+    }
+    if ((ssl != NULL) && (ssl->certHashSigAlgo != NULL)) {
+        ExpectIntEQ(XMEMCMP(ssl->certHashSigAlgo,
+            tooLong + OPAQUE16_LEN + OPAQUE16_LEN + OPAQUE16_LEN,
+            WOLFSSL_MAX_SIGALGO), 0);
+    }
+
+    ExpectIntEQ(wolfSSL_clear(ssl), WOLFSSL_SUCCESS);
+    if (ssl != NULL) {
+        ExpectNull(ssl->certHashSigAlgo);
+        ExpectIntEQ(ssl->certHashSigAlgoSz, 0);
+    }
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 /* RFC 8422 Section 5.1.2: a client that sends the ec_point_formats extension
  * MUST include the uncompressed (0) point format. When the uncompressed format
  * is omitted the server records this (ssl->options.peerNoUncompPF) during

--- a/tests/api/test_tls_ext.h
+++ b/tests/api/test_tls_ext.h
@@ -48,6 +48,7 @@ int test_TLSX_TCA_tls13_msg_type_validation(void);
 int test_TLSX_QUIC_TP_non_quic(void);
 int test_TLSX_ALPN_server_response_count(void);
 int test_TLSX_SupportedCurve_empty_or_unsupported(void);
+int test_TLSX_SignatureAlgorithmsCert_parse(void);
 int test_TLSX_PointFormat_uncompressed_required(void);
 int test_wolfSSL_CTX_add_client_custom_ext(void);
 int test_wolfSSL_custom_ext_handshake(void);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -6591,8 +6591,7 @@ struct WOLFSSL {
     word16          pssAlgo;
 #ifdef WOLFSSL_TLS13
     word16          certHashSigAlgoSz;  /* SigAlgoCert ext length in bytes */
-    byte            certHashSigAlgo[WOLFSSL_MAX_SIGALGO]; /* cert sig/algo to
-                                                           * offer */
+    byte*           certHashSigAlgo;    /* cert sig/algo to offer */
 #endif
 #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
     int             eccVerifyRes;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -6591,7 +6591,7 @@ struct WOLFSSL {
     word16          pssAlgo;
 #ifdef WOLFSSL_TLS13
     word16          certHashSigAlgoSz;  /* SigAlgoCert ext length in bytes */
-    byte*           certHashSigAlgo;    /* cert sig/algo to offer */
+    byte*           certHashSigAlgo;    /* peer's cert sig/algo list */
 #endif
 #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
     int             eccVerifyRes;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3630,26 +3630,6 @@ WOLFSSL_TEST_VIS void wolfSSL_CTX_SetProcessPeerCertCb(WOLFSSL_CTX* ctx,
        CallbackProcessPeerCert cb);
 #endif /* DecodedCert && HAVE_PK_CALLBACKS */
 
-#if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
-typedef struct SignatureAlgorithms {
-    /* Not const since it is modified in TLSX_SignatureAlgorithms_MapPss */
-    WOLFSSL*    ssl;
-    word16      hashSigAlgoSz; /* SigAlgo extension length in bytes */
-    /* Ignore "nonstandard extension used : zero-sized array in struct/union"
-     * MSVC warning */
-    #ifdef _MSC_VER
-    #pragma warning(disable: 4200)
-    #endif
-    /* sig/algo to offer */
-    byte        hashSigAlgo[WC_FLEXIBLE_ARRAY_SIZE];
-} SignatureAlgorithms;
-
-WOLFSSL_LOCAL SignatureAlgorithms* TLSX_SignatureAlgorithms_New(
-        WOLFSSL* ssl, word16 hashSigAlgoSz, void* heap);
-WOLFSSL_LOCAL void TLSX_SignatureAlgorithms_FreeAll(SignatureAlgorithms* sa,
-                                                    void* heap);
-#endif
-
 /** Supported Elliptic Curves - RFC 4492 (session 4) */
 #ifdef HAVE_SUPPORTED_CURVES
 


### PR DESCRIPTION
One of six independent branches that cut allocations and per-object memory in the TLS extension layer. Self-contained and reviewable on its own.

### What changes

**`signature_algorithms` no longer allocates a node per handshake.** The extension stored a `SignatureAlgorithms` heap node whose only live field was a pointer back to the `WOLFSSL` object. Both callers created it with a zero length list, so the flexible array it carried for a per-message algorithm list was never used. The extension now stores the `WOLFSSL` object directly, the way `signature_algorithms_cert` already did. That is one allocation saved per handshake on a client and two on a server, and the extension needs no free handler at all.

`GetSize()` and `Write()` still read the list from `WOLFSSL_SUITES(ssl)`, so `wolfSSL_set1_sigalgs_list()` is honoured exactly as before.

**`signature_algorithms_cert` is allocated only when a peer sends it.** Every `WOLFSSL` carried a fixed `WOLFSSL_MAX_SIGALGO` byte array (128 on a default build) for a list that only a peer sending the extension ever fills. The list now lives in a buffer allocated while parsing and released in `wolfSSL_ResourceFree()` and `wolfSSL_clear()`.

`sizeof(WOLFSSL)` goes from 1456 to 1328 bytes on a default build. A repeated ClientHello after a HelloRetryRequest replaces the buffer rather than growing it.

**And it is released as soon as it has been used.** The list has exactly one consumer: `SetPeerSha1CertOk()` reduces it to the single bit `ssl->options.peerSha1CertOk`, in the same function that parsed it. Nothing reads the bytes again, so it is freed there rather than carried to `wolfSSL_clear()` or object teardown. An established connection now holds nothing at all for this extension.

Post-handshake authentication is unaffected: every CertificateRequest parses its own list and derives the bit again. The read side already carried only the bit across the hand-off, in `dupWrite->postHandshakeSha1CertOk`.

### Notes for review

**One master test assertion changes.** `test_tls13_sha1_cert_chain` checked `ssl_s->certHashSigAlgoSz == 2` after the handshake. It now checks the effect that length decided - `ssl_s->options.peerSha1CertOk` - and that the list itself is gone. Removing the free makes the new assertions fail, so they have teeth.

**The send path is kept, deliberately.** `TLSX_PopulateExtensions()` advertises `certHashSigAlgo` on a client ClientHello, and today the only writer of that field is the parse, so nothing reaches it: an `fprintf` probe on that branch stayed silent through the whole `make check` suite and through an explicit TLS 1.3 mutual-auth handshake. That is already true on master - a client can only receive a CertificateRequest *after* sending its ClientHello - so this change removes nothing that was reachable. The plumbing (`TLSX_SetSignatureAlgorithmsCert()`, the `GetSize`/`Write` callbacks, the empty-list guards) stays intact for the setter API that will feed it.

**A note for whoever adds that setter.** `certHashSigAlgo` is one field doing two jobs, which the parse already resolves in favour of the peer: `SAC_PARSE` runs for `client_hello` on a server and for `certificate_request` on a client, overwriting whatever was there. So on master a client-configured list is destroyed by the first CertificateRequest, with or without this change. The setter will want its own field; this branch renames the member comment to "peer's cert sig/algo list" to record which of the two jobs the field does today.

The frees on the reset paths (`wolfSSL_clear()`, `wolfSSL_ResourceFree()`, and before each parse) stay: a handshake aborted between the parse and `SetPeerSha1CertOk()` still has a buffer to release.

The empty-list guards in `TLSX_GetRequestSize()` / `TLSX_WriteRequest()` enforce RFC 8446 Section 4.2.3, which gives the list a minimum of one entry: the extension is dropped rather than written as an empty vector, whatever ends up feeding it.

`TLSX_SetSignatureAlgorithms()` keeps a non-const `WOLFSSL*` on purpose: its write callback updates `ssl->pssAlgo` through `TLSX_SignatureAlgorithms_MapPss()`. The sibling `...AlgorithmsCert` setter only reads, so that one does take a const object.

### Memory impact

Measured on a 64-bit build with a plain `./configure`:

| | master | this branch |
|---|---|---|
| `sizeof(WOLFSSL)` | 1456 | **1328** |

That is **128 bytes off every `WOLFSSL` object**, for a list only a peer that sends `signature_algorithms_cert` ever fills. An established connection now carries **zero** bytes for it, since the replacement buffer is released as soon as the bit it decides has been recorded.

Allocations per handshake:

- `signature_algorithms` drops **one allocation and free on a client, two on a server**. The node it used to make is gone entirely, and the extension no longer needs a free handler.
- `signature_algorithms_cert` now costs **one short-lived allocation only when a peer actually sends the extension**, sized to the list received rather than `WOLFSSL_MAX_SIGALGO`, and freed within the same message handler. A connection that never receives one pays nothing, and one that does pays nothing past the handshake.

### Testing

New coverage for parsing `signature_algorithms_cert`, for a second list replacing the first, for a list longer than the buffer being truncated to exactly what was allocated, and for `wolfSSL_clear()` releasing it. `test_tls13_sha1_cert_chain` covers the release end-to-end on a real handshake.
