### PR TITLE
Send SNI in external.test so the peer returns its own certificate

### DIFF
--- a/scripts/external.test
+++ b/scripts/external.test
@@ -50,13 +50,21 @@ fi
 
 echo "WOLFSSL_EXTERNAL_TEST set, running test..."
 
+# The CDN in front of $server answers a request without SNI using its own
+# default certificate, whose chain needs a larger RSA key than some builds
+# support, so name the host wherever the build can.
+sni=""
+if ./examples/client/client -S check | grep -q 'SNI is: ON'; then
+    sni="-S $server"
+fi
+
 # is our desired server there?
 "${SCRIPT_DIR}"/ping.test $server 2
 RESULT=$?
 [ $RESULT -ne 0 ] && exit 0
 
 # client test against the server
-$TIMEOUT_KILL_2M ./examples/client/client -X -C -h $server -p 443 -g -A $ca
+$TIMEOUT_KILL_2M ./examples/client/client -X -C -h $server $sni -p 443 -g -A $ca
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 
@@ -66,7 +74,7 @@ RESULT=$?
 BUILD_FLAGS="$(./examples/client/client '-#')"
 if echo "$BUILD_FLAGS" | grep -q "WOLFSSL_SYS_CA_CERTS" && ! echo "$BUILD_FLAGS" | grep -q "WOLFSSL_STATIC_MEMORY"; then
     echo -e "\nConnecting using WOLFSSL_SYS_CA_CERTS..."
-    ./examples/client/client -X -C -h $server -p 443 -g --sys-ca-certs
+    ./examples/client/client -X -C -h $server $sni -p 443 -g --sys-ca-certs
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed when using WOLFSSL_SYS_CA_CERTS" && exit 1
 fi


### PR DESCRIPTION
## Description

`scripts/external.test` connects to `www.wolfssl.com` without a `server_name` extension, so the CDN in front of that host answers with its own default certificate instead of the wolfSSL one. That chain currently runs through the RSA-4096 GlobalSign Root R46, while the intended chain is RSA-2048 throughout. The test therefore only passes on builds that can verify a 4096-bit signature.

Two PRB configurations fail on master because of it:

| Configuration | Error |
|---|---|
| `--enable-fastmath CFLAGS=-DFP_MAX_BITS=6144` (PRB-single-flag) | `-132` `BUFFER_E` |
| `CFLAGS=-m32 LDFLAGS=-m32 --enable-32bit` (PRB-m32) | `-155` `ASN_SIG_CONFIRM_E` |

Both are correct refusals to handle a key larger than the build supports. The 32-bit case is the documented behavior from #7929 and #9633: without `WOLFSSL_X86_64_BUILD`, `WOLFSSL_AARCH64_BUILD` or `OPENSSL_EXTRA`, `settings.h` skips the desktop key-size bump and `SP_INT_BITS` falls back to 3072. The test, not the library, is what needs fixing.

## Change

Name the host with `-S` in both client invocations, gated on the client's own `-S check` probe. The option is a no-op where the build lacks SNI, so those configurations keep their current behavior and lose no coverage.

