### PR TITLE
Fix wolfSSL_EVP_Cipher DES-CBC branch swallowing the DES return code

### DIFF
--- a/tests/api/test_evp_cipher.c
+++ b/tests/api/test_evp_cipher.c
@@ -2818,6 +2818,50 @@ int test_wolfSSL_EVP_des_ede3_ecb_no_key(void)
     return EXPECT_RESULT();
 }
 
+/*
+ * The DES-CBC branch of wolfSSL_EVP_Cipher used to discard the return value of
+ * wc_Des_CbcEncrypt / wc_Des_CbcDecrypt. Because ret starts at WOLFSSL_FAILURE
+ * (numerically zero), the "if (ret == 0)" success path then ran unconditionally
+ * and a rounded byte count was reported even when the DES call had rejected the
+ * request. A length that is not a multiple of DES_BLOCK_SIZE makes the software
+ * DES path return BAD_LENGTH_E, so the one-shot EVP_Cipher call must now fail
+ * rather than return a positive length. A block-multiple length still succeeds.
+ *
+ * FIPS builds use the FIPS-certified DES3 implementation for 3DES, but single
+ * DES is not a FIPS algorithm, so skip the test for FIPS.
+ */
+int test_wolfSSL_EVP_Cipher_des_cbc_error(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_DES3) && !defined(HAVE_FIPS) && defined(OPENSSL_EXTRA)
+    EVP_CIPHER_CTX* ctx = NULL;
+    const byte key[8] = { 0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef };
+    const byte iv[8]  = { 0x12,0x34,0x56,0x78,0x90,0xab,0xcd,0xef };
+    const byte in[16] = {
+        0x4e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
+        0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20
+    };
+    byte out[16];
+
+    XMEMSET(out, 0, sizeof(out));
+
+    /* Not a multiple of DES_BLOCK_SIZE: the DES call fails and EVP_Cipher must
+     * report the failure, not a rounded byte count. */
+    ExpectNotNull(ctx = EVP_CIPHER_CTX_new());
+    ExpectIntEQ(EVP_CipherInit(ctx, EVP_des_cbc(), key, iv, 1), 1);
+    ExpectIntLT(EVP_Cipher(ctx, out, in, 15), 0);
+    EVP_CIPHER_CTX_free(ctx);
+    ctx = NULL;
+
+    /* A block-multiple length still succeeds and reports the full length. */
+    ExpectNotNull(ctx = EVP_CIPHER_CTX_new());
+    ExpectIntEQ(EVP_CipherInit(ctx, EVP_des_cbc(), key, iv, 1), 1);
+    ExpectIntEQ(EVP_Cipher(ctx, out, in, (word32)sizeof(in)), (int)sizeof(in));
+    EVP_CIPHER_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 /* Test for integer overflow in EVP AEAD AAD accumulation.
  *
  * wolfSSL_EVP_CipherUpdate_GCM_AAD (and the CCM/ARIA variants) compute

--- a/tests/api/test_evp_cipher.c
+++ b/tests/api/test_evp_cipher.c
@@ -2846,9 +2846,16 @@ int test_wolfSSL_EVP_Cipher_des_cbc_error(void)
     XMEMSET(out, 0, sizeof(out));
 
     /* Not a multiple of DES_BLOCK_SIZE: the DES call fails and EVP_Cipher must
-     * report the failure, not a rounded byte count. */
+     * report the failure, not a rounded byte count. Both the encrypt and the
+     * decrypt arm of the switch must propagate the error. */
     ExpectNotNull(ctx = EVP_CIPHER_CTX_new());
     ExpectIntEQ(EVP_CipherInit(ctx, EVP_des_cbc(), key, iv, 1), 1);
+    ExpectIntLT(EVP_Cipher(ctx, out, in, 15), 0);
+    EVP_CIPHER_CTX_free(ctx);
+    ctx = NULL;
+
+    ExpectNotNull(ctx = EVP_CIPHER_CTX_new());
+    ExpectIntEQ(EVP_CipherInit(ctx, EVP_des_cbc(), key, iv, 0), 1);
     ExpectIntLT(EVP_Cipher(ctx, out, in, 15), 0);
     EVP_CIPHER_CTX_free(ctx);
     ctx = NULL;

--- a/tests/api/test_evp_cipher.h
+++ b/tests/api/test_evp_cipher.h
@@ -64,6 +64,7 @@ int test_wolfSSL_EVP_enc_null(void);
 int test_wolfSSL_EVP_rc2_cbc(void);
 int test_wolfSSL_EVP_mdc2(void);
 int test_wolfSSL_EVP_des_ede3_ecb_no_key(void);
+int test_wolfSSL_EVP_Cipher_des_cbc_error(void);
 int test_evp_cipher_pkcs7_pad_zero(void);
 int test_evp_cipher_aead_aad_overflow(void);
 
@@ -108,6 +109,7 @@ int test_evp_cipher_aead_aad_overflow(void);
     TEST_DECL_GROUP("evp_cipher", test_wolfSSL_EVP_rc2_cbc),                \
     TEST_DECL_GROUP("evp_cipher", test_wolfSSL_EVP_mdc2),                  \
     TEST_DECL_GROUP("evp_cipher", test_wolfSSL_EVP_des_ede3_ecb_no_key),    \
+    TEST_DECL_GROUP("evp_cipher", test_wolfSSL_EVP_Cipher_des_cbc_error),   \
     TEST_DECL_GROUP("evp_cipher", test_evp_cipher_pkcs7_pad_zero),           \
     TEST_DECL_GROUP("evp_cipher", test_evp_cipher_aead_aad_overflow)
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -9154,9 +9154,9 @@ void wolfSSL_EVP_init(void)
             case WC_DES_CBC_TYPE :
                 WOLFSSL_MSG("DES CBC");
                 if (ctx->enc)
-                    wc_Des_CbcEncrypt(&ctx->cipher.des, dst, src, len);
+                    ret = wc_Des_CbcEncrypt(&ctx->cipher.des, dst, src, len);
                 else
-                    wc_Des_CbcDecrypt(&ctx->cipher.des, dst, src, len);
+                    ret = wc_Des_CbcDecrypt(&ctx->cipher.des, dst, src, len);
                 if (ret == 0)
                     ret = (int)((len / DES_BLOCK_SIZE) * DES_BLOCK_SIZE);
                 break;


### PR DESCRIPTION
## Summary

The `WC_DES_CBC_TYPE` case in `wolfSSL_EVP_Cipher()` called `wc_Des_CbcEncrypt()` / `wc_Des_CbcDecrypt()` without assigning the result to `ret`. `ret` is initialised to `WOLFSSL_FAILURE`, whose numeric value is `0`, so the following `if (ret == 0)` success path always ran and the function returned a block-rounded byte count even when the DES call had rejected the request. This is a fail-open: the caller sees a positive length (apparent success) while the output buffer was never written.

## Root cause

Every sibling case in the same switch (`WC_DES_EDE3_CBC_TYPE`, `WC_DES_ECB_TYPE`, `WC_DES_EDE3_ECB_TYPE`, the AES CBC/ECB/CTR cases, SM4) captures the return value with `ret = wc_...`. The single-DES CBC case was the only one that did not, so an error from the DES backend (software `BAD_FUNC_ARG` / `BAD_LENGTH_E`, or any hardware/platform DES driver error) was silently discarded.

## Fix

Assign the return value of `wc_Des_CbcEncrypt()` / `wc_Des_CbcDecrypt()` to `ret`, matching the 3DES-CBC case directly below it. Both functions return `int`, so this compiles on every backend. On error `ret` is now negative and `wolfSSL_EVP_Cipher()` returns `WOLFSSL_FATAL_ERROR` via its existing `if (ret < 0)` normalisation; on success the byte count is reported as before.

## Impact

Low. `wolfSSL_EVP_Cipher()` with single DES-CBC is a legacy path reached only through the OpenSSL compatibility layer with `OPENSSL_EXTRA`. The common case (a block-aligned length and a valid context) is unaffected. The change turns a silent wrong result into a reported error.

## FIPS boundary

No impact. `evp.c` is the OpenSSL EVP compatibility layer, not a FIPS module boundary file: it carries no `code_seg(".fipsA")` / `FIPS_NO_WRAPPERS` markers and only branches on `HAVE_FIPS` to gate feature exposure. The modified case is single DES, which is not a FIPS-approved algorithm; the approved 3DES-CBC sibling already captures `ret` and is untouched. No CMVP re-validation concern and no change to any approved-algorithm behavior.

## Testing

Added `test_wolfSSL_EVP_Cipher_des_cbc_error` in `tests/api/test_evp_cipher.c`, guarded by `!defined(NO_DES3) && !defined(HAVE_FIPS) && defined(OPENSSL_EXTRA)` and registered in `tests/api/test_evp_cipher.h`. It initialises a DES-CBC context through `EVP_des_cbc()` and then:

- calls `EVP_Cipher()` with a length that is not a multiple of `DES_BLOCK_SIZE`, expecting a negative return (the software DES path returns `BAD_LENGTH_E`);
- calls `EVP_Cipher()` with a block-multiple length, expecting the full length back.

Verified against a `--enable-des3 --enable-opensslextra` build:

| Build | Result |
|---|---|
| Before the fix | `test_evp_cipher.c` assertion fails: `EVP_Cipher(ctx, out, in, 15)` returns `8`, not `< 0` |
| After the fix | `test_wolfSSL_EVP_Cipher_des_cbc_error` passes |


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
