### PR TITLE
Fix wc_hash2mgf returning WC_MGF1SHA3_224 for MD2/MD4/MD5/MD5-SHA

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2340,10 +2340,6 @@ int wc_hash2mgf(enum wc_HashType hType)
 #else
         break;
 #endif
-    case WC_HASH_TYPE_MD2:
-    case WC_HASH_TYPE_MD4:
-    case WC_HASH_TYPE_MD5:
-    case WC_HASH_TYPE_MD5_SHA:
     case WC_HASH_TYPE_SHA3_224:
 #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_224)
         return WC_MGF1SHA3_224;
@@ -2368,9 +2364,14 @@ int wc_hash2mgf(enum wc_HashType hType)
 #else
         break;
 #endif
+    case WC_HASH_TYPE_MD2:
+    case WC_HASH_TYPE_MD4:
+    case WC_HASH_TYPE_MD5:
+    case WC_HASH_TYPE_MD5_SHA:
     case WC_HASH_TYPE_BLAKE2B:
     case WC_HASH_TYPE_BLAKE2S:
     case WC_HASH_TYPE_SM3:
+        /* no MGF1 identifier defined for these hashes */
         break;
 #ifdef WOLFSSL_SHAKE128
     case WC_HASH_TYPE_SHAKE128:


### PR DESCRIPTION
## Summary

`wc_hash2mgf()` in `wolfcrypt/src/rsa.c` mapped `WC_HASH_TYPE_MD2`, `WC_HASH_TYPE_MD4`, `WC_HASH_TYPE_MD5`, and `WC_HASH_TYPE_MD5_SHA` to `WC_MGF1SHA3_224` whenever SHA3-224 was compiled in. These hashes have no MGF1 identifier and must return `WC_MGF1NONE`, the same as the other unsupported-hash cases.

## Root cause

The four MD-family `case` labels were stacked directly above `case WC_HASH_TYPE_SHA3_224:`, which does `return WC_MGF1SHA3_224;` under `#if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_224)`. C fall-through then made the MD-family inputs hit that return. When SHA3-224 was not built, they fell through to `break` and the function tail correctly returned `WC_MGF1NONE`, so the wrong result only appeared in SHA3-enabled builds. This was a regression introduced when SHA3 and SHA-512/224,256 MGF support was added and the neighbouring cases were split out but the MD-family labels were left attached to the SHA3-224 case.

## Fix

Move the MD2/MD4/MD5/MD5-SHA `case` labels to the `break`-only group alongside `WC_HASH_TYPE_BLAKE2B`, `WC_HASH_TYPE_BLAKE2S`, and `WC_HASH_TYPE_SM3`. The switch still lists every `wc_HashType` enumerator, so there is no `-Wswitch-enum` change for the older FIPS build path that wraps this function in `PRAGMA_DIAG_PUSH` / `-Wno-switch-enum`.

## Impact

Low. `wc_hash2mgf()` is `WOLFSSL_LOCAL`. Its only public callers are `wc_RsaSSL_Verify_ex2()` and the RSA-PSS/OAEP OpenSSL-compat layer in `src/pk_rsa.c`, and MD2/MD4/MD5/MD5-SHA are rejected by those layers before `wc_hash2mgf()` is reached, so no supported code path consumed the wrong value. The change converts a silent wrong mapping into the intended `WC_MGF1NONE` sentinel and removes the dependency of the return value on an unrelated build flag.

## Testing

Verified by recompiling `rsa.c` with default symbol visibility and calling `wc_hash2mgf()` directly in a SHA3-enabled configuration:

| Input | Before | After | Expected |
|---|---|---|---|
| MD2 / MD4 / MD5 / MD5-SHA | `WC_MGF1SHA3_224` | `WC_MGF1NONE` | `WC_MGF1NONE` |
| SHA-256 | `WC_MGF1SHA256` | `WC_MGF1SHA256` | `WC_MGF1SHA256` |
| SHA3-224 | `WC_MGF1SHA3_224` | `WC_MGF1SHA3_224` | `WC_MGF1SHA3_224` |

No dedicated unit test is added. `wc_hash2mgf()` is `WOLFSSL_LOCAL` and not linkable from `tests/unit.test` in the default shared-library build, exercising the corrected branch would require promoting the symbol to `WOLFSSL_TEST_VIS` (an exported-symbol change), and the affected inputs are unreachable through any public API.


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
