### PR TITLE
Don't emit an empty policyQualifiers SEQUENCE in certificatePolicies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -324,6 +324,11 @@
   the certificate type extensions, and more generally any malformed handshake
   message reported with `BUFFER_E`.
 
+* **Fix (empty policyQualifiers in generated certificatePolicies)**: a
+  PolicyInformation entry set with `certPolicies` no longer carries an empty
+  `policyQualifiers` SEQUENCE (`30 00`), which RFC 5280 defines as
+  `SIZE (1..MAX)`.
+
 # wolfSSL Release 5.9.2 (Jun 23, 2026)
 
 Release 5.9.2 has been developed according to wolfSSL's development and QA

--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -4115,3 +4115,74 @@ int test_wc_AsnFeatureCoverage(void)
 #endif /* !NO_ASN && HAVE_ECC && USE_CERT_BUFFERS_256 && !HAVE_FIPS */
     return EXPECT_RESULT();
 }
+
+/* RFC 5280 4.2.1.4 defines PolicyInformation.policyQualifiers as
+ * SEQUENCE SIZE (1..MAX) OF PolicyQualifierInfo OPTIONAL, so a policy set
+ * without qualifiers must encode as a SEQUENCE holding only the OID, never
+ * an empty "30 00" qualifier SEQUENCE after it. */
+int test_SetCertificatePolicies_no_empty_qualifiers(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT) && \
+    !defined(NO_RSA) && !defined(NO_CERTS) && !defined(NO_ASN) && \
+    !defined(NO_ASN_TIME) && !defined(NO_SHA256) && \
+    defined(USE_CERT_BUFFERS_2048) && !defined(HAVE_FIPS)
+    {
+        RsaKey key;
+        WC_RNG rng;
+        Cert cert;
+        byte* der;
+        int certSz = 0;
+        word32 idx = 0;
+        /* "1.2.3" */
+        const byte oidTlv[] = { 0x06, 0x02, 0x2a, 0x03 };
+
+        der = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        ExpectNotNull(der);
+
+        XMEMSET(&key, 0, sizeof(key));
+        XMEMSET(&rng, 0, sizeof(rng));
+        ExpectIntEQ(wc_InitRsaKey(&key, HEAP_HINT), 0);
+        ExpectIntEQ(wc_InitRng(&rng), 0);
+        ExpectIntEQ(wc_RsaPrivateKeyDecode(client_key_der_2048, &idx, &key,
+                    sizeof_client_key_der_2048), 0);
+
+        ExpectIntEQ(wc_InitCert(&cert), 0);
+        cert.isCA = 0;
+        cert.sigType = CTC_SHA256wRSA;
+        XSTRNCPY(cert.subject.country, "US", CTC_NAME_SIZE - 1);
+        XSTRNCPY(cert.subject.commonName, "www.wolfssl.com",
+                CTC_NAME_SIZE - 1);
+        XSTRNCPY(cert.certPolicies[0], "1.2.3", CTC_MAX_CERTPOL_SZ - 1);
+        cert.certPoliciesNb = 1;
+
+        if (der != NULL) {
+            ExpectIntGT(certSz = wc_MakeSelfCert(&cert, der, FOURK_BUF, &key,
+                        &rng), 0);
+        }
+
+        if (EXPECT_SUCCESS()) {
+            int i;
+            int found = 0;
+
+            for (i = 2; i + (int)sizeof(oidTlv) <= certSz; i++) {
+                if (XMEMCMP(der + i, oidTlv, sizeof(oidTlv)) == 0 &&
+                        der[i - 2] == 0x30) {
+                    /* The enclosing PolicyInformation SEQUENCE must be
+                     * exactly the OID TLV: 30 04 06 02 2a 03. A length of
+                     * 6 would mean an empty policyQualifiers follows. */
+                    ExpectIntEQ(der[i - 1], sizeof(oidTlv));
+                    found = 1;
+                    break;
+                }
+            }
+            ExpectIntEQ(found, 1);
+        }
+
+        wc_FreeRng(&rng);
+        wc_FreeRsaKey(&key);
+        XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+#endif
+    return EXPECT_RESULT();
+}

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -42,6 +42,7 @@ int test_DecodeCertExtensions_empty_certpol_trailing(void);
 int test_ParseCert_SM3wSM2_short_pubkey(void);
 int test_ParseCert_dnBufferBoundary(void);
 int test_wc_DecodeObjectId(void);
+int test_SetCertificatePolicies_no_empty_qualifiers(void);
 int test_ToTraditional_ex_handcrafted(void);
 int test_ToTraditional_ex_roundtrip(void);
 int test_ToTraditional_ex_negative(void);
@@ -72,6 +73,7 @@ int test_wc_AsnFeatureCoverage(void);
     TEST_DECL_GROUP("asn", test_ParseCert_SM3wSM2_short_pubkey),    \
     TEST_DECL_GROUP("asn", test_ParseCert_dnBufferBoundary),        \
     TEST_DECL_GROUP("asn", test_wc_DecodeObjectId),                 \
+    TEST_DECL_GROUP("asn", test_SetCertificatePolicies_no_empty_qualifiers), \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_handcrafted),      \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_roundtrip),        \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_negative),         \

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -28747,11 +28747,13 @@ static int SetCertificatePolicies(byte *output,
 
         oidSz = sizeof(oid);
         XMEMSET(oid, 0, oidSz);
+        /* Clear before setting noOut, otherwise the clear undoes it and an
+         * empty policyQualifiers SEQUENCE (30 00) is emitted. */
+        XMEMSET(dataASN, 0, sizeof(dataASN));
         dataASN[POLICYINFOASN_IDX_QUALI].noOut = 1;
 
         ret = EncodePolicyOID(oid, &oidSz, input[i], heap);
         if (ret == 0) {
-            XMEMSET(dataASN, 0, sizeof(dataASN));
             SetASN_Buffer(&dataASN[POLICYINFOASN_IDX_ID], oid, oidSz);
             ret = SizeASN_Items(policyInfoASN, dataASN, policyInfoASN_Length,
                                 &piSz);


### PR DESCRIPTION
# Description

Fixed X.509 certificat generation where an empty policyQualifiers sequence ws incorrectly emitted in the certificatePolicies extension. Changed when the ASN.1 struct flags are initialized and added a regression test.

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation