### PR TITLE
Rust wrapper: Remove unused aes_cts cfg detection

### DIFF
--- a/wrapper/rust/wolfssl-wolfcrypt/build.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/build.rs
@@ -464,7 +464,6 @@ fn scan_cfg() -> Result<()> {
     check_cfg(&binding, "wc_AesCcmSetKey", "aes_ccm");
     check_cfg(&binding, "wc_AesCfbEncrypt", "aes_cfb");
     check_cfg(&binding, "wc_AesCtrEncrypt", "aes_ctr");
-    check_cfg(&binding, "wc_AesCtsEncrypt", "aes_cts");
     check_cfg(&binding, "wc_AesCfbDecrypt", "aes_cfb_decrypt");
     check_cfg(&binding, "wc_AesOfbDecrypt", "aes_ofb_decrypt");
     check_cfg(&binding, "wc_AesEaxInit", "aes_eax");


### PR DESCRIPTION
# Description

Rust wrapper: Remove unused aes_cts cfg detection

Fixes F-8294.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
