### PR TITLE
cryptocb: let wc_KeyStore_Derive() request the key size

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -189,6 +189,8 @@
 
 ## New Features
 
+* Added `WC_ALGO_TYPE_KEYSTORE`, a crypto callback algorithm type for lifetime operations on keys held in a hardware key store, with the public API in `wolfssl/wolfcrypt/wc_keystore.h` behind `--enable-cryptocbutils=keystore`. Seven operations - plaintext and wrapped import/export, derive, delete and get-info - address keys by an opaque device-defined reference that wolfCrypt copies through and never interprets, the same way it treats a key object's `id[]` blob. This lets a device create, wrap, derive and destroy keys that never appear in memory, which `WOLF_CRYPTO_CB_SETKEY` and `WOLF_CRYPTO_CB_EXPORT_KEY` cannot express because both are bound to a wolfCrypt key object holding material for its own use.
+
 * Added Argon2 (RFC 9106) password hashing with all three variants - Argon2d, Argon2i and Argon2id - via `--enable-argon2`. Only version 0x13 is implemented. Provides the one-shot `wc_Argon2()`/`wc_Argon2_ex()` and a reusable context API (`wc_Argon2Init`/`wc_Argon2SetParams`/`wc_Argon2DeriveTag`/`wc_Argon2Free`, plus `wc_Argon2New`/`wc_Argon2Delete` unless `WC_NO_CONSTRUCTORS`) that allocates the memory block array once for applications deriving many tags. `--enable-argon2-threads` fills the segments of a slice in parallel, which does not change the derived tag: the one-shot functions use a thread per lane, and the context API takes a count from `wc_Argon2SetThreads()`. by @SparkiDev
 
 ## Fixes

--- a/doc/dox_comments/header_files/wc_keystore.h
+++ b/doc/dox_comments/header_files/wc_keystore.h
@@ -253,6 +253,9 @@ int wc_KeyStore_ExportWrapped(int devId,
     \param keyRefSz length of keyRef in bytes
     \param keyType what the derived key is for, from enum wc_KeyStoreKeyType,
     or WC_KEYSTORE_KEY_NONE to leave it to the device
+    \param keySz size in bytes of the key to create, or 0 to leave it to the
+    device. Unlike the other operations there is nothing else to infer it
+    from: the derivation data length is the input's, not the output's
     \param srcKeyRef opaque reference naming the derivation key
     \param srcKeyRefSz length of srcKeyRef in bytes
     \param kdfType derivation function, from enum wc_KdfType.
@@ -266,7 +269,7 @@ int wc_KeyStore_ExportWrapped(int devId,
     _Example_
     \code
     ret = wc_KeyStore_Derive(devId, keyRef, sizeof(keyRef),
-                             WC_KEYSTORE_KEY_AES,
+                             WC_KEYSTORE_KEY_AES, AES_256_KEY_SIZE,
                              parentRef, sizeof(parentRef),
                              WC_KDF_TYPE_NONE, deriv, sizeof(deriv),
                              WC_KEYSTORE_ATTR_EXPORTABLE, NULL);
@@ -275,7 +278,7 @@ int wc_KeyStore_ExportWrapped(int devId,
     \sa wc_KeyStore_GetInfo
 */
 int wc_KeyStore_Derive(int devId,
-    const byte* keyRef, word32 keyRefSz, word32 keyType,
+    const byte* keyRef, word32 keyRefSz, word32 keyType, word32 keySz,
     const byte* srcKeyRef, word32 srcKeyRefSz,
     word32 kdfType, const byte* deriv, word32 derivSz,
     word32 attrs, const void* ctx);

--- a/tests/api/test_keystore.c
+++ b/tests/api/test_keystore.c
@@ -120,6 +120,7 @@ static int KsCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
             seen->otherRef   = info->keystore.op.derive.srcKeyRef;
             seen->otherRefSz = info->keystore.op.derive.srcKeyRefSz;
             seen->keyType    = info->keystore.op.derive.keyType;
+            seen->keySz      = info->keystore.op.derive.keySz;
             seen->attrs    = info->keystore.op.derive.attrs;
             seen->kdfType  = info->keystore.op.derive.kdfType;
             seen->deriv    = info->keystore.op.derive.deriv;
@@ -386,11 +387,12 @@ int test_wc_KeyStore_Derive(void)
      * kdfType and attrs numerically apart or a transposition reads as equal. */
     ExpectIntEQ(wc_KeyStore_Derive(KS_TEST_DEVID,
         ksKeyRef, (word32)sizeof(ksKeyRef), WC_KEYSTORE_KEY_AES,
-        ksOtherRef, (word32)sizeof(ksOtherRef),
+        AES_256_KEY_SIZE, ksOtherRef, (word32)sizeof(ksOtherRef),
         WC_KDF_TYPE_HKDF, ksDeriv, (word32)sizeof(ksDeriv),
         WC_KEYSTORE_ATTR_PERSISTENT, ksCallerCtx), 0);
     ExpectIntEQ(seen.op, WC_KEYSTORE_DERIVE);
     ExpectIntEQ(seen.keyType, WC_KEYSTORE_KEY_AES);
+    ExpectIntEQ(seen.keySz, AES_256_KEY_SIZE);
     ExpectPtrEq(seen.keyRef, ksKeyRef);
     ExpectIntEQ(seen.keyRefSz, (word32)sizeof(ksKeyRef));
     ExpectPtrEq(seen.otherRef, ksOtherRef);
@@ -403,21 +405,22 @@ int test_wc_KeyStore_Derive(void)
 
     /* WC_KDF_TYPE_NONE asks for the device's own derivation */
     ExpectIntEQ(wc_KeyStore_Derive(KS_TEST_DEVID,
-        ksKeyRef, (word32)sizeof(ksKeyRef), WC_KEYSTORE_KEY_NONE,
+        ksKeyRef, (word32)sizeof(ksKeyRef), WC_KEYSTORE_KEY_NONE, 0,
         ksOtherRef, (word32)sizeof(ksOtherRef),
         WC_KDF_TYPE_NONE, ksDeriv, (word32)sizeof(ksDeriv),
         WC_KEYSTORE_ATTR_EXPORTABLE, NULL), 0);
     ExpectIntEQ(seen.kdfType, WC_KDF_TYPE_NONE);
+    ExpectIntEQ(seen.keySz, 0); /* 0 leaves the size to the device */
     ExpectIntEQ(seen.attrs, WC_KEYSTORE_ATTR_EXPORTABLE);
 
     seen.calls = 0;
     ExpectIntEQ(wc_KeyStore_Derive(KS_TEST_DEVID,
-        ksKeyRef, (word32)sizeof(ksKeyRef), WC_KEYSTORE_KEY_AES, NULL, 0,
+        ksKeyRef, (word32)sizeof(ksKeyRef), WC_KEYSTORE_KEY_AES, 0, NULL, 0,
         WC_KDF_TYPE_NONE, ksDeriv, (word32)sizeof(ksDeriv), 0, NULL),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     /* No derivation data means no length beside it. */
     ExpectIntEQ(wc_KeyStore_Derive(KS_TEST_DEVID,
-        ksKeyRef, (word32)sizeof(ksKeyRef), WC_KEYSTORE_KEY_AES,
+        ksKeyRef, (word32)sizeof(ksKeyRef), WC_KEYSTORE_KEY_AES, 0,
         ksOtherRef, (word32)sizeof(ksOtherRef),
         WC_KDF_TYPE_NONE, NULL, (word32)sizeof(ksDeriv), 0, NULL),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
@@ -532,7 +535,7 @@ int test_wc_KeyStore_NoDevice(void)
     ExpectIntEQ(keySz, 0);
     ExpectIntEQ(attrs, 0);
     ExpectIntEQ(wc_KeyStore_Derive(KS_TEST_DEVID,
-        ksKeyRef, (word32)sizeof(ksKeyRef), WC_KEYSTORE_KEY_AES,
+        ksKeyRef, (word32)sizeof(ksKeyRef), WC_KEYSTORE_KEY_AES, 0,
         ksOtherRef, (word32)sizeof(ksOtherRef),
         WC_KDF_TYPE_NONE, ksDeriv, (word32)sizeof(ksDeriv), 0, NULL),
         WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE));

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -3987,7 +3987,7 @@ int wc_CryptoCb_KeyStoreExportWrapped(int devId,
 }
 
 int wc_CryptoCb_KeyStoreDerive(int devId,
-    const byte* keyRef, word32 keyRefSz, word32 keyType,
+    const byte* keyRef, word32 keyRefSz, word32 keyType, word32 keySz,
     const byte* srcKeyRef, word32 srcKeyRefSz,
     word32 kdfType, const byte* deriv, word32 derivSz,
     word32 attrs, const void* ctx)
@@ -4013,6 +4013,7 @@ int wc_CryptoCb_KeyStoreDerive(int devId,
         cryptoInfo.keystore.op.derive.keyRef      = keyRef;
         cryptoInfo.keystore.op.derive.keyRefSz    = keyRefSz;
         cryptoInfo.keystore.op.derive.keyType     = keyType;
+        cryptoInfo.keystore.op.derive.keySz       = keySz;
         cryptoInfo.keystore.op.derive.srcKeyRef   = srcKeyRef;
         cryptoInfo.keystore.op.derive.srcKeyRefSz = srcKeyRefSz;
         cryptoInfo.keystore.op.derive.deriv       = deriv;

--- a/wolfcrypt/src/wc_keystore.c
+++ b/wolfcrypt/src/wc_keystore.c
@@ -67,12 +67,12 @@ int wc_KeyStore_ExportWrapped(int devId,
 }
 
 int wc_KeyStore_Derive(int devId,
-    const byte* keyRef, word32 keyRefSz, word32 keyType,
+    const byte* keyRef, word32 keyRefSz, word32 keyType, word32 keySz,
     const byte* srcKeyRef, word32 srcKeyRefSz,
     word32 kdfType, const byte* deriv, word32 derivSz,
     word32 attrs, const void* ctx)
 {
-    return wc_CryptoCb_KeyStoreDerive(devId, keyRef, keyRefSz, keyType,
+    return wc_CryptoCb_KeyStoreDerive(devId, keyRef, keyRefSz, keyType, keySz,
         srcKeyRef, srcKeyRefSz, kdfType, deriv, derivSz, attrs, ctx);
 }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -69943,6 +69943,7 @@ static int keystoreTestCb(int cbDevId, wc_CryptoInfo* info, void* ctx)
             c->lastSrcKeyRef = info->keystore.op.derive.srcKeyRef;
             c->lastOtherRefSz = info->keystore.op.derive.srcKeyRefSz;
             c->lastKeyType   = info->keystore.op.derive.keyType;
+            c->lastKeySz     = info->keystore.op.derive.keySz;
             c->lastAttrs     = info->keystore.op.derive.attrs;
             c->lastKdfType   = info->keystore.op.derive.kdfType;
             c->lastDeriv     = info->keystore.op.derive.deriv;
@@ -70051,14 +70052,15 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t keystore_cb_test(void)
     }
 
     ret = wc_KeyStore_Derive(ksDevId, kref, (word32)sizeof(kref),
-            WC_KEYSTORE_KEY_CMAC, sref, (word32)sizeof(sref),
-            WC_KDF_TYPE_HKDF, dd, (word32)sizeof(dd),
+            WC_KEYSTORE_KEY_CMAC, WC_AES_BLOCK_SIZE, sref,
+            (word32)sizeof(sref), WC_KDF_TYPE_HKDF, dd, (word32)sizeof(dd),
             WC_KEYSTORE_ATTR_PERSISTENT, NULL);
     if (ret != 0 || ctx.lastOp != WC_KEYSTORE_DERIVE ||
         ctx.lastKeyRef != kref || ctx.lastKeyRefSz != (word32)sizeof(kref) ||
         ctx.lastSrcKeyRef != sref ||
         ctx.lastOtherRefSz != (word32)sizeof(sref) ||
         ctx.lastKeyType != WC_KEYSTORE_KEY_CMAC ||
+        ctx.lastKeySz != WC_AES_BLOCK_SIZE ||
         ctx.lastAttrs != WC_KEYSTORE_ATTR_PERSISTENT ||
         ctx.lastKdfType != WC_KDF_TYPE_HKDF ||
         ctx.lastDeriv != dd || ctx.lastDerivSz != (word32)sizeof(dd)) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -70052,7 +70052,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t keystore_cb_test(void)
     }
 
     ret = wc_KeyStore_Derive(ksDevId, kref, (word32)sizeof(kref),
-            WC_KEYSTORE_KEY_CMAC, WC_AES_BLOCK_SIZE, sref,
+            WC_KEYSTORE_KEY_CMAC, AES_128_KEY_SIZE, sref,
             (word32)sizeof(sref), WC_KDF_TYPE_HKDF, dd, (word32)sizeof(dd),
             WC_KEYSTORE_ATTR_PERSISTENT, NULL);
     if (ret != 0 || ctx.lastOp != WC_KEYSTORE_DERIVE ||
@@ -70060,7 +70060,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t keystore_cb_test(void)
         ctx.lastSrcKeyRef != sref ||
         ctx.lastOtherRefSz != (word32)sizeof(sref) ||
         ctx.lastKeyType != WC_KEYSTORE_KEY_CMAC ||
-        ctx.lastKeySz != WC_AES_BLOCK_SIZE ||
+        ctx.lastKeySz != AES_128_KEY_SIZE ||
         ctx.lastAttrs != WC_KEYSTORE_ATTR_PERSISTENT ||
         ctx.lastKdfType != WC_KDF_TYPE_HKDF ||
         ctx.lastDeriv != dd || ctx.lastDerivSz != (word32)sizeof(dd)) {

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -910,6 +910,7 @@ typedef struct wc_CryptoInfo {
                 const byte* keyRef;        /* opaque: where it should land */
                 word32      keyRefSz;
                 word32      keyType;       /* enum wc_KeyStoreKeyType */
+                word32      keySz;         /* bytes; 0 = device's own default */
                 word32      attrs;         /* WC_KEYSTORE_ATTR_* */
                 const byte* srcKeyRef;     /* opaque: the derivation key */
                 word32      srcKeyRefSz;
@@ -1418,7 +1419,7 @@ WOLFSSL_LOCAL int wc_CryptoCb_KeyStoreExportWrapped(int devId,
     const byte* wrapKeyRef, word32 wrapKeyRefSz,
     word32 format, byte* blob, word32* blobSz, const void* ctx);
 WOLFSSL_LOCAL int wc_CryptoCb_KeyStoreDerive(int devId,
-    const byte* keyRef, word32 keyRefSz, word32 keyType,
+    const byte* keyRef, word32 keyRefSz, word32 keyType, word32 keySz,
     const byte* srcKeyRef, word32 srcKeyRefSz,
     word32 kdfType, const byte* deriv, word32 derivSz,
     word32 attrs, const void* ctx);

--- a/wolfssl/wolfcrypt/wc_keystore.h
+++ b/wolfssl/wolfcrypt/wc_keystore.h
@@ -77,9 +77,10 @@ WOLFSSL_API int wc_KeyStore_ExportWrapped(int devId,
     word32 format, byte* blob, word32* blobSz, const void* ctx);
 
 /* Derive a new stored key from an existing one without either touching RAM.
- * derivSz is algorithm-specific and often fixed by the hardware. */
+ * keySz is the size in bytes of the key to create, or 0 to leave it to the
+ * device; derivSz is algorithm-specific and often fixed by the hardware. */
 WOLFSSL_API int wc_KeyStore_Derive(int devId,
-    const byte* keyRef, word32 keyRefSz, word32 keyType,
+    const byte* keyRef, word32 keyRefSz, word32 keyType, word32 keySz,
     const byte* srcKeyRef, word32 srcKeyRefSz,
     word32 kdfType, const byte* deriv, word32 derivSz,
     word32 attrs, const void* ctx);


### PR DESCRIPTION
Follow-up to the `WC_ALGO_TYPE_KEYSTORE` crypto callback API added in #11336, which shipped with one gap and no ChangeLog entry. Both are closed here.

`wc_KeyStore_Derive()` is the only key store operation that creates a key without any way to say how big it should be. Every other operation has an answer: `ImportPlain` has the plaintext's length, `ImportWrapped` reads it from the blob, and the exports and `GetInfo` report a property of a key that already exists. Derive has `keyType`, which is a purpose rather than a length (AES is 128 or 256 either way), `derivSz`, which measures the input rather than the output, and `attrs`, which is three flag bits. So the device picks the size, the caller cannot ask for one, and `GetInfo` then reports a size the API gave no way to request.

This adds `keySz`, in bytes, beside the `keyType` it qualifies:

```c
int wc_KeyStore_Derive(int devId,
    const byte* keyRef, word32 keyRefSz, word32 keyType, word32 keySz,
    const byte* srcKeyRef, word32 srcKeyRefSz,
    word32 kdfType, const byte* deriv, word32 derivSz,
    word32 attrs, const void* ctx);
```

Zero keeps the current behavior and leaves the choice to the device, which is the right answer for a key store whose derivation has only one output size. The field is carried to the callback in `wc_CryptoInfo.keystore.op.derive.keySz`.

This is the shape the other key store APIs use: PKCS#11 carries it in `C_DeriveKey`'s template as `CKA_VALUE_LEN`, and PSA in the attributes passed to `psa_key_derivation_output_key()`. The name matches `wc_KeyStore_ImportPlain()`.

The hardware case that motivates it: an NXP EdgeLock slot key is either 128-bit or 256-bit, both derivable from the same source key by the same SP800-108 CMAC KDF, and a 256-bit key spans a slot pair. Without `keySz` the caller has no way to say which one it wants.

The API is new in this release and has no released callers, so widening the signature costs no compatibility. `--enable-cryptocbutils=keystore` is off by default.

The same commit adds the ChangeLog entry for the key store API. #11336 merged without one, and since this is the last change to that API, the entry can describe it as it ships.
