### PR TITLE
Fix failure path of wc_PufEnroll

### DIFF
--- a/wolfcrypt/src/puf.c
+++ b/wolfcrypt/src/puf.c
@@ -681,6 +681,19 @@ int wc_PufReadSram(wc_PufCtx* ctx, const byte* sramAddr, word32 sramSz)
     return 0;
 }
 
+#ifdef WOLFSSL_PUF_TEST
+/* When set, wc_PufEnroll() and wc_PufReconstructEx() treat the final identity
+ * hash as having failed. Lets the test suite reach the hash-failure cleanup
+ * path without a hash backend that can be forced to fail. Not built unless
+ * WOLFSSL_PUF_TEST is defined. */
+static int puf_test_forceHashFail = 0;
+
+void wc_PufTestForceHashFail(int on)
+{
+    puf_test_forceHashFail = on ? 1 : 0;
+}
+#endif /* WOLFSSL_PUF_TEST */
+
 int wc_PufEnroll(wc_PufCtx* ctx)
 {
     int i, ret;
@@ -742,6 +755,10 @@ int wc_PufEnroll(wc_PufCtx* ctx)
 
     /* compute identity = hash(stableBits) */
     ret = wc_PufHashDirect(ctx->stableBits, WC_PUF_STABLE_BYTES, ctx->identity);
+#ifdef WOLFSSL_PUF_TEST
+    if (puf_test_forceHashFail && ret == 0)
+        ret = WC_FAILURE;   /* exercise the identity-hash failure path */
+#endif
 
     /* zeroize sensitive stack buffers */
     ForceZero(msg, sizeof(msg));
@@ -755,8 +772,18 @@ int wc_PufEnroll(wc_PufCtx* ctx)
     wc_MemZero_Check(helperCw, sizeof(helperCw));
 #endif
 
-    if (ret != 0)
+    if (ret != 0) {
+        /* The identity hash failed after ctx->stableBits and ctx->helperData
+         * were already overwritten above. Drop any state a prior successful
+         * enroll left behind so a failed re-enroll cannot leave
+         * WC_PUF_FLAG_ENROLLED / WC_PUF_FLAG_READY set while stableBits holds
+         * the new material and identity still holds the old hash. This matches
+         * the bch_decode() failure path in wc_PufReconstructEx(). */
+        ctx->flags &= (word32)~(WC_PUF_FLAG_ENROLLED | WC_PUF_FLAG_READY);
+        ForceZero(ctx->stableBits, WC_PUF_STABLE_BYTES);
+        ForceZero(ctx->identity, WC_PUF_ID_SZ);
         return PUF_ENROLL_E;
+    }
 
     ctx->flags |= WC_PUF_FLAG_ENROLLED | WC_PUF_FLAG_READY;
     return 0;
@@ -829,6 +856,7 @@ int wc_PufReconstructEx(wc_PufCtx* ctx, const byte* helperData,
             ForceZero(noisyCw, sizeof(noisyCw));
             ForceZero(msg, sizeof(msg));
             ForceZero(ctx->stableBits, WC_PUF_STABLE_BYTES);
+            ForceZero(ctx->identity, WC_PUF_ID_SZ);
         #ifdef WOLFSSL_CHECK_MEM_ZERO
             wc_MemZero_Check(rawCw, sizeof(rawCw));
             wc_MemZero_Check(helperCw, sizeof(helperCw));
@@ -847,6 +875,10 @@ int wc_PufReconstructEx(wc_PufCtx* ctx, const byte* helperData,
 
     /* compute identity */
     ret = wc_PufHashDirect(ctx->stableBits, WC_PUF_STABLE_BYTES, ctx->identity);
+#ifdef WOLFSSL_PUF_TEST
+    if (puf_test_forceHashFail && ret == 0)
+        ret = WC_FAILURE;   /* exercise the identity-hash failure path */
+#endif
 
     /* zeroize sensitive stack buffers */
     ForceZero(rawCw, sizeof(rawCw));
@@ -860,8 +892,17 @@ int wc_PufReconstructEx(wc_PufCtx* ctx, const byte* helperData,
     wc_MemZero_Check(msg, sizeof(msg));
 #endif
 
-    if (ret != 0)
+    if (ret != 0) {
+        /* The identity hash failed after ctx->stableBits was rebuilt. Clear it
+         * and WC_PUF_FLAG_READY exactly as the bch_decode() failure path above
+         * so a failed re-reconstruction cannot leave a prior run's READY flag
+         * set while stableBits holds the new material and identity still holds
+         * the old hash. */
+        ctx->flags &= (word32)~WC_PUF_FLAG_READY;
+        ForceZero(ctx->stableBits, WC_PUF_STABLE_BYTES);
+        ForceZero(ctx->identity, WC_PUF_ID_SZ);
         return PUF_RECONSTRUCT_E;
+    }
 
     ctx->flags |= WC_PUF_FLAG_READY;
     return 0;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -25461,8 +25461,18 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t puf_test(void)
     /* noisy SRAM: same as testSram but with a few flipped bits */
     WOLFSSL_SMALL_STACK_STATIC byte noisySram[WC_PUF_RAW_BYTES];
     WOLFSSL_SMALL_STACK_STATIC byte helperBuf[WC_PUF_HELPER_BYTES];
+    /* helperBuf with a burst of corrupted bits in codeword 0: drives
+     * bch_decode() to fail so Test 11 exercises the BCH-decode failure cleanup
+     * path in wc_PufReconstructEx() (distinct from the identity-hash failure
+     * path). */
+    WOLFSSL_SMALL_STACK_STATIC byte badHelper[WC_PUF_HELPER_BYTES];
     /* rewritten per case by Test 10 */
     WOLFSSL_SMALL_STACK_STATIC byte badSram[WC_PUF_RAW_BYTES];
+    /* all-zero reference for the hash-failure cleanup checks; sized for the
+     * larger of the stableBits and identity buffers it is compared against
+     * (WC_PUF_STABLE_BYTES shrinks with small profiles / codeword counts). */
+    WOLFSSL_SMALL_STACK_STATIC byte zeroBuf[
+        WC_PUF_STABLE_BYTES > WC_PUF_ID_SZ ? WC_PUF_STABLE_BYTES : WC_PUF_ID_SZ];
     const byte info[] = "puf-test-context";
 
     WOLFSSL_ENTER("puf_test");
@@ -26050,6 +26060,123 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t puf_test(void)
         if (XMEMCMP(id1, id2, WC_PUF_ID_SZ) != 0)
             return WC_TEST_RET_ENC_NC;
     }
+
+    /* ---- Test 11: identity-hash failure leaves no stale READY state ---- */
+    /* wc_PufTestForceHashFail() makes wc_PufEnroll() / wc_PufReconstruct() act
+     * as though the final identity hash failed. When that happens on a context
+     * a prior successful run already left ENROLLED|READY, those flags must be
+     * cleared and stableBits / identity scrubbed, so a later wc_PufDeriveKey()
+     * cannot derive HKDF(new stable bits, stale identity) - a key no correct
+     * reconstruction can reproduce. */
+    XMEMSET(zeroBuf, 0, sizeof(zeroBuf));
+
+    /* enroll path: enroll once cleanly, then fail a re-enroll */
+    ret = wc_PufInit(&ctx);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    ret = wc_PufSetTestData(&ctx, testSram, sizeof(testSram));
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    ret = wc_PufReadSram(&ctx, testSram, sizeof(testSram));
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    ret = wc_PufEnroll(&ctx);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    XMEMCPY(helperBuf, ctx.helperData, WC_PUF_HELPER_BYTES);
+
+    wc_PufTestForceHashFail(1);
+    ret = wc_PufEnroll(&ctx);
+    wc_PufTestForceHashFail(0);
+    if (ret != WC_NO_ERR_TRACE(PUF_ENROLL_E))
+        return WC_TEST_RET_ENC_NC;
+    if ((ctx.flags & (WC_PUF_FLAG_ENROLLED | WC_PUF_FLAG_READY)) != 0)
+        return WC_TEST_RET_ENC_NC;
+    if (XMEMCMP(ctx.stableBits, zeroBuf, WC_PUF_STABLE_BYTES) != 0)
+        return WC_TEST_RET_ENC_NC;
+    if (XMEMCMP(ctx.identity, zeroBuf, WC_PUF_ID_SZ) != 0)
+        return WC_TEST_RET_ENC_NC;
+    if (wc_PufDeriveKey(&ctx, info, sizeof(info), key2, sizeof(key2))
+            != WC_NO_ERR_TRACE(PUF_DERIVE_KEY_E))
+        return WC_TEST_RET_ENC_NC;
+    if (wc_PufGetIdentity(&ctx, id3, sizeof(id3))
+            != WC_NO_ERR_TRACE(PUF_IDENTITY_E))
+        return WC_TEST_RET_ENC_NC;
+
+    /* reconstruct path: reconstruct once cleanly, then fail a re-reconstruct */
+    ret = wc_PufInit(&ctx);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    ret = wc_PufSetTestData(&ctx, testSram, sizeof(testSram));
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    ret = wc_PufReadSram(&ctx, testSram, sizeof(testSram));
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    ret = wc_PufReconstruct(&ctx, helperBuf, WC_PUF_HELPER_BYTES);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+
+    wc_PufTestForceHashFail(1);
+    ret = wc_PufReconstruct(&ctx, helperBuf, WC_PUF_HELPER_BYTES);
+    wc_PufTestForceHashFail(0);
+    if (ret != WC_NO_ERR_TRACE(PUF_RECONSTRUCT_E))
+        return WC_TEST_RET_ENC_NC;
+    if ((ctx.flags & WC_PUF_FLAG_READY) != 0)
+        return WC_TEST_RET_ENC_NC;
+    if (XMEMCMP(ctx.stableBits, zeroBuf, WC_PUF_STABLE_BYTES) != 0)
+        return WC_TEST_RET_ENC_NC;
+    if (XMEMCMP(ctx.identity, zeroBuf, WC_PUF_ID_SZ) != 0)
+        return WC_TEST_RET_ENC_NC;
+    if (wc_PufDeriveKey(&ctx, info, sizeof(info), key2, sizeof(key2))
+            != WC_NO_ERR_TRACE(PUF_DERIVE_KEY_E))
+        return WC_TEST_RET_ENC_NC;
+
+    /* bch_decode() failure path: a reconstruct that fails inside BCH decoding
+     * (not in the identity hash) must scrub ctx->stableBits / ctx->identity and
+     * clear WC_PUF_FLAG_READY, exactly as the identity-hash failure path above.
+     * Run a clean reconstruct first so ctx->identity holds a real hash, then a
+     * reconstruct whose first codeword carries a 32-bit helper-data burst. */
+    ret = wc_PufInit(&ctx);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    ret = wc_PufSetTestData(&ctx, testSram, sizeof(testSram));
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    ret = wc_PufReadSram(&ctx, testSram, sizeof(testSram));
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    ret = wc_PufReconstruct(&ctx, helperBuf, WC_PUF_HELPER_BYTES);
+    if (ret != 0)
+        return WC_TEST_RET_ENC_EC(ret);
+    /* the clean reconstruct must have produced a non-zero identity, otherwise
+     * the scrub check below would pass vacuously */
+    if (XMEMCMP(ctx.identity, zeroBuf, WC_PUF_ID_SZ) == 0)
+        return WC_TEST_RET_ENC_NC;
+
+    /* Flip the first 32 helper bits. Those bits all belong to codeword 0 in
+     * every shipped profile (its helper run is at least WC_PUF_BCH_DEG = 49
+     * bits) and form a length-32 burst in the decoder input. A cyclic code
+     * detects every burst shorter than n - k, and no profile can correct 32
+     * errors (t is 7..15), so bch_decode() rejects this deterministically. */
+    XMEMCPY(badHelper, helperBuf, WC_PUF_HELPER_BYTES);
+    badHelper[0] ^= 0xFF;
+    badHelper[1] ^= 0xFF;
+    badHelper[2] ^= 0xFF;
+    badHelper[3] ^= 0xFF;
+
+    ret = wc_PufReconstruct(&ctx, badHelper, WC_PUF_HELPER_BYTES);
+    if (ret != WC_NO_ERR_TRACE(PUF_RECONSTRUCT_E))
+        return WC_TEST_RET_ENC_NC;
+    if ((ctx.flags & WC_PUF_FLAG_READY) != 0)
+        return WC_TEST_RET_ENC_NC;
+    if (XMEMCMP(ctx.stableBits, zeroBuf, WC_PUF_STABLE_BYTES) != 0)
+        return WC_TEST_RET_ENC_NC;
+    if (XMEMCMP(ctx.identity, zeroBuf, WC_PUF_ID_SZ) != 0)
+        return WC_TEST_RET_ENC_NC;
+    if (wc_PufDeriveKey(&ctx, info, sizeof(info), key2, sizeof(key2))
+            != WC_NO_ERR_TRACE(PUF_DERIVE_KEY_E))
+        return WC_TEST_RET_ENC_NC;
 
     return 0;
 #else

--- a/wolfssl/wolfcrypt/puf.h
+++ b/wolfssl/wolfcrypt/puf.h
@@ -293,6 +293,10 @@ WOLFSSL_API int wc_PufZeroize(wc_PufCtx* ctx);
 
 #ifdef WOLFSSL_PUF_TEST
 WOLFSSL_API int wc_PufSetTestData(wc_PufCtx* ctx, const byte* data, word32 sz);
+/* Test hook: when on is non-zero, wc_PufEnroll() and wc_PufReconstructEx()
+ * behave as if the final identity hash failed, so the failure-path state
+ * cleanup can be exercised. */
+WOLFSSL_API void wc_PufTestForceHashFail(int on);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
# Description

`wc_PufEnroll()` and `wc_PufReconstructEx()` overwrite `ctx->stableBits` (and, for enroll, `ctx->helperData`) early, then compute `ctx->identity` last via `wc_PufHashDirect()`. On that final hash call failing, both functions returned a module error (`PUF_ENROLL_E` / `PUF_RECONSTRUCT_E`) without clearing `ctx->flags`. On a re-enroll or re-reconstruction of a context that a prior successful run already left `ENROLLED|READY`, this leaves the READY flag set while `stableBits` holds the new (partial) material and `identity` still holds the old hash. `wc_PufDeriveKey()` gates only on `WC_PUF_FLAG_READY`, so it then passes and derives `HKDF(ikm = new stableBits, salt = stale identity)` — a key that no later correct reconstruction can reproduce. The per-codeword `bch_decode()` failure path in `wc_PufReconstructEx()` already clears `WC_PUF_FLAG_READY` and scrubs `stableBits`, so the final hash-failure path was simply inconsistent with the module's own intent.

This is distinct from the related finding on helper-data persistence / zeroization (F-7402): that one concerns helper data lifetime, this one is stale READY state after a hash failure and needs different cleanup.

PUF is a pure-software module and is outside the FIPS boundary (`WOLFSSL_PUF` + `HAVE_FIPS` is a compile-time `#error` in `puf.h`), so this change does not touch certified code.

## Changes

`wolfcrypt/src/puf.c`

- On the identity-hash failure path of `wc_PufEnroll()`: clear `WC_PUF_FLAG_ENROLLED | WC_PUF_FLAG_READY` and `ForceZero()` both `ctx->stableBits` and `ctx->identity` before returning `PUF_ENROLL_E`.
- On the identity-hash failure path of `wc_PufReconstructEx()`: clear `WC_PUF_FLAG_READY` and `ForceZero()` both `ctx->stableBits` and `ctx->identity` before returning `PUF_RECONSTRUCT_E`, matching the existing `bch_decode()` failure path.
- Add `ForceZero(ctx->identity, WC_PUF_ID_SZ)` to the `bch_decode()` failure path so both failure exits leave identical state.

`wolfssl/wolfcrypt/puf.h`, `wolfcrypt/src/puf.c`

- Add a `WOLFSSL_PUF_TEST`-only test seam `wc_PufTestForceHashFail(int on)` (same pattern as the existing `wc_PufSetTestData()` / `testDataSet` seam). When set, `wc_PufEnroll()` and `wc_PufReconstructEx()` treat the final `wc_PufHashDirect()` as having failed. Two small `#ifdef WOLFSSL_PUF_TEST` hooks, no effect on a normal build.

`wolfcrypt/test/test.c`

- New sub-test in `puf_test()` (Test 11): enroll (resp. reconstruct) once cleanly to reach `ENROLLED|READY`, then force the identity hash to fail on a re-run and assert the error code is returned, the flags are cleared, `stableBits` and `identity` are zeroed, and `wc_PufDeriveKey()` / `wc_PufGetIdentity()` are rejected by the READY gate.
- The all-zero reference buffer is sized to the larger of `WC_PUF_STABLE_BYTES` and `WC_PUF_ID_SZ` (small profiles / low codeword counts make `WC_PUF_STABLE_BYTES` smaller than 32).

Fixes zd#

# Testing

Ran `./wolfcrypt/test/testwolfcrypt` (`puf_test()` includes the new Test 11) on the profile / hash matrix used by `.github/workflows/puf.yml`:

- `--enable-puf --enable-puf-test` (default, t=10, SHA-256) — pass
- `--enable-puf=small --enable-puf-test CPPFLAGS=-DWC_PUF_NUM_CODEWORDS=3` — pass
- `--enable-puf=strong --enable-puf-test CPPFLAGS=-DWC_PUF_HELPER_COMPACT` — pass
- `--enable-puf=strongest --enable-puf-test CPPFLAGS=-DWC_PUF_NUM_CODEWORDS=3` — pass
- `--enable-puf --enable-puf-test --enable-sha3 CPPFLAGS=-DWC_PUF_SHA3` — pass

Regression check: with the test seam kept but the three cleanup hunks in `puf.c` reverted, Test 11 fails (the pre-fix `wc_PufDeriveKey()` returns success after the hash failure, deriving a key from new `stableBits` + stale `identity`); with the fix applied it passes.

Also confirmed independently before wiring the in-tree test: a standalone program interposing `wc_Sha256Hash` (== `wc_PufHashDirect` in the default build) to fail on demand showed 8 state-check failures against the unpatched library and all-pass against the patched one. No hardware and no FIPS bundle required.

Existing `testwolfcrypt` runs show no regression.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation

