### PR TITLE
internal: propagate WANT_WRITE from the DTLS 1.3 receive timeout

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -12178,8 +12178,8 @@ WC_MAYBE_UNUSED static int SendHandshakeMsg(WOLFSSL* ssl, byte* input,
 }
 
 
-/* return bytes received, WOLFSSL_FATAL_ERROR on error,
- * or BAD_FUNC_ARG if ssl is null */
+/* return bytes received, WANT_READ or WANT_WRITE to call again,
+ * WOLFSSL_FATAL_ERROR on error, or BAD_FUNC_ARG if ssl is null */
 static int wolfSSLReceive(WOLFSSL* ssl, byte* buf, word32 sz)
 {
     int recvd;
@@ -12265,8 +12265,14 @@ retry:
             #ifdef WOLFSSL_DTLS
 #ifdef WOLFSSL_DTLS13
                 if (ssl->options.dtls && IsAtLeastTLSv1_3(ssl->version)) {
-                    /* TODO: support WANT_WRITE here */
-                    if (Dtls13RtxTimeout(ssl) < 0) {
+                    int rtxRet = Dtls13RtxTimeout(ssl);
+                    if (rtxRet == WC_NO_ERR_TRACE(WANT_WRITE)) {
+                        /* Record that this ACK or retransmit still owes a
+                         * write, so the next flush sends it. */
+                        ssl->dtls13SendingAckOrRtx = 1;
+                        return WC_NO_ERR_TRACE(WANT_WRITE);
+                    }
+                    if (rtxRet < 0) {
                         WOLFSSL_MSG(
                             "Error trying to retransmit DTLS buffered message");
                         return WOLFSSL_FATAL_ERROR;
@@ -24327,6 +24333,11 @@ static int GetInputData_ex(WOLFSSL *ssl, word32 size, word32 readAhead)
                      (word32)inSz);
         if (in == WC_NO_ERR_TRACE(WANT_READ))
             return WC_NO_ERR_TRACE(WANT_READ);
+
+#ifdef WOLFSSL_DTLS13
+        if (in == WC_NO_ERR_TRACE(WANT_WRITE))
+            return WC_NO_ERR_TRACE(WANT_WRITE);
+#endif
 
         if (in < 0) {
             WOLFSSL_ERROR_VERBOSE(SOCKET_ERROR_E);

--- a/tests/api/test_dtls13.c
+++ b/tests/api/test_dtls13.c
@@ -2486,3 +2486,128 @@ int test_dtls13_reset_clears_alert_history(void)
 #endif
     return EXPECT_RESULT();
 }
+
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS13)
+/* Reports a receive timeout for the first *ctx calls, then no data. A
+ * scheduled ACK takes one timeout of its own before the retransmit runs. */
+static int test_dtls13_rtx_timeout_read_cb(WOLFSSL *ssl, char *data, int sz,
+        void *ctx)
+{
+    int* timeouts = (int*)ctx;
+    (void)ssl;
+    (void)data;
+    (void)sz;
+    if (*timeouts > 0) {
+        (*timeouts)--;
+        return WOLFSSL_CBIO_ERR_TIMEOUT;
+    }
+    return WOLFSSL_CBIO_ERR_WANT_READ;
+}
+#endif
+
+/* A receive timeout makes DTLS 1.3 send an ACK or retransmit. When the
+ * transport cannot take it, the handshake reports want-write and the retry
+ * completes the send. */
+int test_dtls13_rtx_timeout_want_write(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS13)
+    WOLFSSL_CTX *ctx_c = NULL;
+    WOLFSSL *ssl_c = NULL;
+    struct test_memio_ctx test_ctx;
+    int timeouts = 1;
+    int sentBefore;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, NULL, &ssl_c, NULL,
+        wolfDTLSv1_3_client_method, NULL), 0);
+
+    /* Send the ClientHello flight and wait on the server. */
+    ExpectIntEQ(wolfSSL_connect(ssl_c), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    sentBefore = test_ctx.s_len;
+
+    /* The next receive reports a timeout while the transport refuses
+     * writes. */
+    wolfSSL_SetIOReadCtx(ssl_c, &timeouts);
+    wolfSSL_SSLSetIORecv(ssl_c, test_dtls13_rtx_timeout_read_cb);
+    test_memio_simulate_want_write(&test_ctx, 1, 1);
+    ExpectIntEQ(wolfSSL_connect(ssl_c), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_WRITE);
+    ExpectIntEQ(test_ctx.s_len, sentBefore);
+
+    /* With writes allowed again the retransmission reaches the peer. */
+    test_memio_simulate_want_write(&test_ctx, 1, 0);
+    ExpectIntEQ(wolfSSL_connect(ssl_c), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntGT(test_ctx.s_len, sentBefore);
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_CTX_free(ctx_c);
+#endif
+    return EXPECT_RESULT();
+}
+
+/* The same timeout on the read path. wolfSSL_read() reports want-write and
+ * marks the record it held, which wolfSSL_dtls13_do_scheduled_work() sends. */
+int test_dtls13_rtx_timeout_want_write_read(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS13)
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    struct test_memio_ctx test_ctx;
+    const char msg[] = "read-path";
+    const int msgLen = sizeof(msg);
+    char readBuf[sizeof(msg)];
+    int timeouts = 2;
+    int sentBefore;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfDTLSv1_3_client_method, wolfDTLSv1_3_server_method), 0);
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+
+    /* Leave a KeyUpdate buffered so a timeout has something to retransmit. */
+    ExpectIntEQ(wolfSSL_update_keys(ssl_c), WOLFSSL_SUCCESS);
+    sentBefore = test_ctx.s_len;
+
+    /* The next receive reports a timeout while the transport refuses
+     * writes. */
+    wolfSSL_SetIOReadCtx(ssl_c, &timeouts);
+    wolfSSL_SSLSetIORecv(ssl_c, test_dtls13_rtx_timeout_read_cb);
+    test_memio_simulate_want_write(&test_ctx, 1, 1);
+    XMEMSET(readBuf, 0, sizeof(readBuf));
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_WRITE);
+    ExpectIntEQ(test_ctx.s_len, sentBefore);
+
+    /* Reading again reports no data rather than an error, and the record the
+     * timeout could not write is still owed. */
+    test_memio_simulate_want_write(&test_ctx, 1, 0);
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(wolfSSL_dtls13_pending_work(ssl_c), 1);
+
+    /* The pump sends it. */
+    ExpectIntEQ(wolfSSL_dtls13_do_scheduled_work(ssl_c), WOLFSSL_SUCCESS);
+    ExpectIntGT(test_ctx.s_len, sentBefore);
+    ExpectIntEQ(wolfSSL_dtls13_pending_work(ssl_c), 0);
+
+    /* The connection still carries application data. */
+    wolfSSL_SSLSetIORecv(ssl_c, test_memio_read_cb);
+    wolfSSL_SetIOReadCtx(ssl_c, &test_ctx);
+    ExpectIntEQ(wolfSSL_read(ssl_s, readBuf, sizeof(readBuf)), -1);
+    ExpectIntEQ(wolfSSL_get_error(ssl_s, -1), WOLFSSL_ERROR_WANT_READ);
+    ExpectIntEQ(wolfSSL_write(ssl_s, msg, msgLen), msgLen);
+    XMEMSET(readBuf, 0, sizeof(readBuf));
+    ExpectIntEQ(wolfSSL_read(ssl_c, readBuf, sizeof(readBuf)), msgLen);
+    ExpectStrEQ(readBuf, msg);
+
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+#endif
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_dtls13.h
+++ b/tests/api/test_dtls13.h
@@ -61,6 +61,8 @@ int test_dtls13_epoch_slot_reuse_replay(void);
 int test_dtls13_epoch_slot_reuse_decrypt_epoch(void);
 int test_dtls13_plaintext_ack_after_handshake(void);
 int test_dtls13_reset_clears_alert_history(void);
+int test_dtls13_rtx_timeout_want_write(void);
+int test_dtls13_rtx_timeout_want_write_read(void);
 
 #define TEST_DTLS13_DECLS                                                      \
     TEST_DECL_GROUP("dtls13", test_dtls13_bad_epoch_ch),                       \
@@ -74,6 +76,8 @@ int test_dtls13_reset_clears_alert_history(void);
     TEST_DECL_GROUP("dtls13", test_dtls13_finished_send_error_propagation),    \
     TEST_DECL_GROUP("dtls13", test_dtls13_basic_connection_id),                \
     TEST_DECL_GROUP("dtls13", test_dtls13_hrr_want_write),                     \
+    TEST_DECL_GROUP("dtls13", test_dtls13_rtx_timeout_want_write),             \
+    TEST_DECL_GROUP("dtls13", test_dtls13_rtx_timeout_want_write_read),        \
     TEST_DECL_GROUP("dtls13", test_dtls13_every_write_want_write),             \
     TEST_DECL_GROUP("dtls13", test_dtls13_epochs),                             \
     TEST_DECL_GROUP("dtls13", test_dtls13_alert_with_pending_output),          \


### PR DESCRIPTION
### Problem
`wolfSSLReceive()` answers a `WOLFSSL_CBIO_ERR_TIMEOUT` by calling
`Dtls13RtxTimeout()`, which sends a DTLS 1.3 ACK or retransmits the last flight.
On a non-blocking transport that send can return `WANT_WRITE`, but the branch
tested only `< 0` and returned `WOLFSSL_FATAL_ERROR` — the application saw a dead
connection where it should have seen "wait for writability and call again". The
source carried `/* TODO: support WANT_WRITE here */` from the commit that added
the branch.

`wolfSSL_dtls_got_timeout()` already handled the identical return correctly, so
the two ways of driving a DTLS 1.3 timeout disagreed.

Reachable through both supported IO paths: a custom recv callback returning
`WOLFSSL_CBIO_ERR_TIMEOUT` paired with a send callback returning
`WOLFSSL_CBIO_ERR_WANT_WRITE`, and the built-in `EmbedReceiveFrom()` timeout
paths (`dtls_timeout` accounting, `SO_RCVTIMEO`).

Closes f-13343.

### Fix (`src/internal.c`)
- **`wolfSSLReceive()`** captures the result. `WANT_WRITE` sets
  `dtls13SendingAckOrRtx`, marking the record as still owing a write, and
  returns `WANT_WRITE`; a genuine failure still returns `WOLFSSL_FATAL_ERROR`.
- **`GetInputData_ex()`** passes `WANT_WRITE` through rather than folding it into
  `SOCKET_ERROR_E`, under `#ifdef WOLFSSL_DTLS13`.

Both are required: `WANT_WRITE` is `-327`, so without the second hunk the first
is rewritten to `SOCKET_ERROR_E` in the next frame.

Nothing above needed changing. `DoProcessReplyEx()` already permits `WANT_WRITE`
as a retry state, `ReceiveData()` already exempts it from its error-state guard,
and the connect/accept flush and `wolfSSL_dtls13_do_scheduled_work()` already
settle the owed record off `dtls13SendingAckOrRtx`.

### Tests

| Test | Coverage |
|---|---|
| `test_dtls13_rtx_timeout_want_write` | handshake: `wolfSSL_connect()` reports `WANT_WRITE`; the retry sends the retransmission |
| `test_dtls13_rtx_timeout_want_write_read` | post-handshake: `wolfSSL_read()` reports it, `wolfSSL_dtls13_pending_work()` reports the debt, the pump sends it |

### Verification
- Both tests fail with either hunk reverted, pass with both.
- `dtls13` 22/22, `dtls` 82/82, full API 676 passed / 0 failed, `make check` 0 failed.
- Clean builds with `--disable-dtls` and `--enable-dtls --disable-dtls13`; the new
  tests skip rather than fail there.

### Not in this PR
Two sites mishandle the widened return only on record-spanning transports (SCTP
or `WOLFSSL_DTLS_RECORDS_CAN_SPAN_DATAGRAMS`), unreachable on plain UDP:
`GetDtlsRecordHeader()` folds `WANT_WRITE` into `LENGTH_ERROR`, and
`DtlsShouldDrop()` drops it post-handshake. That filter already folds `WANT_READ`
the same way, so all three belong together in a follow-up.