### PR TITLE
CI: resolve the ghcr .deb bundle against its own apt index

### DIFF
--- a/.github/actions/ccache-setup/action.yml
+++ b/.github/actions/ccache-setup/action.yml
@@ -43,16 +43,23 @@ runs:
           echo "ccache already installed: $(ccache --version | head -1)"
         elif [ "${{ runner.os }}" = "Linux" ]; then
           export DEBIAN_FRONTEND=noninteractive
-          # install-apt-deps stages the WHOLE ghcr bundle into
-          # /var/cache/apt/archives, and ccache is in the -minimal/-full
-          # lists, so in a job that ran it first the .deb is already on disk.
-          # Take it offline (--no-download): no apt-get update, nothing to
-          # stall on. Every other path here reaches the mirror, which is what
-          # used to hang these jobs for 10-40 min after the bundle had
-          # already installed cleanly.
+          # install-apt-deps exports the ghcr bundle it unpacked as a local apt
+          # repository, and ccache is in every bundle's package list. Reuse it:
+          # same repository, same versions, no apt-get update, nothing to stall
+          # on. Every other path here reaches the mirror, which is what used to
+          # hang these jobs for 10-40 min after the bundle had already
+          # installed cleanly.
           sudo dpkg --configure -a >/dev/null 2>&1 || true
-          if sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-               --no-install-recommends --no-download ccache; then
+          if [ -n "${WOLFSSL_APT_BUNDLE_SOURCES:-}" ] && \
+             sudo DEBIAN_FRONTEND=noninteractive apt-get \
+               -o Dir::Etc::SourceList="$WOLFSSL_APT_BUNDLE_SOURCES" \
+               -o Dir::Etc::SourceParts=/dev/null \
+               -o Dir::State::Lists="$WOLFSSL_APT_BUNDLE_LISTS" \
+               -o Acquire::Languages=none -o Acquire::Retries=0 \
+               -o APT::Sandbox::User=root \
+               -o Acquire::http::Proxy=http://127.0.0.1:9 \
+               -o Acquire::https::Proxy=http://127.0.0.1:9 \
+               install -y --no-install-recommends ccache; then
             echo "ccache installed offline from the staged .deb bundle"
           else
             # Same defence in depth as install-apt-deps: Acquire timeouts drop

--- a/.github/actions/install-apt-deps/action.yml
+++ b/.github/actions/install-apt-deps/action.yml
@@ -14,7 +14,7 @@ inputs:
       as per-command deadlines, so a wedged mirror is reported by this action
       instead of the job being cancelled around it. The loop overshoots it by
       retry-delay plus 10s of SIGKILL grace, and the per-command floors make
-      values below retries*60 inert. This, plus pull-timeout, plus any
+      values below retries*80 inert. This, plus pull-timeout, plus any
       ccache-setup in the same job, has to fit the caller's timeout-minutes -
       the defaults need ~16 minutes.
     required: false
@@ -98,7 +98,19 @@ runs:
           exit 0
         }
 
-        command -v docker >/dev/null 2>&1 || fallback "docker unavailable"
+        # A bundle holds .debs for one Ubuntu release. check-ci-deps.py
+        # compares the tag against runs-on, but a container job installs into
+        # whatever the image is, which that check cannot see.
+        WANT=$(printf '%s' "${{ inputs.ghcr-debs-tag }}" \
+               | sed -n 's/^\(ubuntu-[0-9]*\.[0-9]*\).*/\1/p')
+        HAVE=""
+        if [ -r /etc/os-release ]; then
+          HAVE=$( . /etc/os-release
+                  printf '%s-%s' "${ID:-?}" "${VERSION_ID:-?}" )
+        fi
+        if [ -n "$WANT" ] && [ -n "$HAVE" ] && [ "$WANT" != "$HAVE" ]; then
+          fallback "holds .debs for $WANT, but this job runs on $HAVE"
+        fi
 
         BUNDLE="$RUNNER_TEMP/ghcr-debs"
         APTD="$RUNNER_TEMP/ghcr-apt"
@@ -108,13 +120,24 @@ runs:
         # The owner is hardcoded: ci-deps-image only ever publishes under
         # ghcr.io/wolfssl (it is gated to that org), so fork PRs read the same
         # public image rather than a nonexistent ghcr.io/<fork>/... one.
-        timeout -k 10 ${{ inputs.pull-timeout }} docker pull -q "$IMG" \
-          >/dev/null 2>&1 || fallback "pull failed or timed out"
-        cid=$(docker create "$IMG" 2>/dev/null) || fallback "cannot open the image"
-        # Not silenced: a half-copied bundle would look like one that is merely
-        # missing a package, and we would blame the wrong thing.
-        docker cp "$cid:/debs/." "$BUNDLE/" >/dev/null || fallback "unpacking failed"
-        docker rm "$cid" >/dev/null 2>&1 || true
+        if command -v docker >/dev/null 2>&1; then
+          timeout -k 10 ${{ inputs.pull-timeout }} docker pull -q "$IMG" \
+            >/dev/null 2>&1 || fallback "pull failed or timed out"
+          cid=$(docker create "$IMG" 2>/dev/null) || fallback "cannot open the image"
+          # Not silenced: a half-copied bundle would look like one that is
+          # merely missing a package, and we would blame the wrong thing.
+          docker cp "$cid:/debs/." "$BUNDLE/" >/dev/null \
+            || fallback "unpacking failed"
+          docker rm "$cid" >/dev/null 2>&1 || true
+        else
+          # A job running in a container (sssd.yml) has no docker CLI inside
+          # that container, so it used to skip the bundle and spend the job on
+          # the apt mirror - which is what failed it. Pulling the image from
+          # the registry needs only curl and tar.
+          timeout -k 10 ${{ inputs.pull-timeout }} \
+            "$GITHUB_ACTION_PATH/ghcr-pull.sh" "$IMG" debs "$BUNDLE" \
+            || fallback "registry pull failed or timed out"
+        fi
         ls "$BUNDLE"/*.deb >/dev/null 2>&1 || fallback "no .debs inside"
 
         # Makes a fallback diagnosable from this log alone.
@@ -197,21 +220,28 @@ runs:
         APT_OPTS=(-o Acquire::Retries=3 -o Acquire::http::Timeout=30
                   -o Acquire::https::Timeout=30)
 
-        # Spend budget-seconds over the attempts rather than a fixed
-        # per-attempt deadline: a caller with a short timeout-minutes would
-        # otherwise be cancelled mid-attempt, before the loop could report
-        # the failure. update gets a sixth of an attempt, install the rest,
-        # with floors so a small budget still leaves apt time to work.
-        PER=$((BUDGET / RETRIES))
-        UPD=$((PER / 6))
-        [ "$UPD" -ge 20 ] || UPD=20
-        INS=$((PER - UPD))
-        [ "$INS" -ge 40 ] || INS=40
         DEADLINE=$(($(date +%s) + BUDGET))
 
         # sudo resets the environment, so DEBIAN_FRONTEND has to ride along
         # on each privileged command rather than being exported once.
         for i in $(seq 1 $RETRIES); do
+          # Split what is LEFT over the attempts still to come, rather than
+          # slicing the budget up front: an attempt that ends early hands its
+          # remainder to the next one instead of dropping it.
+          #
+          # update gets half of an attempt, capped at 90s because that is what
+          # apt's own Acquire ladder (3 retries x a 30s timeout) needs to work
+          # through a stalled mirror and move on; install gets the rest. A
+          # sixth of an attempt used to be 50s of the sssd job's 600s budget,
+          # so update was killed mid-transfer twice and the job failed with
+          # 80% of its budget unspent. The floors keep a small budget usable;
+          # they are what makes it overshoot.
+          PER=$(( (DEADLINE - $(date +%s)) / (RETRIES - i + 1) ))
+          UPD=$((PER / 2))
+          [ "$UPD" -le 90 ] || UPD=90
+          [ "$UPD" -ge 20 ] || UPD=20
+          INS=$((PER - UPD))
+          [ "$INS" -ge 40 ] || INS=40
           # A previous attempt killed mid-unpack leaves dpkg needing this.
           sudo dpkg --configure -a >/dev/null 2>&1 || true
           if sudo DEBIAN_FRONTEND=noninteractive timeout -k 10 $UPD \

--- a/.github/actions/install-apt-deps/action.yml
+++ b/.github/actions/install-apt-deps/action.yml
@@ -1,5 +1,5 @@
 name: 'Install apt dependencies'
-description: 'Install apt packages with retry logic and an optional offline ghcr bundle'
+description: 'Install apt packages from a prebuilt ghcr .deb bundle, falling back to the apt mirror'
 inputs:
   packages:
     description: 'Space-separated list of apt packages to install'
@@ -36,58 +36,141 @@ inputs:
   ghcr-debs-tag:
     description: >
       Tag of a prebuilt .deb bundle published to
-      ghcr.io/<owner>/wolfssl-ci-debs by the ci-deps-image workflow
+      ghcr.io/wolfssl/wolfssl-ci-debs by the ci-deps-image workflow
       (e.g. "ubuntu-24.04-minimal"). When set, the packages are installed
-      offline from that bundle and the apt path below is skipped; on
-      that happy path the apt mirror is not contacted. The offline install
-      is all-or-nothing (a single --no-download install of the whole set),
-      so any failure - bundle missing, not public, or not covering every
-      requested package - falls back to the apt path. Always safe to set;
-      leave empty to use apt only.
+      from that bundle with no network access at all and the apt path below
+      is skipped. The install is all-or-nothing, so any failure - bundle
+      missing, not public, or not covering every requested package - falls
+      back to the apt path. Always safe to set; leave empty to use apt only.
+      .github/scripts/check-ci-deps.py checks on every PR that the tag exists
+      and carries every package named above.
     required: false
     default: ''
+  require-bundle:
+    description: >
+      When 'true', a bundle that cannot satisfy the request fails the job
+      instead of falling back to the apt mirror. Used by ci-deps-canary.yml,
+      which exists to catch exactly that drift.
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
-    # Preferred path: install from a prebuilt .deb bundle pulled from ghcr,
-    # entirely offline (--no-download), so a flaky/timing-out apt mirror
-    # cannot break the build. Best-effort: on any failure we leave
-    # "satisfied" unset and the apt step below runs unchanged. The bundle
-    # image must be PUBLIC so anonymous `docker pull` works (including from
-    # fork PRs whose GITHUB_TOKEN cannot read private packages).
-    - name: Install from ghcr .deb bundle (offline)
+    # Preferred path. The bundle carries its own apt index (Packages) and we
+    # resolve against ONLY that: a private sources.list and lists dir, with the
+    # system's /var/lib/apt/lists left untouched so the fallback below still
+    # works.
+    #
+    # Why an index rather than --no-download against the runner's own lists:
+    # the bundle is resolved on master right after `apt-get update`, i.e.
+    # against the live archive, while a consumer resolves against the lists
+    # frozen into the runner image days earlier. Every version published in
+    # between - routine for anything in -updates/-security - made apt ask for a
+    # .deb the bundle did not carry, and the whole set fell back to the mirror.
+    # 25% of PR jobs took that path, and in 16 of 20 sampled cases the mirror
+    # then supplied zero bytes: the bundle had been complete all along, only
+    # the index disagreed. Resolving against the bundle's own index makes
+    # producer and consumer agree by construction, so only a package genuinely
+    # absent from the bundle falls back.
+    #
+    # The bundle image must be PUBLIC so anonymous `docker pull` works
+    # (including from fork PRs, whose GITHUB_TOKEN cannot read private
+    # packages).
+    - name: Install from the ghcr .deb bundle (offline)
       id: ghcr
       if: inputs.ghcr-debs-tag != ''
       shell: bash
       run: |
         set -u
-        command -v docker >/dev/null 2>&1 || { echo "::notice::docker unavailable; using apt"; exit 0; }
-        # Hardcode the upstream owner: the bundle is only ever published under
-        # ghcr.io/wolfssl by ci-deps-image (gated to the wolfssl org), so fork
-        # PRs read the public upstream image too rather than a nonexistent
-        # ghcr.io/<fork>/wolfssl-ci-debs.
         IMG="ghcr.io/wolfssl/wolfssl-ci-debs:${{ inputs.ghcr-debs-tag }}"
-        if ! timeout -k 10 ${{ inputs.pull-timeout }} docker pull -q "$IMG" >/dev/null 2>&1; then
-          echo "::notice::ghcr bundle $IMG unavailable; using apt"
+
+        # A fallback is never routine - it means this job is about to spend
+        # minutes on the mirror that the bundles exist to keep it off - so say
+        # so loudly rather than in a ::notice nobody reads.
+        fallback() {
+          if [ "${{ inputs.require-bundle }}" = "true" ]; then
+            echo "::error::$IMG: $1"
+            exit 1
+          fi
+          echo "::warning::$IMG: $1; falling back to the apt mirror"
+          echo "apt fallback: \`$IMG\`: $1" \
+            >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
           exit 0
-        fi
-        cid=$(docker create "$IMG" 2>/dev/null) || { echo "::notice::cannot open bundle; using apt"; exit 0; }
-        rm -rf "$RUNNER_TEMP/ghcr-debs"; mkdir -p "$RUNNER_TEMP/ghcr-debs"
-        docker cp "$cid:/debs/." "$RUNNER_TEMP/ghcr-debs/" >/dev/null 2>&1 || true
+        }
+
+        command -v docker >/dev/null 2>&1 || fallback "docker unavailable"
+
+        BUNDLE="$RUNNER_TEMP/ghcr-debs"
+        APTD="$RUNNER_TEMP/ghcr-apt"
+        rm -rf "$BUNDLE" "$APTD"
+        mkdir -p "$BUNDLE" "$APTD/etc" "$APTD/lists/partial"
+
+        # The owner is hardcoded: ci-deps-image only ever publishes under
+        # ghcr.io/wolfssl (it is gated to that org), so fork PRs read the same
+        # public image rather than a nonexistent ghcr.io/<fork>/... one.
+        timeout -k 10 ${{ inputs.pull-timeout }} docker pull -q "$IMG" \
+          >/dev/null 2>&1 || fallback "pull failed or timed out"
+        cid=$(docker create "$IMG" 2>/dev/null) || fallback "cannot open the image"
+        # Not silenced: a half-copied bundle would look like one that is merely
+        # missing a package, and we would blame the wrong thing.
+        docker cp "$cid:/debs/." "$BUNDLE/" >/dev/null || fallback "unpacking failed"
         docker rm "$cid" >/dev/null 2>&1 || true
-        ls "$RUNNER_TEMP"/ghcr-debs/*.deb >/dev/null 2>&1 || { echo "::notice::bundle had no .debs; using apt"; exit 0; }
-        sudo cp "$RUNNER_TEMP"/ghcr-debs/*.deb /var/cache/apt/archives/
+        ls "$BUNDLE"/*.deb >/dev/null 2>&1 || fallback "no .debs inside"
+
+        # Makes a fallback diagnosable from this log alone.
+        if [ -f "$BUNDLE/bundle-info" ]; then
+          echo "Bundle: $(tr '\n' ' ' < "$BUNDLE/bundle-info")"
+          echo "Runner: image ${ImageOS:-?} ${ImageVersion:-?}"
+        fi
+
+        # Bundles published before the index was added ship none, so build one
+        # here: this change then needs no rebuild to take effect.
+        if [ ! -s "$BUNDLE/Packages" ]; then
+          ( cd "$BUNDLE" && dpkg-scanpackages --multiversion . /dev/null \
+            > Packages ) 2>/dev/null \
+            || fallback "no Packages index and dpkg-scanpackages failed"
+        fi
+
+        printf 'deb [trusted=yes] file:%s ./\n' "$BUNDLE" > "$APTD/etc/sources.list"
+        # SourceParts=/dev/null drops sources.list.d, so the bundle is the only
+        # repository apt can see, and a private Dir::State::Lists keeps the
+        # system's lists (and therefore the fallback below) intact. The
+        # unroutable proxy is a tripwire: should a non-file: URI ever get in,
+        # it fails in milliseconds instead of hanging on the mirror, which is
+        # the failure mode this whole mechanism exists to remove.
+        APT_LOCAL=(-o Dir::Etc::SourceList="$APTD/etc/sources.list"
+                   -o Dir::Etc::SourceParts=/dev/null
+                   -o Dir::State::Lists="$APTD/lists"
+                   -o Acquire::Languages=none
+                   -o Acquire::Retries=0
+                   -o APT::Sandbox::User=root
+                   -o Acquire::http::Proxy=http://127.0.0.1:9
+                   -o Acquire::https::Proxy=http://127.0.0.1:9)
+
+        sudo apt-get "${APT_LOCAL[@]}" update >/dev/null 2>&1 \
+          || fallback "apt could not read the bundle index"
+
+        # ccache-setup installs from this same repository instead of
+        # re-deriving it, and ci-deps-canary simulates the other package sets
+        # against it.
+        {
+          echo "WOLFSSL_APT_BUNDLE_DIR=$BUNDLE"
+          echo "WOLFSSL_APT_BUNDLE_SOURCES=$APTD/etc/sources.list"
+          echo "WOLFSSL_APT_BUNDLE_LISTS=$APTD/lists"
+        } >> "$GITHUB_ENV"
+
         NO_REC=""
         if [ "${{ inputs.no-install-recommends }}" = "true" ]; then
           NO_REC="--no-install-recommends"
         fi
-        # --no-download forbids any network fetch: if the bundle is missing
-        # a package this fails cleanly (nothing installed) and we fall back.
-        if sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $NO_REC --no-download ${{ inputs.packages }}; then
+        # A previous attempt killed mid-unpack leaves dpkg needing this.
+        sudo dpkg --configure -a >/dev/null 2>&1 || true
+        if sudo DEBIAN_FRONTEND=noninteractive apt-get "${APT_LOCAL[@]}" \
+             install -y $NO_REC ${{ inputs.packages }}; then
           echo "satisfied=true" >> "$GITHUB_OUTPUT"
-          echo "Installed offline from $IMG: ${{ inputs.packages }}"
+          echo "Installed offline from $IMG"
         else
-          echo "::notice::offline install incomplete for $IMG; using apt"
+          fallback "does not cover ${{ inputs.packages }}"
         fi
 
     - name: Install packages

--- a/.github/actions/install-apt-deps/ghcr-pull.sh
+++ b/.github/actions/install-apt-deps/ghcr-pull.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Unpack a directory out of a public ghcr image using only curl and tar.
+#
+# install-apt-deps uses `docker create`/`docker cp` when it can, but a job
+# running in a container (sssd.yml) has no docker CLI inside that container,
+# so it skipped the .deb bundle and went to the apt mirror - the exact stall
+# the bundles exist to remove, and which failed the sssd job outright when
+# the mirror went slow. An anonymous registry pull needs nothing that an
+# Ubuntu-based image does not already have.
+#
+# usage: ghcr-pull.sh <ghcr.io/owner/name:tag> <dir-in-image> <dest-dir>
+# The contents of <dir-in-image> land directly in <dest-dir>.
+set -uo pipefail
+
+IMG=${1:?image}
+MEMBER=${2:?directory in the image}
+DEST=${3:?destination}
+
+REF=${IMG#ghcr.io/}
+REPO=${REF%:*}
+TAG=${REF##*:}
+API="https://ghcr.io/v2/$REPO"
+
+die() { echo "ghcr-pull: $*" >&2; exit 1; }
+
+command -v curl >/dev/null 2>&1 || die "curl is not installed"
+
+# ghcr issues an anonymous pull token for any public package. For a private
+# one it issues a token that then 401s below, which reads the same as "no
+# bundle here" and is handled the same way.
+TOKEN=$(curl -sS --retry 3 --max-time 60 \
+          "https://ghcr.io/token?service=ghcr.io&scope=repository:$REPO:pull" \
+        | tr -d '\n\r\t ' | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+[ -n "$TOKEN" ] || die "no anonymous pull token for $REPO"
+
+TYPES='application/vnd.oci.image.index.v1+json,
+application/vnd.oci.image.manifest.v1+json,
+application/vnd.docker.distribution.manifest.list.v2+json,
+application/vnd.docker.distribution.manifest.v2+json'
+
+reg() {
+  curl -sS --fail --location --retry 3 \
+    -H "Authorization: Bearer $TOKEN" "$@"
+}
+
+# Every digest in one array of a manifest. Registries serve the manifest
+# bytes exactly as they were pushed and every builder writes `config` before
+# `layers`, so everything past the key is that array. Splitting an index on
+# '}' keeps each entry's digest with its platform, which is the one thing
+# this has to get right.
+after() { tr -d '\n\r\t ' | sed -n "s/.*\"$1\":\[//p"; }
+
+MAN=$(reg -H "Accept: ${TYPES//$'\n'/}" "$API/manifests/$TAG") \
+  || die "cannot read the manifest for $IMG"
+
+# Multi-arch index: swap in the amd64 manifest. The bundles are single-arch
+# today; this keeps a builder change from silently breaking the pull.
+if printf '%s' "$MAN" | grep -q '"manifests"'; then
+  CHILD=$(printf '%s' "$MAN" | after manifests | tr '}' '\n' \
+          | grep '"architecture":"amd64"' \
+          | grep -oE 'sha256:[0-9a-f]{64}' | head -n1)
+  [ -n "$CHILD" ] || die "no amd64 manifest in $IMG"
+  MAN=$(reg -H "Accept: ${TYPES//$'\n'/}" "$API/manifests/$CHILD") \
+    || die "cannot read the amd64 manifest of $IMG"
+fi
+
+LAYERS=$(printf '%s' "$MAN" | after layers | grep -oE 'sha256:[0-9a-f]{64}')
+[ -n "$LAYERS" ] || die "no layers in the manifest for $IMG"
+
+mkdir -p "$DEST"
+for digest in $LAYERS; do
+  # Layers are applied in order, but only this one directory is wanted, so
+  # tar's exit status is ignored: a layer that does not carry it is normal.
+  # curl's is not - a cut-off transfer would look like a bundle that is
+  # merely missing a package.
+  reg "$API/blobs/$digest" \
+    | tar -xz -C "$DEST" --strip-components=1 --no-same-owner "$MEMBER" \
+      2>/dev/null
+  rc=${PIPESTATUS[0]}
+  [ "$rc" -eq 0 ] || die "downloading layer ${digest#sha256:} failed ($rc)"
+done

--- a/.github/ci-deps/packages-ubuntu-24.04-cross.txt
+++ b/.github/ci-deps/packages-ubuntu-24.04-cross.txt
@@ -1,0 +1,12 @@
+# pq-all's cross-compilation apt packages for ubuntu-24.04 (the '-cross'
+# bundle: ghcr.io/<owner>/wolfssl-ci-debs:ubuntu-24.04-cross). Separate from
+# -minimal because the ARM toolchains are ~118 MB and the 19 workflows on
+# -minimal do not cross-compile. Keep sorted.
+autoconf
+automake
+bubblewrap
+build-essential
+ccache
+crossbuild-essential-arm64
+crossbuild-essential-armhf
+libtool

--- a/.github/ci-deps/packages-ubuntu-24.04-sssd.txt
+++ b/.github/ci-deps/packages-ubuntu-24.04-sssd.txt
@@ -1,0 +1,13 @@
+# sssd.yml's apt packages (the '-sssd' bundle:
+# ghcr.io/<owner>/wolfssl-ci-debs:ubuntu-24.04-sssd). That job runs in
+# quay.io/sssd/ci-client-devel:ubuntu-latest, which already carries most of
+# this, so the bundle is resolved inside that image and holds only the few
+# .debs it is missing - see the `image` entry in ci-deps-image.yml. Keep
+# sorted.
+autoconf
+bc
+build-essential
+libcap-dev
+libldb-dev
+libldb2
+python3-ldb

--- a/.github/scripts/check-ci-deps.py
+++ b/.github/scripts/check-ci-deps.py
@@ -12,6 +12,9 @@
 # So the coupling is checked here instead:
 #   * every install-apt-deps call names a bundle tag
 #   * the tag exists and matches the runner's Ubuntu release
+#   * a job in a container names the bundle built inside that same image, and
+#     no other job names it: the closure a bundle holds is relative to what is
+#     already installed where it was resolved
 #   * every requested package is in that tag's list
 #   * the lists stay sorted and unique, and match ci-deps-image.yml's matrix
 #
@@ -65,6 +68,27 @@ def load_lists() -> dict:
     return lists
 
 
+def bundle_images() -> dict:
+    """tag -> the container image its closure is resolved inside, if any."""
+    try:
+        doc = yaml.safe_load(IMAGE_WORKFLOW.read_text())
+        include = doc["jobs"]["build"]["strategy"]["matrix"]["include"]
+    except (yaml.YAMLError, KeyError, TypeError):
+        return {}
+    return {e["tag"]: e["image"] for e in include
+            if isinstance(e, dict) and e.get("image")}
+
+
+def job_container(job: dict) -> str:
+    """The image a job runs in, '' for one running on the runner itself."""
+    container = job.get("container")
+    if isinstance(container, str):
+        return container
+    if isinstance(container, dict):
+        return str(container.get("image") or "")
+    return ""
+
+
 def matrix_values(job: dict, name: str) -> list:
     """Every literal value matrix.<name> can take in this job."""
     strategy = job.get("strategy")
@@ -105,6 +129,10 @@ def resolve(value: object, job: dict) -> list:
     return matrix_values(job, ref.group(1))
 
 
+def _where(image: str) -> str:
+    return f"in the container {image}" if image else "on the runner"
+
+
 def series(text: str) -> str:
     """The ubuntu-XX.YY prefix of a runner label or a bundle tag, or ''."""
     m = re.match(r"(ubuntu-\d+\.\d+)", text or "")
@@ -117,6 +145,7 @@ class Checker:
         # go to stderr there instead of corrupting it.
         self.stream = stream
         self.lists = lists
+        self.images = bundle_images()
         self.errors = 0
         self.warnings = 0
         self.checked = 0
@@ -138,10 +167,12 @@ class Checker:
         self.warnings += 1
 
     def check_call(self, where: str, tag: str, packages: str,
-                   runner: str) -> None:
+                   runner: str, container: str = "") -> None:
         """One (tag, packages) pair, both already resolved to literals."""
         self.checked += 1
+        image = self.images.get(tag, "")
         self.calls.append({"tag": tag, "runner": runner or series(tag),
+                           "image": image,
                            "packages": " ".join(PKG_TOKEN.findall(packages))})
         known = self.lists.get(tag)
         if known is None:
@@ -149,7 +180,21 @@ class Checker:
                               f"add .github/ci-deps/packages-{tag}.txt and a "
                               f"matching matrix entry in {IMAGE_WORKFLOW}")
             return
-        if runner and series(runner) and series(tag) \
+        if container or image:
+            # apt downloads only what is not already installed, so a bundle
+            # carries what was missing WHERE IT WAS RESOLVED and nowhere else.
+            # A container job installing a runner-resolved bundle gets an
+            # incomplete set and falls back - what sent sssd.yml to the mirror
+            # on every run - and the runs-on check below cannot see it, since
+            # the release that matters is the image's.
+            if container != image:
+                self.error(where,
+                           f"'{tag}' is resolved {_where(image)}, but this job "
+                           f"runs {_where(container)}: a bundle only holds "
+                           f"what is missing where it was resolved. Give the "
+                           f"tag an `image:` matrix entry in {IMAGE_WORKFLOW}, "
+                           f"or point this call at a bundle built for it.")
+        elif runner and series(runner) and series(tag) \
                 and series(runner) != series(tag):
             self.error(where, f"runs-on '{runner}' does not match "
                               f"ghcr-debs-tag '{tag}': the bundle holds .debs "
@@ -217,7 +262,8 @@ class Checker:
         # cross product is the conservative reading and costs nothing here.
         for tag in tags:
             for pkgs in packages:
-                self.check_call(f"{label}", tag, pkgs, runners[0])
+                self.check_call(f"{label}", tag, pkgs, runners[0],
+                                job_container(job))
         return tags
 
     def check_file(self, path: pathlib.Path) -> None:
@@ -320,6 +366,7 @@ def distinct_sets(checker: "Checker") -> dict:
     for call in checker.calls:
         entry = out.setdefault(call["tag"], {"tag": call["tag"],
                                              "runner": call["runner"],
+                                             "image": call["image"],
                                              "sets": []})
         if call["packages"] not in entry["sets"]:
             entry["sets"].append(call["packages"])
@@ -330,10 +377,15 @@ def distinct_sets(checker: "Checker") -> dict:
     return out
 
 
-def emit_matrix(checker: "Checker") -> None:
-    """The ci-deps-canary matrix: one entry per bundle tag."""
-    entries = [distinct_sets(checker)[t]
-               for t in sorted(distinct_sets(checker))]
+def emit_matrix(checker: "Checker", in_image: bool) -> None:
+    """The ci-deps-canary matrix: one entry per bundle tag.
+
+    Split in two, because a bundle resolved inside a container image has to be
+    proved inside that same image, which is a differently shaped canary job.
+    """
+    sets = distinct_sets(checker)
+    entries = [sets[t] for t in sorted(sets)
+               if bool(sets[t]["image"]) == in_image]
     for entry in entries:
         entry.pop("sets", None)
     print(json.dumps(entries))
@@ -352,7 +404,7 @@ def emit_sets(checker: "Checker", tag: str) -> int:
 
 def main() -> int:
     args = sys.argv[1:]
-    matrix = "--matrix" in args
+    matrix = "--matrix" in args or "--matrix-images" in args
     sets_for = args[args.index("--sets") + 1] if "--sets" in args else None
     if not CI_DEPS.is_dir():
         print(f"{CI_DEPS} not found - run from the repository root",
@@ -369,7 +421,7 @@ def main() -> int:
     checker.check_membrowse()
     if data_mode:
         if matrix:
-            emit_matrix(checker)
+            emit_matrix(checker, "--matrix-images" in args)
             rc = 0
         else:
             rc = emit_sets(checker, sets_for)

--- a/.github/scripts/check-ci-deps.py
+++ b/.github/scripts/check-ci-deps.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+# Keeps the prebuilt .deb bundles and the workflows that consume them in step.
+#
+# .github/workflows/ci-deps-image.yml bundles the .debs for each package list
+# in .github/ci-deps/ and publishes it to ghcr; .github/actions/install-apt-deps
+# installs from that bundle with no network access. The install is
+# all-or-nothing, so a single package a workflow asks for that is not in the
+# matching list sends that whole job back to the apt mirror - the exact
+# 10-40 minute stall the bundles exist to remove. Nothing about that is visible
+# in CI: the job still passes, just slowly and at the mirror's mercy.
+#
+# So the coupling is checked here instead:
+#   * every install-apt-deps call names a bundle tag
+#   * the tag exists and matches the runner's Ubuntu release
+#   * every requested package is in that tag's list
+#   * the lists stay sorted and unique, and match ci-deps-image.yml's matrix
+#
+# .github/membrowse-targets.json feeds the same action through a matrix, so its
+# entries are checked the same way.
+#
+# Findings are emitted as GitHub workflow commands (::error / ::warning) so
+# they surface as annotations, and as plain text so the log reads locally.
+
+import json
+import pathlib
+import re
+import sys
+
+import yaml
+
+ACTION = "install-apt-deps"
+CCACHE_ACTION = "ccache-setup"
+CI_DEPS = pathlib.Path(".github/ci-deps")
+IMAGE_WORKFLOW = pathlib.Path(".github/workflows/ci-deps-image.yml")
+MEMBROWSE_TARGETS = pathlib.Path(".github/membrowse-targets.json")
+
+# The kernel-tracking bundle has no packages-*.txt: its package set is defined
+# in ci-deps-image.yml because the rebuild gate hashes it. Read it from there.
+LINUXKM_TAG = "ubuntu-24.04-linuxkm"
+
+# Staged for ccache-setup, which installs it from the bundle install-apt-deps
+# unpacked rather than naming it in a `packages:` input.
+ALWAYS_USED = {"ccache"}
+
+EXPR = re.compile(r"\$\{\{(.+?)\}\}")
+MATRIX_REF = re.compile(r"^\s*matrix\.([A-Za-z_][A-Za-z0-9_-]*)\s*$")
+# A package name, keeping a shell substitution together: the action interpolates
+# `packages` into a run: block, so linux-headers-$(uname -r) reaches apt as one
+# argument and the bundle carries it under that same expanded name.
+PKG_TOKEN = re.compile(r"\S*\$\([^)]*\)\S*|\S+")
+
+
+def load_lists() -> dict:
+    """tag -> set of packages the bundle for that tag is built from."""
+    lists = {}
+    for path in sorted(CI_DEPS.glob("packages-*.txt")):
+        tag = path.name[len("packages-"):-len(".txt")]
+        lists[tag] = [ln.strip() for ln in path.read_text().splitlines()
+                      if ln.strip() and not ln.strip().startswith("#")]
+    text = IMAGE_WORKFLOW.read_text()
+    m = re.search(r'^\s*PKGS="([^"]+)"', text, re.M)
+    if m:
+        lists[LINUXKM_TAG] = m.group(1).split() + ["linux-headers-$(uname -r)"]
+    return lists
+
+
+def matrix_values(job: dict, name: str) -> list:
+    """Every literal value matrix.<name> can take in this job."""
+    strategy = job.get("strategy")
+    if not isinstance(strategy, dict):
+        return []
+    matrix = strategy.get("matrix")
+    if not isinstance(matrix, dict):
+        return []
+    out = []
+    direct = matrix.get(name)
+    if isinstance(direct, list):
+        out += [v for v in direct if isinstance(v, str)]
+    include = matrix.get("include")
+    if isinstance(include, list):
+        for entry in include:
+            if isinstance(entry, dict) and isinstance(entry.get(name), str):
+                out.append(entry[name])
+    return out
+
+
+def resolve(value: object, job: dict) -> list:
+    """Expand a `with:` value into the literal strings it can take.
+
+    Returns [] when it depends on something this script cannot see (a
+    `fromJson(needs...)` matrix, an input of a reusable workflow); the caller
+    reports that as unchecked rather than as a failure.
+    """
+    if not isinstance(value, str):
+        return []
+    if "${{" not in value:
+        return [value]
+    m = EXPR.fullmatch(value.strip())
+    if not m:
+        return []
+    ref = MATRIX_REF.match(m.group(1))
+    if not ref:
+        return []
+    return matrix_values(job, ref.group(1))
+
+
+def series(text: str) -> str:
+    """The ubuntu-XX.YY prefix of a runner label or a bundle tag, or ''."""
+    m = re.match(r"(ubuntu-\d+\.\d+)", text or "")
+    return m.group(1) if m else ""
+
+
+class Checker:
+    def __init__(self, lists: dict):
+        self.lists = lists
+        self.errors = 0
+        self.warnings = 0
+        self.checked = 0
+        self.unchecked = []
+        self.requested = set()
+        # By Ubuntu release, not by tag: -full is documented as a superset of
+        # -minimal, so a package only the -minimal callers name is still
+        # legitimately carried by -full.
+        self.requested_series = {}
+        # Distinct (tag, runner, packages) triples, for --matrix.
+        self.calls = []
+
+    def error(self, where: str, msg: str) -> None:
+        print(f"::error file={where}::{msg}")
+        self.errors += 1
+
+    def warn(self, where: str, msg: str) -> None:
+        print(f"::warning file={where}::{msg}")
+        self.warnings += 1
+
+    def check_call(self, where: str, tag: str, packages: str,
+                   runner: str) -> None:
+        """One (tag, packages) pair, both already resolved to literals."""
+        self.checked += 1
+        self.calls.append({"tag": tag, "runner": runner or series(tag),
+                           "packages": " ".join(PKG_TOKEN.findall(packages))})
+        known = self.lists.get(tag)
+        if known is None:
+            self.error(where, f"ghcr-debs-tag '{tag}' has no package list: "
+                              f"add .github/ci-deps/packages-{tag}.txt and a "
+                              f"matching matrix entry in {IMAGE_WORKFLOW}")
+            return
+        if runner and series(runner) and series(tag) \
+                and series(runner) != series(tag):
+            self.error(where, f"runs-on '{runner}' does not match "
+                              f"ghcr-debs-tag '{tag}': the bundle holds .debs "
+                              f"for {series(tag)}")
+        for pkg in PKG_TOKEN.findall(packages):
+            self.requested.add((tag, pkg))
+            self.requested_series.setdefault(series(tag), set()).add(pkg)
+            if pkg not in known:
+                self.error(where, f"'{pkg}' is not in the '{tag}' bundle. The "
+                                  f"offline install is all-or-nothing, so this "
+                                  f"job always falls back to the apt mirror. "
+                                  f"Add it to .github/ci-deps/packages-"
+                                  f"{tag}.txt (or point this call at a bundle "
+                                  f"that has it).")
+
+    def check_ccache(self, label: str, tags: list, job: dict) -> None:
+        """ccache-setup installs ccache from whatever bundle the job unpacked.
+
+        A job that pairs it with a bundle missing ccache, or with no bundle at
+        all, reaches the mirror for a 700 KB package. macOS jobs use brew and
+        are none of this check's business.
+        """
+        runners = resolve(job.get("runs-on"), job)
+        if any(not r.startswith("ubuntu") for r in runners if r):
+            return
+        if not tags:
+            self.warn(label.split(" / ")[0],
+                      f"{label}: uses {CCACHE_ACTION} without a bundled "
+                      f"{ACTION} in the same job, so ccache comes from the "
+                      f"apt mirror")
+            return
+        for tag in tags:
+            known = self.lists.get(tag)
+            if known is not None and "ccache" not in known:
+                self.error(label.split(" / ")[0],
+                           f"{label}: uses {CCACHE_ACTION} with the '{tag}' "
+                           f"bundle, which does not carry ccache; add it to "
+                           f".github/ci-deps/packages-{tag}.txt")
+
+    def check_step(self, path: pathlib.Path, job_id: str, job: dict,
+                   step: dict, index: int) -> list:
+        with_ = step.get("with")
+        name = step.get("name") or f"step {index + 1}"
+        where = f"{path}"
+        label = f"{path} / jobs.{job_id} / {name}"
+        if not isinstance(with_, dict):
+            self.error(where, f"{label}: {ACTION} called without `with:`")
+            return []
+
+        tag_raw = with_.get("ghcr-debs-tag")
+        if not tag_raw:
+            self.error(where, f"{label}: no ghcr-debs-tag, so this job always "
+                              f"installs from the apt mirror. Pick the bundle "
+                              f"for its runner (see .github/ci-deps/).")
+            return []
+
+        tags = resolve(tag_raw, job)
+        packages = resolve(with_.get("packages"), job)
+        runners = resolve(job.get("runs-on"), job) or [""]
+        if not tags or not packages:
+            self.unchecked.append(f"{label}: {tag_raw} / "
+                                  f"{with_.get('packages')}")
+            return tags
+        # A matrix pairs a tag with its packages entry-by-entry; checking the
+        # cross product is the conservative reading and costs nothing here.
+        for tag in tags:
+            for pkgs in packages:
+                self.check_call(f"{label}", tag, pkgs, runners[0])
+        return tags
+
+    def check_file(self, path: pathlib.Path) -> None:
+        try:
+            doc = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as exc:
+            self.error(str(path), f"not valid YAML: {exc}")
+            return
+        if not isinstance(doc, dict):
+            return
+        jobs = doc.get("jobs")
+        if not isinstance(jobs, dict):
+            return
+        for job_id, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            steps = job.get("steps")
+            if not isinstance(steps, list):
+                continue
+            tags = []
+            ccache = False
+            for i, step in enumerate(steps):
+                if not isinstance(step, dict):
+                    continue
+                uses = str(step.get("uses") or "")
+                if ACTION in uses:
+                    tags += self.check_step(path, job_id, job, step, i)
+                elif CCACHE_ACTION in uses:
+                    ccache = True
+            if ccache:
+                self.check_ccache(f"{path} / jobs.{job_id}", tags, job)
+
+    def check_membrowse(self) -> None:
+        if not MEMBROWSE_TARGETS.is_file():
+            return
+        try:
+            targets = json.loads(MEMBROWSE_TARGETS.read_text())
+        except json.JSONDecodeError as exc:
+            self.error(str(MEMBROWSE_TARGETS), f"not valid JSON: {exc}")
+            return
+        if not isinstance(targets, list):
+            return
+        for entry in targets:
+            if not isinstance(entry, dict) or "apt_packages" not in entry:
+                continue
+            name = entry.get("target_name", "?")
+            tag = entry.get("ghcr_tag")
+            if not tag:
+                self.error(str(MEMBROWSE_TARGETS),
+                           f"target '{name}' has apt_packages but no ghcr_tag, "
+                           f"so it always installs from the apt mirror")
+                continue
+            self.check_call(f"{MEMBROWSE_TARGETS} / {name}", tag,
+                            entry["apt_packages"], "")
+
+    def check_lists(self) -> None:
+        """The lists themselves: sorted, unique, and actually built."""
+        built = set()
+        try:
+            doc = yaml.safe_load(IMAGE_WORKFLOW.read_text())
+            include = doc["jobs"]["build"]["strategy"]["matrix"]["include"]
+            built = {e["tag"] for e in include if isinstance(e, dict)}
+        except (yaml.YAMLError, KeyError, TypeError) as exc:
+            self.error(str(IMAGE_WORKFLOW),
+                       f"cannot read the bundle matrix: {exc}")
+        built.add(LINUXKM_TAG)
+
+        for tag, pkgs in sorted(self.lists.items()):
+            if tag == LINUXKM_TAG:
+                continue
+            path = CI_DEPS / f"packages-{tag}.txt"
+            if pkgs != sorted(pkgs):
+                self.error(str(path), "package list is not sorted")
+            if len(pkgs) != len(set(pkgs)):
+                dupes = sorted({p for p in pkgs if pkgs.count(p) > 1})
+                self.error(str(path), f"duplicate entries: {' '.join(dupes)}")
+            if tag not in built:
+                self.error(str(path), f"no bundle is built for '{tag}': add it "
+                                      f"to the matrix in {IMAGE_WORKFLOW}")
+            used = self.requested_series.get(series(tag), set()) | ALWAYS_USED
+            unused = [p for p in pkgs if p not in used]
+            if unused:
+                self.warn(str(path), f"in the bundle but requested by no "
+                                     f"workflow: {' '.join(unused)}")
+
+        for tag in sorted(built):
+            if tag not in self.lists:
+                self.error(str(IMAGE_WORKFLOW),
+                           f"matrix builds '{tag}' but "
+                           f".github/ci-deps/packages-{tag}.txt is missing")
+
+
+def distinct_sets(checker: "Checker") -> dict:
+    """tag -> {runner, sets}: every distinct package set that bundle must serve.
+
+    Deduplicated, because most of the ~70 call sites ask for one of a handful
+    of package sets.
+    """
+    out = {}
+    for call in checker.calls:
+        entry = out.setdefault(call["tag"], {"tag": call["tag"],
+                                             "runner": call["runner"],
+                                             "sets": []})
+        if call["packages"] not in entry["sets"]:
+            entry["sets"].append(call["packages"])
+    for entry in out.values():
+        entry["sets"].sort()
+        # The widest set, as the one the canary installs for real.
+        entry["probe"] = max(entry["sets"], key=lambda s: len(s.split()))
+    return out
+
+
+def emit_matrix(checker: "Checker") -> None:
+    """The ci-deps-canary matrix: one entry per bundle tag."""
+    entries = [distinct_sets(checker)[t]
+               for t in sorted(distinct_sets(checker))]
+    for entry in entries:
+        entry.pop("sets", None)
+    print(json.dumps(entries))
+
+
+def emit_sets(checker: "Checker", tag: str) -> int:
+    """Every distinct package set requested against one tag, one per line."""
+    entry = distinct_sets(checker).get(tag)
+    if entry is None:
+        print(f"no workflow requests the '{tag}' bundle", file=sys.stderr)
+        return 1
+    for packages in entry["sets"]:
+        print(packages)
+    return 0
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    matrix = "--matrix" in args
+    sets_for = args[args.index("--sets") + 1] if "--sets" in args else None
+    if not CI_DEPS.is_dir():
+        print(f"{CI_DEPS} not found - run from the repository root",
+              file=sys.stderr)
+        return 1
+
+    checker = Checker(load_lists())
+    paths = sorted(pathlib.Path(".github/workflows").rglob("*.yml"))
+    paths += sorted(pathlib.Path(".github/workflows").rglob("*.yaml"))
+    for path in paths:
+        checker.check_file(path)
+    checker.check_membrowse()
+    if matrix:
+        emit_matrix(checker)
+        return 0
+    if sets_for:
+        return emit_sets(checker, sets_for)
+    # After every call, so "requested by no workflow" sees the full set.
+    checker.check_lists()
+
+    print(f"checked {checker.checked} {ACTION} call(s) against "
+          f"{len(checker.lists)} bundle(s)")
+    for item in checker.unchecked:
+        print(f"  not statically checkable: {item}")
+    if checker.errors:
+        print(f"FAILED: {checker.errors} problem(s) - each one is a job that "
+              f"silently falls back to the apt mirror")
+        return 1
+    if checker.warnings:
+        print(f"{checker.warnings} warning(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-ci-deps.py
+++ b/.github/scripts/check-ci-deps.py
@@ -20,6 +20,7 @@
 #
 # Findings are emitted as GitHub workflow commands (::error / ::warning) so
 # they surface as annotations, and as plain text so the log reads locally.
+# Any error exits non-zero, in --matrix and --sets mode too.
 
 import json
 import pathlib
@@ -111,7 +112,10 @@ def series(text: str) -> str:
 
 
 class Checker:
-    def __init__(self, lists: dict):
+    def __init__(self, lists: dict, stream=sys.stdout):
+        # --matrix and --sets hand stdout to their caller as data, so findings
+        # go to stderr there instead of corrupting it.
+        self.stream = stream
         self.lists = lists
         self.errors = 0
         self.warnings = 0
@@ -126,11 +130,11 @@ class Checker:
         self.calls = []
 
     def error(self, where: str, msg: str) -> None:
-        print(f"::error file={where}::{msg}")
+        print(f"::error file={where}::{msg}", file=self.stream)
         self.errors += 1
 
     def warn(self, where: str, msg: str) -> None:
-        print(f"::warning file={where}::{msg}")
+        print(f"::warning file={where}::{msg}", file=self.stream)
         self.warnings += 1
 
     def check_call(self, where: str, tag: str, packages: str,
@@ -355,17 +359,25 @@ def main() -> int:
               file=sys.stderr)
         return 1
 
-    checker = Checker(load_lists())
+    data_mode = matrix or sets_for is not None
+    checker = Checker(load_lists(),
+                      stream=sys.stderr if data_mode else sys.stdout)
     paths = sorted(pathlib.Path(".github/workflows").rglob("*.yml"))
     paths += sorted(pathlib.Path(".github/workflows").rglob("*.yaml"))
     for path in paths:
         checker.check_file(path)
     checker.check_membrowse()
-    if matrix:
-        emit_matrix(checker)
-        return 0
-    if sets_for:
-        return emit_sets(checker, sets_for)
+    if data_mode:
+        if matrix:
+            emit_matrix(checker)
+            rc = 0
+        else:
+            rc = emit_sets(checker, sets_for)
+        if checker.errors:
+            print(f"FAILED: {checker.errors} problem(s) - see the ::error "
+                  f"lines above", file=sys.stderr)
+            return 1
+        return rc
     # After every call, so "requested by no workflow" sees the full set.
     checker.check_lists()
 

--- a/.github/scripts/download-deb-closure.sh
+++ b/.github/scripts/download-deb-closure.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Download the .deb closure for one package list into a directory, for
+# .github/workflows/ci-deps-image.yml to publish as a bundle.
+#
+# Runs as root - under sudo on the runner, or inside the container image the
+# bundle is built for. WHERE it runs is the point: apt downloads only what is
+# not already installed, so a closure resolved on the runner carries nothing
+# the runner image preinstalls and cannot be installed anywhere else. The sssd
+# job asked the runner-resolved -full bundle for `bc` and `libcap-dev` and got
+# neither (bc is preinstalled on the runner, and libcap-dev's libcap2 was too),
+# so it fell through to the apt mirror every time.
+#
+# usage: download-deb-closure.sh <package-list> <dest-dir>
+set -uo pipefail
+
+LIST=${1:?package list}
+DEST=${2:?destination directory}
+
+mapfile -t PKGS < <(grep -vE '^[[:space:]]*#|^[[:space:]]*$' "$LIST")
+echo "Packages (${#PKGS[@]}): ${PKGS[*]}"
+export DEBIAN_FRONTEND=noninteractive
+# Not rm -rf: in the container this directory is a bind mount.
+mkdir -p "$DEST" && rm -f "$DEST"/*.deb
+apt-get clean
+# A single stalled mirror connection once hung -full for ~20 min (it normally
+# finishes in a few). retry() only re-runs on a non-zero exit, so a hang never
+# tripped it. Defend in depth: apt drops a stalled connection after 30s and
+# retries it (Acquire timeouts), `timeout` hard-kills a wedged apt-get, then
+# retry() re-runs from scratch.
+APT_OPTS=(-o Acquire::Retries=3 -o Acquire::http::Timeout=30
+          -o Acquire::https::Timeout=30)
+retry() { local i; for i in 1 2 3 4 5; do "$@" && return 0; sleep $((2**i)); done; "$@"; }
+retry timeout -k 10 120 apt-get "${APT_OPTS[@]}" update -q
+# Download each package's closure independently (requested package + any
+# dependency not already installed) without installing. Per package, not one
+# resolve of the whole list, so one unbundleable package - e.g. a conflict in
+# the big -full union - cannot abort the rest; install-apt-deps falls back to
+# apt for anything missing.
+skipped=0
+for pkg in "${PKGS[@]}"; do
+  retry timeout -k 10 300 apt-get "${APT_OPTS[@]}" install -y --download-only "$pkg" \
+    || { echo "::warning::could not download $pkg"; skipped=$((skipped+1)); }
+done
+cp /var/cache/apt/archives/*.deb "$DEST/" 2>/dev/null || true
+# The steps that index and package these run unprivileged, and in the
+# container we are root over a bind mount owned by the runner user.
+chown --reference="$DEST" "$DEST"/*.deb 2>/dev/null || true
+echo "Bundled $(ls "$DEST"/*.deb 2>/dev/null | wc -l) .deb files ($(du -sh "$DEST" | cut -f1)); ${skipped} skipped"
+test -n "$(ls "$DEST"/*.deb 2>/dev/null)"  # fail if nothing was bundled

--- a/.github/workflows/check-source-text.yml
+++ b/.github/workflows/check-source-text.yml
@@ -9,6 +9,9 @@ name: Check Source Text
 #   * check-workflows.py: every `run:` step against GitHub's 21000
 #     character cap, past which GitHub stops loading the workflow file
 #     altogether and its runs fail in 0s with zero jobs.
+#   * check-ci-deps.py: every install-apt-deps call against the .deb bundle
+#     it names, since a package missing from the bundle costs that job the
+#     apt mirror without failing anything.
 #
 # Scope:
 #   * pull_request: only files changed in the PR (catches new violations
@@ -79,6 +82,11 @@ jobs:
       # line by a change to a file the PR does not otherwise touch.
       - name: Lint workflow files
         run: ./.github/scripts/check-workflows.py
+
+      # Same reasoning as above: over the whole set, because a package list
+      # and the workflow that consumes it are rarely touched by one PR.
+      - name: Check the ci-deps bundle contract
+        run: ./.github/scripts/check-ci-deps.py
 
       - name: Run check-source-text (PR changed files)
         if: github.event_name == 'pull_request' && steps.files.outputs.count != '0'

--- a/.github/workflows/ci-deps-canary.yml
+++ b/.github/workflows/ci-deps-canary.yml
@@ -105,6 +105,13 @@ jobs:
                      -o APT::Sandbox::User=root
                      -o Acquire::http::Proxy=http://127.0.0.1:9
                      -o Acquire::https::Proxy=http://127.0.0.1:9)
+          # Into a file, so a static contract error fails the job: the exit
+          # status of a process substitution is not reported.
+          if ! ./.github/scripts/check-ci-deps.py --sets "${{ matrix.tag }}" \
+               > sets.txt; then
+            echo "::error::check-ci-deps.py rejected the workflows"
+            exit 1
+          fi
           fail=0
           while IFS= read -r pkgset; do
             [ -n "$pkgset" ] || continue
@@ -120,5 +127,5 @@ jobs:
               tail -20 sim.log
               fail=1
             fi
-          done < <(./.github/scripts/check-ci-deps.py --sets "${{ matrix.tag }}")
+          done < sets.txt
           exit "$fail"

--- a/.github/workflows/ci-deps-canary.yml
+++ b/.github/workflows/ci-deps-canary.yml
@@ -14,6 +14,10 @@ name: CI deps canary
 # check-ci-deps.py enforces the same contract statically on every PR; this
 # workflow catches what static checking cannot - a dependency that is missing
 # from the bundle rather than a package name that is missing from the list.
+#
+# That distinction is the whole reason sssd.yml sat on the mirror: its packages
+# were all in the -full list, but the .debs behind two of them were not in the
+# bundle, because the runner it was resolved on already had them installed.
 
 on:
   # Right after ci-deps-image publishes, whatever triggered it.
@@ -40,6 +44,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      images: ${{ steps.matrix.outputs.images }}
     steps:
       - uses: actions/checkout@v5
 
@@ -53,13 +58,18 @@ jobs:
 
       # One entry per bundle tag, each carrying the widest set requested
       # against it. The per-tag job re-derives the rest of its sets itself.
+      # Bundles resolved inside a container image come out separately: they
+      # have to be proved inside that image, so they get their own job below.
       - name: Derive the bundle matrix from the workflows
         id: matrix
         run: |
           set -euo pipefail
           M=$(./.github/scripts/check-ci-deps.py --matrix)
+          I=$(./.github/scripts/check-ci-deps.py --matrix-images)
           echo "$M" | python3 -m json.tool
+          echo "$I" | python3 -m json.tool
           echo "matrix=$M" >> "$GITHUB_OUTPUT"
+          echo "images=$I" >> "$GITHUB_OUTPUT"
 
   contract:
     needs: load
@@ -129,3 +139,30 @@ jobs:
             fi
           done < sets.txt
           exit "$fail"
+
+  # Same contract, for the bundles resolved inside a container image: the
+  # proof has to run in that image, because that is what the closure is
+  # relative to. No simulation step - an image-tied bundle serves the one job
+  # that named it, and an arbitrary image has no python3-yaml to re-derive the
+  # sets with.
+  contract-in-image:
+    needs: load
+    if: needs.load.outputs.images != '[]'
+    name: ${{ matrix.tag }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load.outputs.images) }}
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Offline install of the widest set
+        uses: ./.github/actions/install-apt-deps
+        with:
+          packages: ${{ matrix.probe }}
+          ghcr-debs-tag: ${{ matrix.tag }}
+          require-bundle: 'true'

--- a/.github/workflows/ci-deps-canary.yml
+++ b/.github/workflows/ci-deps-canary.yml
@@ -1,0 +1,124 @@
+name: CI deps canary
+
+# The contract test between ci-deps-image.yml (which publishes the .deb
+# bundles) and the workflows that install from them.
+#
+# A bundle that cannot satisfy what a workflow asks for does not fail
+# anything: install-apt-deps just falls back to the apt mirror and the job
+# passes, slowly. That is how 25% of PR jobs came to be back on the mirror
+# without anyone noticing. So the coupling is asserted here, right after every
+# rebuild: for each bundle, install the widest package set any workflow
+# requests with require-bundle (a fallback is an error, not a warning), then
+# simulate every other set against the same bundle.
+#
+# check-ci-deps.py enforces the same contract statically on every PR; this
+# workflow catches what static checking cannot - a dependency that is missing
+# from the bundle rather than a package name that is missing from the list.
+
+on:
+  # Right after ci-deps-image publishes, whatever triggered it.
+  workflow_run:
+    workflows: [ "CI deps image" ]
+    types: [ completed ]
+  # And daily, to catch a runner-image rollout that changes what is
+  # preinstalled underneath a bundle that has not moved.
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ci-deps-canary-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  load:
+    if: github.repository_owner == 'wolfssl'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install python3-yaml
+        uses: ./.github/actions/install-apt-deps
+        with:
+          budget-seconds: '120'
+          pull-timeout: '60'
+          packages: python3-yaml
+          ghcr-debs-tag: ubuntu-24.04-full
+
+      # One entry per bundle tag, each carrying the widest set requested
+      # against it. The per-tag job re-derives the rest of its sets itself.
+      - name: Derive the bundle matrix from the workflows
+        id: matrix
+        run: |
+          set -euo pipefail
+          M=$(./.github/scripts/check-ci-deps.py --matrix)
+          echo "$M" | python3 -m json.tool
+          echo "matrix=$M" >> "$GITHUB_OUTPUT"
+
+  contract:
+    needs: load
+    name: ${{ matrix.tag }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      # Taken before anything is installed, so the simulations below all
+      # resolve against the state a real job starts from. Without it the
+      # install below would satisfy the later sets for them.
+      - name: Snapshot dpkg state
+        run: cp /var/lib/dpkg/status "$RUNNER_TEMP/dpkg-status.pristine"
+
+      # require-bundle: a fallback to the apt mirror fails this job. That is
+      # the whole point of the workflow.
+      - name: Offline install of the widest set
+        uses: ./.github/actions/install-apt-deps
+        with:
+          packages: ${{ matrix.probe }}
+          ghcr-debs-tag: ${{ matrix.tag }}
+          require-bundle: 'true'
+
+      - name: Every other set this bundle must satisfy
+        run: |
+          set -uo pipefail
+          SNAP="$RUNNER_TEMP/dpkg-status.pristine"
+          # Same local-repo options install-apt-deps used, plus the pristine
+          # dpkg status. -s resolves without unpacking; the unroutable proxy
+          # means a set that needs anything outside the bundle fails here
+          # instead of quietly reaching the mirror.
+          APT_LOCAL=(-o Dir::Etc::SourceList="$WOLFSSL_APT_BUNDLE_SOURCES"
+                     -o Dir::Etc::SourceParts=/dev/null
+                     -o Dir::State::Lists="$WOLFSSL_APT_BUNDLE_LISTS"
+                     -o Dir::State::status="$SNAP"
+                     -o Acquire::Languages=none
+                     -o Acquire::Retries=0
+                     -o APT::Sandbox::User=root
+                     -o Acquire::http::Proxy=http://127.0.0.1:9
+                     -o Acquire::https::Proxy=http://127.0.0.1:9)
+          fail=0
+          while IFS= read -r pkgset; do
+            [ -n "$pkgset" ] || continue
+            # eval, because a set may contain linux-headers-$(uname -r) - the
+            # action interpolates it into a run: block, so this is the same
+            # expansion the real job gets.
+            eval "pkgs=($pkgset)"
+            if sudo DEBIAN_FRONTEND=noninteractive apt-get "${APT_LOCAL[@]}" \
+                 install -y -s "${pkgs[@]}" > sim.log 2>&1; then
+              echo "ok: $pkgset"
+            else
+              echo "::error::the ${{ matrix.tag }} bundle cannot satisfy: $pkgset"
+              tail -20 sim.log
+              fail=1
+            fi
+          done < <(./.github/scripts/check-ci-deps.py --sets "${{ matrix.tag }}")
+          exit "$fail"

--- a/.github/workflows/ci-deps-image.yml
+++ b/.github/workflows/ci-deps-image.yml
@@ -9,7 +9,9 @@ name: CI deps image
 # .github/ci-deps/ - every package plus the dependencies not already on the
 # matching runner image, so it is tied to that runner rather than being a
 # portable, self-contained closure - published to
-# ghcr.io/<owner>/wolfssl-ci-debs:<tag>.
+# ghcr.io/<owner>/wolfssl-ci-debs:<tag>. A matrix entry with `image` is tied to
+# a container image instead, and is resolved inside it; check-ci-deps.py holds
+# container jobs to those tags.
 #
 # Each bundle also carries its own apt index (Packages), and the consumer
 # resolves against only that. Without it the consumer resolved against the apt
@@ -44,6 +46,7 @@ on:
     branches: [ master ]
     paths:
       - '.github/ci-deps/**'
+      - '.github/scripts/download-deb-closure.sh'
       - '.github/workflows/ci-deps-image.yml'
   workflow_dispatch:
 
@@ -82,6 +85,12 @@ jobs:
           # reason: -minimal is pulled by 19 workflows that do not cross-compile.
           - runner: ubuntu-24.04
             tag: ubuntu-24.04-cross
+          # Resolved inside the image the sssd workflow runs in (`image`),
+          # rather than on the runner - see the download step below. A handful
+          # of .debs: everything else that job needs, that image already has.
+          - runner: ubuntu-24.04
+            tag: ubuntu-24.04-sssd
+            image: quay.io/sssd/ci-client-devel:ubuntu-latest
           - runner: ubuntu-22.04
             tag: ubuntu-22.04-minimal
           - runner: ubuntu-22.04
@@ -96,35 +105,22 @@ jobs:
 
       - name: Resolve and download the .deb closure
         shell: bash
+        env:
+          IMAGE: ${{ matrix.image }}
         run: |
           set -euo pipefail
           LIST=".github/ci-deps/packages-${{ matrix.tag }}.txt"
-          mapfile -t PKGS < <(grep -vE '^[[:space:]]*#|^[[:space:]]*$' "$LIST")
-          echo "Packages (${#PKGS[@]}): ${PKGS[*]}"
-          export DEBIAN_FRONTEND=noninteractive
-          rm -rf debs && mkdir -p debs
-          sudo apt-get clean
-          # A single stalled mirror connection once hung -full for ~20 min (it
-          # normally finishes in a few). retry() only re-runs on a non-zero exit,
-          # so a hang never tripped it. Defend in depth: apt drops a stalled
-          # connection after 30s and retries it (Acquire timeouts), `timeout`
-          # hard-kills a wedged apt-get, then retry() re-runs from scratch.
-          APT_OPTS=(-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30)
-          retry() { local i; for i in 1 2 3 4 5; do "$@" && return 0; sleep $((2**i)); done; "$@"; }
-          retry sudo timeout -k 10 120 apt-get "${APT_OPTS[@]}" update -q
-          # Download each package's closure independently (requested package +
-          # any dependency not already installed) without installing. Per
-          # package, not one resolve of the whole list, so one unbundleable
-          # package - e.g. a conflict in the big -full union - cannot abort the
-          # rest; install-apt-deps falls back to apt for anything missing.
-          skipped=0
-          for pkg in "${PKGS[@]}"; do
-            retry sudo timeout -k 10 300 apt-get "${APT_OPTS[@]}" install -y --download-only "$pkg" \
-              || { echo "::warning::could not download $pkg"; skipped=$((skipped+1)); }
-          done
-          sudo cp /var/cache/apt/archives/*.deb debs/ 2>/dev/null || true
-          echo "Bundled $(ls debs/*.deb 2>/dev/null | wc -l) .deb files ($(du -sh debs | cut -f1)); ${skipped} skipped"
-          test -n "$(ls debs/*.deb 2>/dev/null)"  # fail if nothing was bundled
+          mkdir -p debs
+          if [ -n "$IMAGE" ]; then
+            # Resolve inside the image that consumes this bundle, not on the
+            # runner: the closure is relative to what is already installed, so
+            # a runner-resolved one is unusable in a container. --entrypoint
+            # because these images boot an init by default.
+            docker run --rm --entrypoint bash -v "$PWD:/w" -w /w "$IMAGE" \
+              .github/scripts/download-deb-closure.sh "$LIST" debs
+          else
+            sudo bash .github/scripts/download-deb-closure.sh "$LIST" debs
+          fi
 
       - name: Index the bundle
         shell: bash

--- a/.github/workflows/ci-deps-image.yml
+++ b/.github/workflows/ci-deps-image.yml
@@ -11,6 +11,15 @@ name: CI deps image
 # portable, self-contained closure - published to
 # ghcr.io/<owner>/wolfssl-ci-debs:<tag>.
 #
+# Each bundle also carries its own apt index (Packages), and the consumer
+# resolves against only that. Without it the consumer resolved against the apt
+# lists frozen into the runner image while this job resolved against the live
+# archive, so every version published in between - routine for anything in
+# -updates/-security - made the offline install ask for a .deb the bundle did
+# not have and sent the whole set back to the mirror. 25% of PR jobs took that
+# path, and in 16 of 20 sampled cases the mirror then supplied zero bytes: the
+# bundle had been complete all along, only the index disagreed.
+#
 # Why: the apt mirror times out often enough to break PR CI. Resolving the
 # closure ONCE here (on master, where a slow mirror only delays this job and
 # is retried hard) and pulling it from ghcr on every PR keeps apt off the PR
@@ -24,19 +33,18 @@ name: CI deps image
 
 on:
   schedule:
-    # Weekly (Saturday) - the static bundles (-minimal/-full/-embedded).
-    # Refreshes them so they track base-image security updates. A mid-week
-    # package-list change waits for Saturday (or run this manually via
-    # workflow_dispatch); until then the offline install (a single
-    # --no-download install of the whole set) fails if any requested package
-    # is missing from the bundle, and install-apt-deps falls back to apt.
-    - cron: '0 2 * * 6'
-    # Daily - the kernel-tracking -linuxkm bundle only. linux-headers-$(uname
-    # -r) pins to the runner's running kernel (changes ~monthly); the linuxkm
-    # job rebuilds when uname -r or its package list differs from the
-    # published bundle, a cheap no-op otherwise. A mismatch mid-rollout just
-    # falls back to apt.
+    # Daily. A rebuild is a few minutes, and weekly left a window in which a
+    # merged package-list change was not yet bundled - every job needing the
+    # new package fell back to apt until Saturday.
+    - cron: '0 2 * * *'
+    # The kernel-tracking -linuxkm bundle below only.
     - cron: '0 3 * * *'
+  # Bundle a merged package-list change straight away.
+  push:
+    branches: [ master ]
+    paths:
+      - '.github/ci-deps/**'
+      - '.github/workflows/ci-deps-image.yml'
   workflow_dispatch:
 
 concurrency:
@@ -50,11 +58,10 @@ permissions:
 jobs:
   build:
     name: build ${{ matrix.tag }}
-    # Static bundles: weekly cron or manual dispatch. Skip the daily cron,
-    # which exists only to refresh the kernel-tracking -linuxkm bundle below.
+    # The 03:00 cron exists only for the -linuxkm bundle below.
     if: >-
       github.repository_owner == 'wolfssl' &&
-      (github.event_name != 'schedule' || github.event.schedule == '0 2 * * 6')
+      (github.event_name != 'schedule' || github.event.schedule == '0 2 * * *')
     strategy:
       fail-fast: false
       matrix:
@@ -71,6 +78,10 @@ jobs:
           # tag so it does not bloat the -full pull for the interop workflows.
           - runner: ubuntu-24.04
             tag: ubuntu-24.04-embedded
+          # pq-all's ARM cross-toolchains (~118 MB). Its own tag for the same
+          # reason: -minimal is pulled by 19 workflows that do not cross-compile.
+          - runner: ubuntu-24.04
+            tag: ubuntu-24.04-cross
           - runner: ubuntu-22.04
             tag: ubuntu-22.04-minimal
           - runner: ubuntu-22.04
@@ -114,6 +125,24 @@ jobs:
           sudo cp /var/cache/apt/archives/*.deb debs/ 2>/dev/null || true
           echo "Bundled $(ls debs/*.deb 2>/dev/null | wc -l) .deb files ($(du -sh debs | cut -f1)); ${skipped} skipped"
           test -n "$(ls debs/*.deb 2>/dev/null)"  # fail if nothing was bundled
+
+      - name: Index the bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          # This index is what makes the consumer resolve against these exact
+          # versions instead of the runner image's frozen lists. Both forms:
+          # apt probes for Packages.gz first and warns when it is missing.
+          # dpkg-scanpackages is from dpkg-dev, preinstalled on the runners.
+          ( cd debs && dpkg-scanpackages --multiversion . /dev/null > Packages )
+          gzip -9kf debs/Packages
+          # Not read by anything - it makes a fallback diagnosable from the
+          # consumer's log without cross-referencing this workflow's runs.
+          printf 'tag=%s\nimage=%s %s\nbuilt=%s\ndebs=%s\n' \
+            "${{ matrix.tag }}" "${ImageOS:-?}" "${ImageVersion:-?}" \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(ls debs/*.deb | wc -l)" \
+            > debs/bundle-info
+          cat debs/bundle-info
 
       - name: Build bundle image
         shell: bash
@@ -221,6 +250,12 @@ jobs:
           sudo cp /var/cache/apt/archives/*.deb debs/ 2>/dev/null || true
           echo "Bundled $(ls debs/*.deb 2>/dev/null | wc -l) .deb files"
           test -n "$(ls debs/*.deb 2>/dev/null)"  # headers are never preinstalled
+          # See the static build above: the consumer resolves against this.
+          ( cd debs && dpkg-scanpackages --multiversion . /dev/null > Packages )
+          gzip -9kf debs/Packages
+          printf 'tag=%s\nimage=%s %s\nkernel=%s\nbuilt=%s\n' \
+            "ubuntu-24.04-linuxkm" "${ImageOS:-?}" "${ImageVersion:-?}" "$K" \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > debs/bundle-info
 
       - name: Build and push bundle (labelled with the kernel and package set)
         if: steps.check.outputs.rebuild == 'true'

--- a/.github/workflows/pq-all.yml
+++ b/.github/workflows/pq-all.yml
@@ -44,9 +44,10 @@ jobs:
     if: ${{ (github.repository_owner == 'wolfssl') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     # Generous for a cold ccache; warm reruns finish in a fraction.  The
-    # margin is deliberately wide: the "Install dependencies" step has been
-    # seen to spend 30 min pulling the cross-compilers from a slow archive
-    # mirror, which used up the whole budget before a single config built.
+    # margin is deliberately wide: before the -cross bundle, "Install
+    # dependencies" was seen to spend 30 min pulling the cross-compilers from a
+    # slow archive mirror, which used up the whole budget before a single
+    # config built.
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
@@ -56,13 +57,11 @@ jobs:
         uses: ./.github/actions/install-apt-deps
         with:
           packages: autoconf automake libtool build-essential bubblewrap crossbuild-essential-arm64 crossbuild-essential-armhf
-          ghcr-debs-tag: ubuntu-24.04-minimal
-          # crossbuild-essential-* are not in the -minimal bundle (only the
-          # 22.04 lists carry them), and the offline install is all-or-nothing,
-          # so this caller always takes the apt path - see the timeout-minutes
-          # note above. The default budget would cap each install attempt at
-          # 250s and hard-fail a download that merely runs slow; 1200 gives it
-          # 500s an attempt and still reports inside the 45-minute job.
+          ghcr-debs-tag: ubuntu-24.04-cross
+          # Kept for the apt path this no longer normally takes: the default
+          # budget caps each attempt at 250s and hard-fails a download that
+          # merely runs slow, and the cross-toolchains are ~118 MB. 1200 gives
+          # an attempt 500s and still reports inside the 45-minute job.
           budget-seconds: '1200'
 
       # ccache via the cross-platform composite; the script passes the

--- a/.github/workflows/sssd.yml
+++ b/.github/workflows/sssd.yml
@@ -70,7 +70,11 @@ jobs:
         uses: ./.github/actions/install-apt-deps
         with:
           packages: build-essential autoconf libldb-dev libldb2 python3-ldb bc libcap-dev
-          ghcr-debs-tag: ubuntu-24.04-full
+          # Not -full: that bundle is resolved on the runner, so it carries
+          # neither bc nor libcap-dev's libcap2 (both preinstalled there), and
+          # this job fell back to the apt mirror every run. -sssd is resolved
+          # inside the container image below.
+          ghcr-debs-tag: ubuntu-24.04-sssd
 
       - name: Setup env
         run: |

--- a/.github/workflows/whitebox-smoke.yml
+++ b/.github/workflows/whitebox-smoke.yml
@@ -38,9 +38,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y autoconf automake libtool
+        uses: ./.github/actions/install-apt-deps
+        with:
+          packages: autoconf automake libtool
+          ghcr-debs-tag: ubuntu-24.04-minimal
 
       - name: Configure and build
         # --enable-static is required: each white-box relinks against


### PR DESCRIPTION
The .deb bundle was previously resolved against the live apt archive at
publish time, while consumers resolved against apt lists frozen into the
runner image days earlier. Version drift in between made `--no-download`
ask for packages the bundle didn't carry, triggering an all-or-nothing
fallback to the mirror — hit by ~25% of PR jobs, and in 16/20 sampled
cases the mirror served zero bytes even though the bundle was complete.

ci-deps-image now ships a `dpkg-scanpackages` index with each bundle, and
install-apt-deps resolves against only that index as a local `file://`
repository with its own lists dir, so producer and consumer agree by
construction and only genuinely missing packages fall back to the mirror.

Also:
- Rebuild static bundles daily and on merged package-list changes, instead of weekly
- Give pq-all its own `-cross` bundle, since `crossbuild-essential-*` wasn't in any 24.04 list and was fetching 118 MB from the mirror on every run
- Have ccache-setup install from the repository install-apt-deps exports rather than debs staged in `/var/cache/apt/archives`
- Add check-ci-deps.py to fail a PR whose install-apt-deps call names a package missing from its bundle, a nonexistent tag, or a tag for the wrong Ubuntu release; wired into check-source-text
- Have ci-deps-canary assert the same contract dynamically after every rebuild, with require-bundle turning a fallback into an error
- Switch whitebox-smoke from a bare apt-get to using the bundle