### PR TITLE
linuxkm: add PQ in-core sanity markers to the PIE redirect table

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -1107,6 +1107,27 @@
             extern int wolfCrypt_FIPS_SHA3_sanity(void);
             extern const unsigned int wolfCrypt_FIPS_sha3_ro_sanity[2];
 #endif
+/* PQ boundary members added in v7.0.0; see fips_test.c DoInCoreCheck. */
+#if defined(WOLFSSL_HAVE_MLKEM) && FIPS_VERSION3_GE(7,0,0)
+            extern int wolfCrypt_FIPS_MLKEM_sanity(void);
+            extern const unsigned int wolfCrypt_FIPS_mlkem_ro_sanity[2];
+#endif
+#if defined(WOLFSSL_HAVE_MLDSA) && FIPS_VERSION3_GE(7,0,0)
+            extern int wolfCrypt_FIPS_MLDSA_sanity(void);
+            extern const unsigned int wolfCrypt_FIPS_mldsa_ro_sanity[2];
+#endif
+#if defined(WOLFSSL_HAVE_SLHDSA) && FIPS_VERSION3_GE(7,0,0)
+            extern int wolfCrypt_FIPS_SLHDSA_sanity(void);
+            extern const unsigned int wolfCrypt_FIPS_slhdsa_ro_sanity[2];
+#endif
+#if defined(WOLFSSL_HAVE_LMS) && FIPS_VERSION3_GE(7,0,0)
+            extern int wolfCrypt_FIPS_LMS_sanity(void);
+            extern const unsigned int wolfCrypt_FIPS_lms_ro_sanity[2];
+#endif
+#if defined(WOLFSSL_HAVE_XMSS) && FIPS_VERSION3_GE(7,0,0)
+            extern int wolfCrypt_FIPS_XMSS_sanity(void);
+            extern const unsigned int wolfCrypt_FIPS_xmss_ro_sanity[2];
+#endif
 #ifndef WOLFSSL_FIPS_DEV_NO_POST
             extern int wolfCrypt_FIPS_FT_sanity(void);
             extern const unsigned int wolfCrypt_FIPS_ft_ro_sanity[2];
@@ -1444,6 +1465,27 @@
 #ifdef WOLFSSL_SHA3
             typeof(wolfCrypt_FIPS_SHA3_sanity) *wolfCrypt_FIPS_SHA3_sanity;
             typeof(wolfCrypt_FIPS_sha3_ro_sanity) *wolfCrypt_FIPS_sha3_ro_sanity;
+#endif
+/* PQ boundary members added in v7.0.0; see fips_test.c DoInCoreCheck. */
+#if defined(WOLFSSL_HAVE_MLKEM) && FIPS_VERSION3_GE(7,0,0)
+            typeof(wolfCrypt_FIPS_MLKEM_sanity) *wolfCrypt_FIPS_MLKEM_sanity;
+            typeof(wolfCrypt_FIPS_mlkem_ro_sanity) *wolfCrypt_FIPS_mlkem_ro_sanity;
+#endif
+#if defined(WOLFSSL_HAVE_MLDSA) && FIPS_VERSION3_GE(7,0,0)
+            typeof(wolfCrypt_FIPS_MLDSA_sanity) *wolfCrypt_FIPS_MLDSA_sanity;
+            typeof(wolfCrypt_FIPS_mldsa_ro_sanity) *wolfCrypt_FIPS_mldsa_ro_sanity;
+#endif
+#if defined(WOLFSSL_HAVE_SLHDSA) && FIPS_VERSION3_GE(7,0,0)
+            typeof(wolfCrypt_FIPS_SLHDSA_sanity) *wolfCrypt_FIPS_SLHDSA_sanity;
+            typeof(wolfCrypt_FIPS_slhdsa_ro_sanity) *wolfCrypt_FIPS_slhdsa_ro_sanity;
+#endif
+#if defined(WOLFSSL_HAVE_LMS) && FIPS_VERSION3_GE(7,0,0)
+            typeof(wolfCrypt_FIPS_LMS_sanity) *wolfCrypt_FIPS_LMS_sanity;
+            typeof(wolfCrypt_FIPS_lms_ro_sanity) *wolfCrypt_FIPS_lms_ro_sanity;
+#endif
+#if defined(WOLFSSL_HAVE_XMSS) && FIPS_VERSION3_GE(7,0,0)
+            typeof(wolfCrypt_FIPS_XMSS_sanity) *wolfCrypt_FIPS_XMSS_sanity;
+            typeof(wolfCrypt_FIPS_xmss_ro_sanity) *wolfCrypt_FIPS_xmss_ro_sanity;
 #endif
 #ifndef WOLFSSL_FIPS_DEV_NO_POST
             typeof(wolfCrypt_FIPS_FT_sanity) *wolfCrypt_FIPS_FT_sanity;

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -1981,6 +1981,37 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
     wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_sha3_ro_sanity =
         &wolfCrypt_FIPS_sha3_ro_sanity;
 #endif
+/* PQ boundary members added in v7.0.0; see fips_test.c DoInCoreCheck. */
+#if defined(WOLFSSL_HAVE_MLKEM) && FIPS_VERSION3_GE(7,0,0)
+    wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_MLKEM_sanity =
+        wolfCrypt_FIPS_MLKEM_sanity;
+    wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_mlkem_ro_sanity =
+        &wolfCrypt_FIPS_mlkem_ro_sanity;
+#endif
+#if defined(WOLFSSL_HAVE_MLDSA) && FIPS_VERSION3_GE(7,0,0)
+    wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_MLDSA_sanity =
+        wolfCrypt_FIPS_MLDSA_sanity;
+    wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_mldsa_ro_sanity =
+        &wolfCrypt_FIPS_mldsa_ro_sanity;
+#endif
+#if defined(WOLFSSL_HAVE_SLHDSA) && FIPS_VERSION3_GE(7,0,0)
+    wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_SLHDSA_sanity =
+        wolfCrypt_FIPS_SLHDSA_sanity;
+    wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_slhdsa_ro_sanity =
+        &wolfCrypt_FIPS_slhdsa_ro_sanity;
+#endif
+#if defined(WOLFSSL_HAVE_LMS) && FIPS_VERSION3_GE(7,0,0)
+    wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_LMS_sanity =
+        wolfCrypt_FIPS_LMS_sanity;
+    wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_lms_ro_sanity =
+        &wolfCrypt_FIPS_lms_ro_sanity;
+#endif
+#if defined(WOLFSSL_HAVE_XMSS) && FIPS_VERSION3_GE(7,0,0)
+    wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_XMSS_sanity =
+        wolfCrypt_FIPS_XMSS_sanity;
+    wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_xmss_ro_sanity =
+        &wolfCrypt_FIPS_xmss_ro_sanity;
+#endif
 
 #ifndef WOLFSSL_FIPS_DEV_NO_POST
     wolfssl_linuxkm_pie_redirect_table.wolfCrypt_FIPS_FT_sanity =


### PR DESCRIPTION
# Description

Preparatory PR: Simply adds the PIE redirects for the in-core integrity check updates to the v7 module.

# Testing

Tested by inspection:

```
=== R: /home/kh/FIPS-all-jobs/PQ-FS-dev-area/nofallback-Branch-testing/clones/kh-R-wolfssl/linuxkm/linuxkm/module_hooks.o
reloc lines: 933
  SHA3_sanity        1
  sha3_ro_sanity     1
  MLKEM_sanity       1
  mlkem_ro_sanity    1
  MLDSA_sanity       1
  mldsa_ro_sanity    1
  SLHDSA_sanity      1
  slhdsa_ro_sanity   1
  LMS_sanity         1
  lms_ro_sanity      1
  XMSS_sanity        1
  xmss_ro_sanity     1
  NOTREAL_sanity     0
=== Rbase: /home/kh/FIPS-all-jobs/PQ-FS-dev-area/nofallback-Branch-testing/clones/kh-Rbase-wolfssl/linuxkm/linuxkm/module_hooks.o
reloc lines: 903
  SHA3_sanity        1
  sha3_ro_sanity     1
  MLKEM_sanity       0
  mlkem_ro_sanity    0
  MLDSA_sanity       0
  mldsa_ro_sanity    0
  SLHDSA_sanity      0
  slhdsa_ro_sanity   0
  LMS_sanity         0
  lms_ro_sanity      0
  XMSS_sanity        0
  xmss_ro_sanity     0
  NOTREAL_sanity     0
  ```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
