### PR TITLE
XMSS/Falcon: zeroize secret working state and key buffers before free

### DIFF
--- a/wolfcrypt/src/falcon.c
+++ b/wolfcrypt/src/falcon.c
@@ -9540,6 +9540,9 @@ int wc_Falcon_PrivateKeyDecode(const byte* input, word32* inOutIdx,
         }
     }
 
+    /* Zeroize the decoded private key before free (matches every other secret
+     * temporary in this file); pubKey is public and needs no scrubbing. */
+    ForceZero(privKey, FALCON_MAX_PRV_KEY_SIZE);
     XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(pubKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     return ret;

--- a/wolfcrypt/src/wc_xmss.c
+++ b/wolfcrypt/src/wc_xmss.c
@@ -787,6 +787,8 @@ static WC_INLINE int wc_xmsskey_signupdate(XmssKey* key, byte* sig,
                 /* Free state after use. */
                 wc_xmss_state_free(state);
             }
+            /* Zeroize working state before free. */
+            ForceZero(state, sizeof(XmssState));
             WC_FREE_VAR_EX(state, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }
@@ -1284,6 +1286,8 @@ int wc_XmssKey_MakeKey(XmssKey* key, WC_RNG* rng)
                 /* Free state after use. */
                 wc_xmss_state_free(state);
             }
+            /* Zeroize working state before free. */
+            ForceZero(state, sizeof(XmssState));
             WC_FREE_VAR_EX(state, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }
@@ -1305,6 +1309,14 @@ int wc_XmssKey_MakeKey(XmssKey* key, WC_RNG* rng)
         key->state = WC_XMSS_STATE_OK;
     }
 
+    /* Zeroize the secret seed (SK_seed || SK_PRF) before freeing the buffer. */
+#ifdef WOLFSSL_SMALL_STACK
+    if (seed != NULL) {
+        ForceZero(seed, 3U * key->params->n);
+    }
+#else
+    ForceZero(seed, sizeof(seed));
+#endif
     WC_FREE_VAR_EX(seed, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     return ret;
 }
@@ -2015,6 +2027,8 @@ int wc_XmssKey_Verify(XmssKey* key, const byte* sig, word32 sigLen,
                 /* Free state after use. */
                 wc_xmss_state_free(state);
             }
+            /* Zeroize working state before free. */
+            ForceZero(state, sizeof(XmssState));
             WC_FREE_VAR_EX(state, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }


### PR DESCRIPTION
## Description

A few secret buffers in the XMSS and Falcon code are freed without being
zeroized first, so key material stays resident in freed heap or on the stack.
This adds ForceZero in each spot, matching the pattern already used by LMS,
ML-KEM, ML-DSA, and SLH-DSA, and by every other secret temporary in falcon.c.

wc_xmss.c
- The XmssState working buffer holds the XMSS private seed S_XMSS and transient
  WOTS secret keys during keygen and sign. It is now ForceZero'd before
  WC_FREE_VAR_EX, mirroring wc_lms.c (ForceZero(state, sizeof(LmsState))). Added
  at the sign, keygen, and verify sites so all three match the LMS treatment.
- The keygen seed buffer (SK_seed || SK_PRF || SEED) is zeroized before it is
  freed; the first 2*n bytes are secret. The adjacent key->sk was already
  zeroized.

falcon.c
- wc_Falcon_PrivateKeyDecode zeroizes the decoded private-key temporary before
  freeing it. pubKey is public and is left as is.

No functional change; behavior is identical.

## Testing

Built and regression tested with:

    ./configure --enable-experimental --enable-xmss --enable-lms --enable-falcon
    make
    ./wolfcrypt/test/testwolfcrypt

XMSS, LMS, and Falcon self-tests pass; the full suite returns 0.
