### PR TITLE
Certifcate Name Id lookup when WOLFSSL_CERT_NAME_ALL defined

### DIFF
--- a/tests/api/test_asn.c
+++ b/tests/api/test_asn.c
@@ -2468,6 +2468,82 @@ int test_ParseCert_SM3wSM2_short_pubkey(void)
 }
 
 #if !defined(NO_CERTS) && !defined(NO_ASN) && !defined(NO_RSA)
+/* Fixed pieces of a hand-built certificate, shared by the tests below that
+ * assemble one around a subject or issuer Name of their own. Laid out in the
+ * order they appear in the encoding:
+ *   dnb_certPreIssuer | <issuer Name> | dnb_certValidity | <subject Name> |
+ *   dnb_rsaSpki | dnb_certSuffix
+ * Callers patch the two SEQUENCE lengths once the total size is known. */
+
+/* Certificate fields up to (not including) the issuer Name. The two 0x0000
+ * placeholders are the outer and tbsCertificate SEQUENCE lengths. */
+static const byte dnb_certPreIssuer[] = {
+    /* Certificate SEQUENCE (length patched) */
+    0x30, 0x82, 0x00, 0x00,
+    /* tbsCertificate SEQUENCE (length patched) */
+    0x30, 0x82, 0x00, 0x00,
+    /* version [0] INTEGER 2 */
+    0xa0, 0x03, 0x02, 0x01, 0x02,
+    /* serialNumber INTEGER 1 */
+    0x02, 0x01, 0x01,
+    /* signature AlgorithmIdentifier: sha256WithRSAEncryption */
+    0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
+    0x0b, 0x05, 0x00
+};
+/* issuer Name: /CN=Test */
+static const byte dnb_issuerCnTest[] = {
+    0x30, 0x0f, 0x31, 0x0d, 0x30, 0x0b, 0x06, 0x03, 0x55, 0x04, 0x03, 0x13,
+    0x04, 0x54, 0x65, 0x73, 0x74
+};
+/* validity: notBefore 20000101000000Z, notAfter 20491231235959Z */
+static const byte dnb_certValidity[] = {
+    0x30, 0x1e,
+    0x17, 0x0d, 0x30, 0x30, 0x30, 0x31, 0x30, 0x31, 0x30, 0x30, 0x30, 0x30,
+    0x30, 0x30, 0x5a,
+    0x17, 0x0d, 0x34, 0x39, 0x31, 0x32, 0x33, 0x31, 0x32, 0x33, 0x35, 0x39,
+    0x35, 0x39, 0x5a
+};
+/* Outer signatureAlgorithm and a placeholder signatureValue. Not checked
+ * because NO_VERIFY is used, but the structure must be present. */
+static const byte dnb_certSuffix[] = {
+    /* signatureAlgorithm: sha256WithRSAEncryption */
+    0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
+    0x0b, 0x05, 0x00,
+    /* signatureValue BIT STRING */
+    0x03, 0x05, 0x00, 0xde, 0xad, 0xbe, 0xef
+};
+/* commonName OID (2.5.4.3). */
+static const byte dnb_cnOid[] = { 0x06, 0x03, 0x55, 0x04, 0x03 };
+/* 2048-bit RSA SubjectPublicKeyInfo, extracted with OpenSSL from
+ * certs/client-cert.pem, so the key decodes and the parse succeeds. */
+static const byte dnb_rsaSpki[] = {
+    0x30, 0x82, 0x01, 0x22, 0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86,
+    0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00, 0x03, 0x82, 0x01, 0x0f, 0x00,
+    0x30, 0x82, 0x01, 0x0a, 0x02, 0x82, 0x01, 0x01, 0x00, 0xc3, 0x03, 0xd1,
+    0x2b, 0xfe, 0x39, 0xa4, 0x32, 0x45, 0x3b, 0x53, 0xc8, 0x84, 0x2b, 0x2a,
+    0x7c, 0x74, 0x9a, 0xbd, 0xaa, 0x2a, 0x52, 0x07, 0x47, 0xd6, 0xa6, 0x36,
+    0xb2, 0x07, 0x32, 0x8e, 0xd0, 0xba, 0x69, 0x7b, 0xc6, 0xc3, 0x44, 0x9e,
+    0xd4, 0x81, 0x48, 0xfd, 0x2d, 0x68, 0xa2, 0x8b, 0x67, 0xbb, 0xa1, 0x75,
+    0xc8, 0x36, 0x2c, 0x4a, 0xd2, 0x1b, 0xf7, 0x8b, 0xba, 0xcf, 0x0d, 0xf9,
+    0xef, 0xec, 0xf1, 0x81, 0x1e, 0x7b, 0x9b, 0x03, 0x47, 0x9a, 0xbf, 0x65,
+    0xcc, 0x7f, 0x65, 0x24, 0x69, 0xa6, 0xe8, 0x14, 0x89, 0x5b, 0xe4, 0x34,
+    0xf7, 0xc5, 0xb0, 0x14, 0x93, 0xf5, 0x67, 0x7b, 0x3a, 0x7a, 0x78, 0xe1,
+    0x01, 0x56, 0x56, 0x91, 0xa6, 0x13, 0x42, 0x8d, 0xd2, 0x3c, 0x40, 0x9c,
+    0x4c, 0xef, 0xd1, 0x86, 0xdf, 0x37, 0x51, 0x1b, 0x0c, 0xa1, 0x3b, 0xf5,
+    0xf1, 0xa3, 0x4a, 0x35, 0xe4, 0xe1, 0xce, 0x96, 0xdf, 0x1b, 0x7e, 0xbf,
+    0x4e, 0x97, 0xd0, 0x10, 0xe8, 0xa8, 0x08, 0x30, 0x81, 0xaf, 0x20, 0x0b,
+    0x43, 0x14, 0xc5, 0x74, 0x67, 0xb4, 0x32, 0x82, 0x6f, 0x8d, 0x86, 0xc2,
+    0x88, 0x40, 0x99, 0x36, 0x83, 0xba, 0x1e, 0x40, 0x72, 0x22, 0x17, 0xd7,
+    0x52, 0x65, 0x24, 0x73, 0xb0, 0xce, 0xef, 0x19, 0xcd, 0xae, 0xff, 0x78,
+    0x6c, 0x7b, 0xc0, 0x12, 0x03, 0xd4, 0x4e, 0x72, 0x0d, 0x50, 0x6d, 0x3b,
+    0xa3, 0x3b, 0xa3, 0x99, 0x5e, 0x9d, 0xc8, 0xd9, 0x0c, 0x85, 0xb3, 0xd9,
+    0x8a, 0xd9, 0x54, 0x26, 0xdb, 0x6d, 0xfa, 0xac, 0xbb, 0xff, 0x25, 0x4c,
+    0xc4, 0xd1, 0x79, 0xf4, 0x71, 0xd3, 0x86, 0x40, 0x18, 0x13, 0xb0, 0x63,
+    0xb5, 0x72, 0x4e, 0x30, 0xc4, 0x97, 0x84, 0x86, 0x2d, 0x56, 0x2f, 0xd7,
+    0x15, 0xf7, 0x7f, 0xc0, 0xae, 0xf5, 0xfc, 0x5b, 0xe5, 0xfb, 0xa1, 0xba,
+    0xd3, 0x02, 0x03, 0x01, 0x00, 0x01
+};
+
 /* Number of bytes needed to DER-encode the definite length "len".
  * Only handles len < 0x10000, which is all this test needs. */
 static int dnb_lenSz(int len)
@@ -2546,71 +2622,6 @@ int test_ParseCert_dnBufferBoundary(void)
     EXPECT_DECLS;
 
 #if !defined(NO_CERTS) && !defined(NO_ASN) && !defined(NO_RSA)
-    /* 2048-bit RSA SubjectPublicKeyInfo, extracted with OpenSSL from
-     * certs/client-cert.pem, so the key decodes and the parse succeeds. */
-    static const byte rsaSpki[] = {
-        0x30, 0x82, 0x01, 0x22, 0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86,
-        0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00, 0x03, 0x82, 0x01, 0x0f, 0x00,
-        0x30, 0x82, 0x01, 0x0a, 0x02, 0x82, 0x01, 0x01, 0x00, 0xc3, 0x03, 0xd1,
-        0x2b, 0xfe, 0x39, 0xa4, 0x32, 0x45, 0x3b, 0x53, 0xc8, 0x84, 0x2b, 0x2a,
-        0x7c, 0x74, 0x9a, 0xbd, 0xaa, 0x2a, 0x52, 0x07, 0x47, 0xd6, 0xa6, 0x36,
-        0xb2, 0x07, 0x32, 0x8e, 0xd0, 0xba, 0x69, 0x7b, 0xc6, 0xc3, 0x44, 0x9e,
-        0xd4, 0x81, 0x48, 0xfd, 0x2d, 0x68, 0xa2, 0x8b, 0x67, 0xbb, 0xa1, 0x75,
-        0xc8, 0x36, 0x2c, 0x4a, 0xd2, 0x1b, 0xf7, 0x8b, 0xba, 0xcf, 0x0d, 0xf9,
-        0xef, 0xec, 0xf1, 0x81, 0x1e, 0x7b, 0x9b, 0x03, 0x47, 0x9a, 0xbf, 0x65,
-        0xcc, 0x7f, 0x65, 0x24, 0x69, 0xa6, 0xe8, 0x14, 0x89, 0x5b, 0xe4, 0x34,
-        0xf7, 0xc5, 0xb0, 0x14, 0x93, 0xf5, 0x67, 0x7b, 0x3a, 0x7a, 0x78, 0xe1,
-        0x01, 0x56, 0x56, 0x91, 0xa6, 0x13, 0x42, 0x8d, 0xd2, 0x3c, 0x40, 0x9c,
-        0x4c, 0xef, 0xd1, 0x86, 0xdf, 0x37, 0x51, 0x1b, 0x0c, 0xa1, 0x3b, 0xf5,
-        0xf1, 0xa3, 0x4a, 0x35, 0xe4, 0xe1, 0xce, 0x96, 0xdf, 0x1b, 0x7e, 0xbf,
-        0x4e, 0x97, 0xd0, 0x10, 0xe8, 0xa8, 0x08, 0x30, 0x81, 0xaf, 0x20, 0x0b,
-        0x43, 0x14, 0xc5, 0x74, 0x67, 0xb4, 0x32, 0x82, 0x6f, 0x8d, 0x86, 0xc2,
-        0x88, 0x40, 0x99, 0x36, 0x83, 0xba, 0x1e, 0x40, 0x72, 0x22, 0x17, 0xd7,
-        0x52, 0x65, 0x24, 0x73, 0xb0, 0xce, 0xef, 0x19, 0xcd, 0xae, 0xff, 0x78,
-        0x6c, 0x7b, 0xc0, 0x12, 0x03, 0xd4, 0x4e, 0x72, 0x0d, 0x50, 0x6d, 0x3b,
-        0xa3, 0x3b, 0xa3, 0x99, 0x5e, 0x9d, 0xc8, 0xd9, 0x0c, 0x85, 0xb3, 0xd9,
-        0x8a, 0xd9, 0x54, 0x26, 0xdb, 0x6d, 0xfa, 0xac, 0xbb, 0xff, 0x25, 0x4c,
-        0xc4, 0xd1, 0x79, 0xf4, 0x71, 0xd3, 0x86, 0x40, 0x18, 0x13, 0xb0, 0x63,
-        0xb5, 0x72, 0x4e, 0x30, 0xc4, 0x97, 0x84, 0x86, 0x2d, 0x56, 0x2f, 0xd7,
-        0x15, 0xf7, 0x7f, 0xc0, 0xae, 0xf5, 0xfc, 0x5b, 0xe5, 0xfb, 0xa1, 0xba,
-        0xd3, 0x02, 0x03, 0x01, 0x00, 0x01
-    };
-    /* Certificate fields up to (not including) the subject Name. The two 0x0000
-     * placeholders are the outer and tbsCertificate SEQUENCE lengths, patched
-     * once the subject size is known. */
-    static const byte certPrefix[] = {
-        /* Certificate SEQUENCE (length patched) */
-        0x30, 0x82, 0x00, 0x00,
-        /* tbsCertificate SEQUENCE (length patched) */
-        0x30, 0x82, 0x00, 0x00,
-        /* version [0] INTEGER 2 */
-        0xa0, 0x03, 0x02, 0x01, 0x02,
-        /* serialNumber INTEGER 1 */
-        0x02, 0x01, 0x01,
-        /* signature AlgorithmIdentifier: sha256WithRSAEncryption */
-        0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
-        0x0b, 0x05, 0x00,
-        /* issuer Name: /CN=Test */
-        0x30, 0x0f, 0x31, 0x0d, 0x30, 0x0b, 0x06, 0x03, 0x55, 0x04, 0x03, 0x13,
-        0x04, 0x54, 0x65, 0x73, 0x74,
-        /* validity: notBefore 20000101000000Z, notAfter 20491231235959Z */
-        0x30, 0x1e,
-        0x17, 0x0d, 0x30, 0x30, 0x30, 0x31, 0x30, 0x31, 0x30, 0x30, 0x30, 0x30,
-        0x30, 0x30, 0x5a,
-        0x17, 0x0d, 0x34, 0x39, 0x31, 0x32, 0x33, 0x31, 0x32, 0x33, 0x35, 0x39,
-        0x35, 0x39, 0x5a
-    };
-    /* Outer signatureAlgorithm and a placeholder signatureValue. Not checked
-     * because NO_VERIFY is used, but the structure must be present. */
-    static const byte certSuffix[] = {
-        /* signatureAlgorithm: sha256WithRSAEncryption */
-        0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
-        0x0b, 0x05, 0x00,
-        /* signatureValue BIT STRING */
-        0x03, 0x05, 0x00, 0xde, 0xad, 0xbe, 0xef
-    };
-    /* commonName OID (2.5.4.3). */
-    static const byte cnOid[] = { 0x06, 0x03, 0x55, 0x04, 0x03 };
     /* emailAddress OID (1.2.840.113549.1.9.1, PKCS#9). */
     static const byte emailOid[] = {
         0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x09, 0x01
@@ -2656,13 +2667,13 @@ int test_ParseCert_dnBufferBoundary(void)
      * under the cap must be kept in full. Both sides are covered per attribute
      * because the too-big guards are independent comparison sites. */
     /* commonName (final catch-all guard). */
-    cases[0].oid        = cnOid;
-    cases[0].oidLen     = (int)sizeof(cnOid);
+    cases[0].oid        = dnb_cnOid;
+    cases[0].oidLen     = (int)sizeof(dnb_cnOid);
     cases[0].valTag     = 0x13;                         /* PrintableString */
     cases[0].valLen     = WC_ASN_NAME_MAX - 9;
     cases[0].expectFull = 0;
-    cases[1].oid        = cnOid;
-    cases[1].oidLen     = (int)sizeof(cnOid);
+    cases[1].oid        = dnb_cnOid;
+    cases[1].oidLen     = (int)sizeof(dnb_cnOid);
     cases[1].valTag     = 0x13;
     cases[1].valLen     = WC_ASN_NAME_MAX - 10;
     cases[1].expectFull = 1;
@@ -2704,12 +2715,16 @@ int test_ParseCert_dnBufferBoundary(void)
         valLen = cases[c].valLen;
         XMEMSET(val2, 'B', (size_t)valLen);
 
-        /* Fixed leading fields. */
-        XMEMCPY(der, certPrefix, sizeof(certPrefix));
-        pos = (int)sizeof(certPrefix);
+        /* Fixed leading fields: everything up to the subject Name. */
+        XMEMCPY(der, dnb_certPreIssuer, sizeof(dnb_certPreIssuer));
+        pos = (int)sizeof(dnb_certPreIssuer);
+        XMEMCPY(&der[pos], dnb_issuerCnTest, sizeof(dnb_issuerCnTest));
+        pos += (int)sizeof(dnb_issuerCnTest);
+        XMEMCPY(&der[pos], dnb_certValidity, sizeof(dnb_certValidity));
+        pos += (int)sizeof(dnb_certValidity);
 
         /* First RDN: /CN=A (a short name that must survive). */
-        rdn1Len = dnb_buildRdn(rdn1, cnOid, (int)sizeof(cnOid), 0x13,
+        rdn1Len = dnb_buildRdn(rdn1, dnb_cnOid, (int)sizeof(dnb_cnOid), 0x13,
             (const byte*)"A", 1);
 
         /* Second RDN length, computed the same way dnb_buildRdn() lays it
@@ -2729,15 +2744,15 @@ int test_ParseCert_dnBufferBoundary(void)
             cases[c].valTag, val2, valLen);
 
         /* SubjectPublicKeyInfo. */
-        XMEMCPY(&der[pos], rsaSpki, sizeof(rsaSpki));
-        pos += (int)sizeof(rsaSpki);
+        XMEMCPY(&der[pos], dnb_rsaSpki, sizeof(dnb_rsaSpki));
+        pos += (int)sizeof(dnb_rsaSpki);
 
         /* tbsCertificate content spans from offset 8 to here. */
         tbsContentLen = pos - 8;
 
         /* Outer signature algorithm and value. */
-        XMEMCPY(&der[pos], certSuffix, sizeof(certSuffix));
-        pos += (int)sizeof(certSuffix);
+        XMEMCPY(&der[pos], dnb_certSuffix, sizeof(dnb_certSuffix));
+        pos += (int)sizeof(dnb_certSuffix);
         derSz = pos;
         outerContentLen = derSz - 4;
 
@@ -2765,6 +2780,296 @@ int test_ParseCert_dnBufferBoundary(void)
     XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(val2, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif /* !NO_CERTS && !NO_ASN && !NO_RSA */
+    return EXPECT_RESULT();
+}
+
+#if !defined(NO_CERTS) && !defined(NO_ASN) && !defined(NO_RSA) && \
+    defined(WOLFSSL_ASN_TEMPLATE)
+/* Assemble a certificate around the given issuer and subject Name encodings.
+ * Returns the number of DER bytes written to der, which must have room for
+ * the fixed parts plus both names. */
+static int cni_buildCert(byte* der, const byte* issuer, int issuerLen,
+    const byte* subject, int subjectLen)
+{
+    int pos = 0;
+    int tbsContentLen;
+    int outerContentLen;
+
+    XMEMCPY(&der[pos], dnb_certPreIssuer, sizeof(dnb_certPreIssuer));
+    pos += (int)sizeof(dnb_certPreIssuer);
+    XMEMCPY(&der[pos], issuer, (size_t)issuerLen);
+    pos += issuerLen;
+    XMEMCPY(&der[pos], dnb_certValidity, sizeof(dnb_certValidity));
+    pos += (int)sizeof(dnb_certValidity);
+    XMEMCPY(&der[pos], subject, (size_t)subjectLen);
+    pos += subjectLen;
+    XMEMCPY(&der[pos], dnb_rsaSpki, sizeof(dnb_rsaSpki));
+    pos += (int)sizeof(dnb_rsaSpki);
+
+    /* tbsCertificate content spans from offset 8 to here. */
+    tbsContentLen = pos - 8;
+
+    XMEMCPY(&der[pos], dnb_certSuffix, sizeof(dnb_certSuffix));
+    pos += (int)sizeof(dnb_certSuffix);
+    outerContentLen = pos - 4;
+
+    /* Patch the two SEQUENCE lengths (both use the 0x82 long form). */
+    der[6] = (byte)(tbsContentLen >> 8);
+    der[7] = (byte)(tbsContentLen & 0xff);
+    der[2] = (byte)(outerContentLen >> 8);
+    der[3] = (byte)(outerContentLen & 0xff);
+
+    return pos;
+}
+
+/* Build a Name of /CN=<cn> followed by one PrintableString attribute of type
+ * oidTlv. Pass a NULL oidTlv for a Name with just the commonName. Returns the
+ * number of bytes written to out.
+ *
+ * PrintableString rather than UTF8String on purpose: InitDecodedCert() presets
+ * the encoding fields of the components stored from the table to CTC_UTF8, so
+ * a test that encoded its values as UTF8String could not tell a stored
+ * encoding from the preset one. */
+static int cni_buildName(byte* out, const char* cn, const byte* oidTlv,
+    int oidTlvLen, const char* val)
+{
+    byte rdns[128];
+    int  rdnsLen;
+    int  idx = 0;
+
+    rdnsLen = dnb_buildRdn(rdns, dnb_cnOid, (int)sizeof(dnb_cnOid), 0x13,
+        (const byte*)cn, (int)XSTRLEN(cn));
+    if (oidTlv != NULL) {
+        rdnsLen += dnb_buildRdn(&rdns[rdnsLen], oidTlv, oidTlvLen, 0x13,
+            (const byte*)val, (int)XSTRLEN(val));
+    }
+
+    out[idx++] = 0x30;                                  /* SEQUENCE */
+    idx += dnb_encodeLen(&out[idx], rdnsLen);
+    XMEMCPY(&out[idx], rdns, (size_t)rdnsLen);
+    idx += rdnsLen;
+
+    return idx;
+}
+#endif /* !NO_CERTS && !NO_ASN && !NO_RSA && WOLFSSL_ASN_TEMPLATE */
+
+/* The name component table in asn.c holds two runs of attribute ids - 2.5.4.3
+ * to 2.5.4.18 and, with WOLFSSL_CERT_NAME_ALL, 2.5.4.41 to 2.5.4.46 - with a
+ * gap between them, so a row's position is not "id - 3". Indexing it that way
+ * put the second run's rows on 2.5.4.19 - 2.5.4.22: those attributes were
+ * reported under the labels and NIDs of the second run, and the attributes the
+ * rows were written for were dropped instead. Each id is checked here against
+ * the label it must produce, including the ones that must produce none. */
+int test_ParseCert_nameComponentIds(void)
+{
+    EXPECT_DECLS;
+
+#if !defined(NO_CERTS) && !defined(NO_ASN) && !defined(NO_RSA) && \
+    defined(WOLFSSL_ASN_TEMPLATE)
+    /* Attribute value used for every case. */
+    static const char attrVal[] = "VALUE";
+    struct {
+        byte        arc;      /* last arc of the 2.5.4.x attribute OID */
+        const char* expStr;   /* label it must carry, NULL if not recognized */
+    } cases[] = {
+        /* First run - unaffected by the gap, checked so a change to the
+         * mapping cannot quietly break them. */
+        { 0x03, "/CN=" },                   /* commonName */
+        { 0x0b, "/OU=" },                   /* organizationalUnitName */
+        { 0x12, "/userid=" },               /* userId */
+        /* The gap. These are real attributes wolfSSL has no rows for, and are
+         * where the second run's rows used to land. */
+        { 0x13, NULL },                     /* physicalDeliveryOfficeName */
+        { 0x14, NULL },                     /* telephoneNumber */
+        { 0x15, NULL },                     /* telexNumber */
+        { 0x16, NULL },                     /* teletexTerminalIdentifier */
+        /* Second run. */
+#ifdef WOLFSSL_CERT_NAME_ALL
+        { 0x29, "/N=" },                    /* name */
+        { 0x2a, "/GN=" },                   /* givenName */
+        { 0x2b, "/initials=" },             /* initials */
+        { 0x2e, "/dnQualifier=" },          /* dnQualifier */
+#else
+        { 0x29, NULL },
+        { 0x2a, NULL },
+        { 0x2b, NULL },
+        { 0x2e, NULL },
+#endif
+        /* Placeholder rows keep the second run contiguous. 2.5.4.44 has no
+         * label, and 2.5.4.45 keeps the one GetRDN() gives it directly - its
+         * value is a BIT STRING rather than a DirectoryString. */
+        { 0x2c, NULL },                     /* generationQualifier */
+        { 0x2d, WOLFSSL_X500_UNIQUE_ID }    /* x500UniqueIdentifier */
+    };
+    DecodedCert cert;
+    byte  arcOid[5] = { 0x06, 0x03, 0x55, 0x04, 0x00 };
+    byte  issuer[64];
+    byte  subject[64];
+    byte* der = NULL;
+    char  expect[64];
+    int   issuerLen;
+    int   subjectLen;
+    int   derSz;
+    int   c;
+
+    ExpectNotNull(der = (byte*)XMALLOC(1024, NULL, DYNAMIC_TYPE_TMP_BUFFER));
+
+    issuerLen = cni_buildName(issuer, "Test", NULL, 0, NULL);
+
+    for (c = 0; (der != NULL) && (c < (int)XELEM_CNT(cases)); c++) {
+        arcOid[4] = cases[c].arc;
+        subjectLen = cni_buildName(subject, "S", arcOid, (int)sizeof(arcOid),
+            attrVal);
+        derSz = cni_buildCert(der, issuer, issuerLen, subject, subjectLen);
+
+        wc_InitDecodedCert(&cert, der, (word32)derSz, NULL);
+        /* An attribute with no row is skipped, not an error. */
+        ExpectIntEQ(wc_ParseCert(&cert, CERT_TYPE, NO_VERIFY, NULL), 0);
+
+        if (cases[c].expStr == NULL) {
+            /* Nothing but the commonName may reach the subject string. */
+            ExpectStrEQ(cert.subject, "/CN=S");
+        }
+        else {
+            XSTRLCPY(expect, "/CN=S", sizeof(expect));
+            XSTRLCAT(expect, cases[c].expStr, sizeof(expect));
+            XSTRLCAT(expect, attrVal, sizeof(expect));
+            ExpectStrEQ(cert.subject, expect);
+        }
+
+    #if defined(WOLFSSL_CERT_NAME_ALL) && (defined(WOLFSSL_CERT_GEN) || \
+        defined(WOLFSSL_CERT_EXT))
+        /* Components of the second run are also stored in DecodedCert: the
+         * value, its length and its encoding, all of which come from the row's
+         * offsets, so a row pointing at the wrong field is only caught by
+         * checking the value itself. The ids in the gap must leave those
+         * fields alone. */
+        switch (cases[c].arc) {
+            case 0x29:
+                ExpectNotNull(cert.subjectN);
+                ExpectIntEQ(cert.subjectNLen, (int)XSTRLEN(attrVal));
+                ExpectIntEQ(XMEMCMP(cert.subjectN, attrVal,
+                    XSTRLEN(attrVal)), 0);
+                ExpectIntEQ(cert.subjectNEnc, ASN_PRINTABLE_STRING);
+                break;
+            case 0x2a:
+                ExpectNotNull(cert.subjectGN);
+                ExpectIntEQ(cert.subjectGNLen, (int)XSTRLEN(attrVal));
+                ExpectIntEQ(XMEMCMP(cert.subjectGN, attrVal,
+                    XSTRLEN(attrVal)), 0);
+                ExpectIntEQ(cert.subjectGNEnc, ASN_PRINTABLE_STRING);
+                break;
+            case 0x2b:
+                ExpectNotNull(cert.subjectI);
+                ExpectIntEQ(cert.subjectILen, (int)XSTRLEN(attrVal));
+                ExpectIntEQ(XMEMCMP(cert.subjectI, attrVal,
+                    XSTRLEN(attrVal)), 0);
+                ExpectIntEQ(cert.subjectIEnc, ASN_PRINTABLE_STRING);
+                break;
+            case 0x2e:
+                ExpectNotNull(cert.subjectDNQ);
+                ExpectIntEQ(cert.subjectDNQLen, (int)XSTRLEN(attrVal));
+                ExpectIntEQ(XMEMCMP(cert.subjectDNQ, attrVal,
+                    XSTRLEN(attrVal)), 0);
+                ExpectIntEQ(cert.subjectDNQEnc, ASN_PRINTABLE_STRING);
+                break;
+            default:
+                ExpectNull(cert.subjectN);
+                ExpectNull(cert.subjectGN);
+                ExpectNull(cert.subjectI);
+                ExpectNull(cert.subjectDNQ);
+                break;
+        }
+    #endif
+        wc_FreeDecodedCert(&cert);
+    }
+
+    XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#endif /* !NO_CERTS && !NO_ASN && !NO_RSA && WOLFSSL_ASN_TEMPLATE */
+    return EXPECT_RESULT();
+}
+
+/* Rows of the name component table carry offsets into DecodedCert, and a row
+ * with no field for a component has a zero offset. Offset zero is the start of
+ * DecodedCert, so storing through such a row writes over its first member
+ * rather than a name field. Most rows have no issuer fields, which made the
+ * issuer side the reachable case - including every row of the second run of
+ * ids, which reaches the same guard through the other range of
+ * CertNameSubjectIdx() and so is driven here too. */
+int test_ParseCert_issuerNameNoField(void)
+{
+    EXPECT_DECLS;
+
+#if !defined(NO_CERTS) && !defined(NO_ASN) && !defined(NO_RSA) && \
+    defined(WOLFSSL_ASN_TEMPLATE) && defined(WOLFSSL_HAVE_ISSUER_NAMES) && \
+    (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT))
+    /* Attribute value used for every case. */
+    static const char attrVal[] = "VALUE";
+    /* An unassigned pilot attribute type (0.9.2342.19200300.100.1.99). GetRDN()
+     * rejects it, which stops the parse after the issuer name has been read and
+     * before the public key is, leaving whatever the issuer name wrote to
+     * DecodedCert's first member in place. */
+    static const byte badPilotOid[] = {
+        0x06, 0x0a, 0x09, 0x92, 0x26, 0x89, 0x93, 0xf2, 0x2c, 0x64, 0x01, 0x63
+    };
+    /* Issuer attributes whose rows have no issuer fields in DecodedCert. Each
+     * must still be reported in the issuer string and must store nothing. */
+    struct {
+        byte        arc;      /* last arc of the 2.5.4.x attribute OID */
+        const char* expStr;   /* label it must carry */
+    } cases[] = {
+        /* First run of ids. Has subject fields but no issuer ones. */
+        { 0x09, "/street=" },               /* streetAddress */
+        { 0x11, "/postalCode=" },           /* postalCode */
+#ifdef WOLFSSL_CERT_NAME_ALL
+        /* Second run of ids - mapped by the other range of
+         * CertNameSubjectIdx(), and with no issuer fields either. */
+        { 0x29, "/N=" },                    /* name */
+        { 0x2b, "/initials=" },             /* initials */
+        { 0x2e, "/dnQualifier=" }           /* dnQualifier */
+#endif
+    };
+    DecodedCert cert;
+    byte  arcOid[5] = { 0x06, 0x03, 0x55, 0x04, 0x00 };
+    byte  issuer[64];
+    byte  subject[64];
+    byte* der = NULL;
+    char  expect[64];
+    int   issuerLen;
+    int   subjectLen;
+    int   derSz;
+    int   c;
+
+    ExpectNotNull(der = (byte*)XMALLOC(1024, NULL, DYNAMIC_TYPE_TMP_BUFFER));
+
+    subjectLen = cni_buildName(subject, "S", badPilotOid,
+        (int)sizeof(badPilotOid), "unknown");
+
+    for (c = 0; (der != NULL) && (c < (int)XELEM_CNT(cases)); c++) {
+        arcOid[4] = cases[c].arc;
+        issuerLen = cni_buildName(issuer, "I", arcOid, (int)sizeof(arcOid),
+            attrVal);
+        derSz = cni_buildCert(der, issuer, issuerLen, subject, subjectLen);
+
+        wc_InitDecodedCert(&cert, der, (word32)derSz, NULL);
+        ExpectIntNE(wc_ParseCert(&cert, CERT_TYPE, NO_VERIFY, NULL), 0);
+
+        /* The component is still reported in the issuer string, under the
+         * label its row carries. */
+        XSTRLCPY(expect, "/CN=I", sizeof(expect));
+        XSTRLCAT(expect, cases[c].expStr, sizeof(expect));
+        XSTRLCAT(expect, attrVal, sizeof(expect));
+        ExpectStrEQ(cert.issuer, expect);
+
+        /* DecodedCert's first member must be untouched: nothing has set the
+         * public key on this path, so a store through a zero offset is the
+         * only thing that could have. */
+        ExpectNull(cert.publicKey);
+        wc_FreeDecodedCert(&cert);
+    }
+
+    XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
     return EXPECT_RESULT();
 }
 

--- a/tests/api/test_asn.h
+++ b/tests/api/test_asn.h
@@ -41,6 +41,8 @@ int test_DecodeCertExtensions_certpol_trailing_junk(void);
 int test_DecodeCertExtensions_empty_certpol_trailing(void);
 int test_ParseCert_SM3wSM2_short_pubkey(void);
 int test_ParseCert_dnBufferBoundary(void);
+int test_ParseCert_nameComponentIds(void);
+int test_ParseCert_issuerNameNoField(void);
 int test_wc_DecodeObjectId(void);
 int test_ToTraditional_ex_handcrafted(void);
 int test_ToTraditional_ex_roundtrip(void);
@@ -71,6 +73,8 @@ int test_wc_AsnFeatureCoverage(void);
     TEST_DECL_GROUP("asn", test_DecodeCertExtensions_empty_certpol_trailing), \
     TEST_DECL_GROUP("asn", test_ParseCert_SM3wSM2_short_pubkey),    \
     TEST_DECL_GROUP("asn", test_ParseCert_dnBufferBoundary),        \
+    TEST_DECL_GROUP("asn", test_ParseCert_nameComponentIds),       \
+    TEST_DECL_GROUP("asn", test_ParseCert_issuerNameNoField),      \
     TEST_DECL_GROUP("asn", test_wc_DecodeObjectId),                 \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_handcrafted),      \
     TEST_DECL_GROUP("asn", test_ToTraditional_ex_roundtrip),        \

--- a/tests/api/test_tls_bounds.c
+++ b/tests/api/test_tls_bounds.c
@@ -62,6 +62,13 @@
     !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT)
     #define TEST_TLS_BOUNDS_SESSION_TICKET_FF
 #endif
+/* test_tls_bounds_load_server_cert() and every test body that calls it. The
+ * certificate and key it loads are RSA and come from the filesystem, so a
+ * build without either has neither the helper nor its callers. */
+#if !defined(NO_WOLFSSL_SERVER) && !defined(NO_CERTS) && !defined(NO_RSA) && \
+    !defined(NO_FILESYSTEM)
+    #define TEST_TLS_BOUNDS_SERVER_CERT
+#endif
 
 /* Each helper below is called only from test bodies whose feature guards differ
  * from one another, so no single condition describes "some caller is compiled
@@ -85,8 +92,7 @@ static void test_tls_bounds_c32to24(word32 in, byte* out)
     out[2] = (byte)in;
 }
 
-#if !defined(NO_WOLFSSL_SERVER) && !defined(NO_CERTS) && !defined(NO_RSA) && \
-    !defined(NO_FILESYSTEM)
+#ifdef TEST_TLS_BOUNDS_SERVER_CERT
 /* SetSSL_CTX() (InitSSL()'s caller) fails wolfSSL_new() with NO_PRIVATE_KEY
  * for a server-side ssl with no certificate/key and no PSK/anon/cert-setup-cb
  * fallback, so every server-side ssl created only to unit-test a WOLFSSL_LOCAL
@@ -1022,6 +1028,7 @@ static int test_TLSX_CSR_write_getsize_status_cb(WOLFSSL* ssl, void* arg)
 int test_TLSX_CSR_write_getsize_bounds(void)
 {
 #if defined(TEST_TLS_BOUNDS_CSR_STATUS_CB) && \
+    defined(TEST_TLS_BOUNDS_SERVER_CERT) && \
     defined(HAVE_TLS_EXTENSIONS)
     EXPECT_DECLS;
     WOLFSSL_CTX* ctx = NULL;
@@ -1150,6 +1157,7 @@ int test_TLSX_CSR_write_getsize_bounds(void)
 int test_TLSX_CSR_SetResponseWithStatusCB_bounds(void)
 {
 #if defined(TEST_TLS_BOUNDS_CSR_STATUS_CB) && \
+    defined(TEST_TLS_BOUNDS_SERVER_CERT) && \
     defined(HAVE_TLS_EXTENSIONS)
     EXPECT_DECLS;
     WOLFSSL_CTX* ctx = NULL;
@@ -1445,6 +1453,7 @@ static int test_ProcessChainOCSPRequest_setup(WOLFSSL_CTX** pctx,
 int test_ProcessChainOCSPRequest_bounds(void)
 {
 #if defined(TEST_TLS_BOUNDS_OCSP_CHAIN) && \
+    defined(TEST_TLS_BOUNDS_SERVER_CERT) && \
     defined(HAVE_TLS_EXTENSIONS)
     EXPECT_DECLS;
     WOLFSSL_CTX* ctx = NULL;
@@ -1996,6 +2005,7 @@ static void* test_TLSX_CSR_Parse_fail_realloc(void* ptr, size_t size)
 int test_TLSX_CSR_Parse_bounds(void)
 {
 #if defined(TEST_TLS_BOUNDS_CSR_PARSE) && \
+    defined(TEST_TLS_BOUNDS_SERVER_CERT) && \
     defined(HAVE_TLS_EXTENSIONS) && \
     !defined(WOLFSSL_NO_TLS12)
     EXPECT_DECLS;
@@ -2100,6 +2110,7 @@ int test_TLSX_CSR_Parse_bounds(void)
 int test_TLSX_CSR2_Parse_bounds(void)
 {
 #if defined(WOLFSSL_TEST_STATIC_BUILD) &&  defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2) && !defined(NO_WOLFSSL_SERVER) && \
+    defined(TEST_TLS_BOUNDS_SERVER_CERT) && \
     defined(HAVE_TLS_EXTENSIONS) && \
     !defined(WOLFSSL_NO_TLS12)
     EXPECT_DECLS;
@@ -2342,6 +2353,7 @@ int test_TLSX_WriteRequest_length_prefix_bounds(void)
 int test_TLSX_WriteResponse_bounds(void)
 {
 #if defined(WOLFSSL_TEST_STATIC_BUILD) && defined(HAVE_EXTENDED_MASTER) &&  !defined(NO_WOLFSSL_SERVER) && !defined(WOLFSSL_NO_TLS12) && \
+    defined(TEST_TLS_BOUNDS_SERVER_CERT) && \
     defined(HAVE_TLS_EXTENSIONS)
     EXPECT_DECLS;
     WOLFSSL_CTX* ctx = NULL;

--- a/tests/unit-mcdc/test_asn_cert_whitebox.c
+++ b/tests/unit-mcdc/test_asn_cert_whitebox.c
@@ -43,14 +43,14 @@
  *
  * RESIDUALS (structurally dead operand, argued from the source, not a gap
  * in this test):
- *   - SetSubject() :15074 / SetIssuer() :15127 1st operand (id >
- *     ASN_COMMON_NAME): both are called from GetRDN() only when typeStr !=
- *     NULL (asn.c:15288), and every dispatch branch that assigns typeStr
- *     also assigns an id of at least ASN_COMMON_NAME (3) -- the v1 branch
- *     is gated on ValidCertNameSubject(id), which requires id - 3 >= 0; the
- *     x500UniqueIdentifier branch uses 0x2d; the rest use the 0x100/0x200
- *     constants. id == ASN_COMMON_NAME is consumed by the preceding `if`,
- *     so the operand is constant true here.
+ *   - SetSubject() / SetIssuer() 1st operand (idx !=
+ *     CERT_NAME_SUBJ_NO_IDX): both are called from GetRDN() only when typeStr
+ *     != NULL (asn.c:15288), and every dispatch branch that assigns typeStr
+ *     for a 2.5.4.x id first found a row for it -- the v1 branch is gated on
+ *     ValidCertNameSubject(), which needs a row. The x500UniqueIdentifier
+ *     branch (0x2d) and the 0x100/0x200 constants reach SetSubject() with no
+ *     row, but are consumed by its later id == ASN_EMAIL / ASN_JURIS_*
+ *     arms, so the operand is constant true where it is evaluated.
  *   - SetAlgoIDImpl() :16774 1st operand (ret == 0): ret comes only from
  *     CALLOC_ASNSETDATA -- whose MEMORY_E is caught and returned at
  *     :16731-:16734 before that line -- and from SizeASN_Items() over the
@@ -580,15 +580,15 @@ static void wb_set_dns_entry(void) { WB_NOTE("WOLFSSL_CERT_GEN/WOLFSSL_ALT_NAMES
 #endif
 
 /* ===========================================================================
- * Section 8: GetRDN()/GetCertName()/GetName() OID dispatch and SetSubject/
- * SetIssuer id-range macro [:14261,:15073,:15126,:15169,:15181,:15190,
+ * Section 8: GetRDN()/GetCertName()/GetName() OID dispatch and the
+ * SetSubject/SetIssuer row lookup [:15073,:15126,:15169,:15181,:15190,
  * :15199,:15208,:15217,:15227,:15239,:15244,:15269,:15391]
  *
  * Drives GetName() (public entry point) with hand-built Name ::= SEQUENCE OF
  * RelativeDistinguishedName ::= SET { SEQUENCE { OID, DirectoryString } }
  * buffers, one RDN OID per vector to isolate each else-if arm of GetRDN()'s
- * OID dispatch (and the ValidCertNameSubject() range macro at :14261, which
- * that dispatch's v1-name-type branch expands into).
+ * OID dispatch (and the CertNameSubjectIdx()/ValidCertNameSubject() row lookup
+ * that dispatch's v1-name-type branch uses).
  * ========================================================================= */
 #ifdef WOLFSSL_ASN_TEMPLATE
 static word32 wb_build_rdn_val(byte* out, const byte* oidContent, word32 oidSz,
@@ -665,10 +665,13 @@ static void wb_get_rdn_get_cert_name(void)
     int ret;
     /* v1 DN type OIDs: {0x55, 0x04, id}. */
     static const byte v1_cn[]  = { 0x55, 0x04, ASN_COMMON_NAME };  /* id=3, in-range */
-    static const byte v1_lo[]  = { 0x55, 0x04, 0x02 };  /* id-3<0 (ASN_DN_NULL side) */
-    /* id-3 past table size; must stay < 0x80 so the byte is still a valid
+    static const byte v1_lo[]  = { 0x55, 0x04, 0x02 };  /* below both runs */
+    /* Past both runs of ids; must stay < 0x80 so the byte is still a valid
      * single-byte OID sub-identifier (no dangling BER continuation bit). */
     static const byte v1_hi[]  = { 0x55, 0x04, 0x50 };
+    /* Between the two runs: a real attribute type (physicalDeliveryOfficeName)
+     * that the table has no row for. */
+    static const byte v1_gap[] = { 0x55, 0x04, 0x13 };
     /* dcOid with last byte changed -> "unknown pilot attribute" arm. */
     byte dcOid_bad[sizeof(dcOid)];
     /* jurisdiction-of-incorporation OIDs. */
@@ -676,31 +679,54 @@ static void wb_get_rdn_get_cert_name(void)
     byte joi_st[ASN_JOI_PREFIX_SZ + 1];
     byte joi_unknown[ASN_JOI_PREFIX_SZ + 1];
 
-    WB_NOTE("GetRDN()/GetCertName(): v1 name-type range macro [:14261]; "
-            "OID dispatch chain [:15169-:15269]");
+    WB_NOTE("GetRDN()/GetCertName(): v1 name-type id-to-row mapping "
+            "(CertNameSubjectIdx()); OID dispatch chain [:15169-:15269]");
 
-    /* id in [3, table) -> ValidCertNameSubject() all true; goes through
-     * SetSubject()'s id>ASN_COMMON_NAME&&id<=ASN_USER_ID (false here, id==
-     * ASN_COMMON_NAME itself) [:15073 2nd-operand-moot via 1st check]. */
+    /* certNameSubject[] covers two runs of ids - 2.5.4.3 to 2.5.4.18, and
+     * 2.5.4.41 to 2.5.4.46 with WOLFSSL_CERT_NAME_ALL - so CertNameSubjectIdx()
+     * decides on two range tests, and ValidCertNameSubject() then on the row's
+     * strLen. Each of the three is driven both ways below. */
+
+    /* First run -> 1st range test true; goes through SetSubject()'s
+     * id == ASN_COMMON_NAME arm rather than the table-offset one. */
     ret = wb_get_name_with_oid(ASN_SUBJECT, v1_cn, sizeof(v1_cn));
-    WB_CHECK(ret == 0, "v1 CN OID, ASN_SUBJECT (:14261 all true)");
+    WB_CHECK(ret == 0, "v1 CN OID, ASN_SUBJECT (1st range test true)");
 
-    /* id-3 < 0 -> ValidCertNameSubject() 1st operand false; unknown type is
-     * silently skipped (typeStr stays NULL, ret stays 0). */
+    /* Below the first run -> both range tests false; unknown type is silently
+     * skipped (typeStr stays NULL, ret stays 0). */
     ret = wb_get_name_with_oid(ASN_SUBJECT, v1_lo, sizeof(v1_lo));
-    WB_CHECK(ret == 0, "v1 OID id-3<0 (:14261 1st operand false)");
+    WB_CHECK(ret == 0, "v1 OID below both runs (both range tests false)");
 
-    /* id-3 >= certNameSubjectSz -> 1st operand true, 2nd false. */
+    /* Between the runs -> 1st range test false on its upper bound, 2nd false
+     * on its lower bound. This is the id that a dense "id - 3" index gave the
+     * second run's rows to. */
+    ret = wb_get_name_with_oid(ASN_SUBJECT, v1_gap, sizeof(v1_gap));
+    WB_CHECK(ret == 0, "v1 OID between the runs (no row)");
+
+    /* Past both runs -> 2nd range test false on its upper bound. */
     ret = wb_get_name_with_oid(ASN_SUBJECT, v1_hi, sizeof(v1_hi));
-    WB_CHECK(ret == 0, "v1 OID id-3 out of range high (:14261 2nd operand false)");
+    WB_CHECK(ret == 0, "v1 OID above both runs (2nd range test false)");
 
-    /* id 12 ("Title") is in range but its certNameSubject[] entry carries
-     * EMPTY_STR/0, so the strLen operand is the one that decides. */
+#ifdef WOLFSSL_CERT_NAME_ALL
+    /* Second run -> 1st range test false, 2nd true. Both ends are driven so
+     * neither bound of the second range test can drift unnoticed. */
+    {
+        static const byte v1_name[] = { 0x55, 0x04, ASN_NAME };
+        static const byte v1_dnq[]  = { 0x55, 0x04, ASN_DNQUALIFIER };
+        ret = wb_get_name_with_oid(ASN_SUBJECT, v1_name, sizeof(v1_name));
+        WB_CHECK(ret == 0, "v1 name OID (2nd range test true, low end)");
+        ret = wb_get_name_with_oid(ASN_SUBJECT, v1_dnq, sizeof(v1_dnq));
+        WB_CHECK(ret == 0, "v1 dnQualifier OID (2nd range test true, high end)");
+    }
+#endif
+
+    /* id 12 ("Title") has a row but it carries EMPTY_STR/0, so
+     * ValidCertNameSubject()'s strLen operand is the one that decides. */
     {
         static const byte v1_empty[] = { 0x55, 0x04, 0x0C };
         ret = wb_get_name_with_oid(ASN_SUBJECT, v1_empty, sizeof(v1_empty));
-        WB_CHECK(ret == 0, "v1 OID with an empty table entry "
-                "(:14261 3rd operand false)");
+        WB_CHECK(ret == 0, "v1 OID with an empty table row "
+                "(strLen operand false)");
     }
 
     /* id in [ASN_COMMON_NAME+1, ASN_USER_ID] -> SetSubject()'s table-offset

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -14334,48 +14334,65 @@ int GetHashId(const byte* id, int length, byte* hash, int hashAlg)
 /* Id for jurisdiction state. */
 #define ASN_JURIS_ST  0x202
 
+/* certNameSubject[] below is indexed by row, not by name component id: the
+ * ids it covers fall into two runs (2.5.4.3 - 2.5.4.18 and 2.5.4.41 -
+ * 2.5.4.46) with a gap between them. Callers map an id to a row with
+ * CertNameSubjectIdx() and pass the row index to the macros here. */
+
+/* Number of rows covering the first run of ids (2.5.4.3 - 2.5.4.18). */
+#define CERT_NAME_SUBJ_LOW_CNT  (ASN_USER_ID - ASN_COMMON_NAME + 1)
+/* Row index meaning "this id has no row in the table". */
+#define CERT_NAME_SUBJ_NO_IDX   (-1)
+
 /* Set the string for a name component into the subject name. */
-#define SetCertNameSubject(cert, id, val) \
-    *((const char**)(((byte *)(cert)) + certNameSubject[(id) - 3].data)) = \
+#define SetCertNameSubject(cert, idx, val) \
+    *((const char**)(((byte *)(cert)) + certNameSubject[idx].data)) = \
         (val)
 /* Set the string length for a name component into the subject name. */
-#define SetCertNameSubjectLen(cert, id, val) \
-    *((int*)(((byte *)(cert)) + certNameSubject[(id) - 3].len)) = (int)(val)
+#define SetCertNameSubjectLen(cert, idx, val) \
+    *((int*)(((byte *)(cert)) + certNameSubject[idx].len)) = (int)(val)
 /* Set the encoding for a name component into the subject name. */
-#define SetCertNameSubjectEnc(cert, id, val) \
-    *((byte*)(((byte *)(cert)) + certNameSubject[(id) - 3].enc)) = (val)
+#define SetCertNameSubjectEnc(cert, idx, val) \
+    *((byte*)(((byte *)(cert)) + certNameSubject[idx].enc)) = (val)
 
 /* Get the string of a name component from the subject name. */
 #ifdef WOLFSSL_NAMES_STATIC
-    #define GetCertNameSubjectStr(id) \
-        ((certNameSubject[(id) - 3].strLen) ? \
-         (certNameSubject[(id) - 3].str) : \
+    #define GetCertNameSubjectStr(idx) \
+        ((certNameSubject[idx].strLen) ? \
+         (certNameSubject[idx].str) : \
          NULL)
 #else
-    #define GetCertNameSubjectStr(id) \
-        (certNameSubject[(id) - 3].str)
+    #define GetCertNameSubjectStr(idx) \
+        (certNameSubject[idx].str)
 #endif
 /* Get the string length of a name component from the subject name. */
-#define GetCertNameSubjectStrLen(id) \
-    (certNameSubject[(id) - 3].strLen)
+#define GetCertNameSubjectStrLen(idx) \
+    (certNameSubject[idx].strLen)
 /* Get the NID of a name component from the subject name. */
-#define GetCertNameSubjectNID(id) \
-    (certNameSubject[(id) - 3].nid)
+#define GetCertNameSubjectNID(idx) \
+    (certNameSubject[idx].nid)
 
-#define ValidCertNameSubject(id) \
-    (((id) - 3) >= 0 && ((id) - 3) < certNameSubjectSz && \
-            (certNameSubject[(id) - 3].strLen > 0))
+/* Whether the row is one this build recognizes. Rows that only exist to keep
+ * the id runs contiguous have no type string. */
+#define ValidCertNameSubject(idx) \
+    (((idx) != CERT_NAME_SUBJ_NO_IDX) && (certNameSubject[idx].strLen > 0))
+
+/* Whether the row has somewhere in DecodedCert to put the subject/issuer
+ * component. A zero offset means there is no such field - offset 0 is
+ * DecodedCert's publicKey, never a name component. */
+#define StoreCertNameSubject(idx)  (certNameSubject[idx].data != 0)
+#define StoreCertNameIssuer(idx)   (certNameSubject[idx].dataI != 0)
 
 /* Set the string for a name component into the issuer name. */
-#define SetCertNameIssuer(cert, id, val) \
-    *((const char**)(((byte *)(cert)) + certNameSubject[(id) - 3].dataI)) = \
+#define SetCertNameIssuer(cert, idx, val) \
+    *((const char**)(((byte *)(cert)) + certNameSubject[idx].dataI)) = \
         (val)
 /* Set the string length for a name component into the issuer name. */
-#define SetCertNameIssuerLen(cert, id, val) \
-    *((int*)(((byte *)(cert)) + certNameSubject[(id) - 3].lenI)) = (int)(val)
+#define SetCertNameIssuerLen(cert, idx, val) \
+    *((int*)(((byte *)(cert)) + certNameSubject[idx].lenI)) = (int)(val)
 /* Set the encoding for a name component into the issuer name. */
-#define SetCertNameIssuerEnc(cert, id, val) \
-    *((byte*)(((byte *)(cert)) + certNameSubject[(id) - 3].encI)) = (val)
+#define SetCertNameIssuerEnc(cert, idx, val) \
+    *((byte*)(((byte *)(cert)) + certNameSubject[idx].encI)) = (val)
 
 
 /* Mapping of certificate name component to useful information. */
@@ -14740,6 +14757,41 @@ static const CertNameData certNameSubject[] = {
         WC_NID_initials
     #endif
     },
+    /* Generation Qualifier, id 44 - not stored, keeps ids contiguous */
+    {
+        EMPTY_STR, 0,
+    #if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
+        0,
+        0,
+        0,
+#ifdef WOLFSSL_HAVE_ISSUER_NAMES
+        0,
+        0,
+        0,
+#endif
+    #endif
+    #ifdef WOLFSSL_X509_NAME_AVAILABLE
+        0,
+    #endif
+    },
+    /* X500 Unique Identifier, id 45 - handled by GetRDN() as its value is a
+     * BIT STRING rather than a DirectoryString. Row keeps ids contiguous. */
+    {
+        EMPTY_STR, 0,
+    #if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
+        0,
+        0,
+        0,
+#ifdef WOLFSSL_HAVE_ISSUER_NAMES
+        0,
+        0,
+        0,
+#endif
+    #endif
+    #ifdef WOLFSSL_X509_NAME_AVAILABLE
+        0,
+    #endif
+    },
     /* DN Qualifier Name, id 46 */
     {
         "/dnQualifier=", 13,
@@ -14762,6 +14814,36 @@ static const CertNameData certNameSubject[] = {
 
 static const int certNameSubjectSz =
         (int) (sizeof(certNameSubject) / sizeof(CertNameData));
+
+/* Map a name component id (the last arc of an OID under 2.5.4) to a row of
+ * certNameSubject[].
+ *
+ * The table holds two runs of ids: 2.5.4.3 - 2.5.4.18 in the first rows and,
+ * when WOLFSSL_CERT_NAME_ALL is defined, 2.5.4.41 - 2.5.4.46 in the rows
+ * after them. Ids between and beyond the runs have no row.
+ *
+ * @param [in] id  Id of name component.
+ * @return  Index into certNameSubject[] for the id.
+ * @return  CERT_NAME_SUBJ_NO_IDX when the id is not in the table.
+ */
+static int CertNameSubjectIdx(int id)
+{
+    int idx = CERT_NAME_SUBJ_NO_IDX;
+
+    if ((id >= ASN_COMMON_NAME) && (id <= ASN_USER_ID)) {
+        idx = id - ASN_COMMON_NAME;
+    }
+    else if ((id >= ASN_NAME) && (id <= ASN_DNQUALIFIER)) {
+        idx = (id - ASN_NAME) + CERT_NAME_SUBJ_LOW_CNT;
+    }
+
+    /* Second run of rows is only compiled in with WOLFSSL_CERT_NAME_ALL. */
+    if (idx >= certNameSubjectSz) {
+        idx = CERT_NAME_SUBJ_NO_IDX;
+    }
+
+    return idx;
+}
 
 
 /* ASN.1 template for an RDN.
@@ -15170,6 +15252,9 @@ static int SetSubject(DecodedCert* cert, int id, const byte* str, int strLen,
                       byte tag)
 {
     int ret = 0;
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
+    int idx = CertNameSubjectIdx(id);
+#endif
 
     /* Put string and encoding into certificate. */
     if (id == ASN_COMMON_NAME) {
@@ -15178,11 +15263,13 @@ static int SetSubject(DecodedCert* cert, int id, const byte* str, int strLen,
         cert->subjectCNEnc = (char)tag;
     }
 #if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
-    else if (id > ASN_COMMON_NAME && id <= ASN_USER_ID) {
-        /* Use table and offsets to put data into appropriate fields. */
-        SetCertNameSubject(cert, id, (const char*)str);
-        SetCertNameSubjectLen(cert, id, strLen);
-        SetCertNameSubjectEnc(cert, id, tag);
+    /* Use table and offsets to put data into appropriate fields. Rows for
+     * components this build has nowhere to store are skipped - writing
+     * through their zero offset would land on DecodedCert's first member. */
+    else if ((idx != CERT_NAME_SUBJ_NO_IDX) && StoreCertNameSubject(idx)) {
+        SetCertNameSubject(cert, idx, (const char*)str);
+        SetCertNameSubjectLen(cert, idx, strLen);
+        SetCertNameSubjectEnc(cert, idx, tag);
     }
 #endif
 #if !defined(IGNORE_NAME_CONSTRAINTS) || \
@@ -15224,6 +15311,7 @@ static int SetIssuer(DecodedCert* cert, int id, const byte* str, int strLen,
                       byte tag)
 {
     int ret = 0;
+    int idx = CertNameSubjectIdx(id);
 
     /* Put string and encoding into certificate. */
     if (id == ASN_COMMON_NAME) {
@@ -15231,11 +15319,13 @@ static int SetIssuer(DecodedCert* cert, int id, const byte* str, int strLen,
         cert->issuerCNLen = (int)strLen;
         cert->issuerCNEnc = (char)tag;
     }
-    else if (id > ASN_COMMON_NAME && id <= ASN_USER_ID) {
-        /* Use table and offsets to put data into appropriate fields. */
-        SetCertNameIssuer(cert, id, (const char*)str);
-        SetCertNameIssuerLen(cert, id, strLen);
-        SetCertNameIssuerEnc(cert, id, tag);
+    /* Use table and offsets to put data into appropriate fields. Many rows
+     * have no issuer fields in DecodedCert; writing through their zero offset
+     * would land on DecodedCert's first member. */
+    else if ((idx != CERT_NAME_SUBJ_NO_IDX) && StoreCertNameIssuer(idx)) {
+        SetCertNameIssuer(cert, idx, (const char*)str);
+        SetCertNameIssuerLen(cert, idx, strLen);
+        SetCertNameIssuerEnc(cert, idx, tag);
     }
     else if (id == ASN_EMAIL) {
         cert->issuerEmail = (const char*)str;
@@ -15275,18 +15365,22 @@ static int GetRDN(DecodedCert* cert, char* full, word32* idx, int* nid,
 
     /* v1 name types */
     if ((oidSz == 3) && (oid[0] == 0x55) && (oid[1] == 0x04)) {
+        int nameIdx;
+
         id = oid[2];
-        /* Check range of supported ids in table. */
-        if (ValidCertNameSubject(id)) {
+        /* Map id to a row of the table - unsupported ids have no row. */
+        nameIdx = CertNameSubjectIdx(id);
+        if (ValidCertNameSubject(nameIdx)) {
             /* Get the type string, length and NID from table. */
-            typeStr = GetCertNameSubjectStr(id);
-            typeStrLen = GetCertNameSubjectStrLen(id);
+            typeStr = GetCertNameSubjectStr(nameIdx);
+            typeStrLen = GetCertNameSubjectStrLen(nameIdx);
         #ifdef WOLFSSL_X509_NAME_AVAILABLE
-            *nid = GetCertNameSubjectNID(id);
+            *nid = GetCertNameSubjectNID(nameIdx);
         #endif
         }
         else if (id == ASN_X500_UNIQUE_ID) {
-            /* Not in the table as its id is outside the contiguous range. */
+            /* Its row is empty as the value is a BIT STRING rather than a
+             * DirectoryString, so it is handled here instead. */
             typeStr = WOLFSSL_X500_UNIQUE_ID;
             typeStrLen = sizeof(WOLFSSL_X500_UNIQUE_ID) - 1;
         #ifdef WOLFSSL_X509_NAME_AVAILABLE

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -818,13 +818,14 @@ enum DN_Tags {
     ASN_BUS_CAT       = 0x0f,   /* businessCategory */
     ASN_POSTAL_CODE   = 0x11,   /* postalCode */
     ASN_USER_ID       = 0x12,   /* UserID */
-    ASN_X500_UNIQUE_ID = 0x2d,  /* x500UniqueIdentifier (2.5.4.45) */
-#ifdef WOLFSSL_CERT_NAME_ALL
+    /* 2.5.4.41 - 2.5.4.46. Always defined - the name component table is
+     * indexed with these ids whether or not the components are stored. */
     ASN_NAME          = 0x29,   /* name */
     ASN_GIVEN_NAME    = 0x2a,   /* GN */
     ASN_INITIALS      = 0x2b,   /* initials */
+    ASN_GEN_QUALIFIER = 0x2c,   /* generationQualifier - not stored */
+    ASN_X500_UNIQUE_ID = 0x2d,  /* x500UniqueIdentifier (2.5.4.45) */
     ASN_DNQUALIFIER   = 0x2e,   /* dnQualifier */
-#endif /* WOLFSSL_CERT_NAME_ALL */
 
 
     ASN_CONTENT_TYPE  = 0x97, /* not actual OID (see attrPkcs9ContentTypeOid) */


### PR DESCRIPTION
# Description

When WOLFSSL_CERT_NAME_ALL there were extra entries that could not be looked up by the default index calculation - the table didn't have enough entries. The last OID value is now passed to CertNameSubjectIdx to be converted to an index.
Code changed to use the new function and tests added and updated.

Fixed --disable-rsa builds.

Fixes zd#22418

# Testing

Regression tested ASN.1 code.
Tests added.