### PR TITLE
Rust wrapper: ecc: fix check() return value comment

### DIFF
--- a/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/ecc.rs
@@ -1300,8 +1300,8 @@ impl ECC {
     ///
     /// # Returns
     ///
-    /// Returns either Ok(ECC) containing the ECC struct instance or Err(e)
-    /// containing the wolfSSL library error code value.
+    /// Returns either Ok(()) if the key is ok or Err(e) containing the wolfSSL
+    /// library error code value.
     ///
     /// # Example
     ///


### PR DESCRIPTION
# Description

Rust wrapper: ecc: fix check() return value comment

Fixes F-12247.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
