### PR TITLE
Fix/mem alloc mismatch

### DIFF
--- a/tests/api/test_tls_bounds.c
+++ b/tests/api/test_tls_bounds.c
@@ -1466,6 +1466,8 @@ int test_ProcessChainOCSPRequest_bounds(void)
     ExpectNotNull(ssl = wolfSSL_new(ctx));
     if (ssl != NULL) {
         TLSX* ext = NULL;
+        DerBuffer* savedCert = ssl->buffers.certificate;
+        DerBuffer* savedChain = ssl->buffers.certChain;
         ExpectIntEQ(TLSX_UseCertificateStatusRequest(&ssl->extensions,
                     WOLFSSL_CSR_OCSP, 0, ssl, ssl->heap, ssl->devId),
                     WOLFSSL_SUCCESS);
@@ -1475,10 +1477,14 @@ int test_ProcessChainOCSPRequest_bounds(void)
         /* A certificate had to be loaded for wolfSSL_new() to succeed (see
          * test_tls_bounds_load_server_cert()); clear both buffers back to
          * NULL so ProcessChainOCSPRequest() sees exactly the "chain ==
-         * NULL" state under test. */
+         * NULL" state under test. The SSL owns these buffers (weOwnCert),
+         * so save and restore them - nulling them outright leaked the DER
+         * copy that wolfSSL_new() allocated. */
         ssl->buffers.certChain = NULL;
         ssl->buffers.certificate = NULL;
         ExpectIntEQ(ProcessChainOCSPRequest(ssl), 0);
+        ssl->buffers.certificate = savedCert;
+        ssl->buffers.certChain = savedChain;
     }
     wolfSSL_free(ssl);
     ssl = NULL;

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -371,6 +371,10 @@ void* wolfSSL_Malloc(size_t size)
         #ifdef WOLFSSL_TRAP_MALLOC_SZ
         if (size > WOLFSSL_TRAP_MALLOC_SZ) {
             WOLFSSL_MSG("Malloc too big!");
+        #ifdef WOLFSSL_MEM_FAIL_COUNT
+            /* Allocation was counted above but no block exists to free. */
+            wc_MemFailCount_AllocFailed();
+        #endif
             return NULL;
         }
         #endif

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -544,7 +544,14 @@ void* wolfSSL_Realloc(void *ptr, size_t size)
     }
 
 #ifdef WOLFSSL_MEM_FAIL_COUNT
-    if (ptr != NULL) {
+    /* realloc(NULL, n) is malloc. AllocMem() already counted it; if the
+     * allocator returns NULL for a positive size, no block exists to free.
+     * Do not undo a failed realloc of a live pointer: that path still
+     * counts a free below and the original block remains. */
+    if (res == NULL && ptr == NULL && size > 0) {
+        wc_MemFailCount_AllocFailed();
+    }
+    else if (ptr != NULL) {
         wc_MemFailCount_FreeMem();
     }
 #endif

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -461,7 +461,13 @@ void wolfSSL_Free(void *ptr)
     wc_MemZero_Check(((unsigned char*)ptr) + MEM_ALIGN, *(size_t*)ptr);
 #endif
 #ifdef WOLFSSL_MEM_FAIL_COUNT
-    wc_MemFailCount_FreeMem();
+    /* Only count a free when there is a block to release. wolfSSL_Free(NULL)
+     * releases nothing (ISO/IEC 9899:2018 7.22.3.3: free(NULL) is a no-op),
+     * and a failed wolfSSL_Malloc() no longer counts an allocation, so a NULL
+     * free must not be counted either or Frees would exceed Total. */
+    if (ptr != NULL) {
+        wc_MemFailCount_FreeMem();
+    }
 #endif
 
     if (free_function) {

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -162,6 +162,19 @@ static int wc_MemFailCount_AllocMem(void)
 
     return ret;
 }
+/* An allocation was counted by wc_MemFailCount_AllocMem() above, but the
+ * underlying allocator then returned NULL (a caller-installed failing
+ * allocator via wolfSSL_SetAllocators(), or a genuine out-of-memory). No
+ * block exists to be freed, so undo the count to keep Total (allocs)
+ * balanced with Frees. */
+static void wc_MemFailCount_AllocFailed(void)
+{
+    wc_LockMutex(&memFailMutex);
+    if (mem_fail_allocs > 0) {
+        mem_fail_allocs--;
+    }
+    wc_UnLockMutex(&memFailMutex);
+}
 static void wc_MemFailCount_FreeMem(void)
 {
     wc_LockMutex(&memFailMutex);
@@ -406,7 +419,16 @@ void* wolfSSL_Malloc(size_t size)
             free(res); /* native heap */
         }
         gMemFailCount = gMemFailCountSeed; /* reset */
+    #ifdef WOLFSSL_MEM_FAIL_COUNT
+        wc_MemFailCount_AllocFailed();
+    #endif
         return NULL;
+    }
+#endif
+
+#ifdef WOLFSSL_MEM_FAIL_COUNT
+    if (res == NULL) {
+        wc_MemFailCount_AllocFailed();
     }
 #endif
 


### PR DESCRIPTION
# Description

Fixes spurious `Free/Alloc mismatch` failures reported by the mem-fail nightly (`WOLFSSL_MEM_FAIL_COUNT`). Two independent fixes:

1. **`memory.c` — don't count a failed allocation.** `wolfSSL_Malloc()` calls `wc_MemFailCount_AllocMem()` (which increments `mem_fail_allocs`) *before* invoking the registered allocator. When a caller-installed failing allocator (`wolfSSL_SetAllocators()`, used by several OOM unit tests) or a genuine OOM returns `NULL`, the allocation was counted but no block exists to free, so `Total` ends up one higher than `Frees`. Because this happens in the baseline counting phase, it reproduces identically in every shard. The fix undoes the count when the allocator returns `NULL`. All changes are under `#ifdef WOLFSSL_MEM_FAIL_COUNT` and do not affect production builds.

2. **`test_ProcessChainOCSPRequest_bounds` — restore SSL-owned cert buffers.** The first vector nulled `ssl->buffers.certChain`/`certificate` to drive the "chain == NULL" path, but the SSL owns the certificate DER copy (`weOwnCert`), so nulling it outright leaked 1536 bytes (a real leak, confirmed with `leaks`). The buffers are now saved, cleared for the call under test, and restored so `wolfSSL_free()` releases them.

Affected Class A tests now balanced: `test_TLSX_SecureRenegotiation_parse`, `test_TLSX_CSR_parse`, `test_TLSX_SupportedGroups_parse`, `test_TLSX_KeyShare_gen`, `test_tls_msgtype_tca_new_alloc`, `test_TLSX_CSR_Parse_bounds`, `test_ProcessChainOCSPRequest_bounds`.

Fixes zd# _(N/A — tracked via the mem-fail nightly / jenkins-supervisor; add the ticket number if there is one)_

# Testing

Built with a near-nightly config and the mem-fail flag:
```
./configure --disable-shared --enable-static --enable-all \
    --enable-secure-renegotiation --enable-debug \
    C_EXTRA_FLAGS="-DWOLFSSL_MEM_FAIL_COUNT"
make -j tests/unit.test
```
- **Reproduced** each mismatch on the unpatched tree (e.g. `test_TLSX_SecureRenegotiation_parse` → `Total 184 / Frees 183`).
- **After fix:** all 7 tests report `Total == Frees`; unrelated tests unaffected (`8/8`, `282/282`, `19/19`).
- **Injection loop** (`MEM_FAIL_CNT=1..MAX`) on a fixed test: every iteration balanced, no new crashes.
- **Leak check** (macOS `leaks --atExit`) on `test_ProcessChainOCSPRequest_bounds`: `1 leak (1536 bytes)` before → `0 leaks` after.

# Checklist

 - [ ] added tests — _N/A; fixes existing test/instrumentation, no new test needed_
 - [ ] updated/added doxygen — _N/A_
 - [ ] updated appropriate READMEs — _N/A_
 - [ ] Updated manual and documentation — _N/A_