### PR TITLE
Rust wrapper: curve25519: add cfgs for shared_secret, import, and export

### DIFF
--- a/wolfssl/wolfcrypt/curve25519.h
+++ b/wolfssl/wolfcrypt/curve25519.h
@@ -201,6 +201,7 @@ int wc_curve25519_set_nonblock(curve25519_key* key, x25519_nb_ctx_t* ctx);
 
 #endif /* WC_X25519_NONBLOCK */
 
+#ifdef HAVE_CURVE25519_SHARED_SECRET
 WOLFSSL_API
 int wc_curve25519_shared_secret(curve25519_key* private_key,
                                 curve25519_key* public_key,
@@ -210,6 +211,7 @@ WOLFSSL_API
 int wc_curve25519_shared_secret_ex(curve25519_key* private_key,
                                    curve25519_key* public_key,
                                    byte* out, word32* outlen, int endian);
+#endif /* HAVE_CURVE25519_SHARED_SECRET */
 
 WOLFSSL_API
 int wc_curve25519_init(curve25519_key* key);
@@ -231,6 +233,7 @@ WOLFSSL_API
 int wc_curve25519_delete(curve25519_key* key, curve25519_key** key_p);
 #endif
 
+#ifdef HAVE_CURVE25519_KEY_IMPORT
 /* raw key helpers */
 WOLFSSL_API
 int wc_curve25519_import_private(const byte* priv, word32 privSz,
@@ -246,13 +249,18 @@ WOLFSSL_API
 int wc_curve25519_import_private_raw_ex(const byte* priv, word32 privSz,
                                         const byte* pub, word32 pubSz,
                                         curve25519_key* key, int endian);
+#endif /* HAVE_CURVE25519_KEY_IMPORT */
+
+#ifdef HAVE_CURVE25519_KEY_EXPORT
 WOLFSSL_API
 int wc_curve25519_export_private_raw(curve25519_key* key, byte* out,
                                      word32* outLen);
 WOLFSSL_API
 int wc_curve25519_export_private_raw_ex(curve25519_key* key, byte* out,
                                         word32* outLen, int endian);
+#endif /* HAVE_CURVE25519_KEY_EXPORT */
 
+#ifdef HAVE_CURVE25519_KEY_IMPORT
 WOLFSSL_API
 int wc_curve25519_import_public(const byte* in, word32 inLen,
                                 curve25519_key* key);
@@ -261,7 +269,9 @@ int wc_curve25519_import_public_ex(const byte* in, word32 inLen,
                                    curve25519_key* key, int endian);
 WOLFSSL_API
 int wc_curve25519_check_public(const byte* pub, word32 pubSz, int endian);
+#endif /* HAVE_CURVE25519_KEY_IMPORT */
 
+#ifdef HAVE_CURVE25519_KEY_EXPORT
 WOLFSSL_API
 int wc_curve25519_export_public(curve25519_key* key, byte* out, word32* outLen);
 WOLFSSL_API
@@ -277,6 +287,8 @@ int wc_curve25519_export_key_raw_ex(curve25519_key* key,
                                     byte* priv, word32 *privSz,
                                     byte* pub, word32 *pubSz,
                                     int endian);
+#endif /* HAVE_CURVE25519_KEY_EXPORT */
+
 /* size helper */
 WOLFSSL_API
 int wc_curve25519_size(curve25519_key* key);

--- a/wrapper/rust/wolfssl-wolfcrypt/build.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/build.rs
@@ -492,6 +492,9 @@ fn scan_cfg() -> Result<()> {
     /* curve25519 */
     check_cfg(&binding, "wc_curve25519_make_pub", "curve25519");
     check_cfg(&binding, "wc_curve25519_make_pub_blind", "curve25519_blinding");
+    check_cfg(&binding, "wc_curve25519_shared_secret", "curve25519_shared_secret");
+    check_cfg(&binding, "wc_curve25519_import_public", "curve25519_import");
+    check_cfg(&binding, "wc_curve25519_export_public", "curve25519_export");
 
     /* dh */
     check_cfg(&binding, "wc_InitDhKey", "dh");

--- a/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/src/curve25519.rs
@@ -53,6 +53,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(()) on success or Err(e) containing the wolfSSL
     /// library error code value.
+    #[cfg(curve25519_import)]
     pub fn check_public(public: &[u8], big_endian: bool) -> Result<(), i32> {
         let public_size = crate::buffer_len_to_u32(public.len())?;
         let endian = if big_endian {sys::EC25519_BIG_ENDIAN} else {sys::EC25519_LITTLE_ENDIAN};
@@ -174,6 +175,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(curve25519key) on success or Err(e) containing the
     /// wolfSSL library error code value.
+    #[cfg(curve25519_import)]
     pub fn import_private(private: &[u8]) -> Result<Self, i32> {
         let private_size = crate::buffer_len_to_u32(private.len())?;
         let mut wc_key: MaybeUninit<sys::curve25519_key> = MaybeUninit::uninit();
@@ -210,6 +212,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(curve25519key) on success or Err(e) containing the
     /// wolfSSL library error code value.
+    #[cfg(curve25519_import)]
     pub fn import_private_ex(private: &[u8], big_endian: bool) -> Result<Self, i32> {
         let private_size = crate::buffer_len_to_u32(private.len())?;
         let mut wc_key: MaybeUninit<sys::curve25519_key> = MaybeUninit::uninit();
@@ -247,6 +250,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(curve25519key) on success or Err(e) containing the
     /// wolfSSL library error code value.
+    #[cfg(curve25519_import)]
     pub fn import_private_raw(private: &[u8], public: &[u8]) -> Result<Self, i32> {
         let private_size = crate::buffer_len_to_u32(private.len())?;
         let public_size = crate::buffer_len_to_u32(public.len())?;
@@ -286,6 +290,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(curve25519key) on success or Err(e) containing the
     /// wolfSSL library error code value.
+    #[cfg(curve25519_import)]
     pub fn import_private_raw_ex(private: &[u8], public: &[u8], big_endian: bool) -> Result<Self, i32> {
         let private_size = crate::buffer_len_to_u32(private.len())?;
         let public_size = crate::buffer_len_to_u32(public.len())?;
@@ -324,6 +329,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(curve25519key) on success or Err(e) containing the
     /// wolfSSL library error code value.
+    #[cfg(curve25519_import)]
     pub fn import_public(public: &[u8]) -> Result<Self, i32> {
         let public_size = crate::buffer_len_to_u32(public.len())?;
         let mut wc_key: MaybeUninit<sys::curve25519_key> = MaybeUninit::uninit();
@@ -360,6 +366,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(curve25519key) on success or Err(e) containing the
     /// wolfSSL library error code value.
+    #[cfg(curve25519_import)]
     pub fn import_public_ex(public: &[u8], big_endian: bool) -> Result<Self, i32> {
         let public_size = crate::buffer_len_to_u32(public.len())?;
         let mut wc_key: MaybeUninit<sys::curve25519_key> = MaybeUninit::uninit();
@@ -508,6 +515,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(size) containing the number of bytes written to `out`
     /// on success or Err(e) containing the wolfSSL library error code value.
+    #[cfg(curve25519_shared_secret)]
     pub fn shared_secret(private_key: &mut Curve25519Key, public_key: &mut Curve25519Key, out: &mut [u8]) -> Result<usize, i32> {
         let mut outlen = crate::buffer_len_to_u32(out.len())?;
         let rc = unsafe {
@@ -614,6 +622,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(size) containing the number of bytes written to `out`
     /// on success or Err(e) containing the wolfSSL library error code value.
+    #[cfg(curve25519_shared_secret)]
     pub fn shared_secret_ex(private_key: &mut Curve25519Key, public_key: &mut Curve25519Key, out: &mut [u8], big_endian: bool) -> Result<usize, i32> {
         let mut outlen = crate::buffer_len_to_u32(out.len())?;
         let endian = if big_endian {sys::EC25519_BIG_ENDIAN} else {sys::EC25519_LITTLE_ENDIAN};
@@ -639,6 +648,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(()) on success or Err(e) containing the wolfSSL
     /// library error code value.
+    #[cfg(curve25519_export)]
     pub fn export_key_raw(&mut self, private: &mut [u8], public: &mut [u8]) -> Result<(), i32> {
         let mut private_size = crate::buffer_len_to_u32(private.len())?;
         let mut public_size = crate::buffer_len_to_u32(public.len())?;
@@ -666,6 +676,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(()) on success or Err(e) containing the wolfSSL
     /// library error code value.
+    #[cfg(curve25519_export)]
     pub fn export_key_raw_ex(&mut self, private: &mut [u8], public: &mut [u8], big_endian: bool) -> Result<(), i32> {
         let mut private_size = crate::buffer_len_to_u32(private.len())?;
         let mut public_size = crate::buffer_len_to_u32(public.len())?;
@@ -692,6 +703,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(size) containing the number of bytes written to `out`
     /// on success or Err(e) containing the wolfSSL library error code value.
+    #[cfg(curve25519_export)]
     pub fn export_private_raw(&mut self, out: &mut [u8]) -> Result<usize, i32> {
         let mut outlen = crate::buffer_len_to_u32(out.len())?;
         let rc = unsafe {
@@ -716,6 +728,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(size) containing the number of bytes written to `out`
     /// on success or Err(e) containing the wolfSSL library error code value.
+    #[cfg(curve25519_export)]
     pub fn export_private_raw_ex(&mut self, out: &mut [u8], big_endian: bool) -> Result<usize, i32> {
         let mut outlen = crate::buffer_len_to_u32(out.len())?;
         let endian = if big_endian {sys::EC25519_BIG_ENDIAN} else {sys::EC25519_LITTLE_ENDIAN};
@@ -740,6 +753,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(size) containing the number of bytes written to `out`
     /// on success or Err(e) containing the wolfSSL library error code value.
+    #[cfg(curve25519_export)]
     pub fn export_public(&mut self, out: &mut [u8]) -> Result<usize, i32> {
         let mut outlen = crate::buffer_len_to_u32(out.len())?;
         let rc = unsafe {
@@ -764,6 +778,7 @@ impl Curve25519Key {
     ///
     /// Returns either Ok(size) containing the number of bytes written to `out`
     /// on success or Err(e) containing the wolfSSL library error code value.
+    #[cfg(curve25519_export)]
     pub fn export_public_ex(&mut self, out: &mut [u8], big_endian: bool) -> Result<usize, i32> {
         let mut outlen = crate::buffer_len_to_u32(out.len())?;
         let endian = if big_endian {sys::EC25519_BIG_ENDIAN} else {sys::EC25519_LITTLE_ENDIAN};

--- a/wrapper/rust/wolfssl-wolfcrypt/tests/test_curve25519.rs
+++ b/wrapper/rust/wolfssl-wolfcrypt/tests/test_curve25519.rs
@@ -1,11 +1,13 @@
 #![cfg(all(curve25519, random))]
 
-#[cfg(feature = "alloc")]
+/* Rc is only used by tests that also need key export. */
+#[cfg(all(feature = "alloc", curve25519_export))]
 use std::rc::Rc;
 use wolfssl_wolfcrypt::curve25519::*;
 use wolfssl_wolfcrypt::random::RNG;
 
 #[test]
+#[cfg(curve25519_import)]
 fn test_check_pub() {
     let rng = RNG::new().expect("Error with new()");
     let mut private_buffer = [0u8; Curve25519Key::KEYSIZE];
@@ -31,7 +33,7 @@ fn test_generate() {
 }
 
 #[test]
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", curve25519_export))]
 fn test_generate_shared_rng() {
     let rng = Rc::new(RNG::new().expect("Error with new()"));
     let mut key1 = Curve25519Key::generate_shared_rng(Rc::clone(&rng)).expect("Error with generate_shared_rng()");
@@ -55,6 +57,7 @@ fn test_generate_shared_rng() {
 }
 
 #[test]
+#[cfg(all(curve25519_import, curve25519_export))]
 fn test_import_no_rng() {
     let rng = RNG::new().expect("Error with new()");
     let mut key = Curve25519Key::generate(rng).expect("Error with generate()");
@@ -66,6 +69,7 @@ fn test_import_no_rng() {
 }
 
 #[test]
+#[cfg(all(curve25519_import, curve25519_export))]
 fn test_import_export_private() {
     let rng = RNG::new().expect("Error with new()");
     let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
@@ -75,6 +79,7 @@ fn test_import_export_private() {
 }
 
 #[test]
+#[cfg(all(curve25519_import, curve25519_export))]
 fn test_import_export_private_ex() {
     let rng = RNG::new().expect("Error with new()");
     let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
@@ -84,6 +89,7 @@ fn test_import_export_private_ex() {
 }
 
 #[test]
+#[cfg(all(curve25519_import, curve25519_export))]
 fn test_import_export_raw() {
     let rng = RNG::new().expect("Error with new()");
     let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
@@ -94,6 +100,7 @@ fn test_import_export_raw() {
 }
 
 #[test]
+#[cfg(all(curve25519_import, curve25519_export))]
 fn test_import_export_raw_ex() {
     let rng = RNG::new().expect("Error with new()");
     let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
@@ -104,6 +111,7 @@ fn test_import_export_raw_ex() {
 }
 
 #[test]
+#[cfg(all(curve25519_import, curve25519_export))]
 fn test_import_export_public() {
     let rng = RNG::new().expect("Error with new()");
     let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
@@ -113,6 +121,7 @@ fn test_import_export_public() {
 }
 
 #[test]
+#[cfg(all(curve25519_import, curve25519_export))]
 fn test_import_export_public_ex() {
     let rng = RNG::new().expect("Error with new()");
     let mut curve25519key = Curve25519Key::generate(rng).expect("Error with generate()");
@@ -141,6 +150,7 @@ fn test_make_pub_blind() {
 }
 
 #[test]
+#[cfg(all(curve25519_shared_secret, curve25519_import, curve25519_export))]
 fn test_shared_secret() {
     /* With the alloc feature the two keys can share a single RNG. */
     #[cfg(feature = "alloc")]
@@ -170,6 +180,7 @@ fn test_shared_secret() {
 }
 
 #[test]
+#[cfg(all(curve25519_shared_secret, curve25519_import, curve25519_export))]
 fn test_shared_secret_ex() {
     /* With the alloc feature the two keys can share a single RNG. */
     #[cfg(feature = "alloc")]


### PR DESCRIPTION
# Description

Rust wrapper: curve25519: add cfgs for shared_secret, import, and export

Fixes F-13031.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
