### PR TITLE
tests: reset freed pointers in mem-fail TLS tests to avoid double-free

### DIFF
--- a/tests/api/test_tls_bounds.c
+++ b/tests/api/test_tls_bounds.c
@@ -899,7 +899,9 @@ int test_TLSX_ALPN_GetSize_overflow(void)
                 WC_NO_ERR_TRACE(LENGTH_ERROR));
 
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
     return EXPECT_RESULT();
 #else
     return TEST_SKIPPED;
@@ -1742,7 +1744,9 @@ int test_TLSX_PopulateExtensions_bounds(void)
         ExpectNull(TLSX_Find(ssl->extensions, TLSX_SUPPORTED_GROUPS));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* The point-format decision's four leaf conditions are
      * "(!IsAtLeastTLSv1_3(ssl->version) || ssl->options.downgrade) &&
@@ -1765,7 +1769,9 @@ int test_TLSX_PopulateExtensions_bounds(void)
         ExpectNull(TLSX_Find(ssl->extensions, TLSX_EC_POINT_FORMATS));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* ctx-level Find == NULL (default, fresh ctx): operand 2 true -
      * independence for operand 2, paired against the vector above. */
@@ -1774,7 +1780,9 @@ int test_TLSX_PopulateExtensions_bounds(void)
     ExpectIntEQ(TLSX_PopulateExtensions(ssl, 0), 0);
     ExpectNotNull(TLSX_Find(ssl->extensions, TLSX_EC_POINT_FORMATS));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
 
     /* Operand 1 of "ssl->options.resuming && ssl->session->namedGroup != 0":
@@ -1792,7 +1800,9 @@ int test_TLSX_PopulateExtensions_bounds(void)
         ssl->options.resuming = 0;
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
 #ifdef HAVE_SESSION_TICKET
     /* Operand 1 of "ssl->options.resuming && ssl->session->ticketLen > 0":
@@ -1818,7 +1828,9 @@ int test_TLSX_PopulateExtensions_bounds(void)
         ssl->session->ticketLen = 0;
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif /* HAVE_SESSION_TICKET */
 
     /* Operand 1 of "client_psk_cb != NULL || client_psk_tls13_cb != NULL":
@@ -1835,7 +1847,9 @@ int test_TLSX_PopulateExtensions_bounds(void)
         ExpectIntEQ(TLSX_PopulateExtensions(ssl, 0), 0);
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* Both operands of "psk_keySz > MAX_PSK_KEY_LEN" and "not equal to USE_HW_PSK",
      * reached through the plain client_psk_cb path. */
@@ -1855,6 +1869,7 @@ int test_TLSX_PopulateExtensions_bounds(void)
                     WC_NO_ERR_TRACE(PSK_KEY_ERROR));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
 #endif
 
     mode = 1;
@@ -1867,6 +1882,7 @@ int test_TLSX_PopulateExtensions_bounds(void)
         ExpectIntEQ(TLSX_PopulateExtensions(ssl, 0), 0);
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
 
     mode = 2;
     ExpectNotNull(ssl = wolfSSL_new(ctx));
@@ -1878,8 +1894,10 @@ int test_TLSX_PopulateExtensions_bounds(void)
         ExpectIntEQ(TLSX_PopulateExtensions(ssl, 0), 0);
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
 
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
     return EXPECT_RESULT();
 #else
     return TEST_SKIPPED;
@@ -1922,6 +1940,7 @@ int test_TLSX_PopulateSupportedGroups_bounds(void)
     wolfSSL_free(ssl);
     ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* "2048/8 >= minDhKeySz && 2048/8 <= maxDhKeySz": both operands. */
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
@@ -1950,8 +1969,10 @@ int test_TLSX_PopulateSupportedGroups_bounds(void)
         ExpectIntEQ(TLSX_PopulateExtensions(ssl, 0), 0);
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
 
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
     return EXPECT_RESULT();
 #else
     return TEST_SKIPPED;
@@ -2033,7 +2054,9 @@ int test_TLSX_CSR_Parse_bounds(void)
         ssl->ctx->cm = origCM;
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* Client side, isRequest == false, TLS 1.3: the internal ticket-style
      * malloc for csr->responses[idx].buffer.
@@ -2089,7 +2112,9 @@ int test_TLSX_CSR_Parse_bounds(void)
         ssl->response_idx = 0;
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     return EXPECT_RESULT();
 #else
@@ -2542,7 +2567,9 @@ int test_TLSX_ext_msgtype_dispatch_bounds(void)
                     &offset), 0);
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* The "both false" baseline row for each of the three OR-shaped msgType
      * splits above (SupportedVersions/ClientCertificateType/
@@ -2582,7 +2609,9 @@ int test_TLSX_ext_msgtype_dispatch_bounds(void)
                     &offset), WC_NO_ERR_TRACE(SANITY_MSG_E));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
     ExpectNotNull(ssl = wolfSSL_new(ctx));
@@ -2602,7 +2631,9 @@ int test_TLSX_ext_msgtype_dispatch_bounds(void)
                     &offset), 0);
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
     ExpectNotNull(ssl = wolfSSL_new(ctx));
@@ -2622,7 +2653,9 @@ int test_TLSX_ext_msgtype_dispatch_bounds(void)
                     &offset), 0);
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     return EXPECT_RESULT();
 #else
@@ -2695,7 +2728,9 @@ int test_TLSX_SecureRenegotiation_Write_bounds(void)
         }
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     return EXPECT_RESULT();
 #else

--- a/tests/api/test_tls_msgtype.c
+++ b/tests/api/test_tls_msgtype.c
@@ -222,7 +222,9 @@ int test_tls_msgtype_certificate_ext_offered(void)
     ExpectIntNE(TLSX_Parse(ssl, buf, len, finished, NULL),
                 WC_NO_ERR_TRACE(UNSUPPORTED_EXTENSION));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* Baseline reject (op0..op4 all "true", via the ctx->extensions arm):
      * Certificate message, TLS 1.3, type not offered anywhere. */
@@ -232,7 +234,9 @@ int test_tls_msgtype_certificate_ext_offered(void)
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, certificate, NULL),
                 WC_NO_ERR_TRACE(UNSUPPORTED_EXTENSION));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op1 false: Certificate message, but not TLS 1.3. */
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method()));
@@ -241,7 +245,9 @@ int test_tls_msgtype_certificate_ext_offered(void)
     ExpectIntNE(TLSX_Parse(ssl, buf, len, certificate, NULL),
                 WC_NO_ERR_TRACE(UNSUPPORTED_EXTENSION));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op2 false: the type was offered at the ssl level. */
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
@@ -251,7 +257,9 @@ int test_tls_msgtype_certificate_ext_offered(void)
     ExpectIntNE(TLSX_Parse(ssl, buf, len, certificate, NULL),
                 WC_NO_ERR_TRACE(UNSUPPORTED_EXTENSION));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op3 false, op4 false: not offered at the ssl level, but the ctx has
      * it - so the type was still offered (CTX-level extensions apply to
@@ -263,7 +271,9 @@ int test_tls_msgtype_certificate_ext_offered(void)
     ExpectIntNE(TLSX_Parse(ssl, buf, len, certificate, NULL),
                 WC_NO_ERR_TRACE(UNSUPPORTED_EXTENSION));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op3 true: ctx forcibly NULL (restored before free). */
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
@@ -277,7 +287,9 @@ int test_tls_msgtype_certificate_ext_offered(void)
         ssl->ctx = savedCtx;
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
     return EXPECT_RESULT();
 }
@@ -1494,7 +1506,9 @@ int test_tls_msgtype_sni_parse_match(void)
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* M2: configured host does not match, and differs in length, so
      * XSTRLEN(hostName) == size is false (masking XSTRNCMP). No mismatch
@@ -1509,7 +1523,9 @@ int test_tls_msgtype_sni_parse_match(void)
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites),
                 WC_NO_ERR_TRACE(UNKNOWN_SNI_HOST_NAME_E));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* M3: configured host does not match, but is the same length, so
      * XSTRLEN(hostName) == size is true and XSTRNCMP(...) == 0 is false. */
@@ -1523,7 +1539,9 @@ int test_tls_msgtype_sni_parse_match(void)
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites),
                 WC_NO_ERR_TRACE(UNKNOWN_SNI_HOST_NAME_E));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* M4: mismatch, but WOLFSSL_SNI_ANSWER_ON_MISMATCH is set on the
      * configured name - the handshake proceeds with a fake match instead
@@ -1539,7 +1557,9 @@ int test_tls_msgtype_sni_parse_match(void)
     len = build_ext_with_body(buf, TLSX_SERVER_NAME, sniBody, sniLen);
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* M5: mismatch, but WOLFSSL_SNI_CONTINUE_ON_MISMATCH is set - the
      * handshake continues without installing a response or aborting. */
@@ -1554,7 +1574,9 @@ int test_tls_msgtype_sni_parse_match(void)
     len = build_ext_with_body(buf, TLSX_SERVER_NAME, sniBody, sniLen);
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
 #endif
     return EXPECT_RESULT();
@@ -1595,16 +1617,28 @@ int test_tls_msgtype_sni_parse_ech_public(void)
     ExpectNotNull(ech = (WOLFSSL_ECH*)XMALLOC(sizeof(WOLFSSL_ECH), ssl->heap,
                 DYNAMIC_TYPE_TMP_BUFFER));
     if (ech != NULL) {
+        int echPushRet;
         XMEMSET(ech, 0, sizeof(WOLFSSL_ECH));
         ech->echConfig = &echConfig;
-        ExpectIntEQ(TLSX_Push(&ssl->extensions, TLSX_ECH, ech, ssl->heap), 0);
+        /* On success ssl->extensions takes ownership of ech and frees it in
+         * wolfSSL_free(). On failure (e.g. an injected allocation failure in
+         * TLSX_New()) ownership is not transferred, so free it here to avoid
+         * leaking it. */
+        echPushRet = TLSX_Push(&ssl->extensions, TLSX_ECH, ech, ssl->heap);
+        ExpectIntEQ(echPushRet, 0);
+        if (echPushRet != 0) {
+            XFREE(ech, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+        ech = NULL;
     }
     XMEMSET(&suites, 0, sizeof(suites));
     sniLen = build_sni_body(sniBody, publicName);
     len = build_ext_with_body(buf, TLSX_SERVER_NAME, sniBody, sniLen);
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* Outer SNI is the same length as the publicName but differs in
      * content: XSTRLEN(...) == size is true, XSTRNCMP(...) == 0 is false,
@@ -1618,16 +1652,28 @@ int test_tls_msgtype_sni_parse_ech_public(void)
     ExpectNotNull(ech = (WOLFSSL_ECH*)XMALLOC(sizeof(WOLFSSL_ECH), ssl->heap,
                 DYNAMIC_TYPE_TMP_BUFFER));
     if (ech != NULL) {
+        int echPushRet;
         XMEMSET(ech, 0, sizeof(WOLFSSL_ECH));
         ech->echConfig = &echConfig;
-        ExpectIntEQ(TLSX_Push(&ssl->extensions, TLSX_ECH, ech, ssl->heap), 0);
+        /* On success ssl->extensions takes ownership of ech and frees it in
+         * wolfSSL_free(). On failure (e.g. an injected allocation failure in
+         * TLSX_New()) ownership is not transferred, so free it here to avoid
+         * leaking it. */
+        echPushRet = TLSX_Push(&ssl->extensions, TLSX_ECH, ech, ssl->heap);
+        ExpectIntEQ(echPushRet, 0);
+        if (echPushRet != 0) {
+            XFREE(ech, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+        ech = NULL;
     }
     XMEMSET(&suites, 0, sizeof(suites));
     sniLen = build_sni_body(sniBody, "pub.examplx");
     len = build_ext_with_body(buf, TLSX_SERVER_NAME, sniBody, sniLen);
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
     return EXPECT_RESULT();
 }
@@ -1664,7 +1710,9 @@ int test_tls_msgtype_psk_ch_id_gates(void)
                     WC_NO_ERR_TRACE(BUFFER_E));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op0 false, op1 true: identities length (6) meets MIN_PSK_ID_LEN, but
      * fewer than 6 bytes actually follow in the extension. (op0 false,
@@ -1680,7 +1728,9 @@ int test_tls_msgtype_psk_ch_id_gates(void)
                     WC_NO_ERR_TRACE(BUFFER_E));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* Per-identity op0 true: identities length (6) is consistent with the
      * outer check, but the single identity inside it claims a 10-byte
@@ -1696,7 +1746,9 @@ int test_tls_msgtype_psk_ch_id_gates(void)
                     WC_NO_ERR_TRACE(BUFFER_E));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* Per-identity op0 false, op1 true: identityLen is one more than
      * MAX_PSK_ID_LEN, with enough buffer supplied to hold it in full. */
@@ -1720,7 +1772,9 @@ int test_tls_msgtype_psk_ch_id_gates(void)
                     WC_NO_ERR_TRACE(BUFFER_E));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
     return EXPECT_RESULT();
 }
@@ -1784,7 +1838,9 @@ int test_tls_msgtype_psk_sh_index(void)
             ExpectIntEQ(list->next->chosen, 1);
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op0 false: a single identity, server selects index 1 - the loop
      * runs out of list (masking op1) before idx reaches 0. */
@@ -1800,7 +1856,9 @@ int test_tls_msgtype_psk_sh_index(void)
     ExpectIntEQ(TLSX_Parse(ssl, shBuf, shLen, server_hello, NULL),
                 WC_NO_ERR_TRACE(PSK_KEY_ERROR));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
     return EXPECT_RESULT();
 }
@@ -1838,7 +1896,9 @@ int test_tls_msgtype_psk_sh_resumption(void)
         ssl->session->version = ssl->ctx->method->version;
     ExpectIntEQ(TLSX_Parse(ssl, shBuf, shLen, server_hello, NULL), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op0 true: cipherSuite0 mismatch. */
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
@@ -1854,7 +1914,9 @@ int test_tls_msgtype_psk_sh_resumption(void)
     ExpectIntEQ(TLSX_Parse(ssl, shBuf, shLen, server_hello, NULL),
                 WC_NO_ERR_TRACE(PSK_KEY_ERROR));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op1 true: cipherSuite mismatch. */
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
@@ -1870,7 +1932,9 @@ int test_tls_msgtype_psk_sh_resumption(void)
     ExpectIntEQ(TLSX_Parse(ssl, shBuf, shLen, server_hello, NULL),
                 WC_NO_ERR_TRACE(PSK_KEY_ERROR));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op2 true: session version.major mismatch. */
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
@@ -1886,7 +1950,9 @@ int test_tls_msgtype_psk_sh_resumption(void)
     ExpectIntEQ(TLSX_Parse(ssl, shBuf, shLen, server_hello, NULL),
                 WC_NO_ERR_TRACE(PSK_KEY_ERROR));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op3 true: session version.minor mismatch. */
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
@@ -1902,7 +1968,9 @@ int test_tls_msgtype_psk_sh_resumption(void)
     ExpectIntEQ(TLSX_Parse(ssl, shBuf, shLen, server_hello, NULL),
                 WC_NO_ERR_TRACE(PSK_KEY_ERROR));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
     return EXPECT_RESULT();
 }
@@ -1944,7 +2012,9 @@ int test_tls_msgtype_psk_ch_binder_gates(void)
                     WC_NO_ERR_TRACE(BUFFER_E));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op0 false, op1 true: binders length (33) meets MIN_PSK_BINDERS_LEN,
      * but far fewer bytes actually remain in the extension. */
@@ -1964,7 +2034,9 @@ int test_tls_msgtype_psk_ch_binder_gates(void)
                     WC_NO_ERR_TRACE(BUFFER_E));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* Per-binder op0 true: the binder length byte (10) is below
      * WC_SHA256_DIGEST_SIZE (32). The declared binders length (34) still
@@ -1989,7 +2061,9 @@ int test_tls_msgtype_psk_ch_binder_gates(void)
                     WC_NO_ERR_TRACE(BUFFER_E));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* Per-binder op1 true (op0 false): the binder length byte (100) is
      * above WC_MAX_DIGEST_SIZE (64). The declared binders length (34) only
@@ -2014,7 +2088,9 @@ int test_tls_msgtype_psk_ch_binder_gates(void)
                     WC_NO_ERR_TRACE(BUFFER_E));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* while(list!=NULL && len>0) op1 (len>0), and the trailing "list !=
      * NULL" gate: two identities, but only one binder - after consuming
@@ -2038,7 +2114,9 @@ int test_tls_msgtype_psk_ch_binder_gates(void)
                     WC_NO_ERR_TRACE(BUFFER_E));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* Trailing "len != 0" gate: one identity but two binders' worth of
      * data - list runs out (becomes NULL) while len still has a second
@@ -2062,7 +2140,9 @@ int test_tls_msgtype_psk_ch_binder_gates(void)
                     WC_NO_ERR_TRACE(BUFFER_E));
     }
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
     return EXPECT_RESULT();
 }
@@ -2105,7 +2185,9 @@ int test_tls_msgtype_cookie_parse_gates(void)
     len = build_ext_with_body(buf, TLSX_COOKIE, body, 6);
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
 
     /* dtls operand false: same setup, but a plain (non-DTLS) TLS 1.3
@@ -2119,7 +2201,9 @@ int test_tls_msgtype_cookie_parse_gates(void)
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites),
                 WC_NO_ERR_TRACE(HRR_COOKIE_ERROR));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
 #if defined(WOLFSSL_TEST_STATIC_BUILD)
     /* An existing Cookie extension (as if this SSL object had already
@@ -2139,7 +2223,9 @@ int test_tls_msgtype_cookie_parse_gates(void)
         ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites),
                     WC_NO_ERR_TRACE(HRR_COOKIE_ERROR));
         wolfSSL_free(ssl);
+        ssl = NULL;
         wolfSSL_CTX_free(ctx);
+        ctx = NULL;
 
         /* op0 false, op1 false: length and content both match - the
          * cookie is accepted and the request-seen flag is cleared. */
@@ -2153,7 +2239,9 @@ int test_tls_msgtype_cookie_parse_gates(void)
         len = build_ext_with_body(buf, TLSX_COOKIE, body, 6);
         ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
         wolfSSL_free(ssl);
+        ssl = NULL;
         wolfSSL_CTX_free(ctx);
+        ctx = NULL;
     }
 #endif /* WOLFSSL_TEST_STATIC_BUILD */
 #endif
@@ -2191,7 +2279,9 @@ int test_tls_msgtype_tca_parse_gates(void)
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, server_hello, NULL),
                 WC_NO_ERR_TRACE(UNSUPPORTED_EXTENSION));
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* 3131 op1 true: TCA configured, but its data was cleared - same
      * outcome via the other operand. */
@@ -2211,7 +2301,12 @@ int test_tls_msgtype_tca_parse_gates(void)
     if (extension != NULL)
         extension->data = savedExtData;
     wolfSSL_free(ssl);
+    ssl = NULL;
+    /* extension pointed into ssl->extensions (freed above); clear the stale
+     * handle so a later block does not touch freed memory. */
+    extension = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* 3131 both false: TCA configured normally, empty response body -
      * accepted, response flag set. */
@@ -2222,7 +2317,9 @@ int test_tls_msgtype_tca_parse_gates(void)
     len = build_ext(buf, TLSX_TRUSTED_CA_KEYS, 0);
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, server_hello, NULL), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* 3145 op1 true: server side, TCA configured but its data was
      * cleared - "not enabled at server side" is taken, not a crash. */
@@ -2249,7 +2346,10 @@ int test_tls_msgtype_tca_parse_gates(void)
     if (extension != NULL)
         extension->data = savedExtData;
     wolfSSL_free(ssl);
+    ssl = NULL;
+    extension = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
     return EXPECT_RESULT();
 }
@@ -2294,7 +2394,9 @@ int test_tls_msgtype_tca_find(void)
             (word16)(2 + entryLen));
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op0 true, op1 false: type matches, but the query's idSz (5)
      * differs from the configured entry's idSz (4). */
@@ -2312,7 +2414,9 @@ int test_tls_msgtype_tca_find(void)
             (word16)(2 + entryLen));
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op0 true, op1 true, op2 false: type and length match, content
      * does not. */
@@ -2330,7 +2434,9 @@ int test_tls_msgtype_tca_find(void)
             (word16)(2 + entryLen));
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op0 true, op1 true, op2 true: exact match - found on the first
      * (only) list entry. */
@@ -2348,7 +2454,9 @@ int test_tls_msgtype_tca_find(void)
             (word16)(2 + entryLen));
     ExpectIntEQ(TLSX_Parse(ssl, buf, len, client_hello, &suites), 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
     return EXPECT_RESULT();
 }
@@ -2427,7 +2535,9 @@ int test_tls_msgtype_tca_new_alloc(void)
     tca_fail_after = -1;
     (void)wolfSSL_SetAllocators(prevM, prevF, prevR);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* X509_NAME: same shape - struct allocation succeeds, id buffer
      * allocation fails. */
@@ -2443,7 +2553,9 @@ int test_tls_msgtype_tca_new_alloc(void)
     tca_fail_after = -1;
     (void)wolfSSL_SetAllocators(prevM, prevF, prevR);
     wolfSSL_free(ssl);
+    ssl = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
     return EXPECT_RESULT();
 }
@@ -2484,7 +2596,15 @@ int test_tls_msgtype_psk_write_chosen(void)
     ExpectIntEQ(TLSX_WriteResponse(ssl, output, server_hello, &offset), 0);
     ExpectIntGT(offset, 0);
     wolfSSL_free(ssl);
+    ssl = NULL;
+    /* pskA, pskB and extension were owned by ssl->extensions and freed by
+     * wolfSSL_free() above; clear the stale handles so the next block does
+     * not dereference freed memory if an Expect assignment is skipped. */
+    pskA = NULL;
+    pskB = NULL;
+    extension = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 
     /* op0 false: a single, unchosen identity - the loop runs off the end
      * of the list before finding a chosen entry. */
@@ -2500,7 +2620,12 @@ int test_tls_msgtype_psk_write_chosen(void)
     ExpectIntEQ(TLSX_WriteResponse(ssl, output, server_hello, &offset),
                 WC_NO_ERR_TRACE(BUILD_MSG_ERROR));
     wolfSSL_free(ssl);
+    ssl = NULL;
+    pskA = NULL;
+    pskB = NULL;
+    extension = NULL;
     wolfSSL_CTX_free(ctx);
+    ctx = NULL;
 #endif
     return EXPECT_RESULT();
 }


### PR DESCRIPTION
# Description

This is a test-only change. It does not change library code or run-time behavior.

The nightly mem-fail job builds with `WOLFSSL_MEM_FAIL_COUNT` and makes each memory allocation fail in turn. When an allocation fails, an `Expect*` assertion fails and latches the test result. After this point, the test framework does not evaluate any more `Expect*` statements. It therefore skips the pointer assignment inside a later `ExpectNotNull(ptr = wolfSSL_new(...))`.

Several unit tests run more than one setup/free block against the same `ssl` and `ctx` variables. If the framework skips the re-assignment in a later block, the variable still holds the pointer that the previous block freed. The unconditional cleanup at the end of the block then frees that pointer a second time. The result is a double-free or use-after-free. Because the failure depends on heap state, it appears as an intermittent SIGSEGV (139) or abort (134), not a stable failure.

The fix sets each pointer to `NULL` immediately after the test frees it. A later skipped assignment then leaves `NULL`, and `wolfSSL_free(NULL)`/`wolfSSL_CTX_free(NULL)` do nothing. Three tests also hold objects that the `WOLFSSL` owns (an ECH struct, pre-shared keys, and TLSX extension pointers) and dereference them in a later block through a bare `if (ptr != NULL)` guard. These handles are cleared for the same reason. In `test_tls_msgtype_sni_parse_ech_public`, a failed `TLSX_Push()` does not transfer ownership of `ech` (`TLSX_New()` returns `NULL` without storing `data`), so the test now frees `ech` on that path instead of leaking it.

The change applies the same pattern that `test_ProcessChainOCSPRequest_bounds` already uses in this file. Two multi-block tests (`test_wolfSSL_SetTlsHmacInner_bounds` and `test_ProcessChainOCSPRequest_bounds`) already reset their pointers and are left unchanged.

Affected tests:
- `test_tls_msgtype.c`: `certificate_ext_offered`, `sni_parse_match`, `sni_parse_ech_public`, `psk_ch_id_gates`, `psk_sh_index`, `psk_sh_resumption`, `psk_ch_binder_gates`, `cookie_parse_gates`, `tca_parse_gates`, `tca_find`, `tca_new_alloc`, `psk_write_chosen`.
- `test_tls_bounds.c`: `test_TLSX_PopulateExtensions_bounds`, `test_TLSX_ext_msgtype_dispatch_bounds`, `test_TLSX_CSR_Parse_bounds`, `test_TLSX_ALPN_GetSize_overflow`, `test_TLSX_PopulateSupportedGroups_bounds`, `test_TLSX_SecureRenegotiation_Write_bounds`.

Note: the crashes are not deterministic, so a single scan can miss one. For this reason the change hardens all multi-block tests in these two files, not only the tests that crashed in one run.

Fixes zd#

# Testing

Build:
```
./configure --disable-shared --enable-static --enable-all \
  --enable-secure-renegotiation --enable-debug \
  C_EXTRA_FLAGS=-DWOLFSSL_MEM_FAIL_COUNT
make
```

Method: for each affected test, read its baseline allocation count, then run the test once per injection point (`MEM_FAIL_CNT=1..MAX`). Repeat each scan several times, because the failure is not deterministic. Record the exit code and compare `MemFailCount Total` against `MemFailCount Frees`.

Results:
- Before: the listed tests produce an intermittent SIGSEGV (139) or abort (134) under injection. A single scan first missed `test_TLSX_CSR_Parse_bounds`; a repeated scan then showed it crashes at `MEM_FAIL_CNT=137`.
- After: 0 crashes across all listed tests, over the full injection range, at 4 to 10 repetitions per point.

Dependency: the same nightly job also reports two `Free/Alloc` mismatches (`test_tls_msgtype_tca_new_alloc` at 22 and `test_ProcessChainOCSPRequest_bounds` at 137). These are memory-count and leak problems, not crashes, and PR #11397 fixes them. The nightly job is fully clean only when both PR #11397 and this PR are present.

# Checklist

 - [ ] added tests — not applicable; this change fixes existing tests and adds no new test.
 - [ ] updated/added doxygen — not applicable; no API change.
 - [ ] updated appropriate READMEs — not applicable.
 - [ ] Updated manual and documentation — not applicable.