### PR TITLE
bsdkm: wc_static_assert define.

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -2436,6 +2436,14 @@ WOLFSSL_API word32 CheckRunTimeSettings(void);
                 wc_static_assert2(__builtin_choose_expr(                \
                                   WC_IS_CONSTEXPR(expr), expr, 1), msg)
         #endif
+    #elif defined(WOLFSSL_BSDKM)
+        /* from CTASSERT(9), FreeBSD Kernel Developer's Manual:
+         * The CTASSERT() macro is deprecated and the C11 standard
+         * _Static_assert() should be used instead. */
+        #define wc_static_assert(expr) _Static_assert(expr, #expr)
+        #ifndef wc_static_assert2
+            #define wc_static_assert2(expr, msg) _Static_assert(expr, msg)
+        #endif
     #else
         #ifdef __COUNTER__
             #define wc_static_assert(expr)                          \


### PR DESCRIPTION
# Description

Add missing assert define for bsdkm build.

Fixes fips-bsdkm build.

# Testing

```sh
  FIPS_CFLAGS="-DWOLFSSL_BSDKM_VERBOSE_DEBUG -DWOLFCRYPT_FIPS_CORE_HASH_VALUE=$fips_hash"
  ./configure --enable-freebsdkm --enable-cryptonly \
    --enable-crypttests \
    --enable-fips=v7 \
    CFLAGS="$BASE_CFLAGS $FIPS_CFLAGS" \
    || exit 1

make && sudo kldload bsdkm/libwolfssl.ko || exit 1
```

dmesg output from kldload and unload:

```sh
info: wolfkmod_event: MOD_LOAD
info: FIPS 140-3 wolfCrypt-fips v7.0.0 startup self-test succeeded.
------------------------------------------------------------------------------
 wolfSSL version 5.9.2
------------------------------------------------------------------------------
wc_RunAllCast_fips passed.
macro    test passed!
error    test passed!
MEMORY   test passed!
...
SLH-DSA  test passed!
CMAC     test passed!
mp       test passed!
logging  test passed!
mutex    test passed!
Test complete
info: wolfCrypt self-test passed.
info: libwolfssl loaded
info: wolfkmod_event: MOD_QUIESCE
info: wolfkmod_event: MOD_UNLOAD
info: wolfCrypt FIPS re-self-test succeeded at unload: all algorithms re-verified.
info: libwolfssl 5.9.2 cleanup complete.
info: libwolfssl unloaded
```

