### PR TITLE
sniffer: copy handshake hashes with the wc_*Copy APIs

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -768,6 +768,10 @@ static int addKeyLogSnifferServerHelper(const char* address,
                                         char* error);
 #endif /* WOLFSSL_SNIFFER_KEYLOGFILE */
 
+#ifdef HAVE_EXTENDED_MASTER
+static void HashFree(HsHashes* hash);
+#endif
+
 
 /* Initialize overall Sniffer */
 void ssl_InitSniffer_ex(int devId)
@@ -947,6 +951,7 @@ static void FreeSnifferSession(SnifferSession* session)
 
         XFREE(session->ticketID, NULL, DYNAMIC_TYPE_SNIFFER_TICKET_ID);
 #ifdef HAVE_EXTENDED_MASTER
+        HashFree(session->hash);
         XFREE(session->hash, NULL, DYNAMIC_TYPE_HASHES);
 #endif
 #ifdef WOLFSSL_TLS13
@@ -1089,6 +1094,26 @@ static int HashInit(HsHashes* hash)
     return ret;
 }
 
+static void HashFree(HsHashes* hash)
+{
+    if (hash != NULL) {
+#ifndef NO_OLD_TLS
+#ifndef NO_SHA
+        wc_ShaFree(&hash->hashSha);
+#endif
+#ifndef NO_MD5
+        wc_Md5Free(&hash->hashMd5);
+#endif
+#endif /* !NO_OLD_TLS */
+#ifndef NO_SHA256
+        wc_Sha256Free(&hash->hashSha256);
+#endif
+#ifdef WOLFSSL_SHA384
+        wc_Sha384Free(&hash->hashSha384);
+#endif
+    }
+}
+
 static int HashUpdate(HsHashes* hash, const byte* input, int sz)
 {
     int ret = 0;
@@ -1120,22 +1145,28 @@ static int HashUpdate(HsHashes* hash, const byte* input, int sz)
 
 static int HashCopy(HS_Hashes* d, HsHashes* s)
 {
+    int ret = 0;
+
 #ifndef NO_OLD_TLS
 #ifndef NO_SHA
-    XMEMCPY(&d->hashSha, &s->hashSha, sizeof(wc_Sha));
+    if (ret == 0)
+        ret = wc_ShaCopy(&s->hashSha, &d->hashSha);
 #endif
 #ifndef NO_MD5
-    XMEMCPY(&d->hashMd5, &s->hashMd5, sizeof(wc_Md5));
+    if (ret == 0)
+        ret = wc_Md5Copy(&s->hashMd5, &d->hashMd5);
 #endif
 #endif /* !NO_OLD_TLS */
 #ifndef NO_SHA256
-    XMEMCPY(&d->hashSha256, &s->hashSha256, sizeof(wc_Sha256));
+    if (ret == 0)
+        ret = wc_Sha256Copy(&s->hashSha256, &d->hashSha256);
 #endif
 #ifdef WOLFSSL_SHA384
-    XMEMCPY(&d->hashSha384, &s->hashSha384, sizeof(wc_Sha384));
+    if (ret == 0)
+        ret = wc_Sha384Copy(&s->hashSha384, &d->hashSha384);
 #endif
 
-    return 0;
+    return ret;
 }
 
 #endif
@@ -4156,6 +4187,7 @@ static int ProcessServerHello(int msgSz, const byte* input, int* sslBytes,
 
 #ifdef HAVE_EXTENDED_MASTER
     if (!session->flags.expectEms) {
+        HashFree(session->hash);
         XFREE(session->hash, NULL, DYNAMIC_TYPE_HASHES);
         session->hash = NULL;
     }
@@ -5050,6 +5082,7 @@ static int DoHandShake(const byte* input, int* sslBytes,
                                 session, FATAL_ERROR_STATE);
                         ret = WOLFSSL_FATAL_ERROR;
                     }
+                    HashFree(session->hash);
                     XMEMSET(session->hash, 0, sizeof(HsHashes));
                     XFREE(session->hash, NULL, DYNAMIC_TYPE_HASHES);
                     session->hash = NULL;
@@ -5558,6 +5591,7 @@ static SnifferSession* CreateSession(IpInfo* ipInfo, TcpInfo* tcpInfo,
         }
         if (HashInit(newHash) != 0) {
             SetError(EXTENDED_MASTER_HASH_STR, error, NULL, 0);
+            HashFree(newHash);
             XFREE(newHash, NULL, DYNAMIC_TYPE_HASHES);
             XFREE(session, NULL, DYNAMIC_TYPE_SNIFFER_SESSION);
             return NULL;

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -5616,23 +5616,20 @@ static SnifferSession* CreateSession(IpInfo* ipInfo, TcpInfo* tcpInfo,
     session->context = GetSnifferServer(ipInfo, tcpInfo);
     if (session->context == NULL) {
         SetError(SERVER_NOT_REG_STR, error, NULL, 0);
-        XFREE(session, NULL, DYNAMIC_TYPE_SNIFFER_SESSION);
+        FreeSnifferSession(session);
         return NULL;
     }
 
     session->sslServer = wolfSSL_new(session->context->ctx);
     if (session->sslServer == NULL) {
         SetError(BAD_NEW_SSL_STR, error, session, FATAL_ERROR_STATE);
-        XFREE(session, NULL, DYNAMIC_TYPE_SNIFFER_SESSION);
+        FreeSnifferSession(session);
         return NULL;
     }
     session->sslClient = wolfSSL_new(session->context->ctx);
     if (session->sslClient == NULL) {
-        wolfSSL_free(session->sslServer);
-        session->sslServer = 0;
-
         SetError(BAD_NEW_SSL_STR, error, session, FATAL_ERROR_STATE);
-        XFREE(session, NULL, DYNAMIC_TYPE_SNIFFER_SESSION);
+        FreeSnifferSession(session);
         return NULL;
     }
     /* put server back into server mode */


### PR DESCRIPTION
### Problem

`HashCopy()` in `src/sniffer.c` copied handshake hash contexts with raw
`XMEMCPY`. Hash contexts own heap state in several configurations — the `W`
scratch buffer under `WOLFSSL_SMALL_STACK_CACHE`, the `msg` buffer under
`WOLFSSL_HASH_KEEP`, plus async, crypto-callback and hardware contexts. Two
defects followed:

- The destinations (`session->sslServer->hsHashes` and
  `session->sslClient->hsHashes`) come from `wolfSSL_new()` →
  `InitHandshakeHashes()` and already own allocated state. `XMEMCPY` leaked
  both and replaced the pointers with the source's, so one buffer was aliased
  by two independently freed `WOLFSSL` objects — a double free once both are
  released.
- The source `HsHashes` wrapper was `XMEMSET` and `XFREE`d without ever
  running `wc_*Free`, discarding the pointers it owned.

Reachable by any sniffer processing a TLS 1.2-or-below handshake that
negotiates extended master secret.

`src/internal.c` already documents this exact hazard for
`InitHandshakeHashesAndCopy()`. The sniffer's private `HsHashes` is a
different struct and needed the same treatment applied locally.

### Fix (`src/sniffer.c`)

- **`HashCopy()`** now calls `wc_ShaCopy()`, `wc_Md5Copy()`,
  `wc_Sha256Copy()` and `wc_Sha384Copy()`, accumulating into a `ret` it
  returns. These APIs free the destination internally and re-allocate
  destination-owned state, so source and both destinations end up disjoint.
- **`HashFree()`**, a new counterpart to `HashInit()`, releases the wrapper's
  hash members and tolerates a `NULL` argument. It is called on every
  `session->hash` teardown path, each of which previously ran a bare `XFREE`:

| Site | Context |
|---|---|
| `FreeSnifferSession()` | session teardown |
| `ProcessServerHello()` | EMS not negotiated |
| `DoHandShake()`, `client_key_exchange` | after the copy |
| `CreateSession()` | `HashInit()` failure |

The `XMEMSET` scrub at the `client_key_exchange` site is retained and now runs
after `HashFree()`: `wc_ShaFree()` and `wc_Md5Free()` do not zero their
structs, so it still wipes the SHA-1 and MD5 transcript state.

Closes f-13332 and f-13333.

### Verification

- Builds clean, no new warnings, with `--enable-sniffer --enable-smallstackcache
  -DWOLFSSL_HASH_KEEP` and with plain `--enable-sniffer`.
- `scripts/sniffer-testsuite.test` passes in both configs; `make check` 6
  passed, 5 skipped, 0 failed.
- Negative control: reverting only `HashCopy()` to `XMEMCPY` makes ASan report
  a heap use-after-free on the SHA-256 `W` buffer via `Transform_Sha256`,
  confirming both the aliasing and that the captures reach the EMS path.

### Test coverage

The existing TLS 1.2 captures do reach the changed code on the success path:
`HashCopy()` runs twice per session (server and client) and the
`client_key_exchange` `HashFree()` runs, both confirmed under ASan. The TLS 1.3
captures do not reach `HashCopy()` at all.

Three branches remain uncovered and are not addressed here:

| Path | Why the suite misses it |
|---|---|
| `HashCopy()` nonzero return | Needs a `wc_*Copy()` failure; the `else` in `DoHandShake()` was dead before this change and is now live |
| `HashFree()` in `CreateSession()` | Only runs when `HashInit()` fails |
| `HashFree()` in `ProcessServerHello()` | Only runs when EMS is *not* negotiated; every capture is generated by wolfSSL peers, which negotiate EMS by default |

The first two need allocation-failure injection the sniffer has no harness for;
the third needs a TLS 1.2 capture generated with EMS disabled on both peers.

